### PR TITLE
Receiver driven intranode gpu ipc protocol

### DIFF
--- a/src/mpid/ch4/include/shmpre.h
+++ b/src/mpid/ch4/include/shmpre.h
@@ -12,6 +12,7 @@
 
 /* shm am status */
 #define MPIDI_SHM_REQ_XPMEM_SEND_LMT (0x1)
+#define MPIDI_SHM_REQ_GPU_IPC_RECV   (0x2)
 
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
 #define MPIDI_SHM_XPMEM_WIN_DECL MPIDI_XPMEM_win_t xpmem;
@@ -21,9 +22,16 @@
 #define MPIDI_SHM_XPMEM_REQUEST_AM_DECL
 #endif
 
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU_IPC
+#define MPIDI_SHM_GPU_REQUEST_AM_DECL MPIDI_GPU_am_request_t gpu;
+#else
+#define MPIDI_SHM_GPU_REQUEST_AM_DECL
+#endif
+
 #define MPIDI_SHM_REQUEST_AM_DECL    uint64_t status;                   \
                                      MPIDI_POSIX_am_request_t posix;    \
-                                     MPIDI_SHM_XPMEM_REQUEST_AM_DECL
+                                     MPIDI_SHM_XPMEM_REQUEST_AM_DECL;   \
+                                     MPIDI_SHM_GPU_REQUEST_AM_DECL
 #define MPIDI_SHM_REQUEST_DECL       MPIDI_POSIX_request_t posix;
 #define MPIDI_SHM_COMM_DECL          MPIDI_POSIX_comm_t posix;
 #define MPIDI_SHM_WIN_DECL           MPIDI_POSIX_win_t posix;   \

--- a/src/mpid/ch4/shm/Makefile.mk
+++ b/src/mpid/ch4/shm/Makefile.mk
@@ -12,3 +12,4 @@ include $(top_srcdir)/src/mpid/ch4/shm/src/Makefile.mk
 include $(top_srcdir)/src/mpid/ch4/shm/stubshm/Makefile.mk
 include $(top_srcdir)/src/mpid/ch4/shm/posix/Makefile.mk
 include $(top_srcdir)/src/mpid/ch4/shm/xpmem/Makefile.mk
+include $(top_srcdir)/src/mpid/ch4/shm/gpu/Makefile.mk

--- a/src/mpid/ch4/shm/gpu/Makefile.mk
+++ b/src/mpid/ch4/shm/gpu/Makefile.mk
@@ -1,0 +1,19 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+if BUILD_SHM_GPU_IPC
+
+noinst_HEADERS += src/mpid/ch4/shm/gpu/shm_inline.h    \
+                  src/mpid/ch4/shm/gpu/gpu_noinline.h  \
+                  src/mpid/ch4/shm/gpu/gpu_impl.h      \
+                  src/mpid/ch4/shm/gpu/gpu_send.h      \
+                  src/mpid/ch4/shm/gpu/gpu_recv.h      \
+                  src/mpid/ch4/shm/gpu/gpu_control.h   \
+                  src/mpid/ch4/shm/gpu/gpu_pre.h
+
+mpi_core_sources += src/mpid/ch4/shm/gpu/globals.c     \
+                    src/mpid/ch4/shm/gpu/gpu_init.c    \
+                    src/mpid/ch4/shm/gpu/gpu_control.c
+endif

--- a/src/mpid/ch4/shm/gpu/globals.c
+++ b/src/mpid/ch4/shm/gpu/globals.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "gpu_pre.h"
+#include "gpu_impl.h"
+
+MPIDI_GPU_global_t MPIDI_GPU_global = { 0 };
+
+#ifdef MPL_USE_DBG_LOGGING
+MPL_dbg_class MPIDI_CH4_SHM_GPU_IPC_GENERAL;
+#endif

--- a/src/mpid/ch4/shm/gpu/gpu_control.c
+++ b/src/mpid/ch4/shm/gpu/gpu_control.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "gpu_pre.h"
+#include "gpu_impl.h"
+#include "gpu_recv.h"
+#include "gpu_control.h"
+
+int MPIDI_GPU_ctrl_send_ipc_recv_req_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIDI_SHM_ctrl_gpu_send_recv_req_t *recv_req_hdr = &ctrl_hdr->gpu_recv_req;
+    MPIR_Request *rreq = NULL;
+    MPIR_Comm *root_comm;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_CTRL_SEND_IPC_RECV_REQ_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_CTRL_SEND_IPC_RECV_REQ_CB);
+
+    root_comm = MPIDIG_context_id_to_comm(recv_req_hdr->context_id);
+    if (root_comm) {
+        while (TRUE) {
+            rreq =
+                MPIDIG_dequeue_posted(recv_req_hdr->src_rank, recv_req_hdr->tag,
+                                      recv_req_hdr->context_id, 1, &MPIDIG_COMM(root_comm,
+                                                                                posted_list));
+            if (rreq) {
+                int is_cancelled;
+                mpi_errno = MPIDI_anysrc_try_cancel_partner(rreq, &is_cancelled);
+                MPIR_ERR_CHECK(mpi_errno);
+                if (!is_cancelled) {
+                    MPIR_Comm_release(root_comm);       /* -1 for posted_list */
+                    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
+                    continue;
+                }
+            }
+            break;
+        }
+    }
+
+    if (rreq) {
+        /* Matching receive was posted */
+        MPIR_Comm_release(root_comm);   /* -1 for posted list */
+        MPIDIG_REQUEST(rreq, rank) = recv_req_hdr->src_rank;
+        MPIDIG_REQUEST(rreq, tag) = recv_req_hdr->tag;
+        MPIDIG_REQUEST(rreq, context_id) = recv_req_hdr->context_id;
+
+        /* Complete GPU IPC receive */
+        mpi_errno =
+            MPIDI_GPU_handle_ipc_recv(recv_req_hdr->data_sz, recv_req_hdr->sreq_ptr,
+                                      recv_req_hdr->mem_handle, rreq);
+        MPIR_ERR_CHECK(mpi_errno);
+    } else {
+        /* We got a send request: sender sent a GPU buffer memory handle. Handle
+         * data transfer in the receiver. */
+        rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2);
+        MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+
+        /* store CH4 am rreq info */
+        MPIDIG_REQUEST(rreq, buffer) = NULL;
+        MPIDIG_REQUEST(rreq, datatype) = MPI_BYTE;
+        MPIDIG_REQUEST(rreq, count) = recv_req_hdr->data_sz;
+        MPIDIG_REQUEST(rreq, rank) = recv_req_hdr->src_rank;
+        MPIDIG_REQUEST(rreq, tag) = recv_req_hdr->tag;
+        MPIDIG_REQUEST(rreq, context_id) = recv_req_hdr->context_id;
+        MPIDI_REQUEST(rreq, is_local) = 1;
+
+        /* store GPU IPC internal info */
+        MPIDI_GPU_IPC_REQUEST(rreq, unexp_rreq).data_sz = recv_req_hdr->data_sz;
+        MPIDI_GPU_IPC_REQUEST(rreq, unexp_rreq).sreq_ptr = recv_req_hdr->sreq_ptr;
+        MPIDI_GPU_IPC_REQUEST(rreq, unexp_rreq).mem_handle = recv_req_hdr->mem_handle;
+        MPIDI_SHM_REQUEST(rreq, status) |= MPIDI_SHM_REQ_GPU_IPC_RECV;
+
+        if (root_comm) {
+            MPIR_Comm_add_ref(root_comm);
+            MPIDIG_enqueue_unexp(rreq, &MPIDIG_COMM(root_comm, unexp_list));
+        } else {
+            MPIDIG_enqueue_unexp(rreq,
+                                 MPIDIG_context_id_to_uelist(MPIDIG_REQUEST(rreq, context_id)));
+        }
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_CTRL_SEND_IPC_RECV_REQ_CB);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_GPU_ctrl_send_ipc_recv_ack_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Request *rreq = (MPIR_Request *) ctrl_hdr->gpu_recv_ack.req_ptr;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_GPU_CTRL_SEND_IPC_RECV_ACK_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_GPU_CTRL_SEND_IPC_RECV_ACK_CB);
+
+    if (MPIDIG_REQUEST(rreq, buffer))
+        MPL_gpu_free(MPIDIG_REQUEST(rreq, buffer));
+
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
+    MPID_Request_complete(rreq);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_GPU_CTRL_SEND_IPC_RECV_ACK_CB);
+    return mpi_errno;
+}

--- a/src/mpid/ch4/shm/gpu/gpu_control.h
+++ b/src/mpid/ch4/shm/gpu/gpu_control.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef GPU_CONTROL_H_INCLUDED
+#define GPU_CONTROL_H_INCLUDED
+
+#include "shm_types.h"
+
+int MPIDI_GPU_ctrl_send_ipc_recv_req_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
+int MPIDI_GPU_ctrl_send_ipc_recv_ack_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
+
+#endif /* GPU_CONTROL_H_INCLUDED */

--- a/src/mpid/ch4/shm/gpu/gpu_impl.h
+++ b/src/mpid/ch4/shm/gpu/gpu_impl.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef GPU_IMPL_H_INCLUDED
+#define GPU_IMPL_H_INCLUDED
+
+#include "mpidimpl.h"
+
+#endif /* GPU_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/shm/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/gpu/gpu_init.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "gpu_impl.h"
+#include "gpu_noinline.h"
+
+int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
+{
+    return MPI_SUCCESS;
+}
+
+int MPIDI_GPU_mpi_finalize_hook(void)
+{
+    return MPI_SUCCESS;
+}

--- a/src/mpid/ch4/shm/gpu/gpu_noinline.h
+++ b/src/mpid/ch4/shm/gpu/gpu_noinline.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef GPU_NOINLINE_H_INCLUDED
+#define GPU_NOINLINE_H_INCLUDED
+
+#include "gpu_impl.h"
+
+int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits);
+int MPIDI_GPU_mpi_finalize_hook(void);
+
+#endif /* GPU_NOINLINE_H_INCLUDED */

--- a/src/mpid/ch4/shm/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/gpu/gpu_pre.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef GPU_PRE_H_INCLUDED
+#define GPU_PRE_H_INCLUDED
+
+typedef struct {
+    int dummy;
+} MPIDI_GPU_global_t;
+
+typedef struct {
+    uint64_t data_sz;
+    uint64_t sreq_ptr;
+    MPL_gpu_ipc_mem_handle_t mem_handle;
+} MPIDI_GPU_am_unexp_rreq_t;
+
+typedef struct {
+    MPIDI_GPU_am_unexp_rreq_t unexp_rreq;
+} MPIDI_GPU_am_request_t;
+
+#define MPIDI_GPU_IPC_REQUEST(req, field) ((req)->dev.ch4.am.shm_am.gpu.field)
+
+#endif /* GPU_PRE_H_INCLUDED */

--- a/src/mpid/ch4/shm/gpu/gpu_recv.h
+++ b/src/mpid/ch4/shm/gpu/gpu_recv.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef GPU_RECV_H_INCLUDED
+#define GPU_RECV_H_INCLUDED
+
+#include "ch4_impl.h"
+#include "shm_control.h"
+#include "gpu_pre.h"
+#include "gpu_impl.h"
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_handle_ipc_recv(size_t src_data_sz,
+                                                       uint64_t sreq_ptr,
+                                                       MPL_gpu_ipc_mem_handle_t mem_handle,
+                                                       MPIR_Request * rreq)
+{
+    int mpi_errno = MPI_SUCCESS;
+    void *src_buf = NULL;
+    size_t data_sz, recv_data_sz;
+    MPIDI_SHM_ctrl_hdr_t recv_ack_hdr;
+    yaksa_request_t yaksa_request;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_GPU_HANDLE_IPC_RECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_GPU_HANDLE_IPC_RECV);
+
+    MPIDI_Datatype_check_size(MPIDIG_REQUEST(rreq, datatype), MPIDIG_REQUEST(rreq, count), data_sz);
+
+    /* Data truncation checking */
+    recv_data_sz = MPL_MIN(src_data_sz, data_sz);
+    if (src_data_sz > data_sz)
+        rreq->status.MPI_ERROR = MPI_ERR_TRUNCATE;
+
+    /* Set receive status */
+    MPIR_STATUS_SET_COUNT(rreq->status, recv_data_sz);
+    rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, rank);
+    rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, tag);
+
+    /* Do copy of data */
+    MPL_gpu_ipc_open_mem_handle(&src_buf, mem_handle);
+
+    MPI_Aint actual_unpack_bytes;
+    mpi_errno =
+        MPIR_Typerep_unpack((const void *) src_buf, src_data_sz,
+                            (char *) MPIDIG_REQUEST(rreq, buffer), recv_data_sz,
+                            MPIDIG_REQUEST(rreq, datatype), 0, &actual_unpack_bytes);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPL_gpu_ipc_close_mem_handle(src_buf);
+
+    /* Send acknowledgment to sender */
+    recv_ack_hdr.gpu_recv_ack.req_ptr = sreq_ptr;
+    mpi_errno = MPIDI_SHM_do_ctrl_send(MPIDIG_REQUEST(rreq, rank),
+                                       MPIDIG_context_id_to_comm(MPIDIG_REQUEST
+                                                                 (rreq, context_id)),
+                                       MPIDI_SHM_GPU_SEND_IPC_RECV_ACK, &recv_ack_hdr);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
+    MPID_Request_complete(rreq);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_GPU_HANDLE_IPC_RECV);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+#endif /* GPU_RECV_H_INCLUDED */

--- a/src/mpid/ch4/shm/gpu/gpu_send.h
+++ b/src/mpid/ch4/shm/gpu/gpu_send.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef GPU_SEND_H_INCLUDED
+#define GPU_SEND_H_INCLUDED
+
+#include "ch4_impl.h"
+#include "shm_control.h"
+#include "gpu_pre.h"
+#include "gpu_impl.h"
+
+static inline int MPIDI_GPU_ipc_isend_recv_req(const void *buf, MPI_Aint count,
+                                               MPI_Datatype datatype, int rank, int tag,
+                                               MPIR_Comm * comm, int context_offset,
+                                               MPIR_Request ** request)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Request *sreq = NULL;
+    size_t data_sz;
+    MPI_Aint true_lb;
+    bool is_contig = true;
+    void *buf_ptr = (void *) buf;
+    MPIDI_SHM_ctrl_hdr_t ctrl_hdr;
+    MPIDI_SHM_ctrl_gpu_send_recv_req_t *send_req_hdr = &ctrl_hdr.gpu_recv_req;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_GPU_IPC_ISEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_GPU_IPC_ISEND);
+
+    MPIR_Datatype_add_ref_if_not_builtin(datatype);
+    sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
+    MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    *request = sreq;
+    MPIDIG_REQUEST(sreq, buffer) = NULL;
+    MPIDIG_REQUEST(sreq, datatype) = datatype;
+    MPIDIG_REQUEST(sreq, rank) = rank;
+    MPIDIG_REQUEST(sreq, count) = count;
+    MPIDIG_REQUEST(sreq, context_id) = comm->context_id + context_offset;
+
+    MPIDI_Datatype_check_contig_size_lb(datatype, count, is_contig, data_sz, true_lb);
+    if (!is_contig) {
+        mpi_errno = MPL_gpu_malloc(&MPIDIG_REQUEST(sreq, buffer), data_sz);
+        MPIR_ERR_CHECK(mpi_errno);
+        buf_ptr = MPIDIG_REQUEST(sreq, buffer);
+        MPI_Aint actual_pack_bytes;
+        MPIR_Typerep_pack(buf, count, datatype, 0, buf_ptr, data_sz, &actual_pack_bytes);
+        MPIR_Assert(actual_pack_bytes == data_sz);
+        true_lb = 0;
+    }
+    buf = (void const *) buf_ptr;
+
+    /* GPU IPC internal info */
+    send_req_hdr->data_sz = data_sz;
+    send_req_hdr->sreq_ptr = (uint64_t) sreq;
+    MPL_gpu_ipc_get_mem_handle(&send_req_hdr->mem_handle, (char *) buf + true_lb);
+
+    /* message matching info */
+    send_req_hdr->src_rank = comm->rank;
+    send_req_hdr->tag = tag;
+    send_req_hdr->context_id = comm->context_id + context_offset;
+
+    mpi_errno = MPIDI_SHM_do_ctrl_send(rank, comm, MPIDI_SHM_GPU_SEND_IPC_RECV_REQ, &ctrl_hdr);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_GPU_IPC_ISEND);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_ipc_isend(const void *buf, MPI_Aint count,
+                                                 MPI_Datatype datatype, int rank, int tag,
+                                                 MPIR_Comm * comm, int context_offset,
+                                                 int ctrl_id, MPIR_Request ** request)
+{
+    if (ctrl_id == MPIDI_SHM_GPU_SEND_IPC_RECV_REQ)
+        return MPIDI_GPU_ipc_isend_recv_req(buf, count, datatype, rank, tag, comm, context_offset,
+                                            request);
+    else {
+        /* TODO: to be replaced by sender driven protocol */
+        MPIR_Assert(0);
+        return MPI_SUCCESS;
+    }
+}
+
+#endif /* GPU_SEND_H_INCLUDED */

--- a/src/mpid/ch4/shm/gpu/shm_inline.h
+++ b/src/mpid/ch4/shm/gpu/shm_inline.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef GPU_INLINE_H_INCLUDED
+#define GPU_INLINE_H_INCLUDED
+
+#include "gpu_control.h"
+#include "gpu_send.h"
+#include "gpu_recv.h"
+
+/* Not-inlined shm functions */
+#include "gpu_noinline.h"
+
+#endif /* GPU_INLINE_H_INCLUDED */

--- a/src/mpid/ch4/shm/gpu/subconfigure.m4
+++ b/src/mpid/ch4/shm/gpu/subconfigure.m4
@@ -1,0 +1,21 @@
+[#] start of __file__
+dnl MPICH_SUBCFG_AFTER=src/mpid/ch4
+
+AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
+    AM_COND_IF([BUILD_CH4],[
+        for shm in $ch4_shm ; do
+            AS_CASE([$shm],[gpu_ipc],[build_ch4_shm_gpu_ipc=yes])
+        done
+
+        if test "$build_ch4_shm_gpu_ipc" = "yes" ; then
+            AC_DEFINE([MPIDI_CH4_SHM_ENABLE_GPU_IPC],[1],[Define if GPU IPC module is enabled])
+        fi
+    ])dnl end of AM_COND_IF(BUILD_CH4,...)
+
+    AM_CONDITIONAL([BUILD_SHM_GPU_IPC],[test "X$build_ch4_shm_gpu_ipc" = "Xyes"])
+])dnl end of _PREREQ
+
+AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
+])dnl end of _BODY
+
+[#] end of __file__

--- a/src/mpid/ch4/shm/src/shm_control.c
+++ b/src/mpid/ch4/shm/src/shm_control.c
@@ -9,6 +9,10 @@
 #include "../xpmem/xpmem_control.h"
 #endif
 
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU_IPC
+#include "../gpu/gpu_control.h"
+#endif
+
 int MPIDI_SHM_ctrl_dispatch(int ctrl_id, void *ctrl_hdr)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -29,6 +33,14 @@ int MPIDI_SHM_ctrl_dispatch(int ctrl_id, void *ctrl_hdr)
             break;
         case MPIDI_SHM_XPMEM_SEND_LMT_CNT_FREE:
             mpi_errno = MPIDI_XPMEM_ctrl_send_lmt_cnt_free_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
+            break;
+#endif
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU_IPC
+        case MPIDI_SHM_GPU_SEND_IPC_RECV_REQ:
+            mpi_errno = MPIDI_GPU_ctrl_send_ipc_recv_req_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
+            break;
+        case MPIDI_SHM_GPU_SEND_IPC_RECV_ACK:
+            mpi_errno = MPIDI_GPU_ctrl_send_ipc_recv_ack_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
             break;
 #endif
         default:

--- a/src/mpid/ch4/shm/src/shm_init.c
+++ b/src/mpid/ch4/shm/src/shm_init.c
@@ -27,6 +27,11 @@ int MPIDI_SHMI_mpi_init_hook(int rank, int size, int *tag_bits)
     }
 #endif
 
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU_IPC
+    ret = MPIDI_GPU_mpi_init_hook(rank, size, tag_bits);
+    MPIR_ERR_CHECK(ret);
+#endif
+
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHMI_MPI_INIT_HOOK);
     return ret;
@@ -46,6 +51,11 @@ int MPIDI_SHMI_mpi_finalize_hook(void)
         ret = MPIDI_XPMEM_mpi_finalize_hook();
         MPIR_ERR_CHECK(ret);
     }
+#endif
+
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU_IPC
+    ret = MPIDI_GPU_mpi_finalize_hook();
+    MPIR_ERR_CHECK(ret);
 #endif
 
     ret = MPIDI_POSIX_mpi_finalize_hook();

--- a/src/mpid/ch4/shm/src/shm_pre.h
+++ b/src/mpid/ch4/shm/src/shm_pre.h
@@ -13,10 +13,17 @@
 #include "../xpmem/xpmem_pre.h"
 #endif
 
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU_IPC
+#include "../gpu/gpu_pre.h"
+#endif
+
 typedef struct {
     MPIDI_POSIX_Global_t posix;
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
     MPIDI_XPMEM_Global_t xpmem;
+#endif
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU_IPC
+    MPIDI_GPU_Global_t gpu;
 #endif
 } MPIDI_SHM_Global_t;
 

--- a/src/mpid/ch4/shm/src/shm_types.h
+++ b/src/mpid/ch4/shm/src/shm_types.h
@@ -14,6 +14,10 @@ typedef enum {
     MPIDI_SHM_XPMEM_SEND_LMT_RECV_FIN,  /* issued by receiver to notify completion of coop copy or single copy */
     MPIDI_SHM_XPMEM_SEND_LMT_CNT_FREE,  /* issued by sender to notify free counter obj in coop copy */
 #endif
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU_IPC
+    MPIDI_SHM_GPU_SEND_IPC_RECV_REQ,    /* issued by sender to request a receiver driven data transfer */
+    MPIDI_SHM_GPU_SEND_IPC_RECV_ACK,    /* issued by receiver to acknowledge receiver driven data transfer completion */
+#endif
     MPIDI_SHM_CTRL_IDS_MAX
 } MPIDI_SHM_ctrl_id_t;
 
@@ -54,6 +58,23 @@ typedef struct MPIDI_SHM_ctrl_xpmem_send_lmt_cnt_free {
 typedef MPIDI_SHM_ctrl_xpmem_send_lmt_send_fin_t MPIDI_SHM_ctrl_xpmem_send_lmt_recv_fin_t;
 #endif
 
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU_IPC
+typedef struct MPIDI_SHM_ctrl_gpu_send_recv_req {
+    uint64_t data_sz;
+    MPL_gpu_ipc_mem_handle_t mem_handle;
+    uint64_t sreq_ptr;
+
+    /* matching info */
+    int src_rank;
+    int tag;
+    MPIR_Context_id_t context_id;
+} MPIDI_SHM_ctrl_gpu_send_recv_req_t;
+
+typedef struct MPIDI_SHM_ctrl_gpu_send_recv_ack {
+    uint64_t req_ptr;
+} MPIDI_SHM_ctrl_gpu_send_recv_ack_t;
+#endif
+
 typedef union {
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
     MPIDI_SHM_ctrl_xpmem_send_lmt_rts_t xpmem_slmt_rts;
@@ -61,6 +82,10 @@ typedef union {
     MPIDI_SHM_ctrl_xpmem_send_lmt_send_fin_t xpmem_slmt_send_fin;
     MPIDI_SHM_ctrl_xpmem_send_lmt_recv_fin_t xpmem_slmt_recv_fin;
     MPIDI_SHM_ctrl_xpmem_send_lmt_cnt_free_t xpmem_slmt_cnt_free;
+#endif
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU_IPC
+    MPIDI_SHM_ctrl_gpu_send_recv_req_t gpu_recv_req;
+    MPIDI_SHM_ctrl_gpu_send_recv_ack_t gpu_recv_ack;
 #endif
     char dummy;                 /* some compilers (suncc) does not like empty struct */
 } MPIDI_SHM_ctrl_hdr_t;

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -154,6 +154,17 @@ static inline void MPIDI_anysrc_free_partner(MPIR_Request * rreq)
         }
     }
 }
+#else
+static inline int MPIDI_anysrc_try_cancel_partner(MPIR_Request * rreq, int *is_cancelled)
+{
+    return MPI_SUCCESS;
+}
+
+static inline void MPIDI_anysrc_free_partner(MPIR_Request * rreq)
+{
+    return;
+}
+
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
 
 #endif /* CH4R_REQUEST_H_INCLUDED */

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -273,6 +273,8 @@ AC_ARG_WITH(ch4-shmmods,
                           posix_only   - Only enable POSIX SHM (default)
                           xpmem        - Enable XPMEM SHM for partial communication paths and use
                                          POSIX SHM as fallback for others
+                          gpu_ipc      - Enable GPU IPC SHM for GPU communication paths and use
+                                         POSIX SHM as fallback for others
                  ],
                  [with_ch4_shmmods=$withval],
                  [with_ch4_shmmods=posix_only])

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -27,4 +27,7 @@ int MPL_gpu_ipc_get_mem_handle(MPL_gpu_ipc_mem_handle_t * h_mem, void *ptr);
 int MPL_gpu_ipc_open_mem_handle(void **ptr, MPL_gpu_ipc_mem_handle_t h_mem);
 int MPL_gpu_ipc_close_mem_handle(void *ptr);
 
+int MPL_gpu_malloc(void **ptr, size_t size);
+int MPL_gpu_free(void *ptr);
+
 #endif /* ifndef MPL_GPU_H_INCLUDED */

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -74,3 +74,27 @@ int MPL_gpu_ipc_close_mem_handle(void *ptr)
   fn_fail:
     return MPL_ERR_GPU_INTERNAL;
 }
+
+int MPL_gpu_malloc(void **ptr, size_t size)
+{
+    cudaError_t ret;
+    ret = cudaMalloc(ptr, size);
+    CUDA_ERR_CHECK(ret);
+
+  fn_exit:
+    return MPL_SUCCESS;
+  fn_fail:
+    return MPL_ERR_GPU_INTERNAL;
+}
+
+int MPL_gpu_free(void *ptr)
+{
+    cudaError_t ret;
+    ret = cudaFree(ptr);
+    CUDA_ERR_CHECK(ret);
+
+  fn_exit:
+    MPL_SUCCESS;
+  fn_fail:
+    return MPL_ERR_GPU_INTERNAL;
+}

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -29,3 +29,15 @@ int MPL_gpu_ipc_close_mem_handle(void *ptr)
     abort();
     return MPL_ERR_GPU_INTERNAL;
 }
+
+int MPL_gpu_malloc(void **ptr, size_t size)
+{
+    abort();
+    return MPL_ERR_GPU_INTERNAL;
+}
+
+int MPL_gpu_free(void *ptr)
+{
+    abort();
+    return MPL_ERR_GPU_INTERNAL;
+}


### PR DESCRIPTION
## Pull Request Description
This PR introduces a new shmmod for GPU intranode communication based on GPU IPC functionality. The PR implements a receiver driven protocol in which the sender prepares a memory handle for the GPU buffer to be sent and exposes this to the receiver using POSIX shared memory. The receive opens the sender's memory handle and maps the buffer into its address space, doing a local copy of the source data to the destination afterwards.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
