### PR TITLE
op: use fortran to handle MPI_REAL16

### DIFF
--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -1046,6 +1046,7 @@ EOT
     print MAKEFD <<EOT;
 mpi_core_sources += src/binding/fortran/mpif_h/fdebug.c \\
 		src/binding/fortran/mpif_h/setbot.c \\
+		src/binding/fortran/mpif_h/fortran_ops.f \\
 		src/binding/fortran/mpif_h/setbotf.f
 mpi_sources += src/binding/fortran/mpif_h/statusf2c.c src/binding/fortran/mpif_h/statusc2f.c
 

--- a/src/binding/fortran/mpif_h/fortran_ops.f
+++ b/src/binding/fortran/mpif_h/fortran_ops.f
@@ -1,0 +1,16 @@
+!
+! Copyright (C) by Argonne National Laboratory
+!     See COPYRIGHT in top-level directory
+!
+
+      subroutine real16_sum(A, B, N)
+        real(16) A(N), B(N)
+        integer N
+        integer i
+
+        DO i = 1, N
+            B(i) = B(i) + A(i)
+        END DO
+
+        return
+      end

--- a/src/include/mpir_op_util.h
+++ b/src/include/mpir_op_util.h
@@ -313,7 +313,7 @@ typedef struct {
 #define MPIR_OP_TYPE_GROUP_FLOATING_POINT_EXTRA                                               \
     MPIR_OP_TYPE_MACRO_HAVE_REAL4_CTYPE(MPI_REAL4, MPIR_REAL4_CTYPE, mpir_typename_real4)     \
     MPIR_OP_TYPE_MACRO_HAVE_REAL8_CTYPE(MPI_REAL8, MPIR_REAL8_CTYPE, mpir_typename_real8)     \
-    MPIR_OP_TYPE_MACRO_HAVE_REAL16_CTYPE(MPI_REAL16, MPIR_REAL16_CTYPE, mpir_typename_real16) \
+    /* MPIR_OP_TYPE_MACRO_HAVE_REAL16_CTYPE(MPI_REAL16, MPIR_REAL16_CTYPE, mpir_typename_real16) */ \
     MPIR_OP_TYPE_MACRO_HAVE_FLOAT16(MPIX_C_FLOAT16, _Float16, mpir_typename_float16)
 
 /* logical group */

--- a/src/mpi/coll/op/opsum.c
+++ b/src/mpi/coll/op/opsum.c
@@ -12,11 +12,14 @@
  */
 #define MPIR_LSUM(a,b) ((a)+(b))
 
+void real16_sum_(void *invec, void *inoutvec, int *Len);
+
 void MPIR_SUM(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
 {
     int i, len = *Len;
 
     switch (*type) {
+/* *INDENT-OFF* */
 #undef MPIR_OP_TYPE_MACRO
 #define MPIR_OP_TYPE_MACRO(mpi_type_, c_type_, type_name_) MPIR_OP_TYPE_REDUCE_CASE(mpi_type_, c_type_, MPIR_LSUM)
             /* no semicolons by necessity */
@@ -49,6 +52,10 @@ void MPIR_SUM(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
 #undef MPIR_OP_TYPE_MACRO
 #undef MPIR_OP_C_COMPLEX_TYPE_MACRO
 #define MPIR_OP_C_COMPLEX_TYPE_MACRO(mpi_type_,c_type_,type_name_) MPIR_OP_TYPE_MACRO(mpi_type_,c_type_,type_name_)
+/* *INDENT-ON* */
+        case MPI_REAL16:
+            real16_sum_(invec, inoutvec, Len);
+            break;
         default:
             MPIR_Assert(0);
             break;
@@ -59,6 +66,7 @@ void MPIR_SUM(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
 int MPIR_SUM_check_dtype(MPI_Datatype type)
 {
     switch (type) {
+/* *INDENT-OFF* */
 #undef MPIR_OP_TYPE_MACRO
 #define MPIR_OP_TYPE_MACRO(mpi_type_, c_type_, type_name_) case (mpi_type_):
             MPIR_OP_TYPE_GROUP(C_INTEGER)
@@ -71,8 +79,10 @@ int MPIR_SUM_check_dtype(MPI_Datatype type)
 
                 MPIR_OP_TYPE_GROUP(COMPLEX)
                 MPIR_OP_TYPE_GROUP(COMPLEX_EXTRA)
+                case (MPI_REAL16):
 #undef MPIR_OP_TYPE_MACRO
                 return MPI_SUCCESS;
+/* *INDENT-ON* */
             /* --BEGIN ERROR HANDLING-- */
         default:
             return MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,


### PR DESCRIPTION
## Pull Request Description
Real*16 in fortran is not the same as long double in C despite having
the same byte-size. To properly handle the reduction, we have to use
fortran to handle the ops.

Ref: issue #4450

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
