### PR TITLE
romio: remove cs_yield outside critical section

### DIFF
--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -1289,7 +1289,9 @@ static int ADIOI_GEN_irc_wait_fn(int count, void **array_of_states,
 
             /* If the progress engine is blocked, we have to yield for another
              * thread to be able to unblock the progress engine. */
-            MPIR_Ext_cs_yield();
+            /* NOTE: we're outside a critical section (safety ensured by standard),
+             * we only need yield in case of user threads */
+            MPL_thread_yield();
         }
     }
 

--- a/src/mpi/romio/adio/common/ad_iwrite_coll.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_coll.c
@@ -1486,7 +1486,9 @@ static int ADIOI_GEN_iwc_wait_fn(int count, void **array_of_states,
 
             /* If the progress engine is blocked, we have to yield for another
              * thread to be able to unblock the progress engine. */
-            MPIR_Ext_cs_yield();
+            /* NOTE: we're outside a critical section (safety ensured by standard),
+             * we only need yield in case of user threads */
+            MPL_thread_yield();
         }
     }
 


### PR DESCRIPTION
## Pull Request Description

The two wait functions are Grequest hooks that are called inside
MPI_Wait, outside ROMIO's critical section. So we shouldn't call
cs_yield. Only a thread_yield in case we are inside a user thread.

NOTE: ROMIO is free to call MPI_Wait inside a ROMIO critical section. If
that happens, we need to make sure to unlock before entering MPI_Wait.

## References

Fixes two tests (that was broken by #4425) that deadlocks due to entering lock twice:

```
summary_junit_xml. - ./io/i_aggregation1 4 | 3 min 0 sec | 3
summary_junit_xml. - ./io/i_hindexed 4 | 3 min 0 sec | 3
```


## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
