### PR TITLE
test/mpi/f08: fix undefined reference bugs

### DIFF
--- a/test/mpi/Makefile_f08.mtest
+++ b/test/mpi/Makefile_f08.mtest
@@ -8,6 +8,7 @@
 AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
 
 LDADD = $(top_builddir)/util/mtest_f08.$(OBJEXT)
+mtest_c_objects = $(top_builddir)/util/mtest.$(OBJEXT) $(top_builddir)/util/mtest_single.$(OBJEXT)
 
 # This is right for many platforms, but not all.  The right fix involves a
 # configure test, but this version is no worse than the simplemake version was.
@@ -15,7 +16,10 @@ AM_FFLAGS = -I.
 
 $(top_builddir)/util/mtest_f08.$(OBJEXT): $(top_srcdir)/util/mtest_f08.f90
 	(cd $(top_builddir)/util && $(MAKE) mtest_f08.$(OBJEXT))
-
+$(top_builddir)/util/mtest.$(OBJEXT): $(top_srcdir)/util/mtest.c
+	(cd $(top_builddir)/util && $(MAKE) mtest.$(OBJEXT))
+$(top_builddir)/util/mtest_single.$(OBJEXT): $(top_srcdir)/util/mtest_single.c
+	(cd $(top_builddir)/util && $(MAKE) mtest_single.$(OBJEXT))
 
 testing:
 	$(top_builddir)/runtests -srcdir=$(srcdir) -tests=testlist \

--- a/test/mpi/Makefile_f77.mtest
+++ b/test/mpi/Makefile_f77.mtest
@@ -18,6 +18,7 @@ AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
 AM_FFLAGS = -I.
 
 LDADD = $(top_builddir)/util/mtest_f77.$(OBJEXT)
+mtest_c_objects = $(top_builddir)/util/mtest.$(OBJEXT) $(top_builddir)/util/mtest_single.$(OBJEXT)
 
 ## FIXME "DEPADD" is a simplemake concept, which we can handle on a per-target
 ## prog_DEPENDENCIES variable, but it would be better to figure out the right
@@ -26,6 +27,10 @@ LDADD = $(top_builddir)/util/mtest_f77.$(OBJEXT)
 
 $(top_builddir)/util/mtest_f77.$(OBJEXT): $(top_srcdir)/util/mtest_f77.f
 	(cd $(top_builddir)/util && $(MAKE) mtest_f77.$(OBJEXT))
+$(top_builddir)/util/mtest.$(OBJEXT): $(top_srcdir)/util/mtest.c
+	(cd $(top_builddir)/util && $(MAKE) mtest.$(OBJEXT))
+$(top_builddir)/util/mtest_single.$(OBJEXT): $(top_srcdir)/util/mtest_single.c
+	(cd $(top_builddir)/util && $(MAKE) mtest_single.$(OBJEXT))
 
 testing:
 	$(top_builddir)/runtests -srcdir=$(srcdir) -tests=testlist \

--- a/test/mpi/Makefile_f90.mtest
+++ b/test/mpi/Makefile_f90.mtest
@@ -8,6 +8,7 @@
 AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
 
 LDADD = $(top_builddir)/util/mtest_f90.$(OBJEXT)
+mtest_c_objects = $(top_builddir)/util/mtest.$(OBJEXT) $(top_builddir)/util/mtest_single.$(OBJEXT)
 
 # This is right for many platforms, but not all.  The right fix involves a
 # configure test, but this version is no worse than the simplemake version was.
@@ -15,7 +16,10 @@ AM_FFLAGS = -I.
 
 $(top_builddir)/util/mtest_f90.$(OBJEXT): $(top_srcdir)/util/mtest_f90.f90
 	(cd $(top_builddir)/util && $(MAKE) mtest_f90.$(OBJEXT))
-
+$(top_builddir)/util/mtest.$(OBJEXT): $(top_srcdir)/util/mtest.c
+	(cd $(top_builddir)/util && $(MAKE) mtest.$(OBJEXT))
+$(top_builddir)/util/mtest_single.$(OBJEXT): $(top_srcdir)/util/mtest_single.c
+	(cd $(top_builddir)/util && $(MAKE) mtest_single.$(OBJEXT))
 
 testing:
 	$(top_builddir)/runtests -srcdir=$(srcdir) -tests=testlist \

--- a/test/mpi/f08/ext/Makefile.am
+++ b/test/mpi/f08/ext/Makefile.am
@@ -17,18 +17,12 @@ c2f2cf90_SOURCES = c2f2cf90.f90 c2f902c.c
 ctypesinf90_SOURCES = ctypesinf90.f90 ctypesfromc.c
 
 # C programs get a different mtest utility object
-c2f90mult_LDADD = $(top_builddir)/util/mtest.o $(top_builddir)/util/mtest_single.o
+c2f90mult_LDADD = $(mtest_c_objects)
 c2f90mult_SOURCES = c2f90mult.c
 
 ## add1size.h will be distributed because it's listed in AC_CONFIG_FILES/AC_OUTPUT
 
 # ensure that dependent tests will be rebuilt when add1size.h is updated
-
-# we don't get this from Makefile_f90.mtest and we don't include Makefile_single.mtest
-$(top_builddir)/util/mtest.o:
-	(cd $(top_builddir)/util && $(MAKE) mtest.o)
-$(top_builddir)/util/mtest_single.o:
-	(cd $(top_builddir)/util && $(MAKE) mtest_single.o)
 
 BUILT_SOURCES = c2f902c.c ctypesfromc.c
 

--- a/test/mpi/f08/ext/Makefile.am
+++ b/test/mpi/f08/ext/Makefile.am
@@ -17,7 +17,7 @@ c2f2cf90_SOURCES = c2f2cf90.f90 c2f902c.c
 ctypesinf90_SOURCES = ctypesinf90.f90 ctypesfromc.c
 
 # C programs get a different mtest utility object
-c2f90mult_LDADD = $(top_builddir)/util/mtest.o
+c2f90mult_LDADD = $(top_builddir)/util/mtest.o $(top_builddir)/util/mtest_single.o
 c2f90mult_SOURCES = c2f90mult.c
 
 ## add1size.h will be distributed because it's listed in AC_CONFIG_FILES/AC_OUTPUT
@@ -27,6 +27,8 @@ c2f90mult_SOURCES = c2f90mult.c
 # we don't get this from Makefile_f90.mtest and we don't include Makefile_single.mtest
 $(top_builddir)/util/mtest.o:
 	(cd $(top_builddir)/util && $(MAKE) mtest.o)
+$(top_builddir)/util/mtest_single.o:
+	(cd $(top_builddir)/util && $(MAKE) mtest_single.o)
 
 BUILT_SOURCES = c2f902c.c ctypesfromc.c
 

--- a/test/mpi/f08/io/Makefile.am
+++ b/test/mpi/f08/io/Makefile.am
@@ -59,7 +59,7 @@ c2f90multio_SOURCES     = c2f90multio.c
 # A) prevent the makefile-wide "LDADD=mtestf90.o" from affecting this program, or
 # B) link with the fortran compiler, otherwise we'll get link failures from
 # compilers with runtime support libs, such as PGI
-c2f90multio_LDADD = $(top_builddir)/util/mtest.o
+c2f90multio_LDADD = $(top_builddir)/util/mtest.o $(top_builddir)/util/mtest_single.o
 
 c2f2ciof90_SOURCES = c2f2ciof90.f90 c2f902cio.c
 

--- a/test/mpi/f08/io/Makefile.am
+++ b/test/mpi/f08/io/Makefile.am
@@ -55,11 +55,8 @@ nodist_writeshf90_SOURCES      = writeshf90.f90
 nodist_iwriteatallf90_SOURCES  = iwriteatallf90.f90
 
 c2f90multio_SOURCES     = c2f90multio.c
-# this is a C only program, so we must either:
-# A) prevent the makefile-wide "LDADD=mtestf90.o" from affecting this program, or
-# B) link with the fortran compiler, otherwise we'll get link failures from
-# compilers with runtime support libs, such as PGI
-c2f90multio_LDADD = $(top_builddir)/util/mtest.o $(top_builddir)/util/mtest_single.o
+# this is a C only program, so we include mtest_c_objects
+c2f90multio_LDADD = $(mtest_c_objects)
 
 c2f2ciof90_SOURCES = c2f2ciof90.f90 c2f902cio.c
 

--- a/test/mpi/f77/ext/Makefile.am
+++ b/test/mpi/f77/ext/Makefile.am
@@ -17,14 +17,10 @@ c2f2cf_SOURCES = c2f2c.c c2f2cf.f
 ctypesinf_SOURCES = ctypesinf.f ctypesfromc.c
 
 # C programs get a different mtest utility object
-c2fmult_LDADD = $(top_builddir)/util/mtest.o $(top_builddir)/util/mtest_single.o
+c2fmult_LDADD = $(mtest_c_objects)
 c2fmult_SOURCES = c2fmult.c
 
 ## add1size.h will be distributed because it's listed in AC_CONFIG_FILES/AC_OUTPUT
 
 # ensure that dependent tests will be rebuilt when add1size.h is updated
 allocmemf.$(OBJEXT): add1size.h
-
-# we don't get this from Makefile_f77.mtest and we don't include Makefile_single.mtest
-$(top_builddir)/util/mtest.o:
-	(cd $(top_builddir)/util && $(MAKE) mtest.o)

--- a/test/mpi/f77/io/Makefile.am
+++ b/test/mpi/f77/io/Makefile.am
@@ -56,11 +56,8 @@ nodist_writeordf_SOURCES     = writeordf.f
 nodist_writeshf_SOURCES      = writeshf.f
 
 c2fmultio_SOURCES     = c2fmultio.c
-# this is a C only program, so we must either:
-# A) prevent the makefile-wide "LDADD=mtestf.o" from affecting this program, or
-# B) link with the fortran compiler, otherwise we'll get link failures from
-# compilers with runtime support libs, such as PGI
-c2fmultio_LDADD = $(top_builddir)/util/mtest.o $(top_builddir)/util/mtest_single.o
+# this is a C only program, so we must include mtest_c_objects
+c2fmultio_LDADD       = $(mtest_c_objects)
 
 c2f2ciof_SOURCES      = c2f2cio.c c2f2ciof.f
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes c tests in `test/mpi/f08` that use the MTest framework.
https://jenkins-pmrs.cels.anl.gov/job/mpich-master-ch4-ucx/compiler=intel,jenkins_configure=default,label=centos64/lastCompletedBuild/testReport/
This bug was introduced by #4429.

This patch does the same thing as the following commit; add `mtest_single.o` to LDADD fe5ad9cce42e753a2114360bf595062f660a1f08

This bug was reported by @hzhou. Thanks!
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
