### PR TITLE
test: add MPI_Barrier to pingping test

### DIFF
--- a/test/mpi/maint/dtp-test-config.txt
+++ b/test/mpi/maint/dtp-test-config.txt
@@ -24,6 +24,7 @@ coll/bcast_comm_world_only::262144:timeLimit=360 mem=1.9:10:16:
 cxx/attr/fkeyvaltypex::1::1:1024:
 cxx/datatype/packsizex::1::1:1024:
 pt2pt/pingping::1 512 262144 17 1018 65530::2:8:32
+pt2pt/pingping_barrier::1::2:8:32
 pt2pt/sendrecv1::1 512 262144 17 1018 65530::2:32:1024
 pt2pt/sendself::1 512 262144 17 1018 65530::1:32:1024
 rma/accfence1::1 512 17 1018::4:16:1024

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -183,6 +183,8 @@ valgrind * * * * sed -i "s+\(^accfence1 .*\)+\1 xfail=ticket0+g" test/mpi/rma/te
 * * * * * sed -i "s+\(^alltoallw1.* env=MPIR_CVAR_IALLTOALLW_INTRA_ALGORITHM=gentran_inplace.*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist.cvar
 * * * * * sed -i "s+\(^alltoallw2.* env=MPIR_CVAR_IALLTOALLW_INTRA_ALGORITHM=gentran_inplace.*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist.cvar
 * * * * * sed -i "s+\(^alltoallw_zeros.* env=MPIR_CVAR_IALLTOALLW_INTRA_ALGORITHM=gentran_inplace.*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist.cvar
+# pingping tests with large testsize currently fails async tests due to netmod handling of large message queue
+* * async * * sed -i "s+\(^pingping .*testsize=32.*\)+\1 xfail=issue4474+g" test/mpi/pt2pt/testlist.dtp
 # release-gather algorithm won't work with multithread
 * * async * * sed -i "s+\(^.*_ALGORITHM=release_gather.*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist.cvar
 # freebsd failures

--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -61,6 +61,7 @@ noinst_PROGRAMS =  \
     irecv_any   \
     large_tag \
     pingping  \
+    pingping_barrier  \
     sendrecv1 \
     sendself
 
@@ -69,6 +70,9 @@ irecv_any_SOURCES  = recv_any.c
 
 pingping_CPPFLAGS = $(AM_CPPFLAGS)
 pingping_SOURCES = pingping.c
+
+pingping_barrier_CPPFLAGS = $(AM_CPPFLAGS) -DUSE_BARRIER
+pingping_barrier_SOURCES = pingping.c
 
 sendrecv1_CPPFLAGS = $(AM_CPPFLAGS)
 sendrecv1_SOURCES = sendrecv1.c

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -178,6 +178,15 @@ int main(int argc, char *argv[])
             }
             DTP_obj_free(recv_obj);
             DTP_obj_free(send_obj);
+#ifdef USE_BARRIER
+            /* NOTE: Without MPI_Barrier, recv side can easily accumulate large unexpected queue
+             * across multiple batches, especially in an async test. Currently, both libfabric and ucx
+             * netmod does not handle large message queue well, resulting in exponential slow-downs.
+             * Adding barrier let the current tests pass.
+             */
+            /* FIXME: fix netmod issues then remove the barrier (and corresponding tests). */
+            MPI_Barrier(comm);
+#endif
         }
         MTestFreeComm(&comm);
     }


### PR DESCRIPTION
## Pull Request Description
In pingping test, one process blindly sends and the other process recvs.
For some (common) providers, the send is very fast locally complete
operation, resulting large amount of messages accumulates at the recv
end as unexpected messages. Without explicit barrier between batches,
the larger testsize gets (more batches), the longer unexpected queue
result at the recv end. Why handling unexpected queue can/should be
optimized, many providers currently handle it very badly, result in very
bad performance.

Since the purpose of pingping test is to test mpich's datatype handling
and detecting thread issues, having large unexpected queue skews the
test result. Therefore, we add a barrier between batches to limit amount
of unexpected messages.


## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
