### PR TITLE
libfabric: patch sockets provider for shallow progress

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1032,6 +1032,11 @@ AC_SUBST([mpllib])
 if test "$with_mpl_prefix" = "embedded" ; then
     # no need for libtool versioning when embedding MPL
     mpl_subdir_args="--disable-versioning --enable-embedded"
+    case $with_device in
+      ch4*)
+        mpl_subdir_args="$mpl_subdir_args --enable-ticketlock"
+        ;;
+    esac
     PAC_CONFIG_SUBDIR_ARGS([src/mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
     PAC_APPEND_FLAG([-I${master_top_builddir}/src/mpl/include], [CPPFLAGS])
     PAC_APPEND_FLAG([-I${use_top_srcdir}/src/mpl/include], [CPPFLAGS])

--- a/src/mpi/pt2pt/recv.c
+++ b/src/mpi/pt2pt/recv.c
@@ -70,6 +70,7 @@ int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag,
     MPIR_ERRTEST_INITIALIZED_ORDIE();
 
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_GLOBAL_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER_BACK(MPID_STATE_MPI_RECV);
 
     /* Validate handle parameters needing to be converted */
@@ -161,6 +162,7 @@ int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag,
   fn_exit:
     MPIR_FUNC_TERSE_PT2PT_EXIT_BACK(MPID_STATE_MPI_RECV);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_GLOBAL_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/pt2pt/send.c
+++ b/src/mpi/pt2pt/send.c
@@ -65,6 +65,7 @@ int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int ta
     MPIR_ERRTEST_INITIALIZED_ORDIE();
 
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_GLOBAL_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER_FRONT(MPID_STATE_MPI_SEND);
 
     /* Validate handle parameters needing to be converted */
@@ -147,6 +148,7 @@ int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int ta
   fn_exit:
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_SEND);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_GLOBAL_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/pt2pt/sendrecv.c
+++ b/src/mpi/pt2pt/sendrecv.c
@@ -76,6 +76,7 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     MPIR_ERRTEST_INITIALIZED_ORDIE();
 
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_GLOBAL_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER_BOTH(MPID_STATE_MPI_SENDRECV);
 
     /* Validate handle parameters needing to be converted */
@@ -233,6 +234,7 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
   fn_exit:
     MPIR_FUNC_TERSE_PT2PT_EXIT_BOTH(MPID_STATE_MPI_SENDRECV);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_GLOBAL_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/pt2pt/ssend.c
+++ b/src/mpi/pt2pt/ssend.c
@@ -59,6 +59,7 @@ int MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
     MPIR_ERRTEST_INITIALIZED_ORDIE();
 
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_GLOBAL_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER_FRONT(MPID_STATE_MPI_SSEND);
 
     /* Validate handle parameters needing to be converted */
@@ -143,6 +144,7 @@ int MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
   fn_exit:
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_SSEND);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_GLOBAL_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpl/Makefile.am
+++ b/src/mpl/Makefile.am
@@ -21,6 +21,7 @@ strsep_LDADD = lib@MPLLIBNAME@.la
 mpl_headers =               \
     include/mpl.h           \
     include/mpl_atomic.h    \
+    include/mpl_ticket_lock.h \
     include/mpl_base.h      \
     include/mpl_math.h      \
     include/mplconfig.h     \

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -679,6 +679,13 @@ AC_DEFINE_UNQUOTED([THREAD_PACKAGE_NAME],[$THREAD_PACKAGE_NAME],[set to the name
 # check for compiler-support for thread-local storage (MPL_TLS)
 PAC_CC_CHECK_TLS
 
+AC_ARG_ENABLE([ticketlock],
+    [AS_HELP_STRING([--enable-ticketlock], [use ticket lock in stead of pthread_mutex_t])],
+    [if test $enableval = 'yes' ; then 
+        AC_DEFINE([USE_TICKET_LOCK], [1], [Define if ticket_lock will be used])
+     fi
+    ])
+
 #######################################################################
 ## END OF THREADS CODE
 #######################################################################

--- a/src/mpl/include/mpl.h
+++ b/src/mpl/include/mpl.h
@@ -13,6 +13,7 @@
 #include "mpl_argstr.h"
 #include "mpl_arg_serial.h"
 #include "mpl_atomic.h"
+#include "mpl_ticket_lock.h"
 #include "mpl_str.h"
 #include "mpl_trmem.h"
 #include "mpl_env.h"

--- a/src/mpl/include/mpl_ticket_lock.h
+++ b/src/mpl/include/mpl_ticket_lock.h
@@ -28,7 +28,7 @@ typedef struct {
     do { \
         int ticket = MPL_atomic_fetch_add_int(&(lock_)->num, 1); \
         while (MPL_atomic_load_int(&(lock_)->next) != ticket) { \
-            MPL_sched_yield(); \
+            sched_yield(); \
         } \
     } while (0)
 

--- a/src/mpl/include/mpl_ticket_lock.h
+++ b/src/mpl/include/mpl_ticket_lock.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+/*
+ * Ticket lock based on MPL atomics
+ */
+
+#ifndef MPL_TICKET_LOCK_H_INCLUDED
+#define MPL_TICKET_LOCK_H_INCLUDED
+
+#include "mpl_atomic.h"
+#include "mpl_yield.h"
+
+typedef struct {
+    MPL_atomic_int_t num;
+    MPL_atomic_int_t next;
+} MPL_ticket_lock;
+
+#define MPL_ticket_lock_init(lock_) \
+    do { \
+        MPL_atomic_store_int(&(lock_)->num, 0); \
+        MPL_atomic_store_int(&(lock_)->next, 0); \
+    } while (0)
+
+#define MPL_ticket_lock_lock(lock_) \
+    do { \
+        int ticket = MPL_atomic_fetch_add_int(&(lock_)->num, 1); \
+        while (MPL_atomic_load_int(&(lock_)->next) != ticket) { \
+            MPL_sched_yield(); \
+        } \
+    } while (0)
+
+#define MPL_ticket_lock_unlock(lock_) \
+    do { \
+        MPL_atomic_fetch_add_int(&(lock_)->next, 1); \
+    } while (0)
+
+#endif /* MPL_TICKET_LOCK_H_INCLUDED */

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -178,7 +178,6 @@ int main(int argc, char *argv[])
             }
             DTP_obj_free(recv_obj);
             DTP_obj_free(send_obj);
-            MPI_Barrier(comm);
         }
         MTestFreeComm(&comm);
     }

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -178,6 +178,7 @@ int main(int argc, char *argv[])
             }
             DTP_obj_free(recv_obj);
             DTP_obj_free(send_obj);
+            MPI_Barrier(comm);
         }
         MTestFreeComm(&comm);
     }


### PR DESCRIPTION
## Pull Request Description

When libfabric accumulates unexpected messages to significant size, each progress test takes longer and longer going through all the entries. The slow progress test takes up critical section longer, blocks posting mpi operations (such as `MPI_Recv`), exacerbates the unexpected message queue problem.

This PR adds a patch to libfabric forcing a shallow approach. Each progress test will only go through 10 entries (configurable) and each time pick up where last time left off. This ensures snappy progress test and avoids needless spin on thousands of entries that can't progress anyway (due to corresponding operation slow to post).

## Note

Ignore the first 8 or so commits.
The PR is based on #4456 relying on a fix of fire mutex to clear the async tests. This PR addresses the netmod issues once the fair mutex is achieved.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
