### PR TITLE
datatype: remove MPI_2COMPLEX and MPI_2DOUBLE_COMPLEX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3889,10 +3889,12 @@ dnl     len_doublecplx=$hexlen
 
     MPI_DOUBLE_COMPLEX=0x4c00${len_doublecplx}22
     MPI_2DOUBLE_PRECISION=0x4c00${len_doublecplx}23
-    MPI_2COMPLEX=0x4c00${len_doublecplx}24
     AC_SUBST(MPI_DOUBLE_COMPLEX)
     AC_SUBST(MPI_2DOUBLE_PRECISION)
-    AC_SUBST(MPI_2COMPLEX)
+
+dnl Removed MPI_2COMPLEX and MPI_2DOUBLE_COMPLEX, leaving comments to explain the gap in seq id
+    # MPI_2COMPLEX=0x4c00${len_doublecplx}24
+    # MPI_2DOUBLE_COMPLEX=0x4c00${len_2dc}25
 
     #
     # Temporary for the vast majority of systems that use 4 byte reals and
@@ -3910,26 +3912,6 @@ dnl     len_doublecplx=$hexlen
         F77_COMPLEX32="MPI_DATATYPE_NULL"
     fi
 
-    len_2dc=`expr $pac_cv_f77_sizeof_double_precision \* 4`
-    firstdigit=0
-    seconddigit=0
-    while test $len_2dc -ge 16 ; do
-        firstdigit=`expr $firstdigit + 1`
-        len_2dc=`expr $len_2dc - 16`
-    done
-    case $len_2dc in
-        10) seconddigit=a ;;
-        11) seconddigit=b ;;
-        12) seconddigit=c ;;
-        13) seconddigit=d ;;
-        14) seconddigit=e ;;
-        15) seconddigit=f ;;
-         *) seconddigit=$len_2dc ;;
-    esac
-    len_2dc="$firstdigit$seconddigit"
-    #echo "2double complex = $len_2dc"
-    MPI_2DOUBLE_COMPLEX=0x4c00${len_2dc}25
-    AC_SUBST(MPI_2DOUBLE_COMPLEX)
     MPI_F77_PACKED=$MPI_PACKED
     MPI_F77_UB=$MPI_UB
     MPI_F77_LB=$MPI_LB
@@ -3945,8 +3927,8 @@ dnl     len_doublecplx=$hexlen
     # even when used only with the match (:) command.  Rather than have
     # configure figure out if expr works, we just use sed.  Sigh.
     for var in CHARACTER INTEGER REAL LOGICAL DOUBLE_PRECISION COMPLEX \
-        DOUBLE_COMPLEX 2INTEGER 2REAL 2COMPLEX 2DOUBLE_PRECISION \
-        2DOUBLE_COMPLEX F77_PACKED F77_UB F77_LB F77_BYTE; do
+        DOUBLE_COMPLEX 2INTEGER 2REAL 2DOUBLE_PRECISION \
+        F77_PACKED F77_UB F77_LB F77_BYTE; do
         fullvar="MPI_$var"
         eval fullvarvalue=\$$fullvar
         #echo "$fullvar = $fullvarvalue"
@@ -5067,7 +5049,6 @@ pthread_mutex_t *MPL_atomic_emulation_lock;
 
 if test "$enable_f77" != "yes" ; then
     # These are Fortran datatypes ONLY.  Set to null if no Fortran compiler.
-    # Removed the invalid 2COMPLEX and 2DOUBLE_COMPLEX
     for name in CHARACTER INTEGER REAL LOGICAL COMPLEX DOUBLE_PRECISION \
 	2INTEGER 2REAL DOUBLE_COMPLEX 2DOUBLE_PRECISION ; do
 	fullname="MPI_$name"
@@ -5088,8 +5069,6 @@ AC_SUBST(MPI_2INTEGER)
 AC_SUBST(MPI_2REAL)
 AC_SUBST(MPI_DOUBLE_COMPLEX)
 AC_SUBST(MPI_2DOUBLE_PRECISION)
-dnl AC_SUBST(MPI_2COMPLEX)
-dnl AC_SUBST(MPI_2DOUBLE_COMPLEX)
 AC_SUBST(MPI_FINT)
 
 # If ROMIO was successfully configured, then ROMIO will have exported the

--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -3855,10 +3855,6 @@ if ($write_mpif) {
 	print MPIFFD "       INTEGER MPI_$key\n";
 	print MPIFFD "       PARAMETER (MPI_$key=\@MPI_$key\@)\n";
     }
-    # 2COMPLEX and 2DOUBLE_COMPLEX were defined in MPI 1 and removed in 
-    # MPI 1.1.  Don't define them for the Fortran interface.
-    #foreach $key ('2COMPLEX', '2DOUBLE_COMPLEX') {
-    #}
     # Value of MPI_BYTE from top level configure!
     $mpidef{"MPI_BYTE"} = hex "0x4c00010d";
     foreach $key (BYTE, UB, LB, PACKED) {

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -202,17 +202,6 @@ static const MPI_Datatype mpich_mpi_long_double_int MPICH_ATTR_TYPE_TAG_LAYOUT_C
 #define MPI_DOUBLE_PRECISION  ((MPI_Datatype)@MPI_DOUBLE_PRECISION@)
 #define MPI_INTEGER           ((MPI_Datatype)@MPI_INTEGER@)
 #define MPI_2INTEGER          ((MPI_Datatype)@MPI_2INTEGER@)
-/* 
- * MPI_2COMPLEX and MPI_2DOUBLE_COMPLEX were defined by accident in 
- * MPI 1.0 and removed in MPI 1.1.  
- *
- * This definition provides backward compatibility.  These definitions
- * will be removed in a subsequent MPICH release
- */
-#ifdef MPICH_DEFINE_2COMPLEX
-#define MPI_2COMPLEX          ((MPI_Datatype)@MPI_2COMPLEX@)
-#define MPI_2DOUBLE_COMPLEX   ((MPI_Datatype)@MPI_2DOUBLE_COMPLEX@)
-#endif 
 #define MPI_2REAL             ((MPI_Datatype)@MPI_2REAL@)
 #define MPI_2DOUBLE_PRECISION ((MPI_Datatype)@MPI_2DOUBLE_PRECISION@)
 #define MPI_CHARACTER         ((MPI_Datatype)@MPI_CHARACTER@)

--- a/src/mpi/datatype/type_debug.c
+++ b/src/mpi/datatype/type_debug.c
@@ -129,10 +129,6 @@ char *MPIR_Datatype_builtin_to_string(MPI_Datatype type)
     static char t_doubleprecision[] = "MPI_DOUBLE_PRECISION";
     static char t_integer[] = "MPI_INTEGER";
     static char t_2integer[] = "MPI_2INTEGER";
-#ifdef MPICH_DEFINE_2COMPLEX
-    static char t_2complex[] = "MPI_2COMPLEX";
-    static char t_2doublecomplex[] = "MPI_2DOUBLE_COMPLEX";
-#endif
     static char t_2real[] = "MPI_2REAL";
     static char t_2doubleprecision[] = "MPI_2DOUBLE_PRECISION";
     static char t_character[] = "MPI_CHARACTER";
@@ -206,12 +202,6 @@ char *MPIR_Datatype_builtin_to_string(MPI_Datatype type)
         return t_integer;
     if (type == MPI_2INTEGER)
         return t_2integer;
-#ifdef MPICH_DEFINE_2COMPLEX
-    if (type == MPI_2COMPLEX)
-        return t_2complex;
-    if (type == MPI_2DOUBLE_COMPLEX)
-        return t_2doublecomplex;
-#endif
     if (type == MPI_2REAL)
         return t_2real;
     if (type == MPI_2DOUBLE_PRECISION)

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -77,10 +77,6 @@ static mpi_names_t mpi_dtypes[] = {
     type_name_entry(MPI_DOUBLE_PRECISION),
     type_name_entry(MPI_INTEGER),
     type_name_entry(MPI_2INTEGER),
-#ifdef MPICH_DEFINE_2COMPLEX
-    type_name_entry(MPI_2COMPLEX),
-    type_name_entry(MPI_2DOUBLE_COMPLEX),
-#endif
     type_name_entry(MPI_2REAL),
     type_name_entry(MPI_2DOUBLE_PRECISION),
     type_name_entry(MPI_CHARACTER),

--- a/src/mpid/ch3/include/mpid_rma_shm.h
+++ b/src/mpid/ch3/include/mpid_rma_shm.h
@@ -223,11 +223,6 @@ static inline int shm_copy(const void *src, int scount, MPI_Datatype stype,
         case MPI_2INTEGER:
 #endif
 
-#if 0   /* Random types not present in the standard */
-        case MPI_2COMPLEX:
-        case MPI_2DOUBLE_COMPLEX:
-#endif
-
         default:
             /* Just to make sure the switch statement is not empty */
             ;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -105,11 +105,9 @@ static inline int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 
 
 #ifdef HAVE_FORTRAN_BINDING
-#ifdef MPICH_DEFINE_2COMPLEX
-#define MPIDI_OFI_DT_SIZES 63
-#else
+/* number of basic types defined in mpi.h */
+/* FIXME: should be defined in mpi.h or mpir_datatype.h and avoid magic number here */
 #define MPIDI_OFI_DT_SIZES 61
-#endif
 #else
 #define MPIDI_OFI_DT_SIZES 40
 #endif

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -416,10 +416,6 @@ static MPI_Datatype mpi_dtypes[] = {
 #ifdef HAVE_FORTRAN_BINDING
     MPI_COMPLEX, MPI_DOUBLE_COMPLEX, MPI_LOGICAL, MPI_REAL,
     MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_2INTEGER,
-
-#ifdef MPICH_DEFINE_2COMPLEX
-    MPI_2COMPLEX, MPI_2DOUBLE_COMPLEX,
-#endif
     MPI_2REAL, MPI_2DOUBLE_PRECISION, MPI_CHARACTER,
     MPI_REAL4, MPI_REAL8, MPI_REAL16, MPI_COMPLEX8, MPI_COMPLEX16,
     MPI_COMPLEX32, MPI_INTEGER1, MPI_INTEGER2, MPI_INTEGER4, MPI_INTEGER8,
@@ -566,10 +562,6 @@ void MPIDI_OFI_index_datatypes()
     add_index(MPI_DOUBLE_PRECISION, &idx);      /* count=40 */
     add_index(MPI_INTEGER, &idx);
     add_index(MPI_2INTEGER, &idx);
-#ifdef MPICH_DEFINE_2COMPLEX
-    add_index(MPI_2COMPLEX, &idx);
-    add_index(MPI_2DOUBLE_COMPLEX, &idx);
-#endif
     add_index(MPI_2REAL, &idx);
     add_index(MPI_2DOUBLE_PRECISION, &idx);
     add_index(MPI_CHARACTER, &idx);

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1473,38 +1473,6 @@ fi
 if test "$pac_cv_have_mpi_integer16" = yes ; then 
     AC_DEFINE(HAVE_MPI_INTEGER16,1,[Define if MPI_INTEGER16 is available])
 fi
-AC_CACHE_CHECK([whether MPI_2DOUBLE_COMPLEX is available],
-pac_cv_have_mpi_2double_complex,[
-    AC_COMPILE_IFELSE([
-        AC_LANG_PROGRAM([#include "mpi.h"],[
-            MPI_Datatype t = MPI_2DOUBLE_COMPLEX;
-        ])
-    ],[
-        pac_cv_have_mpi_2double_complex=yes
-    ],[
-        pac_cv_have_mpi_2double_complex=no
-    ])
-])
-if test "$pac_cv_have_mpi_2double_complex" = yes ; then 
-    AC_DEFINE(HAVE_MPI_2DOUBLE_COMPLEX,1,[Define if MPI_2DOUBLE_COMPLEX is available])
-fi
-# 2COMPLEX was in MPI 1.0 and removed after that.  This allows us to 
-# test 2COMPLEX if it is present
-AC_CACHE_CHECK([whether MPI_2COMPLEX is available],
-pac_cv_have_mpi_2complex,[
-    AC_COMPILE_IFELSE([
-        AC_LANG_PROGRAM([#include "mpi.h"],[
-            MPI_Datatype t = MPI_2COMPLEX;
-        ])
-    ],[
-        pac_cv_have_mpi_2complex=yes
-    ],[
-        pac_cv_have_mpi_2complex=no
-    ])
-])
-if test "$pac_cv_have_mpi_2complex" = yes ; then 
-    AC_DEFINE(HAVE_MPI_2COMPLEX,1,[Define if MPI_2COMPLEX is available])
-fi
 
 # MPI_Aint was intended as an address-sized int.  However, MPI didn't 
 # specify this - MPI_Aint must be large enough to hold an address-sized

--- a/test/mpi/datatype/typename.c
+++ b/test/mpi/datatype/typename.c
@@ -55,14 +55,6 @@ static mpi_names_t mpi_names[] = {
     {MPI_DOUBLE_PRECISION, "MPI_DOUBLE_PRECISION"},
     {MPI_INTEGER, "MPI_INTEGER"},
     {MPI_2INTEGER, "MPI_2INTEGER"},
-    /* 2COMPLEX (and the 2DOUBLE_COMPLEX) were in MPI 1.0 but not later */
-#ifdef HAVE_MPI_2COMPLEX
-    {MPI_2COMPLEX, "MPI_2COMPLEX"},
-#endif
-#ifdef HAVE_MPI_2DOUBLE_COMPLEX
-    /* MPI_2DOUBLE_COMPLEX is an extension - it is not part of MPI 2.1 */
-    {MPI_2DOUBLE_COMPLEX, "MPI_2DOUBLE_COMPLEX"},
-#endif
     {MPI_2REAL, "MPI_2REAL"},
     {MPI_2DOUBLE_PRECISION, "MPI_2DOUBLE_PRECISION"},
     {MPI_CHARACTER, "MPI_CHARACTER"},

--- a/test/mpi/f08/datatype/typenamef08.f90
+++ b/test/mpi/f08/datatype/typenamef08.f90
@@ -62,13 +62,6 @@
            print *, "Expected MPI_2INTEGER but got "//name(1:namelen)
       endif
 
-! 2COMPLEX was present only in MPI 1.0
-!      call MPI_Type_get_name( MPI_2COMPLEX, name, namelen, ierr )
-!      if (name(1:namelen) .ne. "MPI_2COMPLEX") then
-!           errs = errs + 1
-!           print *, "Expected MPI_2COMPLEX but got "//name(1:namelen)
-!      endif
-!
       call MPI_Type_get_name(MPI_2DOUBLE_PRECISION, name, namelen, ierr)
       if (name(1:namelen) .ne. "MPI_2DOUBLE_PRECISION") then
            errs = errs + 1
@@ -81,14 +74,6 @@
            errs = errs + 1
            print *, "Expected MPI_2REAL but got "//name(1:namelen)
       endif
-
-! 2DOUBLE_COMPLEX isn't in MPI 2.1
-!      call MPI_Type_get_name( MPI_2DOUBLE_COMPLEX, name, namelen, ierr )
-!      if (name(1:namelen) .ne. "MPI_2DOUBLE_COMPLEX") then
-!           errs = errs + 1
-!           print *, "Expected MPI_2DOUBLE_COMPLEX but got "//
-!     &          name(1:namelen)
-!      endif
 
       call MPI_Type_get_name( MPI_CHARACTER, name, namelen, ierr )
       if (name(1:namelen) .ne. "MPI_CHARACTER") then

--- a/test/mpi/f77/datatype/typenamef.f
+++ b/test/mpi/f77/datatype/typenamef.f
@@ -61,13 +61,6 @@ C See the C version (typename.c) for the relevant MPI sections
            print *, "Expected MPI_2INTEGER but got "//name(1:namelen)
       endif
 
-C 2COMPLEX was present only in MPI 1.0
-C      call MPI_Type_get_name( MPI_2COMPLEX, name, namelen, ierr )
-C      if (name(1:namelen) .ne. "MPI_2COMPLEX") then
-C           errs = errs + 1
-C           print *, "Expected MPI_2COMPLEX but got "//name(1:namelen)
-C      endif
-C
       call MPI_Type_get_name(MPI_2DOUBLE_PRECISION, name, namelen, ierr)
       if (name(1:namelen) .ne. "MPI_2DOUBLE_PRECISION") then
            errs = errs + 1
@@ -80,14 +73,6 @@ C
            errs = errs + 1
            print *, "Expected MPI_2REAL but got "//name(1:namelen)
       endif
-
-C 2DOUBLE_COMPLEX isn't in MPI 2.1
-C      call MPI_Type_get_name( MPI_2DOUBLE_COMPLEX, name, namelen, ierr )
-C      if (name(1:namelen) .ne. "MPI_2DOUBLE_COMPLEX") then
-C           errs = errs + 1
-C           print *, "Expected MPI_2DOUBLE_COMPLEX but got "//
-C     &          name(1:namelen)
-C      endif
 
       call MPI_Type_get_name( MPI_CHARACTER, name, namelen, ierr )
       if (name(1:namelen) .ne. "MPI_CHARACTER") then


### PR DESCRIPTION
## Pull Request Description

These two datatypes were accidentally defined in MPI 1.0 and meant to be removed. We have disabled them for quite a while. This PR completely removed them. 
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
