### PR TITLE
mpl: defined empty MPL_thread_yield in MPL_THREAD_PACKAGE_NONE

### DIFF
--- a/src/mpl/include/mpl_thread.h
+++ b/src/mpl/include/mpl_thread.h
@@ -40,6 +40,7 @@ typedef void (*MPL_thread_func_t) (void *data);
 #define MPL_thread_mutex_destroy(mutex_ptr_, err_ptr_) { *((int*)err_ptr_) = 0;}
 #define MPL_thread_init(err_ptr_)      do { } while (0)
 #define MPL_thread_finalize(err_ptr_)  do { } while (0)
+#define MPL_thread_yield()             do { } while (0)
 #else
 #error "thread package (MPL_THREAD_PACKAGE_NAME) not defined or unknown"
 #endif


### PR DESCRIPTION
## Pull Request Description

The current jenkins tests for single threaded is broken due to missing `MPL_thread_yield` definition.

Romio uses MPL_thread_yield directly which is not defined when
configured with --with-thread-package=none. This patch provides a noop
definition in that case.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
