### PR TITLE
Yaksa integration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1252,6 +1252,28 @@ else
     yaksalibdir="-L${with_yaksa_prefix}/lib"
 fi
 
+
+##### allow selection of datatype engine
+AC_ARG_WITH([datatype-engine],
+            [AS_HELP_STRING([--with-datatype-engine={yaksa|dataloop|auto}],[controls datatype engine to use])],
+            [],[with_datatype_engine=dataloop])
+if test "${with_datatype_engine}" = "yaksa" ; then
+    AC_DEFINE_UNQUOTED(MPICH_DATATYPE_ENGINE,MPICH_DATATYPE_ENGINE_YAKSA,[Datatype engine])
+elif test "${with_datatype_engine}" = "dataloop" ; then
+    AC_DEFINE_UNQUOTED(MPICH_DATATYPE_ENGINE,MPICH_DATATYPE_ENGINE_DATALOOP,[Datatype engine])
+else
+    if test "$device_name" = "ch4" ; then
+        AC_DEFINE_UNQUOTED(MPICH_DATATYPE_ENGINE,MPICH_DATATYPE_ENGINE_YAKSA,[Datatype engine])
+        with_datatype_engine=yaksa
+    else
+        AC_DEFINE_UNQUOTED(MPICH_DATATYPE_ENGINE,MPICH_DATATYPE_ENGINE_DATALOOP,[Datatype engine])
+        with_datatype_engine=dataloop
+    fi
+fi
+AM_CONDITIONAL([BUILD_YAKSA_ENGINE], [test "${with_datatype_engine}" = "yaksa"])
+AM_CONDITIONAL([BUILD_DATALOOP_ENGINE], [test "${with_datatype_engine}" = "dataloop"])
+
+
 # Set NEEDSPLIB to yes if link commands need both -l$MPILIBNAME
 # and -lp$MPILIBNAME.
 NEEDSPLIB=yes

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -140,7 +140,6 @@ int vsnprintf(char *str, size_t size, const char *format, va_list ap);
 #define MPL_VG_ENABLED 1
 #endif
 
-#include "yaksa.h"
 #include "mpl.h"
 #include "opa_primitives.h"
 #include "mpi.h"

--- a/src/mpi/datatype/typerep/src/Makefile.mk
+++ b/src/mpi/datatype/typerep/src/Makefile.mk
@@ -4,9 +4,21 @@
 ##
 
 mpi_core_sources += \
+   src/mpi/datatype/typerep/src/typerep_flatten.c
+
+if BUILD_YAKSA_ENGINE
+mpi_core_sources += \
+    src/mpi/datatype/typerep/src/typerep_yaksa_create.c \
+    src/mpi/datatype/typerep/src/typerep_yaksa_init.c \
+    src/mpi/datatype/typerep/src/typerep_yaksa_pack.c \
+    src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c \
+    src/mpi/datatype/typerep/src/typerep_yaksa_iov.c \
+    src/mpi/datatype/typerep/src/typerep_yaksa_commit.c \
+    src/mpi/datatype/typerep/src/typerep_yaksa_debug.c
+else
+mpi_core_sources += \
     src/mpi/datatype/typerep/src/typerep_dataloop_create.c \
     src/mpi/datatype/typerep/src/typerep_dataloop_init.c \
-    src/mpi/datatype/typerep/src/typerep_dataloop_flatten.c \
     src/mpi/datatype/typerep/src/typerep_dataloop_pack.c \
     src/mpi/datatype/typerep/src/typerep_dataloop_pack_external.c \
     src/mpi/datatype/typerep/src/typerep_dataloop_iov.c \
@@ -15,6 +27,7 @@ mpi_core_sources += \
     src/mpi/datatype/typerep/src/typerep_dataloop_subarray.c \
     src/mpi/datatype/typerep/src/typerep_dataloop_darray.c \
     src/mpi/datatype/typerep/src/typerep_dataloop_size_external.c
+endif !BUILD_YAKSA_ENGINE
 
 noinst_HEADERS += \
     src/mpi/datatype/typerep/src/typerep_internal.h

--- a/src/mpi/datatype/typerep/src/errnames.txt
+++ b/src/mpi/datatype/typerep/src/errnames.txt
@@ -1,0 +1,1 @@
+**yaksa:Yaksa library returned an error

--- a/src/mpi/datatype/typerep/src/typerep_flatten.c
+++ b/src/mpi/datatype/typerep/src/typerep_flatten.c
@@ -4,8 +4,14 @@
  */
 
 #include <mpiimpl.h>
-#include <dataloop.h>
 #include <stdlib.h>
+#include "typerep_internal.h"
+
+#if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
+#include "yaksa.h"
+#else
+#include <dataloop.h>
+#endif
 
 struct flatten_hdr {
     MPI_Aint size;
@@ -28,11 +34,22 @@ int MPIR_Typerep_flatten_size(MPIR_Datatype * datatype_ptr, int *flattened_type_
     int flattened_loop_size;
     int mpi_errno = MPI_SUCCESS;
 
+#if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
+    uintptr_t size;
+    int rc = yaksa_flatten_size((yaksa_type_t) datatype_ptr->typerep, &size);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    assert(size <= INT_MAX);
+    flattened_loop_size = (int) size;
+#else
     MPIR_Dataloop_flatten_size(datatype_ptr, &flattened_loop_size);
+#endif
 
     *flattened_type_size = flattened_loop_size + sizeof(struct flatten_hdr);
 
+  fn_exit:
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 /*
@@ -45,7 +62,7 @@ int MPIR_Typerep_flatten_size(MPIR_Datatype * datatype_ptr, int *flattened_type_
 int MPIR_Typerep_flatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
 {
     struct flatten_hdr *flatten_hdr = (struct flatten_hdr *) flattened_type;
-    void *flattened_dataloop = (void *) ((char *) flattened_type + sizeof(struct flatten_hdr));
+    void *flattened_typerep = (void *) ((char *) flattened_type + sizeof(struct flatten_hdr));
     int mpi_errno = MPI_SUCCESS;
 
     flatten_hdr->size = datatype_ptr->size;
@@ -60,8 +77,13 @@ int MPIR_Typerep_flatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     flatten_hdr->basic_type = datatype_ptr->basic_type;
     flatten_hdr->max_contig_blocks = datatype_ptr->max_contig_blocks;
 
-    mpi_errno = MPIR_Dataloop_flatten(datatype_ptr, flattened_dataloop);
+#if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
+    int rc = yaksa_flatten((yaksa_type_t) datatype_ptr->typerep, flattened_typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+#else
+    mpi_errno = MPIR_Dataloop_flatten(datatype_ptr, flattened_typerep);
     MPIR_ERR_CHECK(mpi_errno);
+#endif
 
   fn_exit:
     return mpi_errno;
@@ -80,7 +102,7 @@ int MPIR_Typerep_flatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
 int MPIR_Typerep_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
 {
     struct flatten_hdr *flatten_hdr = (struct flatten_hdr *) flattened_type;
-    void *flattened_dataloop = (void *) ((char *) flattened_type + sizeof(struct flatten_hdr));
+    void *flattened_typerep = (void *) ((char *) flattened_type + sizeof(struct flatten_hdr));
     int mpi_errno = MPI_SUCCESS;
 
     datatype_ptr->is_committed = 1;
@@ -100,8 +122,13 @@ int MPIR_Typerep_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     datatype_ptr->contents = NULL;
     datatype_ptr->flattened = NULL;
 
-    mpi_errno = MPIR_Dataloop_unflatten(datatype_ptr, flattened_dataloop);
+#if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
+    int rc = yaksa_unflatten((yaksa_type_t *) & datatype_ptr->typerep, flattened_typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+#else
+    mpi_errno = MPIR_Dataloop_unflatten(datatype_ptr, flattened_typerep);
     MPIR_ERR_CHECK(mpi_errno);
+#endif
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/datatype/typerep/src/typerep_internal.h
+++ b/src/mpi/datatype/typerep/src/typerep_internal.h
@@ -8,6 +8,16 @@
 
 #include "mpiimpl.h"
 
+#define MPICH_DATATYPE_ENGINE_YAKSA    (1)
+#define MPICH_DATATYPE_ENGINE_DATALOOP (2)
+
+#if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
+
+#include "yaksa.h"
+yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type);
+
+#else
+
 int MPII_Typerep_convert_subarray(int ndims, int *array_of_sizes, int *array_of_subsizes,
                                   int *array_of_starts, int order, MPI_Datatype oldtype,
                                   MPI_Datatype * newtype);
@@ -15,4 +25,7 @@ int MPII_Typerep_convert_darray(int size, int rank, int ndims, const int *array_
                                 const int *array_of_distribs, const int *array_of_dargs,
                                 const int *array_of_psizes, int order, MPI_Datatype oldtype,
                                 MPI_Datatype * newtype);
+
+#endif
+
 #endif /* TYPEREP_INTERNAL_H_INCLUDED */

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_commit.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_commit.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+#include "yaksa.h"
+
+void MPIR_Typerep_commit(MPI_Datatype type, void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_COMMIT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_COMMIT);
+
+    switch (type) {
+        case MPI_FLOAT_INT:
+            *typerep = (void *) YAKSA_TYPE__FLOAT_INT;
+            break;
+
+        case MPI_DOUBLE_INT:
+            *typerep = (void *) YAKSA_TYPE__DOUBLE_INT;
+            break;
+
+        case MPI_LONG_INT:
+            *typerep = (void *) YAKSA_TYPE__LONG_INT;
+            break;
+
+        case MPI_SHORT_INT:
+            *typerep = (void *) YAKSA_TYPE__SHORT_INT;
+            break;
+
+        case MPI_LONG_DOUBLE_INT:
+            *typerep = (void *) YAKSA_TYPE__LONG_DOUBLE_INT;
+            break;
+
+        default:
+            break;
+    }
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_COMMIT);
+}
+
+void MPIR_Typerep_free(void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_FREE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_FREE);
+
+    yaksa_type_t type = (yaksa_type_t) (*typerep);
+
+    if (type != YAKSA_TYPE__FLOAT_INT && type != YAKSA_TYPE__DOUBLE_INT &&
+        type != YAKSA_TYPE__LONG_INT && type != YAKSA_TYPE__SHORT_INT &&
+        type != YAKSA_TYPE__LONG_DOUBLE_INT) {
+        yaksa_free(type);
+    }
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_FREE);
+}

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
@@ -1,0 +1,291 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+#include "typerep_internal.h"
+#include "yaksa.h"
+
+int MPIR_Typerep_create_vector(int count, int blocklength, int stride, MPI_Datatype oldtype,
+                               void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_VECTOR);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_VECTOR);
+
+    int mpi_errno = MPI_SUCCESS;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
+
+    int rc = yaksa_create_vector(count, blocklength, stride, type, (yaksa_type_t *) typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_VECTOR);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_create_hvector(int count, int blocklength, MPI_Aint stride, MPI_Datatype oldtype,
+                                void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_HVECTOR);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_HVECTOR);
+
+    int mpi_errno = MPI_SUCCESS;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
+
+    int rc = yaksa_create_hvector(count, blocklength, stride, type,
+                                  (yaksa_type_t *) typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_HVECTOR);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_CONTIG);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_CONTIG);
+
+    int mpi_errno = MPI_SUCCESS;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
+
+    int rc = yaksa_create_contig(count, type, (yaksa_type_t *) typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_CONTIG);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_create_dup(MPI_Datatype oldtype, void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_DUP);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_DUP);
+
+    int mpi_errno = MPI_SUCCESS;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
+
+    int rc = yaksa_create_dup(type, (yaksa_type_t *) typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_DUP);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_create_indexed_block(int count, int blocklength, const int *array_of_displacements,
+                                      MPI_Datatype oldtype, void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED_BLOCK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED_BLOCK);
+
+    int mpi_errno = MPI_SUCCESS;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
+
+    int rc = yaksa_create_indexed_block(count, blocklength, array_of_displacements,
+                                        type, (yaksa_type_t *) typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED_BLOCK);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_create_hindexed_block(int count, int blocklength,
+                                       const MPI_Aint * array_of_displacements,
+                                       MPI_Datatype oldtype, void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED_BLOCK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED_BLOCK);
+
+    int mpi_errno = MPI_SUCCESS;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
+
+    int rc = yaksa_create_hindexed_block(count, blocklength, array_of_displacements,
+                                         type, (yaksa_type_t *) typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED_BLOCK);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_create_indexed(int count, const int *array_of_blocklengths,
+                                const int *array_of_displacements, MPI_Datatype oldtype,
+                                void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED);
+
+    int mpi_errno = MPI_SUCCESS;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
+
+    int rc = yaksa_create_indexed(count, array_of_blocklengths, array_of_displacements,
+                                  type, (yaksa_type_t *) typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_create_hindexed(int count, const int *array_of_blocklengths,
+                                 const MPI_Aint * array_of_displacements, MPI_Datatype oldtype,
+                                 void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED);
+
+    int mpi_errno = MPI_SUCCESS;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
+
+    int rc = yaksa_create_hindexed(count, array_of_blocklengths, array_of_displacements,
+                                   type, (yaksa_type_t *) typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent, void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_RESIZED);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_RESIZED);
+
+    int mpi_errno = MPI_SUCCESS;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
+
+    int rc = yaksa_create_resized(type, lb, extent, (yaksa_type_t *) typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_RESIZED);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_create_struct(int count, const int *array_of_blocklengths,
+                               const MPI_Aint * array_of_displacements,
+                               const MPI_Datatype * array_of_types, void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_STRUCT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_STRUCT);
+
+    int mpi_errno = MPI_SUCCESS;
+    yaksa_type_t *array_of_yaksa_types = (yaksa_type_t *) MPL_malloc(count * sizeof(yaksa_type_t),
+                                                                     MPL_MEM_DATATYPE);
+    int *array_of_real_blocklengths = (int *) MPL_malloc(count * sizeof(int), MPL_MEM_DATATYPE);
+    intptr_t *array_of_real_displacements = (intptr_t *) MPL_malloc(count * sizeof(intptr_t),
+                                                                    MPL_MEM_DATATYPE);
+
+
+    /* MPI_LB and MPI_UB were in the MPI-1 standard and were
+     * deprecated in MPI-2.  We should probably stop supporting them
+     * in the future.  For now, we can simply convert them to a
+     * resized type. */
+    int real_count = 0;
+    for (int i = 0; i < count; i++) {
+        if (array_of_types[i] != MPI_LB && array_of_types[i] != MPI_UB) {
+            array_of_yaksa_types[real_count] = MPII_Typerep_get_yaksa_type(array_of_types[i]);
+            array_of_real_blocklengths[real_count] = array_of_blocklengths[i];
+            array_of_real_displacements[real_count] = (intptr_t) array_of_displacements[i];
+            real_count++;
+        }
+    }
+
+    if (count == real_count) {
+        int rc = yaksa_create_struct(count, array_of_blocklengths, array_of_real_displacements,
+                                     array_of_yaksa_types, (yaksa_type_t *) typerep);
+        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    } else {
+        yaksa_type_t tmp;
+
+        int rc =
+            yaksa_create_struct(real_count, array_of_real_blocklengths, array_of_real_displacements,
+                                array_of_yaksa_types, &tmp);
+        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+        intptr_t lb, ub;
+        uintptr_t extent;
+        rc = yaksa_get_extent(tmp, &lb, &extent);
+        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+        ub = lb + extent;
+
+        /* see if the user set MPI_LB/UB to override these values */
+        for (int i = 0; i < count; i++) {
+            if (array_of_types[i] == MPI_LB)
+                lb = array_of_displacements[i];
+            if (array_of_types[i] == MPI_UB)
+                ub = array_of_displacements[i];
+        }
+
+        rc = yaksa_create_resized(tmp, lb, ub - lb, (yaksa_type_t *) typerep);
+        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+        rc = yaksa_free(tmp);
+        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    }
+
+    MPL_free(array_of_real_displacements);
+    MPL_free(array_of_real_blocklengths);
+    MPL_free(array_of_yaksa_types);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_STRUCT);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
+                                 const int *array_of_starts, int order,
+                                 MPI_Datatype oldtype, void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_SUBARRAY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_SUBARRAY);
+
+    /* MPICH breaks down subarrays into smaller types, so we don't
+     * need to use yaksa subarray types */
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_SUBARRAY);
+    return MPI_SUCCESS;
+}
+
+int MPIR_Typerep_create_darray(int size, int rank, int ndims, const int *array_of_gsizes,
+                               const int *array_of_distribs, const int *array_of_dargs,
+                               const int *array_of_psizes, int order, MPI_Datatype oldtype,
+                               void **typerep)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_DARRAY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_DARRAY);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_DARRAY);
+    return MPI_SUCCESS;
+}

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_debug.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_debug.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+void MPIR_Typerep_debug(MPI_Datatype type)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_DEBUG);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_DEBUG);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_DEBUG);
+}

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
@@ -1,0 +1,401 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+#include "yaksa.h"
+#include "typerep_internal.h"
+
+static yaksa_type_t TYPEREP_YAKSA_TYPE__REAL16;
+static yaksa_type_t TYPEREP_YAKSA_TYPE__COMPLEX32;
+static yaksa_type_t TYPEREP_YAKSA_TYPE__INTEGER16;
+
+yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPII_TYPEREP_GET_YAKSA_TYPE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPII_TYPEREP_GET_YAKSA_TYPE);
+
+    yaksa_type_t yaksa_type;
+
+    if (type == MPI_DATATYPE_NULL) {
+        yaksa_type = YAKSA_TYPE__NULL;
+        goto fn_exit;
+    }
+
+    MPI_Aint basic_type_size = 0;
+    if (HANDLE_IS_BUILTIN(type)) {
+        MPIR_Datatype_get_size_macro(type, basic_type_size);
+    }
+
+    yaksa_type_t float8_t = YAKSA_TYPE__NULL;
+    if (sizeof(float) == 1) {
+        float8_t = YAKSA_TYPE__FLOAT;
+    } else if (sizeof(double) == 1) {
+        float8_t = YAKSA_TYPE__DOUBLE;
+    } else if (sizeof(long double) == 1) {
+        float8_t = YAKSA_TYPE__LONG_DOUBLE;
+    }
+
+    yaksa_type_t float16_t = YAKSA_TYPE__NULL;
+    if (sizeof(float) == 2) {
+        float16_t = YAKSA_TYPE__FLOAT;
+    } else if (sizeof(double) == 2) {
+        float16_t = YAKSA_TYPE__DOUBLE;
+    } else if (sizeof(long double) == 2) {
+        float16_t = YAKSA_TYPE__LONG_DOUBLE;
+    }
+
+    yaksa_type_t float32_t = YAKSA_TYPE__NULL;
+    if (sizeof(float) == 4) {
+        float32_t = YAKSA_TYPE__FLOAT;
+    } else if (sizeof(double) == 4) {
+        float32_t = YAKSA_TYPE__DOUBLE;
+    } else if (sizeof(long double) == 4) {
+        float32_t = YAKSA_TYPE__LONG_DOUBLE;
+    }
+
+    yaksa_type_t float64_t = YAKSA_TYPE__NULL;
+    if (sizeof(float) == 8) {
+        float64_t = YAKSA_TYPE__FLOAT;
+    } else if (sizeof(double) == 8) {
+        float64_t = YAKSA_TYPE__DOUBLE;
+    } else if (sizeof(long double) == 8) {
+        float64_t = YAKSA_TYPE__LONG_DOUBLE;
+    }
+
+    yaksa_type_t float128_t = YAKSA_TYPE__NULL;
+    if (sizeof(float) == 16) {
+        float128_t = YAKSA_TYPE__FLOAT;
+    } else if (sizeof(double) == 16) {
+        float128_t = YAKSA_TYPE__DOUBLE;
+    } else if (sizeof(long double) == 16) {
+        float128_t = YAKSA_TYPE__LONG_DOUBLE;
+    }
+
+    switch (type) {
+        case MPI_CHAR:
+        case MPI_SIGNED_CHAR:
+            yaksa_type = YAKSA_TYPE__CHAR;
+            break;
+
+        case MPI_UNSIGNED_CHAR:
+            yaksa_type = YAKSA_TYPE__UNSIGNED_CHAR;
+            break;
+
+        case MPI_PACKED:
+        case MPI_BYTE:
+            yaksa_type = YAKSA_TYPE__BYTE;
+            break;
+
+        case MPI_WCHAR:
+            yaksa_type = YAKSA_TYPE__WCHAR_T;
+            break;
+
+        case MPI_SHORT:
+            yaksa_type = YAKSA_TYPE__SHORT;
+            break;
+
+        case MPI_UNSIGNED_SHORT:
+            yaksa_type = YAKSA_TYPE__UNSIGNED_SHORT;
+            break;
+
+        case MPI_INT:
+            yaksa_type = YAKSA_TYPE__INT;
+            break;
+
+        case MPI_UNSIGNED:
+            yaksa_type = YAKSA_TYPE__UNSIGNED;
+            break;
+
+        case MPI_LONG:
+            yaksa_type = YAKSA_TYPE__LONG;
+            break;
+
+        case MPI_UNSIGNED_LONG:
+            yaksa_type = YAKSA_TYPE__UNSIGNED_LONG;
+            break;
+
+        case MPI_LONG_LONG:
+            yaksa_type = YAKSA_TYPE__LONG_LONG;
+            break;
+
+        case MPI_UNSIGNED_LONG_LONG:
+            yaksa_type = YAKSA_TYPE__UNSIGNED_LONG_LONG;
+            break;
+
+        case MPI_INT8_T:
+            yaksa_type = YAKSA_TYPE__INT8_T;
+            break;
+
+        case MPI_UINT8_T:
+            yaksa_type = YAKSA_TYPE__UINT8_T;
+            break;
+
+        case MPI_INT16_T:
+            yaksa_type = YAKSA_TYPE__INT16_T;
+            break;
+
+        case MPI_UINT16_T:
+            yaksa_type = YAKSA_TYPE__UINT16_T;
+            break;
+
+        case MPI_INT32_T:
+            yaksa_type = YAKSA_TYPE__INT32_T;
+            break;
+
+        case MPI_UINT32_T:
+            yaksa_type = YAKSA_TYPE__UINT32_T;
+            break;
+
+        case MPI_INT64_T:
+            yaksa_type = YAKSA_TYPE__INT64_T;
+            break;
+
+        case MPI_UINT64_T:
+            yaksa_type = YAKSA_TYPE__UINT64_T;
+            break;
+
+        case MPI_FLOAT:
+            yaksa_type = YAKSA_TYPE__FLOAT;
+            break;
+
+        case MPI_DOUBLE:
+            yaksa_type = YAKSA_TYPE__DOUBLE;
+            break;
+
+        case MPI_LONG_DOUBLE:
+            yaksa_type = YAKSA_TYPE__LONG_DOUBLE;
+            break;
+
+        case MPI_C_COMPLEX:
+            yaksa_type = YAKSA_TYPE__C_COMPLEX;
+            break;
+
+        case MPI_C_DOUBLE_COMPLEX:
+            yaksa_type = YAKSA_TYPE__C_DOUBLE_COMPLEX;
+            break;
+
+        case MPI_C_LONG_DOUBLE_COMPLEX:
+            yaksa_type = YAKSA_TYPE__C_LONG_DOUBLE_COMPLEX;
+            break;
+
+        case MPI_2INT:
+            yaksa_type = YAKSA_TYPE__2INT;
+            break;
+
+        case MPI_AINT:
+        case MPI_OFFSET:
+        case MPI_COUNT:
+        case MPI_C_BOOL:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_LOGICAL:
+#endif /* HAVE_FORTRAN_BINDING */
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_BOOL:
+#endif /* HAVE_CXX_BINDING */
+            switch (basic_type_size) {
+                case 1:
+                    yaksa_type = YAKSA_TYPE__INT8_T;
+                    break;
+
+                case 2:
+                    yaksa_type = YAKSA_TYPE__INT16_T;
+                    break;
+
+                case 4:
+                    yaksa_type = YAKSA_TYPE__INT32_T;
+                    break;
+
+                case 8:
+                    yaksa_type = YAKSA_TYPE__INT64_T;
+                    break;
+
+                default:
+                    assert(0);
+            }
+            break;
+
+        case MPI_LB:
+        case MPI_UB:
+            yaksa_type = YAKSA_TYPE__NULL;
+            break;
+
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_CHARACTER:
+            yaksa_type = YAKSA_TYPE__CHAR;
+            break;
+
+        case MPI_INTEGER:
+            yaksa_type = YAKSA_TYPE__INT;
+            break;
+
+        case MPI_INTEGER1:
+            yaksa_type = YAKSA_TYPE__INT8_T;
+            break;
+
+        case MPI_INTEGER2:
+            yaksa_type = YAKSA_TYPE__INT16_T;
+            break;
+
+        case MPI_INTEGER4:
+            yaksa_type = YAKSA_TYPE__INT32_T;
+            break;
+
+        case MPI_INTEGER8:
+            yaksa_type = YAKSA_TYPE__INT64_T;
+            break;
+
+        case MPI_COMPLEX:
+            yaksa_type = YAKSA_TYPE__C_COMPLEX;
+            break;
+
+        case MPI_DOUBLE_COMPLEX:
+            yaksa_type = YAKSA_TYPE__C_DOUBLE_COMPLEX;
+            break;
+
+        case MPI_2INTEGER:
+            yaksa_type = YAKSA_TYPE__2INT;
+            break;
+
+        case MPI_2REAL:
+            if (basic_type_size / 2 == sizeof(float))
+                yaksa_type = YAKSA_TYPE__C_COMPLEX;
+            else if (basic_type_size / 2 == sizeof(double))
+                yaksa_type = YAKSA_TYPE__C_DOUBLE_COMPLEX;
+            else if (basic_type_size / 2 == sizeof(long double))
+                yaksa_type = YAKSA_TYPE__C_LONG_DOUBLE_COMPLEX;
+            else
+                assert(0);
+            break;
+
+        case MPI_2DOUBLE_PRECISION:
+            yaksa_type = YAKSA_TYPE__C_DOUBLE_COMPLEX;
+            break;
+
+        case MPI_DOUBLE_PRECISION:
+        case MPI_REAL:
+        case MPI_REAL4:
+        case MPI_REAL8:
+            switch (basic_type_size) {
+                case 1:
+                    yaksa_type = float8_t;
+                    break;
+
+                case 2:
+                    yaksa_type = float16_t;
+                    break;
+
+                case 4:
+                    yaksa_type = float32_t;
+                    break;
+
+                case 8:
+                    yaksa_type = float64_t;
+                    break;
+
+                case 16:
+                    yaksa_type = float128_t;
+                    break;
+
+                default:
+                    assert(0);
+            }
+            break;
+
+        case MPI_COMPLEX8:
+            if (sizeof(float) == 8)
+                yaksa_type = YAKSA_TYPE__C_COMPLEX;
+            else if (sizeof(double) == 8)
+                yaksa_type = YAKSA_TYPE__C_DOUBLE_COMPLEX;
+            else if (sizeof(long double) == 8)
+                yaksa_type = YAKSA_TYPE__C_LONG_DOUBLE_COMPLEX;
+            else
+                assert(0);
+            break;
+
+        case MPI_COMPLEX16:
+            if (sizeof(float) == 16)
+                yaksa_type = YAKSA_TYPE__C_COMPLEX;
+            else if (sizeof(double) == 16)
+                yaksa_type = YAKSA_TYPE__C_DOUBLE_COMPLEX;
+            else if (sizeof(long double) == 16)
+                yaksa_type = YAKSA_TYPE__C_LONG_DOUBLE_COMPLEX;
+            else
+                assert(0);
+            break;
+#endif /* HAVE_FORTRAN_BINDING */
+
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_FLOAT_COMPLEX:
+            yaksa_type = YAKSA_TYPE__C_COMPLEX;
+            break;
+
+        case MPI_CXX_DOUBLE_COMPLEX:
+            yaksa_type = YAKSA_TYPE__C_DOUBLE_COMPLEX;
+            break;
+
+        case MPI_CXX_LONG_DOUBLE_COMPLEX:
+            yaksa_type = YAKSA_TYPE__C_LONG_DOUBLE_COMPLEX;
+            break;
+#endif /* HAVE_CXX_BINDING */
+
+        default:
+            {
+                /* some types are handled with if-else branches,
+                 * instead of a switch statement because MPICH might
+                 * define them as "MPI_DATATYPE_NULL". */
+                if (type == MPI_REAL16) {
+                    yaksa_type = TYPEREP_YAKSA_TYPE__REAL16;
+                } else if (type == MPI_COMPLEX32) {
+                    yaksa_type = TYPEREP_YAKSA_TYPE__COMPLEX32;
+                } else if (type == MPI_INTEGER16) {
+                    yaksa_type = TYPEREP_YAKSA_TYPE__INTEGER16;
+                } else {
+                    MPIR_Datatype *typeptr;
+                    MPIR_Datatype_get_ptr(type, typeptr);
+                    yaksa_type = ((yaksa_type_t) typeptr->typerep);
+                }
+            }
+            break;
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPII_TYPEREP_GET_YAKSA_TYPE);
+    return yaksa_type;
+}
+
+void MPIR_Typerep_init(void)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_INIT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_INIT);
+
+    MPI_Aint size;
+
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
+
+    MPIR_Datatype_get_size_macro(MPI_REAL16, size);
+    yaksa_create_contig(size, YAKSA_TYPE__BYTE, &TYPEREP_YAKSA_TYPE__REAL16);
+
+    MPIR_Datatype_get_size_macro(MPI_COMPLEX32, size);
+    yaksa_create_contig(size, YAKSA_TYPE__BYTE, &TYPEREP_YAKSA_TYPE__COMPLEX32);
+
+    MPIR_Datatype_get_size_macro(MPI_INTEGER16, size);
+    yaksa_create_contig(size, YAKSA_TYPE__BYTE, &TYPEREP_YAKSA_TYPE__INTEGER16);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_INIT);
+}
+
+void MPIR_Typerep_finalize(void)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_FINALIZE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_FINALIZE);
+
+    yaksa_free(TYPEREP_YAKSA_TYPE__REAL16);
+    yaksa_free(TYPEREP_YAKSA_TYPE__COMPLEX32);
+    yaksa_free(TYPEREP_YAKSA_TYPE__INTEGER16);
+
+    yaksa_finalize();
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_FINALIZE);
+}

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_iov.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_iov.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+#include "yaksa.h"
+#include "typerep_internal.h"
+#include <assert.h>
+#include <sys/time.h>
+
+/* There is a mismatch between the Typerep API and the yaksa API with
+ * respect to IOVs.  Typerep accepts IOV offsets in terms of bytes,
+ * while yaksa accepts them in terms of IOV elements.  We try to
+ * workaround this mismatch in our code, but perhaps it would be
+ * cleaner if the Typerep API was modified to match what yaksa
+ * provides. */
+int MPIR_Typerep_to_iov(const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                        MPI_Aint byte_offset, struct iovec *iov, int max_iov_len,
+                        MPI_Aint max_iov_bytes, int *actual_iov_len, MPI_Aint * actual_iov_bytes)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_TO_IOV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_TO_IOV);
+
+    int mpi_errno = MPI_SUCCESS;
+    int rc;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(datatype);
+
+    uintptr_t size;
+    rc = yaksa_get_size(type, &size);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    uintptr_t yaksa_max_iov_len;
+    rc = yaksa_iov_len(count, type, &yaksa_max_iov_len);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    /* fast-path: user wants the full IOV */
+    if (byte_offset == 0 && max_iov_bytes >= count * size && max_iov_len == yaksa_max_iov_len) {
+        uintptr_t yaksa_actual_iov_len;
+        rc = yaksa_iov(buf, count, type, 0, iov, max_iov_len, &yaksa_actual_iov_len);
+        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+        assert(max_iov_len == yaksa_actual_iov_len);
+
+        *actual_iov_len = (int) yaksa_actual_iov_len;
+        *actual_iov_bytes = count * size;
+
+        goto fn_exit;
+    } else if (byte_offset == 0) {
+        uintptr_t yaksa_actual_iov_len;
+        rc = yaksa_iov(buf, count, type, 0, iov, max_iov_len, &yaksa_actual_iov_len);
+        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+        *actual_iov_len = (int) yaksa_actual_iov_len;
+    } else {
+        /* yaksa does not accept offsets in bytes, but in number of
+         * IOV elements.  So we cannot directly pass in the
+         * user-provided offset to yaksa.  Instead, create a temporary
+         * IOV array and pass a subset of it to the user. */
+        struct iovec *tmp_iov =
+            (struct iovec *) MPL_malloc(yaksa_max_iov_len * sizeof(struct iovec),
+                                        MPL_MEM_DATATYPE);
+
+        uintptr_t yaksa_actual_iov_len;
+        rc = yaksa_iov(buf, count, type, 0, tmp_iov, yaksa_max_iov_len, &yaksa_actual_iov_len);
+        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+        uintptr_t skip_bytes = (uintptr_t) byte_offset;
+
+        for (uintptr_t i = 0; i < yaksa_actual_iov_len; i++) {
+            if (skip_bytes > tmp_iov[i].iov_len) {
+                skip_bytes -= tmp_iov[i].iov_len;
+            } else if (skip_bytes == tmp_iov[i].iov_len) {
+                tmp_iov[i].iov_len = skip_bytes = 0;
+
+                rc = yaksa_iov(buf, count, type, i + 1, iov, max_iov_len, &yaksa_actual_iov_len);
+                MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+                break;
+            } else {
+                tmp_iov[i].iov_base = (void *) ((char *) tmp_iov[i].iov_base + skip_bytes);
+                tmp_iov[i].iov_len -= skip_bytes;
+                skip_bytes = 0;
+
+                iov[0] = tmp_iov[i];
+
+                rc = yaksa_iov(buf, count, type, i + 1, iov + 1, max_iov_len - 1,
+                               &yaksa_actual_iov_len);
+                MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+                yaksa_actual_iov_len++;
+
+                break;
+            }
+        }
+        *actual_iov_len = (int) yaksa_actual_iov_len;
+
+        MPL_free(tmp_iov);
+    }
+
+    uintptr_t total_bytes = 0;
+    for (int i = 0; i < *actual_iov_len; i++) {
+        if (total_bytes + iov[i].iov_len < max_iov_bytes) {
+            total_bytes += iov[i].iov_len;
+        } else if (total_bytes + iov[i].iov_len == max_iov_bytes) {
+            total_bytes += iov[i].iov_len;
+            *actual_iov_len = i + 1;
+            break;
+        } else if (total_bytes + iov[i].iov_len > max_iov_bytes) {
+            iov[i].iov_len = max_iov_bytes - total_bytes;
+            total_bytes = max_iov_bytes;
+            *actual_iov_len = i + 1;
+            break;
+        }
+    }
+    *actual_iov_bytes = (int) total_bytes;
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_TO_IOV);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_iov_len(MPI_Aint count, MPI_Datatype datatype, MPI_Aint max_iov_bytes,
+                         MPI_Aint * iov_len)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_IOV_LEN);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_IOV_LEN);
+
+    int mpi_errno = MPI_SUCCESS;
+    int rc;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(datatype);
+
+    uintptr_t max_iov_len;
+    rc = yaksa_iov_len(count, type, &max_iov_len);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    uintptr_t size;
+    rc = yaksa_get_size(type, &size);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    if (max_iov_bytes >= count * size) {        /* fast path */
+        *iov_len = (MPI_Aint) max_iov_len;
+    } else {    /* slow path */
+        struct iovec *iov =
+            (struct iovec *) MPL_malloc(max_iov_len * sizeof(struct iovec), MPL_MEM_DATATYPE);
+
+        uintptr_t actual_iov_len;
+        rc = yaksa_iov(NULL, count, type, 0, iov, max_iov_len, &actual_iov_len);
+        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+        MPL_free(iov);
+
+        *iov_len = (MPI_Aint) actual_iov_len;
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_IOV_LEN);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+#include "yaksa.h"
+#include "typerep_internal.h"
+
+int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
+                      MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
+                      MPI_Aint * actual_pack_bytes)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_PACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_PACK);
+
+    int mpi_errno = MPI_SUCCESS;
+    int rc;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(datatype);
+
+    yaksa_request_t request;
+    uintptr_t real_pack_bytes;
+    rc = yaksa_ipack(inbuf, incount, type, inoffset, outbuf, max_pack_bytes, &real_pack_bytes,
+                     &request);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    rc = yaksa_request_wait(request);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    *actual_pack_bytes = (MPI_Aint) real_pack_bytes;
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_PACK);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_Aint outcount,
+                        MPI_Datatype datatype, MPI_Aint outoffset, MPI_Aint * actual_unpack_bytes)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_UNPACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_UNPACK);
+
+    int mpi_errno = MPI_SUCCESS;
+    int rc;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(datatype);
+
+    uintptr_t size;
+    rc = yaksa_get_size(type, &size);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    uintptr_t real_insize = MPL_MIN(insize, size * outcount);
+
+    yaksa_request_t request;
+    uintptr_t real_unpack_bytes;
+    rc = yaksa_iunpack(inbuf, real_insize, outbuf, outcount, type, outoffset, &real_unpack_bytes,
+                       &request);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    rc = yaksa_request_wait(request);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    *actual_unpack_bytes = (MPI_Aint) real_unpack_bytes;
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_UNPACK);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
@@ -1,0 +1,691 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+#include "yaksa.h"
+#include "typerep_internal.h"
+#include <assert.h>
+
+/* Define fixed-width equivalents for floating point types */
+#if SIZEOF_FLOAT == 1
+#define typerep_float8_t float
+#elif SIZEOF_DOUBLE == 1
+#define typerep_float8_t double
+#elif SIZEOF_LONG_DOUBLE == 1
+#define typerep_float8_t long double
+#else
+#define typerep_float8_t float
+#endif
+
+#if SIZEOF_FLOAT == 2
+#define typerep_float16_t float
+#elif SIZEOF_DOUBLE == 2
+#define typerep_float16_t double
+#elif SIZEOF_LONG_DOUBLE == 2
+#define typerep_float16_t long double
+#else
+#define typerep_float16_t float
+#endif
+
+#if SIZEOF_FLOAT == 4
+#define typerep_float32_t float
+#elif SIZEOF_DOUBLE == 4
+#define typerep_float32_t double
+#elif SIZEOF_LONG_DOUBLE == 4
+#define typerep_float32_t long double
+#else
+#define typerep_float32_t float
+#endif
+
+#if SIZEOF_FLOAT == 8
+#define typerep_float64_t float
+#elif SIZEOF_DOUBLE == 8
+#define typerep_float64_t double
+#elif SIZEOF_LONG_DOUBLE == 8
+#define typerep_float64_t long double
+#else
+#define typerep_float64_t float
+#endif
+
+#if SIZEOF_FLOAT == 16
+#define typerep_float128_t float
+#elif SIZEOF_DOUBLE == 16
+#define typerep_float128_t double
+#elif SIZEOF_LONG_DOUBLE == 16
+#define typerep_float128_t long double
+#else
+#define typerep_float128_t float
+#endif
+
+#if SIZEOF_FLOAT == 32
+#define typerep_float256_t float
+#elif SIZEOF_DOUBLE == 32
+#define typerep_float256_t double
+#elif SIZEOF_LONG_DOUBLE == 32
+#define typerep_float256_t long double
+#else
+#define typerep_float256_t float
+#endif
+
+#define PACK_EXTERNAL(iov, outbuf, max_iov_len, src_c_type, dest_c_type) \
+    do {                                                                \
+        dest_c_type *dbuf = (dest_c_type *) outbuf;                     \
+        uintptr_t idx = 0;                                              \
+        for (uintptr_t i = 0; i < max_iov_len; i++) {                   \
+            src_c_type *sbuf = (src_c_type *) iov[i].iov_base;          \
+            for (size_t j = 0; j < iov[i].iov_len / sizeof(src_c_type); j++) { \
+                dbuf[idx++] = (dest_c_type) sbuf[j];                    \
+            }                                                           \
+        }                                                               \
+    } while (0)
+
+#define PACK_EXTERNAL_INT_MAPPED(inbuf, outbuf, max_iov_len, basic_type_size, dest_c_type) \
+    do {                                                                \
+        switch (basic_type_size) {                                      \
+        case 1:                                                         \
+            PACK_EXTERNAL(inbuf, outbuf, max_iov_len, int8_t, dest_c_type); \
+            break;                                                      \
+                                                                        \
+        case 2:                                                         \
+            PACK_EXTERNAL(inbuf, outbuf, max_iov_len, int16_t, dest_c_type); \
+            break;                                                      \
+                                                                        \
+        case 4:                                                         \
+            PACK_EXTERNAL(inbuf, outbuf, max_iov_len, int32_t, dest_c_type); \
+            break;                                                      \
+                                                                        \
+        case 8:                                                         \
+            PACK_EXTERNAL(inbuf, outbuf, max_iov_len, int64_t, dest_c_type); \
+            break;                                                      \
+                                                                        \
+        default:                                                        \
+            assert(0);                                                  \
+        }                                                               \
+    } while (0)
+
+#define PACK_EXTERNAL_FLOAT_MAPPED(inbuf, outbuf, max_iov_len, basic_type_size, dest_c_type) \
+        do {                                                            \
+            switch (basic_type_size) {                                  \
+            case 1:                                                     \
+                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float8_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            case 2:                                                     \
+                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float16_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            case 4:                                                     \
+                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float32_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            case 8:                                                     \
+                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float64_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            case 16:                                                    \
+                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float128_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            case 32:                                                    \
+                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float256_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            default:                                                    \
+                assert(0);                                              \
+            }                                                           \
+        } while (0)
+
+#define UNPACK_EXTERNAL(inbuf, iov, max_iov_len, src_c_type, dest_c_type) \
+    do {                                                                \
+        src_c_type *sbuf = (src_c_type *) inbuf;                        \
+        uintptr_t idx = 0;                                              \
+        for (uintptr_t i = 0; i < max_iov_len; i++) {                   \
+            dest_c_type *dbuf = (dest_c_type *) iov[i].iov_base;        \
+            for (size_t j = 0; j < iov[i].iov_len / sizeof(src_c_type); j++) { \
+                dbuf[j] = (dest_c_type) sbuf[idx++];                    \
+            }                                                           \
+        }                                                               \
+    } while (0)
+
+#define UNPACK_EXTERNAL_INT_MAPPED(inbuf, outbuf, max_iov_len, basic_type_size, dest_c_type) \
+    do {                                                                \
+        switch (basic_type_size) {                                      \
+        case 1:                                                         \
+            UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, int8_t, dest_c_type); \
+            break;                                                      \
+                                                                        \
+        case 2:                                                         \
+            UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, int16_t, dest_c_type); \
+            break;                                                      \
+                                                                        \
+        case 4:                                                         \
+            UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, int32_t, dest_c_type); \
+            break;                                                      \
+                                                                        \
+        case 8:                                                         \
+            UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, int64_t, dest_c_type); \
+            break;                                                      \
+                                                                        \
+        default:                                                        \
+            assert(0);                                                  \
+        }                                                               \
+    } while (0)
+
+#define UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, outbuf, max_iov_len, basic_type_size, dest_c_type) \
+        do {                                                            \
+            switch (basic_type_size) {                                  \
+            case 1:                                                     \
+                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float8_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            case 2:                                                     \
+                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float16_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            case 4:                                                     \
+                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float32_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            case 8:                                                     \
+                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float64_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            case 16:                                                    \
+                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float128_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            case 32:                                                    \
+                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float256_t, dest_c_type); \
+                break;                                                  \
+                                                                        \
+            default:                                                    \
+                assert(0);                                              \
+            }                                                           \
+        } while (0)
+
+int MPIR_Typerep_pack_external(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
+                               void *outbuf, MPI_Aint * actual_pack_bytes)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_PACK_EXTERNAL);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_PACK_EXTERNAL);
+
+    int mpi_errno = MPI_SUCCESS;
+    int rc;
+    struct iovec *iov = NULL;
+
+    assert(datatype != MPI_DATATYPE_NULL);
+
+    MPIR_Datatype *typeptr;
+    MPIR_Datatype_get_ptr(datatype, typeptr);
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(datatype);
+
+    *actual_pack_bytes = typeptr->size * incount;
+
+    /* convert type to IOV */
+    uintptr_t max_iov_len;
+    rc = yaksa_iov_len(incount, type, &max_iov_len);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    uintptr_t actual_iov_len;
+    iov = MPL_malloc(max_iov_len * sizeof(struct iovec), MPL_MEM_DATATYPE);
+    rc = yaksa_iov(inbuf, incount, type, 0, iov, max_iov_len, &actual_iov_len);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    assert(max_iov_len == actual_iov_len);
+    assert(typeptr->basic_type != MPI_DATATYPE_NULL);
+
+    MPI_Datatype basic_type;
+    if (HANDLE_IS_BUILTIN(datatype)) {
+        basic_type = datatype;
+    } else {
+        basic_type = typeptr->basic_type;
+    }
+
+    MPI_Aint basic_type_size;
+    MPIR_Datatype_get_size_macro(basic_type, basic_type_size);
+
+    /* destination sizes are fixed in external32 packing, so we always
+     * map each type to a fixed type.  See table 13.2 in the MPI-3.1
+     * specification (page 540). */
+    /* we do not need to distinguish between signed and unsigned types
+     * because their bit representations are identical for
+     * pack/unpack. */
+    switch (basic_type) {
+        case MPI_PACKED:
+        case MPI_BYTE:
+        case MPI_INT8_T:
+        case MPI_UINT8_T:
+        case MPI_CHAR:
+        case MPI_UNSIGNED_CHAR:
+        case MPI_SIGNED_CHAR:
+        case MPI_C_BOOL:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_CHARACTER:
+        case MPI_INTEGER1:
+#endif /* HAVE_FORTRAN_BINDING */
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_BOOL:
+#endif /* HAVE_CXX_BINDING */
+            PACK_EXTERNAL_INT_MAPPED(iov, outbuf, max_iov_len, basic_type_size, int8_t);
+            break;
+
+        case MPI_WCHAR:
+        case MPI_SHORT:
+        case MPI_UNSIGNED_SHORT:
+        case MPI_INT16_T:
+        case MPI_UINT16_T:
+        case MPI_COUNT:
+        case MPI_OFFSET:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_INTEGER2:
+#endif /* HAVE_FORTRAN_BINDING */
+            PACK_EXTERNAL_INT_MAPPED(iov, outbuf, max_iov_len, basic_type_size, int16_t);
+            break;
+
+        case MPI_INT:
+        case MPI_UNSIGNED:
+        case MPI_LONG:
+        case MPI_UNSIGNED_LONG:
+        case MPI_INT32_T:
+        case MPI_UINT32_T:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_LOGICAL:
+        case MPI_INTEGER:
+        case MPI_INTEGER4:
+#endif /* HAVE_FORTRAN_BINDING */
+            PACK_EXTERNAL_INT_MAPPED(iov, outbuf, max_iov_len, basic_type_size, int32_t);
+            break;
+
+        case MPI_LONG_LONG:
+        case MPI_UNSIGNED_LONG_LONG:
+        case MPI_INT64_T:
+        case MPI_UINT64_T:
+        case MPI_AINT:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_INTEGER8:
+#endif /* HAVE_FORTRAN_BINDING */
+            PACK_EXTERNAL_INT_MAPPED(iov, outbuf, max_iov_len, basic_type_size, int64_t);
+            break;
+
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_FLOAT:
+        case MPI_REAL:
+        case MPI_REAL4:
+            PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
+                                       typerep_float32_t);
+            break;
+#endif /* HAVE_FORTRAN_BINDING */
+
+        case MPI_DOUBLE:
+        case MPI_C_COMPLEX:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_DOUBLE_PRECISION:
+        case MPI_COMPLEX:
+        case MPI_REAL8:
+        case MPI_COMPLEX8:
+#endif /* HAVE_FORTRAN_BINDING */
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_FLOAT_COMPLEX:
+#endif /* HAVE_CXX_BINDING */
+            PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
+                                       typerep_float64_t);
+            break;
+
+        case MPI_C_DOUBLE_COMPLEX:
+        case MPI_LONG_DOUBLE:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_DOUBLE_COMPLEX:
+        case MPI_COMPLEX16:
+#endif /* HAVE_FORTRAN_BINDING */
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_DOUBLE_COMPLEX:
+#endif /* HAVE_CXX_BINDING */
+            PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
+                                       typerep_float128_t);
+            break;
+
+        case MPI_C_LONG_DOUBLE_COMPLEX:
+#ifdef HAVE_FORTRAN_BINDING
+#endif /* HAVE_FORTRAN_BINDING */
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_LONG_DOUBLE_COMPLEX:
+#endif /* HAVE_CXX_BINDING */
+            PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
+                                       typerep_float256_t);
+            break;
+
+        default:
+            /* some types are handled with if-else branches, instead
+             * of a switch statement because MPICH might define them
+             * as "MPI_DATATYPE_NULL". */
+            if (datatype == MPI_REAL16) {
+                PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
+                                           typerep_float128_t);
+            } else if (datatype == MPI_COMPLEX32) {
+                PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
+                                           typerep_float256_t);
+            } else {
+                /* unsupported, including MPI_INTEGER16 */
+                assert(0);
+            }
+    }
+
+  fn_exit:
+    if (iov)
+        MPL_free(iov);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_PACK_EXTERNAL);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_unpack_external(const void *inbuf, void *outbuf, MPI_Aint outcount,
+                                 MPI_Datatype datatype, MPI_Aint * actual_unpack_bytes)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_UNPACK_EXTERNAL);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_UNPACK_EXTERNAL);
+
+    int mpi_errno = MPI_SUCCESS;
+    int rc;
+    struct iovec *iov = NULL;
+
+    assert(datatype != MPI_DATATYPE_NULL);
+
+    MPIR_Datatype *typeptr;
+    MPIR_Datatype_get_ptr(datatype, typeptr);
+
+    *actual_unpack_bytes = typeptr->size * outcount;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(datatype);
+
+    /* convert type to IOV */
+    uintptr_t max_iov_len;
+    rc = yaksa_iov_len(outcount, type, &max_iov_len);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    uintptr_t actual_iov_len;
+    iov = MPL_malloc(max_iov_len * sizeof(struct iovec), MPL_MEM_DATATYPE);
+    rc = yaksa_iov(outbuf, outcount, type, 0, iov, max_iov_len, &actual_iov_len);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    assert(max_iov_len == actual_iov_len);
+    assert(typeptr->basic_type != MPI_DATATYPE_NULL);
+
+    MPI_Aint basic_type;
+    if (HANDLE_IS_BUILTIN(datatype)) {
+        basic_type = datatype;
+    } else {
+        basic_type = typeptr->basic_type;
+    }
+
+    MPI_Aint basic_type_size;
+    MPIR_Datatype_get_size_macro(basic_type, basic_type_size);
+
+    /* destination sizes are fixed in external32 packing, so we always
+     * map each type to a fixed type.  See table 13.2 in the MPI-3.1
+     * specification (page 540). */
+    /* we do not need to distinguish between signed and unsigned types
+     * because their bit representations are identical for
+     * pack/unpack. */
+    switch (basic_type) {
+        case MPI_PACKED:
+        case MPI_BYTE:
+        case MPI_INT8_T:
+        case MPI_UINT8_T:
+        case MPI_CHAR:
+        case MPI_UNSIGNED_CHAR:
+        case MPI_SIGNED_CHAR:
+        case MPI_C_BOOL:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_CHARACTER:
+        case MPI_INTEGER1:
+#endif /* HAVE_FORTRAN_BINDING */
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_BOOL:
+#endif /* HAVE_CXX_BINDING */
+            UNPACK_EXTERNAL_INT_MAPPED(inbuf, iov, max_iov_len, basic_type_size, int8_t);
+            break;
+
+        case MPI_WCHAR:
+        case MPI_SHORT:
+        case MPI_UNSIGNED_SHORT:
+        case MPI_INT16_T:
+        case MPI_UINT16_T:
+        case MPI_COUNT:
+        case MPI_OFFSET:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_INTEGER2:
+#endif /* HAVE_FORTRAN_BINDING */
+            UNPACK_EXTERNAL_INT_MAPPED(inbuf, iov, max_iov_len, basic_type_size, int16_t);
+            break;
+
+        case MPI_INT:
+        case MPI_UNSIGNED:
+        case MPI_LONG:
+        case MPI_UNSIGNED_LONG:
+        case MPI_INT32_T:
+        case MPI_UINT32_T:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_LOGICAL:
+        case MPI_INTEGER:
+        case MPI_INTEGER4:
+#endif /* HAVE_FORTRAN_BINDING */
+            UNPACK_EXTERNAL_INT_MAPPED(inbuf, iov, max_iov_len, basic_type_size, int32_t);
+            break;
+
+        case MPI_LONG_LONG:
+        case MPI_UNSIGNED_LONG_LONG:
+        case MPI_INT64_T:
+        case MPI_UINT64_T:
+        case MPI_AINT:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_INTEGER8:
+#endif /* HAVE_FORTRAN_BINDING */
+            UNPACK_EXTERNAL_INT_MAPPED(inbuf, iov, max_iov_len, basic_type_size, int64_t);
+            break;
+
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_FLOAT:
+        case MPI_REAL:
+        case MPI_REAL4:
+            UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
+                                         typerep_float32_t);
+            break;
+#endif /* HAVE_FORTRAN_BINDING */
+
+        case MPI_DOUBLE:
+        case MPI_C_COMPLEX:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_DOUBLE_PRECISION:
+        case MPI_COMPLEX:
+        case MPI_REAL8:
+        case MPI_COMPLEX8:
+#endif /* HAVE_FORTRAN_BINDING */
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_FLOAT_COMPLEX:
+#endif /* HAVE_CXX_BINDING */
+            UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
+                                         typerep_float64_t);
+            break;
+
+        case MPI_C_DOUBLE_COMPLEX:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_DOUBLE_COMPLEX:
+        case MPI_LONG_DOUBLE:
+        case MPI_COMPLEX16:
+#endif /* HAVE_FORTRAN_BINDING */
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_DOUBLE_COMPLEX:
+#endif /* HAVE_CXX_BINDING */
+            UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
+                                         typerep_float128_t);
+            break;
+
+        case MPI_C_LONG_DOUBLE_COMPLEX:
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_LONG_DOUBLE_COMPLEX:
+#endif /* HAVE_CXX_BINDING */
+            UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
+                                         typerep_float256_t);
+            break;
+
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_INTEGER16:
+#endif /* HAVE_FORTRAN_BINDING */
+        default:
+            /* some types are handled with if-else branches, instead
+             * of a switch statement because MPICH might define them
+             * as "MPI_DATATYPE_NULL". */
+            if (datatype == MPI_REAL16) {
+                UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
+                                             typerep_float128_t);
+            } else if (datatype == MPI_COMPLEX32) {
+                UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
+                                             typerep_float256_t);
+            } else {
+                /* unsupported, including MPI_INTEGER16 */
+                assert(0);
+            }
+    }
+
+  fn_exit:
+    if (iov)
+        MPL_free(iov);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_UNPACK_EXTERNAL);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_size_external32(MPI_Datatype type)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_SIZE_EXTERNAL32);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_SIZE_EXTERNAL32);
+
+    int size;
+
+    assert(type != MPI_DATATYPE_NULL);
+
+    MPIR_Datatype *typeptr;
+    MPIR_Datatype_get_ptr(type, typeptr);
+
+    MPI_Aint basic_type;
+    if (HANDLE_IS_BUILTIN(type)) {
+        basic_type = type;
+    } else {
+        basic_type = typeptr->basic_type;
+    }
+
+    MPI_Aint basic_type_size;
+    MPIR_Datatype_get_size_macro(basic_type, basic_type_size);
+
+    size = typeptr->size / basic_type_size;
+
+    switch (basic_type) {
+        case MPI_PACKED:
+        case MPI_BYTE:
+        case MPI_INT8_T:
+        case MPI_UINT8_T:
+        case MPI_CHAR:
+        case MPI_UNSIGNED_CHAR:
+        case MPI_SIGNED_CHAR:
+        case MPI_C_BOOL:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_CHARACTER:
+        case MPI_INTEGER1:
+#endif /* HAVE_FORTRAN_BINDING */
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_BOOL:
+#endif /* HAVE_CXX_BINDING */
+            size *= 1;
+            break;
+
+        case MPI_WCHAR:
+        case MPI_SHORT:
+        case MPI_UNSIGNED_SHORT:
+        case MPI_INT16_T:
+        case MPI_UINT16_T:
+        case MPI_COUNT:
+        case MPI_OFFSET:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_INTEGER2:
+#endif /* HAVE_FORTRAN_BINDING */
+            size *= 2;
+            break;
+
+        case MPI_INT:
+        case MPI_UNSIGNED:
+        case MPI_LONG:
+        case MPI_UNSIGNED_LONG:
+        case MPI_INT32_T:
+        case MPI_UINT32_T:
+        case MPI_FLOAT:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_LOGICAL:
+        case MPI_INTEGER:
+        case MPI_INTEGER4:
+        case MPI_REAL:
+        case MPI_REAL4:
+#endif /* HAVE_FORTRAN_BINDING */
+            size *= 4;
+            break;
+
+        case MPI_LONG_LONG:
+        case MPI_UNSIGNED_LONG_LONG:
+        case MPI_INT64_T:
+        case MPI_UINT64_T:
+        case MPI_AINT:
+        case MPI_INTEGER8:
+        case MPI_DOUBLE:
+        case MPI_C_COMPLEX:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_DOUBLE_PRECISION:
+        case MPI_COMPLEX:
+        case MPI_REAL8:
+        case MPI_COMPLEX8:
+#endif /* HAVE_FORTRAN_BINDING */
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_FLOAT_COMPLEX:
+#endif /* HAVE_CXX_BINDING */
+            size *= 8;
+            break;
+
+        case MPI_C_DOUBLE_COMPLEX:
+        case MPI_LONG_DOUBLE:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_DOUBLE_COMPLEX:
+        case MPI_COMPLEX16:
+#endif /* HAVE_FORTRAN_BINDING */
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_DOUBLE_COMPLEX:
+#endif /* HAVE_CXX_BINDING */
+            size *= 16;
+            break;
+
+        case MPI_C_LONG_DOUBLE_COMPLEX:
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_LONG_DOUBLE_COMPLEX:
+#endif /* HAVE_CXX_BINDING */
+            size *= 32;
+            break;
+
+        default:
+            /* some types are handled with if-else branches, instead
+             * of a switch statement because MPICH might define them
+             * as "MPI_DATATYPE_NULL". */
+            if (type == MPI_REAL16)
+                size *= 16;
+            else if (type == MPI_COMPLEX32)
+                size *= 32;
+            else if (type == MPI_INTEGER16)
+                size *= 16;
+            else
+                assert(0);
+    }
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_SIZE_EXTERNAL32);
+    return size;
+}

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -163,7 +163,6 @@ int MPI_Finalize(void)
 
     MPII_hwtopo_finalize();
     MPII_nettopo_finalize();
-    yaksa_finalize();
 
     /* Users did not call MPI_T_init_thread(), so we free memories allocated to
      * MPIR_T during MPI_Init here. Otherwise, free them in MPI_T_finalize() */

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -109,7 +109,6 @@ int MPIR_Init_thread(int *argc, char ***argv, int user_required, int *provided)
     MPII_init_binding_fortran();
     MPII_init_binding_cxx();
     MPII_init_binding_f08();
-    yaksa_init();
 
     mpi_errno = MPII_init_local_proc_attrs(&required);
     MPIR_ERR_CHECK(mpi_errno);


### PR DESCRIPTION
## Pull Request Description

This PR integrates the yaksa library into mpich, behind the typerep interface.  It redirects all typerep calls to the yaksa API.  For the cases where yaksa doesn't provide direct support, the typerep glue layer adds the necessary functionality.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
