### PR TITLE
ch3/nemesis: flatten MPID_nem_cell_t

### DIFF
--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
@@ -132,35 +132,17 @@ typedef struct MPID_nem_queue
 } MPID_nem_queue_t, *MPID_nem_queue_ptr_t;
 
 /* Fast Boxes*/ 
-typedef union
+typedef struct MPID_nem_fastbox_t
 {
-    MPL_atomic_int_t value;
-#if MPID_NEM_CACHE_LINE_LEN != 0
-    char padding[MPID_NEM_CACHE_LINE_LEN];
-#endif
-}
-MPID_nem_opt_volint_t;
-
-typedef struct MPID_nem_fbox_common
-{
-    MPID_nem_opt_volint_t  flag;
-} MPID_nem_fbox_common_t, *MPID_nem_fbox_common_ptr_t;
-
-typedef struct MPID_nem_fbox_mpich
-{
-    MPID_nem_opt_volint_t flag;
-    MPID_nem_cell_t cell;
-} MPID_nem_fbox_mpich_t;
-
-#define MPID_NEM_FBOX_LEN     (MPID_NEM_CELL_LEN + offsetof(MPID_nem_fbox_mpich_t, cell))
-#define MPID_NEM_FBOX_DATALEN MPID_NEM_MPICH_DATA_LEN
-
-typedef union 
-{
-    MPID_nem_fbox_common_t common;
-    MPID_nem_fbox_mpich_t mpich;
+    MPL_atomic_int_t flag;
+    char content[];  /* content is a placeholder for cacheline padding and MPID_nem_cell_t */
 } MPID_nem_fastbox_t;
 
+#define MPID_NEM_FBOX_TO_CELL(fbox_ptr_) \
+    ((MPID_nem_cell_t *)((char *)(fbox_ptr_) + MPID_NEM_CACHE_LINE_LEN))
+
+#define MPID_NEM_FBOX_LEN     (MPID_NEM_CELL_LEN + MPID_NEM_CACHE_LINE_LEN)
+#define MPID_NEM_FBOX_DATALEN MPID_NEM_MPICH_DATA_LEN
 
 typedef struct MPID_nem_fbox_arrays
 {

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
@@ -44,15 +44,13 @@
 
    --CELL------------------
    | next                 |
-   | padding              |
-   | --MPICH PKT-------- |
-   | | packet headers   | |
-   | | packet payload   | |
-   | |   .              | |
-   | |   .              | |
-   | |   .              | |
-   | |                  | |
-   | -------------------- |
+   | packet headers       |
+   | [padding]            |
+   | packet payload       |  -- 8-byte aligned
+   |     .                |
+   |     .                |
+   |     .                |
+   |                      |
    ------------------------
 
    For optimization, we want the cell to start at a cacheline boundary
@@ -60,36 +58,20 @@
    avoid false sharing.  We also want payload to start at an 8-byte
    boundary to to optimize memcpys and datatype operations on the
    payload.  To ensure payload is 8-byte aligned, we add aligned attribute
-   to the pkt field.
-
-   Forgive the misnomers of the macros.
+   to the payload field.
 
    MPID_NEM_CELL_LEN size of the whole cell (currently 64K)
-   
-   MPID_NEM_CELL_HEAD_LEN is the size of the next pointer plus the
-       padding.
    
    MPID_NEM_CELL_PAYLOAD_LEN is the maximum length of the packet.
        This is MPID_NEM_CELL_LEN minus the size of the next pointer
        and any padding.
 
-   MPID_NEM_MPICH_HEAD_LEN is the length of the mpich packet header
-       fields.
-
    MPID_NEM_MPICH_DATA_LEN is the maximum length of the mpich packet
-       payload and is basically what's left after the next pointer,
-       padding and packet header.  This is MPID_NEM_CELL_PAYLOAD_LEN -
-       MPID_NEM_MPICH_HEAD_LEN.
-
-   MPID_NEM_CALC_CELL_LEN is the amount of data plus headers in the
-       cell.  I.e., how much of a cell would need to be sent over a
-       network.
+       payload and is basically what's payload to the end of cell.
 */
 
-#define MPID_NEM_CELL_HEAD_LEN    offsetof(MPID_nem_cell_t, pkt)
-#define MPID_NEM_CELL_PAYLOAD_LEN (MPID_NEM_CELL_LEN - MPID_NEM_CELL_HEAD_LEN)
-
-#define MPID_NEM_CALC_CELL_LEN(cellp) (MPID_NEM_CELL_HEAD_LEN + MPID_NEM_MPICH_HEAD_LEN + MPID_NEM_CELL_DLEN (cell))
+#define MPID_NEM_CELL_PAYLOAD_LEN (MPID_NEM_CELL_LEN - offsetof(MPID_nem_cell_t, header))
+#define MPID_NEM_MPICH_DATA_LEN   (MPID_NEM_CELL_LEN - offsetof(MPID_nem_cell_t, payload))
 
 #define MPID_NEM_ALIGNED(addr, bytes) ((((unsigned long)addr) & (((unsigned long)bytes)-1)) == 0)
 
@@ -97,16 +79,11 @@
 #define MPID_NEM_PKT_MPICH      1
 #define MPID_NEM_PKT_MPICH_HEAD 2
 
-#define MPID_NEM_FBOX_SOURCE(cell) (MPID_nem_mem_region.local_procs[(cell)->pkt.header.source])
-#define MPID_NEM_CELL_SOURCE(cell) ((cell)->pkt.header.source)
-#define MPID_NEM_CELL_DEST(cell)   ((cell)->pkt.header.dest)
-#define MPID_NEM_CELL_DLEN(cell)   ((cell)->pkt.header.datalen)
-#define MPID_NEM_CELL_SEQN(cell)   ((cell)->pkt.header.seqno)
-
-#define MPID_NEM_MPICH_HEAD_LEN sizeof(MPID_nem_pkt_header_t)
-#define MPID_NEM_MPICH_DATA_LEN (MPID_NEM_CELL_PAYLOAD_LEN - MPID_NEM_MPICH_HEAD_LEN)
-
-#define MPID_NEM_PKT_HEADER_FIELDS   	    \
+#define MPID_NEM_FBOX_SOURCE(cell) (MPID_nem_mem_region.local_procs[(cell)->header.source])
+#define MPID_NEM_CELL_SOURCE(cell) ((cell)->header.source)
+#define MPID_NEM_CELL_DEST(cell)   ((cell)->header.dest)
+#define MPID_NEM_CELL_DLEN(cell)   ((cell)->header.datalen)
+#define MPID_NEM_CELL_SEQN(cell)   ((cell)->header.seqno)
 
 typedef struct MPID_nem_pkt_header
 {
@@ -116,12 +93,6 @@ typedef struct MPID_nem_pkt_header
     unsigned short seqno;
     unsigned short type; /* currently used only with checkpointing */
 } MPID_nem_pkt_header_t;
-
-typedef struct MPID_nem_pkt
-{
-    MPID_nem_pkt_header_t header;
-    char payload[] MPL_ATTR_ALIGNED(8);   /* C99 flexible array member with 8-byte alignment */
-} MPID_nem_pkt_t;
 
 /* Nemesis cells which are to be used in shared memory need to use
  * "relative pointers" because the absolute pointers to a cell from
@@ -146,7 +117,8 @@ MPID_nem_cell_rel_ptr_t;
 typedef struct MPID_nem_cell
 {
     MPID_nem_cell_rel_ptr_t next;
-    volatile MPID_nem_pkt_t pkt MPL_ATTR_ALIGNED(8);
+    volatile MPID_nem_pkt_header_t header;
+    volatile char payload[] MPL_ATTR_ALIGNED(8);   /* C99 flexible array member with 8-byte alignment */
 } MPID_nem_cell_t;
 typedef MPID_nem_cell_t *MPID_nem_cell_ptr_t;
 

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
@@ -150,20 +150,6 @@ typedef struct MPID_nem_cell
 } MPID_nem_cell_t;
 typedef MPID_nem_cell_t *MPID_nem_cell_ptr_t;
 
-#define MPID_NEM_CELL_TO_PACKET(cellp) (&(cellp)->pkt)
-#define MPID_NEM_PACKET_TO_CELL(packetp) \
-    ((MPID_nem_cell_ptr_t) ((char*)(packetp) - (char *)MPID_NEM_CELL_TO_PACKET((MPID_nem_cell_ptr_t)0)))
-#define MPID_NEM_MIN_PACKET_LEN (sizeof (MPID_nem_pkt_header_t))
-#define MPID_NEM_MAX_PACKET_LEN (MPID_NEM_CELL_PAYLOAD_LEN)
-#define MPID_NEM_PACKET_LEN(pkt) ((pkt)->header.datalen + MPID_NEM_MPICH_HEAD_LEN)
-
-#define MPID_NEM_OPT_LOAD     16 
-#define MPID_NEM_OPT_SIZE     ((sizeof(MPIDI_CH3_Pkt_t)) + (MPID_NEM_OPT_LOAD))
-#define MPID_NEM_OPT_HEAD_LEN ((MPID_NEM_MPICH_HEAD_LEN) + (MPID_NEM_OPT_SIZE))
-
-#define MPID_NEM_PACKET_OPT_LEN(pkt) \
-    (((pkt)->header.datalen < MPID_NEM_OPT_SIZE) ? (MPID_NEM_OPT_HEAD_LEN) : (MPID_NEM_PACKET_LEN(pkt)))
-
 typedef struct MPID_nem_queue
 {
     MPID_nem_cell_rel_ptr_t head;

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_fbox.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_fbox.h
@@ -12,7 +12,7 @@ typedef struct MPID_nem_fboxq_elem
   struct MPID_nem_fboxq_elem *prev;
   struct MPID_nem_fboxq_elem *next;
   int grank;
-  MPID_nem_fbox_mpich_t *fbox;
+  MPID_nem_fastbox_t *fbox;
 } MPID_nem_fboxq_elem_t ;
 
 extern MPID_nem_fboxq_elem_t *MPID_nem_fboxq_head;
@@ -35,15 +35,17 @@ static inline int poll_active_fboxes(MPID_nem_cell_ptr_t *cell)
         orig_fboxq_elem = MPID_nem_curr_fboxq_elem;
         do
         {
-            MPID_nem_fbox_mpich_t *fbox;
+            MPID_nem_fastbox_t *fbox;
+            MPID_nem_cell_t *cell_ptr;
 
             fbox = MPID_nem_curr_fboxq_elem->fbox;
             MPIR_Assert(fbox != NULL);
-            if (MPL_atomic_acquire_load_int(&fbox->flag.value) &&
-                fbox->cell.header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fboxq_elem->grank])
+            cell_ptr = MPID_NEM_FBOX_TO_CELL(fbox);
+            if (MPL_atomic_acquire_load_int(&fbox->flag) &&
+                cell_ptr->header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fboxq_elem->grank])
             {
                 ++MPID_nem_recv_seqno[MPID_nem_curr_fboxq_elem->grank];
-                *cell = &fbox->cell;
+                *cell = cell_ptr;
                 found = TRUE;
                 goto fn_exit;
             }
@@ -62,15 +64,17 @@ fn_exit:
 static inline int poll_every_fbox(MPID_nem_cell_ptr_t *cell)
 {
     MPID_nem_fboxq_elem_t *orig_fbox_el = MPID_nem_curr_fbox_all_poll;
-    MPID_nem_fbox_mpich_t *fbox;
+    MPID_nem_fastbox_t *fbox;
+    MPID_nem_cell_t *cell_ptr;
     int found = FALSE;
 
     do {
         fbox = MPID_nem_curr_fbox_all_poll->fbox;
-        if (fbox && MPL_atomic_acquire_load_int(&fbox->flag.value) &&
-            fbox->cell.header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank]) {
+        cell_ptr = MPID_NEM_FBOX_TO_CELL(fbox);
+        if (fbox && MPL_atomic_acquire_load_int(&fbox->flag) &&
+            cell_ptr->header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank]) {
             ++MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank];
-            *cell = &fbox->cell;
+            *cell = cell_ptr;
             found = TRUE;
             break;
         }
@@ -85,14 +89,16 @@ static inline int poll_every_fbox(MPID_nem_cell_ptr_t *cell)
 
 #define poll_next_fbox(_cell, do_found)                                                             \
     do {                                                                                            \
-        MPID_nem_fbox_mpich_t *fbox;                                                               \
+        MPID_nem_fastbox_t *fbox;                                                               \
+        MPID_nem_cell_t *cell_ptr;                                                                  \
                                                                                                     \
         fbox = MPID_nem_curr_fbox_all_poll->fbox;                                                   \
-        if (fbox && MPL_atomic_acquire_load_int(&fbox->flag.value) &&                               \
-            fbox->cell.header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank]) \
+        cell_ptr = MPID_NEM_FBOX_TO_CELL(fbox);                                                     \
+        if (fbox && MPL_atomic_acquire_load_int(&fbox->flag) &&                               \
+            cell_ptr->header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank])      \
         {                                                                                           \
             ++MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank];                              \
-            *(_cell) = &fbox->cell;                                                                 \
+            *(_cell) = cell_ptr;                                                                    \
             do_found;                                                                               \
         }                                                                                           \
         ++MPID_nem_curr_fbox_all_poll;                                                              \

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_fbox.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_fbox.h
@@ -40,7 +40,7 @@ static inline int poll_active_fboxes(MPID_nem_cell_ptr_t *cell)
             fbox = MPID_nem_curr_fboxq_elem->fbox;
             MPIR_Assert(fbox != NULL);
             if (MPL_atomic_acquire_load_int(&fbox->flag.value) &&
-                fbox->cell.pkt.header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fboxq_elem->grank])
+                fbox->cell.header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fboxq_elem->grank])
             {
                 ++MPID_nem_recv_seqno[MPID_nem_curr_fboxq_elem->grank];
                 *cell = &fbox->cell;
@@ -68,7 +68,7 @@ static inline int poll_every_fbox(MPID_nem_cell_ptr_t *cell)
     do {
         fbox = MPID_nem_curr_fbox_all_poll->fbox;
         if (fbox && MPL_atomic_acquire_load_int(&fbox->flag.value) &&
-            fbox->cell.pkt.header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank]) {
+            fbox->cell.header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank]) {
             ++MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank];
             *cell = &fbox->cell;
             found = TRUE;
@@ -89,7 +89,7 @@ static inline int poll_every_fbox(MPID_nem_cell_ptr_t *cell)
                                                                                                     \
         fbox = MPID_nem_curr_fbox_all_poll->fbox;                                                   \
         if (fbox && MPL_atomic_acquire_load_int(&fbox->flag.value) &&                               \
-            fbox->cell.pkt.header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank]) \
+            fbox->cell.header.seqno == MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank]) \
         {                                                                                           \
             ++MPID_nem_recv_seqno[MPID_nem_curr_fbox_all_poll->grank];                              \
             *(_cell) = &fbox->cell;                                                                 \

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_impl.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_impl.h
@@ -34,13 +34,13 @@ int MPID_nem_lmt_RndvRecv(struct MPIDI_VC *vc, MPIR_Request *rreq);
 
 #define MPID_nem_mpich_release_fbox(cell)                               \
     do {                                                                \
-        MPL_atomic_release_store_int(&MPID_nem_mem_region.mailboxes.in[(cell)->header.source]->mpich.flag.value, 0); \
+        MPL_atomic_release_store_int(&MPID_nem_mem_region.mailboxes.in[(cell)->header.source]->flag, 0); \
     } while (0)
 
-/* assumes value!=0 means the fbox is full.  Contains acquire barrier to
+/* assumes flag!=0 means the fbox is full.  Contains acquire barrier to
  * ensure that later operations that are dependent on this check don't
  * escape earlier than this check. */
-#define MPID_nem_fbox_is_full(pbox_) (MPL_atomic_acquire_load_int(&(pbox_)->flag.value))
+#define MPID_nem_fbox_is_full(pbox_) (MPL_atomic_acquire_load_int(&(pbox_)->flag))
 
 typedef struct MPID_nem_pkt_lmt_rts
 {

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_impl.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_impl.h
@@ -34,7 +34,7 @@ int MPID_nem_lmt_RndvRecv(struct MPIDI_VC *vc, MPIR_Request *rreq);
 
 #define MPID_nem_mpich_release_fbox(cell)                               \
     do {                                                                \
-        MPL_atomic_release_store_int(&MPID_nem_mem_region.mailboxes.in[(cell)->pkt.header.source]->mpich.flag.value, 0); \
+        MPL_atomic_release_store_int(&MPID_nem_mem_region.mailboxes.in[(cell)->header.source]->mpich.flag.value, 0); \
     } while (0)
 
 /* assumes value!=0 means the fbox is full.  Contains acquire barrier to

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
@@ -118,13 +118,13 @@ MPID_nem_mpich_send_header (void* buf, int size, MPIDI_VC_t *vc, int *again)
         if (MPID_nem_fbox_is_full((MPID_nem_fbox_common_ptr_t)pbox))
             goto usequeue_l;
 
-        pbox->cell.pkt.header.source  = MPID_nem_mem_region.local_rank;
-        pbox->cell.pkt.header.datalen = size;
-        pbox->cell.pkt.header.seqno   = vc_ch->send_seqno++;
+        pbox->cell.header.source  = MPID_nem_mem_region.local_rank;
+        pbox->cell.header.datalen = size;
+        pbox->cell.header.seqno   = vc_ch->send_seqno++;
         
-        MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, pbox->cell.pkt.header.type = MPID_NEM_PKT_MPICH_HEAD);
+        MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, pbox->cell.header.type = MPID_NEM_PKT_MPICH_HEAD);
         
-        MPIR_Memcpy((void *)pbox->cell.pkt.payload, buf, size);
+        MPIR_Memcpy((void *)pbox->cell.payload, buf, size);
 
         MPL_atomic_release_store_int(&pbox->flag.value, 1);
 
@@ -164,13 +164,13 @@ MPID_nem_mpich_send_header (void* buf, int size, MPIDI_VC_t *vc, int *again)
 #endif /* PREFETCH_CELL */
 
     DO_PAPI (PAPI_reset (PAPI_EventSet));
-    el->pkt.header.source  = my_rank;
-    el->pkt.header.dest    = vc->lpid;
-    el->pkt.header.datalen = size;
-    el->pkt.header.seqno   = vc_ch->send_seqno++;
-    MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, el->pkt.header.type = MPID_NEM_PKT_MPICH_HEAD);
+    el->header.source  = my_rank;
+    el->header.dest    = vc->lpid;
+    el->header.datalen = size;
+    el->header.seqno   = vc_ch->send_seqno++;
+    MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, el->header.type = MPID_NEM_PKT_MPICH_HEAD);
     
-    MPIR_Memcpy((void *)el->pkt.payload, buf, size);
+    MPIR_Memcpy((void *)el->payload, buf, size);
     DO_PAPI (PAPI_accum_var (PAPI_EventSet, PAPI_vvalues11));
 
     MPL_DBG_MSG (MPIDI_CH3_DBG_CHANNEL, VERBOSE, "--> Sent queue");
@@ -260,7 +260,7 @@ MPID_nem_mpich_sendv (struct iovec **iov, int *n_iov, MPIDI_VC_t *vc, int *again
 #endif /*PREFETCH_CELL     */
 
     payload_len = MPID_NEM_MPICH_DATA_LEN;
-    cell_buf    = (char *) el->pkt.payload; /* cast away volatile */
+    cell_buf    = (char *) el->payload; /* cast away volatile */
     
     while (*n_iov && payload_len >= (*iov)->iov_len)
     {
@@ -280,11 +280,11 @@ MPID_nem_mpich_sendv (struct iovec **iov, int *n_iov, MPIDI_VC_t *vc, int *again
  	payload_len = 0;
     }
 
-    el->pkt.header.source  = my_rank;
-    el->pkt.header.dest    = vc->lpid;
-    el->pkt.header.datalen = MPID_NEM_MPICH_DATA_LEN - payload_len;
-    el->pkt.header.seqno   = vc_ch->send_seqno++;
-    MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, el->pkt.header.type = MPID_NEM_PKT_MPICH);
+    el->header.source  = my_rank;
+    el->header.dest    = vc->lpid;
+    el->header.datalen = MPID_NEM_MPICH_DATA_LEN - payload_len;
+    el->header.seqno   = vc_ch->send_seqno++;
+    MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, el->header.type = MPID_NEM_PKT_MPICH);
 
     MPL_DBG_MSG (MPIDI_CH3_DBG_CHANNEL, VERBOSE, "--> Sent queue");
     MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, MPID_nem_dbg_dump_cell (el));
@@ -343,13 +343,13 @@ MPID_nem_mpich_sendv_header (struct iovec **iov, int *n_iov, MPIDI_VC_t *vc, int
         if (MPID_nem_fbox_is_full((MPID_nem_fbox_common_ptr_t)pbox))
             goto usequeue_l;
 
-        pbox->cell.pkt.header.source  = MPID_nem_mem_region.local_rank;
-        pbox->cell.pkt.header.datalen = (*iov)[1].iov_len + sizeof(MPIDI_CH3_Pkt_t);
-        pbox->cell.pkt.header.seqno   = vc_ch->send_seqno++;
-        MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, pbox->cell.pkt.header.type = MPID_NEM_PKT_MPICH_HEAD);
+        pbox->cell.header.source  = MPID_nem_mem_region.local_rank;
+        pbox->cell.header.datalen = (*iov)[1].iov_len + sizeof(MPIDI_CH3_Pkt_t);
+        pbox->cell.header.seqno   = vc_ch->send_seqno++;
+        MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, pbox->cell.header.type = MPID_NEM_PKT_MPICH_HEAD);
         
-        MPIR_Memcpy((void *)pbox->cell.pkt.payload, (*iov)[0].iov_base, (*iov)[0].iov_len);
-        MPIR_Memcpy ((char *)pbox->cell.pkt.payload + (*iov)[0].iov_len, (*iov)[1].iov_base, (*iov)[1].iov_len);
+        MPIR_Memcpy((void *)pbox->cell.payload, (*iov)[0].iov_base, (*iov)[0].iov_len);
+        MPIR_Memcpy ((char *)pbox->cell.payload + (*iov)[0].iov_len, (*iov)[1].iov_base, (*iov)[1].iov_len);
         
         MPL_atomic_release_store_int(&pbox->flag.value, 1);
         *n_iov = 0;
@@ -387,10 +387,10 @@ MPID_nem_mpich_sendv_header (struct iovec **iov, int *n_iov, MPIDI_VC_t *vc, int
     MPID_nem_queue_dequeue (MPID_nem_mem_region.my_freeQ, &el);
 #endif /*PREFETCH_CELL */
 
-    MPIR_Memcpy((void *)el->pkt.payload, (*iov)->iov_base, sizeof(MPIDI_CH3_Pkt_t));
+    MPIR_Memcpy((void *)el->payload, (*iov)->iov_base, sizeof(MPIDI_CH3_Pkt_t));
     buf_offset += sizeof(MPIDI_CH3_Pkt_t);
 
-    cell_buf = (char *)(el->pkt.payload) + buf_offset;
+    cell_buf = (char *)(el->payload) + buf_offset;
     ++(*iov);
     --(*n_iov);
 
@@ -413,11 +413,11 @@ MPID_nem_mpich_sendv_header (struct iovec **iov, int *n_iov, MPIDI_VC_t *vc, int
 	payload_len = 0;
     }
 
-    el->pkt.header.source  = my_rank;
-    el->pkt.header.dest    = vc->lpid;
-    el->pkt.header.datalen = MPID_NEM_MPICH_DATA_LEN - payload_len;
-    el->pkt.header.seqno   = vc_ch->send_seqno++;
-    MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, el->pkt.header.type = MPID_NEM_PKT_MPICH_HEAD);
+    el->header.source  = my_rank;
+    el->header.dest    = vc->lpid;
+    el->header.datalen = MPID_NEM_MPICH_DATA_LEN - payload_len;
+    el->header.seqno   = vc_ch->send_seqno++;
+    MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, el->header.type = MPID_NEM_PKT_MPICH_HEAD);
 
     MPL_DBG_MSG (MPIDI_CH3_DBG_CHANNEL, VERBOSE, "--> Sent queue");
     MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, MPID_nem_dbg_dump_cell (el));
@@ -500,18 +500,18 @@ MPID_nem_mpich_send_seg_header (void *buf, MPI_Aint count, MPI_Datatype datatype
             goto usequeue_l;
 
 	{
-	    pbox->cell.pkt.header.source  = MPID_nem_mem_region.local_rank;
-	    pbox->cell.pkt.header.datalen = sizeof(MPIDI_CH3_Pkt_t) + msgsize;
-	    pbox->cell.pkt.header.seqno   = vc_ch->send_seqno++;
-            MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, pbox->cell.pkt.header.type = MPID_NEM_PKT_MPICH_HEAD);
+	    pbox->cell.header.source  = MPID_nem_mem_region.local_rank;
+	    pbox->cell.header.datalen = sizeof(MPIDI_CH3_Pkt_t) + msgsize;
+	    pbox->cell.header.seqno   = vc_ch->send_seqno++;
+            MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, pbox->cell.header.type = MPID_NEM_PKT_MPICH_HEAD);
 
             /* copy header */
-            MPIR_Memcpy((void *)pbox->cell.pkt.payload, header, header_sz);
+            MPIR_Memcpy((void *)pbox->cell.payload, header, header_sz);
             
             /* copy data */
             MPI_Aint actual_pack_bytes;
             MPIR_Typerep_pack(buf, count, datatype, *msg_offset,
-                           (char *)pbox->cell.pkt.payload + sizeof(MPIDI_CH3_Pkt_t),
+                           (char *)pbox->cell.payload + sizeof(MPIDI_CH3_Pkt_t),
                            msgsize - *msg_offset, &actual_pack_bytes);
             MPIR_Assert(actual_pack_bytes == msgsize - *msg_offset);
 
@@ -554,7 +554,7 @@ MPID_nem_mpich_send_seg_header (void *buf, MPI_Aint count, MPI_Datatype datatype
 #endif /*PREFETCH_CELL */
 
     /* copy header */
-    MPIR_Memcpy((void *)el->pkt.payload, header, header_sz);
+    MPIR_Memcpy((void *)el->payload, header, header_sz);
     
     buf_offset += sizeof(MPIDI_CH3_Pkt_t);
 
@@ -566,16 +566,16 @@ MPID_nem_mpich_send_seg_header (void *buf, MPI_Aint count, MPI_Datatype datatype
         max_pack_bytes = MPID_NEM_MPICH_DATA_LEN - buf_offset;
 
     MPI_Aint actual_pack_bytes;
-    MPIR_Typerep_pack(buf, count, datatype, *msg_offset, (char *)el->pkt.payload + buf_offset,
+    MPIR_Typerep_pack(buf, count, datatype, *msg_offset, (char *)el->payload + buf_offset,
                    max_pack_bytes, &actual_pack_bytes);
     datalen = buf_offset + actual_pack_bytes;
     *msg_offset += actual_pack_bytes;
 
-    el->pkt.header.source  = my_rank;
-    el->pkt.header.dest    = vc->lpid;
-    el->pkt.header.datalen = datalen;
-    el->pkt.header.seqno   = vc_ch->send_seqno++;
-    MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, el->pkt.header.type = MPID_NEM_PKT_MPICH_HEAD);
+    el->header.source  = my_rank;
+    el->header.dest    = vc->lpid;
+    el->header.datalen = datalen;
+    el->header.seqno   = vc_ch->send_seqno++;
+    MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, el->header.type = MPID_NEM_PKT_MPICH_HEAD);
 
     MPL_DBG_MSG (MPIDI_CH3_DBG_CHANNEL, VERBOSE, "--> Sent queue");
     MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, MPID_nem_dbg_dump_cell (el));
@@ -652,16 +652,16 @@ MPID_nem_mpich_send_seg (void *buf, MPI_Aint count, MPI_Datatype datatype,
         max_pack_bytes = MPID_NEM_MPICH_DATA_LEN;
 
     MPI_Aint actual_pack_bytes;
-    MPIR_Typerep_pack(buf, count, datatype, *msg_offset, (char *)el->pkt.payload,
+    MPIR_Typerep_pack(buf, count, datatype, *msg_offset, (char *)el->payload,
                    max_pack_bytes, &actual_pack_bytes);
     datalen = actual_pack_bytes;
     *msg_offset += actual_pack_bytes;
     
-    el->pkt.header.source  = my_rank;
-    el->pkt.header.dest    = vc->lpid;
-    el->pkt.header.datalen = datalen;
-    el->pkt.header.seqno   = vc_ch->send_seqno++;
-    MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, el->pkt.header.type = MPID_NEM_PKT_MPICH_HEAD);
+    el->header.source  = my_rank;
+    el->header.dest    = vc->lpid;
+    el->header.datalen = datalen;
+    el->header.seqno   = vc_ch->send_seqno++;
+    MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, el->header.type = MPID_NEM_PKT_MPICH_HEAD);
 
     MPL_DBG_MSG (MPIDI_CH3_DBG_CHANNEL, VERBOSE, "--> Sent queue");
     MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, MPID_nem_dbg_dump_cell (el));
@@ -784,10 +784,10 @@ MPID_nem_recv_seqno_matches (MPID_nem_queue_ptr_t qhead)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_RECV_SEQNO_MATCHES);
 
     MPID_nem_cell_ptr_t cell = MPID_nem_queue_head(qhead);
-    source = cell->pkt.header.source;
+    source = cell->header.source;
     
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_RECV_SEQNO_MATCHES);
-    return (cell->pkt.header.seqno == MPID_nem_recv_seqno[source]);
+    return (cell->header.seqno == MPID_nem_recv_seqno[source]);
 }
 
 /*
@@ -838,7 +838,7 @@ MPID_nem_mpich_test_recv(MPID_nem_cell_ptr_t *cell, int *in_fbox, int in_blockin
     
     MPID_nem_queue_dequeue (MPID_nem_mem_region.my_recvQ, cell);
 
-    ++MPID_nem_recv_seqno[(*cell)->pkt.header.source];
+    ++MPID_nem_recv_seqno[(*cell)->header.source];
     *in_fbox = 0;
 
  fn_exit:
@@ -897,7 +897,7 @@ MPID_nem_mpich_test_recv_wait (MPID_nem_cell_ptr_t *cell, int *in_fbox, int time
     
     MPID_nem_queue_dequeue (MPID_nem_mem_region.my_recvQ, cell);
 
-    ++MPID_nem_recv_seqno[(*cell)->pkt.header.source];
+    ++MPID_nem_recv_seqno[(*cell)->header.source];
     *in_fbox = 0;
  exit_l:
     
@@ -979,7 +979,7 @@ MPID_nem_mpich_blocking_recv(MPID_nem_cell_ptr_t *cell, int *in_fbox, int comple
 
     MPID_nem_queue_dequeue (MPID_nem_mem_region.my_recvQ, cell);
 
-    ++MPID_nem_recv_seqno[(*cell)->pkt.header.source];
+    ++MPID_nem_recv_seqno[(*cell)->header.source];
     *in_fbox = 0;
 
  exit_l:    

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_queue.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_queue.h
@@ -39,7 +39,7 @@ static inline void MPID_nem_cell_init(MPID_nem_cell_ptr_t cell)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_CELL_INIT);
 
     MPID_NEM_SET_REL_NULL(cell->next);
-    memset((void *)&cell->pkt, 0, sizeof(MPID_nem_pkt_header_t));
+    memset((void *)&cell->header, 0, sizeof(MPID_nem_pkt_header_t));
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_CELL_INIT);
 }

--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_pre.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_pre.h
@@ -77,8 +77,8 @@ typedef struct MPIDI_CH3I_VC
 
     int is_local;
     unsigned short send_seqno;
-    MPID_nem_fbox_mpich_t *fbox_out;
-    MPID_nem_fbox_mpich_t *fbox_in;
+    MPID_nem_fastbox_t *fbox_out;
+    MPID_nem_fastbox_t *fbox_in;
     MPID_nem_queue_ptr_t recv_queue;
     MPID_nem_queue_ptr_t free_queue;
 

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
@@ -13,7 +13,6 @@ typedef struct MPID_nem_tcp_send_q_element {
     size_t len;                 /* number of bytes left to send */
     char *start;                /* pointer to next byte to send */
     MPID_nem_cell_ptr_t cell;
-    /*     char buf[MPID_NEM_MAX_PACKET_LEN]; *//* data to be sent */
 } MPID_nem_tcp_send_q_element_t;
 
 static struct {

--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -370,8 +370,8 @@ int MPIDI_CH3I_Progress (MPID_Progress_state *progress_state, int is_blocking)
 
             if (cell)
             {
-                char            *cell_buf    = (char *)cell->pkt.payload;
-                intptr_t   payload_len = cell->pkt.header.datalen;
+                char            *cell_buf    = (char *)cell->payload;
+                intptr_t   payload_len = cell->header.datalen;
                 MPIDI_CH3_Pkt_t *pkt         = (MPIDI_CH3_Pkt_t *)cell_buf;
 
                 /* Empty packets are not allowed */

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_debug.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_debug.c
@@ -13,11 +13,11 @@ void MPID_nem_dbg_dump_cell (volatile struct MPID_nem_cell *cell)
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_DBG_DUMP_CELL);
 
-    MPL_DBG_MSG_D (MPIR_DBG_OTHER, TERSE, "  src = %6d", cell->pkt.header.source);
-    MPL_DBG_MSG_D (MPIR_DBG_OTHER, TERSE, "  dst = %6d", cell->pkt.header.dest);
-    MPL_DBG_MSG_D (MPIR_DBG_OTHER, TERSE, "  len = %6d", (int)cell->pkt.header.datalen);
-    MPL_DBG_MSG_D (MPIR_DBG_OTHER, TERSE, "  sqn = %6d", cell->pkt.header.seqno);
-    MPL_DBG_MSG_D (MPIR_DBG_OTHER, TERSE, "  typ = %6d", cell->pkt.header.type);
+    MPL_DBG_MSG_D (MPIR_DBG_OTHER, TERSE, "  src = %6d", cell->header.source);
+    MPL_DBG_MSG_D (MPIR_DBG_OTHER, TERSE, "  dst = %6d", cell->header.dest);
+    MPL_DBG_MSG_D (MPIR_DBG_OTHER, TERSE, "  len = %6d", (int)cell->header.datalen);
+    MPL_DBG_MSG_D (MPIR_DBG_OTHER, TERSE, "  sqn = %6d", cell->header.seqno);
+    MPL_DBG_MSG_D (MPIR_DBG_OTHER, TERSE, "  typ = %6d", cell->header.type);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_DBG_DUMP_CELL);
 }

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -139,7 +139,7 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     MPIR_Assert(sizeof(MPID_nem_cell_rel_ptr_t) == sizeof(MPL_atomic_ptr_t));
 
     /* Make sure payload is aligned on 8-byte boundary */
-    MPIR_Assert(MPID_NEM_ALIGNED(&((MPID_nem_cell_t*)0)->pkt.payload[0], 8));
+    MPIR_Assert(MPID_NEM_ALIGNED(&((MPID_nem_cell_t*)0)->payload[0], 8));
     /* Make sure the padding to cacheline size in MPID_nem_queue_t works */
     MPIR_Assert(MPID_NEM_CACHE_LINE_LEN > 2 * sizeof(MPID_nem_cell_rel_ptr_t));
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -371,8 +371,8 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
 	{
 	    MPID_nem_mem_region.mailboxes.in [i] = (void *) ((char *) fastboxes_p + (MAILBOX_INDEX(i, local_rank)) * MPID_NEM_FBOX_LEN);
 	    MPID_nem_mem_region.mailboxes.out[i] = (void *) ((char *) fastboxes_p + (MAILBOX_INDEX(local_rank, i)) * MPID_NEM_FBOX_LEN);
-	    MPL_atomic_relaxed_store_int(&MPID_nem_mem_region.mailboxes.in [i]->common.flag.value, 0);
-	    MPL_atomic_relaxed_store_int(&MPID_nem_mem_region.mailboxes.out[i]->common.flag.value, 0);
+	    MPL_atomic_relaxed_store_int(&MPID_nem_mem_region.mailboxes.in [i]->flag, 0);
+	    MPL_atomic_relaxed_store_int(&MPID_nem_mem_region.mailboxes.out[i]->flag, 0);
 	}
     }
 #undef MAILBOX_INDEX
@@ -481,8 +481,8 @@ MPID_nem_vc_init (MPIDI_VC_t *vc)
     {
         MPIDI_CHANGE_VC_STATE(vc, ACTIVE);
         
-	vc_ch->fbox_out = &MPID_nem_mem_region.mailboxes.out[MPID_nem_mem_region.local_ranks[vc->lpid]]->mpich;
-	vc_ch->fbox_in = &MPID_nem_mem_region.mailboxes.in[MPID_nem_mem_region.local_ranks[vc->lpid]]->mpich;
+	vc_ch->fbox_out = MPID_nem_mem_region.mailboxes.out[MPID_nem_mem_region.local_ranks[vc->lpid]];
+	vc_ch->fbox_in = MPID_nem_mem_region.mailboxes.in[MPID_nem_mem_region.local_ranks[vc->lpid]];
 	vc_ch->recv_queue = MPID_nem_mem_region.RecvQ[vc->lpid];
 
         /* override nocontig send function */

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
@@ -50,7 +50,7 @@ MPID_nem_mpich_init(void)
         MPID_nem_fboxq_elem_list[i].prev = NULL;
         MPID_nem_fboxq_elem_list[i].next = NULL;
         MPID_nem_fboxq_elem_list[i].grank = MPID_nem_mem_region.local_procs[i];
-        MPID_nem_fboxq_elem_list[i].fbox = &MPID_nem_mem_region.mailboxes.in[i]->mpich;
+        MPID_nem_fboxq_elem_list[i].fbox = MPID_nem_mem_region.mailboxes.in[i];
     }
 	
     MPID_nem_fboxq_head = NULL;


### PR DESCRIPTION
## Pull Request Description

Currently `MPID_nem_cell_t` use a member of `MPID_nem_pkt_t`, which defines a member `payload` as C99 flexible array member. Strictly speaking, we are not allowed to nest struct with flexible array member, even though most compilers allows it. Right now only sun compiler warns on this. This PR flattens the structure so we strictly comply to the standard and squashes sun compiler's warnings.

NOTE: only the first 5 commits. The last 6 commits are contained in PR #4706 

[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
