### PR TITLE
typerep: set extent in the dataloop for resized datatype

### DIFF
--- a/src/mpi/datatype/typerep/dataloop/dataloop_create_contig.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop_create_contig.c
@@ -44,7 +44,7 @@ int MPIR_Dataloop_create_contiguous(MPI_Aint icount, MPI_Datatype oldtype, void 
 
         /* if we have a simple combination of contigs, coalesce */
         if (((old_loop_ptr->kind & MPII_DATALOOP_KIND_MASK) == MPII_DATALOOP_KIND_CONTIG)
-            && (old_size == old_extent)) {
+            && (old_size == old_extent) && (old_loop_ptr->el_size == old_loop_ptr->el_extent)) {
             /* will just copy contig and multiply count */
             apply_contig_coalescing = 1;
         }


### PR DESCRIPTION
## Pull Request Description
Resized datatype simply calls MPIR_Dataloop_dup of its sub-dataloop, but
it needs to ensure its own extent.

EDIT: Further study and understanding reveal my previous analysis was off. We always get extent from `MPIR_Datatype_get_extent_macro` on the type directly, so the resized extent does not get lost, so `MPIR_Dataloop_dup` for resized dataloop is fine. However, there is another optimization in `MPIR_Dataloop_create_contiguous` when the sub-dataloop is also contiguous and it will try to coalesce when it can. It fails to consider the case that the sub-type appears to be a compactly packed (due to resized) but the sub-dataloop is actually not. 

Let's if adding this additional check fix the issue.

Fixes issue #4483
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
