### PR TITLE
Move the typerep hook to the MPIR_Type_struct function

### DIFF
--- a/src/mpi/datatype/type_create_struct.c
+++ b/src/mpi/datatype/type_create_struct.c
@@ -58,10 +58,6 @@ int MPIR_Type_create_struct_impl(int count,
                                            ints, array_of_displacements, array_of_types);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIR_Typerep_create_struct(count, array_of_blocklengths, array_of_displacements,
-                                           array_of_types, &new_dtp->typerep);
-    MPIR_ERR_CHECK(mpi_errno);
-
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);
 
   fn_exit:

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -360,8 +360,16 @@ int MPIR_Type_struct(int count,
         new_dtp->is_contig = 0;
     }
 
+    mpi_errno = MPIR_Typerep_create_struct(count, blocklength_array, displacement_array,
+                                           oldtype_array, &new_dtp->typerep);
+    MPIR_ERR_CHECK(mpi_errno);
+
     *newtype = new_dtp->handle;
+
+  fn_exit:
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 int MPIR_Type_struct_impl(int count, const int *array_of_blocklengths,
@@ -394,10 +402,6 @@ int MPIR_Type_struct_impl(int count, const int *array_of_blocklengths,
                                            count,       /* types */
                                            ints, array_of_displacements, array_of_types);
 
-    MPIR_ERR_CHECK(mpi_errno);
-
-    mpi_errno = MPIR_Typerep_create_struct(count, array_of_blocklengths, array_of_displacements,
-                                           array_of_types, &new_dtp->typerep);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);


### PR DESCRIPTION
## Pull Request Description

The _impl function is not called in some cases, for example when darrays are being created.  The hooks are currently empty, so it doesn't matter for now.  But if someone were to use the hooks (e.g., yaksa), this would break.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
