### PR TITLE
dtpools: add more specific object creation functions

### DIFF
--- a/test/mpi/dtpools/include/dtpools.h
+++ b/test/mpi/dtpools/include/dtpools.h
@@ -37,6 +37,8 @@ int DTP_pool_free(DTP_pool_s dtp);
 
 int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize);
 int DTP_obj_create_idx(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize, int rand_idx);
+int DTP_obj_create_custom(DTP_pool_s dtp, DTP_obj_s * obj, const char *desc);
+
 int DTP_obj_free(DTP_obj_s obj);
 int DTP_obj_get_description(DTP_obj_s obj, char **desc);
 

--- a/test/mpi/dtpools/include/dtpools.h
+++ b/test/mpi/dtpools/include/dtpools.h
@@ -36,6 +36,7 @@ int DTP_pool_create(const char *basic_type_str, MPI_Aint basic_type_count, int s
 int DTP_pool_free(DTP_pool_s dtp);
 
 int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize);
+int DTP_obj_create_idx(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize, int rand_idx);
 int DTP_obj_free(DTP_obj_s obj);
 int DTP_obj_get_description(DTP_obj_s obj, char **desc);
 

--- a/test/mpi/dtpools/include/dtpools_internal.h
+++ b/test/mpi/dtpools/include/dtpools_internal.h
@@ -444,6 +444,7 @@ unsigned int DTPI_high_count(unsigned int count);
 int DTPI_construct_datatype(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s ** attr_tree,
                             MPI_Datatype * newtype, MPI_Aint * new_count);
 int DTPI_populate_dtp_desc(DTPI_obj_s * obj_priv, DTPI_pool_s * dtpi, char **desc);
+void DTPI_rand_init(DTPI_pool_s * dtpi, int seed, int rand_count);
 int DTPI_rand(DTPI_pool_s * dtpi);
 int DTPI_init_verify(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_Attr_s * attr_tree,
                      size_t buf_offset, int *val_start, int val_stride, int *rem_val_count,

--- a/test/mpi/dtpools/include/dtpools_internal.h
+++ b/test/mpi/dtpools/include/dtpools_internal.h
@@ -439,10 +439,13 @@ typedef struct {
 
 int DTPI_obj_free(DTPI_obj_s * obj_priv);
 int DTPI_parse_base_type_str(DTP_pool_s * dtp, const char *str);
+int DTPI_parse_desc(const char *desc, const char **desc_list, int *depth, int max_depth);
 unsigned int DTPI_low_count(unsigned int count);
 unsigned int DTPI_high_count(unsigned int count);
 int DTPI_construct_datatype(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s ** attr_tree,
                             MPI_Datatype * newtype, MPI_Aint * new_count);
+int DTPI_custom_datatype(DTP_pool_s dtp, DTPI_Attr_s ** attr_tree, MPI_Datatype * newtype,
+                         MPI_Aint * new_count, const char **desc_list, int depth);
 int DTPI_populate_dtp_desc(DTPI_obj_s * obj_priv, DTPI_pool_s * dtpi, char **desc);
 void DTPI_rand_init(DTPI_pool_s * dtpi, int seed, int rand_count);
 int DTPI_rand(DTPI_pool_s * dtpi);

--- a/test/mpi/dtpools/src/Makefile.am
+++ b/test/mpi/dtpools/src/Makefile.am
@@ -7,5 +7,5 @@ AM_CPPFLAGS = $(MPI_H_INCLUDE)
 AM_CPPFLAGS += -DDTP_MPI_DATATYPE=@DTP_DATATYPES@   # Coma separated list of MPI datatypes
 
 noinst_LTLIBRARIES = libdtpools.la
-libdtpools_la_SOURCES = dtpools.c dtpools_misc.c dtpools_init_verify.c dtpools_desc.c dtpools_attr.c
+libdtpools_la_SOURCES = dtpools.c dtpools_misc.c dtpools_init_verify.c dtpools_desc.c dtpools_attr.c dtpools_custom.c
 libdtpools_la_CPPFLAGS = -I$(top_srcdir)/include -I../include $(AM_CPPFLAGS)

--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -194,6 +194,59 @@ int DTP_obj_create_idx(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize, int
     goto fn_exit;
 }
 
+int DTP_obj_create_custom(DTP_pool_s dtp, DTP_obj_s * obj, const char *desc)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    DTPI_pool_s *dtpi = dtp.priv;
+    DTPI_ERR_ARG_CHECK(!dtpi, rc);
+
+    DTPI_ALLOC_OR_FAIL(obj->priv, sizeof(DTPI_obj_s), rc);
+    DTPI_obj_s *obj_priv = obj->priv;
+    obj_priv->dtp = dtp;
+    if (desc == NULL) {
+        obj_priv->attr_tree = NULL;
+        obj->DTP_datatype = dtp.DTP_base_type;
+        obj->DTP_type_count = dtpi->base_type_count;
+    } else {
+        const char *desc_parts[10];
+        int num_parts;
+        rc = DTPI_parse_desc(desc, desc_parts, &num_parts, 10);
+        DTPI_ERR_CHK_RC(rc);
+        rc = DTPI_custom_datatype(dtp, &obj_priv->attr_tree, &obj->DTP_datatype,
+                                  &obj->DTP_type_count, desc_parts, num_parts);
+        DTPI_ERR_CHK_RC(rc);
+        rc = MPI_Type_commit(&obj->DTP_datatype);
+        DTPI_ERR_CHK_MPI_RC(rc);
+    }
+
+    MPI_Aint true_lb;
+    MPI_Aint true_extent;
+    MPI_Aint lb;
+    MPI_Aint extent;
+
+    rc = MPI_Type_get_true_extent(obj->DTP_datatype, &true_lb, &true_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    rc = MPI_Type_get_extent(obj->DTP_datatype, &lb, &extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    obj->DTP_bufsize = (extent * obj->DTP_type_count) + true_extent - extent;
+    if (true_lb > 0) {
+        obj->DTP_bufsize += true_lb;
+        obj->DTP_buf_offset = 0;
+    } else {
+        obj->DTP_buf_offset = -true_lb;
+    }
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
 int DTP_obj_get_description(DTP_obj_s obj, char **desc)
 {
     DTPI_obj_s *obj_priv = obj.priv;

--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -29,9 +29,7 @@ int DTP_pool_create(const char *base_type_str, MPI_Aint base_type_count, int see
     DTPI_ERR_CHK_RC(rc);
 
     /* setup the random number generation parameters */
-    dtpi->seed = seed;
-    dtpi->rand_count = 0;
-    dtpi->rand_idx = DTPI_RAND_LIST_SIZE;
+    DTPI_rand_init(dtpi, seed, 0);
 
     dtpi->base_type_count = base_type_count;
 
@@ -168,6 +166,25 @@ int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize)
             }
         }
     }
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+int DTP_obj_create_idx(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize, int rand_idx)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    DTPI_pool_s *dtpi = dtp.priv;
+    DTPI_ERR_ARG_CHECK(!dtpi, rc);
+
+    dtpi->rand_idx = rand_idx % DTPI_RAND_LIST_SIZE;
+    rc = DTP_obj_create(dtp, obj, maxbufsize);
 
   fn_exit:
     DTPI_FUNC_EXIT();

--- a/test/mpi/dtpools/src/dtpools_custom.c
+++ b/test/mpi/dtpools/src/dtpools_custom.c
@@ -1,0 +1,691 @@
+#include <string.h>
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <ctype.h>
+#include "dtpools_internal.h"
+
+#define SKIP_SPACE while (isspace(*s)) s++
+#define EXPECT_DIGIT \
+    do { \
+        while (isspace(*s)) s++; \
+        if (!isdigit(*s)) { \
+            DTPI_ERR_ASSERT(0, rc); \
+        } \
+    } while (0)
+#define EXPECT_ALPHA \
+    do { \
+        while (isspace(*s)) s++; \
+        if (!isalpha(*s)) { \
+            DTPI_ERR_ASSERT(0, rc); \
+        } \
+    } while (0)
+#define EXPECT_CHAR(c) \
+    do { \
+        while (isspace(*s)) s++; \
+        if (*s != (c)) { \
+            DTPI_ERR_ASSERT(0, rc); \
+        } \
+    } while (0)
+#define SKIP_DIGIT \
+    do { \
+        while (*s && isdigit(*s)) s++; \
+        DTPI_ERR_ASSERT(*s, rc); \
+    } while (0)
+#define SKIP_ALPHA \
+    do { \
+        while (*s && isalpha(*s)) s++; \
+        DTPI_ERR_ASSERT(*s, rc); \
+    } while (0)
+#define SKIP_UNTIL(c) \
+    do { \
+        while (*s && *s != (c)) s++; \
+        DTPI_ERR_ASSERT(*s, rc); \
+    } while (0)
+
+int DTPI_parse_desc(const char *s, const char **parts, int *num_parts, int max_parts)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    int i = 0;
+    while (*s) {
+        EXPECT_DIGIT;
+        SKIP_DIGIT;
+        EXPECT_CHAR(':');
+        s++;
+        EXPECT_ALPHA;
+
+        parts[i++] = s;
+        DTPI_ERR_ASSERT(i < max_parts, rc);
+
+        SKIP_ALPHA;
+        EXPECT_CHAR('[');
+        SKIP_UNTIL(']');
+        s++;
+        SKIP_SPACE;
+    }
+    *num_parts = i;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_contig(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                         MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__CONTIG;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "blklen %d", &attr->u.contig.blklen);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    rc = MPI_Type_contiguous(attr->u.contig.blklen, type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_ERR_ASSERT(count % attr->u.contig.blklen == 0, rc);
+    count /= attr->u.contig.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_dup(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                      MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__DUP;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    rc = MPI_Type_dup(type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_resized(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                          MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__RESIZED;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "lb %zd, extent %zd", &attr->u.resized.lb, &attr->u.resized.extent);
+    DTPI_ERR_ASSERT(n == 2, rc);
+    rc = MPI_Type_create_resized(type, attr->u.resized.lb, attr->u.resized.extent, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_vector(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                         MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__VECTOR;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %d, stride %d", &attr->u.vector.numblks,
+               &attr->u.vector.blklen, &attr->u.vector.stride);
+    DTPI_ERR_ASSERT(n == 3, rc);
+    rc = MPI_Type_vector(attr->u.vector.numblks, attr->u.vector.blklen, attr->u.vector.stride, type,
+                         newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_ERR_ASSERT(count % (attr->u.vector.numblks * attr->u.vector.blklen) == 0, rc);
+    count /= attr->u.vector.numblks * attr->u.vector.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_hvector(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                          MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__HVECTOR;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %d, stride %zd", &attr->u.hvector.numblks,
+               &attr->u.hvector.blklen, &attr->u.hvector.stride);
+    DTPI_ERR_ASSERT(n == 3, rc);
+    rc = MPI_Type_hvector(attr->u.hvector.numblks, attr->u.hvector.blklen, attr->u.hvector.stride,
+                          type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_ERR_ASSERT(count % (attr->u.hvector.numblks * attr->u.hvector.blklen) == 0, rc);
+    count /= attr->u.hvector.numblks * attr->u.hvector.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_blkindx(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                          MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__BLKINDX;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %d", &attr->u.blkindx.numblks, &attr->u.blkindx.blklen);
+    DTPI_ERR_ASSERT(n == 2, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.blkindx.array_of_displs, attr->u.blkindx.numblks * sizeof(int), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.blkindx.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.blkindx.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = MPI_Type_create_indexed_block(attr->u.blkindx.numblks, attr->u.blkindx.blklen,
+                                       attr->u.blkindx.array_of_displs, type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_ERR_ASSERT(count % (attr->u.blkindx.numblks * attr->u.blkindx.blklen) == 0, rc);
+    count /= attr->u.blkindx.numblks * attr->u.blkindx.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_blkhindx(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                           MPI_Aint * new_count, const char *desc, MPI_Datatype type,
+                           MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__BLKHINDX;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %d", &attr->u.blkhindx.numblks, &attr->u.blkhindx.blklen);
+    DTPI_ERR_ASSERT(n == 2, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.blkhindx.array_of_displs,
+                       attr->u.blkhindx.numblks * sizeof(MPI_Aint), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.blkhindx.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = MPI_Type_create_hindexed_block(attr->u.blkhindx.numblks, attr->u.blkhindx.blklen,
+                                        attr->u.blkhindx.array_of_displs, type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_ERR_ASSERT(count % (attr->u.blkhindx.numblks * attr->u.blkhindx.blklen) == 0, rc);
+    count /= attr->u.blkhindx.numblks * attr->u.blkhindx.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_indexed(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                          MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__INDEXED;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d", &attr->u.indexed.numblks);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.indexed.array_of_blklens, attr->u.indexed.numblks * sizeof(int), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.indexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.indexed.array_of_blklens[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.indexed.array_of_displs, attr->u.indexed.numblks * sizeof(int), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.indexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.indexed.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = MPI_Type_indexed(attr->u.indexed.numblks, attr->u.indexed.array_of_blklens,
+                          attr->u.indexed.array_of_displs, type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    int total_blklen = 0;
+    for (int i = 0; i < attr->u.indexed.numblks; i++) {
+        total_blklen += attr->u.indexed.array_of_blklens[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_hindexed(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                           MPI_Aint * new_count, const char *desc, MPI_Datatype type,
+                           MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__HINDEXED;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d", &attr->u.hindexed.numblks);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.hindexed.array_of_blklens, attr->u.hindexed.numblks * sizeof(int),
+                       rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.hindexed.array_of_blklens[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.hindexed.array_of_displs,
+                       attr->u.hindexed.numblks * sizeof(MPI_Aint), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.hindexed.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = MPI_Type_hindexed(attr->u.hindexed.numblks, attr->u.hindexed.array_of_blklens,
+                           attr->u.hindexed.array_of_displs, type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    int total_blklen = 0;
+    for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+        total_blklen += attr->u.hindexed.array_of_blklens[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_subarray(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                           MPI_Aint * new_count, const char *desc, MPI_Datatype type,
+                           MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__SUBARRAY;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "ndims %d", &attr->u.subarray.ndims);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_sizes, attr->u.subarray.ndims * sizeof(int), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.subarray.array_of_sizes[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_subsizes, attr->u.subarray.ndims * sizeof(int),
+                       rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.subarray.array_of_subsizes[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_starts, attr->u.subarray.ndims * sizeof(int), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.subarray.array_of_starts[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    SKIP_UNTIL('o');
+    if (strncmp(s, "order MPI_ORDER_C", 17) == 0) {
+        attr->u.subarray.order = MPI_ORDER_C;
+    } else if (strncmp(s, "order MPI_ORDER_FORTRAN", 23) == 0) {
+        attr->u.subarray.order = MPI_ORDER_FORTRAN;
+    } else {
+        DTPI_ERR_ASSERT(0, rc);
+    }
+
+    rc = MPI_Type_create_subarray(attr->u.subarray.ndims, attr->u.subarray.array_of_sizes,
+                                  attr->u.subarray.array_of_subsizes,
+                                  attr->u.subarray.array_of_starts, attr->u.subarray.order, type,
+                                  newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    int total_blklen = 1;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        total_blklen *= attr->u.subarray.array_of_sizes[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_struct(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                         MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__STRUCT;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d", &attr->u.structure.numblks);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.structure.array_of_blklens, attr->u.structure.numblks * sizeof(int),
+                       rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.structure.array_of_blklens[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.structure.array_of_displs,
+                       attr->u.structure.numblks * sizeof(MPI_Aint), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.structure.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    MPI_Datatype *array_of_types;
+    DTPI_ALLOC_OR_FAIL(array_of_types, attr->u.structure.numblks * sizeof(MPI_Datatype), rc);
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        array_of_types[i] = type;
+    }
+    rc = MPI_Type_create_struct(attr->u.structure.numblks, attr->u.structure.array_of_blklens,
+                                attr->u.structure.array_of_displs, array_of_types, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_FREE(array_of_types);
+
+    int total_blklen = 0;
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        total_blklen += attr->u.structure.array_of_blklens[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+int DTPI_custom_datatype(DTP_pool_s dtp, DTPI_Attr_s ** attr_tree, MPI_Datatype * newtype,
+                         MPI_Aint * new_count, const char **desc_list, int depth)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    if (depth == 0) {
+        DTPI_pool_s *dtpi = dtp.priv;
+        *attr_tree = NULL;
+        *newtype = dtp.DTP_base_type;
+        *new_count = dtpi->base_type_count;
+        goto fn_exit;
+    }
+
+    DTPI_Attr_s *attr;
+    DTPI_ALLOC_OR_FAIL(attr, sizeof(DTPI_Attr_s), rc);
+    *attr_tree = attr;
+
+    MPI_Datatype type;
+    MPI_Aint count;
+    rc = DTPI_custom_datatype(dtp, &attr->child, &type, &count, desc_list + 1, depth - 1);
+    DTPI_ERR_CHK_RC(rc);
+
+    const char *s = desc_list[0];
+    if (strncmp(s, "contig", 6) == 0) {
+        rc = custom_contig(dtp, attr, newtype, new_count, s + 6, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "dup", 3) == 0) {
+        rc = custom_dup(dtp, attr, newtype, new_count, s + 3, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "resized", 7) == 0) {
+        rc = custom_resized(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "vector", 6) == 0) {
+        rc = custom_vector(dtp, attr, newtype, new_count, s + 6, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "hvector", 7) == 0) {
+        rc = custom_hvector(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "blkindx", 7) == 0) {
+        rc = custom_blkindx(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "blkhindx", 8) == 0) {
+        rc = custom_blkhindx(dtp, attr, newtype, new_count, s + 8, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "indexed", 7) == 0) {
+        rc = custom_indexed(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "hindexed", 8) == 0) {
+        rc = custom_hindexed(dtp, attr, newtype, new_count, s + 8, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "subarray", 8) == 0) {
+        rc = custom_subarray(dtp, attr, newtype, new_count, s + 8, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "struct", 6) == 0) {
+        rc = custom_struct(dtp, attr, newtype, new_count, s + 6, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else {
+        DTPI_ERR_ASSERT(0, rc);
+    }
+
+    if (depth > 1) {
+        rc = MPI_Type_free(&type);
+        DTPI_ERR_CHK_MPI_RC(rc);
+    }
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}

--- a/test/mpi/dtpools/src/dtpools_misc.c
+++ b/test/mpi/dtpools/src/dtpools_misc.c
@@ -214,6 +214,22 @@ unsigned int DTPI_high_count(unsigned int count)
     return count / DTPI_low_count(count);
 }
 
+void DTPI_rand_init(DTPI_pool_s * dtpi, int seed, int rand_count)
+{
+    dtpi->seed = seed;
+    dtpi->rand_count = rand_count;
+    dtpi->rand_idx = 0;
+
+    srand(dtpi->seed);
+    for (int i = 0; i < dtpi->rand_count; i++)
+        rand();
+
+    for (int i = 0; i < DTPI_RAND_LIST_SIZE; i++) {
+        dtpi->rand_count++;
+        dtpi->rand_list[i] = rand();
+    }
+}
+
 int DTPI_rand(DTPI_pool_s * dtpi)
 {
     int ret;
@@ -225,15 +241,6 @@ int DTPI_rand(DTPI_pool_s * dtpi)
 
     if (dtpi->rand_idx == DTPI_RAND_LIST_SIZE) {
         dtpi->rand_idx = 0;
-
-        srand(dtpi->seed);
-        for (int i = 0; i < dtpi->rand_count; i++)
-            rand();
-
-        for (int i = 0; i < DTPI_RAND_LIST_SIZE; i++) {
-            dtpi->rand_count++;
-            dtpi->rand_list[i] = rand();
-        }
     }
 
     ret = dtpi->rand_list[dtpi->rand_idx];

--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -62,6 +62,7 @@ noinst_PROGRAMS =  \
     large_tag \
     pingping  \
     pingping_barrier  \
+    dtpools_pt2pt \
     sendrecv1 \
     sendself
 

--- a/test/mpi/pt2pt/dtpools_pt2pt.c
+++ b/test/mpi/pt2pt/dtpools_pt2pt.c
@@ -1,0 +1,71 @@
+#include "mpi.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "mpitest.h"
+#include "dtpools.h"
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+    int err = 0;
+    int errs = 0;
+
+
+    MTest_Init(&argc, &argv);
+
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    int count = 262144;
+    DTP_pool_s dtp;
+    err = DTP_pool_create("MPI_INT", count, 0, &dtp);
+    assert(err == DTP_SUCCESS);
+
+    /* *INDENT-OFF* */
+    const char *s_send_obj = NULL;
+    const char *s_recv_obj = "0: blkindx [numblks 1, blklen 131072, displs (0)]"
+                             "1: resized [lb -400, extent 4]"
+                             "2: resized [lb 0, extent 40]";
+    /* *INDENT-ON* */
+    DTP_obj_s dtp_obj;
+    void *buf;
+    if (rank == 0) {
+        err = DTP_obj_create_custom(dtp, &dtp_obj, s_send_obj);
+        assert(err == DTP_SUCCESS);
+        buf = malloc(dtp_obj.DTP_bufsize);
+
+        err = DTP_obj_buf_init(dtp_obj, buf, 0, 1, count);
+        assert(err == DTP_SUCCESS);
+        err =
+            MPI_Send(buf + dtp_obj.DTP_buf_offset, dtp_obj.DTP_type_count, dtp_obj.DTP_datatype, 1,
+                     0, MPI_COMM_WORLD);
+        assert(err == MPI_SUCCESS);
+
+        free(buf);
+        DTP_obj_free(dtp_obj);
+    } else if (rank == 1) {
+        err = DTP_obj_create_custom(dtp, &dtp_obj, s_recv_obj);
+        assert(err == DTP_SUCCESS);
+        buf = malloc(dtp_obj.DTP_bufsize);
+
+        err = DTP_obj_buf_init(dtp_obj, buf, -1, -1, count);
+        assert(err == DTP_SUCCESS);
+        err =
+            MPI_Recv(buf + dtp_obj.DTP_buf_offset, dtp_obj.DTP_type_count, dtp_obj.DTP_datatype, 0,
+                     0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        assert(err == MPI_SUCCESS);
+        err = DTP_obj_buf_check(dtp_obj, buf, 0, 1, count);
+        if (err) {
+            errs++;
+        }
+
+        free(buf);
+        DTP_obj_free(dtp_obj);
+    }
+
+    DTP_pool_free(dtp);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+    return 0;
+}

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -52,3 +52,4 @@ dtype_send 2
 recv_any 2
 irecv_any 2
 large_tag 2
+dtpools_pt2pt 2


### PR DESCRIPTION
## Pull Request Description

The current dtpools code creates datatype according to a internal random number sequence. When we need to troubleshoot certain tests, we often have to replay the entire datatype creation sequence in order to get to the exact datatype that we are interested in. This PR add two additional object creation interface to facilitate more specific debugging need:

* `DTP_obj_create_idx(dtp, &dtp_obj, maxbufsize, idx)`
    It will create the exact datatype matches the `idx`. This is reproducible as long as the same libc pseudo-number generator is being used. TODO: for better reproducibility (even across OS), use internal pseudo-random number generator.

* `DTP_obj_create_custom(dtp, &dtp_obj, desc)`
    Where `desc` is a description string similar to what `DTP_obj_get_description` returns.

## Example
```
    const char *s_send_obj = "0: struct [numblks 1, blklen (5), displs (8)]"
                             "1: blkhindx [numblks 2, blklen 1, displs (8,40)]"
                             "2: resized [lb 8, extent 8]";
    DTP_obj_s send_obj;
    DTP_obj_create_custom(dtp, &send_obj, &desc);
    char * desc;
    DTP_obj_get_description(send_obj, &desc);
    printf("send_obj: %s\n", temp_desc);
    free(temp_desc);
````

Output:
```
send_obj: nesting levels: 3
0: structure [numblks 1, blklen (5), displs (8)]
1: blkhindx [numblks 2, blklen 1, displs (8,40)]
2: resized [lb 8, extent 8]
base: MPI_INT
```

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
