### PR TITLE
GenQ infrastructure

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -5,6 +5,7 @@
 
 #include "mpidimpl.h"
 #include "iqueue_noinline.h"
+#include "mpidu_genq.h"
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
@@ -36,11 +37,8 @@ cvars:
 int MPIDI_POSIX_iqueue_init(int rank, int size)
 {
     int mpi_errno = MPI_SUCCESS;
-    int i;
     MPIDI_POSIX_eager_iqueue_transport_t *transport;
     size_t size_of_terminals;
-    size_t size_of_cells;
-    size_t size_of_shared_memory;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_IQUEUE_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_IQUEUE_INIT);
@@ -51,43 +49,24 @@ int MPIDI_POSIX_iqueue_init(int rank, int size)
     transport->num_cells = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_NUM_CELLS;
     transport->size_of_cell = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE;
 
-    /* Create one terminal for each process with which we will be able to communicate. */
-    size_of_terminals =
-        (size_t) MPIDI_POSIX_global.num_local * sizeof(MPIDI_POSIX_eager_iqueue_terminal_t);
-
-    /* Behind each terminal is a series of cells. We have `num_cells` per queue/terminal per
-     * communicating process. */
-    size_of_cells = (size_t) MPIDI_POSIX_global.num_local * (size_t) transport->num_cells
-        * (size_t) transport->size_of_cell;
-
-    size_of_shared_memory = size_of_terminals + size_of_cells;
-
-    /* Create the shared memory regions that will be used for the iqueue cells and terminals. */
-    mpi_errno = MPIDU_Init_shm_alloc(size_of_shared_memory, &transport->pointer_to_shared_memory);
+    mpi_errno = MPIDU_genq_shmem_pool_create_unsafe(transport->size_of_cell, transport->num_cells,
+                                                    MPIDI_POSIX_global.num_local,
+                                                    MPIDI_POSIX_global.my_local_rank,
+                                                    &transport->cell_pool);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* Set up the appropriate pointers for each of the parts of the queues. */
-    transport->terminals =
-        (MPIDI_POSIX_eager_iqueue_terminal_t *) ((char *) transport->pointer_to_shared_memory);
+    /* Create one terminal for each process with which we will be able to communicate. */
+    size_of_terminals = (size_t) MPIDI_POSIX_global.num_local * sizeof(MPIDU_genq_shmem_queue_u);
 
-    transport->cells = (char *) transport->pointer_to_shared_memory
-        + size_of_terminals +
-        (size_t) MPIDI_POSIX_global.my_local_rank * (size_t) transport->num_cells *
-        (size_t) transport->size_of_cell;
+    /* Create the shared memory regions that will be used for the iqueue cells and terminals. */
+    mpi_errno = MPIDU_Init_shm_alloc(size_of_terminals, (void *) &transport->terminals);
+    MPIR_ERR_CHECK(mpi_errno);
 
-    MPL_atomic_relaxed_store_ptr(&transport->terminals[MPIDI_POSIX_global.my_local_rank].head,
-                                 NULL);
+    transport->my_terminal = &transport->terminals[MPIDI_POSIX_global.my_local_rank];
 
-    /* Do the pointer arithmetic and initialize each of the cell data structures. */
-    for (i = 0; i < transport->num_cells; i++) {
-        MPIDI_POSIX_eager_iqueue_cell_t *cell = (MPIDI_POSIX_eager_iqueue_cell_t *)
-            ((char *) transport->cells + (size_t) transport->size_of_cell * i);
-        cell->type = MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_NULL;
-        cell->from = MPIDI_POSIX_global.my_local_rank;
-        cell->next = NULL;
-        cell->prev = 0;
-        cell->payload_size = 0;
-    }
+    mpi_errno = MPIDU_genq_shmem_queue_init(transport->my_terminal, transport->cell_pool,
+                                            MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Run local procs barrier */
     mpi_errno = MPIDU_Init_shm_barrier();
@@ -97,6 +76,8 @@ int MPIDI_POSIX_iqueue_init(int rank, int size)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_IQUEUE_INIT);
     return mpi_errno;
   fn_fail:
+    MPIDU_Init_shm_free(transport->terminals);
+    MPIDU_genq_shmem_pool_destroy_unsafe(transport->cell_pool);
     goto fn_exit;
 }
 
@@ -110,7 +91,8 @@ int MPIDI_POSIX_iqueue_finalize()
 
     transport = MPIDI_POSIX_eager_iqueue_get_transport();
 
-    mpi_errno = MPIDU_Init_shm_free(transport->pointer_to_shared_memory);
+    mpi_errno = MPIDU_Init_shm_free(transport->terminals);
+    mpi_errno = MPIDU_genq_shmem_pool_destroy_unsafe(transport->cell_pool);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_IQUEUE_FINALIZE);

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
@@ -7,94 +7,13 @@
 #define POSIX_EAGER_IQUEUE_RECV_H_INCLUDED
 
 #include "iqueue_impl.h"
-
-/* Work backward through the queue to find the first cell and put that one in the transport's
- * first_cell position. */
-/* Because of the non-tail recursion here, we can't do the normal inlining. Summary discussion here:
- * https://stackoverflow.com/a/32498407/491687 */
-static void MPIDI_POSIX_eager_iqueue_enqueue_cell(MPIDI_POSIX_eager_iqueue_transport_t * transport,
-                                                  MPIDI_POSIX_eager_iqueue_cell_t * cell)
-{
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_EAGER_IQUEUE_ENQUEUE_CELL);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_EAGER_IQUEUE_ENQUEUE_CELL);
-
-    /* TODO: is there any better way than recursion? Can we avoid
-     * this invertion if we switch to SPSC queue?*/
-
-    /* Ingress queue of cells is inverted. Thus, we need to re-invert it. */
-    if (cell->prev) {
-        MPIDI_POSIX_eager_iqueue_cell_t *prev =
-            MPIDI_POSIX_EAGER_IQUEUE_GET_CELL(transport, cell->prev);
-        MPIDI_POSIX_eager_iqueue_enqueue_cell(transport, prev);
-        cell->prev = 0;
-    }
-    cell->next = NULL;
-    if (transport->last_cell) {
-        transport->last_cell->next = cell;
-    } else {
-        transport->first_cell = cell;
-    }
-    transport->last_cell = cell;
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_EAGER_IQUEUE_ENQUEUE_CELL);
-}
-
-MPL_STATIC_INLINE_PREFIX MPIDI_POSIX_eager_iqueue_cell_t
-    * MPIDI_POSIX_eager_iqueue_receive_cell(MPIDI_POSIX_eager_iqueue_transport_t * transport)
-{
-    MPIDI_POSIX_eager_iqueue_cell_t *cell = NULL;
-    MPIDI_POSIX_eager_iqueue_terminal_t *terminal;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_EAGER_IQUEUE_RECEIVE_CELL);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_EAGER_IQUEUE_RECEIVE_CELL);
-
-    /* Update the first_cell pointer in the queue if we pull out the first cell */
-    if (transport->first_cell) {
-        cell = transport->first_cell;
-        if (cell->next == NULL) {
-            transport->first_cell = NULL;
-            transport->last_cell = NULL;
-        } else {
-            transport->first_cell = cell->next;
-        }
-    } else {
-        /* TODO: current code sets one terminal per receiver. Contention may occur
-         * when multiple senders insert cells into the same receiver simultaneously.
-         * Can we expand the design to be one terminal per sender-receiver peer? I.e.,
-         * the queue will become SPSC, and there will be ppn^2 terminals on each node.
-         * How much performance can be improved by this change?*/
-
-        /* If first_cell wasn't set, grab the next cell from the appropriate terminal */
-        terminal = &transport->terminals[MPIDI_POSIX_global.my_local_rank];
-
-        if (MPL_atomic_load_ptr(&terminal->head)) {
-            void *head = MPL_atomic_swap_ptr(&terminal->head, NULL);
-
-            cell = MPIDI_POSIX_EAGER_IQUEUE_GET_CELL(transport, head);
-
-            /* If the head of the terminal has the prev pointer set, enqueue the current cell and
-             * use that one instead. */
-            if (cell && cell->prev) {
-                MPIDI_POSIX_eager_iqueue_enqueue_cell(transport, cell);
-
-                cell = transport->first_cell;
-                MPIR_Assert(cell != NULL);
-                MPIR_Assert(cell->next != NULL);
-                transport->first_cell = cell->next;
-            }
-        }
-    }
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_EAGER_IQUEUE_RECEIVE_CELL);
-    return cell;
-}
-
+#include "mpidu_genq.h"
 
 MPL_STATIC_INLINE_PREFIX int
 MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t * transaction)
 {
     MPIDI_POSIX_eager_iqueue_transport_t *transport;
-    MPIDI_POSIX_eager_iqueue_cell_t *cell;
+    MPIDI_POSIX_eager_iqueue_cell_t *cell = NULL;
     int ret = MPIDI_POSIX_NOK;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_EAGER_RECV_BEGIN);
@@ -103,7 +22,7 @@ MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t * transaction)
     /* Get the transport with the global variables */
     transport = MPIDI_POSIX_eager_iqueue_get_transport();
 
-    cell = MPIDI_POSIX_eager_iqueue_receive_cell(transport);
+    MPIDU_genq_shmem_queue_dequeue(transport->my_terminal, (void **) &cell);
 
     if (cell) {
         transaction->src_grank = MPIDI_POSIX_global.local_procs[cell->from];
@@ -142,11 +61,7 @@ MPIDI_POSIX_eager_recv_commit(MPIDI_POSIX_eager_recv_transaction_t * transaction
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_EAGER_RECV_COMMIT);
 
     cell = (MPIDI_POSIX_eager_iqueue_cell_t *) transaction->transport.iqueue.pointer_to_cell;
-    MPIR_Assert(cell != NULL);
-    cell->next = NULL;
-    cell->prev = 0;
-    MPL_atomic_compiler_barrier();
-    cell->type = MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_NULL;
+    MPIDU_genq_shmem_pool_cell_free(cell);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_EAGER_RECV_COMMIT);
 }

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_types.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_types.h
@@ -8,10 +8,10 @@
 
 #include <mpidimpl.h>
 #include "mpidu_init_shm.h"
+#include "mpidu_genq.h"
 
-#define MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_NULL 0
-#define MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_HDR 1
-#define MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_DATA 2
+#define MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_HDR 0
+#define MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_DATA 1
 
 typedef struct MPIDI_POSIX_eager_iqueue_cell MPIDI_POSIX_eager_iqueue_cell_t;
 
@@ -20,38 +20,17 @@ struct MPIDI_POSIX_eager_iqueue_cell {
     uint16_t type;              /* Type of cell (head/tail/etc.) */
     uint16_t from;              /* Who is the message in the cell from */
     uint32_t payload_size;      /* Size of the message in the cell */
-    uintptr_t prev;             /* Internal pointer when finding the previous active cell. This is
-                                 * the absolute offset of a cell in the shared memory segment and is
-                                 * the same over all ranks. It is also visible to all ranks. */
-    MPIDI_POSIX_eager_iqueue_cell_t *next;      /* Internal pointer when finding the next active
-                                                 * cell. The pointer is a virtual memory address
-                                                 * (private to the process). */
     MPIDI_POSIX_am_header_t am_header;  /* If this cell is the beginning of a message, it will have
                                          * an active message header and this will point to it. */
 };
 
-/* The terminal describes each of the iqueues, mostly by tracking where the head of the queue is at
- * any given time. */
-typedef union {
-    MPL_atomic_ptr_t head;      /* head of inverted queue of cells */
-    uint8_t pad[MPIDU_SHM_CACHE_LINE_LEN];      /* Padding to make sure the terminals are cache
-                                                 * aligned */
-} MPIDI_POSIX_eager_iqueue_terminal_t;
-
 typedef struct MPIDI_POSIX_eager_iqueue_transport {
     int num_cells;              /* The number of cells allocated to each terminal in this transport */
     int size_of_cell;           /* The size of each of the cells in this transport */
-    void *pointer_to_shared_memory;     /* The entire shared memory region used by both the terminal
-                                         * and the cells in this transport */
-    void *cells;                /* Pointer to the memory containing all of the cells used by this
-                                 * transport */
-    MPIDI_POSIX_eager_iqueue_terminal_t *terminals;     /* The list of all the terminals that
-                                                         * describe each of the cells */
-    MPIDI_POSIX_eager_iqueue_cell_t *first_cell;        /* Internal variable to track the first cell
-                                                         * to be received when receiving multiple
-                                                         * cells. */
-    MPIDI_POSIX_eager_iqueue_cell_t *last_cell; /* Internal variable to track the last cell to be
-                                                 * received when receiving multiple cells. */
+    MPIDU_genq_shmem_queue_u *terminals;        /* The list of all the terminals that
+                                                 * describe each of the cells */
+    MPIDU_genq_shmem_queue_t my_terminal;
+    MPIDU_genq_shmem_pool_t cell_pool;
 } MPIDI_POSIX_eager_iqueue_transport_t;
 
 extern MPIDI_POSIX_eager_iqueue_transport_t MPIDI_POSIX_eager_iqueue_transport_global;
@@ -61,23 +40,10 @@ static inline MPIDI_POSIX_eager_iqueue_transport_t *MPIDI_POSIX_eager_iqueue_get
     return &MPIDI_POSIX_eager_iqueue_transport_global;
 }
 
-#define MPIDI_POSIX_EAGER_IQUEUE_THIS_CELL(transport, index) \
-    (MPIDI_POSIX_eager_iqueue_cell_t*)((char*)(transport)->cells + (size_t)(transport)->size_of_cell * (index))
-
 #define MPIDI_POSIX_EAGER_IQUEUE_CELL_PAYLOAD(cell) \
     ((char*)(cell) + sizeof(MPIDI_POSIX_eager_iqueue_cell_t))
 
 #define MPIDI_POSIX_EAGER_IQUEUE_CELL_CAPACITY(transport) \
     ((transport)->size_of_cell - sizeof(MPIDI_POSIX_eager_iqueue_cell_t))
-
-/* The offset of memory to the beginning of the cell. */
-#define MPIDI_POSIX_EAGER_IQUEUE_GET_HANDLE(transport, cell) \
-    ((cell) ? ((uintptr_t)(cell) - (uintptr_t)(transport)->pointer_to_shared_memory) : 0)
-
-/* Grab a specific cell by using the offset value (from the beginning of the memory used to store
- * all of the cells) of the handle. */
-#define MPIDI_POSIX_EAGER_IQUEUE_GET_CELL(transport, handle) \
-    (MPIDI_POSIX_eager_iqueue_cell_t*)((handle) ? \
-        ((char*)(transport)->pointer_to_shared_memory + (uintptr_t)(handle)) : NULL);
 
 #endif /* POSIX_EAGER_IQUEUE_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -3,6 +3,7 @@ dnl MPICH_SUBCFG_BEFORE=src/mpid/common/sched
 dnl MPICH_SUBCFG_BEFORE=src/mpid/common/datatype
 dnl MPICH_SUBCFG_BEFORE=src/mpid/common/thread
 dnl MPICH_SUBCFG_BEFORE=src/mpid/common/bc
+dnl MPICH_SUBCFG_BEFORE=src/mpid/common/genq
 
 dnl _PREREQ handles the former role of mpichprereq, setup_device, etc
 [#] expansion is: PAC_SUBCFG_PREREQ_[]PAC_SUBCFG_AUTO_SUFFIX
@@ -37,6 +38,7 @@ build_mpid_common_sched=yes
 build_mpid_common_datatype=yes
 build_mpid_common_thread=yes
 build_mpid_common_bc=yes
+build_mpid_common_genq=yes
 
 MPID_MAX_THREAD_LEVEL=MPI_THREAD_MULTIPLE
 MPID_MAX_PROCESSOR_NAME=128

--- a/src/mpid/common/Makefile.mk
+++ b/src/mpid/common/Makefile.mk
@@ -9,3 +9,4 @@ include $(top_srcdir)/src/mpid/common/hcoll/Makefile.mk
 include $(top_srcdir)/src/mpid/common/timers/Makefile.mk
 include $(top_srcdir)/src/mpid/common/shm/Makefile.mk
 include $(top_srcdir)/src/mpid/common/bc/Makefile.mk
+include $(top_srcdir)/src/mpid/common/genq/Makefile.mk

--- a/src/mpid/common/genq/Makefile.mk
+++ b/src/mpid/common/genq/Makefile.mk
@@ -1,0 +1,21 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+if BUILD_MPID_COMMON_GENQ
+
+# there are no AC_OUTPUT_FILES headers, so builddir is unnecessary
+AM_CPPFLAGS += -I$(top_srcdir)/src/mpid/common/genq
+
+noinst_HEADERS += \
+		  src/mpid/common/genq/mpidu_genq.h \
+		  src/mpid/common/genq/mpidu_genq_shmem_pool.h \
+		  src/mpid/common/genq/mpidu_genq_shmem_queue.h \
+		  src/mpid/common/genq/mpidu_genqi_shmem_types.h
+
+mpi_core_sources += \
+		    src/mpid/common/genq/mpidu_genq_shmem_pool.c \
+		    src/mpid/common/genq/mpidu_genq_shmem_queue.c
+
+endif BUILD_MPID_COMMON_GENQ

--- a/src/mpid/common/genq/mpidu_genq.h
+++ b/src/mpid/common/genq/mpidu_genq.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPIDU_GENQ_H_INCLUDED
+#define MPIDU_GENQ_H_INCLUDED
+
+#include "mpidu_genq_shmem_pool.h"
+#include "mpidu_genq_shmem_queue.h"
+
+#endif /* MPIDU_GENQ_H_INCLUDED */

--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "mpidu_genq_shmem_pool.h"
+#include "mpidu_genqi_shmem_types.h"
+#include "mpidu_init_shm.h"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#define RESIZE_TO_MAX_ALIGN(x) \
+    ((((x) / MAX_ALIGNMENT) + !!((x) % MAX_ALIGNMENT)) * MAX_ALIGNMENT)
+
+static int cell_block_alloc(MPIDU_genqi_shmem_pool_s * pool, int block_idx);
+static int cell_block_alloc(MPIDU_genqi_shmem_pool_s * pool, int block_idx)
+{
+    int rc = MPI_SUCCESS;
+    MPIDU_genqi_shmem_cell_header_s **new_cell_headers = NULL;
+
+    new_cell_headers =
+        (MPIDU_genqi_shmem_cell_header_s **) MPL_malloc(pool->cells_per_proc
+                                                        * sizeof(MPIDU_genqi_shmem_cell_header_s *),
+                                                        MPL_MEM_OTHER);
+    MPIR_ERR_CHKANDJUMP(!new_cell_headers, rc, MPI_ERR_OTHER, "**nomem");
+    pool->cell_headers = new_cell_headers;
+
+    /* init cell headers */
+    int idx = block_idx * pool->cells_per_proc;
+    for (int i = 0; i < pool->cells_per_proc; i++) {
+        pool->cell_headers[i] =
+            (MPIDU_genqi_shmem_cell_header_s *) ((char *) pool->cell_header_base
+                                                 + (idx + i) * pool->cell_alloc_size);
+        pool->cell_headers[i]->next = 0;
+        pool->cell_headers[i]->prev = 0;
+        /* The handle value is the one being stored in the next, prev, head, tail pointers.
+         * All valid handle must to be non-zero, a zero handle is equivalent to a NULL pointer. */
+        pool->cell_headers[i]->handle =
+            (uintptr_t) pool->cell_headers[i] - (uintptr_t) pool->cell_header_base + 1;
+        MPL_atomic_store_int(&pool->cell_headers[i]->in_use, 0);
+    }
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    MPL_free(new_cell_headers);
+    goto fn_exit;
+}
+
+int MPIDU_genq_shmem_pool_create_unsafe(uintptr_t cell_size, uintptr_t cells_per_proc,
+                                        uintptr_t num_proc, int rank,
+                                        MPIDU_genq_shmem_pool_t * pool)
+{
+    int rc = MPI_SUCCESS;
+    MPIDU_genqi_shmem_pool_s *pool_obj;
+    uintptr_t slab_size = 0;
+    uintptr_t aligned_cell_size = 0;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_CREATE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_CREATE);
+
+    pool_obj = MPL_malloc(sizeof(MPIDU_genqi_shmem_pool_s), MPL_MEM_OTHER);
+
+    pool_obj->cell_size = cell_size;
+    aligned_cell_size = RESIZE_TO_MAX_ALIGN(cell_size);
+    pool_obj->cell_alloc_size = sizeof(MPIDU_genqi_shmem_cell_header_s) + aligned_cell_size;
+    pool_obj->cells_per_proc = cells_per_proc;
+    pool_obj->num_proc = num_proc;
+    pool_obj->rank = rank;
+
+    /* the global_block_index is at the end of the slab to avoid extra need of alignment */
+    slab_size = num_proc * cells_per_proc * pool_obj->cell_alloc_size + sizeof(MPL_atomic_int_t);
+
+    rc = MPIDU_Init_shm_alloc(slab_size, &pool_obj->slab);
+    MPIR_ERR_CHECK(rc);
+
+    rc = MPL_gpu_register_host(pool_obj->slab, slab_size);
+    MPIR_ERR_CHECK(rc);
+
+    pool_obj->cell_header_base = (MPIDU_genqi_shmem_cell_header_s *) pool_obj->slab;
+
+    rc = MPIDU_Init_shm_barrier();
+    MPIR_ERR_CHECK(rc);
+
+    rc = cell_block_alloc(pool_obj, rank);
+    MPIR_ERR_CHECK(rc);
+
+    *pool = (MPIDU_genq_shmem_pool_t) pool_obj;
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_CREATE);
+    return rc;
+  fn_fail:
+    MPIDU_Init_shm_free(pool_obj->slab);
+    MPL_free(pool_obj);
+    goto fn_exit;
+}
+
+int MPIDU_genq_shmem_pool_destroy_unsafe(MPIDU_genq_shmem_pool_t pool)
+{
+    int rc = MPI_SUCCESS;
+    MPIDU_genqi_shmem_pool_s *pool_obj = (MPIDU_genqi_shmem_pool_s *) pool;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_DESTROY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_DESTROY);
+
+    MPL_free(pool_obj->cell_headers);
+
+    MPIDU_Init_shm_free(pool_obj->slab);
+
+    /* free self */
+    MPL_free(pool_obj);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_DESTROY);
+    return rc;
+}

--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.h
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPIDU_GENQ_SHMEM_POOL_H_INCLUDED
+#define MPIDU_GENQ_SHMEM_POOL_H_INCLUDED
+
+#include "mpidimpl.h"
+#include "mpidu_genqi_shmem_types.h"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef void *MPIDU_genq_shmem_pool_t;
+
+int MPIDU_genq_shmem_pool_create_unsafe(uintptr_t cell_size, uintptr_t cells_per_proc,
+                                        uintptr_t num_proc, int rank,
+                                        MPIDU_genq_shmem_pool_t * pool);
+int MPIDU_genq_shmem_pool_destroy_unsafe(MPIDU_genq_shmem_pool_t pool);
+static inline int MPIDU_genq_shmem_pool_cell_alloc(MPIDU_genq_shmem_pool_t pool, void **cell);
+static inline int MPIDU_genq_shmem_pool_cell_free(void *cell);
+
+static inline int MPIDU_genq_shmem_pool_cell_alloc(MPIDU_genq_shmem_pool_t pool, void **cell)
+{
+    int rc = MPI_SUCCESS;
+    MPIDU_genqi_shmem_pool_s *pool_obj = (MPIDU_genqi_shmem_pool_s *) pool;
+
+    *cell = NULL;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_CELL_ALLOC);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_CELL_ALLOC);
+
+    /* iteratively find a unused cell */
+    for (int i = 0; i < pool_obj->cells_per_proc; i++) {
+        if (!MPL_atomic_load_int(&pool_obj->cell_headers[i]->in_use)) {
+            *cell = HEADER_TO_CELL(pool_obj->cell_headers[i]);
+            MPL_atomic_store_int(&pool_obj->cell_headers[i]->in_use, 1);
+            goto fn_exit;
+        }
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_CELL_ALLOC);
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static inline int MPIDU_genq_shmem_pool_cell_free(void *cell)
+{
+    int rc = MPI_SUCCESS;
+    MPIDU_genqi_shmem_cell_header_s *cell_h = CELL_TO_HEADER(cell);
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_CELL_FREE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_CELL_FREE);
+
+    cell_h->next = 0;
+    cell_h->prev = 0;
+    MPL_atomic_store_int(&cell_h->in_use, 0);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_GENQ_SHMEM_POOL_CELL_FREE);
+    return rc;
+}
+
+#endif /* ifndef MPIDU_GENQ_SHMEM_POOL_H_INCLUDED */

--- a/src/mpid/common/genq/mpidu_genq_shmem_queue.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_queue.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "mpidu_genq_shmem_pool.h"
+#include "mpidu_genq_shmem_queue.h"
+#include "mpidu_genqi_shmem_types.h"
+
+int MPIDU_genq_shmem_queue_init(MPIDU_genq_shmem_queue_t queue, MPIDU_genq_shmem_pool_t pool,
+                                int flags)
+{
+    int rc = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_GENQ_SHMEM_QUEUE_INIT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_GENQ_SHMEM_QUEUE_INIT);
+
+    queue->q.pool = (MPIDU_genqi_shmem_pool_s *) pool;
+    queue->q.flags = flags;
+
+    if (flags & MPIDU_GENQ_SHMEM_QUEUE_TYPE__SERIAL) {
+        queue->q.head.s = 0;
+        queue->q.tail.s = 0;
+    } else {
+        queue->q.head.s = 0;
+        /* sp and mp all use atomic tail */
+        MPL_atomic_store_ptr(&queue->q.tail.m, NULL);
+    }
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_GENQ_SHMEM_QUEUE_INIT);
+    return rc;
+}

--- a/src/mpid/common/genq/mpidu_genq_shmem_queue.h
+++ b/src/mpid/common/genq/mpidu_genq_shmem_queue.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPIDU_GENQ_SHMEM_QUEUE_H_INCLUDED
+#define MPIDU_GENQ_SHMEM_QUEUE_H_INCLUDED
+
+#include "mpidimpl.h"
+#include "mpidu_genq_shmem_pool.h"
+#include "mpidu_genqi_shmem_types.h"
+#include "mpidu_init_shm.h"
+#include <stdint.h>
+#include <stdio.h>
+
+typedef enum {
+    MPIDU_GENQ_SHMEM_QUEUE_TYPE__SERIAL,
+    MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC,
+} MPIDU_genq_shmem_queue_type_e;
+
+typedef union MPIDU_genq_shmem_queue {
+    struct {
+        union {
+            uintptr_t s;
+            MPL_atomic_ptr_t m;
+            uint8_t pad[MPIDU_SHM_CACHE_LINE_LEN];
+        } head;
+        union {
+            uintptr_t s;
+            MPL_atomic_ptr_t m;
+            uint8_t pad[MPIDU_SHM_CACHE_LINE_LEN];
+        } tail;
+        MPIDU_genqi_shmem_pool_s *pool;
+        unsigned flags;
+    } q;
+    uint8_t pad[3 * MPIDU_SHM_CACHE_LINE_LEN];
+} MPIDU_genq_shmem_queue_u;
+
+typedef MPIDU_genq_shmem_queue_u *MPIDU_genq_shmem_queue_t;
+
+int MPIDU_genq_shmem_queue_init(MPIDU_genq_shmem_queue_t queue, MPIDU_genq_shmem_pool_t pool,
+                                int flags);
+static inline int MPIDU_genq_shmem_queue_dequeue(MPIDU_genq_shmem_queue_t queue, void **cell);
+static inline int MPIDU_genq_shmem_queue_enqueue(MPIDU_genq_shmem_queue_t queue, void *cell);
+static inline void *MPIDU_genq_shmem_queue_head(MPIDU_genq_shmem_queue_t queue);
+static inline void *MPIDU_genq_shmem_queue_next(void *cell);
+
+static inline MPIDU_genqi_shmem_cell_header_s
+    * MPIDU_genqi_shmem_get_head_cell_header(MPIDU_genq_shmem_queue_t queue);
+
+#define MPIDU_GENQ_SHMEM_QUEUE_FOREACH(queue, cell) \
+    for (void *tmp = MPIDU_genq_shmem_queue_head((queue)), cell = tmp; tmp; \
+         tmp = MPIDU_genq_shmem_queue_next(tmp))
+
+static inline MPIDU_genqi_shmem_cell_header_s
+    * MPIDU_genqi_shmem_get_head_cell_header(MPIDU_genq_shmem_queue_t queue)
+{
+    void *tail = NULL;
+    MPIDU_genqi_shmem_cell_header_s *head_cell_h = NULL;
+
+    /* prepares the cells for dequeuing from the head in the following steps.
+     * 1. atomic detaching all cells frm the queue tail
+     * 2. find the head of the queue and rebuild the "next" pointers for cells
+     */
+    tail = MPL_atomic_swap_ptr(&queue->q.tail.m, NULL);
+    if (!tail) {
+        return NULL;
+    }
+    head_cell_h = HANDLE_TO_HEADER(queue->q.pool, tail);
+
+    if (head_cell_h != NULL) {
+        uintptr_t curr_handle = head_cell_h->handle;
+        while (head_cell_h->prev) {
+            MPIDU_genqi_shmem_cell_header_s *prev_cell_h = HANDLE_TO_HEADER(queue->q.pool,
+                                                                            head_cell_h->prev);
+            prev_cell_h->next = curr_handle;
+            curr_handle = head_cell_h->prev;
+            head_cell_h = prev_cell_h;
+        }
+        return head_cell_h;
+    } else {
+        return NULL;
+    }
+}
+
+static inline int MPIDU_genq_shmem_queue_dequeue(MPIDU_genq_shmem_queue_t queue, void **cell)
+{
+    int rc = MPI_SUCCESS;
+    MPIDU_genqi_shmem_cell_header_s *cell_h = NULL;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_GENQ_SHMEM_QUEUE_DEQUEUE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_GENQ_SHMEM_QUEUE_DEQUEUE);
+
+    if (queue->q.flags == MPIDU_GENQ_SHMEM_QUEUE_TYPE__SERIAL) {
+        cell_h = HANDLE_TO_HEADER(queue->q.pool, queue->q.head.s);
+        if (queue->q.head.s) {
+            queue->q.head.s = cell_h->next;
+            if (!cell_h->next) {
+                queue->q.tail.s = 0;
+            }
+            *cell = HEADER_TO_CELL(cell_h);
+        } else {
+            *cell = NULL;
+        }
+    } else {    /* MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC */
+        if (!queue->q.head.s) {
+            cell_h = MPIDU_genqi_shmem_get_head_cell_header(queue);
+            if (cell_h) {
+                *cell = HEADER_TO_CELL(cell_h);
+                queue->q.head.s = cell_h->next;
+            } else {
+                *cell = NULL;
+            }
+        } else {
+            cell_h = HANDLE_TO_HEADER(queue->q.pool, queue->q.head.s);
+            *cell = HEADER_TO_CELL(cell_h);
+            queue->q.head.s = cell_h->next;
+        }
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_GENQ_SHMEM_QUEUE_DEQUEUE);
+    return rc;
+}
+
+static inline int MPIDU_genq_shmem_queue_enqueue(MPIDU_genq_shmem_queue_t queue, void *cell)
+{
+    int rc = MPI_SUCCESS;
+    MPIDU_genqi_shmem_cell_header_s *cell_h = CELL_TO_HEADER(cell);
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_GENQ_SHMEM_QUEUE_ENQUEUE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_GENQ_SHMEM_QUEUE_ENQUEUE);
+
+    if (queue->q.flags == MPIDU_GENQ_SHMEM_QUEUE_TYPE__SERIAL) {
+        uintptr_t handle = cell_h->handle;
+
+        if (queue->q.tail.s) {
+            HANDLE_TO_HEADER(queue->q.pool, queue->q.tail.s)->next = handle;
+        }
+        cell_h->prev = queue->q.tail.s;
+        queue->q.tail.s = handle;
+        if (!queue->q.head.s) {
+            queue->q.head.s = queue->q.tail.s;
+        }
+    } else {    /* MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC */
+        void *prev_handle = NULL;
+        void *handle = (void *) cell_h->handle;
+
+        do {
+            prev_handle = MPL_atomic_load_ptr(&queue->q.tail.m);
+            cell_h->prev = (uintptr_t) prev_handle;
+        } while (MPL_atomic_cas_ptr(&queue->q.tail.m, prev_handle, handle) != prev_handle);
+    }
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_GENQ_SHMEM_QUEUE_ENQUEUE);
+    return rc;
+}
+
+static inline void *MPIDU_genq_shmem_queue_head(MPIDU_genq_shmem_queue_t queue)
+{
+    MPIDU_genqi_shmem_cell_header_s *cell_h = NULL;
+
+    if (queue->q.flags == MPIDU_GENQ_SHMEM_QUEUE_TYPE__SERIAL) {
+        cell_h = HANDLE_TO_HEADER(queue->q.pool, queue->q.head.s);
+    } else {    /* MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC */
+        if (!queue->q.head.s) {
+            cell_h = MPIDU_genqi_shmem_get_head_cell_header(queue);
+        } else {
+            cell_h = HANDLE_TO_HEADER(queue->q.pool, queue->q.head.s);
+        }
+
+    }
+    if (cell_h) {
+        return HEADER_TO_CELL(cell_h);
+    } else {
+        return NULL;
+    }
+}
+
+static inline void *MPIDU_genq_shmem_queue_next(void *cell)
+{
+    return HEADER_TO_CELL(CELL_TO_HEADER(cell)->next);
+}
+
+#endif /* ifndef MPIDU_GENQ_SHMEM_QUEUE_H_INCLUDED */

--- a/src/mpid/common/genq/mpidu_genqi_shmem_types.h
+++ b/src/mpid/common/genq/mpidu_genqi_shmem_types.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPIDU_GENQI_SHMEM_TYPES_H_INCLUDED
+#define MPIDU_GENQI_SHMEM_TYPES_H_INCLUDED
+
+#include "mpl.h"
+#include "mpidu_init_shm.h"
+
+typedef struct MPIDU_genqi_shmem_cell_header {
+    uintptr_t handle;
+    MPL_atomic_int_t in_use;
+    uintptr_t next;
+    uintptr_t prev;
+} MPIDU_genqi_shmem_cell_header_s;
+
+typedef struct MPIDU_genqi_shmem_pool {
+    uintptr_t cell_size;
+    uintptr_t cell_alloc_size;
+    uintptr_t cells_per_proc;
+    uintptr_t num_proc;
+    int rank;
+
+    void *slab;
+    MPIDU_genqi_shmem_cell_header_s *cell_header_base;
+    MPIDU_genqi_shmem_cell_header_s **cell_headers;
+} MPIDU_genqi_shmem_pool_s;
+
+#define HEADER_TO_CELL(header) \
+    ((char *) (header) + sizeof(MPIDU_genqi_shmem_cell_header_s))
+
+#define CELL_TO_HEADER(cell) \
+    ((MPIDU_genqi_shmem_cell_header_s *) ((char *) (cell) \
+                                          - sizeof(MPIDU_genqi_shmem_cell_header_s)))
+
+/* The handle value is calculated using (address_offset + 1), see MPIDU_genq_shmem_pool.h */
+#define HANDLE_TO_HEADER(pool, handle) \
+    ((MPIDU_genqi_shmem_cell_header_s *) ((char *) (pool)->cell_header_base + (uintptr_t) (handle) \
+                                          - 1))
+
+#endif /* ifndef MPIDU_GENQI_SHMEM_TYPES_H_INCLUDED */

--- a/src/mpid/common/genq/subconfigure.m4
+++ b/src/mpid/common/genq/subconfigure.m4
@@ -1,0 +1,10 @@
+[#] start of __file__
+
+dnl _PREREQ handles the former role of mpichprereq, setup_device, etc
+AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
+    AM_CONDITIONAL([BUILD_MPID_COMMON_GENQ],[test "$build_mpid_common_genq" = "yes"])
+])
+
+dnl _BODY handles the former role of configure in the subsystem
+AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[])
+[#] end of __file__


### PR DESCRIPTION
## Pull Request Description

This PR adds a new pool/queue infrastructure, called GenQ.  The POSIX/iqueue usage is replaced by this new implementation.

There are four concepts introduced in this PR: shmem pool, shmem queue, private pool, and cells.

Pools have storage associated with them in the form of cells, and allow for cells to allocated and freed.  Cells in a pool are not ordered and can be allocated in arbitrary order.  Queues do not have any storage associated with them, but they are FIFO ordered.  A cell that is allocated from a pool can be enqueued into or dequeued from a queue.

Shmem pools are backed by shared memory storage.  Private pools are backed by user-defined memory (through a memory allocation function).  For both pools, the actual allocation of the storage is performed by the GenQ infrastructure.

|                       |  Multi-process safety | Multi-thread safety | Allocation | Pool Size |
|--------------|-----------------------|--------------------|-----------|------|
| Shmem pool |   MPSC                         |  No                            |  Collective | Fixed |
| Shmem queue | MPSC or SERIAL      |  No                            |  Local        | N.A.  |
| Private pool  |   N.A.                            |  No                            |  Local        | Dynamic |

The current version of the code does not provide any thread safety.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
