### PR TITLE
datatype: Add flattening helper function

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -132,6 +132,10 @@ struct MPIR_Datatype {
     /* pointer to contents and envelope data for the datatype */
     MPIR_Datatype_contents *contents;
 
+    /* flattened representation */
+    void *flattened;
+    int flattened_sz;
+
     /* internal type representation */
     void *typerep;              /* might be optimized for homogenous */
 
@@ -146,6 +150,7 @@ extern MPIR_Datatype MPIR_Datatype_direct[];
 extern MPIR_Object_alloc_t MPIR_Datatype_mem;
 
 void MPIR_Datatype_free(MPIR_Datatype * ptr);
+void MPIR_Datatype_get_flattened(MPI_Datatype type, void **flattened, int *flattened_sz);
 
 #define MPIR_Datatype_ptr_add_ref(datatype_ptr) MPIR_Object_add_ref((datatype_ptr))
 
@@ -441,6 +446,7 @@ static inline int MPIR_Datatype_set_contents(MPIR_Datatype * new_dtp,
         MPIR_Memcpy(ptr, array_of_aints, nr_aints * sizeof(MPI_Aint));
     }
     new_dtp->contents = cp;
+    new_dtp->flattened = NULL;
 
     /* increment reference counts on all the derived types used here */
     for (i = 0; i < nr_types; i++) {

--- a/src/mpi/datatype/type_blockindexed.c
+++ b/src/mpi/datatype/type_blockindexed.c
@@ -61,6 +61,7 @@ int MPIR_Type_blockindexed(int count,
     new_dtp->attributes = NULL;
     new_dtp->name[0] = 0;
     new_dtp->contents = NULL;
+    new_dtp->flattened = NULL;
 
     new_dtp->typerep = NULL;
 

--- a/src/mpi/datatype/type_contiguous.c
+++ b/src/mpi/datatype/type_contiguous.c
@@ -54,6 +54,7 @@ int MPIR_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype
     new_dtp->attributes = NULL;
     new_dtp->name[0] = 0;
     new_dtp->contents = NULL;
+    new_dtp->flattened = NULL;
 
     new_dtp->typerep = NULL;
 

--- a/src/mpi/datatype/type_create_pairtype.c
+++ b/src/mpi/datatype/type_create_pairtype.c
@@ -71,6 +71,7 @@ int MPIR_Type_create_pairtype(MPI_Datatype type, MPIR_Datatype * new_dtp)
     new_dtp->attributes = NULL;
     new_dtp->name[0] = 0;
     new_dtp->contents = NULL;
+    new_dtp->flattened = NULL;
 
     new_dtp->typerep = NULL;
 

--- a/src/mpi/datatype/type_create_resized.c
+++ b/src/mpi/datatype/type_create_resized.c
@@ -58,6 +58,7 @@ int MPIR_Type_create_resized(MPI_Datatype oldtype,
     new_dtp->attributes = 0;
     new_dtp->name[0] = 0;
     new_dtp->contents = 0;
+    new_dtp->flattened = NULL;
 
     new_dtp->typerep = NULL;
 

--- a/src/mpi/datatype/type_indexed.c
+++ b/src/mpi/datatype/type_indexed.c
@@ -68,6 +68,7 @@ int MPIR_Type_indexed(int count,
     new_dtp->attributes = NULL;
     new_dtp->name[0] = 0;
     new_dtp->contents = NULL;
+    new_dtp->flattened = NULL;
 
     new_dtp->typerep = NULL;
 

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -175,6 +175,7 @@ int MPIR_Type_struct(int count,
     new_dtp->attributes = NULL;
     new_dtp->name[0] = 0;
     new_dtp->contents = NULL;
+    new_dtp->flattened = NULL;
 
     new_dtp->typerep = NULL;
 

--- a/src/mpi/datatype/type_vector.c
+++ b/src/mpi/datatype/type_vector.c
@@ -57,6 +57,7 @@ int MPIR_Type_vector(int count,
     new_dtp->attributes = NULL;
     new_dtp->name[0] = 0;
     new_dtp->contents = NULL;
+    new_dtp->flattened = NULL;
 
     new_dtp->typerep = NULL;
 

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_flatten.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_flatten.c
@@ -98,6 +98,7 @@ int MPIR_Typerep_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     datatype_ptr->has_sticky_ub = flatten_hdr->has_sticky_ub;
     datatype_ptr->has_sticky_lb = flatten_hdr->has_sticky_lb;
     datatype_ptr->contents = NULL;
+    datatype_ptr->flattened = NULL;
 
     mpi_errno = MPIR_Dataloop_unflatten(datatype_ptr, flattened_dataloop);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -307,6 +307,7 @@ int MPII_Type_zerolen(MPI_Datatype * newtype)
     new_dtp->attributes = NULL;
     new_dtp->name[0] = 0;
     new_dtp->contents = NULL;
+    new_dtp->flattened = NULL;
 
     new_dtp->typerep = NULL;
 
@@ -564,5 +565,22 @@ void MPIR_Datatype_free(MPIR_Datatype * ptr)
     if (ptr->typerep) {
         MPIR_Typerep_free(&(ptr->typerep));
     }
+    MPL_free(ptr->flattened);
     MPIR_Handle_obj_free(&MPIR_Datatype_mem, ptr);
+}
+
+void MPIR_Datatype_get_flattened(MPI_Datatype type, void **flattened, int *flattened_sz)
+{
+    MPIR_Datatype *dt_ptr;
+
+    MPIR_Datatype_get_ptr(type, dt_ptr);
+    if (dt_ptr->flattened == NULL) {
+        MPIR_Typerep_flatten_size(dt_ptr, &dt_ptr->flattened_sz);
+        dt_ptr->flattened = MPL_malloc(dt_ptr->flattened_sz, MPL_MEM_DATATYPE);
+        MPIR_Assert(dt_ptr->flattened);
+        MPIR_Typerep_flatten(dt_ptr, dt_ptr->flattened);
+    }
+
+    *flattened = dt_ptr->flattened;
+    *flattened_sz = dt_ptr->flattened_sz;
 }

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -110,6 +110,7 @@ typedef struct MPIDIG_put_req_t {
     int origin_count;
     MPI_Datatype origin_datatype;
     void *target_addr;
+    MPI_Datatype target_datatype;
 } MPIDIG_put_req_t;
 
 typedef struct MPIDIG_get_req_t {
@@ -120,6 +121,7 @@ typedef struct MPIDIG_get_req_t {
     int count;
     void *flattened_dt;
     MPIR_Datatype *dt;
+    MPI_Datatype target_datatype;
 } MPIDIG_get_req_t;
 
 typedef struct MPIDIG_cswap_req_t {

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -1096,7 +1096,7 @@ static int get_ack_target_cmpl_cb(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_GET_ACK_TARGET_CMPL_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_GET_ACK_TARGET_CMPL_CB);
 
-    MPL_free(MPIDIG_REQUEST(rreq, req->greq.flattened_dt));
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->greq.target_datatype));
 
     win = MPIDIG_REQUEST(rreq, req->greq.win_ptr);
     MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
@@ -1165,9 +1165,7 @@ int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_A
     preq = (MPIR_Request *) msg_hdr->preq_ptr;
     win = MPIDIG_REQUEST(preq, req->preq.win_ptr);
 
-    MPL_free(MPIDIG_REQUEST(preq, req->preq.flattened_dt));
-    if (MPIDIG_REQUEST(preq, req->preq.dt))
-        MPIR_Datatype_ptr_release(MPIDIG_REQUEST(preq, req->preq.dt));
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(preq, req->preq.target_datatype));
 
     MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(preq, rank));
 


### PR DESCRIPTION
## Pull Request Description

Make it easy to cache and retrieve flattened representation of a datatype. Utilize in the ch4/am code.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Reduce the amount of times ch4/am code flattens datatypes.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
