### PR TITLE
mpi/test/threads: add declaration of MTest_thread_yield

### DIFF
--- a/test/mpi/include/mpithreadtest.h
+++ b/test/mpi/include/mpithreadtest.h
@@ -64,6 +64,7 @@ int MTest_thread_lock_create(MTEST_THREAD_LOCK_TYPE *);
 int MTest_thread_lock(MTEST_THREAD_LOCK_TYPE *);
 int MTest_thread_unlock(MTEST_THREAD_LOCK_TYPE *);
 int MTest_thread_lock_free(MTEST_THREAD_LOCK_TYPE *);
+int MTest_thread_yield(void);
 int MTest_thread_barrier_init(void);
 int MTest_thread_barrier(int);
 int MTest_thread_barrier_free(void);


### PR DESCRIPTION

## Pull Request Description

This PR fixes a bug in #4421. An external function, `MTest_thread_yield()`, was newly added but not declared in `mpithreadtest.h`. This PR adds a 
declaration of `MTest_thread_yield()` in this header.

This issue has been reported by @hzhou. Thank you!

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

This is a bug fix.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
