### PR TITLE
Fix vpath builds with json-c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1306,7 +1306,10 @@ AC_SUBST([jsonsrcdir])
 jsonlib=""
 AC_SUBST([jsonlib])
 
+PAC_PUSH_ALL_FLAGS()
+PAC_RESET_ALL_FLAGS()
 PAC_CONFIG_SUBDIR_ARGS([modules/json-c],[--disable-werror],[],[AC_MSG_ERROR(json-c configure failed)])
+PAC_POP_ALL_FLAGS()
 jsonsrcdir="${master_top_builddir}/modules/json-c"
 jsonlib="${master_top_builddir}/modules/json-c/libjson-c.la"
 PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/json-c],[CPPFLAGS])


### PR DESCRIPTION
## Pull Request Description

Adding the json-c submodule meant that vpath builds no longer worked
because json-c expected to find a config.h file from autoconf. It
actually found some other submodule's config.h when building outside the
source tree. This fixes the problem by stashing all of the flags added
to the various environment variables (e.g. CFLAGS) before configuring
json-c.

## Expected Impact

N/A

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
