### PR TITLE
ROMIO: add missed fixes in 4b7d553

### DIFF
--- a/src/mpi/romio/adio/ad_ime/ad_ime_io.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_io.c
@@ -28,8 +28,8 @@ static void IME_IOContig(ADIO_File fd,
     static char myname[] = "ADIOI_IME_IOCONTIG";
 
     if (count == 0) {
-        *error_code = MPI_SUCCESS;
-        return;
+        ret = 0;
+        goto fn_exit;
     }
 
     MPI_Type_size_x(datatype, &datatype_size);
@@ -64,8 +64,10 @@ static void IME_IOContig(ADIO_File fd,
         fd->fp_ind += ret;
     fd->fp_sys_posn = file_offset + ret;
 
+  fn_exit:
 #ifdef HAVE_STATUS_SET_BYTES
-    MPIR_Status_set_bytes(status, datatype, ret);
+    if (status)
+        MPIR_Status_set_bytes(status, datatype, ret);
 #endif
 
     *error_code = MPI_SUCCESS;

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
@@ -153,8 +153,8 @@ static void ADIOI_LUSTRE_IOContig(ADIO_File fd, const void *buf, int count,
     char *p;
 
     if (count == 0) {
-        *error_code = MPI_SUCCESS;
-        return;
+        err = 0;
+        goto fn_exit;
     }
 
     MPI_Type_size_x(datatype, &datatype_size);
@@ -214,8 +214,10 @@ static void ADIOI_LUSTRE_IOContig(ADIO_File fd, const void *buf, int count,
     if (file_ptr_type == ADIO_INDIVIDUAL) {
         fd->fp_ind += bytes_xfered;
     }
+
+  fn_exit:
 #ifdef HAVE_STATUS_SET_BYTES
-    if (status)
+    if (status && err != -1)
         MPIR_Status_set_bytes(status, datatype, bytes_xfered);
 #endif
     *error_code = MPI_SUCCESS;

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_read.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_read.c
@@ -72,7 +72,7 @@ void ADIOI_NFS_ReadContig(ADIO_File fd, void *buf, int count,
 
   fn_exit:
 #ifdef HAVE_STATUS_SET_BYTES
-    if (err != -1)
+    if (status && err != -1)
         MPIR_Status_set_bytes(status, datatype, bytes_xfered);
 #endif
 

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_write.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_write.c
@@ -69,7 +69,8 @@ void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
 
   fn_exit:
 #ifdef HAVE_STATUS_SET_BYTES
-    MPIR_Status_set_bytes(status, datatype, bytes_xfered);
+    if (status && err != -1)
+        MPIR_Status_set_bytes(status, datatype, bytes_xfered);
 #endif
 
     *error_code = MPI_SUCCESS;

--- a/src/mpi/romio/adio/ad_panfs/ad_panfs_read.c
+++ b/src/mpi/romio/adio/ad_panfs/ad_panfs_read.c
@@ -17,8 +17,8 @@ void ADIOI_PANFS_ReadContig(ADIO_File fd, void *buf, int count,
     static char myname[] = "ADIOI_PANFS_READCONTIG";
 
     if (count == 0) {
-        *error_code = MPI_SUCCESS;
-        return;
+        err = 0;
+        goto fn_exit;
     }
 
     MPI_Type_size_x(datatype, &datatype_size);
@@ -59,8 +59,10 @@ void ADIOI_PANFS_ReadContig(ADIO_File fd, void *buf, int count,
     if (file_ptr_type == ADIO_INDIVIDUAL) {
         fd->fp_ind += err;
     }
+
+  fn_exit:
 #ifdef HAVE_STATUS_SET_BYTES
-    if (err != -1)
+    if (status && err != -1)
         MPIR_Status_set_bytes(status, datatype, err);
 #endif
 

--- a/src/mpi/romio/adio/ad_panfs/ad_panfs_write.c
+++ b/src/mpi/romio/adio/ad_panfs/ad_panfs_write.c
@@ -17,8 +17,8 @@ void ADIOI_PANFS_WriteContig(ADIO_File fd, const void *buf, int count,
     static char myname[] = "ADIOI_PANFS_WRITECONTIG";
 
     if (count == 0) {
-        *error_code = MPI_SUCCESS;
-        return;
+        err = 0;
+        goto fn_exit;
     }
 
     MPI_Type_size_x(datatype, &datatype_size);
@@ -59,8 +59,10 @@ void ADIOI_PANFS_WriteContig(ADIO_File fd, const void *buf, int count,
     if (file_ptr_type == ADIO_INDIVIDUAL) {
         fd->fp_ind += err;
     }
+
+  fn_exit:
 #ifdef HAVE_STATUS_SET_BYTES
-    if (err != -1 && status)
+    if (status && err != -1)
         MPIR_Status_set_bytes(status, datatype, err);
 #endif
 

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_read.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_read.c
@@ -21,6 +21,10 @@ void ADIOI_PVFS2_ReadContig(ADIO_File fd, void *buf, int count,
     static char myname[] = "ADIOI_PVFS2_READCONTIG";
 
     if (count == 0) {
+#ifdef HAVE_STATUS_SET_BYTES
+        if (status)
+            MPIR_Status_set_bytes(status, datatype, 0);
+#endif
         *error_code = MPI_SUCCESS;
         return;
     }
@@ -84,7 +88,8 @@ void ADIOI_PVFS2_ReadContig(ADIO_File fd, void *buf, int count,
     fd->fp_sys_posn = offset + (int) resp_io.total_completed;
 
 #ifdef HAVE_STATUS_SET_BYTES
-    MPIR_Status_set_bytes(status, datatype, resp_io.total_completed);
+    if (status)
+        MPIR_Status_set_bytes(status, datatype, resp_io.total_completed);
 #endif
 
     *error_code = MPI_SUCCESS;

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_write.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_write.c
@@ -20,6 +20,10 @@ void ADIOI_PVFS2_WriteContig(ADIO_File fd, const void *buf, int count,
     static char myname[] = "ADIOI_PVFS2_WRITECONTIG";
 
     if (count == 0) {
+#ifdef HAVE_STATUS_SET_BYTES
+        if (status)
+            MPIR_Status_set_bytes(status, datatype, 0);
+#endif
         *error_code = MPI_SUCCESS;
         return;
     }
@@ -97,7 +101,8 @@ void ADIOI_PVFS2_WriteContig(ADIO_File fd, const void *buf, int count,
         fd->fp_sys_posn = fd->fp_ind;
     }
 #ifdef HAVE_STATUS_SET_BYTES
-    MPIR_Status_set_bytes(status, datatype, resp_io.total_completed);
+    if (status)
+        MPIR_Status_set_bytes(status, datatype, resp_io.total_completed);
 #endif
     *error_code = MPI_SUCCESS;
   fn_exit:

--- a/src/mpi/romio/adio/ad_xfs/ad_xfs_read.c
+++ b/src/mpi/romio/adio/ad_xfs/ad_xfs_read.c
@@ -23,8 +23,8 @@ void ADIOI_XFS_ReadContig(ADIO_File fd, void *buf, int count,
     static char myname[] = "ADIOI_XFS_READCONTIG";
 
     if (count == 0) {
-        *error_code = MPI_SUCCESS;
-        return;
+        err = 0;
+        goto fn_exit;
     }
 
     MPI_Type_size_x(datatype, &datatype_size);
@@ -92,8 +92,9 @@ void ADIOI_XFS_ReadContig(ADIO_File fd, void *buf, int count,
     if (file_ptr_type == ADIO_INDIVIDUAL)
         fd->fp_ind += err;
 
+  fn_exit:
 #ifdef HAVE_STATUS_SET_BYTES
-    if (err != -1)
+    if (status && err != -1)
         MPIR_Status_set_bytes(status, datatype, err);
 #endif
 

--- a/src/mpi/romio/adio/ad_xfs/ad_xfs_write.c
+++ b/src/mpi/romio/adio/ad_xfs/ad_xfs_write.c
@@ -25,8 +25,9 @@ void ADIOI_XFS_WriteContig(ADIO_File fd, void *buf, int count,
     static char myname[] = "ADIOI_XFS_WRITECONTIG";
 
     if (count == 0) {
-        *error_code = MPI_SUCCESS;
-        return;
+        err = 0;
+        len = 0;
+        goto leaving;
     }
 
     MPI_Type_size_x(datatype, &datatype_size);
@@ -113,11 +114,11 @@ void ADIOI_XFS_WriteContig(ADIO_File fd, void *buf, int count,
     if (file_ptr_type == ADIO_INDIVIDUAL)
         fd->fp_ind += len;
 
+  leaving:
 #ifdef HAVE_STATUS_SET_BYTES
-    if (err != -1)
+    if (status && err != -1)
         MPIR_Status_set_bytes(status, datatype, len);
 #endif
-  leaving:
     if (err == -1) {
         *error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
                                            myname, __LINE__, MPI_ERR_IO, "**io",


### PR DESCRIPTION
add missed fixes of 4b7d553b4cbcd54ec6f4a6365871db267aac63ea
`romio: set status even if zero bytes requested`
