### PR TITLE
Replace calls to MPL_thread_yield with ROMIO_THREAD_CS_YIELD

### DIFF
--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -1291,7 +1291,7 @@ static int ADIOI_GEN_irc_wait_fn(int count, void **array_of_states,
              * thread to be able to unblock the progress engine. */
             /* NOTE: we're outside a critical section (safety ensured by standard),
              * we only need yield in case of user threads */
-            MPL_thread_yield();
+            ROMIO_THREAD_CS_YIELD();
         }
     }
 

--- a/src/mpi/romio/adio/common/ad_iwrite_coll.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_coll.c
@@ -1488,7 +1488,7 @@ static int ADIOI_GEN_iwc_wait_fn(int count, void **array_of_states,
              * thread to be able to unblock the progress engine. */
             /* NOTE: we're outside a critical section (safety ensured by standard),
              * we only need yield in case of user threads */
-            MPL_thread_yield();
+            ROMIO_THREAD_CS_YIELD();
         }
     }
 

--- a/src/mpi/romio/mpi-io/mpioimpl.h
+++ b/src/mpi/romio/mpi-io/mpioimpl.h
@@ -18,7 +18,7 @@
 
 #define ROMIO_THREAD_CS_ENTER() MPIR_Ext_cs_enter()
 #define ROMIO_THREAD_CS_EXIT() MPIR_Ext_cs_exit()
-#define ROMIO_THREAD_CS_YIELD() MPIR_Ext_cs_yield()
+#define ROMIO_THREAD_CS_YIELD() MPL_thread_yield()
 
 /* committed datatype checking support in ROMIO */
 #define MPIO_DATATYPE_ISCOMMITTED(dtype_, err_)        \


### PR DESCRIPTION
Using macro ROMIO_THREAD_CS_YIELD defined in mpioimpl.h allows
ROMIO to be built outside MPICH. Also see commit
da361cf7b3e5252da38e83fe8cec3c89c5685e1e

