### PR TITLE
test: fix a fprintf warning in mt_probe_impl.c

### DIFF
--- a/test/mpi/threads/pt2pt/mt_probe_impl.c
+++ b/test/mpi/threads/pt2pt/mt_probe_impl.c
@@ -97,7 +97,7 @@ int probetest_invoke_probe(int sender_rank, int tag, MPI_Comm comm, int *recv_co
             }
             break;
         default:
-            fprintf(stderr, "thread: %d: Probe type not defined \n");
+            fprintf(stderr, "Probe type not defined \n");
             MPI_Abort(MPI_COMM_WORLD, 1);
     }
     /* Find data count */


### PR DESCRIPTION

## Pull Request Description

Missing thread id parameter, removed from fprintf message.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
