### PR TITLE
Fix minor issues in test/mpi

### DIFF
--- a/test/mpi/dtpools/src/dtpools_init_verify.c
+++ b/test/mpi/dtpools/src/dtpools_init_verify.c
@@ -62,133 +62,98 @@ static int init_verify_basic_datatype(MPI_Datatype type_, char *buf, int val, in
     else if (type == MPI_LONG_LONG)
         type = MPI_LONG_LONG_INT;
 
-    switch (type) {
-        case MPI_CHAR:
-        case MPI_BYTE:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, char);
-            val += val_stride;
-            break;
-        case MPI_WCHAR:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, wchar_t);
-            val += val_stride;
-            break;
-        case MPI_SHORT:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, short);
-            val += val_stride;
-            break;
-        case MPI_INT:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int);
-            val += val_stride;
-            break;
-        case MPI_LONG:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, long);
-            val += val_stride;
-            break;
-        case MPI_LONG_LONG_INT:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, long long);
-            val += val_stride;
-            break;
-        case MPI_UNSIGNED_CHAR:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, unsigned char);
-            val += val_stride;
-            break;
-        case MPI_UNSIGNED:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, unsigned);
-            val += val_stride;
-            break;
-        case MPI_UNSIGNED_LONG:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, unsigned long);
-            val += val_stride;
-            break;
-        case MPI_UNSIGNED_LONG_LONG:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, unsigned long long);
-            val += val_stride;
-            break;
-        case MPI_FLOAT:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, float);
-            val += val_stride;
-            break;
-        case MPI_DOUBLE:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, double);
-            val += val_stride;
-            break;
-        case MPI_LONG_DOUBLE:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, long double);
-            val += val_stride;
-            break;
-        case MPI_INT8_T:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int8_t);
-            val += val_stride;
-            break;
-        case MPI_INT16_T:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int16_t);
-            val += val_stride;
-            break;
-        case MPI_INT32_T:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int32_t);
-            val += val_stride;
-            break;
-        case MPI_INT64_T:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int64_t);
-            val += val_stride;
-            break;
-        case MPI_UINT8_T:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint8_t);
-            val += val_stride;
-            break;
-        case MPI_UINT16_T:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint16_t);
-            val += val_stride;
-            break;
-        case MPI_UINT32_T:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint32_t);
-            val += val_stride;
-            break;
-        case MPI_UINT64_T:
-            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint64_t);
-            val += val_stride;
-            break;
-
-        case MPI_C_COMPLEX:
-            INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, float, float);
-            val += (2 * val_stride);
-            break;
-        case MPI_C_DOUBLE_COMPLEX:
-            INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, double, double);
-            val += (2 * val_stride);
-            break;
-        case MPI_C_LONG_DOUBLE_COMPLEX:
-            INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, long double,
-                                   long double);
-            val += (2 * val_stride);
-            break;
-        case MPI_FLOAT_INT:
-            INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, float, int);
-            val += (2 * val_stride);
-            break;
-        case MPI_DOUBLE_INT:
-            INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, double, int);
-            val += (2 * val_stride);
-            break;
-        case MPI_LONG_INT:
-            INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, long, int);
-            val += (2 * val_stride);
-            break;
-        case MPI_2INT:
-            INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, int, int);
-            val += (2 * val_stride);
-            break;
-        case MPI_SHORT_INT:
-            INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, short, int);
-            val += (2 * val_stride);
-            break;
-        case MPI_LONG_DOUBLE_INT:
-            INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, long double, int);
-            val += (2 * val_stride);
-            break;
-
-        default:
-            DTPI_ERR_ASSERT(0, rc);
+    if (type == MPI_CHAR || type == MPI_BYTE) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, char);
+        val += val_stride;
+    } else if (type == MPI_WCHAR) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, wchar_t);
+        val += val_stride;
+    } else if (type == MPI_SHORT) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, short);
+        val += val_stride;
+    } else if (type == MPI_INT) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int);
+        val += val_stride;
+    } else if (type == MPI_LONG) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, long);
+        val += val_stride;
+    } else if (type == MPI_LONG_LONG_INT) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, long long);
+        val += val_stride;
+    } else if (type == MPI_UNSIGNED_CHAR) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, unsigned char);
+        val += val_stride;
+    } else if (type == MPI_UNSIGNED) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, unsigned);
+        val += val_stride;
+    } else if (type == MPI_UNSIGNED_LONG) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, unsigned long);
+        val += val_stride;
+    } else if (type == MPI_UNSIGNED_LONG_LONG) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, unsigned long long);
+        val += val_stride;
+    } else if (type == MPI_FLOAT) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, float);
+        val += val_stride;
+    } else if (type == MPI_DOUBLE) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, double);
+        val += val_stride;
+    } else if (type == MPI_LONG_DOUBLE) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, long double);
+        val += val_stride;
+    } else if (type == MPI_INT8_T) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int8_t);
+        val += val_stride;
+    } else if (type == MPI_INT16_T) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int16_t);
+        val += val_stride;
+    } else if (type == MPI_INT32_T) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int32_t);
+        val += val_stride;
+    } else if (type == MPI_INT64_T) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int64_t);
+        val += val_stride;
+    } else if (type == MPI_UINT8_T) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint8_t);
+        val += val_stride;
+    } else if (type == MPI_UINT16_T) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint16_t);
+        val += val_stride;
+    } else if (type == MPI_UINT32_T) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint32_t);
+        val += val_stride;
+    } else if (type == MPI_UINT64_T) {
+        INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint64_t);
+        val += val_stride;
+    } else if (type == MPI_C_COMPLEX) {
+        INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, float, float);
+        val += (2 * val_stride);
+    } else if (type == MPI_C_DOUBLE_COMPLEX) {
+        INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, double, double);
+        val += (2 * val_stride);
+    } else if (type == MPI_C_LONG_DOUBLE_COMPLEX) {
+        INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, long double, long double);
+        val += (2 * val_stride);
+    } else if (type == MPI_FLOAT_INT) {
+        INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, float, int);
+        val += (2 * val_stride);
+    } else if (type == MPI_DOUBLE_INT) {
+        INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, double, int);
+        val += (2 * val_stride);
+    } else if (type == MPI_LONG_INT) {
+        INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, long, int);
+        val += (2 * val_stride);
+    } else if (type == MPI_2INT) {
+        INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, int, int);
+        val += (2 * val_stride);
+    } else if (type == MPI_SHORT_INT) {
+        INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, short, int);
+        val += (2 * val_stride);
+    } else if (type == MPI_LONG_DOUBLE_INT) {
+        INIT_VERIFY_DOUBLE_VAL(rc, buf, val, val + val_stride, verify, long double, int);
+        val += (2 * val_stride);
+    } else {
+        DTPI_ERR_ASSERT(0, rc);
     }
 
   fn_exit:

--- a/test/mpi/dtpools/src/dtpools_init_verify.c
+++ b/test/mpi/dtpools/src/dtpools_init_verify.c
@@ -3,6 +3,7 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include <stdint.h>
 #include "dtpools_internal.h"
 
 #define MAX_ERRCOUNT 10

--- a/test/mpi/errors/pt2pt/truncmsg2.c
+++ b/test/mpi/errors/pt2pt/truncmsg2.c
@@ -56,8 +56,8 @@ int main(int argc, char *argv[])
     int contig_indexed_count = 3;
     int contig_indexed_blocklens[] = { 1, 2, 1 };
     int contig_indexed_indices[] = { 4, 8, 16 };
-    int contig_indexed_inner_type = MPI_INT;
-    int contig_indexed_type;
+    MPI_Datatype contig_indexed_inner_type = MPI_INT;
+    MPI_Datatype contig_indexed_type;
 
     MTest_Init(&argc, &argv);
     ret = MPI_Comm_rank(MPI_COMM_WORLD, &myrank);

--- a/test/mpi/mpi_t/cvarwrite.c
+++ b/test/mpi/mpi_t/cvarwrite.c
@@ -19,7 +19,8 @@ int main(int argc, char *argv[])
     int required, provided;
     int num_cvar;
     char name[MAX_VAR_NAME_LEN];
-    int namelen, verbosity, datatype, desclen, binding, scope, count;
+    int namelen, verbosity, desclen, binding, scope, count;
+    MPI_Datatype datatype;
     MPI_T_enum enumtype = MPI_T_ENUM_NULL;
     int iin, iout, iold;
     unsigned uin, uout, uold;


### PR DESCRIPTION
## Pull Request Description

This PR fixes some minor issues in `test/mpi`. Specifically it fixes the following issues:
- Use `MPI_Datatype` constants in `switch-case`
- Lack of a header (`stdint.h`)
- Use `int` as `MPI_Datatype`

Note that they do not become a problem with the current certain MPICH implementation but are problematic with non-MPICH MPI systems.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

These changes do not change the coverage of the current tests.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
