### PR TITLE
mpir: simplify completion of non-device requests

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -418,6 +418,17 @@ static inline void MPIR_Request_free(MPIR_Request * req)
     }
 }
 
+/* Requests that are not created inside device (general requests, nonblocking collective
+ * requests such as sched, gentran, hcoll) should call MPIR_Request_complete.
+ * MPID_Request_complete are called inside device critical section, therefore, potentially
+ * are unsafe to call outside the device. (NOTE: this will come into effect with ch4 multi-vci.)
+ */
+MPL_STATIC_INLINE_PREFIX void MPIR_Request_complete(MPIR_Request * req)
+{
+    MPIR_cc_set(&req->cc, 0);
+    MPIR_Request_free(req);
+}
+
 /* The "fastpath" version of MPIR_Request_completion_processing.  It only handles
  * MPIR_REQUEST_KIND__SEND and MPIR_REQUEST_KIND__RECV kinds, and it does not attempt to
  * deal with status structures under the assumption that bleeding fast code will

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -268,7 +268,7 @@ int MPII_Genutil_progress_hook(int *made_progress)
 
             req = MPL_container_of(coll_req, MPIR_Request, u.nbc.coll);
             DL_DELETE(MPII_coll_queue.head, coll_req);
-            MPID_Request_complete(req);
+            MPIR_Request_complete(req);
         }
         if (++count >= MPIR_CVAR_PROGRESS_MAX_COLLS)
             break;

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -412,13 +412,13 @@ int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm, MPI
 
     if (unlikely(sched->total_vtcs == 0)) {
         MPII_Genutil_sched_free(sched);
-        MPID_Request_complete(reqp);
+        MPIR_Request_complete(reqp);
         goto fn_exit;
     }
     /* Kick start progress on this collective's schedule */
     mpi_errno = MPII_Genutil_sched_poke(sched, &is_complete, &made_progress);
     if (is_complete) {
-        MPID_Request_complete(reqp);
+        MPIR_Request_complete(reqp);
         goto fn_exit;
     }
 

--- a/src/mpi/request/greq_complete.c
+++ b/src/mpi/request/greq_complete.c
@@ -31,12 +31,7 @@ int MPI_Grequest_complete(MPI_Request request)
    into nothing otherwise. */
 void MPIR_Grequest_complete(MPIR_Request * request_ptr)
 {
-    /* Set the request as completed.  This does not change the
-     * reference count on the generalized request */
-    MPID_Request_complete(request_ptr);
-
-    /* The request release comes with the wait/test, not this complete
-     * routine, so we don't call the MPIR_Request_free routine */
+    MPIR_Request_complete(request_ptr);
 }
 
 #endif

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -295,7 +295,7 @@ static void coll_handle_complete(void *handle)
     MPIR_Request *req;
     if (NULL != handle) {
         req = (MPIR_Request *) handle;
-        MPID_Request_complete(req);
+        MPIR_Request_complete(req);
     }
 }
 

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -962,8 +962,7 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
                     break;
             }
 
-            mpi_errno = MPID_Request_complete(s->req);
-            MPIR_ERR_CHECK(mpi_errno);
+            MPIR_Request_complete(s->req);
 
             s->req = NULL;
             MPL_free(s->entries);


### PR DESCRIPTION
## Pull Request Description

Requests that are not created by device layer and not completed by device layer, such as general requests, gentran requests, sched requests, hcoll requests, don't need call `MPID_Request_complete`, which runs additional device specific checks and maybe called inside a device specific critical section. With ch4 per-vci critical section, and the need to avoid nested critical sections in critical paths, this become very tricky. Recognizing that these non-device requests can be simply completed by clearing completion counter directly, we let them to use `MPIR_Request_complete` instead. 

This separation is a pre-requisite for switching to multi-vci per-vci locking.

## Notes

The whole contention point is we call `MPIR_Request_free` inside the request completion. If it is called from a per-vci critical section, such as from device progress, we shouldn't enter the lock again. If it is called outside device, such as `MPI_Grequest_complete` and various progress hooks, we need the per-vci (or per request pool) lock to protect `MPIR_Request_free`.

We may remove the need to call `MPIR_Request_free` inside `MPIR_Request_complete` if all these requests are freed in a `MPI_Wait` family of wait-call. Currently the only place preventing that is due to ch3 rma window synchronization code calls `MPIR_Ibarrier` then frees the request right away without waiting for it. We can make the code simpler if we fix that usage.


<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
