### PR TITLE
test/mpi: fix improper MPI_NULL_COPY_FN and MPI_NULL_DELETE_FN

### DIFF
--- a/test/mpi/attr/attrordertype.c
+++ b/test/mpi/attr/attrordertype.c
@@ -28,7 +28,8 @@ int main(int argc, char *argv[])
         type = MPI_INT;
         /* Create key values */
         for (i = 0; i < 3; i++) {
-            MPI_Type_create_keyval(MPI_NULL_COPY_FN, MPI_NULL_DELETE_FN, &key[i], (void *) 0);
+            MPI_Type_create_keyval(MPI_TYPE_NULL_COPY_FN, MPI_TYPE_NULL_DELETE_FN, &key[i],
+                                   (void *) 0);
             attrval[i] = 1024 * i;
         }
 

--- a/test/mpi/attr/fkeyvaltype.c
+++ b/test/mpi/attr/fkeyvaltype.c
@@ -92,7 +92,8 @@ int main(int argc, char *argv[])
         /* We create some dummy keyvals here in case the same keyval
          * is reused */
         for (i = 0; i < 32; i++) {
-            MPI_Type_create_keyval(MPI_NULL_COPY_FN, MPI_NULL_DELETE_FN, &key[i], (void *) 0);
+            MPI_Type_create_keyval(MPI_TYPE_NULL_COPY_FN, MPI_TYPE_NULL_DELETE_FN, &key[i],
+                                   (void *) 0);
         }
 
         if (attrval != 1) {

--- a/test/mpi/attr/keyval_double_free_type.c
+++ b/test/mpi/attr/keyval_double_free_type.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
     MPI_Type_dup(MPI_INT, &type);
     MPI_Type_dup(MPI_INT, &type_dup);
 
-    MPI_Type_create_keyval(MPI_NULL_COPY_FN, delete_fn, &keyval, NULL);
+    MPI_Type_create_keyval(MPI_TYPE_NULL_COPY_FN, delete_fn, &keyval, NULL);
     keyval_copy = keyval;
     MPI_Type_set_attr(type, keyval, NULL);
     MPI_Type_set_attr(type_dup, keyval, NULL);

--- a/test/mpi/attr/keyval_double_free_win.c
+++ b/test/mpi/attr/keyval_double_free_win.c
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
     MPI_Alloc_mem(DATA_SZ, MPI_INFO_NULL, &base_ptr[1]);
     MPI_Win_create(base_ptr[1], DATA_SZ, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &windows[1]);
 
-    MPI_Win_create_keyval(MPI_NULL_COPY_FN, delete_fn, &keyval, NULL);
+    MPI_Win_create_keyval(MPI_WIN_NULL_COPY_FN, delete_fn, &keyval, NULL);
     keyval_copy = keyval;
 
     MPI_Win_set_attr(windows[0], keyval, NULL);

--- a/test/mpi/rma/attrorderwin.c
+++ b/test/mpi/rma/attrorderwin.c
@@ -32,7 +32,8 @@ int main(int argc, char *argv[])
 
         /* Create key values */
         for (i = 0; i < 3; i++) {
-            MPI_Win_create_keyval(MPI_NULL_COPY_FN, MPI_NULL_DELETE_FN, &key[i], (void *) 0);
+            MPI_Win_create_keyval(MPI_WIN_NULL_COPY_FN, MPI_WIN_NULL_DELETE_FN, &key[i],
+                                  (void *) 0);
             attrval[i] = 1024 * i;
         }
 

--- a/test/mpi/rma/fkeyvalwin.c
+++ b/test/mpi/rma/fkeyvalwin.c
@@ -63,7 +63,8 @@ int main(int argc, char *argv[])
         /* We create some dummy keyvals here in case the same keyval
          * is reused */
         for (i = 0; i < 32; i++) {
-            MPI_Win_create_keyval(MPI_NULL_COPY_FN, MPI_NULL_DELETE_FN, &key[i], (void *) 0);
+            MPI_Win_create_keyval(MPI_WIN_NULL_COPY_FN, MPI_WIN_NULL_DELETE_FN, &key[i],
+                                  (void *) 0);
         }
 
         MTestFreeWin(&win);


### PR DESCRIPTION

## Pull Request Description

`MPI_NULL_COPY_FN` and `MPI_NULL_DELETE_FN` should not be used for `MPI_Type_create_keyval()` and `MPI_Win_create_keyval()`.

- `MPI_Type_create_keyval()`'s copy/delete functions take `MPI_Datatype` as the first argument.
- `MPI_Win_create_keyval()`'s copy/delete functions take `MPI_Win` as the first argument.

Passing `MPI_NULL_COPY_FN` and `MPI_NULL_DELETE_FN` is not allowed as far as I checked the MPI standard; they can be used for only `MPI_Keyval_create()` and `MPI_Comm_create_keyval()`.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

This is a minor fix. This does not change the coverage of tests.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
