### PR TITLE
ch4/ofi: enabling multiple vci for pt2pt operations

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -240,7 +240,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IMRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IMRECV);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
+    int vci = MPIDI_Request_get_vci(message);
+#endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
 
     MPIDIG_REQUEST(message, req->rreq.mrcv_buffer) = buf;
     MPIDIG_REQUEST(message, req->rreq.mrcv_count) = count;
@@ -263,7 +266,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
     /* MPIDI_CS_EXIT(); */
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IMRECV);
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -218,12 +218,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv(void *buf,
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_RECV);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno =
         MPIDIG_do_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0ULL);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_RECV);
     return mpi_errno;
   fn_fail:
@@ -237,6 +239,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IMRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IMRECV);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     MPIDIG_REQUEST(message, req->rreq.mrcv_buffer) = buf;
     MPIDIG_REQUEST(message, req->rreq.mrcv_count) = count;
@@ -259,6 +262,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
     /* MPIDI_CS_EXIT(); */
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IMRECV);
     return mpi_errno;
   fn_fail:
@@ -276,11 +280,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irecv(void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IRECV);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno =
         MPIDIG_do_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0ULL);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IRECV);
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -213,7 +213,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv(void *buf,
                                              int tag,
                                              MPIR_Comm * comm,
                                              int context_offset, MPI_Status * status,
-                                             MPIR_Request ** request)
+                                             MPIR_Request ** request, int is_local)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RECV);
@@ -225,6 +225,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv(void *buf,
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
+    MPIDI_REQUEST_SET_LOCAL(*request, is_local, NULL);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_RECV);
     return mpi_errno;
@@ -275,7 +276,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irecv(void *buf,
                                               int rank,
                                               int tag,
                                               MPIR_Comm * comm, int context_offset,
-                                              MPIR_Request ** request)
+                                              MPIR_Request ** request,
+                                              int is_local, MPIR_Request * partner)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IRECV);
@@ -286,6 +288,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irecv(void *buf,
         MPIDIG_do_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0ULL);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
+    MPIDI_REQUEST_SET_LOCAL(*request, is_local, partner);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IRECV);
     return mpi_errno;

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -282,7 +282,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irecv(void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IRECV);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    /* For anysource recv, we may be called while holding the vci lock of shm request (to
+     * prevent shm progress). Therefore, recursive locking is allowed here */
+    MPID_THREAD_CS_ENTER_REC_VCI(MPIDI_VCI(0).lock);
 
     mpi_errno =
         MPIDIG_do_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0ULL);

--- a/src/mpid/ch4/generic/am/mpidig_am_send.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_send.h
@@ -256,10 +256,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_send(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_SEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_SEND);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                   request, MPIDIG_SEND, MPIR_ERR_NONE);
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_SEND);
     return mpi_errno;
 }
@@ -273,11 +275,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_send_coll(const void *buf, MPI_Aint count,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_SEND_COLL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_COLL);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno =
         MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr, request,
                           MPIDIG_SEND, *errflag);
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_SEND_COLL);
     return mpi_errno;
 }
@@ -292,10 +296,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_ISEND);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                   request, MPIDIG_SEND, MPIR_ERR_NONE);
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_ISEND);
     return mpi_errno;
 }
@@ -310,11 +316,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_coll(const void *buf, MPI_Aint count,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ISEND_COLL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ISEND_COLL);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno =
         MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr, request,
                           MPIDIG_SEND, *errflag);
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ISEND_COLL);
     return mpi_errno;
 }
@@ -330,10 +338,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rsend(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_RSEND);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                   request, MPIDIG_SEND, MPIR_ERR_NONE);
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_RSEND);
     return mpi_errno;
 }
@@ -349,10 +359,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irsend(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IRSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IRSEND);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                   request, MPIDIG_SEND, MPIR_ERR_NONE);
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IRSEND);
     return mpi_errno;
 }
@@ -367,10 +379,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_ssend(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_SSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_SSEND);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                   request, MPIDIG_SSEND_REQ, MPIR_ERR_NONE);
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_SSEND);
     return mpi_errno;
 }
@@ -385,10 +399,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_issend(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_ISSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_ISSEND);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                   request, MPIDIG_SSEND_REQ, MPIR_ERR_NONE);
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_ISSEND);
     return mpi_errno;
 }

--- a/src/mpid/ch4/include/mpid_thread.h
+++ b/src/mpid/ch4/include/mpid_thread.h
@@ -20,6 +20,18 @@ typedef MPIDU_Thread_mutex_t MPID_Thread_mutex_t;
 #define MPID_THREAD_CS_YIELD       MPIDU_THREAD_CS_YIELD
 #define MPID_THREAD_ASSERT_IN_CS   MPIDU_THREAD_ASSERT_IN_CS
 
+/* In limited cases we need use recusive mutex. For example, during establishing anysource
+ * receive, we need hold shm vci lock while setting up netmod request -- both may be the
+ * same vci or different vci. Recursive locking allows us to proceed in both cases.
+ * NOTE: use cautiously and comment on the reasoning of its usage.
+ */
+
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
+#define MPID_THREAD_CS_ENTER_REC_VCI(mutex)   MPIDUI_THREAD_CS_ENTER_REC(mutex)
+#else
+#define MPID_THREAD_CS_ENTER_REC_VCI(mutex)     /* NOOP */
+#endif
+
 #define MPID_Thread_init           MPIDU_Thread_init
 #define MPID_Thread_finalize       MPIDU_Thread_finalize
 #define MPID_Thread_mutex_create   MPIDU_Thread_mutex_create

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -309,10 +309,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_av_is_local(MPIDI_av_entry_t * av);
    them in the NETMOD_INLINE mode */
 #include "ch4_request.h"
 
+/* vci is used by both generic and lower layer, need come early */
+#include "ch4_vci.h"
+
 /* Active message and generic implementatiions */
 #include "mpidig_am.h"
 #include "mpidch4r.h"
-#include "ch4_vci.h"
 
 /* Include netmod and shm implementations  */
 /* Prototypes are split from impl to avoid */

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -264,8 +264,14 @@ typedef struct {
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
 #define MPIDI_REQUEST_ANYSOURCE_PARTNER(req)  (((req)->dev).anysource_partner_request)
+#define MPIDI_REQUEST_SET_LOCAL(req, is_local_, partner_) \
+    do { \
+        (req)->dev.is_local = is_local_; \
+        (req)->dev.anysource_partner_request = partner_; \
+    } while (0)
 #else
 #define MPIDI_REQUEST_ANYSOURCE_PARTNER(req)  NULL
+#define MPIDI_REQUEST_SET_LOCAL(req, is_local_, partner_)  do { } while (0)
 #endif
 
 MPL_STATIC_INLINE_PREFIX void MPID_Request_create_hook(struct MPIR_Request *req);

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -101,7 +101,8 @@ typedef int (*MPIDI_NM_mpi_recv_t) (void *buf, MPI_Aint count, MPI_Datatype data
                                     MPIR_Request ** request);
 typedef int (*MPIDI_NM_mpi_irecv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
                                      int tag, MPIR_Comm * comm, int context_offset,
-                                     MPIDI_av_entry_t * addr, MPIR_Request ** request);
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request,
+                                     MPIR_Request * partner);
 typedef int (*MPIDI_NM_mpi_imrecv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype,
                                       MPIR_Request * message);
 typedef int (*MPIDI_NM_mpi_cancel_recv_t) (MPIR_Request * rreq);
@@ -622,7 +623,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Da
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Request ** request,
+                                                MPIR_Request * partner) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  MPIR_Request * message) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
@@ -15,7 +15,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
                                                int context_offset, MPIDI_av_entry_t * addr,
                                                MPI_Status * status, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request);
+    return MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request,
+                           0);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
@@ -31,9 +32,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 int rank,
                                                 int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
+                                                MPIR_Request * partner)
 {
-    return MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 0,
+                            partner);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -343,7 +343,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Da
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request)
+                                                MPIR_Request ** request, MPIR_Request * partner)
 {
     int ret;
 
@@ -352,7 +352,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_D
 
     ret =
         MPIDI_NM_native_func->mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                        request);
+                                        request, partner);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_IRECV);
     return ret;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -431,13 +431,15 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
         }
 
         remote_key = recv_elem->remote_info.rma_key;
+        int vni_src = recv_elem->remote_info.vni_src;
+        int vni_dst = recv_elem->remote_info.vni_dst;
 
         MPIDI_OFI_cntr_incr();
-        MPIDI_OFI_CALL_RETRY(fi_read(MPIDI_OFI_global.ctx[0].tx,        /* endpoint     */
+        MPIDI_OFI_CALL_RETRY(fi_read(MPIDI_OFI_global.ctx[vni_dst].tx,  /* endpoint     */
                                      (void *) ((uintptr_t) recv_elem->wc.buf + recv_elem->cur_offset),  /* local buffer */
                                      bytesToGet,        /* bytes        */
                                      NULL,      /* descriptor   */
-                                     MPIDI_OFI_comm_to_phys(recv_elem->comm_ptr, recv_elem->remote_info.origin_rank, 0, 0),     /* Destination  */
+                                     MPIDI_OFI_comm_to_phys(recv_elem->comm_ptr, recv_elem->remote_info.origin_rank, vni_dst, vni_src), /* Destination  */
                                      recv_rbase(recv_elem) + recv_elem->cur_offset,     /* remote maddr */
                                      remote_key,        /* Key          */
                                      (void *) &recv_elem->context), rdma_readfrom,      /* Context */

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -186,10 +186,13 @@ static int recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq, int ev
                                                   MPIDI_OFI_SYNC_SEND_ACK);
         MPIR_Comm *c = rreq->comm;
         int r = rreq->status.MPI_SOURCE;
-        MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[0].tx, NULL /* buf */ ,
+        /* NOTE: use target rank, reply to src */
+        int vni_src = MPIDI_OFI_get_vni_src(c, c->rank, rreq->status.MPI_TAG);
+        int vni_dst = MPIDI_OFI_get_vni_dst(c, c->rank, rreq->status.MPI_TAG);
+        MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[vni_dst].tx, NULL /* buf */ ,
                                             0 /* len */ ,
                                             MPIR_Comm_rank(c),
-                                            MPIDI_OFI_comm_to_phys(c, r, 0, 0),
+                                            MPIDI_OFI_comm_to_phys(c, r, vni_dst, vni_src),
                                             ss_bits), tinjectdata, FALSE /* eagain */);
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -38,6 +38,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_mpi_acc_op_index(int op)
 }
 
 int MPIDI_OFI_progress(int vci, int blocking);
+
+/* vni mapping */
+/* NOTE: concerned by the modulo? If we restrict num_vnis to power of 2,
+ * we may get away with bit mask */
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_vni_src(MPIR_Comm * comm_ptr, int rank, int tag)
+{
+    return MPIDI_vci_get_src(comm_ptr, rank, tag) % MPIDI_OFI_global.num_vnis;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_vni_dst(MPIR_Comm * comm_ptr, int rank, int tag)
+{
+    return MPIDI_vci_get_dst(comm_ptr, rank, tag) % MPIDI_OFI_global.num_vnis;
+}
+
 /*
  * Helper routines and macros for request completion
  */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -363,6 +363,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_vci_to_vni(int vci)
     return vci;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_vci_to_vni_assert(int vci)
+{
+    int vni = MPIDI_OFI_vci_to_vni(vci);
+    MPIR_Assert(vni < MPIDI_OFI_global.num_vnis);
+    return vni;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_av_insert(int vni, int rank, void *addrname)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -576,6 +576,11 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     MPIR_Assert(num_vnis == 1 || MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS);
 #endif
 
+    /* WorkQ only works with single vni for now */
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPIR_Assert(num_vnis == 1);
+#endif
+
     MPIDI_OFI_global.num_vnis = num_vnis;
 
     /* Create MPIDI_OFI_global.ctx[0] first  */

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -115,8 +115,11 @@ static inline int MPIDI_NM_mpi_improbe(int source,
     }
 
     /* Set flags for mprobe peek, when ready */
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDI_OFI_do_iprobe(source, tag, comm, context_offset, addr,
                                     flag, status, message, FI_CLAIM | FI_COMPLETION);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+
     if (mpi_errno != MPI_SUCCESS)
         goto fn_exit;
 
@@ -143,8 +146,10 @@ static inline int MPIDI_NM_mpi_iprobe(int source,
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, flag, status);
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno =
             MPIDI_OFI_do_iprobe(source, tag, comm, context_offset, addr, flag, status, NULL, 0ULL);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_IPROBE);

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -24,7 +24,8 @@
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_t data_sz,      /* data_sz passed in here for reusing */
                                                 int rank, uint64_t match_bits, uint64_t mask_bits,
                                                 MPIR_Comm * comm, MPIR_Context_id_t context_id,
-                                                MPIDI_av_entry_t * addr, MPIR_Request * rreq,
+                                                MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
+                                                MPIR_Request * rreq,
                                                 MPIR_Datatype * dt_ptr, uint64_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -73,9 +74,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
     msg.ignore = mask_bits;
     msg.context = (void *) &(MPIDI_OFI_REQUEST(rreq, context));
     msg.data = 0;
-    msg.addr = (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr, 0, 0);
+    msg.addr =
+        (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr, vni_dst, vni_src);
 
-    MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[0].rx, &msg, flags), trecv, FALSE);
+    MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[vni_dst].rx, &msg, flags), trecv, FALSE);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_RECV_IOV);
@@ -96,7 +98,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
                                                 int tag,
                                                 MPIR_Comm * comm,
                                                 int context_offset,
-                                                MPIDI_av_entry_t * addr,
+                                                MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
                                                 MPIR_Request ** request, int mode, uint64_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -123,7 +125,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         } else
 #endif
         {
-            MPIDI_OFI_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__RECV, 0);
+            MPIDI_OFI_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__RECV, vni_dst);
         }
         rreq = *request;
 
@@ -161,7 +163,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
             !force_gpu_pack) {
             mpi_errno =
                 MPIDI_OFI_recv_iov(buf, count, data_sz, rank, match_bits, mask_bits, comm,
-                                   context_id, addr, rreq, dt_ptr, flags);
+                                   context_id, addr, vni_src, vni_dst, rreq, dt_ptr, flags);
             if (mpi_errno == MPI_SUCCESS)       /* Receive posted using iov */
                 goto fn_exit;
             else if (mpi_errno != MPIDI_OFI_RECV_NEEDS_UNPACK)
@@ -204,12 +206,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         MPIDI_OFI_REQUEST(rreq, event_id) = MPIDI_OFI_EVENT_RECV;
 
     if (!flags) /* Branch should compile out */
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[0].rx,
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[vni_dst].rx,
                                       recv_buf,
                                       data_sz,
                                       NULL,
-                                      (MPI_ANY_SOURCE ==
-                                       rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr, 0, 0),
+                                      (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC :
+                                      MPIDI_OFI_av_to_phys(addr, vni_dst, vni_src),
                                       match_bits, mask_bits,
                                       (void *) &(MPIDI_OFI_REQUEST(rreq, context))), trecv, FALSE);
     else {
@@ -225,7 +227,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         msg.data = 0;
         msg.addr = FI_ADDR_UNSPEC;
 
-        MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[0].rx, &msg, flags), trecv, FALSE);
+        MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[vni_dst].rx, &msg, flags), trecv,
+                             FALSE);
     }
 
   fn_exit:
@@ -234,6 +237,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
   fn_fail:
     goto fn_exit;
 }
+
+/* Common macro used by all MPIDI_NM_mpi_recv routines to facilitate tuning */
+#define MPIDI_OFI_RECV_VNIS(vni_src_, vni_dst_) \
+    do { \
+        if (*request != NULL || context_offset != 0) { \
+            /* workq path  or collectives */ \
+            vni_src_ = 0; \
+            vni_dst_ = 0; \
+        } else { \
+            /* NOTE: hashing is based on target rank */ \
+            vni_src_ = MPIDI_OFI_get_vni_src(comm, comm->rank, tag); \
+            vni_dst_ = MPIDI_OFI_get_vni_dst(comm, comm->rank, tag); \
+        } \
+    } while (0)
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
@@ -254,11 +271,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
             MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request,
                             0);
     } else {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        int vni_src, vni_dst;
+        MPIDI_OFI_RECV_VNIS(vni_src, vni_dst);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_dst).lock);
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, rank, tag, comm,
-                                       context_offset, addr, request, MPIDI_OFI_ON_HEAP, 0ULL);
+                                       context_offset, addr, vni_src, vni_dst, request,
+                                       MPIDI_OFI_ON_HEAP, 0ULL);
         MPIDI_REQUEST_SET_LOCAL(*request, 0, NULL);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_dst).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_RECV);
@@ -282,8 +302,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
         int vci = MPIDI_Request_get_vci(rreq);
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
         av = MPIDIU_comm_rank_to_av(rreq->comm, message->status.MPI_SOURCE);
+        /* FIXME: need get vni_src in the request */
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, message->status.MPI_SOURCE,
-                                       message->status.MPI_TAG, rreq->comm, 0, av,
+                                       message->status.MPI_TAG, rreq->comm, 0, av, 0, vci,
                                        &rreq, MPIDI_OFI_USE_EXISTING, FI_CLAIM | FI_COMPLETION);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
     }
@@ -312,11 +333,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
             MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 0,
                              partner);
     } else {
-        MPID_THREAD_CS_ENTER_REC_VCI(MPIDI_VCI(0).lock);
+        int vni_src, vni_dst;
+        MPIDI_OFI_RECV_VNIS(vni_src, vni_dst);
+        MPID_THREAD_CS_ENTER_REC_VCI(MPIDI_VCI(vni_dst).lock);
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, rank, tag, comm,
-                                       context_offset, addr, request, MPIDI_OFI_ON_HEAP, 0ULL);
+                                       context_offset, addr, vni_src, vni_dst, request,
+                                       MPIDI_OFI_ON_HEAP, 0ULL);
         MPIDI_REQUEST_SET_LOCAL(*request, 0, partner);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_dst).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_IRECV);

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -251,11 +251,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
 
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno =
-            MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request);
+            MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request,
+                            0);
     } else {
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, rank, tag, comm,
                                        context_offset, addr, request, MPIDI_OFI_ON_HEAP, 0ULL);
+        MPIDI_REQUEST_SET_LOCAL(*request, 0, NULL);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
@@ -296,7 +298,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 int rank,
                                                 int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
+                                                MPIR_Request * partner)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IRECV);
@@ -304,11 +307,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
 
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno =
-            MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request);
+            MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 0,
+                             partner);
     } else {
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, rank, tag, comm,
                                        context_offset, addr, request, MPIDI_OFI_ON_HEAP, 0ULL);
+        MPIDI_REQUEST_SET_LOCAL(*request, 0, partner);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -253,8 +253,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
         mpi_errno =
             MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request);
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, rank, tag, comm,
                                        context_offset, addr, request, MPIDI_OFI_ON_HEAP, 0ULL);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_RECV);
@@ -275,11 +277,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
         mpi_errno = MPIDIG_mpi_imrecv(buf, count, datatype, message);
     } else {
         rreq = message;
-
+        int vci = MPIDI_Request_get_vci(rreq);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
         av = MPIDIU_comm_rank_to_av(rreq->comm, message->status.MPI_SOURCE);
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, message->status.MPI_SOURCE,
                                        message->status.MPI_TAG, rreq->comm, 0, av,
                                        &rreq, MPIDI_OFI_USE_EXISTING, FI_CLAIM | FI_COMPLETION);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_IMRECV);
@@ -302,8 +306,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
         mpi_errno =
             MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request);
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, rank, tag, comm,
                                        context_offset, addr, request, MPIDI_OFI_ON_HEAP, 0ULL);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_IRECV);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -159,7 +159,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIR_cc_incr(sreq->cc_ptr, &c);
         ssend_match = MPIDI_OFI_init_recvtag(&ssend_mask, comm->context_id + context_offset, tag);
         ssend_match |= MPIDI_OFI_SYNC_SEND_ACK;
-        /* FIXME: check that MPIDI_OFI_EVENT_SSEND_ACK send back to the correct vni */
         MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[vni_src].rx, /* endpoint    */
                                       NULL,     /* recvbuf     */
                                       0,        /* data sz     */

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -245,7 +245,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIDI_OFI_REQUEST(sreq, event_id) = MPIDI_OFI_EVENT_SEND_HUGE;
         MPIR_cc_incr(sreq->cc_ptr, &c);
 
-        /* FIXME: check MPIDI_OFI_EVENT_SEND_HUGE use the correct vni */
         if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
             /* Set up a memory region for the lmt data transfer */
             ctrl.rma_key = MPIDI_OFI_mr_key_alloc();
@@ -289,6 +288,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         ctrl.type = MPIDI_OFI_CTRL_HUGE;
         ctrl.seqno = 0;
         ctrl.tag = tag;
+        ctrl.vni_src = vni_src;
+        ctrl.vni_dst = vni_dst;
 
         /* Send information about the memory region here to get the lmt going. */
         mpi_errno = MPIDI_OFI_do_control_send(&ctrl, send_buf, data_sz, dst_rank, comm, sreq);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -13,18 +13,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
                                                         uint64_t cq_data,
                                                         int dst_rank,
                                                         int tag, MPIR_Comm * comm,
-                                                        int context_offset, MPIDI_av_entry_t * addr)
+                                                        int context_offset,
+                                                        MPIDI_av_entry_t * addr,
+                                                        int vni_src, int vni_dst)
 {
     int mpi_errno = MPI_SUCCESS;
     uint64_t match_bits;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT);
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, tag, 0);
-    MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[0].tx,
+    MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[vni_src].tx,
                                         buf,
                                         data_sz,
                                         cq_data,
-                                        MPIDI_OFI_av_to_phys(addr, 0, 0),
+                                        MPIDI_OFI_av_to_phys(addr, vni_src, vni_dst),
                                         match_bits),
                          tinjectdata, comm->hints[MPIR_COMM_HINT_EAGAIN]);
   fn_exit:
@@ -50,8 +52,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count, size_t data_sz,
                                                 uint64_t cq_data,
                                                 int dst_rank, uint64_t match_bits, MPIR_Comm * comm,
-                                                MPIDI_av_entry_t * addr, MPIR_Request * sreq,
-                                                MPIR_Datatype * dt_ptr)
+                                                MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
+                                                MPIR_Request * sreq, MPIR_Datatype * dt_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     struct iovec *originv = NULL;
@@ -93,9 +95,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     msg.ignore = 0ULL;
     msg.context = (void *) &(MPIDI_OFI_REQUEST(sreq, context));
     msg.data = cq_data;
-    msg.addr = MPIDI_OFI_av_to_phys(addr, 0, 0);
+    msg.addr = MPIDI_OFI_av_to_phys(addr, vni_src, vni_dst);
 
-    MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[0].tx, &msg, flags), tsendv, FALSE);
+    MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[vni_src].tx, &msg, flags), tsendv, FALSE);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_SEND_IOV);
@@ -113,7 +115,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                                    MPI_Datatype datatype,
                                                    uint64_t cq_data, int dst_rank, int tag,
                                                    MPIR_Comm * comm, int context_offset,
-                                                   MPIDI_av_entry_t * addr, MPIR_Request ** request,
+                                                   MPIDI_av_entry_t * addr, int vni_src,
+                                                   int vni_dst, MPIR_Request ** request,
                                                    int dt_contig, size_t data_sz,
                                                    MPIR_Datatype * dt_ptr, MPI_Aint dt_true_lb,
                                                    uint64_t type)
@@ -134,7 +137,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     } else
 #endif
     {
-        MPIDI_OFI_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__SEND, 0);
+        MPIDI_OFI_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__SEND, vni_src);
     }
 
     MPIR_Request *sreq = *request;
@@ -156,11 +159,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIR_cc_incr(sreq->cc_ptr, &c);
         ssend_match = MPIDI_OFI_init_recvtag(&ssend_mask, comm->context_id + context_offset, tag);
         ssend_match |= MPIDI_OFI_SYNC_SEND_ACK;
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[0].rx,       /* endpoint    */
+        /* FIXME: check that MPIDI_OFI_EVENT_SSEND_ACK send back to the correct vni */
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[vni_src].rx, /* endpoint    */
                                       NULL,     /* recvbuf     */
                                       0,        /* data sz     */
                                       NULL,     /* memregion descr  */
-                                      MPIDI_OFI_av_to_phys(addr, 0, 0), /* remote proc */
+                                      MPIDI_OFI_av_to_phys(addr, vni_src, vni_dst),     /* remote proc */
                                       ssend_match,      /* match bits  */
                                       0ULL,     /* mask bits   */
                                       (void *) &(ackreq->context)), trecvsync, FALSE);
@@ -182,9 +186,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     if (!dt_contig && data_sz) {
         if (MPIDI_OFI_ENABLE_PT2PT_NOPACK && data_sz <= MPIDI_OFI_global.max_msg_size &&
             !force_gpu_pack) {
-            mpi_errno =
-                MPIDI_OFI_send_iov(buf, count, data_sz, cq_data, dst_rank, match_bits, comm, addr,
-                                   sreq, dt_ptr);
+            mpi_errno = MPIDI_OFI_send_iov(buf, count, data_sz, cq_data, dst_rank, match_bits,
+                                           comm, addr, vni_src, vni_dst, sreq, dt_ptr);
             if (mpi_errno == MPI_SUCCESS)       /* Send posted using iov */
                 goto fn_exit;
             else if (mpi_errno != MPIDI_OFI_SEND_NEEDS_PACK)
@@ -218,18 +221,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     }
 
     if (data_sz <= MPIDI_OFI_global.max_buffered_send) {
-        MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[0].tx,
+        MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[vni_src].tx,
                                             send_buf,
                                             data_sz,
                                             cq_data,
-                                            MPIDI_OFI_av_to_phys(addr, 0, 0),
+                                            MPIDI_OFI_av_to_phys(addr, vni_src, vni_dst),
                                             match_bits), tinjectdata, FALSE /* eagain */);
         MPIDI_OFI_send_event(NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
     } else if (data_sz <= MPIDI_OFI_global.max_msg_size) {
-        MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[0].tx,
+        MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[vni_src].tx,
                                           send_buf, data_sz, NULL /* desc */ ,
                                           cq_data,
-                                          MPIDI_OFI_av_to_phys(addr, 0, 0),
+                                          MPIDI_OFI_av_to_phys(addr, vni_src, vni_dst),
                                           match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
                              tsenddata, FALSE /* eagain */);
@@ -243,13 +246,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIDI_OFI_REQUEST(sreq, event_id) = MPIDI_OFI_EVENT_SEND_HUGE;
         MPIR_cc_incr(sreq->cc_ptr, &c);
 
+        /* FIXME: check MPIDI_OFI_EVENT_SEND_HUGE use the correct vni */
         if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
             /* Set up a memory region for the lmt data transfer */
             ctrl.rma_key = MPIDI_OFI_mr_key_alloc();
             rma_key = ctrl.rma_key;
         }
 
-        MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.ctx[0].domain,        /* In:  Domain Object */
+        MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.ctx[vni_src].domain,  /* In:  Domain Object */
                                  send_buf,      /* In:  Lower memory address */
                                  data_sz,       /* In:  Length              */
                                  FI_REMOTE_READ,        /* In:  Expose MR for read  */
@@ -276,10 +280,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIR_Comm_add_ref(comm);
         MPIDI_OFI_REQUEST(sreq, util_id) = dst_rank;
         match_bits |= MPIDI_OFI_HUGE_SEND;      /* Add the bit for a huge message */
-        MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[0].tx,
+        MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[vni_src].tx,
                                           send_buf, MPIDI_OFI_global.max_msg_size, NULL /* desc */ ,
                                           cq_data,
-                                          MPIDI_OFI_av_to_phys(addr, 0, 0),
+                                          MPIDI_OFI_av_to_phys(addr, vni_src, vni_dst),
                                           match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
                              tsenddata, FALSE /* eagain */);
@@ -302,6 +306,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                             int dst_rank, int tag, MPIR_Comm * comm,
                                             int context_offset, MPIDI_av_entry_t * addr,
+                                            int vni_src, int vni_dst,
                                             MPIR_Request ** request, int noreq,
                                             uint64_t syncflag, MPIR_Errflag_t err_flag)
 {
@@ -333,8 +338,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
                 send_buf = host_buf;
             }
         }
-        mpi_errno = MPIDI_OFI_send_lightweight(send_buf, data_sz,
-                                               cq_data, dst_rank, tag, comm, context_offset, addr);
+        mpi_errno = MPIDI_OFI_send_lightweight(send_buf, data_sz, cq_data, dst_rank, tag, comm,
+                                               context_offset, addr, vni_src, vni_dst);
         if (actual_pack_bytes > 0) {
             /* Free stage host buf (asigned to send_buf already) after
              * lightweight_send. */
@@ -345,13 +350,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         }
     } else {
         mpi_errno = MPIDI_OFI_send_normal(buf, count, datatype, cq_data, dst_rank, tag, comm,
-                                          context_offset, addr, request, dt_contig,
-                                          data_sz, dt_ptr, dt_true_lb, syncflag);
+                                          context_offset, addr, vni_src, vni_dst, request,
+                                          dt_contig, data_sz, dt_ptr, dt_true_lb, syncflag);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_SEND);
     return mpi_errno;
 }
+
+/* Common macro used by all MPIDI_NM_mpi_send routines to facilitate tuning */
+#define MPIDI_OFI_SEND_VNIS(vni_src_, vni_dst_) \
+    do { \
+        if (*request != NULL) { \
+            /* workq path */ \
+            vni_src_ = 0; \
+            vni_dst_ = 0; \
+        } else { \
+            vni_src_ = MPIDI_OFI_get_vni_src(comm, rank, tag); \
+            vni_dst_ = MPIDI_OFI_get_vni_dst(comm, rank, tag); \
+        } \
+    } while (0)
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
                                                MPI_Datatype datatype, int rank, int tag,
@@ -366,11 +384,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
         mpi_errno =
             MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
     } else {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        int vni_src, vni_dst;
+        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, request, (*request == NULL), 0ULL,
-                                   MPIR_ERR_NONE);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+                                   context_offset, addr, vni_src, vni_dst, request,
+                                   (*request == NULL), 0ULL, MPIR_ERR_NONE);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SEND);
@@ -402,6 +422,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_SEND_COLL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_SEND_COLL);
 
+    /* NOTE: collective use vci 0 and critical section taken at ch4-layer */
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno =
             MPIDIG_send_coll(buf, count, datatype, d_rank, tag, comm, context_offset, addr, request,
@@ -409,7 +430,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
     } else {
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, d_rank, tag, comm, context_offset,
-                                   addr, request, (*request == NULL), 0ULL, *errflag);
+                                   addr, 0, 0, request, (*request == NULL), 0ULL, *errflag);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
@@ -430,11 +451,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
         mpi_errno =
             MPIDIG_mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
     } else {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        int vni_src, vni_dst;
+        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, request, 0, MPIDI_OFI_SYNC_SEND,
-                                   MPIR_ERR_NONE);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+                                   context_offset, addr, vni_src, vni_dst, request, 0,
+                                   MPIDI_OFI_SYNC_SEND, MPIR_ERR_NONE);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SSEND);
@@ -455,10 +478,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
         mpi_errno =
             MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
     } else {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        int vni_src, vni_dst;
+        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, request, 0, 0ULL, MPIR_ERR_NONE);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+                                   context_offset, addr, vni_src, vni_dst,
+                                   request, 0, 0ULL, MPIR_ERR_NONE);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ISEND);
@@ -490,6 +516,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_ISEND_COLL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_ISEND_COLL);
 
+    /* NOTE: collective use vci 0 and critical section taken at ch4-layer */
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno =
             MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
@@ -497,7 +524,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
     } else {
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, request, 0, 0ULL, *errflag);
+                                   context_offset, addr, 0, 0, request, 0, 0ULL, *errflag);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
@@ -518,11 +545,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count
         mpi_errno =
             MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
     } else {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        int vni_src, vni_dst;
+        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, request, 0, MPIDI_OFI_SYNC_SEND,
-                                   MPIR_ERR_NONE);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+                                   context_offset, addr, vni_src, vni_dst, request, 0,
+                                   MPIDI_OFI_SYNC_SEND, MPIR_ERR_NONE);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ISSEND);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -366,9 +366,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
         mpi_errno =
             MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, request, (*request == NULL), 0ULL,
                                    MPIR_ERR_NONE);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SEND);
@@ -405,8 +407,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
             MPIDIG_send_coll(buf, count, datatype, d_rank, tag, comm, context_offset, addr, request,
                              errflag);
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, d_rank, tag, comm, context_offset,
                                    addr, request, (*request == NULL), 0ULL, *errflag);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_SEND_COLL);
@@ -426,9 +430,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
         mpi_errno =
             MPIDIG_mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, request, 0, MPIDI_OFI_SYNC_SEND,
                                    MPIR_ERR_NONE);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SSEND);
@@ -449,8 +455,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
         mpi_errno =
             MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, request, 0, 0ULL, MPIR_ERR_NONE);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ISEND);
@@ -487,8 +495,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
             MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
                               request, errflag);
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, request, 0, 0ULL, *errflag);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_ISEND_COLL);
@@ -508,9 +518,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count
         mpi_errno =
             MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, request, 0, MPIDI_OFI_SYNC_SEND,
                                    MPIR_ERR_NONE);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ISSEND);

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -403,6 +403,8 @@ typedef struct {
     int endpoint_id;
     uint64_t rma_key;
     int tag;
+    int vni_src;
+    int vni_dst;
 } MPIDI_OFI_send_control_t;
 
 typedef struct MPIDI_OFI_win_acc_hint {

--- a/src/mpid/ch4/netmod/stubnm/stubnm_recv.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_recv.h
@@ -36,7 +36,8 @@ static inline int MPIDI_NM_mpi_irecv(void *buf,
                                      int rank,
                                      int tag,
                                      MPIR_Comm * comm, int context_offset,
-                                     MPIDI_av_entry_t * addr, MPIR_Request ** request)
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request,
+                                     MPIR_Request * partner)
 {
     int err = MPI_SUCCESS;
     MPIR_Assert(0);

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -23,6 +23,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
     ucp_tag_message_h message_h;
     MPIR_Request *req = NULL;
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+
     tag_mask = MPIDI_UCX_tag_mask(tag, source);
     ucp_tag = MPIDI_UCX_recv_tag(tag, source, comm->recvcontext_id + context_offset);
 
@@ -47,6 +49,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
     *message = req;
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -66,6 +69,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
     ucp_tag_recv_info_t info;
     ucp_tag_message_h message_h;
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+
     tag_mask = MPIDI_UCX_tag_mask(tag, source);
     ucp_tag = MPIDI_UCX_recv_tag(tag, source, comm->recvcontext_id + context_offset);
 
@@ -84,6 +89,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
     } else {
         *flag = 0;
     }
+
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -166,6 +166,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
     MPIDI_UCX_ucp_request_t *ucp_request;
     MPIR_Datatype *dt_ptr;
 
+    int vci = MPIDI_Request_get_vci(message);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
     if (dt_contig) {
         ucp_request =
@@ -199,6 +201,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
     }
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -214,7 +217,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
                                                MPIDI_av_entry_t * addr,
                                                MPI_Status * status, MPIR_Request ** request)
 {
-    return MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
+    int mpi_errno;
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno =
+        MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
@@ -225,7 +233,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 MPIR_Comm * comm, int context_offset,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
+    int mpi_errno;
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno =
+        MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -221,6 +221,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno =
         MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
+    MPIDI_REQUEST_SET_LOCAL(*request, 0, NULL);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     return mpi_errno;
 }
@@ -231,12 +232,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 int rank,
                                                 int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
+                                                MPIR_Request * partner)
 {
     int mpi_errno;
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno =
         MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
+    MPIDI_REQUEST_SET_LOCAL(*request, 0, partner);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -166,7 +166,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
     MPIDI_UCX_ucp_request_t *ucp_request;
     MPIR_Datatype *dt_ptr;
 
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
     int vci = MPIDI_Request_get_vci(message);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
     if (dt_contig) {

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -113,6 +113,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_SEND_COLL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_SEND_COLL);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     switch (*errflag) {
         case MPIR_ERR_NONE:
@@ -127,6 +128,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
     mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset, addr, request,
                                0, 0);
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_SEND_COLL);
 
     return mpi_errno;
@@ -140,8 +142,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf,
                                                MPIR_Comm * comm, int context_offset,
                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
-                          addr, request, 0, 0);
+    int mpi_errno;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
+                               addr, request, 0, 0);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf,
@@ -152,8 +160,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf,
                                                 MPIR_Comm * comm, int context_offset,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
-                          addr, request, 0, 1);
+    int mpi_errno;
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
+                               addr, request, 0, 1);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,
@@ -166,6 +178,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_ISEND_COLL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_ISEND_COLL);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     switch (*errflag) {
         case MPIR_ERR_NONE:
@@ -180,6 +193,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
     mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
                                addr, request, 1, 0);
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_ISEND_COLL);
 
     return mpi_errno;
@@ -193,8 +207,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
                                                 MPIR_Comm * comm, int context_offset,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
-                          addr, request, 1, 0);
+    int mpi_errno;
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
+                               addr, request, 1, 0);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf,
@@ -205,8 +223,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf,
                                                  MPIR_Comm * comm, int context_offset,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
-                          addr, request, 1, 1);
+    int mpi_errno;
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
+                               addr, request, 1, 1);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq)

--- a/src/mpid/ch4/shm/ipc/src/ipc_recv.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_recv.h
@@ -64,9 +64,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_imrecv(void *buf, MPI_Aint count, MPI
     bool recvd_flag = false;
 
     /* Try IPC specific matched receive */
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
+    int vci = MPIDI_Request_get_vci(message);
+#endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
     mpi_errno = MPIDI_IPCI_try_matched_recv(buf, count, datatype, message, &recvd_flag);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* If not received, then fallback to POSIX matched receive */

--- a/src/mpid/ch4/shm/ipc/src/ipc_recv.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_recv.h
@@ -137,6 +137,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_irecv(void *buf, MPI_Aint count, MPI_
     }
 
   fn_exit:
+    MPIDI_REQUEST_SET_LOCAL(*request, 1, NULL);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPC_MPI_IRECV);
     return mpi_errno;

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -28,6 +28,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_isend(const void *buf, MPI_Aint count
 
     MPIDI_Datatype_check_contig_size_lb(datatype, count, dt_contig, data_sz, true_lb);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     MPIDI_IPCI_mem_attr_t attr;
     MPIDI_IPCI_get_mem_attr((char *) buf + true_lb, &attr);
 
@@ -42,6 +43,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_isend(const void *buf, MPI_Aint count
         /* TODO: add flattening datatype protocol for noncontig send. Different
          * threshold may be required to tradeoff the flattening overhead.*/
     }
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno = MPIDI_POSIX_mpi_isend(buf, count, datatype, rank, tag, comm,
                                       context_offset, addr, request);

--- a/src/mpid/ch4/shm/posix/posix_recv.h
+++ b/src/mpid/ch4/shm/posix/posix_recv.h
@@ -32,7 +32,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_recv(void *buf,
                                                   MPIR_Request ** request)
 {
     int mpi_errno =
-        MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request);
+        MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request, 1);
     MPIDI_POSIX_recv_posted_hook(*request, rank, comm);
     return mpi_errno;
 }
@@ -52,7 +52,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_irecv(void *buf,
                                                    MPIR_Request ** request)
 {
     int mpi_errno =
-        MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request);
+        MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, NULL);
     MPIDI_POSIX_recv_posted_hook(*request, rank, comm);
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/src/shm_am_fallback_recv.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_recv.h
@@ -15,7 +15,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf,
                                                 int context_offset, MPI_Status * status,
                                                 MPIR_Request ** request)
 {
-    return MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request);
+    return MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request,
+                           1);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf,
@@ -33,7 +34,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf,
                                                  MPIR_Comm * comm, int context_offset,
                                                  MPIR_Request ** request)
 {
-    return MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1,
+                            NULL);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq)

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -174,8 +174,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_IMRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_IMRECV);
 
-    int vci = MPIDI_Request_get_vci(message);
-
     mpi_errno = MPIDI_IPC_mpi_imrecv(buf, count, datatype, message);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -174,6 +174,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_IMRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_IMRECV);
 
+    int vci = MPIDI_Request_get_vci(message);
+
     mpi_errno = MPIDI_IPC_mpi_imrecv(buf, count, datatype, message);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/src/ch4_probe.h
+++ b/src/mpid/ch4/src/ch4_probe.h
@@ -99,13 +99,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_safe(int source,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPROBE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPROBE_SAFE);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-
     MPIDI_workq_vci_progress_unsafe();
-    mpi_errno = MPIDI_iprobe_unsafe(source, tag, comm, context_offset, av, flag, status);
-
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
+#endif
+    mpi_errno = MPIDI_iprobe_unsafe(source, tag, comm, context_offset, av, flag, status);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -127,13 +126,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_improbe_safe(int source,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IMPROBE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMPROBE_SAFE);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-
     MPIDI_workq_vci_progress_unsafe();
-    mpi_errno = MPIDI_improbe_unsafe(source, tag, comm, context_offset, av, flag, message, status);
-
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
+#endif
+    mpi_errno = MPIDI_improbe_unsafe(source, tag, comm, context_offset, av, flag, message, status);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -225,11 +225,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
                               status, *req, NULL /*flag */ , NULL /*message */ ,
                               NULL /*processed */);
 #else
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = NULL;
     mpi_errno = MPIDI_recv_unsafe(buf, count, datatype, rank, tag, comm,
                                   context_offset, av, status, req);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 #endif
 
   fn_exit:
@@ -264,10 +262,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
                               NULL /*status */ , *req, NULL /*flag */ , NULL /*message */ ,
                               NULL /*processed */);
 #else
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = NULL;
     mpi_errno = MPIDI_irecv_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 #endif
 
   fn_exit:
@@ -298,9 +294,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
                               NULL /*status */ , request, NULL /*flag */ ,
                               &message, NULL /*processed */);
 #else
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDI_imrecv_unsafe(buf, count, datatype, message);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 #endif
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -23,7 +23,9 @@ static inline int anysource_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
     /* 1. hold shm vci lock to prevent shm progress while we establish netmod request.
      * 2. MPIDI_NM_mpi_irecv need use recursive locking in case it share the shm vci lock
      */
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
     int shm_vci = MPIDI_Request_get_vci(*request);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(shm_vci).lock);
     need_unlock = 1;
     if (!MPIR_Request_is_complete(*request) && !MPIDIG_REQUEST_IN_PROGRESS(*request)) {
@@ -298,7 +300,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_safe(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CANCEL_RECV_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CANCEL_RECV_SAFE);
 
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
     int vci = MPIDI_Request_get_vci(rreq);
+#endif
     /* MPIDI_NM_mpi_cancel_recv is used both externally and internally. For internal
      * usage it's often used inside a critical section (e.g. progress and anysource
      * receive). Therefore, we allow recursive lock usage here.

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -317,12 +317,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_safe(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CANCEL_RECV_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CANCEL_RECV_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-
+    int vci = MPIDI_Request_get_vci(rreq);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
     mpi_errno = MPIDI_cancel_recv_unsafe(rreq);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -259,10 +259,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
                               NULL /*status */ , *req, NULL /*flag */ ,
                               NULL /*message */ , NULL /*processed */);
 #else
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = NULL;
     mpi_errno = MPIDI_send_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 #endif
 
   fn_exit:
@@ -296,11 +294,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
     MPIDI_workq_csend_enqueue(CSEND, buf, count, datatype, rank, tag, comm,
                               context_offset, av, *req, errflag);
 #else
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = NULL;
     mpi_errno = MPIDI_send_coll_unsafe(buf, count, datatype, rank, tag, comm,
                                        context_offset, av, req, errflag);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 #endif
 
   fn_exit:
@@ -334,10 +330,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
                               NULL /*status */ , *req, NULL /*flag */ ,
                               NULL /*message */ , NULL /*processed */);
 #else
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = NULL;
     mpi_errno = MPIDI_isend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 #endif
 
   fn_exit:
@@ -371,11 +365,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
     MPIDI_workq_csend_enqueue(ICSEND, buf, count, datatype, rank, tag, comm,
                               context_offset, av, *req, errflag);
 #else
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = NULL;
     mpi_errno = MPIDI_isend_coll_unsafe(buf, count, datatype, rank, tag, comm,
                                         context_offset, av, req, errflag);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 #endif
 
   fn_exit:
@@ -409,10 +401,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
                               NULL /*status */ , *req, NULL /*flag */ ,
                               NULL /*message */ , NULL /*processed */);
 #else
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = NULL;
     mpi_errno = MPIDI_ssend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 #endif
 
   fn_exit:
@@ -446,10 +436,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
                               NULL /*status */ , *req, NULL /*flag */ ,
                               NULL /*message */ , NULL /*processed */);
 #else
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = NULL;
     mpi_errno = MPIDI_issend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 #endif
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4r_probe.h
+++ b/src/mpid/ch4/src/ch4r_probe.h
@@ -16,6 +16,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
     MPIR_Request *unexp_req;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IPROBE);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     root_comm = MPIDIG_context_id_to_comm(comm->context_id);
 
@@ -36,6 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
     }
     /* MPIDI_CS_EXIT(); */
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IPROBE);
     return mpi_errno;
 }
@@ -50,6 +52,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IMPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IMPROBE);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     root_comm = MPIDIG_context_id_to_comm(comm->context_id);
 
@@ -79,6 +82,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
     }
     /* MPIDI_CS_EXIT(); */
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IMPROBE);
     return mpi_errno;
 }

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -82,6 +82,11 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_request_init(MPIR_Request * req,
  * At matching time, we cancel one of them (but not freed).
  * At completion time, we complete and free both.
  */
+/* Thread-safety: MPIDI_anysrc_try_cancel_partner need be called inside the correct
+ * critical section, as both MPIDI_NM_mpi_cancel_recv and MPIDI_SHM_mpi_cancel_recv
+ * are unsafe. This assumes netmod, shmmod and am share the same vci. If that changes,
+ * here we need be called outside lock and shift the lock responsibility into netmod,
+ * shmmod, and am */
 static inline int MPIDI_anysrc_try_cancel_partner(MPIR_Request * rreq, int *is_cancelled)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -320,6 +320,9 @@ AC_ARG_WITH(ch4-max-vcis,
 if test $with_ch4_max_vcis -le 0 ; then
    AC_MSG_ERROR(Number of VCIs must be greater than 0)
 fi
+if test $with_ch4_max_vcis -gt 1 -a $thread_granularity != MPICH_THREAD_GRANULARITY__VCI ; then
+    AC_MSG_ERROR(CH4_MAX_VCIS greater than 1 requires --enable-thread-cs=per-vci)
+fi
 AC_DEFINE_UNQUOTED([MPIDI_CH4_MAX_VCIS], [$with_ch4_max_vcis], [Number of VCIs configured in CH4])
 
 # Check for enable-ch4-vci-method choice

--- a/src/mpid/common/thread/mpidu_thread_fallback.h
+++ b/src/mpid/common/thread/mpidu_thread_fallback.h
@@ -115,6 +115,27 @@ M*/
 /* ***************************************** */
 #if defined(MPICH_IS_THREADED)
 
+#define MPIDUI_THREAD_CS_ENTER_REC(mutex)                               \
+    do {                                                                \
+        if (MPIR_ThreadInfo.isThreaded) {                               \
+            int equal_ = 0;                                             \
+            MPL_thread_id_t self_, owner_;                              \
+            MPL_thread_self(&self_);                                    \
+            owner_ = mutex.owner;                                       \
+            MPL_thread_same(&self_, &owner_, &equal_);                  \
+            if (!equal_) {                                              \
+                int err_ = 0;                                           \
+                MPL_DBG_MSG_P(MPIR_DBG_THREAD,VERBOSE,"enter MPIDU_Thread_mutex_lock %p", &mutex); \
+                MPIDU_Thread_mutex_lock(&mutex, &err_, MPL_THREAD_PRIO_HIGH);\
+                MPL_DBG_MSG_P(MPIR_DBG_THREAD,VERBOSE,"exit MPIDU_Thread_mutex_lock %p", &mutex); \
+                MPIR_Assert(err_ == 0);                                 \
+                MPIR_Assert(mutex.count == 0);                          \
+                MPL_thread_self(&mutex.owner);                          \
+            }                                                           \
+            mutex.count++;                                              \
+        }                                                               \
+    } while (0)
+
 #define MPIDUI_THREAD_CS_ENTER(mutex)                                   \
     do {                                                                \
         if (MPIR_ThreadInfo.isThreaded) {                               \
@@ -179,7 +200,7 @@ M*/
             MPL_thread_id_t self_;                                      \
             MPL_thread_self(&self_);                                    \
             MPL_thread_same(&self_, &mutex.owner, &equal_);             \
-            MPIR_Assert(equal_ && mutex.count == 1); \
+            MPIR_Assert(equal_ && mutex.count >= 1); \
         } \
     } while (0)
 


### PR DESCRIPTION
## Pull Request Description

We'll enable multiple vci pt2pt operations in the ofi netmod path. 

* We'll use a default communicator based vci method for the basic use case that an application duplicates multiple comm, one for each thread. In this case, each comm will get to assigned a different vci in a round robin fashion.

* Progress will poll each vci in turn. This is a temporary patch. It should pose no impact for the backward case when multiple vci is not enabled. For multiple-vci case when both it is configured and run-time cvar enabled, it will pose as global contention point and provide slower performance (even than single-vci). A coming PR will address this performance issue.

* Move the lock in send/recv paths from ch4-layer down to netmod/shmmod layer. This allows shmmod, netmod, as well as active message path all may use different vci schemes. For now, we are only enabling the pt2pt patch in OFI netmod.

* Since we moved the critical section down, some critical code at ch4-layer is exposed. In particular, the any-source receive and internal cancel receive path need coordination from both shmmod and netmod. Because both modules may take the same or different vci locks, we allow recursive locking in a few places for simplicity.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
