### PR TITLE
Create a new Typerep API for IOV-based offsets

### DIFF
--- a/src/include/mpir_typerep.h
+++ b/src/include/mpir_typerep.h
@@ -47,9 +47,15 @@ int MPIR_Typerep_flatten_size(MPIR_Datatype * datatype_ptr, int *flattened_type_
 int MPIR_Typerep_flatten(MPIR_Datatype * datatype_ptr, void *flattened_type);
 int MPIR_Typerep_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type);
 
+/* byte-based offset routine: do not use; only maintained for backward
+ * compatibility with ch3 */
 int MPIR_Typerep_to_iov(const void *buf, MPI_Aint count, MPI_Datatype type, MPI_Aint byte_offset,
                         struct iovec *iov, int max_iov_len, MPI_Aint max_iov_bytes,
                         int *actual_iov_len, MPI_Aint * actual_iov_bytes);
+/* iov element count based routine */
+int MPIR_Typerep_to_iov_offset(const void *buf, MPI_Aint count, MPI_Datatype type,
+                               MPI_Aint iov_offset, struct iovec *iov, MPI_Aint max_iov_len,
+                               MPI_Aint * actual_iov_len);
 int MPIR_Typerep_iov_len(MPI_Aint count, MPI_Datatype type, MPI_Aint max_iov_bytes,
                          MPI_Aint * iov_len);
 

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_iov.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_iov.c
@@ -27,6 +27,40 @@ int MPIR_Typerep_to_iov(const void *buf, MPI_Aint count, MPI_Datatype type, MPI_
     return mpi_errno;
 }
 
+int MPIR_Typerep_to_iov_offset(const void *buf, MPI_Aint count, MPI_Datatype type,
+                               MPI_Aint iov_offset, struct iovec *iov, MPI_Aint max_iov_len,
+                               MPI_Aint * actual_iov_len)
+{
+    MPIR_Segment *seg;
+    int mpi_errno = MPI_SUCCESS;
+
+    seg = MPIR_Segment_alloc(buf, count, type);
+
+    MPI_Aint last;
+
+    /* skip through IOV elements to get to the required IOV offset */
+    MPI_Aint byte_offset = 0;
+    MPI_Aint rem_iov_offset = iov_offset;
+    while (rem_iov_offset) {
+        last = MPIR_AINT_MAX;
+        int iov_len = MPL_MIN(max_iov_len, rem_iov_offset);
+        MPIR_Segment_to_iov(seg, byte_offset, &last, iov, &iov_len);
+        rem_iov_offset += iov_len;
+        for (int i = 0; i < iov_len; i++)
+            byte_offset += iov[i].iov_len;
+    }
+
+    /* Final conversion to get the correct IOV set */
+    last = MPIR_AINT_MAX;
+    int iov_len = max_iov_len;
+    MPIR_Segment_to_iov(seg, byte_offset, &last, iov, &iov_len);
+    *actual_iov_len = (MPI_Aint) iov_len;
+
+    MPIR_Segment_free(seg);
+
+    return mpi_errno;
+}
+
 int MPIR_Typerep_iov_len(MPI_Aint count, MPI_Datatype type, MPI_Aint max_iov_bytes,
                          MPI_Aint * iov_len)
 {

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_iov.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_iov.c
@@ -122,6 +122,30 @@ int MPIR_Typerep_to_iov(const void *buf, MPI_Aint count, MPI_Datatype datatype,
     goto fn_exit;
 }
 
+int MPIR_Typerep_to_iov_offset(const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                               MPI_Aint iov_offset, struct iovec *iov, MPI_Aint max_iov_len,
+                               MPI_Aint * actual_iov_len)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_TO_IOV_OFFSET);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_TO_IOV_OFFSET);
+
+    int mpi_errno = MPI_SUCCESS;
+    int rc;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(datatype);
+    uintptr_t yaksa_actual_iov_len;
+    rc = yaksa_iov(buf, count, type, iov_offset, iov, max_iov_len, &yaksa_actual_iov_len);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    *actual_iov_len = (MPI_Aint) yaksa_actual_iov_len;
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_TO_IOV_OFFSET);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPIR_Typerep_iov_len(MPI_Aint count, MPI_Datatype datatype, MPI_Aint max_iov_bytes,
                          MPI_Aint * iov_len)
 {


### PR DESCRIPTION
## Pull Request Description

Allow mpich to use the typerep API by passing IOV-based offsets, instead of byte-based offsets.  IOV-based offsets are more efficient and more natural for MPICH to use.

The byte-based offset functions are not deleted to avoid churn in ch3, but their usage is discouraged.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
