### PR TITLE
runtests: update file locking routines to be more portable

### DIFF
--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -810,7 +810,7 @@ sub RunMPIProgram {
         }
     } elsif ($test_opt->{mem}) {
         # implicit lock by checking memory annotation
-        $lockfile="/tmp/runtests-mem.lock";
+        $lockfile="/tmp/runtests-memory.lock";
         if ($test_opt->{mem} > $g_opt->{memory_total}) {
             SkippedTest($programname, $np, $test_opt, $curdir, "xfail due to memory requirement");
             next;

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -914,7 +914,7 @@ sub RunMPIProgram {
 
     # release lock if needed
     if ($got_lock) {
-        relese_lock($lockfile);
+        release_lock($lockfile);
     }
 
     if ($found_error) {
@@ -1427,7 +1427,7 @@ sub get_lock {
     }
 }
 
-sub relese_lock {
+sub release_lock {
     my ($lockfile) = @_;
     if ($verbose) {
         print "Releasing lock [$lockfile]\n";

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -46,6 +46,9 @@ use File::Copy qw(move);
 # Use high resolution timers
 use Time::HiRes qw(gettimeofday tv_interval);
 
+# Import flock constants
+use Fcntl qw(:flock);
+
 # Global variables
 our $g_opt = {};   # global options. TODO: migrate global option vars into the hash
 $g_opt->{memory_total} = 20;      # Total memory in GB
@@ -798,15 +801,14 @@ sub RunMPIProgram {
 
     # acquire lock if requested
     my ($lockfile, $got_lock);
-    my ($lock_sh, $lock_ex) = (1, 2);
     if ($test_opt->{lock}) {
         # explict lock by setting "lock=[shared|name]" on testline directly
         my $name = $test_opt->{lock};
         $lockfile = "/tmp/runtests-$name.lock";
         if ($name eq "shared") {
-            $got_lock = get_lock($lockfile, $lock_sh);
+            $got_lock = get_lock($lockfile, LOCK_SH);
         } else {
-            $got_lock = get_lock($lockfile, $lock_ex);
+            $got_lock = get_lock($lockfile, LOCK_EX);
         }
     } elsif ($test_opt->{mem}) {
         # implicit lock by checking memory annotation
@@ -815,9 +817,9 @@ sub RunMPIProgram {
             SkippedTest($programname, $np, $test_opt, $curdir, "xfail due to memory requirement");
             next;
         } elsif ($test_opt->{mem} * $g_opt->{memory_multiplier} > $g_opt->{memory_total} ) {
-            $got_lock = get_lock($lockfile, $lock_ex);
+            $got_lock = get_lock($lockfile, LOCK_EX);
         } else {
-            $got_lock = get_lock($lockfile, $lock_sh);
+            $got_lock = get_lock($lockfile, LOCK_SH);
         }
     }
 
@@ -1406,8 +1408,8 @@ sub InitQuickTimeout {
 # ----------------------------------------------------------------------------
 # util routines
 
-# file locking using flock: the lock is acquired while the file is open and
-#     released when file is closed (or process is terminated and OS closes the file)
+# file locking to control concurrent jobs.
+
 sub get_lock {
     my ($lockfile, $lock_type) = @_;
     if ($verbose) {
@@ -1416,15 +1418,14 @@ sub get_lock {
     if (! -e $lockfile) {
         system "touch $lockfile";
     }
-    if(open LOCK, "$lockfile"){
-        # flock blocks until the lock is taken
-        flock(LOCK, $lock_type);
-        return 1;
+    while (1) {
+        my $ret = update_lockfile($lockfile, $lock_type);
+        if ($ret) {
+            last;
+        }
+        sleep 1;
     }
-    else{
-        warn "failed to open lockfile $lockfile\n";
-        return 0;
-    }
+    return 1;
 }
 
 sub release_lock {
@@ -1432,5 +1433,60 @@ sub release_lock {
     if ($verbose) {
         print "Releasing lock [$lockfile]\n";
     }
-    close(LOCK);
+    update_lockfile($lockfile, LOCK_UN);
+}
+
+sub update_lockfile {
+    my ($lockfile, $lock_type) = @_;
+    my $exclusive_count = 100;
+
+    my $got_it;
+    if (open LOCK, '+<', $lockfile) {
+        flock(LOCK, LOCK_EX) or die "Cannot obtain lock on $lockfile\n";
+        my $count = 0;
+        my %pids;
+        while(<LOCK>){
+            if (/^(\d+)\s+(\d+)/) {
+                my ($pid, $cnt) = ($1, $2);
+                my $is_running = kill(0, $pid);
+                if ($is_running) {
+                    $count += $cnt;
+                    $pids{$pid} = $cnt;
+                }
+            }
+        }
+        if ($lock_type == LOCK_SH and $count < $exclusive_count) {
+            $got_it = 1;
+        } elsif ($lock_type == LOCK_EX && !$count) {
+            $got_it = 1;
+        } elsif ($lock_type == LOCK_UN) {
+            $got_it = 1;
+        } else {
+            $got_it = 0;
+        }
+
+        if ($got_it) {
+            seek LOCK, 0, 0;
+            truncate LOCK, 0;
+            if ($lock_type == LOCK_EX) {
+                $pids{$$} = $exclusive_count;
+            }
+            elsif ($lock_type == LOCK_SH) {
+                $pids{$$} = 1;
+            }
+            elsif ($lock_type == LOCK_UN) {
+                delete $pids{$$};
+            }
+
+            while (my ($k, $v) = each %pids) {
+                print LOCK "$k $v\n";
+            }
+        }
+        close LOCK;
+    } else {
+        warn "failed to open lockfile $lockfile\n";
+        return 1;  # so dont' block, effectively without locking
+    }
+
+    return $got_it;
 }


### PR DESCRIPTION
## Pull Request Description

The previous simple file locking routines works on linux. However, the
support on Solaris is incorrect resulting in 1 exclusive lock and
multiple shared locks to co-exist.

Since the exclusive lock works and more widely supported, we update the
mechanism by actually tracking locked processes by its pid. This patch
matches the previous interface so it should work as before. The new
locking scheme provide more flexibility which should facilitate adding
more test control ability if that is needed.

## Design

Each process if need take lock, it opens lockfile (default `/tmp/runtests-mem.lock`) , checks existing processes that already holds the lock, if the condition fits, adds its pid to the file and a declaration of holding the lock.

To hold a shared lock, it only need check no other process holds the exclusive lock already.
To hold an exclusive lock, it need make sure no other process hold the lock at all.
To unlock, just remove its pid from the lock file.

The access to the lockfile is controled by `flock` with exclusive to achieve atomicity.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
