### PR TITLE
test: set default to not run ft tests

### DIFF
--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -195,8 +195,8 @@ AC_ARG_ENABLE(large-tests,
 
 AC_ARG_ENABLE(ft-tests,
 	[AC_HELP_STRING([--enable-ft-tests],
-		[Include tests for fault tolerance (default)])],,
-	[enable_ft_tests=yes])
+		[Include tests for fault tolerance (default no)])],,
+	[enable_ft_tests=no])
 
 AC_ARG_ENABLE(comm-overlap-tests,
 	[AC_HELP_STRING([--enable-comm-overlap-tests],


### PR DESCRIPTION
## Pull Request Description

FT are not part of MPI standards, and we are no longer supporting it.
Therefore, we should not run these tests by default.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
