### PR TITLE
mpl: define attribute macros direct when they are supported

### DIFF
--- a/src/mpl/include/mpl_base.h
+++ b/src/mpl/include/mpl_base.h
@@ -46,19 +46,19 @@
 #define MPL_STATIC_INLINE_SUFFIX ATTRIBUTE((always_inline))
 
 #ifdef MPL_HAVE_FUNC_ATTRIBUTE_FALLTHROUGH
-#define MPL_FALLTHROUGH ATTRIBUTE((fallthrough))
+#define MPL_FALLTHROUGH __attribute__((fallthrough))
 #else
 #define MPL_FALLTHROUGH
 #endif
 
 #ifdef MPL_HAVE_VAR_ATTRIBUTE_ALIGNED
-#define MPL_ATTR_ALIGNED(x) ATTRIBUTE((aligned(x)))
+#define MPL_ATTR_ALIGNED(x) __attribute__((aligned(x)))
 #else
 #define MPL_ATTR_ALIGNED(x)
 #endif
 
 #ifdef MPL_HAVE_VAR_ATTRIBUTE_USED
-#define MPL_USED ATTRIBUTE((used))
+#define MPL_USED __attribute__((used))
 #else
 #define MPL_USED
 #endif


### PR DESCRIPTION
## Pull Request Description

Macro `HAVE_GCC_ATTRIBUTE` (from `confdb/aclocal_cc.m4`) checks both
`__attribute__((pure))` and `__attribute__((format..))` before defining it.
Because the latter macro are less supported, this often result in macro
`ATTRIBUTE` not defined even when many other attributes are defined.

Directly define specific attribute macros using `__attribute__` when the
specific "HAVE" macros are defined by configure.



<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
