### PR TITLE
ch4: add thread protection to MPIR_pmi_spawn_multiple

### DIFF
--- a/src/mpid/ch4/src/ch4_spawn.c
+++ b/src/mpid/ch4/src/ch4_spawn.c
@@ -56,8 +56,10 @@ int MPID_Comm_spawn_multiple(int count, char *commands[], char **argvs[], const 
             preput_keyval_vector.key = MPIDI_PARENT_PORT_KVSKEY;
             preput_keyval_vector.val = port_name;
 
+            MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_DYNPROC_MUTEX);
             mpi_errno = MPIR_pmi_spawn_multiple(count, commands, argvs, maxprocs, info_ptrs,
                                                 1, &preput_keyval_vector, pmi_errcodes);
+            MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_DYNPROC_MUTEX);
             if (mpi_errno != MPI_SUCCESS) {
                 spawn_error = 1;
             }


### PR DESCRIPTION
## Pull Request Description

PMI calls are not thread-safe (specifically, PMI1 call). Add thread
protection using MPIDIU_THREAD_DYNPROC_MUTEX in per-vci model.


<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
       Potentially fixes #4536 
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
