### PR TITLE
shm: disable init_shm with --enable-nolocal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -634,11 +634,8 @@ AC_ARG_WITH(name-publisher,
     [],
     with_namepublisher=$with_name_publisher,)
 
-AC_ARG_ENABLE(dbg-nolocal, AC_HELP_STRING([--enable-dbg-nolocal], [enables debugging mode where shared-memory communication is disabled]),
-    AC_DEFINE(ENABLED_NO_LOCAL, 1, [Define to disable shared-memory communication for debugging]))
-
-AC_ARG_ENABLE(dbg-localoddeven, AC_HELP_STRING([--enable-dbg-localoddeven], [enables debugging mode where shared-memory communication is enabled only between even processes or odd processes on a node]),
-    AC_DEFINE(ENABLED_ODD_EVEN_CLIQUES, 1, [Define to enable debugging mode where shared-memory communication is done only between even procs or odd procs]))
+AC_ARG_ENABLE(nolocal, AC_HELP_STRING([--enable-nolocal], [enables nolocal mode where shared-memory communication is disabled]),
+    AC_DEFINE(ENABLED_NO_LOCAL, 1, [Define to disable shared-memory communication]))
 
 AC_CANONICAL_TARGET
 

--- a/configure.ac
+++ b/configure.ac
@@ -635,7 +635,7 @@ AC_ARG_WITH(name-publisher,
     with_namepublisher=$with_name_publisher,)
 
 AC_ARG_ENABLE(nolocal, AC_HELP_STRING([--enable-nolocal], [enables nolocal mode where shared-memory communication is disabled]),
-    AC_DEFINE(ENABLED_NO_LOCAL, 1, [Define to disable shared-memory communication]))
+    AC_DEFINE(ENABLE_NO_LOCAL, 1, [Define to disable shared-memory communication]))
 
 AC_CANONICAL_TARGET
 

--- a/src/mpid/ch3/channels/nemesis/subconfigure.m4
+++ b/src/mpid/ch3/channels/nemesis/subconfigure.m4
@@ -149,12 +149,6 @@ for net in $nemesis_networks ; do
 done
 nemesis_nets_array_sz=$net_index
 
-AC_ARG_ENABLE(nemesis-dbg-nolocal, AC_HELP_STRING([--enable-nemesis-dbg-nolocal], [alias for --enable-dbg-nolocal]),
-    AC_DEFINE(ENABLED_NO_LOCAL, 1, [Define to disable shared-memory communication for debugging]))
-
-AC_ARG_ENABLE(nemesis-dbg-localoddeven, AC_HELP_STRING([--enable-nemesis-dbg-localoddeven], [alias for --enable-dbg-localoddeven]),
-    AC_DEFINE(ENABLED_ODD_EVEN_CLIQUES, 1, [Define to enable debugging mode where shared-memory communication is done only between even procs or odd procs]))
-
 AC_ARG_WITH(papi, [--with-papi[=path] - specify path where papi include and lib directories can be found],, with_papi=no)
 
 if test "${with_papi}" != "no" ; then

--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -10,6 +10,44 @@
 #include "mpir_pmi.h"
 #include "mpidu_shm_seg.h"
 
+#ifdef ENABLED_NO_LOCAL
+/* shared memory disabled, just stubs */
+
+int MPIDU_Init_shm_init(void)
+{
+    return MPI_SUCCESS;
+}
+
+int MPIDU_Init_shm_finalize(void)
+{
+    return MPI_SUCCESS;
+}
+
+int MPIDU_Init_shm_barrier(void)
+{
+    return MPI_SUCCESS;
+}
+
+/* proper code should never call following under NO_LOCAL */
+int MPIDU_Init_shm_put(void *orig, size_t len)
+{
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
+}
+
+int MPIDU_Init_shm_get(int local_rank, size_t len, void *target)
+{
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
+}
+
+int MPIDU_Init_shm_query(int local_rank, void **target_addr)
+{
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
+}
+
+#else /* ENABLED_NO_LOCAL */
 typedef struct Init_shm_barrier {
     OPA_int_t val;
     OPA_int_t wait;
@@ -309,3 +347,5 @@ int MPIDU_Init_shm_query(int local_rank, void **target_addr)
 
     return mpi_errno;
 }
+
+#endif /* ENABLED_NO_LOCAL */

--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -10,7 +10,7 @@
 #include "mpir_pmi.h"
 #include "mpidu_shm_seg.h"
 
-#ifdef ENABLED_NO_LOCAL
+#ifdef ENABLE_NO_LOCAL
 /* shared memory disabled, just stubs */
 
 int MPIDU_Init_shm_init(void)
@@ -47,7 +47,7 @@ int MPIDU_Init_shm_query(int local_rank, void **target_addr)
     return MPI_SUCCESS;
 }
 
-#else /* ENABLED_NO_LOCAL */
+#else /* ENABLE_NO_LOCAL */
 typedef struct Init_shm_barrier {
     OPA_int_t val;
     OPA_int_t wait;
@@ -348,4 +348,4 @@ int MPIDU_Init_shm_query(int local_rank, void **target_addr)
     return mpi_errno;
 }
 
-#endif /* ENABLED_NO_LOCAL */
+#endif /* ENABLE_NO_LOCAL */

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -914,11 +914,7 @@ static int get_option_num_cliques(void)
     if (MPIR_CVAR_NUM_CLIQUES > 1) {
         return MPIR_CVAR_NUM_CLIQUES;
     } else {
-#ifdef ENABLED_ODD_EVEN_CLIQUES
-        return 2;
-#else
         return MPIR_CVAR_ODD_EVEN_CLIQUES ? 2 : 1;
-#endif
     }
 }
 

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -899,7 +899,7 @@ static int build_nodemap(int *nodemap, int sz, int *p_max_node_id)
 static int get_option_no_local(void)
 {
     /* Used for debugging only.  This disables communication over shared memory */
-#ifdef ENABLED_NO_LOCAL
+#ifdef ENABLE_NO_LOCAL
     return 1;
 #else
     return MPIR_CVAR_NOLOCAL;


### PR DESCRIPTION
## Pull Request Description

Disable shared memory and skip entire init_shm with `--enable-nolocal` config option. This provides a simplified code path that doesn't depend on unneeded components. For example, when compiler native atomics support is missing and falling back to lock-emulated inter process lock is complicated and doesn't perform anyway. Providing the "NOLOCAL" option will eliminate that dependency.

TODO: automatically turn on `ENABLE_NO_LOCAL` when lock-emulated atomics are being used.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
