### PR TITLE
runtests: open lockfile for writing when obtaining exclusive lock

### DIFF
--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -46,6 +46,9 @@ use File::Copy qw(move);
 # Use high resolution timers
 use Time::HiRes qw(gettimeofday tv_interval);
 
+# Import flock constants
+use Fcntl qw(:flock);
+
 # Global variables
 our $g_opt = {};   # global options. TODO: migrate global option vars into the hash
 $g_opt->{memory_total} = 20;      # Total memory in GB
@@ -765,15 +768,14 @@ sub RunMPIProgram {
 
     # acquire lock if requested
     my ($lockfile, $got_lock);
-    my ($lock_sh, $lock_ex) = (1, 2);
     if ($test_opt->{lock}) {
         # explict lock by setting "lock=[shared|name]" on testline directly
         my $name = $test_opt->{lock};
         $lockfile = "/tmp/runtests-$name.lock";
         if ($name eq "shared") {
-            $got_lock = get_lock($lockfile, $lock_sh);
+            $got_lock = get_lock($lockfile, LOCK_SH);
         } else {
-            $got_lock = get_lock($lockfile, $lock_ex);
+            $got_lock = get_lock($lockfile, LOCK_EX);
         }
     } elsif ($test_opt->{mem}) {
         # implicit lock by checking memory annotation
@@ -782,9 +784,9 @@ sub RunMPIProgram {
             SkippedTest($programname, $np, $test_opt, $curdir, "xfail due to memory requirement");
             next;
         } elsif ($test_opt->{mem} * $g_opt->{memory_multiplier} > $g_opt->{memory_total} ) {
-            $got_lock = get_lock($lockfile, $lock_ex);
+            $got_lock = get_lock($lockfile, LOCK_EX);
         } else {
-            $got_lock = get_lock($lockfile, $lock_sh);
+            $got_lock = get_lock($lockfile, LOCK_SH);
         }
     }
 

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -1385,7 +1385,14 @@ sub get_lock {
     if (! -e $lockfile) {
         system "touch $lockfile";
     }
-    if(open LOCK, "$lockfile"){
+
+    my $lock = $lockfile;
+    if ($lock_type == LOCK_EX) {
+        # To obtain exclusive lock, some platform require open the file for writing
+        $lock = "> $lockfile"
+    }
+
+    if(open LOCK, $lock){
         # flock blocks until the lock is taken
         flock(LOCK, $lock_type);
         return 1;


### PR DESCRIPTION
## Pull Request Description

 On some platform, e.g. Solaris, we need to open the file for reading when obtaining shared lock, and open the file for writing when obtaining exclusive lock.

## Expected Impact

Fix the Solaris jenkins tests memory contention issues.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
