### PR TITLE
adio: extract flock to_string methods to it's own file

### DIFF
--- a/src/mpi/romio/adio/Makefile.mk
+++ b/src/mpi/romio/adio/Makefile.mk
@@ -14,6 +14,7 @@ noinst_HEADERS +=                      \
     adio/include/adioi_error.h         \
     adio/include/adioi_fs_proto.h      \
     adio/include/heap_sort.h           \
+    adio/include/lock_internal.h       \
     adio/include/mpio_error.h          \
     adio/include/mpipr.h               \
     adio/include/mpiu_greq.h           \

--- a/src/mpi/romio/adio/common/Makefile.mk
+++ b/src/mpi/romio/adio/common/Makefile.mk
@@ -61,6 +61,7 @@ romio_other_sources +=                  \
     adio/common/heap_sort.c             \
     adio/common/iscontig.c              \
     adio/common/lock.c                  \
+    adio/common/lock_internal.c         \
     adio/common/malloc.c                \
     adio/common/shfp_fname.c            \
     adio/common/status_setb.c           \

--- a/src/mpi/romio/adio/common/lock.c
+++ b/src/mpi/romio/adio/common/lock.c
@@ -4,49 +4,7 @@
  */
 
 #include "adio.h"
-
-static const char *flock_cmd_to_string(int cmd)
-{
-    switch (cmd) {
-#ifdef F_GETLK64
-        case F_GETLK64:
-            return "F_GETLK64";
-#else
-        case F_GETLK:
-            return "F_GETLK";
-#endif
-#ifdef F_SETLK64
-        case F_SETLK64:
-            return "F_SETLK64";
-#else
-        case F_SETLK:
-            return "F_SETLK";
-#endif
-#ifdef F_SETLKW64
-        case F_SETLKW64:
-            return "F_SETLKW64";
-#else
-        case F_SETLKW:
-            return "F_SETLKW";
-#endif
-        default:
-            return "UNEXPECTED";
-    }
-}
-
-static const char *flock_type_to_string(int type)
-{
-    switch (type) {
-        case F_RDLCK:
-            return "F_RDLCK";
-        case F_WRLCK:
-            return "F_WRLCK";
-        case F_UNLCK:
-            return "F_UNLOCK";
-        default:
-            return "UNEXPECTED";
-    }
-}
+#include "lock_internal.h"
 
 #ifdef ROMIO_NTFS
 /* This assumes that lock will always remain in the common directory and
@@ -165,8 +123,9 @@ int ADIOI_GEN_SetLock(ADIO_File fd, int cmd, int type, ADIO_Offset offset, int w
                 if ((err_count < 5) || (err_count > 9995)) {
                     fprintf(stderr,
                             "File locking failed in ADIOI_GEN_SetLock(fd %#X,cmd %s/%#X,type %s/%#X,whence %#X) with return value %#X and errno %#X.  Retry (%d).\n",
-                            fd_sys, flock_cmd_to_string(cmd), cmd, flock_type_to_string(type), type,
-                            whence, err, errno, err_count);
+                            fd_sys, ADIOI_GEN_flock_cmd_to_string(cmd), cmd,
+                            ADIOI_GEN_flock_type_to_string(type), type, whence, err, errno,
+                            err_count);
                     perror("ADIOI_GEN_SetLock:");
                     fprintf(stderr, "ADIOI_GEN_SetLock:offset %#llx, length %#llx\n",
                             (unsigned long long) offset, (unsigned long long) len);
@@ -183,8 +142,8 @@ int ADIOI_GEN_SetLock(ADIO_File fd, int cmd, int type, ADIO_Offset offset, int w
                 "This requires fcntl(2) to be implemented. As of 8/25/2011 it is not. Generic MPICH Message: File locking failed in ADIOI_GEN_SetLock(fd %X,cmd %s/%X,type %s/%X,whence %X) with return value %X and errno %X.\n"
                 "- If the file system is NFS, you need to use NFS version 3, ensure that the lockd daemon is running on all the machines, and mount the directory with the 'noac' option (no attribute caching).\n"
                 "- If the file system is LUSTRE, ensure that the directory is mounted with the 'flock' option.\n",
-                fd_sys, flock_cmd_to_string(cmd), cmd, flock_type_to_string(type), type, whence,
-                err, errno);
+                fd_sys, ADIOI_GEN_flock_cmd_to_string(cmd), cmd,
+                ADIOI_GEN_flock_type_to_string(type), type, whence, err, errno);
         perror("ADIOI_GEN_SetLock:");
         FPRINTF(stderr, "ADIOI_GEN_SetLock:offset %llu, length %llu\n", (unsigned long long) offset,
                 (unsigned long long) len);
@@ -226,8 +185,8 @@ int ADIOI_GEN_SetLock64(ADIO_File fd, int cmd, int type, ADIO_Offset offset, int
         FPRINTF(stderr,
                 "File locking failed in ADIOI_GEN_SetLock64(fd %X,cmd %s/%X,type %s/%X,whence %X) with return value %X and errno %X.\n"
                 "If the file system is NFS, you need to use NFS version 3, ensure that the lockd daemon is running on all the machines, and mount the directory with the 'noac' option (no attribute caching).\n",
-                fd_sys, flock_cmd_to_string(cmd), cmd, flock_type_to_string(type), type, whence,
-                err, errno);
+                fd_sys, ADIOI_GEN_flock_cmd_to_string(cmd), cmd,
+                ADIOI_GEN_flock_type_to_string(type), type, whence, err, errno);
         perror("ADIOI_GEN_SetLock64:");
         FPRINTF(stderr, "ADIOI_GEN_SetLock:offset %llu, length %llu\n", (unsigned long long) offset,
                 (unsigned long long) len);

--- a/src/mpi/romio/adio/common/lock_internal.c
+++ b/src/mpi/romio/adio/common/lock_internal.c
@@ -1,0 +1,44 @@
+#include "lock_internal.h"
+
+const char *ADIOI_GEN_flock_cmd_to_string(int cmd)
+{
+    switch (cmd) {
+#ifdef F_GETLK64
+        case F_GETLK64:
+            return "F_GETLK64";
+#else
+        case F_GETLK:
+            return "F_GETLK";
+#endif
+#ifdef F_SETLK64
+        case F_SETLK64:
+            return "F_SETLK64";
+#else
+        case F_SETLK:
+            return "F_SETLK";
+#endif
+#ifdef F_SETLKW64
+        case F_SETLKW64:
+            return "F_SETLKW64";
+#else
+        case F_SETLKW:
+            return "F_SETLKW";
+#endif
+        default:
+            return "UNEXPECTED";
+    }
+}
+
+const char *ADIOI_GEN_flock_type_to_string(int type)
+{
+    switch (type) {
+        case F_RDLCK:
+            return "F_RDLCK";
+        case F_WRLCK:
+            return "F_WRLCK";
+        case F_UNLCK:
+            return "F_UNLOCK";
+        default:
+            return "UNEXPECTED";
+    }
+}

--- a/src/mpi/romio/adio/include/lock_internal.h
+++ b/src/mpi/romio/adio/include/lock_internal.h
@@ -1,0 +1,9 @@
+#ifndef LOCK_INTERNAL_H_INCLUDED
+#define LOCK_INTERNAL_H_INCLUDED
+
+#include <fcntl.h>
+
+const char *ADIOI_GEN_flock_cmd_to_string(int cmd);
+const char *ADIOI_GEN_flock_type_to_string(int type);
+
+#endif /* LOCK_INTERNAL_H_INCLUDED */


### PR DESCRIPTION
Filesystems have the option to implement their own locks now. These
to_string methods should be available to other filesystem interfaces.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
