### PR TITLE
test/mpi: fix mtest for single threaded tests

### DIFF
--- a/test/mpi/include/mpithreadtest.h
+++ b/test/mpi/include/mpithreadtest.h
@@ -68,10 +68,9 @@ int MTest_thread_yield(void);
 int MTest_thread_barrier_init(void);
 int MTest_thread_barrier(int);
 int MTest_thread_barrier_free(void);
+#endif
 
 void MTest_init_thread_pkg(void);
 void MTest_finalize_thread_pkg(void);
-
-#endif
 
 #endif /* MPITHREADTEST_H_INCLUDED */

--- a/test/mpi/util/mtest_thread.c
+++ b/test/mpi/util/mtest_thread.c
@@ -8,6 +8,20 @@
    -D_POSIX_C_SOURCE=199506L, -std=c89 and -std=c99,
    that disallow pthread_barrier_t and friends.
 */
+
+#if THREAD_PACKAGE_NAME == THREAD_PACKAGE_NONE
+
+/* Only empty initialization and finalization functions are supported. */
+void MTest_init_thread_pkg(void)
+{
+}
+
+void MTest_finalize_thread_pkg(void)
+{
+}
+
+#else /* THREAD_PACKAGE_NAME != THREAD_PACKAGE_NONE */
+
 #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE < 200112L
 #undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
@@ -133,4 +147,7 @@ void MTest_init_thread_pkg(void)
 void MTest_finalize_thread_pkg(void)
 {
 }
+
+#endif /* THREAD_PACKAGE_NAME != THREAD_PACKAGE_NONE */
+
 #endif /* Default MTest_init_thread_pkg */


### PR DESCRIPTION

## Pull Request Description

This PR fixes compilation failures of single threaded tests introduced by `mtest` modification: for example, https://jenkins-pmrs.cels.anl.gov/job/mpich-master-special-tests/

This happens because the current `mtest.c` always requires `MTest_init_thread_pkg()` and `MTest_finalize_thread_pkg()` while they are not available with a single-threaded configuration.
This PR implements them when `--with-thread-package=none`.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
