### PR TITLE
ch4: add missing error check after MPID_Progress_test

### DIFF
--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -19,7 +19,8 @@ extern MPIDI_POSIX_release_gather_tree_type_t MPIDI_POSIX_Bcast_tree_type,
         while (MPL_atomic_acquire_load_uint64(ptr) < (value))    { \
             if (++spin_count >= 10000) {                           \
                 /* Call progress only after waiting for a while */ \
-                MPID_Progress_test(NULL);                              \
+                int err_ = MPID_Progress_test(NULL);               \
+                MPIR_Assert(err_ == MPI_SUCCESS);                  \
                 spin_count = 0;                                    \
             }                                                      \
         }                                                          \

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -50,7 +50,8 @@ static void progress(void)
     int made_progress;
 
     if (0 == world_comm_destroying) {
-        MPID_Progress_test(NULL);
+        ret = MPID_Progress_test(NULL);
+        MPIR_Assert(ret == MPI_SUCCESS);
     } else {
         /* FIXME: The hcoll library needs to be updated to return
          * error codes.  The progress function pointer right now


### PR DESCRIPTION
## Pull Request Description

A few places are calling `MPID_Progress_test` without checking error code. We should.

While just returning `mpi_errno` works, having the extra `MPIR_ERR_CHECK` inserts a log trace in case of error, and it is also more visually easier as it fits our usual code pattern.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
