### PR TITLE
test/mpi: fix mtest with a thread package

### DIFF
--- a/test/mpi/util/mtest_thread.c
+++ b/test/mpi/util/mtest_thread.c
@@ -3,15 +3,11 @@
  *     See COPYRIGHT in top-level directory
  */
 
-/*
-   Define macro to override gcc strict flags,
-   -D_POSIX_C_SOURCE=199506L, -std=c89 and -std=c99,
-   that disallow pthread_barrier_t and friends.
-*/
-
 #include <stdio.h>
 #include <stdlib.h>
 #include "mpitest.h"
+
+/* This file provides a portability layer for using threads. */
 
 #if THREAD_PACKAGE_NAME == THREAD_PACKAGE_NONE
 
@@ -26,15 +22,15 @@ void MTest_finalize_thread_pkg(void)
 
 #else /* THREAD_PACKAGE_NAME != THREAD_PACKAGE_NONE */
 
+/*
+   Define macro to override gcc strict flags,
+   -D_POSIX_C_SOURCE=199506L, -std=c89 and -std=c99,
+   that disallow pthread_barrier_t and friends.
+*/
 #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE < 200112L
 #undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
 #endif
-
-/* This file provides a portability layer for using threads.  Currently,
-   it supports POSIX threads (pthreads) and Windows threads.  Testing has
-   been performed for pthreads.
- */
 
 /* We remember all of the threads we create; this similifies terminating
    (joining) them. */

--- a/test/mpi/util/mtest_thread.c
+++ b/test/mpi/util/mtest_thread.c
@@ -9,6 +9,10 @@
    that disallow pthread_barrier_t and friends.
 */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include "mpitest.h"
+
 #if THREAD_PACKAGE_NAME == THREAD_PACKAGE_NONE
 
 /* Only empty initialization and finalization functions are supported. */
@@ -26,10 +30,6 @@ void MTest_finalize_thread_pkg(void)
 #undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
 #endif
-
-#include <stdio.h>
-#include <stdlib.h>
-#include "mpitest.h"
 
 /* This file provides a portability layer for using threads.  Currently,
    it supports POSIX threads (pthreads) and Windows threads.  Testing has


### PR DESCRIPTION
## Pull Request Description

This PR fixes a bug introduced by https://github.com/pmodels/mpich/pull/4552.

`THREAD_PACKAGE_NAME` is defined in `mpitest.h`, so `#include mpitest.h` should come before `#if THREAD_PACKAGE_NAME == THREAD_PACKAGE_NONE`.

I should have checked the modification with multithreaded tests. I will be careful.
@hzhou  Thank you for reporting this issue.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
