### PR TITLE
ch4: make MPIDI_Progress_test a wrapper for compatibility

### DIFF
--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -24,7 +24,7 @@ int MPIDI_OFI_retry_progress()
     /* We do not call progress on hooks form netmod level
      * because it is not reentrant safe.
      */
-    return MPID_Progress_test();
+    return MPIDI_Progress_test(MPIDI_PROGRESS_NM | MPIDI_PROGRESS_SHM);
 }
 
 typedef struct MPIDI_OFI_mr_key_allocator_t {

--- a/src/mpid/ch4/shm/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/xpmem/xpmem_init.c
@@ -123,11 +123,8 @@ int MPIDI_XPMEM_mpi_finalize_hook(void)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_MPI_FINALIZE_HOOK);
 
     /* Ensure all counter objs are freed at MPIDI_XPMEM_ctrl_send_lmt_cnt_free_cb */
-    while (MPIR_cc_get(MPIDI_XPMEM_global.num_pending_cnt)) {
-        /* Since it is non-critical in finalize, we call global progress
-         * instead of shm/posix progress for simplicity */
-        MPID_Progress_test();
-    }
+    while (MPIR_cc_get(MPIDI_XPMEM_global.num_pending_cnt))
+        MPIDI_Progress_test(MPIDI_PROGRESS_SHM);
 
     /* Free pre-attached direct coop counter */
     for (i = 0; i < MPIDI_XPMEM_global.num_local; ++i) {

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -11,6 +11,7 @@
 #include "mpidu_shm.h"
 #include "mpidig_gpu_utils.h"
 
+int MPIDI_Progress_test(int flags);
 int MPIDIG_get_context_index(uint64_t context_id);
 uint64_t MPIDIG_generate_win_id(MPIR_Comm * comm_ptr);
 


### PR DESCRIPTION
## Pull Request Description
Downstrems have code extensively uses MPIDI_Progress_test. This commit
adds a wrapper to maintain compatibility.

This essentially reverts "https://github.com/pmodels/mpich/pull/4472/commits/5330f10bfc49cf5390da4dba3497e70461f2f918 ch4: move MPIDI_Progress_test internal
to ch4_progress"



## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
