### PR TITLE
warnings: pattern look like header guard

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/fbox/func_table.c
+++ b/src/mpid/ch4/shm/posix/eager/fbox/func_table.c
@@ -3,7 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#ifndef POSIX_EAGER_INLINE
+#ifdef POSIX_EAGER_INLINE
+/* this file is empty */
+#else
+
 #define POSIX_EAGER_DISABLE_INLINES
 
 #include <mpidimpl.h>

--- a/src/mpid/ch4/shm/posix/eager/iqueue/func_table.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/func_table.c
@@ -3,7 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#ifndef POSIX_EAGER_INLINE
+#ifdef POSIX_EAGER_INLINE
+/* this file is empty */
+#else
+
 #define POSIX_EAGER_DISABLE_INLINES
 
 #include <mpidimpl.h>

--- a/src/mpid/ch4/shm/posix/eager/stub/func_table.c
+++ b/src/mpid/ch4/shm/posix/eager/stub/func_table.c
@@ -3,7 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#ifndef POSIX_EAGER_INLINE
+#ifdef POSIX_EAGER_INLINE
+/* this file is empty */
+#else
+
 #define POSIX_EAGER_DISABLE_INLINES
 
 #include <mpidimpl.h>


### PR DESCRIPTION

## Pull Request Description

`Clang` is confused by this #ifdef / #define pattern for header guard and
warns with [-Wheader-guard]

From nightly warning tests:
```
warning.src/mpid/ch4/shm/posix/eager/iqueue/func_table.c:6:9        
Error Details          
 src/mpid/ch4/shm/posix/eager/iqueue/func_table.c:6:9: warning: 'POSIX_EAGER_INLINE' is used as a header guard here, followed by #define of a different macro [-Wheader-guard]
```

This warning shows up since 5/16/2020, probably related to PR #4317, but I don't yet understand why (it didn't trigger before).
<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
