### PR TITLE
warnings: tell the compiler that the allocation variable is always smaller than ptrdiff_t

### DIFF
--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -262,10 +262,29 @@ typedef struct {
 
 #else /* MPL_USE_MEMORY_TRACING */
 /* No memory tracing; just use native functions */
-#define MPL_malloc(a,b)    malloc((size_t)(a))
-#define MPL_calloc(a,b,c)  calloc((size_t)(a),(size_t)(b))
+/* size_t allows for larger values than PTRDIFF_MAX.  GCC throws a
+ * warning if we pass a signed integer to MPL_malloc and friends,
+ * which when typecast to size_t becomes a very large number, saying
+ * that the max size exceeds that of PTRDIFF_MAX. */
+static inline void *MPL_malloc(size_t size, MPL_memory_class memclass)
+{
+    assert(size <= PTRDIFF_MAX);
+    return malloc(size);
+}
+
+static inline void *MPL_calloc(size_t nmemb, size_t size, MPL_memory_class memclass)
+{
+    assert(size <= PTRDIFF_MAX);
+    return calloc(nmemb, size);
+}
+
+static inline void *MPL_realloc(void *ptr, size_t size, MPL_memory_class memclass)
+{
+    assert(size <= PTRDIFF_MAX);
+    return realloc(ptr, size);
+}
+
 #define MPL_free(a)      free((void *)(a))
-#define MPL_realloc(a,b,c)  realloc((void *)(a),(size_t)(b))
 #define MPL_mmap(a,b,c,d,e,f,g) mmap((void *)(a),(size_t)(b),(int)(c),(int)(d),(int)(e),(off_t)(f))
 #define MPL_munmap(a,b,c)  munmap((void *)(a),(size_t)(b))
 


### PR DESCRIPTION
## Pull Request Description

GCC seems to have an overly aggressive check to see the maximum bounds of each variable.  When an integer is passed to the allocation, in theory, it could have a negative value (which, when cast to size_t becomes a very large value).  GCC complains about this case with [-Walloc-size-larger-than=].

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
