### PR TITLE
Another attempt at PTRDIFF_MAX allocation warnings

### DIFF
--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -268,20 +268,29 @@ typedef struct {
  * that the max size exceeds that of PTRDIFF_MAX. */
 static inline void *MPL_malloc(size_t size, MPL_memory_class memclass)
 {
-    assert(size <= PTRDIFF_MAX);
-    return malloc(size);
+    if (size <= PTRDIFF_MAX) {
+        return malloc(size);
+    } else {
+        return NULL;
+    }
 }
 
 static inline void *MPL_calloc(size_t nmemb, size_t size, MPL_memory_class memclass)
 {
-    assert(size <= PTRDIFF_MAX);
-    return calloc(nmemb, size);
+    if (size <= PTRDIFF_MAX) {
+        return calloc(nmemb, size);
+    } else {
+        return NULL;
+    }
 }
 
 static inline void *MPL_realloc(void *ptr, size_t size, MPL_memory_class memclass)
 {
-    assert(size <= PTRDIFF_MAX);
-    return realloc(ptr, size);
+    if (size <= PTRDIFF_MAX) {
+        return realloc(ptr, size);
+    } else {
+        return NULL;
+    }
 }
 
 #define MPL_free(a)      free((void *)(a))


### PR DESCRIPTION
## Pull Request Description

The patch in [bd07c1e62713] does not work when the user passes
-DNDEBUG.  This version simply returns a NULL when the user asks for
more the PTRDIFF_MAX.  The system is not allowed to allocate more than
PTRDIFF_MAX anyway, and it is natural for the memory allocation
routines to return NULL when the requested allocation cannot be
satisfied.  So this patch might be more natural too.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
