### PR TITLE
Remove infrastructure for MPI_LB/UB

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -63,7 +63,7 @@ typedef struct MPIR_Datatype_contents {
   efficiency was outweighed by the added complexity of the implementation.
 
   A number of fields contain only boolean inforation ('is_contig',
-  'has_sticky_ub', 'has_sticky_lb', 'is_committed').  These
+  'is_committed').  These
   could be combined and stored in a single bit vector.
 
   'MPI_Type_dup' could be implemented with a shallow copy, where most of the
@@ -100,7 +100,6 @@ struct MPIR_Datatype {
     /* private fields */
     /* chars affecting subsequent datatype processing and creation */
     MPI_Aint alignsize;
-    int has_sticky_ub, has_sticky_lb;
     int is_committed;
 
     /* element information; used for accumulate and get elements

--- a/src/mpi/datatype/get_elements_x.c
+++ b/src/mpi/datatype/get_elements_x.c
@@ -287,9 +287,6 @@ int MPIR_Get_elements_x_impl(MPI_Count * byte_count, MPI_Datatype datatype, MPI_
      */
     if (HANDLE_IS_BUILTIN(datatype) ||
         (datatype_ptr->builtin_element_size != -1 && datatype_ptr->size > 0)) {
-        /* QUESTION: WHAT IF SOMEONE GAVE US AN MPI_UB OR MPI_LB???
-         */
-
         /* in both cases we do not limit the number of types that might
          * be in bytes
          */

--- a/src/mpi/datatype/type_blockindexed.c
+++ b/src/mpi/datatype/type_blockindexed.c
@@ -79,8 +79,6 @@ int MPIR_Type_blockindexed(int count,
         old_is_contig = 1;
 
         new_dtp->size = (MPI_Aint) count *(MPI_Aint) blocklength *el_sz;
-        new_dtp->has_sticky_lb = 0;
-        new_dtp->has_sticky_ub = 0;
 
         new_dtp->alignsize = el_sz;     /* ??? */
         new_dtp->n_builtin_elements = count * blocklength;
@@ -104,8 +102,6 @@ int MPIR_Type_blockindexed(int count,
         MPIR_Datatype_is_contig(oldtype, &old_is_contig);
 
         new_dtp->size = (MPI_Aint) count *(MPI_Aint) blocklength *(MPI_Aint) old_dtp->size;
-        new_dtp->has_sticky_lb = old_dtp->has_sticky_lb;
-        new_dtp->has_sticky_ub = old_dtp->has_sticky_ub;
 
         new_dtp->alignsize = old_dtp->alignsize;
         new_dtp->n_builtin_elements = count * blocklength * old_dtp->n_builtin_elements;

--- a/src/mpi/datatype/type_contiguous.c
+++ b/src/mpi/datatype/type_contiguous.c
@@ -65,8 +65,6 @@ int MPIR_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype
         el_type = oldtype;
 
         new_dtp->size = count * el_sz;
-        new_dtp->has_sticky_ub = 0;
-        new_dtp->has_sticky_lb = 0;
         new_dtp->true_lb = 0;
         new_dtp->lb = 0;
         new_dtp->true_ub = count * el_sz;
@@ -89,8 +87,6 @@ int MPIR_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype
         el_type = old_dtp->basic_type;
 
         new_dtp->size = count * old_dtp->size;
-        new_dtp->has_sticky_ub = old_dtp->has_sticky_ub;
-        new_dtp->has_sticky_lb = old_dtp->has_sticky_lb;
 
         MPII_DATATYPE_CONTIG_LB_UB((MPI_Aint) count,
                                    old_dtp->lb,

--- a/src/mpi/datatype/type_create_darray.c
+++ b/src/mpi/datatype/type_create_darray.c
@@ -259,11 +259,6 @@ PMPI_LOCAL int MPIR_Type_cyclic(const int *array_of_gsizes,
         disps[1] = (MPI_Aint) rank *(MPI_Aint) blksize *orig_extent;
         disps[2] = orig_extent * (MPI_Aint) (array_of_gsizes[dim]);
 
-/* Instead of using MPI_LB/MPI_UB, which have been removed from MPI in MPI-3,
-   use MPI_Type_create_resized. Use hindexed_block to set the starting displacement
-   of the datatype (disps[1]) and type_create_resized to set lb to 0 (disps[0])
-   and extent to disps[2], which makes ub = disps[2].
- */
         mpi_errno = MPIR_Type_blockindexed(1, 1, &disps[1], 1,  /* 1 means disp is in bytes */
                                            *type_new, &type_indexed);
 
@@ -621,11 +616,6 @@ int MPI_Type_create_darray(int size,
 
     disps[0] = 0;
 
-/* Instead of using MPI_LB/MPI_UB, which have been removed from MPI in MPI-3,
-   use MPI_Type_create_resized. Use hindexed_block to set the starting displacement
-   of the datatype (disps[1]) and type_create_resized to set lb to 0 (disps[0])
-   and extent to disps[2], which makes ub = disps[2].
- */
     mpi_errno = MPIR_Type_blockindexed(1, 1, &disps[1], 1,      /* 1 means disp is in bytes */
                                        type_new, &tmp_type);
 

--- a/src/mpi/datatype/type_create_pairtype.c
+++ b/src/mpi/datatype/type_create_pairtype.c
@@ -110,11 +110,9 @@ int MPIR_Type_create_pairtype(MPI_Datatype type, MPIR_Datatype * new_dtp)
     new_dtp->builtin_element_size = el_size;
     new_dtp->basic_type = type;
 
-    new_dtp->has_sticky_lb = 0;
     new_dtp->true_lb = 0;
     new_dtp->lb = 0;
 
-    new_dtp->has_sticky_ub = 0;
     new_dtp->true_ub = true_ub;
 
     new_dtp->size = type_size;

--- a/src/mpi/datatype/type_create_resized.c
+++ b/src/mpi/datatype/type_create_resized.c
@@ -67,8 +67,6 @@ int MPIR_Type_create_resized(MPI_Datatype oldtype,
         int oldsize = MPIR_Datatype_get_basic_size(oldtype);
 
         new_dtp->size = oldsize;
-        new_dtp->has_sticky_ub = 0;
-        new_dtp->has_sticky_lb = 0;
         new_dtp->true_lb = 0;
         new_dtp->lb = lb;
         new_dtp->true_ub = oldsize;
@@ -87,8 +85,6 @@ int MPIR_Type_create_resized(MPI_Datatype oldtype,
         MPIR_Datatype_get_ptr(oldtype, old_dtp);
 
         new_dtp->size = old_dtp->size;
-        new_dtp->has_sticky_ub = 0;
-        new_dtp->has_sticky_lb = 0;
         new_dtp->true_lb = old_dtp->true_lb;
         new_dtp->lb = lb;
         new_dtp->true_ub = old_dtp->true_ub;

--- a/src/mpi/datatype/type_create_subarray.c
+++ b/src/mpi/datatype/type_create_subarray.c
@@ -251,12 +251,6 @@ int MPI_Type_create_subarray(int ndims,
 
     disps[0] = 0;
 
-/* Instead of using MPI_LB/MPI_UB, which have been removed from MPI in MPI-3,
-   use MPI_Type_create_resized. Use hindexed_block to set the starting displacement
-   of the datatype (disps[1]) and type_create_resized to set lb to 0 (disps[0])
-   and extent to disps[2], which makes ub = disps[2].
- */
-
     mpi_errno = MPIR_Type_blockindexed(1, 1, &disps[1], 1,      /* 1 means disp is in bytes */
                                        tmp1, &tmp2);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/datatype/type_debug.c
+++ b/src/mpi/datatype/type_debug.c
@@ -36,19 +36,11 @@ void MPII_Datatype_printf(MPI_Datatype type,
 #ifdef MPL_USE_DBG_LOGGING
     char *string;
     MPI_Aint size;
-    MPI_Aint extent, true_lb, true_ub, lb, ub, sticky_lb, sticky_ub;
+    MPI_Aint extent, true_lb, true_ub, lb, ub;
 
     if (HANDLE_IS_BUILTIN(type)) {
         string = MPIR_Datatype_builtin_to_string(type);
         MPIR_Assert(string != NULL);
-        if (type == MPI_LB)
-            sticky_lb = 1;
-        else
-            sticky_lb = 0;
-        if (type == MPI_UB)
-            sticky_ub = 1;
-        else
-            sticky_ub = 0;
     } else {
         MPIR_Datatype *type_ptr;
 
@@ -56,8 +48,6 @@ void MPII_Datatype_printf(MPI_Datatype type,
         MPIR_Assert(type_ptr != NULL);
         string = MPIR_Datatype_combiner_to_string(type_ptr->contents->combiner);
         MPIR_Assert(string != NULL);
-        sticky_lb = type_ptr->has_sticky_lb;
-        sticky_ub = type_ptr->has_sticky_ub;
     }
 
     MPIR_Datatype_get_size_macro(type, size);
@@ -71,19 +61,17 @@ void MPII_Datatype_printf(MPI_Datatype type,
         MPL_DBG_OUT(MPIR_DBG_DATATYPE,
                     "------------------------------------------------------------------------------------------------------------------------------------------\n");
         MPL_DBG_OUT(MPIR_DBG_DATATYPE,
-                    "depth                   type         size       extent      true_lb      true_ub           lb(s)           ub(s)         disp       blklen\n");
+                    "depth                   type         size       extent      true_lb      true_ub           lb           ub         disp       blklen\n");
         MPL_DBG_OUT(MPIR_DBG_DATATYPE,
                     "------------------------------------------------------------------------------------------------------------------------------------------\n");
     }
     MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE,
                     (MPL_DBG_FDEST,
                      "%5d  %21s  %11d  " MPI_AINT_FMT_DEC_SPEC "  " MPI_AINT_FMT_DEC_SPEC "  "
-                     MPI_AINT_FMT_DEC_SPEC "  " MPI_AINT_FMT_DEC_SPEC "(" MPI_AINT_FMT_DEC_SPEC
-                     ")  " MPI_AINT_FMT_DEC_SPEC "(" MPI_AINT_FMT_DEC_SPEC ")  "
+                     MPI_AINT_FMT_DEC_SPEC "  " MPI_AINT_FMT_DEC_SPEC " " MPI_AINT_FMT_DEC_SPEC " "
                      MPI_AINT_FMT_DEC_SPEC "  %11d", depth, string, (int) size, (MPI_Aint) extent,
-                     (MPI_Aint) true_lb, (MPI_Aint) true_ub, (MPI_Aint) lb, (MPI_Aint) sticky_lb,
-                     (MPI_Aint) ub, (MPI_Aint) sticky_ub, (MPI_Aint) displacement,
-                     (int) blocklength));
+                     (MPI_Aint) true_lb, (MPI_Aint) true_ub, (MPI_Aint) lb,
+                     (MPI_Aint) ub, (MPI_Aint) displacement, (int) blocklength));
 #endif
     return;
 }
@@ -331,13 +319,11 @@ void MPIR_Datatype_debug(MPI_Datatype type, int array_ct)
     MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                         "# Size = " MPI_AINT_FMT_DEC_SPEC ", Extent = "
                                         MPI_AINT_FMT_DEC_SPEC ", LB = " MPI_AINT_FMT_DEC_SPEC
-                                        "%s, UB = " MPI_AINT_FMT_DEC_SPEC "%s, Extent = "
+                                        ", UB = " MPI_AINT_FMT_DEC_SPEC ", Extent = "
                                         MPI_AINT_FMT_DEC_SPEC ", Element Size = "
                                         MPI_AINT_FMT_DEC_SPEC " (%s), %s", (MPI_Aint) dtp->size,
                                         (MPI_Aint) dtp->extent, (MPI_Aint) dtp->lb,
-                                        (dtp->has_sticky_lb) ? "(sticky)" : "", (MPI_Aint) dtp->ub,
-                                        (dtp->has_sticky_ub) ? "(sticky)" : "",
-                                        (MPI_Aint) dtp->extent,
+                                        (MPI_Aint) dtp->ub, (MPI_Aint) dtp->extent,
                                         (MPI_Aint) dtp->builtin_element_size,
                                         dtp->builtin_element_size ==
                                         -1 ? "multiple types" :

--- a/src/mpi/datatype/type_dup.c
+++ b/src/mpi/datatype/type_dup.c
@@ -60,8 +60,6 @@ int MPIR_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
         new_dtp->true_ub = old_dtp->true_ub;
         new_dtp->true_lb = old_dtp->true_lb;
         new_dtp->alignsize = old_dtp->alignsize;
-        new_dtp->has_sticky_ub = old_dtp->has_sticky_ub;
-        new_dtp->has_sticky_lb = old_dtp->has_sticky_lb;
         new_dtp->is_committed = old_dtp->is_committed;
 
         new_dtp->attributes = NULL;     /* Attributes are copied in the

--- a/src/mpi/datatype/type_indexed.c
+++ b/src/mpi/datatype/type_indexed.c
@@ -90,9 +90,6 @@ int MPIR_Type_indexed(int count,
         old_extent = (MPI_Aint) el_sz;
         old_is_contig = 1;
 
-        new_dtp->has_sticky_ub = 0;
-        new_dtp->has_sticky_lb = 0;
-
         MPIR_Assign_trunc(new_dtp->alignsize, el_sz, MPI_Aint);
         new_dtp->builtin_element_size = el_sz;
         new_dtp->basic_type = el_type;
@@ -118,9 +115,6 @@ int MPIR_Type_indexed(int count,
         old_true_ub = old_dtp->true_ub;
         old_extent = old_dtp->extent;
         MPIR_Datatype_is_contig(oldtype, &old_is_contig);
-
-        new_dtp->has_sticky_lb = old_dtp->has_sticky_lb;
-        new_dtp->has_sticky_ub = old_dtp->has_sticky_ub;
 
         new_dtp->alignsize = old_dtp->alignsize;
         new_dtp->builtin_element_size = (MPI_Aint) el_sz;

--- a/src/mpi/datatype/type_vector.c
+++ b/src/mpi/datatype/type_vector.c
@@ -76,8 +76,6 @@ int MPIR_Type_vector(int count,
         old_is_contig = 1;
 
         new_dtp->size = (MPI_Aint) count *(MPI_Aint) blocklength *el_sz;
-        new_dtp->has_sticky_lb = 0;
-        new_dtp->has_sticky_ub = 0;
 
         new_dtp->alignsize = el_sz;     /* ??? */
         new_dtp->n_builtin_elements = count * blocklength;
@@ -104,8 +102,6 @@ int MPIR_Type_vector(int count,
         MPIR_Datatype_is_contig(oldtype, &old_is_contig);
 
         new_dtp->size = count * blocklength * old_dtp->size;
-        new_dtp->has_sticky_lb = old_dtp->has_sticky_lb;
-        new_dtp->has_sticky_ub = old_dtp->has_sticky_ub;
 
         new_dtp->alignsize = old_dtp->alignsize;
         new_dtp->n_builtin_elements = count * blocklength * old_dtp->n_builtin_elements;

--- a/src/mpi/datatype/typerep/dataloop/typesize_support.h
+++ b/src/mpi/datatype/typerep/dataloop/typesize_support.h
@@ -18,8 +18,6 @@ typedef struct MPIDU_Type_footprint_s {
      */
     MPI_Aint lb, ub, alignsz;
     MPI_Aint true_lb, true_ub;
-    int has_sticky_lb;
-    int has_sticky_ub;
 } MPII_Dataloop_type_footprint;
 
 void MPIDU_Type_calc_footprint(MPI_Datatype type, MPII_Dataloop_type_footprint * tfp);

--- a/src/mpi/datatype/typerep/src/typerep_flatten.c
+++ b/src/mpi/datatype/typerep/src/typerep_flatten.c
@@ -16,7 +16,6 @@
 struct flatten_hdr {
     MPI_Aint size;
     MPI_Aint extent, ub, lb, true_ub, true_lb;
-    int has_sticky_ub, has_sticky_lb;
     int is_contig;
     int basic_type;
     MPI_Aint max_contig_blocks;
@@ -71,8 +70,6 @@ int MPIR_Typerep_flatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     flatten_hdr->lb = datatype_ptr->lb;
     flatten_hdr->true_ub = datatype_ptr->true_ub;
     flatten_hdr->true_lb = datatype_ptr->true_lb;
-    flatten_hdr->has_sticky_ub = datatype_ptr->has_sticky_ub;
-    flatten_hdr->has_sticky_lb = datatype_ptr->has_sticky_lb;
     flatten_hdr->is_contig = datatype_ptr->is_contig;
     flatten_hdr->basic_type = datatype_ptr->basic_type;
     flatten_hdr->max_contig_blocks = datatype_ptr->max_contig_blocks;
@@ -117,8 +114,6 @@ int MPIR_Typerep_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     datatype_ptr->lb = flatten_hdr->lb;
     datatype_ptr->true_ub = flatten_hdr->true_ub;
     datatype_ptr->true_lb = flatten_hdr->true_lb;
-    datatype_ptr->has_sticky_ub = flatten_hdr->has_sticky_ub;
-    datatype_ptr->has_sticky_lb = flatten_hdr->has_sticky_lb;
     datatype_ptr->contents = NULL;
     datatype_ptr->flattened = NULL;
 

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
@@ -202,60 +202,15 @@ int MPIR_Typerep_create_struct(int count, const int *array_of_blocklengths,
     int mpi_errno = MPI_SUCCESS;
     yaksa_type_t *array_of_yaksa_types = (yaksa_type_t *) MPL_malloc(count * sizeof(yaksa_type_t),
                                                                      MPL_MEM_DATATYPE);
-    int *array_of_real_blocklengths = (int *) MPL_malloc(count * sizeof(int), MPL_MEM_DATATYPE);
-    intptr_t *array_of_real_displacements = (intptr_t *) MPL_malloc(count * sizeof(intptr_t),
-                                                                    MPL_MEM_DATATYPE);
 
-
-    /* MPI_LB and MPI_UB were in the MPI-1 standard and were
-     * deprecated in MPI-2.  We should probably stop supporting them
-     * in the future.  For now, we can simply convert them to a
-     * resized type. */
-    int real_count = 0;
     for (int i = 0; i < count; i++) {
-        if (array_of_types[i] != MPI_LB && array_of_types[i] != MPI_UB) {
-            array_of_yaksa_types[real_count] = MPII_Typerep_get_yaksa_type(array_of_types[i]);
-            array_of_real_blocklengths[real_count] = array_of_blocklengths[i];
-            array_of_real_displacements[real_count] = (intptr_t) array_of_displacements[i];
-            real_count++;
-        }
+        array_of_yaksa_types[i] = MPII_Typerep_get_yaksa_type(array_of_types[i]);
     }
 
-    if (count == real_count) {
-        int rc = yaksa_type_create_struct(count, array_of_blocklengths, array_of_real_displacements,
-                                          array_of_yaksa_types, (yaksa_type_t *) typerep);
-        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
-    } else {
-        yaksa_type_t tmp;
+    int rc = yaksa_type_create_struct(count, array_of_blocklengths, array_of_displacements,
+                                      array_of_yaksa_types, (yaksa_type_t *) typerep);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
-        int rc = yaksa_type_create_struct(real_count, array_of_real_blocklengths,
-                                          array_of_real_displacements,
-                                          array_of_yaksa_types, &tmp);
-        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
-
-        intptr_t lb, ub;
-        uintptr_t extent;
-        rc = yaksa_type_get_extent(tmp, &lb, &extent);
-        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
-        ub = lb + extent;
-
-        /* see if the user set MPI_LB/UB to override these values */
-        for (int i = 0; i < count; i++) {
-            if (array_of_types[i] == MPI_LB)
-                lb = array_of_displacements[i];
-            if (array_of_types[i] == MPI_UB)
-                ub = array_of_displacements[i];
-        }
-
-        rc = yaksa_type_create_resized(tmp, lb, ub - lb, (yaksa_type_t *) typerep);
-        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
-
-        rc = yaksa_type_free(tmp);
-        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
-    }
-
-    MPL_free(array_of_real_displacements);
-    MPL_free(array_of_real_blocklengths);
     MPL_free(array_of_yaksa_types);
 
   fn_exit:

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
@@ -171,11 +171,6 @@ yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type)
             }
             break;
 
-        case MPI_LB:
-        case MPI_UB:
-            yaksa_type = YAKSA_TYPE__NULL;
-            break;
-
 #ifdef HAVE_FORTRAN_BINDING
         case MPI_CHARACTER:
             yaksa_type = YAKSA_TYPE__CHAR;

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -310,8 +310,6 @@ int MPII_Type_zerolen(MPI_Datatype * newtype)
     new_dtp->typerep = NULL;
 
     new_dtp->size = 0;
-    new_dtp->has_sticky_ub = 0;
-    new_dtp->has_sticky_lb = 0;
     new_dtp->lb = 0;
     new_dtp->ub = 0;
     new_dtp->true_lb = 0;


### PR DESCRIPTION
## Pull Request Description

We maintain a lot of extra code for the old MPI_LB/UB API usage.  This is unnecessary.  It's easier to translate any usage of the old API to the new API instead.  It adds a little bit of extra overhead, but: (1) the overhead is at type creation time, and (2) users should really be using the new API anyway.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
