### PR TITLE
ch4: fix segfault in am iprobe

### DIFF
--- a/src/mpid/ch4/src/ch4r_probe.h
+++ b/src/mpid/ch4/src/ch4r_probe.h
@@ -30,9 +30,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
         unexp_req->status.MPI_TAG = MPIDIG_REQUEST(unexp_req, tag);
         MPIR_STATUS_SET_COUNT(unexp_req->status, MPIDIG_REQUEST(unexp_req, count));
 
-        status->MPI_TAG = unexp_req->status.MPI_TAG;
-        status->MPI_SOURCE = unexp_req->status.MPI_SOURCE;
-        MPIR_STATUS_SET_COUNT(*status, MPIDIG_REQUEST(unexp_req, count));
+        MPIR_Request_extract_status(unexp_req, status);
     } else {
         *flag = 0;
     }
@@ -75,9 +73,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
         MPIR_STATUS_SET_COUNT(unexp_req->status, MPIDIG_REQUEST(unexp_req, count));
         MPIDIG_REQUEST(unexp_req, req->status) |= MPIDIG_REQ_UNEXP_DQUED;
 
-        status->MPI_TAG = unexp_req->status.MPI_TAG;
-        status->MPI_SOURCE = unexp_req->status.MPI_SOURCE;
-        MPIR_STATUS_SET_COUNT(*status, MPIDIG_REQUEST(unexp_req, count));
+        MPIR_Request_extract_status(unexp_req, status);
     } else {
         *flag = 0;
     }

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -35,8 +35,6 @@
 * * * ch4:ofi * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
 * * * ch4:ucx * sed -i "s+\(^idup_comm_gen .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
 * * * ch4:ucx * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
-* * am-only ch4:ofi * sed -i "s+\(^truncmsg_mrecv .*\)+\1 xfail=ticket0+g" test/mpi/errors/pt2pt/testlist
-* * am-only ch4:ucx * sed -i "s+\(^truncmsg_mrecv .*\)+\1 xfail=ticket0+g" test/mpi/errors/pt2pt/testlist
 ################################################################################
 # xfail known failures of UCX build for Hackathon
 * * * ch4:ucx * sed -i "s+\(^win_large_shm .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist


### PR DESCRIPTION
## Pull Request Description
User may pass in MPI_STATUS_IGNORE so we need check before deferencing
the status pointer. Use MPIR_Request_extract_status macro that already
does that check.

## Reference

This bug is triggered by nightly test `./errors/pt2pt/truncmsg_mrecv 2` in `shm` config (because it is in the active message path).

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
