### PR TITLE
ch3: fix handle leak in imrecv error case

### DIFF
--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_probe_template.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_probe_template.c
@@ -149,15 +149,20 @@ int ADD_SUFFIX(MPID_nem_ofi_improbe) (struct MPIDI_VC * vc,
                                       MPIR_Comm * comm,
                                       int context_offset,
                                       int *flag, MPIR_Request ** message, MPI_Status * status) {
-    int old_error = status->MPI_ERROR;
+    int old_error;
     int s;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_IMPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_IMPROBE);
     *flag = CLAIM_PEEK;
+    if (status != MPI_STATUS_IGNORE) {
+        old_error = status->MPI_ERROR;
+    }
     s = ADD_SUFFIX(MPID_nem_ofi_iprobe_impl) (vc, source,
                                               tag, comm, context_offset, flag, status, message);
     if (*flag) {
-        status->MPI_ERROR = old_error;
+        if (status != MPI_STATUS_IGNORE) {
+            status->MPI_ERROR = old_error;
+        }
         (*message)->kind = MPIR_REQUEST_KIND__MPROBE;
     }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_IMPROBE);

--- a/src/mpid/ch3/src/mpid_imrecv.c
+++ b/src/mpid/ch3/src/mpid_imrecv.c
@@ -81,6 +81,7 @@ int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
             }
 
             mpi_errno = rreq->status.MPI_ERROR;
+            MPIR_ERR_CHECK(mpi_errno);
             goto fn_exit;
         }
         else
@@ -132,6 +133,8 @@ int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
 fn_exit:
     return mpi_errno;
 fn_fail:
+    MPIR_Request_free(rreq);
+    rreq = NULL;
     goto fn_exit;
 }
 

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -180,6 +180,3 @@ valgrind * * * * sed -i "s+\(^accfence1 .*\)+\1 xfail=ticket0+g" test/mpi/rma/te
 * * async * * sed -i "s+\(^.*_ALGORITHM=release_gather.*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist.cvar
 # freebsd failures
 * * debug ch3:tcp freebsd64 sed -i "s+\(^comm_create_group_threads .*\)+\1 xfail=issue4372+g" test/mpi/threads/comm/testlist
-# truncation test for mrecv leaks handles with ch3
-* * debug ch3:tcp * sed -i "s+\(^truncmsg_mrecv .*\)+\1 xfail=ticket0+g" test/mpi/errors/pt2pt/testlist
-* * debug ch3:sock * sed -i "s+\(^truncmsg_mrecv .*\)+\1 xfail=ticket0+g" test/mpi/errors/pt2pt/testlist


### PR DESCRIPTION
## Pull Request Description

When error occurs in imrecv, we should free the request since there
won't be a wait for it.



<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
