### PR TITLE
config: remove the confusing echo message

### DIFF
--- a/src/mpid/ch4/netmod/ucx/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ucx/subconfigure.m4
@@ -29,7 +29,6 @@ dnl Parse the device arguments
     IFS=':'
     args_array=$ucx_netmod_args
     do_am_only=false
-    echo "Parsing Arguments for UCX Netmod"
     for arg in $args_array; do
     case ${arg} in
       am-only)


### PR DESCRIPTION
## Pull Request Description
This echo "Parsing Arguments for UCX Netmod" is shown regardless whether
we are configure with ch4:ucx or not, even with ch3. The message is
rather confusing, thus removed.

For example:
```
...
checking whether the gfortran linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
Parsing Arguments for UCX Netmod
checking hcoll/api/hcoll_api.h usability... no
checking hcoll/api/hcoll_api.h presence... no
checking for hcoll/api/hcoll_api.h... no
checking for hcoll_init in -lhcoll... no
configure: RUNNING PREREQ FOR ch3:nemesis
configure: ===== configuring src/mpl =====
...
```


<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
