### PR TITLE
Improve typerep abstraction

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -135,8 +135,11 @@ struct MPIR_Datatype {
     void *flattened;
     int flattened_sz;
 
-    /* internal type representation */
-    void *typerep;              /* might be optimized for homogenous */
+    /* handle to the backend datatype engine + some content that we
+     * query from it and cache over here for performance reasons */
+    struct {
+        void *handle;
+    } typerep;
 
     /* Other, device-specific information */
 #ifdef MPID_DEV_DATATYPE_DECL

--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -122,11 +122,6 @@ struct MPIR_Datatype {
      * contiguous.
      */
     int is_contig;
-    /* Upper bound on the number of contig blocks for one instance.
-     * It is not trivial to calculate the *real* number of contig
-     * blocks in the case where old datatype is non-contiguous
-     */
-    MPI_Aint max_contig_blocks;
 
     /* pointer to contents and envelope data for the datatype */
     MPIR_Datatype_contents *contents;
@@ -139,6 +134,7 @@ struct MPIR_Datatype {
      * query from it and cache over here for performance reasons */
     struct {
         void *handle;
+        MPI_Aint num_contig_blocks;     /* contig blocks in one datatype element */
     } typerep;
 
     /* Other, device-specific information */
@@ -280,7 +276,7 @@ void MPIR_Datatype_get_flattened(MPI_Datatype type, void **flattened, int *flatt
             MPIR_Datatype_get_ptr((datatype_), dt_ptr_);        \
             MPI_Aint size_;                                     \
             MPIR_Datatype_get_size_macro((datatype_), size_);   \
-            (density_) = size_ / dt_ptr_->max_contig_blocks;    \
+            (density_) = size_ / dt_ptr_->typerep.num_contig_blocks;    \
         }                                                       \
     } while (0)
 

--- a/src/include/mpir_typerep.h
+++ b/src/include/mpir_typerep.h
@@ -12,36 +12,37 @@ void MPIR_Typerep_init(void);
 void MPIR_Typerep_finalize(void);
 
 int MPIR_Typerep_create_vector(int count, int blocklength, int stride, MPI_Datatype oldtype,
-                               void **typerep);
+                               MPIR_Datatype * newtype);
 int MPIR_Typerep_create_hvector(int count, int blocklength, MPI_Aint stride, MPI_Datatype oldtype,
-                                void **typerep);
-int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, void **newtype);
-int MPIR_Typerep_create_dup(MPI_Datatype oldtype, void **newtype);
+                                MPIR_Datatype * newtype);
+int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, MPIR_Datatype * newtype);
+int MPIR_Typerep_create_dup(MPI_Datatype oldtype, MPIR_Datatype * newtype);
 int MPIR_Typerep_create_indexed_block(int count, int blocklength, const int *array_of_displacements,
-                                      MPI_Datatype oldtype, void **newtype);
+                                      MPI_Datatype oldtype, MPIR_Datatype * newtype);
 int MPIR_Typerep_create_hindexed_block(int count, int blocklength,
                                        const MPI_Aint * array_of_displacements,
-                                       MPI_Datatype oldtype, void **newtype);
+                                       MPI_Datatype oldtype, MPIR_Datatype * newtype);
 int MPIR_Typerep_create_indexed(int count, const int *array_of_blocklengths,
                                 const int *array_of_displacements, MPI_Datatype oldtype,
-                                void **newtype);
+                                MPIR_Datatype * newtype);
 int MPIR_Typerep_create_hindexed(int count, const int *array_of_blocklengths,
                                  const MPI_Aint * array_of_displacements, MPI_Datatype oldtype,
-                                 void **newtype);
-int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent, void **newtype);
+                                 MPIR_Datatype * newtype);
+int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent,
+                                MPIR_Datatype * newtype);
 int MPIR_Typerep_create_struct(int count, const int *array_of_blocklengths,
                                const MPI_Aint * array_of_displacements,
-                               const MPI_Datatype * array_of_types, void **newtype);
+                               const MPI_Datatype * array_of_types, MPIR_Datatype * newtype);
 int MPIR_Typerep_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
-                                 const int *array_of_starts, int order,
-                                 MPI_Datatype oldtype, void **newtype);
+                                 const int *array_of_starts, int order, MPI_Datatype oldtype,
+                                 MPIR_Datatype * newtype);
 int MPIR_Typerep_create_darray(int size, int rank, int ndims, const int *array_of_gsizes,
                                const int *array_of_distribs, const int *array_of_dargs,
                                const int *array_of_psizes, int order, MPI_Datatype oldtype,
-                               void **newtype);
+                               MPIR_Datatype * newtype);
 
-void MPIR_Typerep_commit(MPI_Datatype type, void **typerep_p);
-void MPIR_Typerep_free(void **typerep_p);
+void MPIR_Typerep_commit(MPI_Datatype type);
+void MPIR_Typerep_free(MPIR_Datatype * typeptr);
 
 int MPIR_Typerep_flatten_size(MPIR_Datatype * datatype_ptr, int *flattened_type_size);
 int MPIR_Typerep_flatten(MPIR_Datatype * datatype_ptr, void *flattened_type);

--- a/src/mpi/datatype/type_blockindexed.c
+++ b/src/mpi/datatype/type_blockindexed.c
@@ -61,7 +61,7 @@ int MPIR_Type_blockindexed(int count,
     new_dtp->contents = NULL;
     new_dtp->flattened = NULL;
 
-    new_dtp->typerep = NULL;
+    new_dtp->typerep.handle = NULL;
 
     if (HANDLE_IS_BUILTIN(oldtype)) {
         MPI_Aint el_sz = (MPI_Aint) MPIR_Datatype_get_basic_size(oldtype);
@@ -149,11 +149,11 @@ int MPIR_Type_blockindexed(int count,
 
     if (dispinbytes) {
         mpi_errno = MPIR_Typerep_create_hindexed_block(count, blocklength, displacement_array,
-                                                       oldtype, &new_dtp->typerep);
+                                                       oldtype, new_dtp);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno = MPIR_Typerep_create_indexed_block(count, blocklength, displacement_array,
-                                                      oldtype, &new_dtp->typerep);
+                                                      oldtype, new_dtp);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/datatype/type_blockindexed.c
+++ b/src/mpi/datatype/type_blockindexed.c
@@ -79,8 +79,6 @@ int MPIR_Type_blockindexed(int count,
         new_dtp->n_builtin_elements = count * blocklength;
         new_dtp->builtin_element_size = el_sz;
         new_dtp->basic_type = oldtype;
-
-        new_dtp->max_contig_blocks = count;
     } else {
         /* user-defined base type (oldtype) */
         MPIR_Datatype *old_dtp;
@@ -100,8 +98,6 @@ int MPIR_Type_blockindexed(int count,
         new_dtp->n_builtin_elements = count * blocklength * old_dtp->n_builtin_elements;
         new_dtp->builtin_element_size = old_dtp->builtin_element_size;
         new_dtp->basic_type = old_dtp->basic_type;
-
-        new_dtp->max_contig_blocks = old_dtp->max_contig_blocks * count * blocklength;
     }
 
     /* priming for loop */
@@ -141,7 +137,6 @@ int MPIR_Type_blockindexed(int count,
                                                                blocklength,
                                                                displacement_array,
                                                                dispinbytes, old_extent);
-        new_dtp->max_contig_blocks = contig_count;
         if ((contig_count == 1) && ((MPI_Aint) new_dtp->size == new_dtp->extent)) {
             new_dtp->is_contig = 1;
         }

--- a/src/mpi/datatype/type_commit.c
+++ b/src/mpi/datatype/type_commit.c
@@ -38,7 +38,7 @@ int MPIR_Type_commit(MPI_Datatype * datatype_p)
         MPIR_Typerep_commit(*datatype_p);
 
         MPL_DBG_MSG_D(MPIR_DBG_DATATYPE, TERSE, "# contig blocks = %d\n",
-                      (int) datatype_ptr->max_contig_blocks);
+                      (int) datatype_ptr->typerep.num_contig_blocks);
 
         MPID_Type_commit_hook(datatype_ptr);
 

--- a/src/mpi/datatype/type_commit.c
+++ b/src/mpi/datatype/type_commit.c
@@ -35,7 +35,7 @@ int MPIR_Type_commit(MPI_Datatype * datatype_p)
     if (datatype_ptr->is_committed == 0) {
         datatype_ptr->is_committed = 1;
 
-        MPIR_Typerep_commit(*datatype_p, &datatype_ptr->typerep);
+        MPIR_Typerep_commit(*datatype_p);
 
         MPL_DBG_MSG_D(MPIR_DBG_DATATYPE, TERSE, "# contig blocks = %d\n",
                       (int) datatype_ptr->max_contig_blocks);

--- a/src/mpi/datatype/type_contiguous.c
+++ b/src/mpi/datatype/type_contiguous.c
@@ -70,8 +70,6 @@ int MPIR_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype
         new_dtp->builtin_element_size = el_sz;
         new_dtp->basic_type = oldtype;
         new_dtp->is_contig = 1;
-        new_dtp->max_contig_blocks = 1;
-
     } else {
         /* user-defined base type (oldtype) */
         MPIR_Datatype *old_dtp;
@@ -97,10 +95,6 @@ int MPIR_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype
         new_dtp->basic_type = old_dtp->basic_type;
 
         MPIR_Datatype_is_contig(oldtype, &new_dtp->is_contig);
-        if (new_dtp->is_contig)
-            new_dtp->max_contig_blocks = 1;
-        else
-            new_dtp->max_contig_blocks = count * old_dtp->max_contig_blocks;
     }
 
     mpi_errno = MPIR_Typerep_create_contig(count, oldtype, new_dtp);

--- a/src/mpi/datatype/type_contiguous.c
+++ b/src/mpi/datatype/type_contiguous.c
@@ -53,7 +53,7 @@ int MPIR_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype
     new_dtp->contents = NULL;
     new_dtp->flattened = NULL;
 
-    new_dtp->typerep = NULL;
+    new_dtp->typerep.handle = NULL;
 
     if (HANDLE_IS_BUILTIN(oldtype)) {
         MPI_Aint el_sz = MPIR_Datatype_get_basic_size(oldtype);
@@ -103,7 +103,7 @@ int MPIR_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype
             new_dtp->max_contig_blocks = count * old_dtp->max_contig_blocks;
     }
 
-    mpi_errno = MPIR_Typerep_create_contig(count, oldtype, &new_dtp->typerep);
+    mpi_errno = MPIR_Typerep_create_contig(count, oldtype, new_dtp);
     MPIR_ERR_CHECK(mpi_errno);
 
     *newtype = new_dtp->handle;

--- a/src/mpi/datatype/type_create_darray.c
+++ b/src/mpi/datatype/type_create_darray.c
@@ -671,7 +671,7 @@ int MPI_Type_create_darray(int size,
 
     mpi_errno = MPIR_Typerep_create_darray(size, rank, ndims, array_of_gsizes, array_of_distribs,
                                            array_of_dargs, array_of_psizes, order, oldtype,
-                                           &datatype_ptr->typerep);
+                                           datatype_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);

--- a/src/mpi/datatype/type_create_pairtype.c
+++ b/src/mpi/datatype/type_create_pairtype.c
@@ -125,7 +125,6 @@ int MPIR_Type_create_pairtype(MPI_Datatype type, MPIR_Datatype * new_dtp)
     }
 
     new_dtp->is_contig = (((MPI_Aint) type_size) == type_extent) ? 1 : 0;
-    new_dtp->max_contig_blocks = (((MPI_Aint) type_size) == type_extent) ? 1 : 2;
 
     return mpi_errno;
 }

--- a/src/mpi/datatype/type_create_pairtype.c
+++ b/src/mpi/datatype/type_create_pairtype.c
@@ -71,7 +71,7 @@ int MPIR_Type_create_pairtype(MPI_Datatype type, MPIR_Datatype * new_dtp)
     new_dtp->contents = NULL;
     new_dtp->flattened = NULL;
 
-    new_dtp->typerep = NULL;
+    new_dtp->typerep.handle = NULL;
 
     switch (type) {
         case MPI_FLOAT_INT:

--- a/src/mpi/datatype/type_create_resized.c
+++ b/src/mpi/datatype/type_create_resized.c
@@ -60,7 +60,7 @@ int MPIR_Type_create_resized(MPI_Datatype oldtype,
     new_dtp->contents = 0;
     new_dtp->flattened = NULL;
 
-    new_dtp->typerep = NULL;
+    new_dtp->typerep.handle = NULL;
 
     /* if oldtype is a basic, we build a contiguous typerep of count = 1 */
     if (HANDLE_IS_BUILTIN(oldtype)) {
@@ -102,7 +102,7 @@ int MPIR_Type_create_resized(MPI_Datatype oldtype,
         new_dtp->max_contig_blocks = old_dtp->max_contig_blocks;
     }
 
-    int mpi_errno = MPIR_Typerep_create_resized(oldtype, lb, extent, &new_dtp->typerep);
+    int mpi_errno = MPIR_Typerep_create_resized(oldtype, lb, extent, new_dtp);
     MPIR_ERR_CHECK(mpi_errno);
 
     *newtype_p = new_dtp->handle;

--- a/src/mpi/datatype/type_create_resized.c
+++ b/src/mpi/datatype/type_create_resized.c
@@ -77,7 +77,6 @@ int MPIR_Type_create_resized(MPI_Datatype oldtype,
         new_dtp->builtin_element_size = oldsize;
         new_dtp->is_contig = (extent == oldsize) ? 1 : 0;
         new_dtp->basic_type = oldtype;
-        new_dtp->max_contig_blocks = 3; /* lb, data, ub */
     } else {
         /* user-defined base type */
         MPIR_Datatype *old_dtp;
@@ -99,7 +98,6 @@ int MPIR_Type_create_resized(MPI_Datatype oldtype,
             MPIR_Datatype_is_contig(oldtype, &new_dtp->is_contig);
         else
             new_dtp->is_contig = 0;
-        new_dtp->max_contig_blocks = old_dtp->max_contig_blocks;
     }
 
     int mpi_errno = MPIR_Typerep_create_resized(oldtype, lb, extent, new_dtp);

--- a/src/mpi/datatype/type_create_subarray.c
+++ b/src/mpi/datatype/type_create_subarray.c
@@ -290,7 +290,7 @@ int MPI_Type_create_subarray(int ndims,
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Typerep_create_subarray(ndims, array_of_sizes, array_of_subsizes,
-                                             array_of_starts, order, oldtype, &new_dtp->typerep);
+                                             array_of_starts, order, oldtype, new_dtp);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);

--- a/src/mpi/datatype/type_dup.c
+++ b/src/mpi/datatype/type_dup.c
@@ -72,14 +72,14 @@ int MPIR_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
 
         new_dtp->max_contig_blocks = old_dtp->max_contig_blocks;
 
-        new_dtp->typerep = NULL;
+        new_dtp->typerep.handle = NULL;
         *newtype = new_dtp->handle;
 
         if (old_dtp->is_committed) {
             MPID_Type_commit_hook(new_dtp);
         }
 
-        mpi_errno = MPIR_Typerep_create_dup(oldtype, &new_dtp->typerep);
+        mpi_errno = MPIR_Typerep_create_dup(oldtype, new_dtp);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/datatype/type_dup.c
+++ b/src/mpi/datatype/type_dup.c
@@ -70,8 +70,6 @@ int MPIR_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
         new_dtp->builtin_element_size = old_dtp->builtin_element_size;
         new_dtp->basic_type = old_dtp->basic_type;
 
-        new_dtp->max_contig_blocks = old_dtp->max_contig_blocks;
-
         new_dtp->typerep.handle = NULL;
         *newtype = new_dtp->handle;
 

--- a/src/mpi/datatype/type_indexed.c
+++ b/src/mpi/datatype/type_indexed.c
@@ -69,7 +69,7 @@ int MPIR_Type_indexed(int count,
     new_dtp->contents = NULL;
     new_dtp->flattened = NULL;
 
-    new_dtp->typerep = NULL;
+    new_dtp->typerep.handle = NULL;
 
     if (HANDLE_IS_BUILTIN(oldtype)) {
         /* builtins are handled differently than user-defined types because
@@ -195,12 +195,12 @@ int MPIR_Type_indexed(int count,
     if (dispinbytes) {
         mpi_errno =
             MPIR_Typerep_create_hindexed(count, blocklength_array, displacement_array, oldtype,
-                                         &new_dtp->typerep);
+                                         new_dtp);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno =
             MPIR_Typerep_create_indexed(count, blocklength_array, displacement_array, oldtype,
-                                        &new_dtp->typerep);
+                                        new_dtp);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/datatype/type_indexed.c
+++ b/src/mpi/datatype/type_indexed.c
@@ -89,8 +89,6 @@ int MPIR_Type_indexed(int count,
         MPIR_Assign_trunc(new_dtp->alignsize, el_sz, MPI_Aint);
         new_dtp->builtin_element_size = el_sz;
         new_dtp->basic_type = oldtype;
-
-        new_dtp->max_contig_blocks = count;
     } else {
         /* user-defined base type (oldtype) */
         MPIR_Datatype *old_dtp;
@@ -113,11 +111,6 @@ int MPIR_Type_indexed(int count,
         new_dtp->alignsize = old_dtp->alignsize;
         new_dtp->builtin_element_size = old_dtp->builtin_element_size;
         new_dtp->basic_type = old_dtp->basic_type;
-
-        new_dtp->max_contig_blocks = 0;
-        for (i = 0; i < count; i++)
-            new_dtp->max_contig_blocks
-                += old_dtp->max_contig_blocks * ((MPI_Aint) blocklength_array[i]);
     }
 
     /* find the first nonzero blocklength element */
@@ -185,7 +178,6 @@ int MPIR_Type_indexed(int count,
                                                           blklens,
                                                           displacement_array, dispinbytes,
                                                           old_extent);
-        new_dtp->max_contig_blocks = contig_count;
         if ((contig_count == 1) && ((MPI_Aint) new_dtp->size == new_dtp->extent)) {
             new_dtp->is_contig = 1;
         }

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -101,7 +101,6 @@ static int type_struct(int count,
         return MPII_Type_zerolen(newtype);
     }
 
-    new_dtp->max_contig_blocks = 0;
     for (i = 0; i < count; i++) {
         MPI_Aint tmp_lb, tmp_ub, tmp_true_lb, tmp_true_ub;
         MPI_Aint tmp_el_sz;
@@ -126,8 +125,6 @@ static int type_struct(int count,
             tmp_true_ub = tmp_ub;
 
             size += tmp_el_sz * blocklength_array[i];
-
-            new_dtp->max_contig_blocks++;
         } else {
             MPIR_Datatype_get_ptr(oldtype_array[i], old_dtp);
 
@@ -144,8 +141,6 @@ static int type_struct(int count,
             tmp_true_ub = tmp_ub + (old_dtp->true_ub - old_dtp->ub);
 
             size += old_dtp->size * blocklength_array[i];
-
-            new_dtp->max_contig_blocks += old_dtp->max_contig_blocks * blocklength_array[i];
         }
 
         /* element size and type */

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -89,7 +89,7 @@ static int type_struct(int count,
     new_dtp->contents = NULL;
     new_dtp->flattened = NULL;
 
-    new_dtp->typerep = NULL;
+    new_dtp->typerep.handle = NULL;
 
     /* check for junk struct with all zero blocks */
     for (i = 0; i < count; i++)
@@ -245,7 +245,7 @@ static int type_struct(int count,
     }
 
     mpi_errno = MPIR_Typerep_create_struct(count, blocklength_array, displacement_array,
-                                           oldtype_array, &new_dtp->typerep);
+                                           oldtype_array, new_dtp);
     MPIR_ERR_CHECK(mpi_errno);
 
     *newtype = new_dtp->handle;

--- a/src/mpi/datatype/type_vector.c
+++ b/src/mpi/datatype/type_vector.c
@@ -58,7 +58,7 @@ int MPIR_Type_vector(int count,
     new_dtp->contents = NULL;
     new_dtp->flattened = NULL;
 
-    new_dtp->typerep = NULL;
+    new_dtp->typerep.handle = NULL;
 
     if (HANDLE_IS_BUILTIN(oldtype)) {
         MPI_Aint el_sz = (MPI_Aint) MPIR_Datatype_get_basic_size(oldtype);
@@ -128,12 +128,10 @@ int MPIR_Type_vector(int count,
     }
 
     if (strideinbytes) {
-        mpi_errno =
-            MPIR_Typerep_create_hvector(count, blocklength, stride, oldtype, &new_dtp->typerep);
+        mpi_errno = MPIR_Typerep_create_hvector(count, blocklength, stride, oldtype, new_dtp);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
-        mpi_errno =
-            MPIR_Typerep_create_vector(count, blocklength, stride, oldtype, &new_dtp->typerep);
+        mpi_errno = MPIR_Typerep_create_vector(count, blocklength, stride, oldtype, new_dtp);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/datatype/type_vector.c
+++ b/src/mpi/datatype/type_vector.c
@@ -78,8 +78,6 @@ int MPIR_Type_vector(int count,
         new_dtp->builtin_element_size = el_sz;
         new_dtp->basic_type = oldtype;
 
-        new_dtp->max_contig_blocks = count;
-
         eff_stride = (strideinbytes) ? stride : (stride * el_sz);
     } else {    /* user-defined base type (oldtype) */
 
@@ -102,8 +100,6 @@ int MPIR_Type_vector(int count,
         new_dtp->builtin_element_size = old_dtp->builtin_element_size;
         new_dtp->basic_type = old_dtp->basic_type;
 
-        new_dtp->max_contig_blocks = old_dtp->max_contig_blocks * count * blocklength;
-
         eff_stride = (strideinbytes) ? stride : (stride * old_dtp->extent);
     }
 
@@ -122,7 +118,6 @@ int MPIR_Type_vector(int count,
     if ((MPI_Aint) (new_dtp->size) == new_dtp->extent &&
         eff_stride == (MPI_Aint) blocklength * old_sz && old_is_contig) {
         new_dtp->is_contig = 1;
-        new_dtp->max_contig_blocks = 1;
     } else {
         new_dtp->is_contig = 0;
     }

--- a/src/mpi/datatype/typerep/dataloop/dataloop.h
+++ b/src/mpi/datatype/typerep/dataloop/dataloop.h
@@ -17,12 +17,12 @@ struct MPIR_Datatype;
         case HANDLE_KIND_DIRECT:                                        \
             MPIR_Assert(HANDLE_INDEX(a) < MPIR_DATATYPE_PREALLOC);      \
             ptr = MPIR_Datatype_direct+HANDLE_INDEX(a);                 \
-            lptr_ = ((MPIR_Datatype *)ptr)->typerep;                    \
+            lptr_ = ((MPIR_Datatype *)ptr)->typerep.handle;             \
             break;                                                      \
         case HANDLE_KIND_INDIRECT:                                      \
             ptr = ((MPIR_Datatype *)                                    \
                    MPIR_Handle_get_ptr_indirect(a,&MPIR_Datatype_mem)); \
-            lptr_ = ((MPIR_Datatype *)ptr)->typerep;                    \
+            lptr_ = ((MPIR_Datatype *)ptr)->typerep.handle;             \
             break;                                                      \
         case HANDLE_KIND_INVALID:                                       \
         case HANDLE_KIND_BUILTIN:                                       \
@@ -38,12 +38,12 @@ struct MPIR_Datatype;
         case HANDLE_KIND_DIRECT:                                        \
             MPIR_Assert(HANDLE_INDEX(a) < MPIR_DATATYPE_PREALLOC);      \
             ptr = MPIR_Datatype_direct+HANDLE_INDEX(a);                 \
-            ((MPIR_Datatype *)ptr)->typerep = lptr_;                    \
+            ((MPIR_Datatype *)ptr)->typerep.handle = lptr_;             \
             break;                                                      \
         case HANDLE_KIND_INDIRECT:                                      \
             ptr = ((MPIR_Datatype *)                                    \
                    MPIR_Handle_get_ptr_indirect(a,&MPIR_Datatype_mem)); \
-            ((MPIR_Datatype *)ptr)->typerep = lptr_;                    \
+            ((MPIR_Datatype *)ptr)->typerep.handle = lptr_;             \
             break;                                                      \
         case HANDLE_KIND_INVALID:                                       \
         case HANDLE_KIND_BUILTIN:                                       \

--- a/src/mpi/datatype/typerep/dataloop/dataloop_debug.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop_debug.c
@@ -207,7 +207,7 @@ void MPIR_Dataloop_printf(MPI_Datatype type, int depth, int header)
         MPII_Dataloop *loop_p;
 
         MPIR_Datatype_get_ptr(type, dt_p);
-        loop_p = (MPII_Dataloop *) dt_p->typerep;
+        loop_p = (MPII_Dataloop *) dt_p->typerep.handle;
 
         dot_printf(loop_p, depth, header);
         return;

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
@@ -64,6 +64,15 @@ static int create_pairtype(MPI_Datatype type, void **dlp_p)
 
 static void create_named(MPI_Datatype type, void **dlp_p);
 
+#define GET_NUM_CONTIG_BLOCKS(ctype1, ctype2, num_contig_blocks)        \
+    do {                                                                \
+        struct {                                                        \
+            ctype1 x;                                                   \
+            ctype2 y;                                                   \
+        } z;                                                            \
+        num_contig_blocks = (sizeof(z.x) + sizeof(z.y) == sizeof(z)) ? 1 : 2; \
+    } while (0)
+
 void MPIR_Typerep_commit(MPI_Datatype type)
 {
     int i;
@@ -87,11 +96,36 @@ void MPIR_Typerep_commit(MPI_Datatype type)
     MPIR_Datatype_get_ptr(type, typeptr);
     void **dlp_p = (void **) &typeptr->typerep.handle;
 
-    if (type == MPI_FLOAT_INT || type == MPI_DOUBLE_INT ||
-        type == MPI_LONG_INT || type == MPI_SHORT_INT ||
-        type == MPI_LONG_DOUBLE_INT || type == MPI_2INT) {
-        create_pairtype(type, dlp_p);
-        return;
+    switch (type) {
+        case MPI_FLOAT_INT:
+            create_pairtype(type, dlp_p);
+            GET_NUM_CONTIG_BLOCKS(float, int, typeptr->typerep.num_contig_blocks);
+            return;
+
+        case MPI_DOUBLE_INT:
+            create_pairtype(type, dlp_p);
+            GET_NUM_CONTIG_BLOCKS(double, int, typeptr->typerep.num_contig_blocks);
+            return;
+
+        case MPI_LONG_INT:
+            create_pairtype(type, dlp_p);
+            GET_NUM_CONTIG_BLOCKS(long, int, typeptr->typerep.num_contig_blocks);
+            return;
+
+        case MPI_SHORT_INT:
+            create_pairtype(type, dlp_p);
+            GET_NUM_CONTIG_BLOCKS(short, int, typeptr->typerep.num_contig_blocks);
+            return;
+
+        case MPI_LONG_DOUBLE_INT:
+            create_pairtype(type, dlp_p);
+            GET_NUM_CONTIG_BLOCKS(long double, int, typeptr->typerep.num_contig_blocks);
+            return;
+
+        case MPI_2INT:
+            create_pairtype(type, dlp_p);
+            GET_NUM_CONTIG_BLOCKS(int, int, typeptr->typerep.num_contig_blocks);
+            return;
     }
 
     MPIR_Type_get_envelope(type, &nr_ints, &nr_aints, &nr_types, &combiner);

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
@@ -19,7 +19,7 @@
         types[1] = mt2_;                                                \
     }
 
-#define GET_NUM_CONTIG_BLOCKS(ctype1, ctype2, num_contig_blocks)        \
+#define PAIRTYPE_GET_NUM_CONTIG_BLOCKS(ctype1, ctype2, num_contig_blocks)        \
     do {                                                                \
         struct {                                                        \
             ctype1 x;                                                   \
@@ -59,22 +59,22 @@ static int create_pairtype(MPI_Datatype type)
 
     if (type == MPI_FLOAT_INT) {
         PAIRTYPE_CONTENTS(MPI_FLOAT, float, MPI_INT, int);
-        GET_NUM_CONTIG_BLOCKS(float, int, typeptr->typerep.num_contig_blocks);
+        PAIRTYPE_GET_NUM_CONTIG_BLOCKS(float, int, typeptr->typerep.num_contig_blocks);
     } else if (type == MPI_DOUBLE_INT) {
         PAIRTYPE_CONTENTS(MPI_DOUBLE, double, MPI_INT, int);
-        GET_NUM_CONTIG_BLOCKS(double, int, typeptr->typerep.num_contig_blocks);
+        PAIRTYPE_GET_NUM_CONTIG_BLOCKS(double, int, typeptr->typerep.num_contig_blocks);
     } else if (type == MPI_LONG_INT) {
         PAIRTYPE_CONTENTS(MPI_LONG, long, MPI_INT, int);
-        GET_NUM_CONTIG_BLOCKS(long, int, typeptr->typerep.num_contig_blocks);
+        PAIRTYPE_GET_NUM_CONTIG_BLOCKS(long, int, typeptr->typerep.num_contig_blocks);
     } else if (type == MPI_SHORT_INT) {
         PAIRTYPE_CONTENTS(MPI_SHORT, short, MPI_INT, int);
-        GET_NUM_CONTIG_BLOCKS(short, int, typeptr->typerep.num_contig_blocks);
+        PAIRTYPE_GET_NUM_CONTIG_BLOCKS(short, int, typeptr->typerep.num_contig_blocks);
     } else if (type == MPI_LONG_DOUBLE_INT) {
         PAIRTYPE_CONTENTS(MPI_LONG_DOUBLE, long double, MPI_INT, int);
-        GET_NUM_CONTIG_BLOCKS(long double, int, typeptr->typerep.num_contig_blocks);
+        PAIRTYPE_GET_NUM_CONTIG_BLOCKS(long double, int, typeptr->typerep.num_contig_blocks);
     } else if (type == MPI_2INT) {
         PAIRTYPE_CONTENTS(MPI_INT, int, MPI_INT, int);
-        GET_NUM_CONTIG_BLOCKS(int, int, typeptr->typerep.num_contig_blocks);
+        PAIRTYPE_GET_NUM_CONTIG_BLOCKS(int, int, typeptr->typerep.num_contig_blocks);
     }
 
     return MPIR_Dataloop_create_struct(2, blocks, disps, types, (void **) &typeptr->typerep.handle);

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
@@ -19,12 +19,20 @@
         types[1] = mt2_;                                                \
     }
 
+#define GET_NUM_CONTIG_BLOCKS(ctype1, ctype2, num_contig_blocks)        \
+    do {                                                                \
+        struct {                                                        \
+            ctype1 x;                                                   \
+            ctype2 y;                                                   \
+        } z;                                                            \
+        num_contig_blocks = (sizeof(z.x) + sizeof(z.y) == sizeof(z)) ? 1 : 2; \
+    } while (0)
+
 /*@
 create_pairtype - create dataloop for a pairtype
 
    Arguments:
 +  MPI_Datatype type - the pairtype
-.  void **output_dataloop_ptr
 
 .N Errors
 .N Returns 0 on success, -1 on failure.
@@ -36,7 +44,7 @@ create_pairtype - create dataloop for a pairtype
    This same function could be used to create dataloops for any type
    that actually consists of two distinct elements.
 @*/
-static int create_pairtype(MPI_Datatype type, void **dlp_p)
+static int create_pairtype(MPI_Datatype type)
 {
     int blocks[2] = { 1, 1 };
     MPI_Aint disps[2];
@@ -46,32 +54,33 @@ static int create_pairtype(MPI_Datatype type, void **dlp_p)
                 type == MPI_LONG_INT || type == MPI_SHORT_INT ||
                 type == MPI_LONG_DOUBLE_INT || type == MPI_2INT);
 
-    if (type == MPI_FLOAT_INT)
-        PAIRTYPE_CONTENTS(MPI_FLOAT, float, MPI_INT, int);
-    if (type == MPI_DOUBLE_INT)
-        PAIRTYPE_CONTENTS(MPI_DOUBLE, double, MPI_INT, int);
-    if (type == MPI_LONG_INT)
-        PAIRTYPE_CONTENTS(MPI_LONG, long, MPI_INT, int);
-    if (type == MPI_SHORT_INT)
-        PAIRTYPE_CONTENTS(MPI_SHORT, short, MPI_INT, int);
-    if (type == MPI_LONG_DOUBLE_INT)
-        PAIRTYPE_CONTENTS(MPI_LONG_DOUBLE, long double, MPI_INT, int);
-    if (type == MPI_2INT)
-        PAIRTYPE_CONTENTS(MPI_INT, int, MPI_INT, int);
+    MPIR_Datatype *typeptr;
+    MPIR_Datatype_get_ptr(type, typeptr);
 
-    return MPIR_Dataloop_create_struct(2, blocks, disps, types, (void **) dlp_p);
+    if (type == MPI_FLOAT_INT) {
+        PAIRTYPE_CONTENTS(MPI_FLOAT, float, MPI_INT, int);
+        GET_NUM_CONTIG_BLOCKS(float, int, typeptr->typerep.num_contig_blocks);
+    } else if (type == MPI_DOUBLE_INT) {
+        PAIRTYPE_CONTENTS(MPI_DOUBLE, double, MPI_INT, int);
+        GET_NUM_CONTIG_BLOCKS(double, int, typeptr->typerep.num_contig_blocks);
+    } else if (type == MPI_LONG_INT) {
+        PAIRTYPE_CONTENTS(MPI_LONG, long, MPI_INT, int);
+        GET_NUM_CONTIG_BLOCKS(long, int, typeptr->typerep.num_contig_blocks);
+    } else if (type == MPI_SHORT_INT) {
+        PAIRTYPE_CONTENTS(MPI_SHORT, short, MPI_INT, int);
+        GET_NUM_CONTIG_BLOCKS(short, int, typeptr->typerep.num_contig_blocks);
+    } else if (type == MPI_LONG_DOUBLE_INT) {
+        PAIRTYPE_CONTENTS(MPI_LONG_DOUBLE, long double, MPI_INT, int);
+        GET_NUM_CONTIG_BLOCKS(long double, int, typeptr->typerep.num_contig_blocks);
+    } else if (type == MPI_2INT) {
+        PAIRTYPE_CONTENTS(MPI_INT, int, MPI_INT, int);
+        GET_NUM_CONTIG_BLOCKS(int, int, typeptr->typerep.num_contig_blocks);
+    }
+
+    return MPIR_Dataloop_create_struct(2, blocks, disps, types, (void **) &typeptr->typerep.handle);
 }
 
-static void create_named(MPI_Datatype type, void **dlp_p);
-
-#define GET_NUM_CONTIG_BLOCKS(ctype1, ctype2, num_contig_blocks)        \
-    do {                                                                \
-        struct {                                                        \
-            ctype1 x;                                                   \
-            ctype2 y;                                                   \
-        } z;                                                            \
-        num_contig_blocks = (sizeof(z.x) + sizeof(z.y) == sizeof(z)) ? 1 : 2; \
-    } while (0)
+static void create_named(MPI_Datatype type);
 
 void MPIR_Typerep_commit(MPI_Datatype type)
 {
@@ -96,43 +105,17 @@ void MPIR_Typerep_commit(MPI_Datatype type)
     MPIR_Datatype_get_ptr(type, typeptr);
     void **dlp_p = (void **) &typeptr->typerep.handle;
 
-    switch (type) {
-        case MPI_FLOAT_INT:
-            create_pairtype(type, dlp_p);
-            GET_NUM_CONTIG_BLOCKS(float, int, typeptr->typerep.num_contig_blocks);
-            return;
-
-        case MPI_DOUBLE_INT:
-            create_pairtype(type, dlp_p);
-            GET_NUM_CONTIG_BLOCKS(double, int, typeptr->typerep.num_contig_blocks);
-            return;
-
-        case MPI_LONG_INT:
-            create_pairtype(type, dlp_p);
-            GET_NUM_CONTIG_BLOCKS(long, int, typeptr->typerep.num_contig_blocks);
-            return;
-
-        case MPI_SHORT_INT:
-            create_pairtype(type, dlp_p);
-            GET_NUM_CONTIG_BLOCKS(short, int, typeptr->typerep.num_contig_blocks);
-            return;
-
-        case MPI_LONG_DOUBLE_INT:
-            create_pairtype(type, dlp_p);
-            GET_NUM_CONTIG_BLOCKS(long double, int, typeptr->typerep.num_contig_blocks);
-            return;
-
-        case MPI_2INT:
-            create_pairtype(type, dlp_p);
-            GET_NUM_CONTIG_BLOCKS(int, int, typeptr->typerep.num_contig_blocks);
-            return;
+    if (type == MPI_FLOAT_INT || type == MPI_DOUBLE_INT || type == MPI_LONG_INT ||
+        type == MPI_SHORT_INT || type == MPI_LONG_DOUBLE_INT || type == MPI_2INT) {
+        create_pairtype(type);
+        return;
     }
 
     MPIR_Type_get_envelope(type, &nr_ints, &nr_aints, &nr_types, &combiner);
 
     /* some named types do need dataloops; handle separately. */
     if (combiner == MPI_COMBINER_NAMED) {
-        create_named(type, dlp_p);
+        create_named(type);
         return;
     } else if (combiner == MPI_COMBINER_F90_REAL || combiner == MPI_COMBINER_F90_COMPLEX ||
                combiner == MPI_COMBINER_F90_INTEGER) {
@@ -355,10 +338,8 @@ void MPIR_Typerep_commit(MPI_Datatype type)
   such as MPI_SHORT_INT, have multiple elements with potential gaps
   and padding. these types need dataloops for correct processing.
 @*/
-static void create_named(MPI_Datatype type, void **dlp_p)
+static void create_named(MPI_Datatype type)
 {
-    void *dlp;
-
     /* special case: pairtypes need dataloops too.
      *
      * note: not dealing with MPI_2INT because size == extent
@@ -370,18 +351,17 @@ static void create_named(MPI_Datatype type, void **dlp_p)
      */
     if (type == MPI_FLOAT_INT || type == MPI_DOUBLE_INT || type == MPI_LONG_INT ||
         type == MPI_SHORT_INT || type == MPI_LONG_DOUBLE_INT) {
+        void *dlp;
         MPIR_DATALOOP_GET_LOOPPTR(type, dlp);
         if (dlp != NULL) {
-            /* dataloop already created; just return it. */
-            *dlp_p = dlp;
+            /* dataloop already created */
         } else {
-            create_pairtype(type, dlp_p);
+            create_pairtype(type);
         }
         return;
     }
     /* no other combiners need dataloops; exit. */
     else {
-        *dlp_p = NULL;
         return;
     }
 }

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_create.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_create.c
@@ -10,17 +10,69 @@
 int MPIR_Typerep_create_vector(int count, int blocklength, int stride, MPI_Datatype oldtype,
                                MPIR_Datatype * newtype)
 {
+    int old_is_contig;
+    MPI_Aint old_extent;
+
+    if (HANDLE_IS_BUILTIN(oldtype)) {
+        newtype->typerep.num_contig_blocks = count;
+        old_is_contig = 1;
+        old_extent = (MPI_Aint) MPIR_Datatype_get_basic_size(oldtype);
+    } else {
+        MPIR_Datatype *old_dtp;
+        MPIR_Datatype_get_ptr(oldtype, old_dtp);
+        newtype->typerep.num_contig_blocks =
+            old_dtp->typerep.num_contig_blocks * count * blocklength;
+
+        MPIR_Datatype_is_contig(oldtype, &old_is_contig);
+        old_extent = old_dtp->extent;
+    }
+
+    if (old_is_contig && stride * old_extent == old_extent * blocklength) {
+        newtype->typerep.num_contig_blocks = 1;
+    }
+
     return MPI_SUCCESS;
 }
 
 int MPIR_Typerep_create_hvector(int count, int blocklength, MPI_Aint stride, MPI_Datatype oldtype,
                                 MPIR_Datatype * newtype)
 {
+    int old_is_contig;
+    MPI_Aint old_extent;
+
+    if (HANDLE_IS_BUILTIN(oldtype)) {
+        newtype->typerep.num_contig_blocks = count;
+        old_is_contig = 1;
+        old_extent = (MPI_Aint) MPIR_Datatype_get_basic_size(oldtype);
+    } else {
+        MPIR_Datatype *old_dtp;
+        MPIR_Datatype_get_ptr(oldtype, old_dtp);
+        newtype->typerep.num_contig_blocks =
+            old_dtp->typerep.num_contig_blocks * count * blocklength;
+
+        MPIR_Datatype_is_contig(oldtype, &old_is_contig);
+        old_extent = old_dtp->extent;
+    }
+
+    if (old_is_contig && stride == old_extent * blocklength) {
+        newtype->typerep.num_contig_blocks = 1;
+    }
+
     return MPI_SUCCESS;
 }
 
 int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
+    if (HANDLE_IS_BUILTIN(oldtype)) {
+        newtype->typerep.num_contig_blocks = 1;
+    } else if (newtype->is_contig) {
+        newtype->typerep.num_contig_blocks = 1;
+    } else {
+        MPIR_Datatype *old_dtp;
+        MPIR_Datatype_get_ptr(oldtype, old_dtp);
+        newtype->typerep.num_contig_blocks = count * old_dtp->typerep.num_contig_blocks;
+    }
+
     return MPI_SUCCESS;
 }
 
@@ -32,12 +84,38 @@ int MPIR_Typerep_create_dup(MPI_Datatype oldtype, MPIR_Datatype * newtype)
     if (dtp->is_committed)
         MPIR_Dataloop_dup(dtp->typerep.handle, &newtype->typerep.handle);
 
+    newtype->typerep.num_contig_blocks = dtp->typerep.num_contig_blocks;
+
     return MPI_SUCCESS;
 }
 
 int MPIR_Typerep_create_indexed_block(int count, int blocklength, const int *array_of_displacements,
                                       MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
+    int old_is_contig;
+    MPI_Aint old_extent;
+
+    if (HANDLE_IS_BUILTIN(oldtype)) {
+        newtype->typerep.num_contig_blocks = count;
+        old_is_contig = 1;
+        old_extent = (MPI_Aint) MPIR_Datatype_get_basic_size(oldtype);
+    } else {
+        MPIR_Datatype *old_dtp;
+        MPIR_Datatype_get_ptr(oldtype, old_dtp);
+        newtype->typerep.num_contig_blocks =
+            count * old_dtp->typerep.num_contig_blocks * blocklength;
+
+        MPIR_Datatype_is_contig(oldtype, &old_is_contig);
+        old_extent = old_dtp->extent;
+    }
+
+    if (old_is_contig) {
+        newtype->typerep.num_contig_blocks =
+            MPII_Datatype_blockindexed_count_contig(count, blocklength,
+                                                    (const void *) array_of_displacements,
+                                                    0, old_extent);
+    }
+
     return MPI_SUCCESS;
 }
 
@@ -45,6 +123,30 @@ int MPIR_Typerep_create_hindexed_block(int count, int blocklength,
                                        const MPI_Aint * array_of_displacements,
                                        MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
+    int old_is_contig;
+    MPI_Aint old_extent;
+
+    if (HANDLE_IS_BUILTIN(oldtype)) {
+        newtype->typerep.num_contig_blocks = count;
+        old_is_contig = 1;
+        old_extent = (MPI_Aint) MPIR_Datatype_get_basic_size(oldtype);
+    } else {
+        MPIR_Datatype *old_dtp;
+        MPIR_Datatype_get_ptr(oldtype, old_dtp);
+        newtype->typerep.num_contig_blocks =
+            count * old_dtp->typerep.num_contig_blocks * blocklength;
+
+        MPIR_Datatype_is_contig(oldtype, &old_is_contig);
+        old_extent = old_dtp->extent;
+    }
+
+    if (old_is_contig) {
+        newtype->typerep.num_contig_blocks =
+            MPII_Datatype_blockindexed_count_contig(count, blocklength,
+                                                    (const void *) array_of_displacements,
+                                                    1, old_extent);
+    }
+
     return MPI_SUCCESS;
 }
 
@@ -52,6 +154,38 @@ int MPIR_Typerep_create_indexed(int count, const int *array_of_blocklengths,
                                 const int *array_of_displacements, MPI_Datatype oldtype,
                                 MPIR_Datatype * newtype)
 {
+    int old_is_contig;
+    MPI_Aint old_extent;
+
+    if (HANDLE_IS_BUILTIN(oldtype)) {
+        newtype->typerep.num_contig_blocks = count;
+        old_is_contig = 1;
+        old_extent = (MPI_Aint) MPIR_Datatype_get_basic_size(oldtype);
+    } else {
+        MPIR_Datatype *old_dtp;
+        MPIR_Datatype_get_ptr(oldtype, old_dtp);
+
+        newtype->typerep.num_contig_blocks = 0;
+        for (int i = 0; i < count; i++)
+            newtype->typerep.num_contig_blocks +=
+                old_dtp->typerep.num_contig_blocks * array_of_blocklengths[i];
+
+        MPIR_Datatype_is_contig(oldtype, &old_is_contig);
+        old_extent = old_dtp->extent;
+    }
+
+    if (old_is_contig) {
+        MPI_Aint *blklens = MPL_malloc(count * sizeof(MPI_Aint), MPL_MEM_DATATYPE);
+        MPIR_Assert(blklens != NULL);
+        for (int i = 0; i < count; i++)
+            blklens[i] = (MPI_Aint) array_of_blocklengths[i];
+        newtype->typerep.num_contig_blocks =
+            MPII_Datatype_indexed_count_contig(count, blklens,
+                                               (const void *) array_of_displacements, 0,
+                                               old_extent);
+        MPL_free(blklens);
+    }
+
     return MPI_SUCCESS;
 }
 
@@ -59,12 +193,52 @@ int MPIR_Typerep_create_hindexed(int count, const int *array_of_blocklengths,
                                  const MPI_Aint * array_of_displacements, MPI_Datatype oldtype,
                                  MPIR_Datatype * newtype)
 {
+    int old_is_contig;
+    MPI_Aint old_extent;
+
+    if (HANDLE_IS_BUILTIN(oldtype)) {
+        newtype->typerep.num_contig_blocks = count;
+        old_is_contig = 1;
+        old_extent = (MPI_Aint) MPIR_Datatype_get_basic_size(oldtype);
+    } else {
+        MPIR_Datatype *old_dtp;
+        MPIR_Datatype_get_ptr(oldtype, old_dtp);
+
+        newtype->typerep.num_contig_blocks = 0;
+        for (int i = 0; i < count; i++)
+            newtype->typerep.num_contig_blocks +=
+                old_dtp->typerep.num_contig_blocks * array_of_blocklengths[i];
+
+        MPIR_Datatype_is_contig(oldtype, &old_is_contig);
+        old_extent = old_dtp->extent;
+    }
+
+    if (old_is_contig) {
+        MPI_Aint *blklens = MPL_malloc(count * sizeof(MPI_Aint), MPL_MEM_DATATYPE);
+        MPIR_Assert(blklens != NULL);
+        for (int i = 0; i < count; i++)
+            blklens[i] = (MPI_Aint) array_of_blocklengths[i];
+        newtype->typerep.num_contig_blocks =
+            MPII_Datatype_indexed_count_contig(count, blklens,
+                                               (const void *) array_of_displacements, 1,
+                                               old_extent);
+        MPL_free(blklens);
+    }
+
     return MPI_SUCCESS;
 }
 
 int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent,
                                 MPIR_Datatype * newtype)
 {
+    if (HANDLE_IS_BUILTIN(oldtype)) {
+        newtype->typerep.num_contig_blocks = 3; /* lb, data, ub */
+    } else {
+        MPIR_Datatype *old_dtp;
+        MPIR_Datatype_get_ptr(oldtype, old_dtp);
+        newtype->typerep.num_contig_blocks = old_dtp->typerep.num_contig_blocks;
+    }
+
     return MPI_SUCCESS;
 }
 
@@ -72,6 +246,18 @@ int MPIR_Typerep_create_struct(int count, const int *array_of_blocklengths,
                                const MPI_Aint * array_of_displacements,
                                const MPI_Datatype * array_of_types, MPIR_Datatype * newtype)
 {
+    newtype->typerep.num_contig_blocks = 0;
+    for (int i = 0; i < count; i++) {
+        if (HANDLE_IS_BUILTIN(array_of_types[i])) {
+            newtype->typerep.num_contig_blocks++;
+        } else {
+            MPIR_Datatype *old_dtp;
+            MPIR_Datatype_get_ptr(array_of_types[i], old_dtp);
+            newtype->typerep.num_contig_blocks +=
+                old_dtp->typerep.num_contig_blocks * array_of_blocklengths[i];
+        }
+    }
+
     return MPI_SUCCESS;
 }
 

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_create.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_create.c
@@ -8,75 +8,76 @@
 #include "mpir_typerep.h"
 
 int MPIR_Typerep_create_vector(int count, int blocklength, int stride, MPI_Datatype oldtype,
-                               void **typerep)
+                               MPIR_Datatype * newtype)
 {
     return MPI_SUCCESS;
 }
 
 int MPIR_Typerep_create_hvector(int count, int blocklength, MPI_Aint stride, MPI_Datatype oldtype,
-                                void **typerep)
+                                MPIR_Datatype * newtype)
 {
     return MPI_SUCCESS;
 }
 
-int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, void **newtype)
+int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
     return MPI_SUCCESS;
 }
 
-int MPIR_Typerep_create_dup(MPI_Datatype oldtype, void **newtype)
+int MPIR_Typerep_create_dup(MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
     MPIR_Datatype *dtp;
 
     MPIR_Datatype_get_ptr(oldtype, dtp);
     if (dtp->is_committed)
-        MPIR_Dataloop_dup(dtp->typerep, newtype);
+        MPIR_Dataloop_dup(dtp->typerep.handle, &newtype->typerep.handle);
 
     return MPI_SUCCESS;
 }
 
 int MPIR_Typerep_create_indexed_block(int count, int blocklength, const int *array_of_displacements,
-                                      MPI_Datatype oldtype, void **newtype)
+                                      MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
     return MPI_SUCCESS;
 }
 
 int MPIR_Typerep_create_hindexed_block(int count, int blocklength,
                                        const MPI_Aint * array_of_displacements,
-                                       MPI_Datatype oldtype, void **newtype)
+                                       MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
     return MPI_SUCCESS;
 }
 
 int MPIR_Typerep_create_indexed(int count, const int *array_of_blocklengths,
                                 const int *array_of_displacements, MPI_Datatype oldtype,
-                                void **newtype)
+                                MPIR_Datatype * newtype)
 {
     return MPI_SUCCESS;
 }
 
 int MPIR_Typerep_create_hindexed(int count, const int *array_of_blocklengths,
                                  const MPI_Aint * array_of_displacements, MPI_Datatype oldtype,
-                                 void **newtype)
+                                 MPIR_Datatype * newtype)
 {
     return MPI_SUCCESS;
 }
 
-int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent, void **newtype)
+int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent,
+                                MPIR_Datatype * newtype)
 {
     return MPI_SUCCESS;
 }
 
 int MPIR_Typerep_create_struct(int count, const int *array_of_blocklengths,
                                const MPI_Aint * array_of_displacements,
-                               const MPI_Datatype * array_of_types, void **newtype)
+                               const MPI_Datatype * array_of_types, MPIR_Datatype * newtype)
 {
     return MPI_SUCCESS;
 }
 
 int MPIR_Typerep_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
                                  const int *array_of_starts, int order,
-                                 MPI_Datatype oldtype, void **newtype)
+                                 MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
     return MPI_SUCCESS;
 }
@@ -84,7 +85,7 @@ int MPIR_Typerep_create_subarray(int ndims, const int *array_of_sizes, const int
 int MPIR_Typerep_create_darray(int size, int rank, int ndims, const int *array_of_gsizes,
                                const int *array_of_distribs, const int *array_of_dargs,
                                const int *array_of_psizes, int order, MPI_Datatype oldtype,
-                               void **newtype)
+                               MPIR_Datatype * newtype)
 {
     return MPI_SUCCESS;
 }

--- a/src/mpi/datatype/typerep/src/typerep_flatten.c
+++ b/src/mpi/datatype/typerep/src/typerep_flatten.c
@@ -35,7 +35,7 @@ int MPIR_Typerep_flatten_size(MPIR_Datatype * datatype_ptr, int *flattened_type_
 
 #if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
     uintptr_t size;
-    int rc = yaksa_flatten_size((yaksa_type_t) datatype_ptr->typerep, &size);
+    int rc = yaksa_flatten_size((yaksa_type_t) datatype_ptr->typerep.handle, &size);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
     assert(size <= INT_MAX);
     flattened_loop_size = (int) size;
@@ -75,7 +75,7 @@ int MPIR_Typerep_flatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     flatten_hdr->max_contig_blocks = datatype_ptr->max_contig_blocks;
 
 #if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
-    int rc = yaksa_flatten((yaksa_type_t) datatype_ptr->typerep, flattened_typerep);
+    int rc = yaksa_flatten((yaksa_type_t) datatype_ptr->typerep.handle, flattened_typerep);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 #else
     mpi_errno = MPIR_Dataloop_flatten(datatype_ptr, flattened_typerep);
@@ -118,7 +118,7 @@ int MPIR_Typerep_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     datatype_ptr->flattened = NULL;
 
 #if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
-    int rc = yaksa_unflatten((yaksa_type_t *) & datatype_ptr->typerep, flattened_typerep);
+    int rc = yaksa_unflatten((yaksa_type_t *) & datatype_ptr->typerep.handle, flattened_typerep);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 #else
     mpi_errno = MPIR_Dataloop_unflatten(datatype_ptr, flattened_typerep);

--- a/src/mpi/datatype/typerep/src/typerep_flatten.c
+++ b/src/mpi/datatype/typerep/src/typerep_flatten.c
@@ -18,7 +18,7 @@ struct flatten_hdr {
     MPI_Aint extent, ub, lb, true_ub, true_lb;
     int is_contig;
     int basic_type;
-    MPI_Aint max_contig_blocks;
+    MPI_Aint num_contig_blocks;
 };
 
 /*
@@ -72,7 +72,7 @@ int MPIR_Typerep_flatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     flatten_hdr->true_lb = datatype_ptr->true_lb;
     flatten_hdr->is_contig = datatype_ptr->is_contig;
     flatten_hdr->basic_type = datatype_ptr->basic_type;
-    flatten_hdr->max_contig_blocks = datatype_ptr->max_contig_blocks;
+    flatten_hdr->num_contig_blocks = datatype_ptr->typerep.num_contig_blocks;
 
 #if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
     int rc = yaksa_flatten((yaksa_type_t) datatype_ptr->typerep.handle, flattened_typerep);
@@ -106,7 +106,7 @@ int MPIR_Typerep_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     datatype_ptr->attributes = 0;
     datatype_ptr->name[0] = 0;
     datatype_ptr->is_contig = flatten_hdr->is_contig;
-    datatype_ptr->max_contig_blocks = flatten_hdr->max_contig_blocks;
+    datatype_ptr->typerep.num_contig_blocks = flatten_hdr->num_contig_blocks;
     datatype_ptr->size = flatten_hdr->size;
     datatype_ptr->extent = flatten_hdr->extent;
     datatype_ptr->basic_type = flatten_hdr->basic_type;

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_commit.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_commit.c
@@ -6,30 +6,33 @@
 #include "mpiimpl.h"
 #include "yaksa.h"
 
-void MPIR_Typerep_commit(MPI_Datatype type, void **typerep)
+void MPIR_Typerep_commit(MPI_Datatype type)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_COMMIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_COMMIT);
 
+    MPIR_Datatype *typeptr;
+    MPIR_Datatype_get_ptr(type, typeptr);
+
     switch (type) {
         case MPI_FLOAT_INT:
-            *typerep = (void *) YAKSA_TYPE__FLOAT_INT;
+            typeptr->typerep.handle = (void *) YAKSA_TYPE__FLOAT_INT;
             break;
 
         case MPI_DOUBLE_INT:
-            *typerep = (void *) YAKSA_TYPE__DOUBLE_INT;
+            typeptr->typerep.handle = (void *) YAKSA_TYPE__DOUBLE_INT;
             break;
 
         case MPI_LONG_INT:
-            *typerep = (void *) YAKSA_TYPE__LONG_INT;
+            typeptr->typerep.handle = (void *) YAKSA_TYPE__LONG_INT;
             break;
 
         case MPI_SHORT_INT:
-            *typerep = (void *) YAKSA_TYPE__SHORT_INT;
+            typeptr->typerep.handle = (void *) YAKSA_TYPE__SHORT_INT;
             break;
 
         case MPI_LONG_DOUBLE_INT:
-            *typerep = (void *) YAKSA_TYPE__LONG_DOUBLE_INT;
+            typeptr->typerep.handle = (void *) YAKSA_TYPE__LONG_DOUBLE_INT;
             break;
 
         default:
@@ -39,12 +42,12 @@ void MPIR_Typerep_commit(MPI_Datatype type, void **typerep)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_COMMIT);
 }
 
-void MPIR_Typerep_free(void **typerep)
+void MPIR_Typerep_free(MPIR_Datatype * typeptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_FREE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_FREE);
 
-    yaksa_type_t type = (yaksa_type_t) (*typerep);
+    yaksa_type_t type = (yaksa_type_t) typeptr->typerep.handle;
 
     if (type != YAKSA_TYPE__FLOAT_INT && type != YAKSA_TYPE__DOUBLE_INT &&
         type != YAKSA_TYPE__LONG_INT && type != YAKSA_TYPE__SHORT_INT &&

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_commit.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_commit.c
@@ -17,29 +17,38 @@ void MPIR_Typerep_commit(MPI_Datatype type)
     switch (type) {
         case MPI_FLOAT_INT:
             typeptr->typerep.handle = (void *) YAKSA_TYPE__FLOAT_INT;
+            yaksa_iov_len(1, YAKSA_TYPE__FLOAT_INT, &typeptr->typerep.num_contig_blocks);
             break;
 
         case MPI_DOUBLE_INT:
             typeptr->typerep.handle = (void *) YAKSA_TYPE__DOUBLE_INT;
+            yaksa_iov_len(1, YAKSA_TYPE__DOUBLE_INT, &typeptr->typerep.num_contig_blocks);
             break;
 
         case MPI_LONG_INT:
             typeptr->typerep.handle = (void *) YAKSA_TYPE__LONG_INT;
+            yaksa_iov_len(1, YAKSA_TYPE__LONG_INT, &typeptr->typerep.num_contig_blocks);
             break;
 
         case MPI_SHORT_INT:
             typeptr->typerep.handle = (void *) YAKSA_TYPE__SHORT_INT;
+            yaksa_iov_len(1, YAKSA_TYPE__SHORT_INT, &typeptr->typerep.num_contig_blocks);
             break;
 
         case MPI_LONG_DOUBLE_INT:
             typeptr->typerep.handle = (void *) YAKSA_TYPE__LONG_DOUBLE_INT;
+            yaksa_iov_len(1, YAKSA_TYPE__LONG_DOUBLE_INT, &typeptr->typerep.num_contig_blocks);
             break;
 
         default:
             break;
     }
 
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_COMMIT);
+    return;
+  fn_fail:
+    goto fn_exit;
 }
 
 void MPIR_Typerep_free(MPIR_Datatype * typeptr)

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
@@ -21,6 +21,10 @@ int MPIR_Typerep_create_vector(int count, int blocklength, int stride, MPI_Datat
                                       (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
+                       &newtype->typerep.num_contig_blocks);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_VECTOR);
     return mpi_errno;
@@ -42,6 +46,10 @@ int MPIR_Typerep_create_hvector(int count, int blocklength, MPI_Aint stride, MPI
                                        (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
+                       &newtype->typerep.num_contig_blocks);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_HVECTOR);
     return mpi_errno;
@@ -59,6 +67,10 @@ int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, MPIR_Datatype * 
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
 
     int rc = yaksa_type_create_contig(count, type, (yaksa_type_t *) & newtype->typerep.handle);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
+                       &newtype->typerep.num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -80,6 +92,10 @@ int MPIR_Typerep_create_dup(MPI_Datatype oldtype, MPIR_Datatype * newtype)
     int rc = yaksa_type_create_dup(type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
+                       &newtype->typerep.num_contig_blocks);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_DUP);
     return mpi_errno;
@@ -99,6 +115,10 @@ int MPIR_Typerep_create_indexed_block(int count, int blocklength, const int *arr
 
     int rc = yaksa_type_create_indexed_block(count, blocklength, array_of_displacements,
                                              type, (yaksa_type_t *) & newtype->typerep.handle);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
+                       &newtype->typerep.num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -123,6 +143,10 @@ int MPIR_Typerep_create_hindexed_block(int count, int blocklength,
                                               type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
+                       &newtype->typerep.num_contig_blocks);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED_BLOCK);
     return mpi_errno;
@@ -143,6 +167,10 @@ int MPIR_Typerep_create_indexed(int count, const int *array_of_blocklengths,
 
     int rc = yaksa_type_create_indexed(count, array_of_blocklengths, array_of_displacements,
                                        type, (yaksa_type_t *) & newtype->typerep.handle);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
+                       &newtype->typerep.num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -167,6 +195,10 @@ int MPIR_Typerep_create_hindexed(int count, const int *array_of_blocklengths,
                                         type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
+                       &newtype->typerep.num_contig_blocks);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED);
     return mpi_errno;
@@ -186,6 +218,10 @@ int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint exte
 
     int rc =
         yaksa_type_create_resized(type, lb, extent, (yaksa_type_t *) & newtype->typerep.handle);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
+                       &newtype->typerep.num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -213,6 +249,10 @@ int MPIR_Typerep_create_struct(int count, const int *array_of_blocklengths,
     int rc = yaksa_type_create_struct(count, array_of_blocklengths, array_of_displacements,
                                       array_of_yaksa_types,
                                       (yaksa_type_t *) & newtype->typerep.handle);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
+                       &newtype->typerep.num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
     MPL_free(array_of_yaksa_types);

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
@@ -8,7 +8,7 @@
 #include "yaksa.h"
 
 int MPIR_Typerep_create_vector(int count, int blocklength, int stride, MPI_Datatype oldtype,
-                               void **typerep)
+                               MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_VECTOR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_VECTOR);
@@ -17,7 +17,8 @@ int MPIR_Typerep_create_vector(int count, int blocklength, int stride, MPI_Datat
 
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
 
-    int rc = yaksa_type_create_vector(count, blocklength, stride, type, (yaksa_type_t *) typerep);
+    int rc = yaksa_type_create_vector(count, blocklength, stride, type,
+                                      (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -28,7 +29,7 @@ int MPIR_Typerep_create_vector(int count, int blocklength, int stride, MPI_Datat
 }
 
 int MPIR_Typerep_create_hvector(int count, int blocklength, MPI_Aint stride, MPI_Datatype oldtype,
-                                void **typerep)
+                                MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_HVECTOR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_HVECTOR);
@@ -38,7 +39,7 @@ int MPIR_Typerep_create_hvector(int count, int blocklength, MPI_Aint stride, MPI
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
 
     int rc = yaksa_type_create_hvector(count, blocklength, stride, type,
-                                       (yaksa_type_t *) typerep);
+                                       (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -48,7 +49,7 @@ int MPIR_Typerep_create_hvector(int count, int blocklength, MPI_Aint stride, MPI
     goto fn_exit;
 }
 
-int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, void **typerep)
+int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_CONTIG);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_CONTIG);
@@ -57,7 +58,7 @@ int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, void **typerep)
 
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
 
-    int rc = yaksa_type_create_contig(count, type, (yaksa_type_t *) typerep);
+    int rc = yaksa_type_create_contig(count, type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -67,7 +68,7 @@ int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, void **typerep)
     goto fn_exit;
 }
 
-int MPIR_Typerep_create_dup(MPI_Datatype oldtype, void **typerep)
+int MPIR_Typerep_create_dup(MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_DUP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_DUP);
@@ -76,7 +77,7 @@ int MPIR_Typerep_create_dup(MPI_Datatype oldtype, void **typerep)
 
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
 
-    int rc = yaksa_type_create_dup(type, (yaksa_type_t *) typerep);
+    int rc = yaksa_type_create_dup(type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -87,7 +88,7 @@ int MPIR_Typerep_create_dup(MPI_Datatype oldtype, void **typerep)
 }
 
 int MPIR_Typerep_create_indexed_block(int count, int blocklength, const int *array_of_displacements,
-                                      MPI_Datatype oldtype, void **typerep)
+                                      MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED_BLOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED_BLOCK);
@@ -97,7 +98,7 @@ int MPIR_Typerep_create_indexed_block(int count, int blocklength, const int *arr
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
 
     int rc = yaksa_type_create_indexed_block(count, blocklength, array_of_displacements,
-                                             type, (yaksa_type_t *) typerep);
+                                             type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -109,7 +110,7 @@ int MPIR_Typerep_create_indexed_block(int count, int blocklength, const int *arr
 
 int MPIR_Typerep_create_hindexed_block(int count, int blocklength,
                                        const MPI_Aint * array_of_displacements,
-                                       MPI_Datatype oldtype, void **typerep)
+                                       MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED_BLOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED_BLOCK);
@@ -119,7 +120,7 @@ int MPIR_Typerep_create_hindexed_block(int count, int blocklength,
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
 
     int rc = yaksa_type_create_hindexed_block(count, blocklength, array_of_displacements,
-                                              type, (yaksa_type_t *) typerep);
+                                              type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -131,7 +132,7 @@ int MPIR_Typerep_create_hindexed_block(int count, int blocklength,
 
 int MPIR_Typerep_create_indexed(int count, const int *array_of_blocklengths,
                                 const int *array_of_displacements, MPI_Datatype oldtype,
-                                void **typerep)
+                                MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED);
@@ -141,7 +142,7 @@ int MPIR_Typerep_create_indexed(int count, const int *array_of_blocklengths,
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
 
     int rc = yaksa_type_create_indexed(count, array_of_blocklengths, array_of_displacements,
-                                       type, (yaksa_type_t *) typerep);
+                                       type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -153,7 +154,7 @@ int MPIR_Typerep_create_indexed(int count, const int *array_of_blocklengths,
 
 int MPIR_Typerep_create_hindexed(int count, const int *array_of_blocklengths,
                                  const MPI_Aint * array_of_displacements, MPI_Datatype oldtype,
-                                 void **typerep)
+                                 MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED);
@@ -163,7 +164,7 @@ int MPIR_Typerep_create_hindexed(int count, const int *array_of_blocklengths,
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
 
     int rc = yaksa_type_create_hindexed(count, array_of_blocklengths, array_of_displacements,
-                                        type, (yaksa_type_t *) typerep);
+                                        type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -173,7 +174,8 @@ int MPIR_Typerep_create_hindexed(int count, const int *array_of_blocklengths,
     goto fn_exit;
 }
 
-int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent, void **typerep)
+int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent,
+                                MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_RESIZED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_RESIZED);
@@ -182,7 +184,8 @@ int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint exte
 
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(oldtype);
 
-    int rc = yaksa_type_create_resized(type, lb, extent, (yaksa_type_t *) typerep);
+    int rc =
+        yaksa_type_create_resized(type, lb, extent, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
   fn_exit:
@@ -194,7 +197,7 @@ int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint exte
 
 int MPIR_Typerep_create_struct(int count, const int *array_of_blocklengths,
                                const MPI_Aint * array_of_displacements,
-                               const MPI_Datatype * array_of_types, void **typerep)
+                               const MPI_Datatype * array_of_types, MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_STRUCT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_STRUCT);
@@ -208,7 +211,8 @@ int MPIR_Typerep_create_struct(int count, const int *array_of_blocklengths,
     }
 
     int rc = yaksa_type_create_struct(count, array_of_blocklengths, array_of_displacements,
-                                      array_of_yaksa_types, (yaksa_type_t *) typerep);
+                                      array_of_yaksa_types,
+                                      (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
     MPL_free(array_of_yaksa_types);
@@ -222,7 +226,7 @@ int MPIR_Typerep_create_struct(int count, const int *array_of_blocklengths,
 
 int MPIR_Typerep_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
                                  const int *array_of_starts, int order,
-                                 MPI_Datatype oldtype, void **typerep)
+                                 MPI_Datatype oldtype, MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_SUBARRAY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_SUBARRAY);
@@ -236,7 +240,7 @@ int MPIR_Typerep_create_subarray(int ndims, const int *array_of_sizes, const int
 int MPIR_Typerep_create_darray(int size, int rank, int ndims, const int *array_of_gsizes,
                                const int *array_of_distribs, const int *array_of_dargs,
                                const int *array_of_psizes, int order, MPI_Datatype oldtype,
-                               void **typerep)
+                               MPIR_Datatype * newtype)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_CREATE_DARRAY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_CREATE_DARRAY);

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
@@ -344,7 +344,7 @@ yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type)
                 } else {
                     MPIR_Datatype *typeptr;
                     MPIR_Datatype_get_ptr(type, typeptr);
-                    yaksa_type = ((yaksa_type_t) typeptr->typerep);
+                    yaksa_type = ((yaksa_type_t) typeptr->typerep.handle);
                 }
             }
             break;

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -440,7 +440,7 @@ int MPII_Type_zerolen(MPI_Datatype * newtype)
     new_dtp->contents = NULL;
     new_dtp->flattened = NULL;
 
-    new_dtp->typerep = NULL;
+    new_dtp->typerep.handle = NULL;
 
     new_dtp->size = 0;
     new_dtp->lb = 0;
@@ -673,8 +673,8 @@ void MPIR_Datatype_free(MPIR_Datatype * ptr)
     if (ptr->contents) {
         MPIR_Datatype_free_contents(ptr);
     }
-    if (ptr->typerep) {
-        MPIR_Typerep_free(&(ptr->typerep));
+    if (ptr->typerep.handle) {
+        MPIR_Typerep_free(ptr);
     }
     MPL_free(ptr->flattened);
     MPIR_Handle_obj_free(&MPIR_Datatype_mem, ptr);

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -878,7 +878,7 @@ static inline int do_accumulate_op(void *source_buf, int source_count, MPI_Datat
         int accumulated_count;
 
         MPIR_Datatype_get_ptr(target_dtp, dtp);
-        vec_len = dtp->max_contig_blocks * target_count + 1;
+        vec_len = dtp->typerep.num_contig_blocks * target_count + 1;
         /* +1 needed because Rob says so */
         typerep_vec = (struct iovec *)
             MPL_malloc(vec_len * sizeof(struct iovec), MPL_MEM_DATATYPE);

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -965,7 +965,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_compute_acc_op(void *source_buf, int source_
 
         MPIR_Datatype_get_ptr(target_dtp, dtp);
         MPIR_Assert(dtp != NULL);
-        vec_len = dtp->max_contig_blocks * target_count + 1;
+        vec_len = dtp->typerep.num_contig_blocks * target_count + 1;
         /* +1 needed because Rob says so */
         typerep_vec = (struct iovec *)
             MPL_malloc(vec_len * sizeof(struct iovec), MPL_MEM_RMA);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -101,7 +101,7 @@ cvars:
       scope       : MPI_T_SCOPE_LOCAL
       description : >-
         Defines the threshold of high-density datatype. The
-        density is calculated by (datatype_size / datatype_max_contig_blocks).
+        density is calculated by (datatype_size / datatype_num_contig_blocks).
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 


### PR DESCRIPTION
## Pull Request Description

MPICH tries to recalculate parts of the typerep engine (such as the max_contig_blocks) internally because (1) querying typerep can be expensive and (2) the typerep engine might not be ready by the time these fields are important.  This is an incorrect design because, in reality, MPICH does not know what optimizations the backend is using to manage its data layout.  For example, in some cases, two blocks of data that are contiguous might be treated as noncontiguous if it is not easy to detect the data layout.  This calculation seems to match what dataloop does, but does not match what yaksa does causing some tests to fail with yaksa.

The right approach would be to always query the backend typerep engine and cache the information inside MPICH.  The backend engine is ready to be queried at datatype creation time for yaksa, but is only ready at datatype commit time for dataloop.

This PR brings the code one step closer to having Typerep truly abstract the datatype code in MPICH.

This PR depends on https://github.com/pmodels/mpich/pull/4586

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
