### PR TITLE
general: preparation for enabling multiple vcis

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -542,11 +542,6 @@ AC_ARG_ENABLE(thread-cs,
                          per-object, per-vci, lock-free. By default, CH3 uses global,
                          while CH4 uses per-vci.]),,enable_thread_cs=default)
 
-AC_ARG_ENABLE(vci-method,
-	AC_HELP_STRING([--enable-vci-method=type],
-			[Choose the method used for vci selection when enable-thread-cs=per-vci is selected.
-                          Values may be zero (default), communicator, tag, implicit, explicit]),,enable_vci_method=zero)
-
 AC_ARG_ENABLE(refcount,
 	AC_HELP_STRING([--enable-refcount=type],
 			[Choose the method for ensuring atomic updates
@@ -1549,35 +1544,6 @@ if test "$enable_threads" = "multiple" ; then
     esac
 fi
 AC_DEFINE_UNQUOTED([MPICH_THREAD_GRANULARITY],$thread_granularity,[Method used to implement atomic updates and access])
-
-# Check for enable-vci-method choice
-vci_method=MPICH_VCI__ZERO
-case $enable_vci_method in
-    zero)
-    # Essentially single VCI
-    vci_method=MPICH_VCI__ZERO
-    ;;
-    communicator)
-    # Every communicator gets a new VCI in a round-robin fashion
-    vci_method=MPICH_VCI__COMM
-    ;;
-    tag)
-    # Explicit VCI info embedded with a tag scheme (5 bit src vci, 5 bit dst vci, plus 5 bit user)
-    vci_method=MPICH_VCI__TAG
-    ;;
-    implicit)
-    # An automatic scheme taking into account of user hints
-    vci_method=MPICH_VCI__IMPLICIT
-    ;;
-    explicit)
-    # Directly passing down vci in parameters (MPIX or Endpoint rank)
-    vci_method=MPICH_VCI__EXPLICIT
-    ;;
-    *)
-    AC_MSG_ERROR([Unrecognized value $enable_vci_method for --enable-vci-method])
-    ;;
-esac
-AC_DEFINE_UNQUOTED([MPIDI_CH4_VCI_METHOD], $vci_method, [Method used to select vci])
 
 if test "$thread_granularity" = "MPICH_THREAD_GRANULARITY__POBJ" -a "$device_name" == "ch4" ; then
     AC_MSG_ERROR([the ch4 device does not support the per-object critical section])

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -197,12 +197,8 @@ struct MPIR_Comm {
     /* A sequence number used for e.g. vci hashing. We can't directly use context_id
      * because context_id is non-sequential and can't be used to identify user-level
      * communicators (due to sub-comms). */
-
-    /* As an optimization for comm_world, if seq==0, every processes in the comm
-     * has seq=0. */
     int seq;
-    int *seq_table;             /* Table of sequence numbers for each rank.
-                                 * If seq==0, seq_table is NULL */
+
     int hints[MPIR_COMM_HINT_MAX];      /* Hints to the communicator
                                          * use int array for fast access */
 

--- a/src/mpi/coll/igather/igather_inter_sched_short.c
+++ b/src/mpi/coll/igather/igather_inter_sched_short.c
@@ -26,7 +26,10 @@ int MPIR_Igather_inter_sched_short(const void *sendbuf, int sendcount, MPI_Datat
     remote_size = comm_ptr->remote_size;
     local_size = comm_ptr->local_size;
 
-    if (root == MPI_ROOT) {
+    if (root == MPI_PROC_NULL) {
+        /* local processes other than root do nothing */
+        mpi_errno = MPI_SUCCESS;
+    } else if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
         mpi_errno = MPIR_Sched_recv(recvbuf, recvcount * remote_size, recvtype, 0, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -312,6 +312,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_av_is_local(MPIDI_av_entry_t * av);
 /* Active message and generic implementatiions */
 #include "mpidig_am.h"
 #include "mpidch4r.h"
+#include "ch4_vci.h"
 
 /* Include netmod and shm implementations  */
 /* Prototypes are split from impl to avoid */
@@ -332,7 +333,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_av_is_local(MPIDI_av_entry_t * av);
 #include "ch4_rma.h"
 #include "ch4_proc.h"
 #include "ch4_coll.h"
-#include "ch4_vci.h"
 
 #define MPIDI_MAX_NETMOD_STRING_LEN 64
 extern int MPIDI_num_netmods;

--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -8,6 +8,11 @@
 
 #include "ch4_impl.h"
 
+/* vci is embedded in the request's pool index */
+
+#define MPIDI_Request_get_vci(req) \
+    (((req)->handle & REQUEST_POOL_MASK) >> REQUEST_POOL_SHIFT)
+
 /* VCI hashing function (fast path)
  * Call these function to get src_vci and dst_vci
  * NOTE: The returned vci should always MOD NUMVCIS, where NUMVCIS is

--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -37,11 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_vci_get_src(MPIR_Comm * comm_ptr, int rank, i
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_vci_get_dst(MPIR_Comm * comm_ptr, int rank, int tag)
 {
-    if (comm_ptr->seq > 0) {
-        return comm_ptr->seq_table[rank];
-    } else {
-        return 0;
-    }
+    return comm_ptr->seq;
 }
 
 #elif MPIDI_CH4_VCI_METHOD == MPICH_VCI__TAG

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -323,10 +323,17 @@ AC_DEFINE_UNQUOTED([MPIDI_CH4_MAX_VCIS], [$with_ch4_max_vcis], [Number of VCIs c
 AC_ARG_ENABLE(ch4-vci-method,
 	AC_HELP_STRING([--enable-ch4-vci-method=type],
 			[Choose the method used for vci selection when enable-thread-cs=per-vci is selected.
-                          Values may be zero (default), communicator, tag, implicit, explicit]),,enable_ch4_vci_method=zero)
+                          Values may be default, zero, communicator, tag, implicit, explicit]),,enable_ch4_vci_method=default)
 
 vci_method=MPICH_VCI__ZERO
 case $enable_ch4_vci_method in
+    default)
+    if test "$with_ch4_max_vcis" = 1 ; then
+        vci_method=MPICH_VCI__ZERO
+    else
+        vci_method=MPICH_VCI__COMM
+    fi
+    ;;
     zero)
     # Essentially single VCI
     vci_method=MPICH_VCI__ZERO

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -319,6 +319,40 @@ if test $with_ch4_max_vcis -le 0 ; then
 fi
 AC_DEFINE_UNQUOTED([MPIDI_CH4_MAX_VCIS], [$with_ch4_max_vcis], [Number of VCIs configured in CH4])
 
+# Check for enable-ch4-vci-method choice
+AC_ARG_ENABLE(ch4-vci-method,
+	AC_HELP_STRING([--enable-ch4-vci-method=type],
+			[Choose the method used for vci selection when enable-thread-cs=per-vci is selected.
+                          Values may be zero (default), communicator, tag, implicit, explicit]),,enable_ch4_vci_method=zero)
+
+vci_method=MPICH_VCI__ZERO
+case $enable_ch4_vci_method in
+    zero)
+    # Essentially single VCI
+    vci_method=MPICH_VCI__ZERO
+    ;;
+    communicator)
+    # Every communicator gets a new VCI in a round-robin fashion
+    vci_method=MPICH_VCI__COMM
+    ;;
+    tag)
+    # Explicit VCI info embedded with a tag scheme (5 bit src vci, 5 bit dst vci, plus 5 bit user)
+    vci_method=MPICH_VCI__TAG
+    ;;
+    implicit)
+    # An automatic scheme taking into account of user hints
+    vci_method=MPICH_VCI__IMPLICIT
+    ;;
+    explicit)
+    # Directly passing down vci in parameters (MPIX or Endpoint rank)
+    vci_method=MPICH_VCI__EXPLICIT
+    ;;
+    *)
+    AC_MSG_ERROR([Unrecognized value $enable_ch4_vci_method for --enable-ch4-vci-method])
+    ;;
+esac
+AC_DEFINE_UNQUOTED([MPIDI_CH4_VCI_METHOD], $vci_method, [Method used to select vci])
+
 AC_ARG_ENABLE(ch4-mt,
     [--enable-ch4-mt=model
        Select model for multi-threading


### PR DESCRIPTION
## Pull Request Description

Some of the low impact but necessary preparations for enabling multiple vcis.

* Let communicator create and share a sequence number on commit. Previously we allow each process to have their own unique sequence number and share with a sequence table. Because this sequence number is mainly used for hashing into a consistent vci, it is not important to maintain the uniqueness -- as long as the intended usage, consecutive `MPI_Comm_dup` -- will generate round-robin vcis, it will be sufficient. So simply let root `Bcast` its sequence number is sufficient and significantly simpler (and more robust).

* To enable multiple vci, we'll need configure with `--with-ch4-max-vcis` and a runtime cvar `MPIR_CVAR_CH4_NUM_VCIS`, we default the `--enable-ch4-vci-method` to `communicator` when multiple vci is configured.

* Since we reuse the pool index in the request handle as vci, we create appropriate macro for better semantics. 

## Reference

Split from #4530

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
