### PR TITLE
ch4/ofi: add mutltiple vni support

### DIFF
--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -23,6 +23,7 @@ typedef union {
 typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_bits,
                                     MPIR_Comm * init_comm);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
+typedef int (*MPIDI_NM_post_init_t) (void);
 typedef int (*MPIDI_NM_get_vci_attr_t) (int vci);
 typedef int (*MPIDI_NM_progress_t) (int vci, int blocking);
 typedef int (*MPIDI_NM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info, int root,
@@ -364,6 +365,7 @@ typedef int (*MPIDI_NM_mpi_op_free_hook_t) (MPIR_Op * op_p);
 typedef struct MPIDI_NM_funcs {
     MPIDI_NM_mpi_init_t mpi_init;
     MPIDI_NM_mpi_finalize_t mpi_finalize;
+    MPIDI_NM_post_init_t post_init;
     MPIDI_NM_get_vci_attr_t get_vci_attr;
     MPIDI_NM_progress_t progress;
     MPIDI_NM_mpi_comm_connect_t mpi_comm_connect;
@@ -520,6 +522,7 @@ extern char MPIDI_NM_strings[][MPIDI_MAX_NETMOD_STRING_LEN];
 
 int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm);
 int MPIDI_NM_mpi_finalize_hook(void);
+int MPIDI_NM_post_init(void);
 int MPIDI_NM_get_vci_attr(int vci);
 int MPIDI_NM_progress(int vci, int blocking);
 int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root, int timeout,

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -14,6 +14,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     .mpi_init = MPIDI_OFI_mpi_init_hook,
     .mpi_finalize = MPIDI_OFI_mpi_finalize_hook,
+    .post_init = MPIDI_OFI_post_init,
     .progress = MPIDI_OFI_progress,
     .mpi_comm_connect = MPIDI_OFI_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_OFI_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -164,7 +164,7 @@ static inline int MPIDI_OFI_do_rdma_read(void *dst,
             .msg_iov = &iov,
             .desc = NULL,
             .iov_count = 1,
-            .addr = MPIDI_OFI_comm_to_phys(comm, src_rank),
+            .addr = MPIDI_OFI_comm_to_phys(comm, src_rank, 0, 0),
             .rma_iov = &rma_iov,
             .rma_iov_count = 1,
             .context = &am_req->context,
@@ -304,10 +304,10 @@ static inline int MPIDI_OFI_dispatch_ack(int rank, int context_id, MPIR_Request 
     msg.hdr.am_type = am_type;
     msg.hdr.seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank);
     msg.hdr.fi_src_addr
-        = MPIDI_OFI_comm_to_phys(MPIR_Process.comm_world, MPIR_Process.comm_world->rank);
+        = MPIDI_OFI_comm_to_phys(MPIR_Process.comm_world, MPIR_Process.comm_world->rank, 0, 0);
     msg.pyld.sreq_ptr = sreq_ptr;
     MPIDI_OFI_CALL_RETRY_AM(fi_inject(MPIDI_OFI_global.ctx[0].tx, &msg, sizeof(msg),
-                                      MPIDI_OFI_comm_to_phys(comm, rank)), inject);
+                                      MPIDI_OFI_comm_to_phys(comm, rank, 0, 0)), inject);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DISPATCH_ACK);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -189,7 +189,7 @@ static int recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq, int ev
         MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[0].tx, NULL /* buf */ ,
                                             0 /* len */ ,
                                             MPIR_Comm_rank(c),
-                                            MPIDI_OFI_comm_to_phys(c, r),
+                                            MPIDI_OFI_comm_to_phys(c, r, 0, 0),
                                             ss_bits), tinjectdata, FALSE /* eagain */);
     }
 
@@ -434,7 +434,7 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
                                      (void *) ((uintptr_t) recv_elem->wc.buf + recv_elem->cur_offset),  /* local buffer */
                                      bytesToGet,        /* bytes        */
                                      NULL,      /* descriptor   */
-                                     MPIDI_OFI_comm_to_phys(recv_elem->comm_ptr, recv_elem->remote_info.origin_rank),   /* Destination  */
+                                     MPIDI_OFI_comm_to_phys(recv_elem->comm_ptr, recv_elem->remote_info.origin_rank, 0, 0),     /* Destination  */
                                      recv_rbase(recv_elem) + recv_elem->cur_offset,     /* remote maddr */
                                      remote_key,        /* Key          */
                                      (void *) &recv_elem->context), rdma_readfrom,      /* Context */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -41,15 +41,15 @@ int MPIDI_OFI_progress(int vci, int blocking);
 /*
  * Helper routines and macros for request completion
  */
-#define MPIDI_OFI_PROGRESS()                                      \
+#define MPIDI_OFI_PROGRESS(vni)                                   \
     do {                                                          \
-        mpi_errno = MPIDI_OFI_progress(0, 0);                     \
+        mpi_errno = MPIDI_OFI_progress(vni, 0);                   \
         MPIR_ERR_CHECK(mpi_errno);                                \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
     } while (0)
 
-#define MPIDI_OFI_PROGRESS_WHILE(cond)                 \
-    while (cond) MPIDI_OFI_PROGRESS()
+#define MPIDI_OFI_PROGRESS_WHILE(cond, vni) \
+    while (cond) MPIDI_OFI_PROGRESS(vni)
 
 #define MPIDI_OFI_ERR  MPIR_ERR_CHKANDJUMP4
 #define MPIDI_OFI_CALL(FUNC,STR)                                     \

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -405,7 +405,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_reque
  */
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_vci_to_vni(int vci)
 {
-    /* MPIR_Assert(MPIDI_OFI_global.num_ctx == MPIDI_global.n_vcis); */
     return vci;
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -20,11 +20,11 @@
 #define MPIDI_OFI_COMM(comm)     ((comm)->dev.ch4.netmod.ofi)
 #define MPIDI_OFI_COMM_TO_INDEX(comm,rank) \
     MPIDIU_comm_rank_to_pid(comm, rank, NULL, NULL)
-#define MPIDI_OFI_AV_TO_PHYS(av) (MPIDI_OFI_AV(av).dest)
+#define MPIDI_OFI_AV_TO_PHYS(av) (MPIDI_OFI_AV(av).dest[0][0])
 #define MPIDI_OFI_COMM_TO_PHYS(comm,rank)                       \
-    MPIDI_OFI_AV(MPIDIU_comm_rank_to_av((comm), (rank))).dest
+    MPIDI_OFI_AV(MPIDIU_comm_rank_to_av((comm), (rank))).dest[0][0]
 #define MPIDI_OFI_TO_PHYS(avtid, lpid)                                 \
-    MPIDI_OFI_AV(&MPIDIU_get_av((avtid), (lpid))).dest
+    MPIDI_OFI_AV(&MPIDIU_get_av((avtid), (lpid))).dest[0][0]
 
 #define MPIDI_OFI_WIN(win)     ((win)->dev.netmod.ofi)
 
@@ -414,7 +414,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_av_insert(int vni, int rank, void *addrna
     fi_addr_t addr;
     MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[vni].av, addrname, 1, &addr, 0ULL, NULL),
                    avmap);
-    MPIDI_OFI_AV(&MPIDIU_get_av(vni, rank)).dest = addr;
+    MPIDI_OFI_AV(&MPIDIU_get_av(vni, rank)).dest[0][0] = addr;
 #if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
     MPIDI_OFI_AV(&MPIDIU_get_av(vni, rank)).ep_idx = 0;
 #endif
@@ -431,7 +431,7 @@ MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int 
         MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(MPIDIU_comm_rank_to_av(comm, rank));
         int ep_num = MPIDI_OFI_av_to_ep(av);
         int rx_idx = ep_num;
-        return fi_rx_addr(av->dest, rx_idx, MPIDI_OFI_MAX_ENDPOINTS_BITS);
+        return fi_rx_addr(av->dest[0][0], rx_idx, MPIDI_OFI_MAX_ENDPOINTS_BITS);
     } else {
         return MPIDI_OFI_COMM_TO_PHYS(comm, rank);
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -401,12 +401,6 @@ MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_av_to_phys(MPIDI_av_entry_t * av,
 #endif
 }
 
-MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_to_phys(int grank, int vni_src, int vni_dst)
-{
-    MPIDI_av_entry_t *av = &MPIDIU_get_av(0, grank);
-    return MPIDI_OFI_av_to_phys(av, vni_src, vni_dst);
-}
-
 MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int rank,
                                                           int vni_src, int vni_dst)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -422,26 +422,38 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_av_insert(int vni, int rank, void *addrna
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_av_to_phys(MPIDI_av_entry_t * av)
+MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_av_to_phys(MPIDI_av_entry_t * av,
+                                                        int vni_src, int vni_dst)
 {
+#ifdef MPIDI_OFI_VNI_USE_DOMAIN
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         int ep_num = MPIDI_OFI_av_to_ep(&MPIDI_OFI_AV(av));
-        return fi_rx_addr(MPIDI_OFI_AV(av).dest[0][0], ep_num, MPIDI_OFI_MAX_ENDPOINTS_BITS);
+        return fi_rx_addr(MPIDI_OFI_AV(av).dest[vni_src][vni_dst], ep_num,
+                          MPIDI_OFI_MAX_ENDPOINTS_BITS);
     } else {
+        return MPIDI_OFI_AV(av).dest[vni_src][vni_dst];
+    }
+#else /* MPIDI_OFI_VNI_USE_SEPCTX */
+    if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
+        return fi_rx_addr(MPIDI_OFI_AV(av).dest[0][0], vni_dst, MPIDI_OFI_MAX_ENDPOINTS_BITS);
+    } else {
+        MPIR_Assert(vni_dst == 0);
         return MPIDI_OFI_AV(av).dest[0][0];
     }
+#endif
 }
 
-MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_to_phys(int grank)
+MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_to_phys(int grank, int vni_src, int vni_dst)
 {
     MPIDI_av_entry_t *av = &MPIDIU_get_av(0, grank);
-    return MPIDI_OFI_av_to_phys(av);
+    return MPIDI_OFI_av_to_phys(av, vni_src, vni_dst);
 }
 
-MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int rank)
+MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int rank,
+                                                          int vni_src, int vni_dst)
 {
     MPIDI_av_entry_t *av = MPIDIU_comm_rank_to_av(comm, rank);
-    return MPIDI_OFI_av_to_phys(av);
+    return MPIDI_OFI_av_to_phys(av, vni_src, vni_dst);
 }
 
 MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_is_tag_sync(uint64_t match_bits)

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -563,14 +563,14 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     /* TODO: update num_vnis according to provider capabilities, such as
      * prov_use->domain_attr->{tx,rx}_ctx_cnt
      */
-    if (num_vnis > MPIDI_OFI_MAX_CONTEXTS) {
-        num_vnis = MPIDI_OFI_MAX_CONTEXTS;
+    if (num_vnis > MPIDI_OFI_MAX_VNIS) {
+        num_vnis = MPIDI_OFI_MAX_VNIS;
     }
     /* for best performance, we ensure 1-to-1 vci/vni mapping. ref: MPIDI_OFI_vci_to_vni */
     /* TODO: allow less num_vnis. Option 1. runtime MOD; 2. overide MPIDI_global.n_vcis */
     MPIR_Assert(num_vnis == MPIDI_global.n_vcis);
 
-    MPIDI_OFI_global.num_ctx = num_vnis;
+    MPIDI_OFI_global.num_vnis = num_vnis;
 
     /* Create MPIDI_OFI_global.ctx[0] first  */
     mpi_errno = create_vni_context(0);
@@ -578,7 +578,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
 
     /* Creating the additional vni contexts.
      * This code maybe moved to a later stage */
-    for (i = 1; i < MPIDI_OFI_global.num_ctx; i++) {
+    for (i = 1; i < MPIDI_OFI_global.num_vnis; i++) {
         mpi_errno = create_vni_context(i);
         MPIR_ERR_CHECK(mpi_errno);
     }
@@ -761,7 +761,7 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     MPIR_Assert(MPL_atomic_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) == 0);
 
     /* Tearing down endpoints */
-    for (i = 1; i < MPIDI_OFI_global.num_ctx; i++) {
+    for (i = 1; i < MPIDI_OFI_global.num_vnis; i++) {
         mpi_errno = destroy_vni_context(i);
         MPIR_ERR_CHECK(mpi_errno);
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1815,6 +1815,7 @@ static int addr_exchange_root_vni(MPIR_Comm * init_comm)
                        avmap);
 
         for (int i = 0; i < num_nodes; i++) {
+            MPIR_Assert(mapped_table[i] != FI_ADDR_NOTAVAIL);
             MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).dest[0][0] = mapped_table[i];
 #if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
             MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).ep_idx = 0;
@@ -1841,6 +1842,7 @@ static int addr_exchange_root_vni(MPIR_Comm * init_comm)
                        (MPIDI_OFI_global.ctx[0].av, table, size, mapped_table, 0ULL, NULL), avmap);
 
         for (int i = 0; i < size; i++) {
+            MPIR_Assert(mapped_table[i] != FI_ADDR_NOTAVAIL);
             MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[0][0] = mapped_table[i];
 #if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
             MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).ep_idx = 0;
@@ -1903,7 +1905,9 @@ static int addr_exchange_all_vnis(void)
                     /* don't overwrite existing addr, or bad things will happen */
                     continue;
                 }
-                av->dest[vni_local][vni_remote] = mapped_table[r * num_vnis + vni_remote];
+                int idx = r * num_vnis + vni_remote;
+                MPIR_Assert(mapped_table[idx] != FI_ADDR_NOTAVAIL);
+                av->dest[vni_local][vni_remote] = mapped_table[idx];
             }
         }
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -755,6 +755,11 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
+int MPIDI_OFI_post_init(void)
+{
+    return MPI_SUCCESS;
+}
+
 int MPIDI_OFI_get_vci_attr(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -619,7 +619,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
                            avmap);
 
             for (i = 0; i < num_nodes; i++) {
-                MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).dest = mapped_table[i];
+                MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).dest[0][0] = mapped_table[i];
 #if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
                 MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).ep_idx = 0;
 #endif
@@ -646,7 +646,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
                            avmap);
 
             for (i = 0; i < size; i++) {
-                MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest = mapped_table[i];
+                MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[0][0] = mapped_table[i];
 #if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
                 MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).ep_idx = 0;
 #endif
@@ -1212,7 +1212,7 @@ static int try_open_shared_av(struct fid_domain *domain, struct fid_av **p_av)
         /* directly references the mapped fi_addr_t array instead               */
         fi_addr_t *mapped_table = (fi_addr_t *) av_attr.map_addr;
         for (int i = 0; i < MPIR_Process.size; i++) {
-            MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest = mapped_table[i];
+            MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[0][0] = mapped_table[i];
 #if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
             MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).ep_idx = 0;
 #endif

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -428,7 +428,7 @@ static int conn_manager_destroy()
         }
 
         for (i = 0; i < j; ++i) {
-            MPIDI_OFI_PROGRESS_WHILE(!req[i].done);
+            MPIDI_OFI_PROGRESS_WHILE(!req[i].done, 0);
             MPIDI_OFI_global.conn_mgr.conn_list[i].state = MPIDI_OFI_DYNPROC_DISCONNECTED;
             MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                             (MPL_DBG_FDEST, "conn_id=%d closed", i));
@@ -485,7 +485,7 @@ static int dynproc_send_disconnect(int conn_id)
         MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[0].tx, &msg,
                                          FI_COMPLETION | FI_TRANSMIT_COMPLETE | FI_REMOTE_CQ_DATA),
                              tsendmsg, FALSE);
-        MPIDI_OFI_PROGRESS_WHILE(!req.done);
+        MPIDI_OFI_PROGRESS_WHILE(!req.done, 0);
     }
 
     switch (MPIDI_OFI_global.conn_mgr.conn_list[conn_id].state) {
@@ -685,8 +685,9 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Progress until we drain all inflight RMA send long buffers */
+    /* NOTE: am currently only use vni 0. Need update once that changes */
     while (MPL_atomic_load_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs) > 0)
-        MPIDI_OFI_PROGRESS();
+        MPIDI_OFI_PROGRESS(0);
 
     /* Destroy RMA key allocator */
     MPIDI_OFI_mr_key_allocator_destroy();
@@ -698,8 +699,9 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Progress until we drain all inflight injection emulation requests */
+    /* NOTE: am currently only use vni 0. Need update once that changes */
     while (MPL_atomic_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) > 0)
-        MPIDI_OFI_PROGRESS();
+        MPIDI_OFI_PROGRESS(0);
     MPIR_Assert(MPL_atomic_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) == 0);
 
     /* Tearing down endpoints */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -324,6 +324,8 @@ static int conn_manager_init(void);
 static int conn_manager_destroy(void);
 static int dynproc_send_disconnect(int conn_id);
 
+static int addr_exchange_root_vni(MPIR_Comm * init_comm);
+
 static int get_ofi_version(void)
 {
     if (MPIDI_OFI_MAJOR_VERSION != -1 && MPIDI_OFI_MINOR_VERSION != -1)
@@ -512,8 +514,6 @@ static int dynproc_send_disconnect(int conn_id)
 int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm)
 {
     int mpi_errno = MPI_SUCCESS, i;
-    void *table = NULL;
-    fi_addr_t *mapped_table;
     size_t optlen;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_INIT_HOOK);
@@ -588,72 +588,8 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     /* ------------------------------------------------------------------------ */
 
     if (!MPIDI_OFI_global.got_named_av) {
-        /* No pre-published address table, need do address exchange. */
-        /* First, each get its own name */
-        MPIDI_OFI_global.addrnamelen = FI_NAME_MAX;
-        MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[0].ep, MPIDI_OFI_global.addrname,
-                                  &MPIDI_OFI_global.addrnamelen), getname);
-        MPIR_Assert(MPIDI_OFI_global.addrnamelen <= FI_NAME_MAX);
-
-        /* Second, exchange names using PMI */
-        /* If MPIR_CVAR_CH4_ROOTS_ONLY_PMI is true, we only collect a table of node-roots.
-         * Otherwise, we collect a table of everyone. */
-        int ret_bc_len;
-        mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map[0],
-                                          &MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
-                                          TRUE, MPIR_CVAR_CH4_ROOTS_ONLY_PMI, &table, &ret_bc_len);
+        mpi_errno = addr_exchange_root_vni(init_comm);
         MPIR_ERR_CHECK(mpi_errno);
-        /* MPIR_Assert(ret_bc_len = MPIDI_OFI_global.addrnamelen); */
-
-        /* Third, each fi_av_insert those addresses */
-        if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-            /* if "ROOTS_ONLY", we do a two stage bootstrapping ... */
-            int num_nodes = MPIR_Process.num_nodes;
-            int *node_roots = MPIR_Process.node_root_map;
-            int *rank_map, recv_bc_len;
-
-            /* First, insert address of node-roots, init_comm become useful */
-            mapped_table = (fi_addr_t *) MPL_malloc(num_nodes * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
-            MPIDI_OFI_CALL(fi_av_insert
-                           (MPIDI_OFI_global.ctx[0].av, table, num_nodes, mapped_table, 0ULL, NULL),
-                           avmap);
-
-            for (i = 0; i < num_nodes; i++) {
-                MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).dest[0][0] = mapped_table[i];
-#if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
-                MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).ep_idx = 0;
-#endif
-            }
-            MPL_free(mapped_table);
-            /* Then, allgather all address names using init_comm */
-            MPIDU_bc_allgather(init_comm, MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
-                               TRUE, &table, &rank_map, &recv_bc_len);
-
-            /* Insert the rest of the addresses */
-            for (i = 0; i < MPIR_Process.size; i++) {
-                if (rank_map[i] >= 0) {
-                    mpi_errno =
-                        MPIDI_OFI_av_insert(0, i, (char *) table + recv_bc_len * rank_map[i]);
-                    MPIR_ERR_CHECK(mpi_errno);
-                }
-            }
-            MPIDU_bc_table_destroy();
-        } else {
-            /* not "ROOTS_ONLY", we already have everyone's address name, insert all of them */
-            mapped_table = (fi_addr_t *) MPL_malloc(size * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
-            MPIDI_OFI_CALL(fi_av_insert
-                           (MPIDI_OFI_global.ctx[0].av, table, size, mapped_table, 0ULL, NULL),
-                           avmap);
-
-            for (i = 0; i < size; i++) {
-                MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[0][0] = mapped_table[i];
-#if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
-                MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).ep_idx = 0;
-#endif
-            }
-            MPL_free(mapped_table);
-            MPIDU_bc_table_destroy();
-        }
     }
 
     /* -------------------------------- */
@@ -1822,4 +1758,85 @@ static void dump_global_settings(void)
     /* Discover the tag_ub */
     fprintf(stdout, "MAXIMUM TAG: %lu\n", 1UL << MPIDI_OFI_TAG_BITS);
     fprintf(stdout, "======================================\n");
+}
+
+/* static address exchange routines */
+static int addr_exchange_root_vni(MPIR_Comm * init_comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int size = MPIR_Process.size;
+    int rank = MPIR_Process.rank;
+
+    /* No pre-published address table, need do address exchange. */
+    /* First, each get its own name */
+    MPIDI_OFI_global.addrnamelen = FI_NAME_MAX;
+    MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[0].ep, MPIDI_OFI_global.addrname,
+                              &MPIDI_OFI_global.addrnamelen), getname);
+    MPIR_Assert(MPIDI_OFI_global.addrnamelen <= FI_NAME_MAX);
+
+    /* Second, exchange names using PMI */
+    /* If MPIR_CVAR_CH4_ROOTS_ONLY_PMI is true, we only collect a table of node-roots.
+     * Otherwise, we collect a table of everyone. */
+    void *table = NULL;
+    int ret_bc_len;
+    mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map[0],
+                                      &MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
+                                      TRUE, MPIR_CVAR_CH4_ROOTS_ONLY_PMI, &table, &ret_bc_len);
+    MPIR_ERR_CHECK(mpi_errno);
+    /* MPIR_Assert(ret_bc_len = MPIDI_OFI_global.addrnamelen); */
+
+    /* Third, each fi_av_insert those addresses */
+    if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
+        /* if "ROOTS_ONLY", we do a two stage bootstrapping ... */
+        int num_nodes = MPIR_Process.num_nodes;
+        int *node_roots = MPIR_Process.node_root_map;
+        int *rank_map, recv_bc_len;
+
+        /* First, insert address of node-roots, init_comm become useful */
+        fi_addr_t *mapped_table;
+        mapped_table = (fi_addr_t *) MPL_malloc(num_nodes * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
+        MPIDI_OFI_CALL(fi_av_insert
+                       (MPIDI_OFI_global.ctx[0].av, table, num_nodes, mapped_table, 0ULL, NULL),
+                       avmap);
+
+        for (int i = 0; i < num_nodes; i++) {
+            MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).dest[0][0] = mapped_table[i];
+#if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
+            MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).ep_idx = 0;
+#endif
+        }
+        MPL_free(mapped_table);
+        /* Then, allgather all address names using init_comm */
+        MPIDU_bc_allgather(init_comm, MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
+                           TRUE, &table, &rank_map, &recv_bc_len);
+
+        /* Insert the rest of the addresses */
+        for (int i = 0; i < MPIR_Process.size; i++) {
+            if (rank_map[i] >= 0) {
+                mpi_errno = MPIDI_OFI_av_insert(0, i, (char *) table + recv_bc_len * rank_map[i]);
+                MPIR_ERR_CHECK(mpi_errno);
+            }
+        }
+        MPIDU_bc_table_destroy();
+    } else {
+        /* not "ROOTS_ONLY", we already have everyone's address name, insert all of them */
+        fi_addr_t *mapped_table;
+        mapped_table = (fi_addr_t *) MPL_malloc(size * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
+        MPIDI_OFI_CALL(fi_av_insert
+                       (MPIDI_OFI_global.ctx[0].av, table, size, mapped_table, 0ULL, NULL), avmap);
+
+        for (int i = 0; i < size; i++) {
+            MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[0][0] = mapped_table[i];
+#if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
+            MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).ep_idx = 0;
+#endif
+        }
+        MPL_free(mapped_table);
+        MPIDU_bc_table_destroy();
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -757,7 +757,11 @@ int MPIDI_OFI_mpi_finalize_hook(void)
 
 int MPIDI_OFI_post_init(void)
 {
-    return MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS;
+    if (MPIDI_OFI_global.num_vnis > 1) {
+        mpi_errno = addr_exchange_all_vnis();
+    }
+    return mpi_errno;
 }
 
 int MPIDI_OFI_get_vci_attr(int vci)

--- a/src/mpid/ch4/netmod/ofi/ofi_noinline.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_noinline.h
@@ -87,6 +87,7 @@ int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win);
 /* ofi_init.h */
 int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm);
 int MPIDI_OFI_mpi_finalize_hook(void);
+int MPIDI_OFI_post_init(void);
 int MPIDI_OFI_get_vci_attr(int vci);
 void *MPIDI_OFI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_OFI_mpi_free_mem(void *ptr);
@@ -98,6 +99,7 @@ int MPIDI_OFI_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, con
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_mpi_init_hook MPIDI_OFI_mpi_init_hook
 #define MPIDI_NM_mpi_finalize_hook MPIDI_OFI_mpi_finalize_hook
+#define MPIDI_NM_post_init MPIDI_OFI_post_init
 #define MPIDI_NM_get_vci_attr MPIDI_OFI_get_vci_attr
 #define MPIDI_NM_mpi_alloc_mem MPIDI_OFI_mpi_alloc_mem
 #define MPIDI_NM_mpi_free_mem MPIDI_OFI_mpi_free_mem

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -206,7 +206,11 @@ typedef struct {
 } MPIDI_OFI_win_t;
 
 typedef struct {
-    fi_addr_t dest;
+#ifdef MPIDI_OFI_VNI_USE_DOMAIN
+    fi_addr_t dest[MPIDI_CH4_MAX_VCIS][MPIDI_CH4_MAX_VCIS];     /* [local_vni][remote_vni] */
+#else
+    fi_addr_t dest[1][1];
+#endif
 #if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
     unsigned ep_idx:MPIDI_OFI_MAX_ENDPOINTS_BITS_SCALABLE;
 #endif

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -30,7 +30,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
     if (unlikely(MPI_ANY_SOURCE == source))
         remote_proc = FI_ADDR_UNSPEC;
     else
-        remote_proc = MPIDI_OFI_av_to_phys(addr);
+        remote_proc = MPIDI_OFI_av_to_phys(addr, 0, 0);
 
     if (message) {
         rreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__MPROBE, 0);

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -64,7 +64,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
     }
 
     MPIDI_OFI_CALL(ofi_err, trecvmsg);
-    MPIDI_OFI_PROGRESS_WHILE(MPIDI_OFI_REQUEST(rreq, util_id) == MPIDI_OFI_PEEK_START);
+    MPIDI_OFI_PROGRESS_WHILE(MPIDI_OFI_REQUEST(rreq, util_id) == MPIDI_OFI_PEEK_START, 0);
 
     switch (MPIDI_OFI_REQUEST(rreq, util_id)) {
         case MPIDI_OFI_PEEK_NOT_FOUND:

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.c
@@ -16,6 +16,14 @@ int MPIDI_OFI_progress(int vci, int blocking)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_PROGRESS);
 
     int vni = MPIDI_OFI_vci_to_vni(vci);
+    if (vni >= MPIDI_OFI_global.num_vnis) {
+        /* The requests generated from ofi will have vni/vci within our range.
+         * All requests that have vci beyond num_vnis are not from us, nothing
+         * to do, so simply return.
+         * NOTE: it is not an error since global progress will poll every vci.
+         */
+        return MPI_SUCCESS;
+    }
 
     if (unlikely(MPIDI_OFI_get_buffered(wc, 1)))
         mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1);

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -73,7 +73,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
     msg.ignore = mask_bits;
     msg.context = (void *) &(MPIDI_OFI_REQUEST(rreq, context));
     msg.data = 0;
-    msg.addr = (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr);
+    msg.addr = (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr, 0, 0);
 
     MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[0].rx, &msg, flags), trecv, FALSE);
 
@@ -199,7 +199,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
                                       data_sz,
                                       NULL,
                                       (MPI_ANY_SOURCE ==
-                                       rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr),
+                                       rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr, 0, 0),
                                       match_bits, mask_bits,
                                       (void *) &(MPIDI_OFI_REQUEST(rreq, context))), trecv, FALSE);
     else {

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -100,7 +100,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
                                                 MPIR_Request ** request, int mode, uint64_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *rreq = *request;
+    MPIR_Request *rreq;
     uint64_t match_bits, mask_bits;
     MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
     size_t data_sz;
@@ -116,7 +116,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_IRECV);
 
     if (mode == MPIDI_OFI_ON_HEAP) {    /* Branch should compile out */
-        MPIDI_OFI_REQUEST_CREATE_CONDITIONAL(rreq, MPIR_REQUEST_KIND__RECV);
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+        /* TODO: what cases when *request is NULL under workq? */
+        if (*request) {
+            MPIR_Request_add_ref(*request);
+        } else
+#endif
+        {
+            MPIDI_OFI_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__RECV, 0);
+        }
+        rreq = *request;
+
         /* Need to set the source to UNDEFINED for anysource matching */
         rreq->status.MPI_SOURCE = MPI_UNDEFINED;
     } else if (mode == MPIDI_OFI_USE_EXISTING) {

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -71,7 +71,7 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
         msg_len = MPL_MIN(origin_iov[origin_cur].iov_len, target_iov[target_cur].iov_len);
 
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(addr);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, 0, 0);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -156,7 +156,7 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         msg_len = MPL_MIN(actual_pack_bytes - i, req->noncontig.put.target.iov[target_cur].iov_len);
 
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.put.target.addr);
+        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.put.target.addr, 0, 0);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -243,7 +243,7 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         msg_len = MPL_MIN(get_bytes - i, req->noncontig.get.target.iov[target_cur].iov_len);
 
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.get.target.addr);
+        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.get.target.addr, 0, 0);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -184,7 +184,19 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
 
     /* large contiguous messages */
     if (origin_contig && target_contig) {
-        MPIDI_OFI_INIT_SIGNAL_REQUEST(win, sigreq, &flags);
+        if (sigreq) {
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+            if (*sigreq) {
+                MPIR_Request_add_ref(*sigreq);
+            } else
+#endif
+            {
+                MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
+            }
+            flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
+        } else {
+            flags = FI_DELIVERY_COMPLETE;
+        }
         offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
         msg.desc = NULL;
         msg.addr = MPIDI_OFI_av_to_phys(addr, 0, 0);
@@ -328,7 +340,19 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     if (origin_contig && target_contig) {
         offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
         if (sigreq) {
-            MPIDI_OFI_INIT_SIGNAL_REQUEST(win, sigreq, &flags);
+            if (sigreq) {
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+                if (*sigreq) {
+                    MPIR_Request_add_ref(*sigreq);
+                } else
+#endif
+                {
+                    MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
+                }
+                flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
+            } else {
+                flags = FI_DELIVERY_COMPLETE;
+            }
         } else {
             flags = 0;
         }

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -172,7 +172,7 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
         MPIDI_OFI_win_cntr_incr(win);
         MPIDI_OFI_CALL_RETRY(fi_inject_write(MPIDI_OFI_WIN(win).ep,
                                              (char *) origin_addr + origin_true_lb, target_bytes,
-                                             MPIDI_OFI_av_to_phys(addr),
+                                             MPIDI_OFI_av_to_phys(addr, 0, 0),
                                              (uint64_t) MPIDI_OFI_winfo_base(win, target_rank)
                                              + target_disp * MPIDI_OFI_winfo_disp_unit(win,
                                                                                        target_rank)
@@ -187,7 +187,7 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
         MPIDI_OFI_INIT_SIGNAL_REQUEST(win, sigreq, &flags);
         offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(addr);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, 0, 0);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -335,7 +335,7 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
         msg.desc = NULL;
         msg.msg_iov = &iov;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, 0, 0);
         msg.rma_iov = &riov;
         msg.rma_iov_count = 1;
         msg.context = NULL;
@@ -533,7 +533,7 @@ static inline int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av);
+    msg.addr = MPIDI_OFI_av_to_phys(av, 0, 0);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;
@@ -837,7 +837,7 @@ static inline int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av);
+    msg.addr = MPIDI_OFI_av_to_phys(av, 0, 0);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -24,7 +24,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
                                         buf,
                                         data_sz,
                                         cq_data,
-                                        MPIDI_OFI_av_to_phys(addr),
+                                        MPIDI_OFI_av_to_phys(addr, 0, 0),
                                         match_bits),
                          tinjectdata, comm->hints[MPIR_COMM_HINT_EAGAIN]);
   fn_exit:
@@ -93,7 +93,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     msg.ignore = 0ULL;
     msg.context = (void *) &(MPIDI_OFI_REQUEST(sreq, context));
     msg.data = cq_data;
-    msg.addr = MPIDI_OFI_av_to_phys(addr);
+    msg.addr = MPIDI_OFI_av_to_phys(addr, 0, 0);
 
     MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[0].tx, &msg, flags), tsendv, FALSE);
 
@@ -151,7 +151,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                       NULL,     /* recvbuf     */
                                       0,        /* data sz     */
                                       NULL,     /* memregion descr  */
-                                      MPIDI_OFI_av_to_phys(addr),       /* remote proc */
+                                      MPIDI_OFI_av_to_phys(addr, 0, 0), /* remote proc */
                                       ssend_match,      /* match bits  */
                                       0ULL,     /* mask bits   */
                                       (void *) &(ackreq->context)), trecvsync, FALSE);
@@ -213,14 +213,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                             send_buf,
                                             data_sz,
                                             cq_data,
-                                            MPIDI_OFI_av_to_phys(addr),
+                                            MPIDI_OFI_av_to_phys(addr, 0, 0),
                                             match_bits), tinjectdata, FALSE /* eagain */);
         MPIDI_OFI_send_event(NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
     } else if (data_sz <= MPIDI_OFI_global.max_msg_size) {
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[0].tx,
                                           send_buf, data_sz, NULL /* desc */ ,
                                           cq_data,
-                                          MPIDI_OFI_av_to_phys(addr),
+                                          MPIDI_OFI_av_to_phys(addr, 0, 0),
                                           match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
                              tsenddata, FALSE /* eagain */);
@@ -270,7 +270,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[0].tx,
                                           send_buf, MPIDI_OFI_global.max_msg_size, NULL /* desc */ ,
                                           cq_data,
-                                          MPIDI_OFI_av_to_phys(addr),
+                                          MPIDI_OFI_av_to_phys(addr, 0, 0),
                                           match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
                              tsenddata, FALSE /* eagain */);

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -920,7 +920,8 @@ int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char 
 
     for (i = 0; i < comm->local_size; i++) {
         (*local_upid_size)[i] = MPIDI_OFI_global.addrnamelen;
-        MPIDI_OFI_VCI_CALL(fi_av_lookup(MPIDI_OFI_global.ctx[0].av, MPIDI_OFI_COMM_TO_PHYS(comm, i),
+        MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(MPIDIU_comm_rank_to_av(comm, i));
+        MPIDI_OFI_VCI_CALL(fi_av_lookup(MPIDI_OFI_global.ctx[0].av, av->dest[0][0],
                                         &temp_buf[i * MPIDI_OFI_global.addrnamelen],
                                         &(*local_upid_size)[i]), 0, avlookup);
         total_size += (*local_upid_size)[i];

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -881,14 +881,11 @@ int MPIDI_OFI_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_
             MPIDI_OFI_VCI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[0].av, new_upids[i],
                                             1,
                                             (fi_addr_t *) &
-                                            MPIDI_OFI_AV(&MPIDIU_get_av(avtid, i)).dest, 0ULL,
+                                            MPIDI_OFI_AV(&MPIDIU_get_av(avtid, i)).dest[0][0], 0ULL,
                                             NULL), 0, avmap);
 #if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
             MPIDI_OFI_AV(&MPIDIU_get_av(avtid, i)).ep_idx = 0;
 #endif
-            MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_MAP, VERBOSE,
-                            (MPL_DBG_FDEST, "\tupids to lupids avtid %d lpid %d mapped to %" PRIu64,
-                             avtid, i, MPIDI_OFI_AV(&MPIDIU_get_av(avtid, i)).dest));
             /* highest bit is marked as 1 to indicate this is a new process */
             (*remote_lupids)[new_avt_procs[i]] = MPIDIU_LUPID_CREATE(avtid, i);
             MPIDIU_LUPID_SET_NEW_AVT_MARK((*remote_lupids)[new_avt_procs[i]]);

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -578,6 +578,7 @@ int MPIDI_OFI_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root
         MPIR_ERR_CHECK(mpi_errno);
         MPIDI_OFI_VCI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[0].av, conname, 1, &conn, 0ULL, NULL),
                            0, avmap);
+        MPIR_Assert(conn != FI_ADDR_NOTAVAIL);
         mpi_errno =
             dynproc_exchange_map(root, DYNPROC_SENDER, port_id, &conn, conname, comm_ptr,
                                  &parent_root, &remote_size, &remote_upid_size, &remote_upids,
@@ -761,6 +762,7 @@ int MPIDI_OFI_mpi_comm_accept(const char *port_name, MPIR_Info * info, int root,
         MPIR_ERR_CHECK(mpi_errno);
         MPIDI_OFI_VCI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[0].av, conname, 1, &conn, 0ULL, NULL),
                            0, avmap);
+        MPIR_Assert(conn != FI_ADDR_NOTAVAIL);
         mpi_errno = dynproc_handshake(root, DYNPROC_SENDER, 0, port_id, &conn, comm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno =
@@ -878,11 +880,11 @@ int MPIDI_OFI_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_
         MPIR_ERR_CHECK(mpi_errno);
 
         for (i = 0; i < n_new_procs; i++) {
+            fi_addr_t addr;
             MPIDI_OFI_VCI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[0].av, new_upids[i],
-                                            1,
-                                            (fi_addr_t *) &
-                                            MPIDI_OFI_AV(&MPIDIU_get_av(avtid, i)).dest[0][0], 0ULL,
-                                            NULL), 0, avmap);
+                                            1, &addr, 0ULL, NULL), 0, avmap);
+            MPIR_Assert(addr != FI_ADDR_NOTAVAIL);
+            MPIDI_OFI_AV(&MPIDIU_get_av(avtid, i)).dest[0][0] = addr;
 #if MPIDI_OFI_ENABLE_ENDPOINTS_BITS
             MPIDI_OFI_AV(&MPIDIU_get_av(avtid, i)).ep_idx = 0;
 #endif

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -22,8 +22,8 @@
      : __FILE__                                 \
 )
 
-/* TODO: make it a configure option */
-#define MPIDI_OFI_MAX_CONTEXTS                  16
+/* TODO: This should come from provider capability */
+#define MPIDI_OFI_MAX_VNIS                  16
 
 #define MPIDI_OFI_MAP_NOT_FOUND            ((void*)(-1UL))
 #define MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE  (16 * 1024)
@@ -340,8 +340,8 @@ typedef struct {
 
     /* Mutexes and endpoints */
     MPIDI_OFI_cacheline_mutex_t mutexes[MAX_OFI_MUTEXES];
-    MPIDI_OFI_context_t ctx[MPIDI_OFI_MAX_CONTEXTS];
-    int num_ctx;
+    MPIDI_OFI_context_t ctx[MPIDI_OFI_MAX_VNIS];
+    int num_vnis;
 
     /* Window/RMA Globals */
     void *win_map;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -30,7 +30,7 @@ static inline int MPIDI_OFI_win_do_progress(MPIR_Win * win)
 
         while (tcount > donecount) {
             MPIR_Assert(donecount <= tcount);
-            MPIDI_OFI_PROGRESS();
+            MPIDI_OFI_PROGRESS(0);
             donecount = fi_cntr_read(MPIDI_OFI_WIN(win).cmpl_cntr);
             itercount++;
 

--- a/src/mpid/ch4/netmod/src/netmod_impl.c
+++ b/src/mpid/ch4/netmod/src/netmod_impl.c
@@ -382,6 +382,19 @@ int MPIDI_NM_mpi_finalize_hook(void)
     return ret;
 }
 
+int MPIDI_NM_post_init(void)
+{
+    int ret;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_POST_INIT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_POST_INIT);
+
+    ret = MPIDI_NM_func->post_init();
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_POST_INIT);
+    return ret;
+}
+
 int MPIDI_NM_get_vci_attr(int vci)
 {
     int ret;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.c
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.c
@@ -22,6 +22,13 @@ int MPIDI_STUBNM_mpi_finalize_hook(void)
     return mpi_errno;
 }
 
+int MPIDI_STUBNM_post_init(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Assert(0);
+    return mpi_errno;
+}
+
 int MPIDI_STUBNM_get_vci_attr(int vci)
 {
     MPIR_Assert(0);

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -14,6 +14,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     .mpi_init = MPIDI_UCX_mpi_init_hook,
     .mpi_finalize = MPIDI_UCX_mpi_finalize_hook,
+    .post_init = MPIDI_UCX_post_init,
     .progress = MPIDI_UCX_progress,
     .mpi_comm_connect = MPIDI_UCX_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_UCX_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -184,6 +184,11 @@ int MPIDI_UCX_mpi_finalize_hook(void)
 
 }
 
+int MPIDI_UCX_post_init(void)
+{
+    return MPI_SUCCESS;
+}
+
 int MPIDI_UCX_get_vci_attr(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);

--- a/src/mpid/ch4/netmod/ucx/ucx_noinline.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_noinline.h
@@ -87,6 +87,7 @@ int MPIDI_UCX_mpi_win_free_hook(MPIR_Win * win);
 /* ucx_init.h */
 int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm);
 int MPIDI_UCX_mpi_finalize_hook(void);
+int MPIDI_UCX_post_init(void);
 int MPIDI_UCX_get_vci_attr(int vci);
 void *MPIDI_UCX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_UCX_mpi_free_mem(void *ptr);
@@ -98,6 +99,7 @@ int MPIDI_UCX_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, con
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_mpi_init_hook MPIDI_UCX_mpi_init_hook
 #define MPIDI_NM_mpi_finalize_hook MPIDI_UCX_mpi_finalize_hook
+#define MPIDI_NM_post_init MPIDI_UCX_post_init
 #define MPIDI_NM_get_vci_attr MPIDI_UCX_get_vci_attr
 #define MPIDI_NM_mpi_alloc_mem MPIDI_UCX_mpi_alloc_mem
 #define MPIDI_NM_mpi_free_mem MPIDI_UCX_mpi_free_mem

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -640,6 +640,9 @@ int MPID_InitCompleted(void)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INITCOMPLETED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INITCOMPLETED);
 
+    mpi_errno = MPIDI_NM_post_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
     if (MPIR_Process.has_parent) {
         mpi_errno = MPIR_pmi_kvs_get(-1, MPIDI_PARENT_PORT_KVSKEY, parent_port, MPI_MAX_PORT_NAME);
         MPIR_ERR_CHECK(mpi_errno);
@@ -653,7 +656,7 @@ int MPID_InitCompleted(void)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INITCOMPLETED);
 
   fn_exit:
-    return MPI_SUCCESS;
+    return mpi_errno;
 
   fn_fail:
     goto fn_exit;


### PR DESCRIPTION
## Pull Request Description

Exchange addresses and establish all to all address table so that ofi netmod is ready for multiple vni communications. 

Note: this PR adds a netmod API `MPIDI_NM_post_init` so that we could establish complete address tables after all the rest of the initialization is done. In particular, so we could use collectives.

## Notes on `MPIDI_OFI_VNI_USE_DOMAIN`

There are two ways to implement vci context in ofi netmod: 
* use scalable endpoints in a single `fi_domain`, with each vni context having separate receive context, a send context, and a completion queue.  
* use different `fi_domain` for each vni context

The former will share a address table inside libfabric, therefore greatly simplifies addressing between VNIs. However, current libfabric providers internally need lock the av table each time for accessing, it creates a global contention point that restricts the maximum parallel performance. (Note that potentially this is fixable, for example, by restricting dynamic process or using lighter weight atomics for access control.)

The current default is to use separate domain for each vni context. This provides maximum performance at the cost of managing `N by N` addressing (N refers to number of vnis). 

The plan is to allow both options controlled by configure option `--enable-ofi-domain`. We'll use proper abstractions to restrict the differences to `init/finalize` and a set of wrapper macros.

Current PR assumes the default of `MPIDI_OFI_VNI_USE_DOMAIN` is true (mostly due to the time constraint to ensure a working alternate). A following PR will complete the option of `--disable-ofi-domain`.

## Reference

Split from PR #4530

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
