### PR TITLE
Warning squashes

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -514,6 +514,7 @@ if test "$enable_strict_done" != "yes" ; then
         -Wtype-limits
         -Werror-implicit-function-declaration
         -Wstack-usage=262144
+        -diag-disable=all
     "
 
     if test -z "$1"; then

--- a/maint/clmake.in
+++ b/maint/clmake.in
@@ -47,7 +47,7 @@ $rootSrcDir = "";
 	      "compiling ROMIO in", 
 	      "Make completed",
 	      "echo", "cat",
-	      "CC", "CCLD", "AR", "RANLIB", "LIBTOOL", "MV", 
+	      "NVCC", "CC", "CCLD", "AR", "RANLIB", "LIBTOOL", "MV",
               "MOD", "GEN", "F77", "FC", "CXXLD", "CXX", "FCLD",
 	      "CP", # "terse" make versions
 	      "\\(?cd",


### PR DESCRIPTION
## Pull Request Description

Some warning squashes that were needed in yaksa while testing CUDA support.  These are technically not needed in MPICH yet, but these fixes are good and could be useful in the future.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
