### PR TITLE
More warning squashes

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_yaksa_commit.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_commit.c
@@ -14,30 +14,36 @@ void MPIR_Typerep_commit(MPI_Datatype type)
     MPIR_Datatype *typeptr;
     MPIR_Datatype_get_ptr(type, typeptr);
 
+    uintptr_t num_contig_blocks;
     switch (type) {
         case MPI_FLOAT_INT:
             typeptr->typerep.handle = (void *) YAKSA_TYPE__FLOAT_INT;
-            yaksa_iov_len(1, YAKSA_TYPE__FLOAT_INT, &typeptr->typerep.num_contig_blocks);
+            yaksa_iov_len(1, YAKSA_TYPE__FLOAT_INT, &num_contig_blocks);
+            typeptr->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
             break;
 
         case MPI_DOUBLE_INT:
             typeptr->typerep.handle = (void *) YAKSA_TYPE__DOUBLE_INT;
-            yaksa_iov_len(1, YAKSA_TYPE__DOUBLE_INT, &typeptr->typerep.num_contig_blocks);
+            yaksa_iov_len(1, YAKSA_TYPE__DOUBLE_INT, &num_contig_blocks);
+            typeptr->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
             break;
 
         case MPI_LONG_INT:
             typeptr->typerep.handle = (void *) YAKSA_TYPE__LONG_INT;
-            yaksa_iov_len(1, YAKSA_TYPE__LONG_INT, &typeptr->typerep.num_contig_blocks);
+            yaksa_iov_len(1, YAKSA_TYPE__LONG_INT, &num_contig_blocks);
+            typeptr->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
             break;
 
         case MPI_SHORT_INT:
             typeptr->typerep.handle = (void *) YAKSA_TYPE__SHORT_INT;
-            yaksa_iov_len(1, YAKSA_TYPE__SHORT_INT, &typeptr->typerep.num_contig_blocks);
+            yaksa_iov_len(1, YAKSA_TYPE__SHORT_INT, &num_contig_blocks);
+            typeptr->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
             break;
 
         case MPI_LONG_DOUBLE_INT:
             typeptr->typerep.handle = (void *) YAKSA_TYPE__LONG_DOUBLE_INT;
-            yaksa_iov_len(1, YAKSA_TYPE__LONG_DOUBLE_INT, &typeptr->typerep.num_contig_blocks);
+            yaksa_iov_len(1, YAKSA_TYPE__DOUBLE_INT, &num_contig_blocks);
+            typeptr->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
             break;
 
         default:

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
@@ -21,9 +21,10 @@ int MPIR_Typerep_create_vector(int count, int blocklength, int stride, MPI_Datat
                                       (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
-    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
-                       &newtype->typerep.num_contig_blocks);
+    uintptr_t num_contig_blocks;
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle, &num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    newtype->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_VECTOR);
@@ -46,9 +47,10 @@ int MPIR_Typerep_create_hvector(int count, int blocklength, MPI_Aint stride, MPI
                                        (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
-    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
-                       &newtype->typerep.num_contig_blocks);
+    uintptr_t num_contig_blocks;
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle, &num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    newtype->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_HVECTOR);
@@ -69,9 +71,10 @@ int MPIR_Typerep_create_contig(int count, MPI_Datatype oldtype, MPIR_Datatype * 
     int rc = yaksa_type_create_contig(count, type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
-    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
-                       &newtype->typerep.num_contig_blocks);
+    uintptr_t num_contig_blocks;
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle, &num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    newtype->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_CONTIG);
@@ -92,9 +95,10 @@ int MPIR_Typerep_create_dup(MPI_Datatype oldtype, MPIR_Datatype * newtype)
     int rc = yaksa_type_create_dup(type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
-    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
-                       &newtype->typerep.num_contig_blocks);
+    uintptr_t num_contig_blocks;
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle, &num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    newtype->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_DUP);
@@ -117,9 +121,10 @@ int MPIR_Typerep_create_indexed_block(int count, int blocklength, const int *arr
                                              type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
-    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
-                       &newtype->typerep.num_contig_blocks);
+    uintptr_t num_contig_blocks;
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle, &num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    newtype->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED_BLOCK);
@@ -143,9 +148,10 @@ int MPIR_Typerep_create_hindexed_block(int count, int blocklength,
                                               type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
-    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
-                       &newtype->typerep.num_contig_blocks);
+    uintptr_t num_contig_blocks;
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle, &num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    newtype->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED_BLOCK);
@@ -169,9 +175,10 @@ int MPIR_Typerep_create_indexed(int count, const int *array_of_blocklengths,
                                        type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
-    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
-                       &newtype->typerep.num_contig_blocks);
+    uintptr_t num_contig_blocks;
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle, &num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    newtype->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_INDEXED);
@@ -195,9 +202,10 @@ int MPIR_Typerep_create_hindexed(int count, const int *array_of_blocklengths,
                                         type, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
-    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
-                       &newtype->typerep.num_contig_blocks);
+    uintptr_t num_contig_blocks;
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle, &num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    newtype->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_HINDEXED);
@@ -220,9 +228,10 @@ int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint exte
         yaksa_type_create_resized(type, lb, extent, (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
-    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
-                       &newtype->typerep.num_contig_blocks);
+    uintptr_t num_contig_blocks;
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle, &num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    newtype->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_CREATE_RESIZED);
@@ -251,9 +260,10 @@ int MPIR_Typerep_create_struct(int count, const int *array_of_blocklengths,
                                       (yaksa_type_t *) & newtype->typerep.handle);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
-    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle,
-                       &newtype->typerep.num_contig_blocks);
+    uintptr_t num_contig_blocks;
+    rc = yaksa_iov_len(1, (yaksa_type_t) newtype->typerep.handle, &num_contig_blocks);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    newtype->typerep.num_contig_blocks = (MPI_Aint) num_contig_blocks;
 
     MPL_free(array_of_yaksa_types);
 

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -10,7 +10,7 @@
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     cudaError_t ret;
-    struct cudaPointerAttributes ptr_attr = { 0 };
+    struct cudaPointerAttributes ptr_attr;
     ret = cudaPointerGetAttributes(&ptr_attr, ptr);
     if (ret == cudaSuccess) {
         switch (ptr_attr.type) {


### PR DESCRIPTION
## Pull Request Description

Squash warnings that showed up when trying to enable GPU builds in the warnings tests.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
