### PR TITLE
mpir: better granularity in contextid allocation code

### DIFF
--- a/src/include/mpir_contextid.h
+++ b/src/include/mpir_contextid.h
@@ -100,6 +100,9 @@ typedef uint16_t MPIR_Context_id_t;
 #define MPIR_MAX_CONTEXT_MASK \
     ((1 << (MPIR_CONTEXT_ID_BITS - (MPIR_CONTEXT_PREFIX_SHIFT + MPIR_CONTEXT_DYNAMIC_PROC_WIDTH))) / MPIR_CONTEXT_INT_BITS)
 
+/* Init */
+void MPIR_context_id_init(void);
+
 /* Utility routines.  Where possible, these are kept in the source directory
    with the other comm routines (src/mpi/comm, in mpicomm.h).  However,
    to create a new communicator after a spawn or connect-accept operation,

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -101,6 +101,7 @@ int MPIR_Init_thread(int *argc, char ***argv, int user_required, int *provided)
     /**********************************************************************/
 
     MPIR_Typerep_init();
+    MPIR_context_id_init();
     MPII_thread_mutex_create();
     MPII_init_request();
     MPII_hwtopo_init();


### PR DESCRIPTION
## Pull Request Description

In context_id allocation algorithm, there are a few global states need to be protected, namely `gcn` queue and `context_mask` array. During contention, when multiple threads creating communicators, it uses a policy that let lowest context id group win to prevent deadlock. Current code incurs critical section even for threads that have to wait, which adds pressure to the mutex contention. This PR refactors the code to identify critical states more clearly, uses atomic variable to prevent waiting threads to contend for critical section, and uses more granular locks to ease the code maintenance.

Fixes #4595 

As I commented in the issue, there are actually two parts of thread contention makes that particular test (`threads/comm/dup_leak_test`) slow: The contention on `MPIR_THREAD_VCI_CTX_MULTEX` and the progress contention in `MPIR_Allreduce`. Both critical sections interweave each other which makes it very unpredictable.

This PR alleviates the first contention, essentially using `eager_in_use` and `mask_in_use` as spin locks on `context_mask`. The progress contention is due to mutex monopoly and need either "heavy" yield in progress or a fair mutex. For example, with this PR, my local test with default posix mutex takes `1m12sec`. If I use ticketlock instead, it only takes `3.3 seconds`.

[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
