### PR TITLE
ch4/xpmem: use buffer pool for segment cache

### DIFF
--- a/src/mpid/ch4/shm/ipc/xpmem/globals.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/globals.c
@@ -12,12 +12,3 @@ MPIDI_XPMEMI_global_t MPIDI_XPMEMI_global;
 #ifdef MPL_USE_DBG_LOGGING
 MPL_dbg_class MPIDI_XPMEMI_DBG_GENERAL;
 #endif
-
-/* Preallocated segment objects */
-/* TODO: should use memory pool API. Direct pool objects is not needed. */
-MPIDI_XPMEMI_seg_t MPIDI_XPMEMI_seg_mem_direct[MPIDI_XPMEMI_SEG_PREALLOC];
-
-MPIR_Object_alloc_t MPIDI_XPMEMI_seg_mem = { 0, 0, 0, 0, MPIR_INTERNAL,
-    sizeof(MPIDI_XPMEMI_seg_t), MPIDI_XPMEMI_seg_mem_direct,
-    MPIDI_XPMEMI_SEG_PREALLOC
-};

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
@@ -57,6 +57,10 @@ int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *tag_bits)
     /* Initialize other global parameters */
     MPIDI_XPMEMI_global.sys_page_sz = (size_t) sysconf(_SC_PAGESIZE);
 
+    MPL_COMPILE_TIME_ASSERT(sizeof(MPIDI_XPMEMI_seg_t) <= MPIDI_XPMEMI_SEG_BUF_POOL_SIZE);
+    MPIDI_XPMEMI_global.seg_buf_pool =
+        MPIDIU_create_buf_pool(MPIDI_XPMEMI_SEG_BUF_POOL_NUM, MPIDI_XPMEMI_SEG_BUF_POOL_SIZE);
+
     for (i = 0; i < MPIR_Process.local_size; ++i) {
         /* Init AVL tree based segment cache */
         MPIDI_XPMEMI_segtree_init(&MPIDI_XPMEMI_global.segmaps[i].segcache_ubuf);       /* Initialize user buffer tree */
@@ -109,6 +113,8 @@ int MPIDI_XPMEM_mpi_finalize_hook(void)
         /* success(0) or failure(-1) */
         MPIR_ERR_CHKANDJUMP(ret == -1, mpi_errno, MPI_ERR_OTHER, "**xpmem_remove");
     }
+
+    MPIDIU_destroy_buf_pool(MPIDI_XPMEMI_global.seg_buf_pool);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_MPI_FINALIZE_HOOK);

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_types.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_types.h
@@ -7,10 +7,10 @@
 #define XPMEM_TYPES_H_INCLUDED
 
 #define MPIDI_XPMEMI_PERMIT_VALUE ((void *)0600)
-#define MPIDI_XPMEMI_SEG_PREALLOC 8     /* Number of segments to preallocate in the "direct" block */
+#define MPIDI_XPMEMI_SEG_BUF_POOL_SIZE            (128)
+#define MPIDI_XPMEMI_SEG_BUF_POOL_NUM             (1024)
 
 typedef struct MPIDI_XPMEMI_seg {
-    MPIR_OBJECT_HEADER;
     /* AVL-tree internal components start */
     struct MPIDI_XPMEMI_seg *parent;
     struct MPIDI_XPMEMI_seg *left;
@@ -38,11 +38,11 @@ typedef struct {
 typedef struct {
     xpmem_segid_t segid;        /* my local segid associated with entire address space */
     MPIDI_XPMEMI_segmap_t *segmaps;     /* remote seg info for every local processes. */
+    MPIDIU_buf_pool_t *seg_buf_pool;
     size_t sys_page_sz;
 } MPIDI_XPMEMI_global_t;
 
 extern MPIDI_XPMEMI_global_t MPIDI_XPMEMI_global;
-extern MPIR_Object_alloc_t MPIDI_XPMEMI_seg_mem;
 
 #ifdef MPL_USE_DBG_LOGGING
 extern MPL_dbg_class MPIDI_XPMEMI_DBG_GENERAL;


### PR DESCRIPTION
Previous code used MPIR_Handle_obj_alloc for segment cache which
contains unnecessary direct preallocated region. Thus, we replace
it with simpler buffer pool routines.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
