### PR TITLE
test: xfail dup_leak_test with large iterations

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -176,6 +176,8 @@ valgrind * * * * sed -i "s+\(^accfence1 .*\)+\1 xfail=ticket0+g" test/mpi/rma/te
 * * * * * sed -i "s+\(^alltoallw_zeros.* env=MPIR_CVAR_IALLTOALLW_INTRA_ALGORITHM=gentran_inplace.*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist.cvar
 # pingping tests with large testsize currently fails async tests due to netmod handling of large message queue
 * * async * * sed -i "s+\(^pingping .*testsize=32.*\)+\1 xfail=issue4474+g" test/mpi/pt2pt/testlist.dtp
+# dup_leak_test suffers from mutex unfairness issue under load for ch4:ofi
+* * * ch4:ofi * sed -i "s+\(^dup_leak_test .*iter=12345.*\)+\1 xfail=issue4595+g" test/mpi/threads/comm/testlist
 # release-gather algorithm won't work with multithread
 * * async * * sed -i "s+\(^.*_ALGORITHM=release_gather.*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist.cvar
 # freebsd failures

--- a/test/mpi/threads/comm/dup_leak_test.c
+++ b/test/mpi/threads/comm/dup_leak_test.c
@@ -15,13 +15,11 @@
 #include "mpitest.h"
 #include "mpithreadtest.h"
 
-#ifndef NITER
-#define NITER 12345
-#endif /* ! NITER */
-
 #ifndef NTHREADS
 #define NTHREADS 4
 #endif /* ! NTHREADS */
+
+int num_iter;
 
 MTEST_THREAD_RETURN_TYPE do_thread(void *v);
 MTEST_THREAD_RETURN_TYPE do_thread(void *v)
@@ -29,7 +27,7 @@ MTEST_THREAD_RETURN_TYPE do_thread(void *v)
     int x;
     MPI_Comm comm = *(MPI_Comm *) v;
     MPI_Comm newcomm;
-    for (x = 0; x < NITER; ++x) {
+    for (x = 0; x < num_iter; ++x) {
         MPI_Comm_dup(comm, &newcomm);
         MPI_Comm_free(&newcomm);
     }
@@ -49,6 +47,9 @@ int main(int argc, char **argv)
         printf("unable to initialize with MPI_THREAD_MULTIPLE\n");
         goto fn_fail;
     }
+
+    MTestArgList *head = MTestArgListCreate(argc, argv);
+    num_iter = MTestArgListGetInt(head, "iter");
 
     for (x = 0; x < NTHREADS; ++x) {
         MPI_Comm_dup(MPI_COMM_WORLD, &comms[x]);

--- a/test/mpi/threads/comm/testlist.in
+++ b/test/mpi/threads/comm/testlist.in
@@ -1,5 +1,6 @@
 ctxdup 4
-dup_leak_test 2
+dup_leak_test 2 arg=-iter=12345
+dup_leak_test 2 arg=-iter=1234
 comm_dup_deadlock 4
 comm_create_threads 4
 comm_create_group_threads 4


### PR DESCRIPTION
## Pull Request Description

Reference issue #4595. `threads/comm/dup_leak_test` sporadically fails for ch4:ofi. Xfail the one with large iterations and keep a shorter test to cover the basics.


## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
