### PR TITLE
warnings: fix some warnings for centos32

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -197,7 +197,7 @@ static inline int MPIDI_OFI_am_isend_long(int rank,
                                           int handler_id,
                                           const void *am_hdr,
                                           size_t am_hdr_sz,
-                                          const void *data, size_t data_sz, MPIR_Request * sreq)
+                                          const void *data, MPI_Aint data_sz, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -278,7 +278,7 @@ static inline int MPIDI_OFI_am_isend_short(int rank,
                                            int handler_id,
                                            const void *am_hdr,
                                            size_t am_hdr_sz,
-                                           const void *data, size_t data_sz, MPIR_Request * sreq)
+                                           const void *data, MPI_Aint data_sz, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -334,7 +334,7 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
 {
     int dt_contig, mpi_errno = MPI_SUCCESS;
     char *send_buf;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPI_Aint dt_true_lb, last;
     MPIR_Datatype *dt_ptr;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -93,7 +93,7 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
         msg.rma_iov_count = 1;
         iov.iov_base = origin_iov[origin_cur].iov_base;
         iov.iov_len = msg_len;
-        riov.addr = (uint64_t) target_iov[target_cur].iov_base;
+        riov.addr = (uintptr_t) target_iov[target_cur].iov_base;
         riov.len = msg_len;
         riov.key = MPIDI_OFI_winfo_mr_key(win, target_rank);
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
@@ -178,7 +178,7 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         msg.rma_iov_count = 1;
         iov.iov_base = (char *) req->noncontig.put.origin.pack_buffer + i;
         iov.iov_len = msg_len;
-        riov.addr = (uint64_t) req->noncontig.put.target.iov[target_cur].iov_base;
+        riov.addr = (uintptr_t) req->noncontig.put.target.iov[target_cur].iov_base;
         riov.len = msg_len;
         riov.key = req->noncontig.put.target.key;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
@@ -265,7 +265,7 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         msg.rma_iov_count = 1;
         iov.iov_base = (char *) req->noncontig.get.origin.pack_buffer + i;
         iov.iov_len = msg_len;
-        riov.addr = (uint64_t) req->noncontig.get.target.iov[target_cur].iov_base;
+        riov.addr = (uintptr_t) req->noncontig.get.target.iov[target_cur].iov_base;
         riov.len = msg_len;
         riov.key = req->noncontig.get.target.key;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);

--- a/src/mpid/ch4/shm/ipc/src/ipc_control.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.c
@@ -12,7 +12,7 @@
 int MPIDI_IPCI_send_contig_lmt_fin_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *sreq = (MPIR_Request *) ctrl_hdr->ipc_contig_slmt_fin.req_ptr;
+    MPIR_Request *sreq = ctrl_hdr->ipc_contig_slmt_fin.req_ptr;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT_FIN_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT_FIN_CB);
@@ -38,7 +38,7 @@ int MPIDI_IPCI_send_contig_lmt_rts_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT_RTS_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT_RTS_CB);
 
-    IPC_TRACE("send_contig_lmt_rts_cb: received data_sz 0x%lx, sreq_ptr 0x%lx, "
+    IPC_TRACE("send_contig_lmt_rts_cb: received data_sz 0x%lx, sreq_ptr 0x%p, "
               "src_lrank %d, match info[src_rank %d, tag %d, context_id 0x%x]\n",
               slmt_rts_hdr->data_sz, slmt_rts_hdr->sreq_ptr,
               slmt_rts_hdr->src_lrank, slmt_rts_hdr->src_rank, slmt_rts_hdr->tag,

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -52,7 +52,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
 
     slmt_req_hdr->src_lrank = MPIR_Process.local_rank;
     slmt_req_hdr->data_sz = data_sz;
-    slmt_req_hdr->sreq_ptr = (uint64_t) sreq;
+    slmt_req_hdr->sreq_ptr = sreq;
     slmt_req_hdr->ipc_type = attr.ipc_type;
     slmt_req_hdr->mem_handle = attr.mem_handle;
 
@@ -61,7 +61,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
     slmt_req_hdr->tag = tag;
     slmt_req_hdr->context_id = comm->context_id + context_offset;
 
-    IPC_TRACE("send_contig_lmt: shm ctrl_id %d, data_sz 0x%lx, sreq_ptr 0x%lx, "
+    IPC_TRACE("send_contig_lmt: shm ctrl_id %d, data_sz 0x%lx, sreq_ptr 0x%p, "
               "src_lrank %d, match info[dest %d, src_rank %d, tag %d, context_id 0x%x]\n",
               MPIDI_IPC_SEND_CONTIG_LMT_RTS, slmt_req_hdr->data_sz, slmt_req_hdr->sreq_ptr,
               slmt_req_hdr->src_lrank, rank, slmt_req_hdr->src_rank, slmt_req_hdr->tag,
@@ -86,7 +86,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
 MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_type,
                                                         MPIDI_IPCI_mem_handle_t mem_handle,
                                                         size_t src_data_sz,
-                                                        uint64_t sreq_ptr,
+                                                        MPIR_Request * sreq_ptr,
                                                         int src_lrank, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/shm/ipc/src/ipc_pre.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_pre.h
@@ -14,7 +14,7 @@
 typedef struct MPIDI_IPC_am_unexp_rreq {
     MPIDI_IPCI_mem_handle_t mem_handle;
     uint64_t data_sz;
-    uint64_t sreq_ptr;
+    MPIR_Request *sreq_ptr;
     int src_lrank;
 } MPIDI_IPC_am_unexp_rreq_t;
 
@@ -37,7 +37,7 @@ typedef struct MPIDI_IPC_ctrl_send_contig_lmt_rts {
     MPIDI_IPCI_type_t ipc_type;
     MPIDI_IPCI_mem_handle_t mem_handle;
     uint64_t data_sz;           /* data size in bytes */
-    uint64_t sreq_ptr;          /* send request pointer */
+    MPIR_Request *sreq_ptr;     /* send request pointer */
     int src_lrank;              /* sender rank on local node */
 
     /* matching info */
@@ -48,7 +48,7 @@ typedef struct MPIDI_IPC_ctrl_send_contig_lmt_rts {
 
 typedef struct MPIDI_IPC_ctrl_send_contig_lmt_fin {
     MPIDI_IPCI_type_t ipc_type;
-    uint64_t req_ptr;
+    MPIR_Request *req_ptr;
 } MPIDI_IPC_ctrl_send_contig_lmt_fin_t;
 
 #endif /* IPC_PRE_H_INCLUDED */

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -148,7 +148,7 @@ static void *generate_random_addr(size_t size)
         iter--;
 
         if (iter == 0) {
-            map_pointer = -1ULL;
+            map_pointer = UINTPTR_MAX;
             goto fn_exit;
         }
     }


### PR DESCRIPTION
## Pull Request Description

Mostly due to the assumption that `uint64_t` is the same size as pointer size. Not true on 32-bit OS.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
