### PR TITLE
Cxx binding fix

### DIFF
--- a/src/binding/cxx/Makefile.mk
+++ b/src/binding/cxx/Makefile.mk
@@ -17,7 +17,7 @@ cxx_buildiface_out_files = $(top_srcdir)/src/binding/cxx/mpicxx.h.in \
 if MAINTAINER_MODE
 $(cxx_buildiface_out_files): src/binding/cxx/buildiface-stamp
 src/binding/cxx/buildiface-stamp: $(top_srcdir)/src/binding/cxx/buildiface $(top_srcdir)/src/include/mpi.h.in
-	( cd $(top_srcdir)/src/binding/cxx && ./buildiface -nosep -initfile=cxx.vlist )
+	( cd $(top_srcdir)/src/binding/cxx && ./buildiface -nosep -initfile=./cxx.vlist )
 endif MAINTAINER_MODE
 
 

--- a/src/binding/cxx/cxxdecl3.dat
+++ b/src/binding/cxx/cxxdecl3.dat
@@ -121,6 +121,8 @@ win-Get_attr bool (, , ,return ) const
 win-Get_name void (, ,in:refint ) const
 win-Set_attr void (, ,in:const )
 win-Set_name void (,in:const )
+op-Is_commutative () const
+op-Reduce_local void (in:const, , ,in:constref:Datatype, ,) const
 file-Close void ()
 file-Delete static void (in:const ,in:constref:Info )
 file-Get_amode int (,return) const
@@ -248,8 +250,6 @@ dtype-Pack_size int (, ,in:constref:Comm ,return) const
 # op-Init requires special handling
 #op-Init void (,User_function* function ,in:bool )
 op-Free void ()
-op-Is_commutative () const
-op-Reduce_local void (in:const, , ,in:constref:Datatype, ,) const
 #intra-Allreduce void (in:const , , ,in:constref:Datatype ,in:constref:Op ) const
 #intra-Reduce_scatter void (in:const , , ,in:constref:Datatype ,in:constref:Op ) const
 intra-Scan void (in:const , , ,in:constref:Datatype ,in:constref:Op ) const


### PR DESCRIPTION
On some systems (may due to older version of perl), the generated cxx binding header file contains duplicated Reduce_local function for MPI::Op class.


## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
