### PR TITLE
test/mpi: Add support for GPU testing

### DIFF
--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1489,4 +1489,5 @@
 /cxx/attr/testlist.dtp
 /cxx/datatype/testlist.dtp
 /pt2pt/testlist.dtp
+/pt2pt/testlist.gpu
 /rma/testlist.dtp

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1491,3 +1491,4 @@
 /pt2pt/testlist.dtp
 /pt2pt/testlist.gpu
 /rma/testlist.dtp
+/rma/testlist.gpu

--- a/test/mpi/Makefile_common.mtest
+++ b/test/mpi/Makefile_common.mtest
@@ -12,8 +12,9 @@
 ## Makefile.am
 
 # AM_CPPFLAGS are used for C++ code as well
-AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
-LDADD = $(top_builddir)/util/mtest.$(OBJEXT) $(top_builddir)/util/mtest_common.$(OBJEXT)
+AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include @cuda_CPPFLAGS@
+AM_LDFLAGS = @cuda_LDFLAGS@
+LDADD = $(top_builddir)/util/mtest.$(OBJEXT) $(top_builddir)/util/mtest_common.$(OBJEXT) @cuda_LIBS@
 
 # Add libdtpools support
 AM_CPPFLAGS += -I$(top_srcdir)/dtpools/include

--- a/test/mpi/Makefile_common.mtest
+++ b/test/mpi/Makefile_common.mtest
@@ -29,7 +29,11 @@ $(top_builddir)/util/mtest_common.$(OBJEXT): $(top_srcdir)/util/mtest_common.c
 $(top_builddir)/dtpools/src/libdtpools.la:
 	(cd $(top_builddir)/dtpools && $(MAKE))
 
+if HAVE_CUDA
+TESTLIST ?= testlist,testlist.dtp,testlist.cvar,testlist.gpu
+else
 TESTLIST ?= testlist,testlist.dtp,testlist.cvar
+endif
 SUMMARY_BASENAME ?= summary
 
 testing:

--- a/test/mpi/coll/bcast.c
+++ b/test/mpi/coll/bcast.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include "mpitest.h"
 #include "dtpools.h"
+#include <assert.h>
 
 /*
 static char MTEST_Descrip[] = "Test of broadcast with various roots and datatypes";
@@ -82,10 +83,7 @@ int main(int argc, char *argv[])
                 }
 
                 buf = malloc(obj.DTP_bufsize);
-                if (buf == NULL) {
-                    errs++;
-                    break;
-                }
+                assert(buf);
 
                 if (rank == root) {
                     err = DTP_obj_buf_init(obj, buf, 0, 1, count);

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -153,6 +153,35 @@ fi
 
 AC_SUBST(DTP_SWITCH)
 
+# GPU support
+PAC_PUSH_FLAG([CPPFLAGS])
+PAC_PUSH_FLAG([LDFLAGS])
+PAC_PUSH_FLAG([LIBS])
+PAC_SET_HEADER_LIB_PATH([cuda])
+PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cuda=yes],[have_cuda=no])
+cuda_CPPFLAGS=""
+cuda_LDFLAGS=""
+cuda_LIBS=""
+if test "X${have_cuda}" = "Xyes" ; then
+    AC_DEFINE([HAVE_CUDA],[1],[Define if CUDA is available])
+    if test -n "${with_cuda}" ; then
+        cuda_CPPFLAGS="-I${with_cuda}/include"
+        if test -d ${with_cuda}/lib64 ; then
+            cuda_LDFLAGS="-L${with_cuda}/lib64 -L${with_cuda}/lib"
+        else
+            cuda_LDFLAGS="-L${with_cuda}/lib"
+        fi
+        cuda_LIBS="-lcudart"
+    fi
+fi
+AM_CONDITIONAL([HAVE_CUDA],[test "X${have_cuda}" = "Xyes"])
+AC_SUBST([cuda_CPPFLAGS])
+AC_SUBST([cuda_LDFLAGS])
+AC_SUBST([cuda_LIBS])
+PAC_POP_FLAG([CPPFLAGS])
+PAC_POP_FLAG([LDFLAGS])
+PAC_POP_FLAG([LIBS])
+
 AC_ARG_ENABLE(cxx,
 	[AC_HELP_STRING([--enable-cxx],[Turn on C++ tests (default)])],,[enable_cxx=yes])
 

--- a/test/mpi/include/mtest_common.h
+++ b/test/mpi/include/mtest_common.h
@@ -10,6 +10,19 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef HAVE_CUDA
+#include <cuda_runtime_api.h>
+extern int ndevices;
+extern int device_id;
+#endif
+
+typedef enum {
+    MTEST_MEM_TYPE__UNSET,
+    MTEST_MEM_TYPE__UNREGISTERED_HOST,
+    MTEST_MEM_TYPE__REGISTERED_HOST,
+    MTEST_MEM_TYPE__DEVICE,
+} mtest_mem_type_e;
+
 MPI_Aint MTestDefaultMaxBufferSize();
 
 typedef void MTestArgList;
@@ -18,5 +31,9 @@ char *MTestArgListGetString(MTestArgList * head, const char *arg);
 int MTestArgListGetInt(MTestArgList * head, const char *arg);
 long MTestArgListGetLong(MTestArgList * head, const char *arg);
 void MTestArgListDestroy(MTestArgList * head);
+
+void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devicebuf);
+void MTestFree(mtest_mem_type_e type, void *hostbuf, void *devicebuf);
+void MTestCopyContent(const void *sbuf, void *dbuf, size_t size, mtest_mem_type_e type);
 
 #endif

--- a/test/mpi/include/mtest_common.h
+++ b/test/mpi/include/mtest_common.h
@@ -30,6 +30,7 @@ MTestArgList *MTestArgListCreate(int argc, char *argv[]);
 char *MTestArgListGetString(MTestArgList * head, const char *arg);
 int MTestArgListGetInt(MTestArgList * head, const char *arg);
 long MTestArgListGetLong(MTestArgList * head, const char *arg);
+mtest_mem_type_e MTestArgListGetMemType(MTestArgList * head, const char *arg);
 void MTestArgListDestroy(MTestArgList * head);
 
 void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devicebuf);

--- a/test/mpi/maint/dtp-test-config.txt
+++ b/test/mpi/maint/dtp-test-config.txt
@@ -5,7 +5,7 @@
 # This file is used by autogen.sh to generate multiple binary files for datatype testing.
 # Every line must have the format:
 #
-# <test pathname>:<ssv args>:<ssv counts>:<passthru args>:<procs#>:<mintestsize>:<maxtestsize>:<maxbufsize>
+# <test pathname>:<ssv args>:<ssv counts>:<passthru args>:<procs#>:<mintestsize>:<maxtestsize>:<maxbufsize>:<gacc>
 #
 # <passthru args> are space separated arguments that directly passed to testlist files.
 # It can be used to add attributes such as "timeLimit=<seconds>" and "mem=<GB>".
@@ -16,42 +16,42 @@
 #
 # NOTE: the second (ssv args), fourth (timeLimit) and seventh (maxtestsize) fields are optional.
 
-attr/fkeyvaltype::1::1:1024:
-coll/bcast::1 512::4:16:1024
-coll/bcast::262144:timeLimit=420 mem=1.2:4:16:
-coll/bcast_comm_world_only::1 512::10:16:1024
-coll/bcast_comm_world_only::262144:timeLimit=360 mem=1.9:10:16:
-cxx/attr/fkeyvaltypex::1::1:1024:
-cxx/datatype/packsizex::1::1:1024:
-pt2pt/pingping::1 512 262144 17 1018 65530::2:8:32
-pt2pt/pingping_barrier::1::2:8:32
-pt2pt/sendrecv1::1 512 262144 17 1018 65530::2:32:1024
-pt2pt/sendself::1 512 262144 17 1018 65530::1:32:1024
-rma/accfence1::1 512 17 1018::4:16:1024
-rma/accfence1::65530 262144:mem=1.2:4:16:
-rma/accpscw1::1 512 17 1018::4:16:1024
-rma/accpscw1::65530 262144:mem=1.7:4:16:
-rma/epochtest::1 512 17 1018::4:16:1024
-rma/epochtest::65530 262144:timeLimit=300 mem=5:4:16:
-rma/getfence1::1 512 17 1018::2:16:1024
-rma/getfence1::65530 262144:mem=2:2:16:
-rma/getfence1::16000000:timeLimit=1800 mem=3:2:4:
-rma/lock_contention_dt::1 512 17 1018::4:16:1024
-rma/lock_contention_dt::65530 262144:timeLimit=600 mem=2.1:4:16:
-rma/lock_dt::1 512 262144 17 1018 65530::2:16:1024
-rma/lock_dt_flush::1 512 262144 17 1018 65530::2:16:1024
-rma/lock_dt_flushlocal::1 512 262144 17 1018 65530::2:16:1024
-rma/lockall_dt::1 512 17 1018::4:16:1024
-rma/lockall_dt::65530 262144:timeLimit=600 mem=1.1:4:16:
-rma/lockall_dt_flush::1 512 262144 17 1018::4:16:1024
-rma/lockall_dt_flush::65530:timeLimit=600:4:16:
-rma/lockall_dt_flushall::1 512 262144 17 1018::4:16:1024
-rma/lockall_dt_flushall::65530:timeLimit=600:4:16:
-rma/lockall_dt_flushlocal::1 512 17 1018::4:16:1024
-rma/lockall_dt_flushlocal::65530 262144:timeLimit=600 mem=5:4:16:
-rma/lockall_dt_flushlocalall::1 512 17 1018::4:16:1024
-rma/lockall_dt_flushlocalall::65530 262144:timeLimit=600 mem=3:4:16:
-rma/putfence1::1 512 262144 17 1018 65530::2:16:1024
-rma/putfence1::16000000:timeLimit=1800 mem=2:2:4:
-rma/putpscw1::1 512 17 1018::4:16:1024
-rma/putpscw1::65530 262144:mem=4:4:16:
+attr/fkeyvaltype::1::1:1024::0
+coll/bcast::1 512::4:16:1024:0
+coll/bcast::262144:timeLimit=420 mem=1.2:4:16::0
+coll/bcast_comm_world_only::1 512::10:16:1024:0
+coll/bcast_comm_world_only::262144:timeLimit=360 mem=1.9:10:16::0
+cxx/attr/fkeyvaltypex::1::1:1024::0
+cxx/datatype/packsizex::1::1:1024::0
+pt2pt/pingping::1 512 262144 17 1018 65530::2:8:32:0
+pt2pt/pingping_barrier::1::2:8:32:0
+pt2pt/sendrecv1::1 512 262144 17 1018 65530::2:32:1024:0
+pt2pt/sendself::1 512 262144 17 1018 65530::1:32:1024:0
+rma/accfence1::1 512 17 1018::4:16:1024:0
+rma/accfence1::65530 262144:mem=1.2:4:16::0
+rma/accpscw1::1 512 17 1018::4:16:1024:0
+rma/accpscw1::65530 262144:mem=1.7:4:16::0
+rma/epochtest::1 512 17 1018::4:16:1024:0
+rma/epochtest::65530 262144:timeLimit=300 mem=5:4:16::0
+rma/getfence1::1 512 17 1018::2:16:1024:0
+rma/getfence1::65530 262144:mem=2:2:16::0
+rma/getfence1::16000000:timeLimit=1800 mem=3:2:4::0
+rma/lock_contention_dt::1 512 17 1018::4:16:1024:1
+rma/lock_contention_dt::65530 262144:timeLimit=600 mem=2.1:4:16::1
+rma/lock_dt::1 512 262144 17 1018 65530::2:16:1024:1
+rma/lock_dt_flush::1 512 262144 17 1018 65530::2:16:1024:1
+rma/lock_dt_flushlocal::1 512 262144 17 1018 65530::2:16:1024:1
+rma/lockall_dt::1 512 17 1018::4:16:1024:1
+rma/lockall_dt::65530 262144:timeLimit=600 mem=1.1:4:16::1
+rma/lockall_dt_flush::1 512 262144 17 1018::4:16:1024:1
+rma/lockall_dt_flush::65530:timeLimit=600:4:16::1
+rma/lockall_dt_flushall::1 512 262144 17 1018::4:16:1024:1
+rma/lockall_dt_flushall::65530:timeLimit=600:4:16::1
+rma/lockall_dt_flushlocal::1 512 17 1018::4:16:1024:1
+rma/lockall_dt_flushlocal::65530 262144:timeLimit=600 mem=5:4:16::1
+rma/lockall_dt_flushlocalall::1 512 17 1018::4:16:1024:1
+rma/lockall_dt_flushlocalall::65530 262144:timeLimit=600 mem=3:4:16::1
+rma/putfence1::1 512 262144 17 1018 65530::2:16:1024:0
+rma/putfence1::16000000:timeLimit=1800 mem=2:2:4::0
+rma/putpscw1::1 512 17 1018::4:16:1024:0
+rma/putpscw1::65530 262144:mem=4:4:16::0

--- a/test/mpi/maint/gentests_dtp.sh
+++ b/test/mpi/maint/gentests_dtp.sh
@@ -159,6 +159,38 @@ while read -r line ; do
                     echo "${testname} $procs arg=-type=${type} arg=-sendcnt=${sendcount} arg=-recvcnt=${recvcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-sendmem=device arg=-recvmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
                     seed=$((seed + 1))
                 done
+            elif [ $testdir = "rma" ] ; then
+                if [ $gacc = "1" ] ; then # specify resultmem for MPI_GET_ACCUMULATE tests
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${testsize} ${other_args} arg=-origmem=host arg=-targetmem=host arg=-resultmem=host $timelimit" >> ${builddir}/${testdir}/testlist.dtp
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-origmem=host arg=-targetmem=device arg=-resultmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=$((gputestsize / 2)) ${other_args} arg=-origmem=reg_host arg=-targetmem=device arg=-resultmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-origmem=device arg=-targetmem=host arg=-resultmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=$((gputestsize / 2)) ${other_args} arg=-origmem=device arg=-targetmem=reg_host arg=-resultmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-origmem=device arg=-targetmem=device arg=-resultmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-origmem=device arg=-targetmem=host arg=-resultmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-origmem=device arg=-targetmem=host arg=-resultmem=reg_host $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                else
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${testsize} ${other_args} arg=-origmem=host arg=-targetmem=host $timelimit" >> ${builddir}/${testdir}/testlist.dtp
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-origmem=host arg=-targetmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=$((gputestsize / 2)) ${other_args} arg=-origmem=reg_host arg=-targetmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-origmem=device arg=-targetmem=host $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=$((gputestsize / 2)) ${other_args} arg=-origmem=device arg=-targetmem=reg_host $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-origmem=device arg=-targetmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    fi
             else
                 echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${testsize} ${other_args} $timelimit" >> ${builddir}/${testdir}/testlist.dtp
                 seed=$((seed + 1))

--- a/test/mpi/maint/gentests_dtp.sh
+++ b/test/mpi/maint/gentests_dtp.sh
@@ -112,6 +112,7 @@ while read -r line ; do
     if test "$found" = "0" ; then
         dirs="$dirs $testdir"
         printf "" > ${builddir}/${testdir}/testlist.dtp
+        printf "" > ${builddir}/${testdir}/testlist.gpu
     fi
 
     # prepare extra args
@@ -137,13 +138,24 @@ while read -r line ; do
                 if [ $testsize -lt $mintestsize ] ; then testsize=$mintestsize; fi
                 if [ $testsize -gt $maxtestsize ] ; then testsize=$maxtestsize; fi
             fi
+            gputestsize=$((testsize / 2)) # reduce GPU test iteration to avoid timeouts
 
             if [ $testdir = "pt2pt" ] ; then # only send/recv comm can use types from different pools
                 # do combination of different send recv count where recv count >= send count
                 # limit the mixed pool case to only one
                 # TODO: this should be defined in the config file
                 for recvcount in $sendcount $((sendcount * 2)) ; do
-                    echo "${testname} $procs arg=-type=${type} arg=-sendcnt=${sendcount} arg=-recvcnt=${recvcount} arg=-seed=$seed arg=-testsize=${testsize} ${other_args} $timelimit" >> ${builddir}/${testdir}/testlist.dtp
+                    echo "${testname} $procs arg=-type=${type} arg=-sendcnt=${sendcount} arg=-recvcnt=${recvcount} arg=-seed=$seed arg=-testsize=${testsize} ${other_args} arg=-sendmem=host arg=-recvmem=host $timelimit" >> ${builddir}/${testdir}/testlist.dtp
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-sendcnt=${sendcount} arg=-recvcnt=${recvcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-sendmem=host arg=-recvmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-sendcnt=${sendcount} arg=-recvcnt=${recvcount} arg=-seed=$seed arg=-testsize=$((gputestsize / 2)) ${other_args} arg=-sendmem=reg_host arg=-recvmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-sendcnt=${sendcount} arg=-recvcnt=${recvcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-sendmem=device arg=-recvmem=host $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-sendcnt=${sendcount} arg=-recvcnt=${recvcount} arg=-seed=$seed arg=-testsize=$((gputestsize / 2)) ${other_args} arg=-sendmem=device arg=-recvmem=reg_host $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                    seed=$((seed + 1))
+                    echo "${testname} $procs arg=-type=${type} arg=-sendcnt=${sendcount} arg=-recvcnt=${recvcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-sendmem=device arg=-recvmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
                     seed=$((seed + 1))
                 done
             else

--- a/test/mpi/maint/gentests_dtp.sh
+++ b/test/mpi/maint/gentests_dtp.sh
@@ -72,6 +72,7 @@ while read -r line ; do
         procs=`echo $line | cut -f5 -d':'`
         mintestsize=`echo $line | cut -f6 -d':'`
         maxtestsize=`echo $line | cut -f7 -d':'`
+        gacc=`echo $line | cut -f8 -d':'`
         other_args=""
     else
         # the line is a comment

--- a/test/mpi/maint/gentests_dtp.sh
+++ b/test/mpi/maint/gentests_dtp.sh
@@ -191,6 +191,15 @@ while read -r line ; do
                     echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-origmem=device arg=-targetmem=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
                     seed=$((seed + 1))
                     fi
+            elif [ $testdir = "coll" ] ; then
+                echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${testsize} ${other_args} arg=-evenmemtype=host arg=-oddmemtype=host $timelimit" >> ${builddir}/${testdir}/testlist.dtp
+                seed=$((seed + 1))
+                echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-evenmemtype=host arg=-oddmemtype=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                seed=$((seed + 1))
+                echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-evenmemtype=device arg=-oddmemtype=reg_host $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                seed=$((seed + 1))
+                echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${gputestsize} ${other_args} arg=-evenmemtype=device arg=-oddmemtype=device $timelimit" >> ${builddir}/${testdir}/testlist.gpu
+                seed=$((seed + 1))
             else
                 echo "${testname} $procs arg=-type=${type} arg=-count=${sendcount} arg=-seed=$seed arg=-testsize=${testsize} ${other_args} $timelimit" >> ${builddir}/${testdir}/testlist.dtp
                 seed=$((seed + 1))

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include "mpitest.h"
 #include "dtpools.h"
+#include <assert.h>
 
 /*
 static char MTEST_Descrip[] = "Send flood test";
@@ -102,10 +103,7 @@ int main(int argc, char *argv[])
 
             if (rank == source) {
                 MTestAlloc(send_obj.DTP_bufsize, sendmem, &sendbuf_h, &sendbuf);
-                if (sendbuf == NULL || sendbuf_h == NULL) {
-                    errs++;
-                    break;
-                }
+                assert(sendbuf && sendbuf_h);
 
                 err = DTP_obj_buf_init(send_obj, sendbuf_h, 0, 1, count[0]);
                 if (err != DTP_SUCCESS) {
@@ -138,10 +136,7 @@ int main(int argc, char *argv[])
                 MTestFree(sendmem, sendbuf_h, sendbuf);
             } else if (rank == dest) {
                 MTestAlloc(recv_obj.DTP_bufsize, recvmem, &recvbuf_h, &recvbuf);
-                if (recvbuf == NULL) {
-                    errs++;
-                    break;
-                }
+                assert(recvbuf && recvbuf_h);
 
                 recvcount = recv_obj.DTP_type_count;
                 recvtype = recv_obj.DTP_datatype;

--- a/test/mpi/pt2pt/sendrecv1.c
+++ b/test/mpi/pt2pt/sendrecv1.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include "mpitest.h"
 #include "dtpools.h"
+#include <assert.h>
 
 /*
 static char MTEST_Descrip[] = "Send-Recv";
@@ -92,10 +93,7 @@ int main(int argc, char *argv[])
 
             if (rank == source) {
                 MTestAlloc(send_obj.DTP_bufsize, sendmem, &sendbuf_h, &sendbuf);
-                if (sendbuf == NULL || sendbuf_h == NULL) {
-                    errs++;
-                    break;
-                }
+                assert(sendbuf && sendbuf_h);
 
                 err = DTP_obj_buf_init(send_obj, sendbuf_h, 0, 1, count[0]);
                 if (err != DTP_SUCCESS) {
@@ -119,10 +117,7 @@ int main(int argc, char *argv[])
                 MTestFree(sendmem, sendbuf_h, sendbuf);
             } else if (rank == dest) {
                 MTestAlloc(recv_obj.DTP_bufsize, recvmem, &recvbuf_h, &recvbuf);
-                if (recvbuf == NULL || recvbuf_h == NULL) {
-                    errs++;
-                    break;
-                }
+                assert(recvbuf && recvbuf_h);
 
                 err = DTP_obj_buf_init(recv_obj, recvbuf_h, -1, -1, count[0]);
                 if (err != DTP_SUCCESS) {

--- a/test/mpi/pt2pt/sendrecv1.c
+++ b/test/mpi/pt2pt/sendrecv1.c
@@ -27,7 +27,10 @@ int main(int argc, char *argv[])
     DTP_pool_s dtp;
     DTP_obj_s send_obj, recv_obj;
     void *sendbuf, *recvbuf;
+    void *sendbuf_h, *recvbuf_h;
     char *basic_type;
+    mtest_mem_type_e sendmem;
+    mtest_mem_type_e recvmem;
 
     MTest_Init(&argc, &argv);
 
@@ -37,6 +40,8 @@ int main(int argc, char *argv[])
     count[0] = MTestArgListGetLong(head, "sendcnt");
     count[1] = MTestArgListGetLong(head, "recvcnt");
     basic_type = MTestArgListGetString(head, "type");
+    sendmem = MTestArgListGetMemType(head, "sendmem");
+    recvmem = MTestArgListGetMemType(head, "recvmem");
 
     maxbufsize = MTestDefaultMaxBufferSize();
 
@@ -86,17 +91,18 @@ int main(int argc, char *argv[])
             }
 
             if (rank == source) {
-                sendbuf = malloc(send_obj.DTP_bufsize);
-                if (sendbuf == NULL) {
+                MTestAlloc(send_obj.DTP_bufsize, sendmem, &sendbuf_h, &sendbuf);
+                if (sendbuf == NULL || sendbuf_h == NULL) {
                     errs++;
                     break;
                 }
 
-                err = DTP_obj_buf_init(send_obj, sendbuf, 0, 1, count[0]);
+                err = DTP_obj_buf_init(send_obj, sendbuf_h, 0, 1, count[0]);
                 if (err != DTP_SUCCESS) {
                     errs++;
                     break;
                 }
+                MTestCopyContent(sendbuf_h, sendbuf, send_obj.DTP_bufsize, sendmem);
 
                 sendcount = send_obj.DTP_type_count;
                 sendtype = send_obj.DTP_datatype;
@@ -110,19 +116,20 @@ int main(int argc, char *argv[])
                     }
                 }
 
-                free(sendbuf);
+                MTestFree(sendmem, sendbuf_h, sendbuf);
             } else if (rank == dest) {
-                recvbuf = malloc(recv_obj.DTP_bufsize);
-                if (recvbuf == NULL) {
+                MTestAlloc(recv_obj.DTP_bufsize, recvmem, &recvbuf_h, &recvbuf);
+                if (recvbuf == NULL || recvbuf_h == NULL) {
                     errs++;
                     break;
                 }
 
-                err = DTP_obj_buf_init(recv_obj, recvbuf, -1, -1, count[0]);
+                err = DTP_obj_buf_init(recv_obj, recvbuf_h, -1, -1, count[0]);
                 if (err != DTP_SUCCESS) {
                     errs++;
                     break;
                 }
+                MTestCopyContent(recvbuf_h, recvbuf, recv_obj.DTP_bufsize, recvmem);
 
                 recvcount = recv_obj.DTP_type_count;
                 recvtype = recv_obj.DTP_datatype;
@@ -137,6 +144,7 @@ int main(int argc, char *argv[])
                     }
                 }
 
+                MTestCopyContent(recvbuf, recvbuf_h, recv_obj.DTP_bufsize, recvmem);
                 err = DTP_obj_buf_check(recv_obj, recvbuf, 0, 1, count[0]);
                 if (err != DTP_SUCCESS) {
                     if (errs < 10) {
@@ -152,7 +160,7 @@ int main(int argc, char *argv[])
                     errs++;
                 }
 
-                free(recvbuf);
+                MTestFree(recvmem, recvbuf_h, recvbuf);
             }
             DTP_obj_free(recv_obj);
             DTP_obj_free(send_obj);

--- a/test/mpi/pt2pt/sendself.c
+++ b/test/mpi/pt2pt/sendself.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include "mpitest.h"
 #include "dtpools.h"
+#include <assert.h>
 
 /*
 static char MTEST_Descrip[] = "Test of sending to self (with a preposted receive)";
@@ -73,16 +74,10 @@ int main(int argc, char *argv[])
         }
 
         MTestAlloc(send_obj.DTP_bufsize, sendmem, &sendbuf_h, &sendbuf);
-        if (sendbuf_h == NULL || sendbuf == NULL) {
-            errs++;
-            break;
-        }
+        assert(sendbuf && sendbuf_h);
 
         MTestAlloc(recv_obj.DTP_bufsize, recvmem, &recvbuf_h, &recvbuf);
-        if (recvbuf_h == NULL || recvbuf == NULL) {
-            errs++;
-            break;
-        }
+        assert(recvbuf && recvbuf_h);
 
         err = DTP_obj_buf_init(send_obj, sendbuf_h, 0, 1, count[0]);
         if (err != DTP_SUCCESS) {

--- a/test/mpi/rma/accfence1.c
+++ b/test/mpi/rma/accfence1.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include "mpitest.h"
 #include "dtpools.h"
+#include <assert.h>
 
 /*
 static char MTEST_Descrip[] = "Accumulate/Replace with Fence";
@@ -67,8 +68,7 @@ int main(int argc, char *argv[])
     }
 
     MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
-    if (targetbuf == NULL || targetbuf_h == NULL)
-        errs++;
+    assert(targetbuf && targetbuf_h);
 
     /* The following illustrates the use of the routines to
      * run through a selection of communicators and datatypes.
@@ -123,10 +123,7 @@ int main(int argc, char *argv[])
 
             if (rank == orig) {
                 MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
-                if (origbuf == NULL || origbuf_h == NULL) {
-                    errs++;
-                    break;
-                }
+                assert(origbuf && origbuf_h);
 
                 err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {

--- a/test/mpi/rma/accfence1.c
+++ b/test/mpi/rma/accfence1.c
@@ -35,7 +35,10 @@ int main(int argc, char *argv[])
     DTP_pool_s dtp;
     DTP_obj_s orig_obj, target_obj;
     void *origbuf, *targetbuf;
+    void *origbuf_h, *targetbuf_h;
     char *basic_type;
+    mtest_mem_type_e origmem;
+    mtest_mem_type_e targetmem;
 
     MTest_Init(&argc, &argv);
 
@@ -44,6 +47,8 @@ int main(int argc, char *argv[])
     testsize = MTestArgListGetInt(head, "testsize");
     count = MTestArgListGetLong(head, "count");
     basic_type = MTestArgListGetString(head, "type");
+    origmem = MTestArgListGetMemType(head, "origmem");
+    targetmem = MTestArgListGetMemType(head, "targetmem");
 
     maxbufsize = MTestDefaultMaxBufferSize();
 
@@ -61,8 +66,8 @@ int main(int argc, char *argv[])
         goto fn_exit;
     }
 
-    targetbuf = malloc(maxbufsize);
-    if (targetbuf == NULL)
+    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
+    if (targetbuf == NULL || targetbuf_h == NULL)
         errs++;
 
     /* The following illustrates the use of the routines to
@@ -104,11 +109,12 @@ int main(int argc, char *argv[])
                 break;
             }
 
-            err = DTP_obj_buf_init(target_obj, targetbuf, -1, -1, count);
+            err = DTP_obj_buf_init(target_obj, targetbuf_h, -1, -1, count);
             if (err != DTP_SUCCESS) {
                 errs++;
                 break;
             }
+            MTestCopyContent(targetbuf_h, targetbuf, maxbufsize, targetmem);
 
             targetcount = target_obj.DTP_type_count;
             targettype = target_obj.DTP_datatype;
@@ -116,17 +122,18 @@ int main(int argc, char *argv[])
             MPI_Win_fence(0, win);
 
             if (rank == orig) {
-                origbuf = malloc(orig_obj.DTP_bufsize);
-                if (origbuf == NULL) {
+                MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
+                if (origbuf == NULL || origbuf_h == NULL) {
                     errs++;
                     break;
                 }
 
-                err = DTP_obj_buf_init(orig_obj, origbuf, 0, 1, count);
+                err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {
                     errs++;
                     break;
                 }
+                MTestCopyContent(origbuf_h, origbuf, orig_obj.DTP_bufsize, origmem);
 
                 origcount = orig_obj.DTP_type_count;
                 origtype = orig_obj.DTP_datatype;
@@ -158,12 +165,13 @@ int main(int argc, char *argv[])
                     }
                 }
 
-                free(origbuf);
+                MTestFree(origmem, origbuf_h, origbuf);
             } else if (rank == target) {
                 MPI_Win_fence(0, win);
                 /* This should have the same effect, in terms of
                  * transfering data, as a send/recv pair */
-                err = DTP_obj_buf_check(target_obj, targetbuf, 0, 1, count);
+                MTestCopyContent(targetbuf, targetbuf_h, target_obj.DTP_bufsize, targetmem);
+                err = DTP_obj_buf_check(target_obj, targetbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {
                     char *orig_desc, *target_desc;
                     DTP_obj_get_description(orig_obj, &orig_desc);
@@ -186,7 +194,7 @@ int main(int argc, char *argv[])
         MTestFreeComm(&comm);
     }
 
-    free(targetbuf);
+    MTestFree(targetmem, targetbuf_h, targetbuf);
 
   fn_exit:
     DTP_pool_free(dtp);

--- a/test/mpi/rma/accpscw1.c
+++ b/test/mpi/rma/accpscw1.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include "mpitest.h"
 #include "dtpools.h"
+#include <assert.h>
 
 /*
 static char MTEST_Descrip[] = "Accumulate/replace with Post/Start/Complete/Wait";
@@ -64,8 +65,7 @@ int main(int argc, char *argv[])
     }
 
     MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
-    if (targetbuf == NULL || targetbuf_h == NULL)
-        errs++;
+    assert(targetbuf && targetbuf_h);
 
     /* The following illustrates the use of the routines to
      * run through a selection of communicators and datatypes.
@@ -119,10 +119,7 @@ int main(int argc, char *argv[])
 
             if (rank == orig) {
                 MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
-                if (origbuf == NULL || origbuf_h == NULL) {
-                    errs++;
-                    break;
-                }
+                assert(origbuf && origbuf_h);
 
                 err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {

--- a/test/mpi/rma/accpscw1.c
+++ b/test/mpi/rma/accpscw1.c
@@ -31,7 +31,10 @@ int main(int argc, char *argv[])
     DTP_pool_s dtp;
     DTP_obj_s orig_obj, target_obj;
     void *origbuf, *targetbuf;
+    void *origbuf_h, *targetbuf_h;
     char *basic_type;
+    mtest_mem_type_e origmem;
+    mtest_mem_type_e targetmem;
 
     MTest_Init(&argc, &argv);
 
@@ -40,6 +43,8 @@ int main(int argc, char *argv[])
     testsize = MTestArgListGetInt(head, "testsize");
     count = MTestArgListGetLong(head, "count");
     basic_type = MTestArgListGetString(head, "type");
+    origmem = MTestArgListGetMemType(head, "origmem");
+    targetmem = MTestArgListGetMemType(head, "targetmem");
 
     maxbufsize = MTestDefaultMaxBufferSize();
 
@@ -58,8 +63,8 @@ int main(int argc, char *argv[])
         goto fn_exit;
     }
 
-    targetbuf = malloc(maxbufsize);
-    if (targetbuf == NULL)
+    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
+    if (targetbuf == NULL || targetbuf_h == NULL)
         errs++;
 
     /* The following illustrates the use of the routines to
@@ -102,23 +107,29 @@ int main(int argc, char *argv[])
                 break;
             }
 
-            err = DTP_obj_buf_init(target_obj, targetbuf, -1, -1, count);
+            err = DTP_obj_buf_init(target_obj, targetbuf_h, -1, -1, count);
             if (err != DTP_SUCCESS) {
                 errs++;
                 break;
             }
+            MTestCopyContent(targetbuf_h, targetbuf, maxbufsize, targetmem);
 
             targetcount = target_obj.DTP_type_count;
             targettype = target_obj.DTP_datatype;
 
             if (rank == orig) {
-                origbuf = malloc(orig_obj.DTP_bufsize);
+                MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
+                if (origbuf == NULL || origbuf_h == NULL) {
+                    errs++;
+                    break;
+                }
 
-                err = DTP_obj_buf_init(orig_obj, origbuf, 0, 1, count);
+                err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {
                     errs++;
                     break;
                 }
+                MTestCopyContent(origbuf_h, origbuf, orig_obj.DTP_bufsize, origmem);
 
                 origcount = orig_obj.DTP_type_count;
                 origtype = orig_obj.DTP_datatype;
@@ -148,7 +159,7 @@ int main(int argc, char *argv[])
                     }
                 }
 
-                free(origbuf);
+                MTestFree(origmem, origbuf_h, origbuf);
             } else if (rank == target) {
                 MPI_Group_incl(wingroup, 1, &orig, &neighbors);
                 MPI_Win_post(neighbors, 0, win);
@@ -156,7 +167,8 @@ int main(int argc, char *argv[])
                 MPI_Win_wait(win);
                 /* This should have the same effect, in terms of
                  * transfering data, as a send/recv pair */
-                err = DTP_obj_buf_check(target_obj, targetbuf, 0, 1, count);
+                MTestCopyContent(targetbuf, targetbuf_h, maxbufsize, targetmem);
+                err = DTP_obj_buf_check(target_obj, targetbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {
                     errs++;
                     if (errs < 10) {
@@ -184,7 +196,7 @@ int main(int argc, char *argv[])
         MTestFreeComm(&comm);
     }
 
-    free(targetbuf);
+    MTestFree(targetmem, targetbuf_h, targetbuf);
 
   fn_exit:
     DTP_pool_free(dtp);

--- a/test/mpi/rma/epochtest.c
+++ b/test/mpi/rma/epochtest.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include "mpitest.h"
 #include "dtpools.h"
+#include <assert.h>
 
 /*
 static char MTEST_Descrip[] = "Put with Fences used to separate epochs";
@@ -88,8 +89,7 @@ int main(int argc, char **argv)
     }
 
     MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
-    if (targetbuf == NULL || targetbuf_h == NULL)
-        errs++;
+    assert(targetbuf && targetbuf_h);
 
     while (MTestGetIntracommGeneral(&comm, minsize, 1)) {
         if (comm == MPI_COMM_NULL) {
@@ -126,10 +126,7 @@ int main(int argc, char **argv)
             }
 
             MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
-            if (origbuf == NULL || origbuf_h == NULL) {
-                errs++;
-                break;
-            }
+            assert(origbuf && origbuf_h);
 
             err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);
             if (err != DTP_SUCCESS) {

--- a/test/mpi/rma/fence.c
+++ b/test/mpi/rma/fence.c
@@ -15,6 +15,10 @@
 static char MTEST_Descrip[] = "Get with Fence";
 */
 
+static mtest_mem_type_e origmem;
+static mtest_mem_type_e targetmem;
+static void *targetbuf_h;
+
 static inline int test(MPI_Comm comm, int rank, int orig, int target,
                        MPI_Aint count, MPI_Aint maxbufsize,
                        DTP_obj_s orig_obj, DTP_pool_s dtp, DTP_obj_s target_obj, void *targetbuf,
@@ -25,6 +29,7 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
     MPI_Aint extent, lb;
     MPI_Datatype origtype, targettype;
     void *origbuf;
+    void *origbuf_h;
 
     origtype = orig_obj.DTP_datatype;
     origcount = orig_obj.DTP_type_count;
@@ -44,11 +49,13 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
         if (err != DTP_SUCCESS) {
             return ++errs;
         }
+        MTestCopyContent(targetbuf_h, targetbuf, maxbufsize, targetmem);
 #elif defined(USE_PUT)
         err = DTP_obj_buf_init(target_obj, targetbuf, -1, -1, count);
         if (err != DTP_SUCCESS) {
             return ++errs;
         }
+        MTestCopyContent(targetbuf_h, targetbuf, maxbufsize, targetmem);
 #endif
 
         /* The target does not need to do anything besides the
@@ -57,7 +64,8 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
         MPI_Win_fence(0, win);
 
 #if defined(USE_PUT)
-        err = DTP_obj_buf_check(target_obj, targetbuf, 0, 1, count);
+        MTestCopyContent(targetbuf, targetbuf_h, maxbufsize, targetmem);
+        err = DTP_obj_buf_check(target_obj, targetbuf_h, 0, 1, count);
         if (err != DTP_SUCCESS) {
             errs++;
             if (errs < 10) {
@@ -68,20 +76,22 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
         }
 #endif
     } else if (rank == orig) {
-        origbuf = malloc(orig_obj.DTP_bufsize);
-        if (origbuf == NULL)
+        MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
+        if (origbuf == NULL || origbuf_h == NULL)
             return ++errs;
 
 #if defined(USE_GET)
-        err = DTP_obj_buf_init(orig_obj, origbuf, -1, -1, count);
+        err = DTP_obj_buf_init(orig_obj, origbuf_h, -1, -1, count);
         if (err != DTP_SUCCESS) {
             return ++errs;
         }
+        MTestCopyContent(origbuf_h, origbuf, orig_obj.DTP_bufsize, origmem);
 #elif defined(USE_PUT)
-        err = DTP_obj_buf_init(orig_obj, origbuf, 0, 1, count);
+        err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);
         if (err != DTP_SUCCESS) {
             return ++errs;
         }
+        MTestCopyContent(origbuf_h, origbuf, orig_obj.DTP_bufsize, origmem);
 #endif
 
         /* To improve reporting of problems about operations, we
@@ -123,7 +133,8 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
             }
         }
 #if defined(USE_GET)
-        err = DTP_obj_buf_check(orig_obj, origbuf, 0, 1, count);
+        MTestCopyContent(origbuf, origbuf_h, orig_obj.DTP_bufsize, origmem);
+        err = DTP_obj_buf_check(orig_obj, origbuf_h, 0, 1, count);
         if (err != DTP_SUCCESS) {
             errs++;
             if (errs < 10) {
@@ -134,7 +145,7 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
         }
 #endif
 
-        free(origbuf);
+        MTestFree(origmem, origbuf_h, origbuf);
     } else {
         MPI_Win_fence(0, win);
         MPI_Win_fence(0, win);
@@ -170,6 +181,8 @@ int main(int argc, char *argv[])
     testsize = MTestArgListGetInt(head, "testsize");
     count = MTestArgListGetLong(head, "count");
     basic_type = MTestArgListGetString(head, "type");
+    origmem = MTestArgListGetMemType(head, "origmem");
+    targetmem = MTestArgListGetMemType(head, "targetmem");
 
     maxbufsize = MTestDefaultMaxBufferSize();
 
@@ -198,8 +211,8 @@ int main(int argc, char *argv[])
         goto fn_exit;
     }
 
-    targetbuf = malloc(maxbufsize);
-    if (targetbuf == NULL) {
+    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
+    if (targetbuf == NULL || targetbuf_h == NULL) {
         return ++errs;
     }
 
@@ -249,7 +262,7 @@ int main(int argc, char *argv[])
         MTestFreeComm(&comm);
     }
 
-    free(targetbuf);
+    MTestFree(targetmem, targetbuf_h, targetbuf);
 
   fn_exit:
     DTP_pool_free(dtp);

--- a/test/mpi/rma/fence.c
+++ b/test/mpi/rma/fence.c
@@ -10,6 +10,7 @@
 #include <limits.h>
 #include "mpitest.h"
 #include "dtpools.h"
+#include <assert.h>
 
 /*
 static char MTEST_Descrip[] = "Get with Fence";
@@ -77,8 +78,7 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
 #endif
     } else if (rank == orig) {
         MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
-        if (origbuf == NULL || origbuf_h == NULL)
-            return ++errs;
+        assert(origbuf && origbuf_h);
 
 #if defined(USE_GET)
         err = DTP_obj_buf_init(orig_obj, origbuf_h, -1, -1, count);
@@ -212,9 +212,7 @@ int main(int argc, char *argv[])
     }
 
     MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
-    if (targetbuf == NULL || targetbuf_h == NULL) {
-        return ++errs;
-    }
+    assert(targetbuf && targetbuf_h);
 
     /* The following illustrates the use of the routines to
      * run through a selection of communicators and datatypes.

--- a/test/mpi/rma/lock_x_dt.c
+++ b/test/mpi/rma/lock_x_dt.c
@@ -19,6 +19,14 @@ enum acc_type {
     ACC_TYPE__GACC,
 };
 
+static mtest_mem_type_e origmem;
+static mtest_mem_type_e targetmem;
+static mtest_mem_type_e resultmem;
+static void *origbuf_h;
+static void *targetbuf_h;
+static void *resultbuf_h;
+static MPI_Aint maxbufsize;
+
 static int run_test(MPI_Comm comm, MPI_Win win, DTP_obj_s orig_obj, void *origbuf,
                     DTP_pool_s dtp, DTP_obj_s target_obj, void *targetbuf,
                     DTP_obj_s result_obj, void *resultbuf, int count, enum acc_type acc)
@@ -100,12 +108,13 @@ static int run_test(MPI_Comm comm, MPI_Win win, DTP_obj_s orig_obj, void *origbu
      * second one informs the origin that the target is done
      * checking. */
     if (rank == orig) {
-        origbuf = malloc(orig_obj.DTP_bufsize);
-        assert(origbuf);
+        MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
+        assert(origbuf && origbuf_h);
 
-        err = DTP_obj_buf_init(orig_obj, origbuf, 0, 1, count);
+        err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);
         if (err != DTP_SUCCESS)
             errs++;
+        MTestCopyContent(origbuf_h, origbuf, orig_obj.DTP_bufsize, origmem);
 
         if (lock_type == LOCK_TYPE__LOCK) {
             MPI_Win_lock(MPI_LOCK_SHARED, target, 0, win);
@@ -131,13 +140,14 @@ static int run_test(MPI_Comm comm, MPI_Win win, DTP_obj_s orig_obj, void *origbu
                                targettype, MPI_REPLACE, win);
             }
         } else {
-            resultbuf = malloc(result_obj.DTP_bufsize);
-            assert(resultbuf);
+            MTestAlloc(result_obj.DTP_bufsize, resultmem, &resultbuf_h, &resultbuf);
+            assert(resultbuf && resultbuf_h);
 
 #if !defined(MULTI_ORIGIN) && !defined(MULTI_TARGET)
             err = DTP_obj_buf_init(result_obj, resultbuf, -1, -1, count);
             if (err != DTP_SUCCESS)
                 errs++;
+            MTestCopyContent(resultbuf_h, resultbuf, result_obj.DTP_bufsize, resultmem);
 #endif
 
             for (t = target_start_idx; t <= target_end_idx; t++) {
@@ -152,11 +162,13 @@ static int run_test(MPI_Comm comm, MPI_Win win, DTP_obj_s orig_obj, void *origbu
             for (t = target_start_idx; t <= target_end_idx; t++)
                 MPI_Win_flush_local(t, win);
             /* reset the send buffer to test local completion */
-            DTP_obj_buf_init(orig_obj, origbuf, 0, 0, count);
+            DTP_obj_buf_init(orig_obj, origbuf_h, 0, 0, count);
+            MTestCopyContent(origbuf_h, origbuf, orig_obj.DTP_bufsize, origmem);
         } else if (flush_local_type == FLUSH_LOCAL_TYPE__FLUSH_LOCAL_ALL) {
             MPI_Win_flush_local_all(win);
             /* reset the send buffer to test local completion */
-            DTP_obj_buf_init(orig_obj, origbuf, 0, 0, count);
+            DTP_obj_buf_init(orig_obj, origbuf_h, 0, 0, count);
+            MTestCopyContent(origbuf_h, origbuf, orig_obj.DTP_bufsize, origmem);
         }
 
         if (flush_type == FLUSH_TYPE__FLUSH_ALL) {
@@ -187,20 +199,22 @@ static int run_test(MPI_Comm comm, MPI_Win win, DTP_obj_s orig_obj, void *origbu
             /* this check is not valid for multi-origin tests, as some
              * origins might receive the value that has already been
              * overwritten by other origins */
+            MTestCopyContent(resultbuf, resultbuf_h, result_obj.DTP_bufsize, resultmem);
             err = DTP_obj_buf_check(result_obj, resultbuf, 1, 2, count);
             if (err != DTP_SUCCESS)
                 errs++;
 #endif
 
-            free(resultbuf);
+            MTestFree(resultmem, resultbuf_h, resultbuf);
         }
 
-        free(origbuf);
+        MTestFree(origmem, origbuf_h, origbuf);
     } else if (rank == target) {
         MPI_Barrier(comm);
         MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, win);
 
-        err = DTP_obj_buf_check(target_obj, targetbuf, 0, 1, count);
+        MTestCopyContent(targetbuf, targetbuf_h, maxbufsize, targetmem);
+        err = DTP_obj_buf_check(target_obj, targetbuf_h, 0, 1, count);
         if (err != DTP_SUCCESS)
             errs++;
 
@@ -226,7 +240,7 @@ int main(int argc, char *argv[])
     int i, seed, testsize;
     MPI_Comm comm;
     MPI_Win win;
-    MPI_Aint lb, extent, count, maxbufsize;
+    MPI_Aint lb, extent, count;
     DTP_obj_s orig_obj, target_obj, result_obj;
     DTP_pool_s dtp;
     void *origbuf, *targetbuf, *resultbuf;
@@ -239,6 +253,9 @@ int main(int argc, char *argv[])
     testsize = MTestArgListGetInt(head, "testsize");
     count = MTestArgListGetLong(head, "count");
     basic_type = MTestArgListGetString(head, "type");
+    origmem = MTestArgListGetMemType(head, "origmem");
+    targetmem = MTestArgListGetMemType(head, "targetmem");
+    resultmem = MTestArgListGetMemType(head, "resultmem");
 
     maxbufsize = MTestDefaultMaxBufferSize();
 
@@ -257,8 +274,8 @@ int main(int argc, char *argv[])
         goto fn_exit;
     }
 
-    targetbuf = malloc(maxbufsize);
-    assert(targetbuf);
+    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
+    assert(targetbuf && targetbuf_h);
 
     while (MTestGetIntracommGeneral(&comm, minsize, 1)) {
         if (comm == MPI_COMM_NULL) {
@@ -295,11 +312,12 @@ int main(int argc, char *argv[])
                 break;
             }
 
-            err = DTP_obj_buf_init(target_obj, targetbuf, 1, 2, count);
+            err = DTP_obj_buf_init(target_obj, targetbuf_h, 1, 2, count);
             if (err != DTP_SUCCESS) {
                 errs++;
                 break;
             }
+            MTestCopyContent(targetbuf_h, targetbuf, maxbufsize, targetmem);
 
             /* do a barrier to ensure that the target buffer is
              * initialized before we start writing data to it */
@@ -318,7 +336,7 @@ int main(int argc, char *argv[])
         MTestFreeComm(&comm);
     }
 
-    free(targetbuf);
+    MTestFree(targetmem, targetbuf_h, targetbuf);
 
   fn_exit:
     DTP_pool_free(dtp);

--- a/test/mpi/rma/putpscw1.c
+++ b/test/mpi/rma/putpscw1.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include "mpitest.h"
 #include "dtpools.h"
+#include <assert.h>
 
 /*
 static char MTEST_Descrip[] = "Put with Post/Start/Complete/Wait";
@@ -65,8 +66,7 @@ int main(int argc, char *argv[])
     }
 
     MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
-    if (targetbuf == NULL || targetbuf_h == NULL)
-        errs++;
+    assert(targetbuf && targetbuf_h);
 
     /* The following illustrates the use of the routines to
      * run through a selection of communicators and datatypes.
@@ -120,10 +120,7 @@ int main(int argc, char *argv[])
 
             if (rank == orig) {
                 MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
-                if (origbuf == NULL || origbuf_h == NULL) {
-                    errs++;
-                    break;
-                }
+                assert(origbuf && origbuf_h);
 
                 err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {

--- a/test/mpi/rma/putpscw1.c
+++ b/test/mpi/rma/putpscw1.c
@@ -31,7 +31,10 @@ int main(int argc, char *argv[])
     DTP_pool_s dtp;
     DTP_obj_s orig_obj, target_obj;
     void *origbuf, *targetbuf;
+    void *origbuf_h, *targetbuf_h;
     char *basic_type;
+    mtest_mem_type_e origmem;
+    mtest_mem_type_e targetmem;
 
     MTest_Init(&argc, &argv);
 
@@ -40,6 +43,8 @@ int main(int argc, char *argv[])
     testsize = MTestArgListGetInt(head, "testsize");
     count = MTestArgListGetLong(head, "count");
     basic_type = MTestArgListGetString(head, "type");
+    origmem = MTestArgListGetMemType(head, "origmem");
+    targetmem = MTestArgListGetMemType(head, "targetmem");
 
     maxbufsize = MTestDefaultMaxBufferSize();
 
@@ -59,8 +64,8 @@ int main(int argc, char *argv[])
         extent = 1;
     }
 
-    targetbuf = malloc(maxbufsize);
-    if (targetbuf == NULL)
+    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
+    if (targetbuf == NULL || targetbuf_h == NULL)
         errs++;
 
     /* The following illustrates the use of the routines to
@@ -99,11 +104,12 @@ int main(int argc, char *argv[])
                 break;
             }
 
-            err = DTP_obj_buf_init(target_obj, targetbuf, -1, -1, count);
+            err = DTP_obj_buf_init(target_obj, targetbuf_h, -1, -1, count);
             if (err != DTP_SUCCESS) {
                 errs++;
                 break;
             }
+            MTestCopyContent(targetbuf_h, targetbuf, maxbufsize, targetmem);
 
             targetcount = target_obj.DTP_type_count;
             targettype = target_obj.DTP_datatype;
@@ -113,17 +119,18 @@ int main(int argc, char *argv[])
             MPI_Win_set_errhandler(win, MPI_ERRORS_RETURN);
 
             if (rank == orig) {
-                origbuf = malloc(orig_obj.DTP_bufsize);
-                if (origbuf == NULL) {
+                MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
+                if (origbuf == NULL || origbuf_h == NULL) {
                     errs++;
                     break;
                 }
 
-                err = DTP_obj_buf_init(orig_obj, origbuf, 0, 1, count);
+                err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {
                     errs++;
                     break;
                 }
+                MTestCopyContent(origbuf_h, origbuf, orig_obj.DTP_bufsize, origmem);
 
                 origcount = orig_obj.DTP_type_count;
                 origtype = orig_obj.DTP_datatype;
@@ -153,7 +160,7 @@ int main(int argc, char *argv[])
                     }
                 }
 
-                free(origbuf);
+                MTestFree(origmem, origbuf_h, origbuf);
             } else if (rank == target) {
                 MPI_Group_incl(wingroup, 1, &orig, &neighbors);
                 MPI_Win_post(neighbors, 0, win);
@@ -161,7 +168,8 @@ int main(int argc, char *argv[])
                 MPI_Win_wait(win);
                 /* This should have the same effect, in terms of
                  * transfering data, as a send/recv pair */
-                err = DTP_obj_buf_check(target_obj, targetbuf, 0, 1, count);
+                MTestCopyContent(targetbuf, targetbuf_h, maxbufsize, targetmem);
+                err = DTP_obj_buf_check(target_obj, targetbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {
                     errs++;
                     if (errs < 10) {
@@ -189,7 +197,7 @@ int main(int argc, char *argv[])
         MTestFreeComm(&comm);
     }
 
-    free(targetbuf);
+    MTestFree(targetmem, targetbuf_h, targetbuf);
     DTP_pool_free(dtp);
 
     MTest_Finalize(errs);

--- a/test/mpi/util/Makefile.am
+++ b/test/mpi/util/Makefile.am
@@ -3,7 +3,7 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
-AM_CPPFLAGS = -I$(srcdir)/../include -I../include -I$(srcdir)/../dtpools/include
+AM_CPPFLAGS = -I$(srcdir)/../include -I../include -I$(srcdir)/../dtpools/include @cuda_CPPFLAGS@
 
 EXTRA_PROGRAMS = mtestcheck dtypes
 mtestcheck_SOURCES = mtestcheck.c mtest.c mtest_common.c

--- a/test/mpi/util/mtest.c
+++ b/test/mpi/util/mtest.c
@@ -26,6 +26,7 @@
 #include <sys/resource.h>
 #endif
 #include <errno.h>
+#include <assert.h>
 
 /*
  * Utility routines for writing MPI tests.
@@ -151,6 +152,20 @@ void MTest_Init(int *argc, char ***argv)
 #if MPI_VERSION >= 2 || defined(HAVE_MPI_INIT_THREAD)
     const char *str = 0;
     int threadLevel;
+
+#ifdef HAVE_CUDA
+    cudaGetDeviceCount(&ndevices);
+    assert(ndevices != -1);
+    if (ndevices > 1)
+        /*
+         * set initial device id to 1 to simulate the case where
+         * the user is trying to move data from a device that is
+         * not the "current" device
+         */
+        device_id = 1;
+    else
+        device_id = 0;
+#endif
 
     threadLevel = MPI_THREAD_SINGLE;
     str = getenv("MTEST_THREADLEVEL_DEFAULT");

--- a/test/mpi/util/mtest_common.c
+++ b/test/mpi/util/mtest_common.c
@@ -140,6 +140,19 @@ long MTestArgListGetLong(MTestArgList * head, const char *arg)
     return atol(MTestArgListGetString(head, arg));
 }
 
+mtest_mem_type_e MTestArgListGetMemType(MTestArgList * head, const char *arg)
+{
+    char *memtype = MTestArgListGetString(head, arg);
+    if (strcmp(memtype, "host") == 0)
+        return MTEST_MEM_TYPE__UNREGISTERED_HOST;
+    else if (strcmp(memtype, "reg_host") == 0)
+        return MTEST_MEM_TYPE__REGISTERED_HOST;
+    else if (strcmp(memtype, "device") == 0)
+        return MTEST_MEM_TYPE__DEVICE;
+    else
+        return MTEST_MEM_TYPE__UNSET;
+}
+
 int MTestIsBasicDtype(MPI_Datatype type)
 {
     int numints, numaddrs, numtypes, combiner;


### PR DESCRIPTION
## Pull Request Description

Integrate support for GPU (CUDA) testing. Memory allocation utilities are added. Proof of concept integration with pt2pt dtpools tests in `test/mpi/pt2pt`. Only send buffers are modified so far.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
