### PR TITLE
Introduce new Typerep_copy function

### DIFF
--- a/src/include/mpir_typerep.h
+++ b/src/include/mpir_typerep.h
@@ -60,6 +60,7 @@ int MPIR_Typerep_to_iov_offset(const void *buf, MPI_Aint count, MPI_Datatype typ
 int MPIR_Typerep_iov_len(MPI_Aint count, MPI_Datatype type, MPI_Aint max_iov_bytes,
                          MPI_Aint * iov_len);
 
+int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes);
 int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                       MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
                       MPI_Aint * actual_pack_bytes);

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
@@ -6,6 +6,20 @@
 #include "mpiimpl.h"
 #include <dataloop.h>
 
+int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_COPY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_COPY);
+
+    MPIR_Memcpy(outbuf, inbuf, num_bytes);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_COPY);
+    return MPI_SUCCESS;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                       MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
                       MPI_Aint * actual_pack_bytes)

--- a/src/mpid/ch4/generic/am/mpidig_am_msg.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_msg.h
@@ -135,7 +135,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_copy(void *in_data, MPIR_Request * rre
         }
 
         data_sz = MPL_MIN(data_sz, in_data_sz);
-        MPIR_Memcpy(data, in_data, data_sz);
+        MPIR_Typerep_copy(data, in_data, data_sz);
         MPIR_STATUS_SET_COUNT(rreq->status, data_sz);
     } else {
         /* noncontig case */
@@ -146,7 +146,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_copy(void *in_data, MPIR_Request * rre
         int rem = in_data_sz;
         for (int i = 0; i < iov_len && rem > 0; i++) {
             int curr_len = MPL_MIN(rem, iov[i].iov_len);
-            MPIR_Memcpy(iov[i].iov_base, (char *) in_data + done, curr_len);
+            MPIR_Typerep_copy(iov[i].iov_base, (char *) in_data + done, curr_len);
             rem -= curr_len;
             done += curr_len;
         }
@@ -240,14 +240,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_recv_copy_seg(void *payload, MPI_Aint payloa
         int iov_done = 0;
         for (int i = 0; i < p->iov_num; i++) {
             if (payload_sz < p->iov_ptr[i].iov_len) {
-                MPIR_Memcpy(p->iov_ptr[i].iov_base, payload, payload_sz);
+                MPIR_Typerep_copy(p->iov_ptr[i].iov_base, payload, payload_sz);
                 p->iov_ptr[i].iov_base = (char *) p->iov_ptr[i].iov_base + payload_sz;
                 p->iov_ptr[i].iov_len -= payload_sz;
                 /* not done */
                 break;
             } else {
                 /* fill one iov */
-                MPIR_Memcpy(p->iov_ptr[i].iov_base, payload, p->iov_ptr[i].iov_len);
+                MPIR_Typerep_copy(p->iov_ptr[i].iov_base, payload, p->iov_ptr[i].iov_len);
                 payload = (char *) payload + p->iov_ptr[i].iov_len;
                 payload_sz -= p->iov_ptr[i].iov_len;
                 iov_done++;

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -82,7 +82,7 @@ static inline int MPIDIG_handle_unexpected(void *buf, MPI_Aint count, MPI_Dataty
         if (nbytes > 0) {
             char *addr = (char *) buf + dt_true_lb;
             assert(addr);       /* to supress gcc-8 warning: -Wnonnull */
-            MPIR_Memcpy(addr, MPIDIG_REQUEST(rreq, buffer), nbytes);
+            MPIR_Typerep_copy(addr, MPIDIG_REQUEST(rreq, buffer), nbytes);
         }
     }
 

--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_recv.h
@@ -103,7 +103,7 @@ MPL_STATIC_INLINE_PREFIX void
 MPIDI_POSIX_eager_recv_memcpy(MPIDI_POSIX_eager_recv_transaction_t * transaction,
                               void *dst, const void *src, size_t size)
 {
-    MPIR_Memcpy(dst, src, size);
+    MPIR_Typerep_copy(dst, src, size);
 }
 
 MPL_STATIC_INLINE_PREFIX void

--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_send.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_send.h
@@ -64,7 +64,7 @@ MPIDI_POSIX_eager_send(int grank,
     /* Copy all of the user data that will fit into the fastbox. */
     for (i = 0; i < *iov_num; i++) {
         if (unlikely(fbox_payload_size_left < (*iov)[i].iov_len)) {
-            MPIR_Memcpy(fbox_payload_ptr, (*iov)[i].iov_base, fbox_payload_size_left);
+            MPIR_Typerep_copy(fbox_payload_ptr, (*iov)[i].iov_base, fbox_payload_size_left);
 
             (*iov)[i].iov_base = (char *) (*iov)[i].iov_base + fbox_payload_size_left;
             (*iov)[i].iov_len -= fbox_payload_size_left;
@@ -74,7 +74,7 @@ MPIDI_POSIX_eager_send(int grank,
             break;
         }
 
-        MPIR_Memcpy(fbox_payload_ptr, (*iov)[i].iov_base, (*iov)[i].iov_len);
+        MPIR_Typerep_copy(fbox_payload_ptr, (*iov)[i].iov_base, (*iov)[i].iov_len);
 
         fbox_payload_ptr += (*iov)[i].iov_len;
         fbox_payload_size_left -= (*iov)[i].iov_len;

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
@@ -130,9 +130,7 @@ MPL_STATIC_INLINE_PREFIX void
 MPIDI_POSIX_eager_recv_memcpy(MPIDI_POSIX_eager_recv_transaction_t * transaction,
                               void *dst, const void *src, size_t size)
 {
-    MPI_Aint actual_pack_bytes;
-    MPIR_Typerep_pack(src, size, MPI_BYTE, 0, dst, size, &actual_pack_bytes);
-    MPIR_Assert(actual_pack_bytes == size);
+    MPIR_Typerep_copy(dst, src, size);
 }
 
 MPL_STATIC_INLINE_PREFIX void

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -103,10 +103,7 @@ MPIDI_POSIX_eager_send(int grank,
     for (i = 0; i < *iov_num; i++) {
         /* Optimize for the case where the message will fit into the cell. */
         if (likely(available >= (*iov)[i].iov_len)) {
-            MPI_Aint actual_pack_bytes;
-            MPIR_Typerep_pack((*iov)[i].iov_base, (*iov)[i].iov_len, MPI_BYTE,
-                              0, payload, (*iov)[i].iov_len, &actual_pack_bytes);
-            MPIR_Assert(actual_pack_bytes == (*iov)[i].iov_len);
+            MPIR_Typerep_copy(payload, (*iov)[i].iov_base, (*iov)[i].iov_len);
 
             payload += (*iov)[i].iov_len;
             available -= (*iov)[i].iov_len;
@@ -115,10 +112,7 @@ MPIDI_POSIX_eager_send(int grank,
         } else {
             /* If the message won't fit, put as much as we can and update the iovec for the next
              * time around. */
-            MPI_Aint actual_pack_bytes;
-            MPIR_Typerep_pack((*iov)[i].iov_base, available, MPI_BYTE,
-                              0, payload, available, &actual_pack_bytes);
-            MPIR_Assert(actual_pack_bytes == available);
+            MPIR_Typerep_copy(payload, (*iov)[i].iov_base, available);
 
             (*iov)[i].iov_base = (char *) (*iov)[i].iov_base + available;
             (*iov)[i].iov_len -= available;

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -230,7 +230,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
     am_hdr_sz = 0;
 
     for (i = 0; i < iov_len; i++) {
-        MPIR_Memcpy(am_hdr_buf + am_hdr_sz, am_hdr[i].iov_base, am_hdr[i].iov_len);
+        MPIR_Typerep_copy(am_hdr_buf + am_hdr_sz, am_hdr[i].iov_base, am_hdr[i].iov_len);
         am_hdr_sz += am_hdr[i].iov_len;
     }
 

--- a/src/mpid/ch4/shm/posix/posix_am_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_am_impl.h
@@ -65,7 +65,7 @@ static inline int MPIDI_POSIX_am_init_req_hdr(const void *am_hdr,
     }
 
     if (am_hdr) {
-        MPIR_Memcpy(req_hdr->am_hdr, am_hdr, am_hdr_sz);
+        MPIR_Typerep_copy(req_hdr->am_hdr, am_hdr, am_hdr_sz);
     }
 
     req_hdr->am_hdr_sz = am_hdr_sz;

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -422,9 +422,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_compare_and_swap(const void *origin
     if (MPIDIG_WIN(win, shm_allocated))
         MPIDI_POSIX_RMA_MUTEX_LOCK(posix_win->shm_mutex_ptr);
 
-    MPIR_Memcpy(result_addr, target_addr, dtype_sz);
+    MPIR_Typerep_copy(result_addr, target_addr, dtype_sz);
     if (MPIR_Compare_equal(compare_addr, target_addr, datatype)) {
-        MPIR_Memcpy(target_addr, origin_addr, dtype_sz);
+        MPIR_Typerep_copy(target_addr, origin_addr, dtype_sz);
     }
 
     if (MPIDIG_WIN(win, shm_allocated))
@@ -576,7 +576,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_fetch_and_op(const void *origin_add
     if (MPIDIG_WIN(win, shm_allocated))
         MPIDI_POSIX_RMA_MUTEX_LOCK(posix_win->shm_mutex_ptr);
 
-    MPIR_Memcpy(result_addr, target_addr, dtype_sz);
+    MPIR_Typerep_copy(result_addr, target_addr, dtype_sz);
 
     if (op != MPI_NO_OP) {
         /* We need to make sure op is valid here.

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -124,13 +124,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
                     MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                 }
                 MPIR_Get_count_impl(&status, MPI_BYTE, &recv_bytes);
-                MPIR_Memcpy(bcast_data_addr, &recv_bytes, sizeof(int));
+                MPIR_Typerep_copy(bcast_data_addr, &recv_bytes, sizeof(int));
                 /* It is necessary to copy the errflag as well to handle the case when non-root
                  * becomes temporary root as part of compositions (or smp aware colls). These temp
                  * roots might expect same data as other ranks but different from the actual root.
                  * So only datasize mismatch handling is not sufficient */
-                MPIR_Memcpy((char *) bcast_data_addr + MPIDU_SHM_CACHE_LINE_LEN, errflag,
-                            sizeof(MPIR_Errflag_t));
+                MPIR_Typerep_copy((char *) bcast_data_addr + MPIDU_SHM_CACHE_LINE_LEN, errflag,
+                                  sizeof(MPIR_Errflag_t));
                 if ((int) recv_bytes != count) {
                     /* It is OK to compare with count because datatype is always MPI_BYTE for Bcast */
                     *errflag = MPIR_ERR_OTHER;
@@ -157,13 +157,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
             /* When error checking is enabled, place the datasize in shm_buf first, followed by the
              * errflag, followed by the actual data with an offset of (2*cacheline_size) bytes from
              * the starting address */
-            MPIR_Memcpy(bcast_data_addr, &count, sizeof(int));
+            MPIR_Typerep_copy(bcast_data_addr, &count, sizeof(int));
             /* It is necessary to copy the errflag as well to handle the case when non-root
              * becomes root as part of compositions (or smp aware colls). These roots might
              * expect same data as other ranks but different from the actual root. So only
              * datasize mismatch handling is not sufficient */
-            MPIR_Memcpy((char *) bcast_data_addr + MPIDU_SHM_CACHE_LINE_LEN, errflag,
-                        sizeof(MPIR_Errflag_t));
+            MPIR_Typerep_copy((char *) bcast_data_addr + MPIDU_SHM_CACHE_LINE_LEN, errflag,
+                              sizeof(MPIR_Errflag_t));
             mpi_errno =
                 MPIR_Localcopy(local_buf, count, datatype,
                                (char *) bcast_data_addr + 2 * MPIDU_SHM_CACHE_LINE_LEN, count,
@@ -227,9 +227,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
              * expecting. Also, the errflag is copied out. In case of mismatch mpi_errno is set.
              * Actual data starts after (2*cacheline_size) bytes */
             int recv_bytes, recv_errflag;
-            MPIR_Memcpy(&recv_bytes, bcast_data_addr, sizeof(int));
-            MPIR_Memcpy(&recv_errflag, (char *) bcast_data_addr + MPIDU_SHM_CACHE_LINE_LEN,
-                        sizeof(int));
+            MPIR_Typerep_copy(&recv_bytes, bcast_data_addr, sizeof(int));
+            MPIR_Typerep_copy(&recv_errflag, (char *) bcast_data_addr + MPIDU_SHM_CACHE_LINE_LEN,
+                              sizeof(int));
             if (recv_bytes != count || recv_errflag != MPI_SUCCESS) {
                 /* It is OK to compare with count because datatype is always MPI_BYTE for Bcast */
                 *errflag = MPIR_ERR_OTHER;

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -178,8 +178,8 @@ static int handle_unexp_cmpl(MPIR_Request * rreq)
             match_req->status.MPI_ERROR = mpi_errno;
         }
     } else {
-        MPIR_Memcpy((char *) MPIDIG_REQUEST(match_req, buffer) + dt_true_lb,
-                    MPIDIG_REQUEST(rreq, buffer), nbytes);
+        MPIR_Typerep_copy((char *) MPIDIG_REQUEST(match_req, buffer) + dt_true_lb,
+                          MPIDIG_REQUEST(rreq, buffer), nbytes);
     }
 
     /* Now that the unexpected message has been completed, unset the status bit. */

--- a/src/mpid/ch4/src/ch4r_recv.h
+++ b/src/mpid/ch4/src/ch4r_recv.h
@@ -94,7 +94,7 @@ static inline int MPIDIG_handle_unexp_mrecv(MPIR_Request * rreq)
             rreq->status.MPI_ERROR = mpi_errno;
         }
     } else {
-        MPIR_Memcpy((char *) buf + dt_true_lb, MPIDIG_REQUEST(rreq, buffer), nbytes);
+        MPIR_Typerep_copy((char *) buf + dt_true_lb, MPIDIG_REQUEST(rreq, buffer), nbytes);
     }
 
     MPL_free(MPIDIG_REQUEST(rreq, buffer));

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -869,8 +869,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
 
     p_data = MPL_malloc(data_sz * 2, MPL_MEM_BUFFER);
     MPIR_Assert(p_data);
-    MPIR_Memcpy(p_data, (char *) origin_addr, data_sz);
-    MPIR_Memcpy((char *) p_data + data_sz, (char *) compare_addr, data_sz);
+    MPIR_Typerep_copy(p_data, (char *) origin_addr, data_sz);
+    MPIR_Typerep_copy((char *) p_data + data_sz, (char *) compare_addr, data_sz);
 
     sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -970,10 +970,10 @@ static int cswap_target_cmpl_cb(MPIR_Request * rreq)
 
     if (MPIR_Compare_equal((void *) MPIDIG_REQUEST(rreq, req->creq.addr), compare_addr,
                            MPIDIG_REQUEST(rreq, req->creq.datatype))) {
-        MPIR_Memcpy(compare_addr, (void *) MPIDIG_REQUEST(rreq, req->creq.addr), data_sz);
-        MPIR_Memcpy((void *) MPIDIG_REQUEST(rreq, req->creq.addr), origin_addr, data_sz);
+        MPIR_Typerep_copy(compare_addr, (void *) MPIDIG_REQUEST(rreq, req->creq.addr), data_sz);
+        MPIR_Typerep_copy((void *) MPIDIG_REQUEST(rreq, req->creq.addr), origin_addr, data_sz);
     } else {
-        MPIR_Memcpy(compare_addr, (void *) MPIDIG_REQUEST(rreq, req->creq.addr), data_sz);
+        MPIR_Typerep_copy(compare_addr, (void *) MPIDIG_REQUEST(rreq, req->creq.addr), data_sz);
     }
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD


### PR DESCRIPTION
## Pull Request Description

Replace most of the `MPIR_Memcpy` usage with `MPIR_Typerep_copy`.  `MPIR_Typerep_copy` allows for both CPU and GPU buffers, unlike `MPIR_Memcpy`.  It's also lighter weight than `MPIR_Typerep_pack` because it doesn't need datatype decoding.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
