### PR TITLE
Apply generic AVL tree to GPU communication

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -1509,6 +1509,8 @@ is too big (> MPIU_SHMW_GHND_SZ)
 
 ## GAVL tree related error messages
 **mpl_gavl_search: mpl_gavl_search failed
+**mpl_gavl_insert: mpl_gavl_insert failed
+**mpl_gavl_create: mpl_gavl_create failed
 # -----------------------------------------------------------------------------
 # The following names are defined but not used (see the -careful option 
 # for extracterrmsgs) (still to do: move the undefined names here)

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -1505,6 +1505,7 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **gpu_init: gpu_init failed
 **gpu_finalize: gpu_finalize failed
 **gpu_get_global_dev_ids: gpu_get_global_dev_ids failed
+**gpu_get_buffer_info: gpu_get_buffer_info failed
 
 ## GAVL tree related error messages
 **mpl_gavl_search: mpl_gavl_search failed

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -1511,6 +1511,7 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **mpl_gavl_search: mpl_gavl_search failed
 **mpl_gavl_insert: mpl_gavl_insert failed
 **mpl_gavl_create: mpl_gavl_create failed
+**mpl_gavl_delete: mpl_gavl_delete failed
 # -----------------------------------------------------------------------------
 # The following names are defined but not used (see the -careful option 
 # for extracterrmsgs) (still to do: move the undefined names here)

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -25,7 +25,7 @@ int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
         goto fn_exit;
 
     int *global_ids = MPL_malloc(sizeof(int) * device_count, MPL_MEM_OTHER);
-    assert(global_ids);
+    MPIR_Assert(global_ids);
 
     mpl_err = MPL_gpu_get_global_dev_ids(global_ids, device_count);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
@@ -36,13 +36,13 @@ int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
     for (int i = 0; i < device_count; ++i) {
         MPIDI_GPUI_dev_id_t *id_obj =
             (MPIDI_GPUI_dev_id_t *) MPL_malloc(sizeof(MPIDI_GPUI_dev_id_t), MPL_MEM_OTHER);
-        assert(id_obj);
+        MPIR_Assert(id_obj);
         id_obj->local_dev_id = i;
         id_obj->global_dev_id = global_ids[i];
         HASH_ADD_INT(MPIDI_GPUI_global.local_to_global_map, local_dev_id, id_obj, MPL_MEM_OTHER);
 
         id_obj = (MPIDI_GPUI_dev_id_t *) MPL_malloc(sizeof(MPIDI_GPUI_dev_id_t), MPL_MEM_OTHER);
-        assert(id_obj);
+        MPIR_Assert(id_obj);
         id_obj->local_dev_id = i;
         id_obj->global_dev_id = global_ids[i];
         HASH_ADD_INT(MPIDI_GPUI_global.global_to_local_map, global_dev_id, id_obj, MPL_MEM_OTHER);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -60,16 +60,19 @@ int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
     }
     MPIDU_Init_shm_barrier();
 
+    MPIDI_GPUI_global.global_max_dev_id = node_max_dev_id;
+
     MPIR_CHKPMEM_MALLOC(MPIDI_GPUI_global.visible_dev_global_id, int **,
                         sizeof(int *) * MPIR_Process.local_size, mpi_errno, "gpu devmaps",
                         MPL_MEM_SHM);
     for (int i = 0; i < MPIR_Process.local_size; ++i) {
         MPIDI_GPUI_global.visible_dev_global_id[i] =
-            (int *) MPL_malloc(sizeof(int) * (node_max_dev_id + 1), MPL_MEM_OTHER);
+            (int *) MPL_malloc(sizeof(int) * (MPIDI_GPUI_global.global_max_dev_id + 1),
+                               MPL_MEM_OTHER);
         MPIR_Assert(MPIDI_GPUI_global.visible_dev_global_id[i]);
 
         if (i == MPIR_Process.local_rank) {
-            for (int j = 0; j < node_max_dev_id; ++j) {
+            for (int j = 0; j < (MPIDI_GPUI_global.global_max_dev_id + 1); ++j) {
                 MPIDI_GPUI_dev_id_t *tmp = NULL;
                 HASH_FIND_INT(MPIDI_GPUI_global.global_to_local_map, &j, tmp);
                 if (tmp)
@@ -78,7 +81,7 @@ int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
                     MPIDI_GPUI_global.visible_dev_global_id[i][j] = 0;
             }
             MPIDU_Init_shm_put(MPIDI_GPUI_global.visible_dev_global_id[i],
-                               sizeof(int) * (node_max_dev_id + 1));
+                               sizeof(int) * (MPIDI_GPUI_global.global_max_dev_id + 1));
         }
     }
     MPIDU_Init_shm_barrier();
@@ -86,9 +89,10 @@ int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
     /* FIXME: current implementation uses MPIDU_Init_shm_get to exchange visible id.
      * shm buffer size is defined as 64 bytes by default. Therefore, if number of
      * gpu device is larger than 16, the MPIDU_Init_shm_get would fail. */
-    MPIR_Assert((node_max_dev_id + 1) <= MPIDU_INIT_SHM_BLOCK_SIZE / sizeof(int));
+    MPIR_Assert((MPIDI_GPUI_global.global_max_dev_id + 1) <=
+                MPIDU_INIT_SHM_BLOCK_SIZE / sizeof(int));
     for (int i = 0; i < MPIR_Process.local_size; ++i)
-        MPIDU_Init_shm_get(i, sizeof(int) * (node_max_dev_id + 1),
+        MPIDU_Init_shm_get(i, sizeof(int) * (MPIDI_GPUI_global.global_max_dev_id + 1),
                            MPIDI_GPUI_global.visible_dev_global_id[i]);
     MPIDU_Init_shm_barrier();
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -9,18 +9,26 @@
 
 int MPIDI_GPU_get_ipc_attr(const void *vaddr, MPIDI_IPCI_ipc_attr_t * ipc_attr)
 {
-    int mpi_errno = MPI_SUCCESS, mpl_err = MPL_SUCCESS;
+    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_GET_IPC_ATTR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_GET_IPC_ATTR);
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     int local_dev_id;
     MPIDI_GPUI_dev_id_t *tmp;
+    void *pbase;
+    uintptr_t len;
+    int mpl_err = MPL_SUCCESS;
 
     ipc_attr->ipc_type = MPIDI_IPCI_TYPE__GPU;
-    mpl_err = MPL_gpu_ipc_handle_create(vaddr, &ipc_attr->ipc_handle.gpu.ipc_handle);
+    mpl_err = MPL_gpu_get_buffer_bounds(vaddr, &pbase, &len);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_get_buffer_info");
+
+    mpl_err = MPL_gpu_ipc_handle_create(pbase, &ipc_attr->ipc_handle.gpu.ipc_handle);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                         "**gpu_ipc_handle_create");
+
+    ipc_attr->ipc_handle.gpu.offset = (uintptr_t) vaddr - (uintptr_t) pbase;
 
     MPL_gpu_get_dev_id(ipc_attr->gpu_attr.device, &local_dev_id);
     HASH_FIND_INT(MPIDI_GPUI_global.local_to_global_map, &local_dev_id, tmp);
@@ -49,22 +57,25 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_IPC_HANDLE_MAP);
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
+    void *pbase;
     int recv_dt_contig, mpl_err = MPL_SUCCESS;
     MPIDI_GPUI_dev_id_t *avail_id = NULL;
     MPIDI_Datatype_check_contig(recv_type, recv_dt_contig);
     HASH_FIND_INT(MPIDI_GPUI_global.global_to_local_map, &handle.global_dev_id, avail_id);
 
     if (avail_id == NULL)
-        mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, dev_handle, vaddr);
+        mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, dev_handle, &pbase);
     else {
         MPL_gpu_device_handle_t remote_dev_handle;
         MPL_gpu_get_dev_handle(avail_id->local_dev_id, &remote_dev_handle);
         if (!recv_dt_contig)
-            mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, dev_handle, vaddr);
+            mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, dev_handle, &pbase);
         else
-            mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, remote_dev_handle, vaddr);
+            mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, remote_dev_handle, &pbase);
     }
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_map");
+
+    *vaddr = (void *) ((uintptr_t) pbase + handle.offset);
 #endif
 
   fn_exit:
@@ -82,7 +93,7 @@ int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle)
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     int mpl_err = MPL_SUCCESS;
-    mpl_err = MPL_gpu_ipc_handle_unmap(vaddr, handle.ipc_handle);
+    mpl_err = MPL_gpu_ipc_handle_unmap((void *) ((uintptr_t) vaddr - handle.offset));
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_unmap");
 #endif
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -7,6 +7,49 @@
 #include "gpu_pre.h"
 #include "gpu_types.h"
 
+static int ipc_handle_cache_search(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len,
+                                   void **handle_obj)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_IPC_HANDLE_CACHE_SEARCH);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_IPC_HANDLE_CACHE_SEARCH);
+
+    *handle_obj = NULL;
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU
+    int mpl_err = MPL_SUCCESS;
+    mpl_err = MPL_gavl_tree_search(gavl_tree, addr, len, handle_obj);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**mpl_gavl_search");
+#endif
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_IPC_HANDLE_CACHE_SEARCH);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int ipc_handle_cache_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len,
+                                   const void *handle_obj)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_IPC_HANDLE_CACHE_INSERT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_IPC_HANDLE_CACHE_INSERT);
+
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU
+    int mpl_err = MPL_SUCCESS;
+    mpl_err = MPL_gavl_tree_insert(gavl_tree, addr, len, handle_obj);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**mpl_gavl_insert");
+#endif
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_IPC_HANDLE_CACHE_INSERT);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 static int get_map_device(int remote_global_dev_id,
                           MPL_gpu_device_handle_t local_dev_handle,
                           MPI_Datatype recv_type, int *dev_id)
@@ -71,6 +114,14 @@ int MPIDI_GPU_get_ipc_attr(const void *vaddr, MPIDI_IPCI_ipc_attr_t * ipc_attr)
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                         "**gpu_ipc_handle_create");
 
+    /* MPIDI_GPU_get_ipc_attr will be called by sender to create an ipc handle.
+     * remote_base_addr, len and node_rank attributes in ipc handle will be sent
+     * to receiver and used to search cached ipc handle and/or insert new allocated
+     * handle obj on receiver side. offset attribute is always needed no matter
+     * whether we use caching or not in order to compute correct user addr. */
+    ipc_attr->ipc_handle.gpu.remote_base_addr = (uintptr_t) pbase;
+    ipc_attr->ipc_handle.gpu.len = len;
+    ipc_attr->ipc_handle.gpu.node_rank = MPIR_Process.local_rank;
     ipc_attr->ipc_handle.gpu.offset = (uintptr_t) vaddr - (uintptr_t) pbase;
 
     MPL_gpu_get_dev_id(ipc_attr->gpu_attr.device, &local_dev_id);
@@ -103,14 +154,36 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle,
     void *pbase;
     int mpl_err = MPL_SUCCESS;
     int dev_id;
+    MPIDI_GPUI_handle_obj_s *handle_obj = NULL;
+
     mpi_errno = get_map_device(handle.global_dev_id, dev_handle, recv_type, &dev_id);
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPL_gpu_get_dev_handle(dev_id, &dev_handle);
-    mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, dev_handle, &pbase);
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_map");
+    mpi_errno = ipc_handle_cache_search(MPIDI_GPUI_global.ipc_handle_mapped_trees[handle.node_rank]
+                                        [handle.global_dev_id][dev_id],
+                                        (void *) handle.remote_base_addr, handle.len,
+                                        (void **) &handle_obj);
+    MPIR_ERR_CHECK(mpi_errno);
 
-    *vaddr = (void *) ((uintptr_t) pbase + handle.offset);
+    if (handle_obj == NULL) {
+        MPL_gpu_get_dev_handle(dev_id, &dev_handle);
+        mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, dev_handle, &pbase);
+        MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                            "**gpu_ipc_handle_map");
+
+        *vaddr = (void *) ((uintptr_t) pbase + handle.offset);
+
+        handle_obj =
+            (MPIDI_GPUI_handle_obj_s *) MPL_malloc(sizeof(MPIDI_GPUI_handle_obj_s), MPL_MEM_OTHER);
+        MPIR_Assert(handle_obj != NULL);
+        handle_obj->mapped_base_addr = (uintptr_t) pbase;
+        mpi_errno =
+            ipc_handle_cache_insert(MPIDI_GPUI_global.ipc_handle_mapped_trees[handle.node_rank]
+                                    [handle.global_dev_id][dev_id],
+                                    (void *) handle.remote_base_addr, handle.len, handle_obj);
+    } else {
+        *vaddr = (void *) (handle_obj->mapped_base_addr + handle.offset);
+    }
 #endif
 
   fn_exit:
@@ -125,12 +198,6 @@ int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_IPC_HANDLE_UNMAP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_IPC_HANDLE_UNMAP);
-
-#ifdef MPIDI_CH4_SHM_ENABLE_GPU
-    int mpl_err = MPL_SUCCESS;
-    mpl_err = MPL_gpu_ipc_handle_unmap((void *) ((uintptr_t) vaddr - handle.offset));
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_unmap");
-#endif
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_IPC_HANDLE_UNMAP);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -89,5 +89,6 @@ int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle)
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_IPC_HANDLE_UNMAP);
     return mpi_errno;
-  fn_fail:goto fn_exit;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -26,12 +26,14 @@ cvars:
 
 #include "gpu_pre.h"
 
-int MPIDI_GPU_get_ipc_attr(const void *vaddr, MPIDI_IPCI_ipc_attr_t * ipc_attr);
+int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
+                           MPIDI_IPCI_ipc_attr_t * ipc_attr);
 int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle,
                              MPL_gpu_device_handle_t dev_handle,
                              MPI_Datatype recv_type, void **vaddr);
 int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle);
 int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits);
 int MPIDI_GPU_mpi_finalize_hook(void);
+int MPIDI_GPU_ipc_handle_cache_insert(int rank, MPIR_Comm * comm, MPIDI_GPU_ipc_handle_t handle);
 
 #endif /* GPU_POST_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -11,6 +11,7 @@
 typedef struct MPIDI_GPU_ipc_handle {
     MPL_gpu_ipc_mem_handle_t ipc_handle;
     int global_dev_id;
+    uintptr_t offset;
 } MPIDI_GPU_ipc_handle_t;
 
 #endif /* GPU_PRE_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -8,6 +8,11 @@
 
 #include "mpl.h"
 
+enum {
+    MPIDI_GPU_IPC_HANDLE_VALID,
+    MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED,
+};
+
 typedef struct MPIDI_GPU_ipc_handle {
     MPL_gpu_ipc_mem_handle_t ipc_handle;
     int global_dev_id;
@@ -15,6 +20,7 @@ typedef struct MPIDI_GPU_ipc_handle {
     uintptr_t len;
     int node_rank;
     uintptr_t offset;
+    int handle_status;
 } MPIDI_GPU_ipc_handle_t;
 
 #endif /* GPU_PRE_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -11,6 +11,9 @@
 typedef struct MPIDI_GPU_ipc_handle {
     MPL_gpu_ipc_mem_handle_t ipc_handle;
     int global_dev_id;
+    uintptr_t remote_base_addr;
+    uintptr_t len;
+    int node_rank;
     uintptr_t offset;
 } MPIDI_GPU_ipc_handle_t;
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
@@ -20,6 +20,7 @@ typedef struct {
     int **visible_dev_global_id;
     int *local_ranks;
     int *local_procs;
+    int global_max_dev_id;
     int initialized;
 } MPIDI_GPUI_global_t;
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
@@ -20,9 +20,15 @@ typedef struct {
     int **visible_dev_global_id;
     int *local_ranks;
     int *local_procs;
+    int local_device_count;
     int global_max_dev_id;
     int initialized;
+    MPL_gavl_tree_t ***ipc_handle_mapped_trees;
 } MPIDI_GPUI_global_t;
+
+typedef struct {
+    uintptr_t mapped_base_addr;
+} MPIDI_GPUI_handle_obj_s;
 
 extern MPIDI_GPUI_global_t MPIDI_GPUI_global;
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
@@ -24,6 +24,7 @@ typedef struct {
     int global_max_dev_id;
     int initialized;
     MPL_gavl_tree_t ***ipc_handle_mapped_trees;
+    MPL_gavl_tree_t **ipc_handle_track_trees;
 } MPIDI_GPUI_global_t;
 
 typedef struct {

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -61,6 +61,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
     slmt_req_hdr->tag = tag;
     slmt_req_hdr->context_id = comm->context_id + context_offset;
 
+    if (ipc_attr.gpu_attr.type == MPL_GPU_POINTER_DEV) {
+        mpi_errno = MPIDI_GPU_ipc_handle_cache_insert(rank, comm, ipc_attr.ipc_handle.gpu);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
     IPC_TRACE("send_contig_lmt: shm ctrl_id %d, data_sz 0x%" PRIu64 ", sreq_ptr 0x%p, "
               "src_lrank %d, match info[dest %d, src_rank %d, tag %d, context_id 0x%x]\n",
               MPIDI_IPC_SEND_CONTIG_LMT_RTS, slmt_req_hdr->data_sz, slmt_req_hdr->sreq_ptr,

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -36,7 +36,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_isend(const void *buf, MPI_Aint count
     MPIR_GPU_query_pointer_attr(vaddr, &ipc_attr.gpu_attr);
 
     if (ipc_attr.gpu_attr.type == MPL_GPU_POINTER_DEV) {
-        mpi_errno = MPIDI_GPU_get_ipc_attr(vaddr, &ipc_attr);
+        mpi_errno = MPIDI_GPU_get_ipc_attr(vaddr, rank, comm, &ipc_attr);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno = MPIDI_XPMEM_get_ipc_attr(vaddr, data_sz, &ipc_attr);

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -83,7 +83,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
     MPIR_GPU_query_pointer_attr(win->base, &ipc_attr.gpu_attr);
 
     if (ipc_attr.gpu_attr.type == MPL_GPU_POINTER_DEV) {
-        mpi_errno = MPIDI_GPU_get_ipc_attr(win->base, &ipc_attr);
+        mpi_errno = MPIDI_GPU_get_ipc_attr(win->base, shm_comm_ptr->rank, shm_comm_ptr, &ipc_attr);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno = MPIDI_XPMEM_get_ipc_attr(win->base, win->size, &ipc_attr);

--- a/src/mpl/include/mpl_gavl.h
+++ b/src/mpl/include/mpl_gavl.h
@@ -13,5 +13,6 @@ int MPL_gavl_tree_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t 
                          const void *val);
 int MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len, void **val);
 int MPL_gavl_tree_free(MPL_gavl_tree_t gavl_tree);
+int MPL_gavl_tree_delete(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len);
 
 #endif /* MPL_GAVL_H_INCLUDED  */

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -51,4 +51,6 @@ int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle);
 int MPL_gpu_get_global_dev_ids(int *global_ids, int count);
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len);
 
+int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr));
+
 #endif /* ifndef MPL_GPU_H_INCLUDED */

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -33,7 +33,7 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle);
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
                            void **ptr);
-int MPL_gpu_ipc_handle_unmap(void *ptr, MPL_gpu_ipc_mem_handle_t ipc_handle);
+int MPL_gpu_ipc_handle_unmap(void *ptr);
 
 int MPL_gpu_malloc_host(void **ptr, size_t size);
 int MPL_gpu_free_host(void *ptr);
@@ -49,5 +49,6 @@ int MPL_gpu_finalize(void);
 int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id);
 int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle);
 int MPL_gpu_get_global_dev_ids(int *global_ids, int count);
+int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len);
 
 #endif /* ifndef MPL_GPU_H_INCLUDED */

--- a/src/mpl/include/mpl_gpu_cuda.h
+++ b/src/mpl/include/mpl_gpu_cuda.h
@@ -9,10 +9,7 @@
 #include "cuda.h"
 #include "cuda_runtime_api.h"
 
-typedef struct {
-    cudaIpcMemHandle_t handle;
-    uintptr_t offset;
-} MPL_gpu_ipc_mem_handle_t;
+typedef cudaIpcMemHandle_t MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 #define MPL_GPU_DEVICE_INVALID -1
 

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -8,10 +8,7 @@
 
 #include "level_zero/ze_api.h"
 
-typedef struct {
-    uintptr_t offset;
-    ze_ipc_mem_handle_t handle;
-} MPL_gpu_ipc_mem_handle_t;
+typedef ze_ipc_mem_handle_t MPL_gpu_ipc_mem_handle_t;
 typedef ze_device_handle_t MPL_gpu_device_handle_t;
 #define MPL_GPU_DEVICE_INVALID NULL
 

--- a/src/mpl/src/gavl/mpl_gavl.c
+++ b/src/mpl/src/gavl/mpl_gavl.c
@@ -54,6 +54,11 @@ typedef struct gavl_tree {
         value = stack[--stack##_sp]; \
     } while (0)
 
+#define CLEAR_STACK(stack)           \
+    do {                             \
+        stack##_sp = 0;              \
+    } while (0)
+
 #define STACK_EMPTY(stack) (!stack##_sp)
 
 static void gavl_update_node_info(gavl_tree_node_s * node_iptr)
@@ -128,12 +133,26 @@ static int gavl_subset_cmp_func(uintptr_t ustart, uintptr_t len, gavl_tree_node_
     uintptr_t tstart = tnode->addr;
     uintptr_t tend = tnode->addr + tnode->len;
 
-    if (ustart < tstart)
-        return SEARCH_LEFT;
-    else if (uend <= tend)
+    if (tstart <= ustart && uend <= tend)
         return BUFFER_MATCH;
+    else if (ustart < tstart)
+        return SEARCH_LEFT;
     else
         return SEARCH_RIGHT;
+}
+
+static int gavl_intersect_cmp_func(uintptr_t ustart, uintptr_t len, gavl_tree_node_s * tnode)
+{
+    uintptr_t uend = ustart + len;
+    uintptr_t tstart = tnode->addr;
+    uintptr_t tend = tnode->addr + tnode->len;
+
+    if (uend <= tstart)
+        return SEARCH_LEFT;
+    else if (tend <= ustart)
+        return SEARCH_RIGHT;
+    else
+        return BUFFER_MATCH;
 }
 
 int MPL_gavl_tree_create(void (*free_fn) (void *), MPL_gavl_tree_t * gavl_tree)
@@ -284,4 +303,134 @@ int MPL_gavl_tree_free(MPL_gavl_tree_t gavl_tree)
     }
     MPL_free(gavl_tree_iptr);
     return mpl_err;
+}
+
+int MPL_gavl_tree_delete(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len)
+{
+    int mpl_err = MPL_SUCCESS;
+    gavl_tree_node_s *cur_node;
+    gavl_tree_node_s *inorder_node;
+    gavl_tree_s *gavl_tree_iptr = (gavl_tree_s *) gavl_tree;
+
+    DECLARE_STACK(gavl_tree_node_s *, node_stack);
+
+    void *val;
+    do {
+        CLEAR_STACK(node_stack);
+        cur_node = gavl_tree_iptr->root;
+        val = NULL;
+        if (cur_node == NULL) {
+            goto fn_exit;
+        } else {
+            do {
+                int cmp_ret = gavl_intersect_cmp_func((uintptr_t) addr, len, cur_node);
+                if (cmp_ret == SEARCH_LEFT) {
+                    if (cur_node->left != NULL) {
+                        STACK_PUSH(node_stack, cur_node);
+                        cur_node = cur_node->left;
+                        continue;
+                    } else {
+                        break;
+                    }
+                } else if (cmp_ret == SEARCH_RIGHT) {
+                    if (cur_node->right != NULL) {
+                        STACK_PUSH(node_stack, cur_node);
+                        cur_node = cur_node->right;
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+
+                if (cur_node->right == NULL) {
+                    if (cur_node->parent == NULL) {
+                        /* delete root node */
+                        if (cur_node->left) {
+                            gavl_tree_iptr->root = cur_node->left;
+                            gavl_tree_iptr->root->parent = NULL;
+                        } else {
+                            gavl_tree_iptr->root = NULL;
+                        }
+                        val = (void *) cur_node->val;
+                        MPL_free(cur_node);
+                        break;
+                    } else {
+                        inorder_node = cur_node->parent;
+                        if (inorder_node->left == cur_node)
+                            inorder_node->left = cur_node->left;
+                        else
+                            inorder_node->right = cur_node->left;
+                        if (cur_node->left)
+                            cur_node->left->parent = inorder_node;
+
+                        val = (void *) cur_node->val;
+                        MPL_free(cur_node);
+                        STACK_PUSH(node_stack, inorder_node);
+                    }
+                } else {
+                    inorder_node = cur_node->right;
+                    STACK_PUSH(node_stack, cur_node);
+                    while (inorder_node->left) {
+                        STACK_PUSH(node_stack, inorder_node);
+                        inorder_node = inorder_node->left;
+                    }
+
+                    if (inorder_node->parent != cur_node) {
+                        if (inorder_node->right)
+                            inorder_node->right->parent = inorder_node->parent;
+                        inorder_node->parent->left = inorder_node->right;
+                    } else {
+                        /* only right child of deleted node */
+                        cur_node->right = NULL;
+                    }
+                    val = (void *) cur_node->val;
+                    cur_node->addr = inorder_node->addr;
+                    cur_node->len = inorder_node->len;
+                    cur_node->val = inorder_node->val;
+                    MPL_free(inorder_node);
+                }
+
+                STACK_POP(node_stack, cur_node);
+
+              stack_recovery:
+                gavl_update_node_info(cur_node);
+
+                int lheight = cur_node->left == NULL ? 0 : cur_node->left->height;
+                int rheight = cur_node->right == NULL ? 0 : cur_node->right->height;
+                if (lheight - rheight > 1) {
+                    gavl_tree_node_s *lnode = cur_node->left;
+                    int llheight = lnode->left == NULL ? 0 : lnode->left->height;
+                    if (llheight + 1 == lheight)
+                        gavl_right_rotation(cur_node, lnode);
+                    else
+                        gavl_left_right_rotation(cur_node, lnode);
+                } else if (rheight - lheight > 1) {
+                    gavl_tree_node_s *rnode = cur_node->right;
+                    int rlheight = rnode->left == NULL ? 0 : rnode->left->height;
+                    if (rlheight + 1 == rheight)
+                        gavl_right_left_rotation(cur_node, rnode);
+                    else
+                        gavl_left_rotation(cur_node, rnode);
+                }
+
+                if (!STACK_EMPTY(node_stack)) {
+                    STACK_POP(node_stack, cur_node);
+                    goto stack_recovery;
+                } else {
+                    break;
+                }
+            } while (1);
+
+            while (gavl_tree_iptr->root && gavl_tree_iptr->root->parent != NULL)
+                gavl_tree_iptr->root = gavl_tree_iptr->root->parent;
+
+            if (val && gavl_tree_iptr->gavl_free_fn)
+                gavl_tree_iptr->gavl_free_fn(val);
+        }
+    } while (val);
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -26,7 +26,7 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_h
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_handle_unmap(void *ptr, MPL_gpu_ipc_mem_handle_t ipc_handle)
+int MPL_gpu_ipc_handle_unmap(void *ptr)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;
@@ -87,6 +87,11 @@ int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
 }
 
 int MPL_gpu_get_global_dev_ids(int *global_ids, int count)
+{
+    return MPL_SUCCESS;
+}
+
+int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
 {
     return MPL_SUCCESS;
 }

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -95,3 +95,8 @@ int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
 {
     return MPL_SUCCESS;
 }
+
+int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr))
+{
+    return MPL_SUCCESS;
+}

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -294,4 +294,9 @@ int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
     return MPL_SUCCESS;
 }
 
+int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr))
+{
+    return MPL_SUCCESS;
+}
+
 #endif /* MPL_HAVE_ZE */

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -4,13 +4,14 @@
  */
 
 #include "mpl.h"
+#include <assert.h>
 
 MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 
 #ifdef MPL_HAVE_ZE
 
 ze_driver_handle_t global_ze_driver_handle;
-ze_device_handle_t *device_handles;
+ze_device_handle_t *global_ze_devices_handle;
 int gpu_ze_init_driver();
 
 #define ZE_ERR_CHECK(ret) \
@@ -21,20 +22,21 @@ int gpu_ze_init_driver();
 
 int MPL_gpu_init(int *device_count_ptr, int *max_dev_id_ptr)
 {
-    int ret_error;
-    int device_count;
+    ze_result_t ret;
+    int ret_error, device_count;
     ret_error = gpu_ze_init_driver();
     if (ret_error != MPL_SUCCESS)
         goto fn_fail;
 
+    zeDriverGet(NULL, &global_ze_driver_handle);
     ret = zeDeviceGet(global_ze_driver_handle, &device_count, NULL);
     ZE_ERR_CHECK(ret);
 
-    device_handles = MPL_malloc(device_count * sizeof(ze_device_handle_t), MPL_MEM_OTHER);
-    ret = zeDeviceGet(global_ze_driver_handle, &device_count, device_handles);
-    ZE_ERR_CHECK(ret);
-
     *max_dev_id_ptr = *device_count_ptr = device_count;
+    global_ze_devices_handle =
+        (ze_device_handle_t *) MPL_malloc(sizeof(ze_device_handle_t) * device_count, MPL_MEM_OTHER);
+    ret = zeDeviceGet(global_ze_driver_handle, &device_count, global_ze_devices_handle);
+    ZE_ERR_CHECK(ret);
 
   fn_exit:
     return MPL_SUCCESS;
@@ -110,15 +112,15 @@ int gpu_ze_init_driver()
 
 int MPL_gpu_finalize()
 {
-    MPL_free(device_handles);
+    MPL_free(global_ze_devices_handle);
     return MPL_SUCCESS;
 }
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
+    int mpl_err;
     ze_result_t ret;
-    ipc_handle->offset = 0;
-    ret = zeDriverGetMemIpcHandle(global_ze_driver_handle, ptr, &ipc_handle->handle);
+    ret = zeDriverGetMemIpcHandle(global_ze_driver_handle, ptr, ipc_handle);
     ZE_ERR_CHECK(ret);
 
   fn_exit:
@@ -130,24 +132,28 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
                            void **ptr)
 {
+    int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
+
     ret =
-        zeDriverOpenMemIpcHandle(global_ze_driver_handle, dev_handle, ipc_handle.handle,
-                                 ZE_IPC_MEMORY_FLAG_NONE, ptr);
-    ZE_ERR_CHECK(ret);
+        zeDriverOpenMemIpcHandle(global_ze_driver_handle,
+                                 global_ze_devices_handle[ipc_handle.global_dev_id],
+                                 ipc_handle.handle, ZE_IPC_MEMORY_FLAG_NONE, ptr);
+    if (ret != ZE_RESULT_SUCCESS) {
+        mpl_err = MPL_ERR_GPU_INTERNAL;
+        goto fn_fail;
+    }
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_unmap(void *ptr, MPL_gpu_ipc_mem_handle_t ipc_handle)
+int MPL_gpu_ipc_handle_unmap(void *ptr)
 {
     ze_result_t ret;
-    ret =
-        zeDriverCloseMemIpcHandle(global_ze_driver_handle,
-                                  (void *) ((char *) ptr - ipc_handle.offset));
+    ret = zeDriverCloseMemIpcHandle(global_ze_driver_handle, ptr);
     ZE_ERR_CHECK(ret);
 
   fn_exit:
@@ -279,6 +285,12 @@ int MPL_gpu_get_global_dev_ids(int *global_ids, int count)
 {
     for (int i = 0; i < count; ++i)
         global_ids[i] = i;
+    return MPL_SUCCESS;
+}
+
+int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
+{
+    /* TODO: need to find oneAPI function to retrieve base addr and buffer len */
     return MPL_SUCCESS;
 }
 


### PR DESCRIPTION
## Pull Request Description
This PR provides the following functions:
- add `MPL_gavl_tree_delete` to delete a node in gavl tree and return the corresponding buffer handle
- applies generic AVL tree to IPC GPU communication
- implement cache invalidation when user calls `cudaFree/cudaMemFree`
