### PR TITLE
coll: bug fix in ibcast_intra_sched_smp

### DIFF
--- a/src/mpi/coll/ibcast/ibcast_intra_sched_smp.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_smp.c
@@ -49,18 +49,19 @@ int MPIR_Ibcast_intra_sched_smp(void *buffer, int count, MPI_Datatype datatype, 
     if (comm_ptr->node_comm != NULL && MPIR_Get_intranode_rank(comm_ptr, root) > 0) {   /* is not the node root (0) *//* and is on our node (!-1) */
         if (root == comm_ptr->rank) {
             mpi_errno = MPIR_Sched_send(buffer, count, datatype, 0, comm_ptr->node_comm, s);
+            MPIR_ERR_CHECK(mpi_errno);
         } else if (0 == comm_ptr->node_comm->rank) {
             mpi_errno =
                 MPIR_Sched_recv_status(buffer, count, datatype,
                                        MPIR_Get_intranode_rank(comm_ptr, root), comm_ptr->node_comm,
                                        &ibcast_state->status, s);
-        }
-        MPIR_ERR_CHECK(mpi_errno);
-        MPIR_SCHED_BARRIER(s);
+            MPIR_ERR_CHECK(mpi_errno);
 #ifdef HAVE_ERROR_CHECKING
-        mpi_errno = MPIR_Sched_cb(&sched_test_length, ibcast_state, s);
-        MPIR_ERR_CHECK(mpi_errno);
+            MPIR_SCHED_BARRIER(s);
+            mpi_errno = MPIR_Sched_cb(&sched_test_length, ibcast_state, s);
+            MPIR_ERR_CHECK(mpi_errno);
 #endif
+        }
         MPIR_SCHED_BARRIER(s);
     }
 


### PR DESCRIPTION
## Pull Request Description
The ERROR_CHECKING of sched_test_length is supposed only for recv side,
but we accidentally checked on both side. The send side status is simply
garbage, causing errors.

Thanks Eric for reporting issue #4635.

## TODO

* [x] check testsuite to confirm the bug case is not covered or understand why
* [x] add test to cover the bug case if necessary

## Expected Impact
Fixes #4635 

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
