### PR TITLE
prerequisite patches for generic AVL tree

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -1498,9 +1498,12 @@ is too big (> MPIU_SHMW_GHND_SZ)
 
 ## GPU related error messages
 **gpu_query_ptr: gpu_query_pointer_attr failed
-**gpu_ipc_open_mem_handle: gpu_ipc_open_mem_handle failed
-**gpu_ipc_get_mem_handle: gpu_ipc_get_mem_handle failed
-**gpu_ipc_close_mem_handle: gpu_ipc_close_mem_handle failed
+**gpu_ipc_handle_map: gpu_ipc_handle_map failed
+**gpu_ipc_handle_create: gpu_ipc_handle_create failed
+**gpu_ipc_handle_unmap: gpu_ipc_handle_unmap failed
+
+## GAVL tree related error messages
+**mpl_gavl_search: mpl_gavl_search failed
 # -----------------------------------------------------------------------------
 # The following names are defined but not used (see the -careful option 
 # for extracterrmsgs) (still to do: move the undefined names here)

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -169,15 +169,15 @@ int MPI_Finalize(void)
      * for atomic file updates makes this harder. */
     MPII_final_coverage_delay(rank);
 
+    mpi_errno = MPL_gpu_finalize();
+    MPIR_ERR_CHECK(mpi_errno);
+
     /* All memory should be freed at this point */
     MPII_finalize_memory_tracing();
 
     MPII_thread_mutex_destroy();
     MPIR_Typerep_finalize();
     MPL_atomic_store_int(&MPIR_Process.mpich_state, MPICH_MPI_STATE__POST_FINALIZED);
-
-    mpi_errno = MPL_gpu_finalize();
-    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
   fn_exit:

--- a/src/mpi/init/init.c
+++ b/src/mpi/init/init.c
@@ -135,9 +135,6 @@ int MPI_Init(int *argc, char ***argv)
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
-    mpi_errno = MPL_gpu_init();
-    MPIR_ERR_CHECK(mpi_errno);
-
     /* ... end of body of routine ... */
     MPIR_FUNC_TERSE_INIT_EXIT(MPID_STATE_MPI_INIT);
     return mpi_errno;

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -202,6 +202,9 @@ int MPIR_Init_thread(int *argc, char ***argv, int user_required, int *provided)
 
     if (provided)
         *provided = MPIR_ThreadInfo.thread_provided;
+
+    mpi_errno = MPL_gpu_init();
+    MPIR_ERR_CHECK(mpi_errno);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpid/ch4/include/shmpre.h
+++ b/src/mpid/ch4/include/shmpre.h
@@ -18,8 +18,7 @@
                                      MPIDI_IPC_am_request_t ipc;
 #define MPIDI_SHM_REQUEST_DECL       MPIDI_POSIX_request_t posix;
 #define MPIDI_SHM_COMM_DECL          MPIDI_POSIX_comm_t posix;
-#define MPIDI_SHM_WIN_DECL           MPIDI_POSIX_win_t posix;   \
-                                     MPIDI_IPC_win_t ipc;
+#define MPIDI_SHM_WIN_DECL           MPIDI_POSIX_win_t posix;
 
 #define MPIDI_SHM_REQUEST(req, field)  ((req)->dev.ch4.am.shm_am.field)
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -35,9 +35,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPC
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     attr->ipc_type = MPIDI_IPCI_TYPE__GPU;
-    mpl_err = MPL_gpu_ipc_get_mem_handle(&attr->mem_handle.gpu.ipc_handle, (void *) vaddr);
+    mpl_err = MPL_gpu_ipc_handle_create(vaddr, &attr->mem_handle.gpu.ipc_handle);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                        "**gpu_ipc_get_mem_handle");
+                        "**gpu_ipc_handle_create");
 
     attr->threshold.send_lmt_sz = MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD;
 #else
@@ -60,9 +60,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_han
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
 
-    mpl_err = MPL_gpu_ipc_open_mem_handle(vaddr, mem_handle.ipc_handle, dev_handle);
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                        "**gpu_ipc_open_mem_handle");
+    mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, dev_handle, vaddr);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_map");
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
@@ -77,9 +76,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_close_mem(void *vaddr, MPL_gpu_ipc_mem_ha
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_CLOSE_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_CLOSE_MEM);
 
-    mpl_err = MPL_gpu_ipc_close_mem_handle(vaddr, ipc_handle);
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                        "**gpu_ipc_close_mem_handle");
+    mpl_err = MPL_gpu_ipc_handle_unmap(vaddr, ipc_handle);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_unmap");
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_CLOSE_MEM);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -46,7 +46,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPC
     attr->threshold.send_lmt_sz = MPIR_AINT_MAX;
 #endif
 
-
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_GET_MEM_ATTR);
     return mpi_errno;
@@ -55,8 +54,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPC
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
-                                                  MPL_gpu_device_handle_t dev_handle,
-                                                  MPIDI_GPU_mem_seg_t * mem_seg, void **vaddr)
+                                                  MPL_gpu_device_handle_t dev_handle, void **vaddr)
 {
     int mpi_errno = MPI_SUCCESS, mpl_err = MPL_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
@@ -65,8 +63,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_han
     mpl_err = MPL_gpu_ipc_open_mem_handle(vaddr, mem_handle.ipc_handle, dev_handle);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                         "**gpu_ipc_open_mem_handle");
-    mem_seg->vaddr = *vaddr;
-    mem_seg->ipc_handle = mem_handle.ipc_handle;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
@@ -75,13 +71,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_han
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_close_mem(MPIDI_GPU_mem_seg_t mem_seg)
+MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_close_mem(void *vaddr, MPL_gpu_ipc_mem_handle_t ipc_handle)
 {
     int mpi_errno = MPI_SUCCESS, mpl_err = MPL_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_CLOSE_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_CLOSE_MEM);
 
-    mpl_err = MPL_gpu_ipc_close_mem_handle(mem_seg.vaddr, mem_seg.ipc_handle);
+    mpl_err = MPL_gpu_ipc_close_mem_handle(vaddr, ipc_handle);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                         "**gpu_ipc_close_mem_handle");
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -10,9 +10,4 @@ typedef struct MPIDI_GPU_mem_handle {
     MPL_gpu_ipc_mem_handle_t ipc_handle;
 } MPIDI_GPU_mem_handle_t;
 
-typedef struct MPIDI_GPU_mem_seg {
-    MPL_gpu_ipc_mem_handle_t ipc_handle;
-    void *vaddr;
-} MPIDI_GPU_mem_seg_t;
-
 #endif /* GPU_PRE_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/src/ipc_mem.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_mem.h
@@ -45,22 +45,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_attach_mem(MPIDI_IPCI_type_t ipc_type,
                                                    int node_rank,
                                                    MPIDI_IPCI_mem_handle_t mem_handle,
                                                    MPL_gpu_device_handle_t dev_handle, size_t size,
-                                                   MPIDI_IPCI_mem_seg_t * mem_seg, void **vaddr)
+                                                   void **vaddr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_ATTACH_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_ATTACH_MEM);
 
-    mem_seg->ipc_type = ipc_type;
-
     switch (ipc_type) {
         case MPIDI_IPCI_TYPE__XPMEM:
-            mpi_errno = MPIDI_XPMEM_attach_mem(node_rank, mem_handle.xpmem, size,
-                                               &mem_seg->u.xpmem, vaddr);
+            mpi_errno = MPIDI_XPMEM_attach_mem(node_rank, mem_handle.xpmem, size, vaddr);
             break;
         case MPIDI_IPCI_TYPE__GPU:
-            mpi_errno = MPIDI_GPU_attach_mem(mem_handle.gpu, dev_handle, &mem_seg->u.gpu, vaddr);
+            mpi_errno = MPIDI_GPU_attach_mem(mem_handle.gpu, dev_handle, vaddr);
             break;
         case MPIDI_IPCI_TYPE__NONE:
             /* no-op */
@@ -75,19 +72,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_attach_mem(MPIDI_IPCI_type_t ipc_type,
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_close_mem(MPIDI_IPCI_mem_seg_t mem_seg)
+MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_close_mem(MPIDI_IPCI_type_t ipc_type, void *vaddr,
+                                                  MPIDI_IPCI_mem_handle_t mem_handle)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_CLOSE_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_CLOSE_MEM);
 
-    switch (mem_seg.ipc_type) {
+    switch (ipc_type) {
         case MPIDI_IPCI_TYPE__XPMEM:
-            mpi_errno = MPIDI_XPMEM_close_mem(mem_seg.u.xpmem);
             break;
         case MPIDI_IPCI_TYPE__GPU:
-            mpi_errno = MPIDI_GPU_close_mem(mem_seg.u.gpu);
+            mpi_errno = MPIDI_GPU_close_mem(vaddr, mem_handle.gpu.ipc_handle);
             break;
         case MPIDI_IPCI_TYPE__NONE:
             /* noop */
@@ -101,4 +98,5 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_close_mem(MPIDI_IPCI_mem_seg_t mem_seg)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_CLOSE_MEM_HANDLE);
     return mpi_errno;
 }
+
 #endif /* IPC_MEM_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -90,7 +90,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
                                                         int src_lrank, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIDI_IPCI_mem_seg_t mem_seg;
     void *src_buf = NULL;
     size_t data_sz, recv_data_sz;
     MPIDI_SHMI_ctrl_hdr_t ack_ctrl_hdr;
@@ -99,7 +98,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_HANDLE_LMT_RECV);
 
     MPIDI_Datatype_check_size(MPIDIG_REQUEST(rreq, datatype), MPIDIG_REQUEST(rreq, count), data_sz);
-    memset(&mem_seg, 0, sizeof(mem_seg));
 
     /* Data truncation checking */
     recv_data_sz = MPL_MIN(src_data_sz, data_sz);
@@ -115,7 +113,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
     MPIR_GPU_query_pointer_attr(MPIDIG_REQUEST(rreq, buffer), &attr);
 
     mpi_errno = MPIDI_IPCI_attach_mem(ipc_type, src_lrank, mem_handle, attr.device, src_data_sz,
-                                      &mem_seg, &src_buf);
+                                      &src_buf);
     MPIR_ERR_CHECK(mpi_errno);
 
     IPC_TRACE("handle_lmt_recv: handle matched rreq %p [source %d, tag %d, "
@@ -131,7 +129,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
                                     MPIDIG_REQUEST(rreq, datatype), 0, &actual_unpack_bytes);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIDI_IPCI_close_mem(mem_seg);
+    mpi_errno = MPIDI_IPCI_close_mem(ipc_type, src_buf, mem_handle);
     MPIR_ERR_CHECK(mpi_errno);
 
     ack_ctrl_hdr.ipc_contig_slmt_fin.ipc_type = ipc_type;

--- a/src/mpid/ch4/shm/ipc/src/ipc_pre.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_pre.h
@@ -26,12 +26,6 @@ typedef struct MPIDI_IPC_am_request {
     MPIDI_IPC_am_unexp_rreq_t unexp_rreq;
 } MPIDI_IPC_am_request_t;
 
-/* window extension */
-typedef struct MPIDI_IPC_win {
-    MPIDI_IPCI_mem_seg_t *mem_segs;     /* store opened memory handles
-                                         * for all local processes in the window. */
-} MPIDI_IPC_win_t;
-
 /* ctrl packet header types */
 typedef struct MPIDI_IPC_ctrl_send_contig_lmt_rts {
     MPIDI_IPCI_type_t ipc_type;

--- a/src/mpid/ch4/shm/ipc/src/ipc_types.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_types.h
@@ -21,8 +21,7 @@ typedef struct {
 /* memory handle definition
  * MPIDI_IPCI_mem_handle_t: local memory handle
  * MPIDI_IPCI_mem_attr_t: local memory attributes including available handle,
- *                        IPC type, and thresholds
- * MPIDI_IPCI_mem_seg_t: mapped segment with remote memory handle */
+ *                        IPC type, and thresholds */
 typedef union MPIDI_IPCI_mem_handle {
     MPIDI_XPMEM_mem_handle_t xpmem;
     MPIDI_GPU_mem_handle_t gpu;
@@ -36,14 +35,6 @@ typedef struct MPIDI_IPCI_mem_attr {
         size_t send_lmt_sz;
     } threshold;
 } MPIDI_IPCI_mem_attr_t;
-
-typedef struct MPIDI_IPCI_mem_seg {
-    MPIDI_IPCI_type_t ipc_type;
-    union {
-        MPIDI_XPMEM_mem_seg_t xpmem;
-        MPIDI_GPU_mem_seg_t gpu;
-    } u;
-} MPIDI_IPCI_mem_seg_t;
 
 #ifdef MPL_USE_DBG_LOGGING
 extern MPL_dbg_class MPIDI_IPCI_DBG_GENERAL;

--- a/src/mpid/ch4/shm/ipc/xpmem/globals.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/globals.c
@@ -12,12 +12,3 @@ MPIDI_XPMEMI_global_t MPIDI_XPMEMI_global;
 #ifdef MPL_USE_DBG_LOGGING
 MPL_dbg_class MPIDI_XPMEMI_DBG_GENERAL;
 #endif
-
-/* Preallocated segment objects */
-/* TODO: should use memory pool API. Direct pool objects is not needed. */
-MPIDI_XPMEMI_seg_t MPIDI_XPMEMI_seg_mem_direct[MPIDI_XPMEMI_SEG_PREALLOC];
-
-MPIR_Object_alloc_t MPIDI_XPMEMI_seg_mem = { 0, 0, 0, 0, MPIR_INTERNAL,
-    sizeof(MPIDI_XPMEMI_seg_t), MPIDI_XPMEMI_seg_mem_direct,
-    MPIDI_XPMEMI_SEG_PREALLOC
-};

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_mem.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_mem.c
@@ -6,33 +6,16 @@
 #include "xpmem_post.h"
 
 int MPIDI_XPMEM_attach_mem(int node_rank,
-                           MPIDI_XPMEM_mem_handle_t handle,
-                           size_t size, MPIDI_XPMEM_mem_seg_t * mem_seg, void **vaddr)
+                           MPIDI_XPMEM_mem_handle_t handle, size_t size, void **vaddr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_ATTACH_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_ATTACH_MEM);
 
-    MPIDI_XPMEMI_seg_t *seg_ptr = (MPIDI_XPMEMI_seg_t *) mem_seg->seg_ptr;
     mpi_errno = MPIDI_XPMEMI_seg_regist(node_rank, size, (void *) handle.src_offset,
-                                        &seg_ptr, vaddr,
+                                        vaddr,
                                         &MPIDI_XPMEMI_global.segmaps[node_rank].segcache_ubuf);
-    mem_seg->seg_ptr = seg_ptr;
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_ATTACH_MEM);
-    return mpi_errno;
-}
-
-int MPIDI_XPMEM_close_mem(MPIDI_XPMEM_mem_seg_t mem_seg)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_CLOSE_MEM);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_CLOSE_MEM);
-
-    MPIR_Assert(mem_seg.seg_ptr);
-
-    mpi_errno = MPIDI_XPMEMI_seg_deregist((MPIDI_XPMEMI_seg_t *) mem_seg.seg_ptr);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_CLOSE_MEM);
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
@@ -65,8 +65,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_mem_attr(const void *vaddr,
 int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *tag_bits);
 int MPIDI_XPMEM_mpi_finalize_hook(void);
 int MPIDI_XPMEM_attach_mem(int node_rank, MPIDI_XPMEM_mem_handle_t handle, size_t size,
-                           MPIDI_XPMEM_mem_seg_t * mem_seg, void **vaddr);
-int MPIDI_XPMEM_close_mem(MPIDI_XPMEM_mem_seg_t mem_seg);
-
+                           void **vaddr);
 
 #endif /* XPMEM_POST_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_pre.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_pre.h
@@ -11,10 +11,6 @@ typedef struct {
     uint64_t src_offset;
 } MPIDI_XPMEM_mem_handle_t;
 
-typedef struct {
-    void *seg_ptr;
-} MPIDI_XPMEM_mem_seg_t;
-
 /* request extension definition */
 typedef struct {
     int dummy;

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
@@ -45,13 +45,12 @@ MPL_STATIC_INLINE_PREFIX int seg_do_create(MPIDI_XPMEMI_seg_t ** seg_ptr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEG_DO_CREATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEG_DO_CREATE);
 
-    *seg_ptr = MPIR_Handle_obj_alloc(&MPIDI_XPMEMI_seg_mem);
+    *seg_ptr = (MPIDI_XPMEMI_seg_t *) MPL_malloc(sizeof(MPIDI_XPMEMI_seg_t), MPL_MEM_OTHER);
     MPIR_ERR_CHKANDJUMP1(!(*seg_ptr), mpi_errno, MPI_ERR_OTHER, "**nomem",
                          "**nomem %s", "MPIDI_XPMEMI_seg_t");
     seg = *seg_ptr;
     seg->low = low;
     seg->high = high;
-    MPIR_Object_set_ref(seg, 0);
 
     xpmem_addr.apid = apid;
     xpmem_addr.offset = seg->low;
@@ -63,8 +62,7 @@ MPL_STATIC_INLINE_PREFIX int seg_do_create(MPIDI_XPMEMI_seg_t ** seg_ptr,
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEG_DO_CREATE);
     return mpi_errno;
   fn_fail:
-    if (seg)    /* in case xpmem_attach fails */
-        MPIR_Handle_obj_free(&MPIDI_XPMEMI_seg_mem, seg);
+    MPL_free(seg);
     goto fn_exit;
 }
 
@@ -76,10 +74,9 @@ MPL_STATIC_INLINE_PREFIX int seg_do_release(MPIDI_XPMEMI_seg_t * seg)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEG_DO_RELEASE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEG_DO_RELEASE);
 
-    MPIR_Assert(MPIR_Object_get_ref(seg) == 0);
     ret = xpmem_detach((void *) seg->vaddr);
     MPIR_ERR_CHKANDJUMP(ret == -1, mpi_errno, MPI_ERR_OTHER, "**xpmem_detach");
-    MPIR_Handle_obj_free(&MPIDI_XPMEMI_seg_mem, seg);
+    MPL_free(seg);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEG_DO_RELEASE);
@@ -497,9 +494,7 @@ int MPIDI_XPMEMI_segtree_delete_all(MPIDI_XPMEMI_segtree_t * tree)
  * - vaddr:   corresponding start address of the remote buffer in local
  *            virtual address space. */
 int MPIDI_XPMEMI_seg_regist(int node_rank, size_t size,
-                            void *remote_vaddr,
-                            MPIDI_XPMEMI_seg_t ** seg_ptr,
-                            void **vaddr, MPIDI_XPMEMI_segtree_t * segcache)
+                            void *remote_vaddr, void **vaddr, MPIDI_XPMEMI_segtree_t * segcache)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_XPMEMI_segmap_t *segmap = &MPIDI_XPMEMI_global.segmaps[node_rank];
@@ -528,32 +523,16 @@ int MPIDI_XPMEMI_seg_regist(int node_rank, size_t size,
         segtree_do_search_and_insert_safe(segcache, seg_low, seg_high,
                                           segmap->apid, &seg, &voffset);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_Object_add_ref(seg);
+
     /* return mapped vaddr without round down */
     *vaddr = (void *) ((off_t) seg->vaddr + offset_diff + voffset);
-    *seg_ptr = seg;
-    XPMEM_TRACE("seg: register segment %p(refcount %d) for node_rank %d, apid 0x%lx, "
+    XPMEM_TRACE("seg: register segment %p for node_rank %d, apid 0x%lx, "
                 "size 0x%lx->0x%lx, seg->low %p->0x%lx, attached_vaddr %p, vaddr %p\n", seg,
-                MPIR_Object_get_ref(seg), node_rank, (uint64_t) segmap->apid, size, seg_size,
+                node_rank, (uint64_t) segmap->apid, size, seg_size,
                 remote_vaddr, seg->low, seg->vaddr, *vaddr);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEG_REGIST);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
-}
-
-/* Deregister a segment from cache.
- * It only decreases the segment's reference count. */
-int MPIDI_XPMEMI_seg_deregist(MPIDI_XPMEMI_seg_t * seg)
-{
-    int mpi_errno = MPI_SUCCESS, c = 0;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEG_DEREGIST);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEG_DEREGIST);
-    MPIR_Object_release_ref(seg, &c);
-    XPMEM_TRACE("seg: deregister segment %p(refcount %d) vaddr=%p\n", seg,
-                MPIR_Object_get_ref(seg), seg->vaddr);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEG_DEREGIST);
-    return mpi_errno;
 }

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.h
@@ -11,9 +11,6 @@
 int MPIDI_XPMEMI_segtree_init(MPIDI_XPMEMI_segtree_t * tree);
 int MPIDI_XPMEMI_segtree_delete_all(MPIDI_XPMEMI_segtree_t * tree);
 int MPIDI_XPMEMI_seg_regist(int node_rank, size_t size,
-                            void *remote_vaddr,
-                            MPIDI_XPMEMI_seg_t ** seg_ptr,
-                            void **vaddr, MPIDI_XPMEMI_segtree_t * segcache);
-int MPIDI_XPMEMI_seg_deregist(MPIDI_XPMEMI_seg_t * seg);
+                            void *remote_vaddr, void **vaddr, MPIDI_XPMEMI_segtree_t * segcache);
 
 #endif /* XPMEM_SEG_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_stub.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_stub.c
@@ -17,12 +17,7 @@ int MPIDI_XPMEM_mpi_finalize_hook(void)
 }
 
 int MPIDI_XPMEM_attach_mem(int node_rank, MPIDI_XPMEM_mem_handle_t handle,
-                           size_t size, MPIDI_XPMEM_mem_seg_t * mem_seg, void **vaddr)
-{
-    return MPI_SUCCESS;
-}
-
-int MPIDI_XPMEM_close_mem(MPIDI_XPMEM_mem_seg_t mem_seg)
+                           size_t size, void **vaddr)
 {
     return MPI_SUCCESS;
 }

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_types.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_types.h
@@ -10,10 +10,8 @@
 #include <xpmem.h>
 
 #define MPIDI_XPMEMI_PERMIT_VALUE ((void *)0600)
-#define MPIDI_XPMEMI_SEG_PREALLOC 8     /* Number of segments to preallocate in the "direct" block */
 
 typedef struct MPIDI_XPMEMI_seg {
-    MPIR_OBJECT_HEADER;
     /* AVL-tree internal components start */
     struct MPIDI_XPMEMI_seg *parent;
     struct MPIDI_XPMEMI_seg *left;
@@ -45,7 +43,6 @@ typedef struct {
 } MPIDI_XPMEMI_global_t;
 
 extern MPIDI_XPMEMI_global_t MPIDI_XPMEMI_global;
-extern MPIR_Object_alloc_t MPIDI_XPMEMI_seg_mem;
 
 #ifdef MPL_USE_DBG_LOGGING
 extern MPL_dbg_class MPIDI_XPMEMI_DBG_GENERAL;

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -30,10 +30,10 @@ typedef struct {
 
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
 
-int MPL_gpu_ipc_get_mem_handle(MPL_gpu_ipc_mem_handle_t * h_mem, void *ptr);
-int MPL_gpu_ipc_open_mem_handle(void **ptr, MPL_gpu_ipc_mem_handle_t h_mem,
-                                MPL_gpu_device_handle_t h_device);
-int MPL_gpu_ipc_close_mem_handle(void *ptr, MPL_gpu_ipc_mem_handle_t h_mem);
+int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle);
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
+                           void **ptr);
+int MPL_gpu_ipc_handle_unmap(void *ptr, MPL_gpu_ipc_mem_handle_t ipc_handle);
 
 int MPL_gpu_malloc_host(void **ptr, size_t size);
 int MPL_gpu_free_host(void *ptr);

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -8,7 +8,10 @@
 
 #include "level_zero/ze_api.h"
 
-typedef ze_ipc_mem_handle_t MPL_gpu_ipc_mem_handle_t;
+typedef struct {
+    uintptr_t offset;
+    ze_ipc_mem_handle_t handle;
+} MPL_gpu_ipc_mem_handle_t;
 typedef ze_device_handle_t MPL_gpu_device_handle_t;
 #define MPL_GPU_DEVICE_INVALID NULL
 

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -13,20 +13,20 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     return MPL_SUCCESS;
 }
 
-int MPL_gpu_ipc_get_mem_handle(MPL_gpu_ipc_mem_handle_t * h_mem, void *ptr)
+int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_open_mem_handle(void **ptr, MPL_gpu_ipc_mem_handle_t h_mem,
-                                MPL_gpu_device_handle_t h_device)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
+                           void **ptr)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_close_mem_handle(void *ptr, MPL_gpu_ipc_mem_handle_t h_mem)
+int MPL_gpu_ipc_handle_unmap(void *ptr, MPL_gpu_ipc_mem_handle_t ipc_handle)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;


### PR DESCRIPTION
## Pull Request Description
This PR is the prerequisite of genric avl tree PR #4621 
It does the following changes:
- remove mem_seg parameters used in IPC and lower layers
- move `MPL_gpu_init` init function into `MPIR_Init_thread` 
- move `MPL_gpu_finalize` before memory trace checking function to avoid memory leak complaints
- rewrite `get/open/close` MPL operations and replace them with ipc handle `create/map/unmap`
