### PR TITLE
Add MPL gpu dev id and mapping logic

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -1503,6 +1503,7 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **gpu_ipc_handle_unmap: gpu_ipc_handle_unmap failed
 **gpu_init: gpu_init failed
 **gpu_finalize: gpu_finalize failed
+**gpu_get_global_dev_ids: gpu_get_global_dev_ids failed
 
 ## GAVL tree related error messages
 **mpl_gavl_search: mpl_gavl_search failed

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -1501,6 +1501,8 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **gpu_ipc_handle_map: gpu_ipc_handle_map failed
 **gpu_ipc_handle_create: gpu_ipc_handle_create failed
 **gpu_ipc_handle_unmap: gpu_ipc_handle_unmap failed
+**gpu_init: gpu_init failed
+**gpu_finalize: gpu_finalize failed
 
 ## GAVL tree related error messages
 **mpl_gavl_search: mpl_gavl_search failed

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -169,9 +169,6 @@ int MPI_Finalize(void)
      * for atomic file updates makes this harder. */
     MPII_final_coverage_delay(rank);
 
-    mpi_errno = MPL_gpu_finalize();
-    MPIR_ERR_CHECK(mpi_errno);
-
     /* All memory should be freed at this point */
     MPII_finalize_memory_tracing();
 

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -203,8 +203,6 @@ int MPIR_Init_thread(int *argc, char ***argv, int user_required, int *provided)
     if (provided)
         *provided = MPIR_ThreadInfo.thread_provided;
 
-    mpi_errno = MPL_gpu_init();
-    MPIR_ERR_CHECK(mpi_errno);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpid/ch4/shm/ipc/gpu/Makefile.mk
+++ b/src/mpid/ch4/shm/ipc/gpu/Makefile.mk
@@ -6,6 +6,7 @@
 noinst_HEADERS += src/mpid/ch4/shm/ipc/gpu/gpu_pre.h       \
                   src/mpid/ch4/shm/ipc/gpu/gpu_post.h
 
+mpi_core_sources += src/mpid/ch4/shm/ipc/gpu/gpu_post.c
 if BUILD_SHM_IPC_GPU
 mpi_core_sources += src/mpid/ch4/shm/ipc/gpu/gpu_init.c
 else

--- a/src/mpid/ch4/shm/ipc/gpu/Makefile.mk
+++ b/src/mpid/ch4/shm/ipc/gpu/Makefile.mk
@@ -6,4 +6,8 @@
 noinst_HEADERS += src/mpid/ch4/shm/ipc/gpu/gpu_pre.h       \
                   src/mpid/ch4/shm/ipc/gpu/gpu_post.h
 
+if BUILD_SHM_IPC_GPU
+mpi_core_sources += src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+else
 mpi_core_sources += src/mpid/ch4/shm/ipc/gpu/gpu_stub.c
+endif

--- a/src/mpid/ch4/shm/ipc/gpu/Makefile.mk
+++ b/src/mpid/ch4/shm/ipc/gpu/Makefile.mk
@@ -8,7 +8,10 @@ noinst_HEADERS += src/mpid/ch4/shm/ipc/gpu/gpu_pre.h       \
 
 mpi_core_sources += src/mpid/ch4/shm/ipc/gpu/gpu_post.c
 if BUILD_SHM_IPC_GPU
-mpi_core_sources += src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+mpi_core_sources += src/mpid/ch4/shm/ipc/gpu/globals.c     \
+                    src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+
+noinst_HEADERS += src/mpid/ch4/shm/ipc/gpu/gpu_types.h
 else
 mpi_core_sources += src/mpid/ch4/shm/ipc/gpu/gpu_stub.c
 endif

--- a/src/mpid/ch4/shm/ipc/gpu/globals.c
+++ b/src/mpid/ch4/shm/ipc/gpu/globals.c
@@ -1,0 +1,9 @@
+/*
+ *  Copyright (C) by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include "mpidimpl.h"
+#include "gpu_types.h"
+
+MPIDI_GPUI_global_t MPIDI_GPUI_global;

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -5,30 +5,136 @@
 
 #include "mpidimpl.h"
 #include "gpu_post.h"
+#include "gpu_types.h"
 
 int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
 {
     int mpl_err, mpi_errno = MPI_SUCCESS;
+    int device_count = -1;
+    int my_max_dev_id, node_max_dev_id = -1;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_MPI_INIT_HOOK);
+    MPIR_CHKPMEM_DECL(1);
 
-    mpl_err = MPL_gpu_init();
+    MPIDI_GPUI_global.initialized = 0;
+    mpl_err = MPL_gpu_init(&device_count, &my_max_dev_id);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_init");
+
+    if (device_count == -1)
+        goto fn_exit;
+
+    int *global_ids = MPL_malloc(sizeof(int) * device_count, MPL_MEM_OTHER);
+    assert(global_ids);
+
+    mpl_err = MPL_gpu_get_global_dev_ids(global_ids, device_count);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                        "**gpu_get_global_dev_ids");
+
+    MPIDI_GPUI_global.local_to_global_map = NULL;
+    MPIDI_GPUI_global.global_to_local_map = NULL;
+    for (int i = 0; i < device_count; ++i) {
+        MPIDI_GPUI_dev_id_t *id_obj =
+            (MPIDI_GPUI_dev_id_t *) MPL_malloc(sizeof(MPIDI_GPUI_dev_id_t), MPL_MEM_OTHER);
+        assert(id_obj);
+        id_obj->local_dev_id = i;
+        id_obj->global_dev_id = global_ids[i];
+        HASH_ADD_INT(MPIDI_GPUI_global.local_to_global_map, local_dev_id, id_obj, MPL_MEM_OTHER);
+
+        id_obj = (MPIDI_GPUI_dev_id_t *) MPL_malloc(sizeof(MPIDI_GPUI_dev_id_t), MPL_MEM_OTHER);
+        assert(id_obj);
+        id_obj->local_dev_id = i;
+        id_obj->global_dev_id = global_ids[i];
+        HASH_ADD_INT(MPIDI_GPUI_global.global_to_local_map, global_dev_id, id_obj, MPL_MEM_OTHER);
+    }
+
+    MPL_free(global_ids);
+    MPIDU_Init_shm_put(&my_max_dev_id, sizeof(int));
+    MPIDU_Init_shm_barrier();
+
+    /* get node max device id */
+    for (int i = 0; i < MPIR_Process.local_size; i++) {
+        MPIDU_Init_shm_get(i, sizeof(int), &my_max_dev_id);
+        if (my_max_dev_id > node_max_dev_id)
+            node_max_dev_id = my_max_dev_id;
+    }
+    MPIDU_Init_shm_barrier();
+
+    MPIR_CHKPMEM_MALLOC(MPIDI_GPUI_global.visible_dev_global_id, int **,
+                        sizeof(int *) * MPIR_Process.local_size, mpi_errno, "gpu devmaps",
+                        MPL_MEM_SHM);
+    for (int i = 0; i < MPIR_Process.local_size; ++i) {
+        MPIDI_GPUI_global.visible_dev_global_id[i] =
+            (int *) MPL_malloc(sizeof(int) * (node_max_dev_id + 1), MPL_MEM_OTHER);
+        MPIR_Assert(MPIDI_GPUI_global.visible_dev_global_id[i]);
+
+        if (i == MPIR_Process.local_rank) {
+            for (int j = 0; j < node_max_dev_id; ++j) {
+                MPIDI_GPUI_dev_id_t *tmp = NULL;
+                HASH_FIND_INT(MPIDI_GPUI_global.global_to_local_map, &j, tmp);
+                if (tmp)
+                    MPIDI_GPUI_global.visible_dev_global_id[i][j] = 1;
+                else
+                    MPIDI_GPUI_global.visible_dev_global_id[i][j] = 0;
+            }
+            MPIDU_Init_shm_put(MPIDI_GPUI_global.visible_dev_global_id[i],
+                               sizeof(int) * (node_max_dev_id + 1));
+        }
+    }
+    MPIDU_Init_shm_barrier();
+
+    /* FIXME: current implementation uses MPIDU_Init_shm_get to exchange visible id.
+     * shm buffer size is defined as 64 bytes by default. Therefore, if number of
+     * gpu device is larger than 16, the MPIDU_Init_shm_get would fail. */
+    MPIR_Assert((node_max_dev_id + 1) <= MPIDU_INIT_SHM_BLOCK_SIZE / sizeof(int));
+    for (int i = 0; i < MPIR_Process.local_size; ++i)
+        MPIDU_Init_shm_get(i, sizeof(int) * (node_max_dev_id + 1),
+                           MPIDI_GPUI_global.visible_dev_global_id[i]);
+    MPIDU_Init_shm_barrier();
+
+    MPIDI_GPUI_global.local_procs = MPIR_Process.node_local_map;
+    MPIDI_GPUI_global.local_ranks =
+        (int *) MPL_malloc(MPIR_Process.size * sizeof(int), MPL_MEM_SHM);
+    for (int i = 0; i < MPIR_Process.size; ++i) {
+        MPIDI_GPUI_global.local_ranks[i] = -1;
+    }
+    for (int i = 0; i < MPIR_Process.local_size; i++) {
+        MPIDI_GPUI_global.local_ranks[MPIDI_GPUI_global.local_procs[i]] = i;
+    }
+
+    MPIDI_GPUI_global.initialized = 1;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_MPI_INIT_HOOK);
     return mpi_errno;
   fn_fail:
+    MPIR_CHKPMEM_REAP();
     goto fn_exit;
 }
 
 int MPIDI_GPU_mpi_finalize_hook(void)
 {
     int mpl_err, mpi_errno = MPI_SUCCESS;
+    MPIDI_GPUI_dev_id_t *current, *tmp;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_MPI_FINALIZE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_MPI_FINALIZE_HOOK);
+
+    if (MPIDI_GPUI_global.initialized) {
+        HASH_ITER(hh, MPIDI_GPUI_global.local_to_global_map, current, tmp) {
+            HASH_DEL(MPIDI_GPUI_global.local_to_global_map, current);
+            MPL_free(current);
+        }
+
+        HASH_ITER(hh, MPIDI_GPUI_global.global_to_local_map, current, tmp) {
+            HASH_DEL(MPIDI_GPUI_global.global_to_local_map, current);
+            MPL_free(current);
+        }
+        MPL_free(MPIDI_GPUI_global.local_ranks);
+        for (int i = 0; i < MPIR_Process.local_size; ++i)
+            MPL_free(MPIDI_GPUI_global.visible_dev_global_id[i]);
+        MPL_free(MPIDI_GPUI_global.visible_dev_global_id);
+    }
 
     mpl_err = MPL_gpu_finalize();
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_finalize");

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "gpu_post.h"
+
+int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
+{
+    int mpl_err, mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_MPI_INIT_HOOK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_MPI_INIT_HOOK);
+
+    mpl_err = MPL_gpu_init();
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_init");
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_MPI_INIT_HOOK);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_GPU_mpi_finalize_hook(void)
+{
+    int mpl_err, mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_MPI_FINALIZE_HOOK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_MPI_FINALIZE_HOOK);
+
+    mpl_err = MPL_gpu_finalize();
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_finalize");
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_MPI_FINALIZE_HOOK);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -17,6 +17,7 @@ int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPCI_mem_attr_t * attr)
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                         "**gpu_ipc_handle_create");
 
+    MPL_gpu_get_dev_id(attr->gpu_attr.device, &attr->mem_handle.gpu.dev_id);
     attr->threshold.send_lmt_sz = MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD;
 #else
     /* Do not support IPC data transfer */
@@ -40,7 +41,13 @@ int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     int mpl_err = MPL_SUCCESS;
-    mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, dev_handle, vaddr);
+    if (mem_handle.dev_id == -1)
+        mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, dev_handle, vaddr);
+    else {
+        MPL_gpu_device_handle_t remote_dev_handle;
+        MPL_gpu_get_dev_handle(mem_handle.dev_id, &remote_dev_handle);
+        mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, remote_dev_handle, vaddr);
+    }
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_map");
 #endif
 
@@ -51,7 +58,7 @@ int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
     goto fn_exit;
 }
 
-int MPIDI_GPU_close_mem(void *vaddr, MPL_gpu_ipc_mem_handle_t ipc_handle)
+int MPIDI_GPU_close_mem(void *vaddr, MPIDI_GPU_mem_handle_t ipc_handle)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_CLOSE_MEM);
@@ -59,7 +66,7 @@ int MPIDI_GPU_close_mem(void *vaddr, MPL_gpu_ipc_mem_handle_t ipc_handle)
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     int mpl_err = MPL_SUCCESS;
-    mpl_err = MPL_gpu_ipc_handle_unmap(vaddr, ipc_handle);
+    mpl_err = MPL_gpu_ipc_handle_unmap(vaddr, handle.ipc_handle);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_unmap");
 #endif
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -40,23 +40,28 @@ int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPCI_mem_attr_t * attr)
 }
 
 int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
-                         MPL_gpu_device_handle_t dev_handle, void **vaddr)
+                         MPL_gpu_device_handle_t dev_handle, MPI_Datatype recv_type, void **vaddr)
 {
     int mpi_errno = MPI_SUCCESS;
+
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
-    int mpl_err = MPL_SUCCESS;
-    if (mem_handle.global_dev_id == -1)
+    int recv_dt_contig, mpl_err = MPL_SUCCESS;
+    MPIDI_GPUI_dev_id_t *avail_id = NULL;
+    MPIDI_Datatype_check_contig(recv_type, recv_dt_contig);
+    HASH_FIND_INT(MPIDI_GPUI_global.global_to_local_map, &mem_handle.global_dev_id, avail_id);
+
+    if (avail_id == NULL)
         mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, dev_handle, vaddr);
     else {
         MPL_gpu_device_handle_t remote_dev_handle;
-        MPIDI_GPUI_dev_id_t *tmp;
-        HASH_FIND_INT(MPIDI_GPUI_global.global_to_local_map, &mem_handle.global_dev_id, tmp);
-
-        MPL_gpu_get_dev_handle(tmp->local_dev_id, &remote_dev_handle);
-        mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, remote_dev_handle, vaddr);
+        MPL_gpu_get_dev_handle(avail_id->local_dev_id, &remote_dev_handle);
+        if (!recv_dt_contig)
+            mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, dev_handle, vaddr);
+        else
+            mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, remote_dev_handle, vaddr);
     }
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_map");
 #endif

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "gpu_pre.h"
+
+int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPCI_mem_attr_t * attr)
+{
+    int mpi_errno = MPI_SUCCESS, mpl_err = MPL_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_GET_MEM_ATTR);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPC_GET_MEM_ATTR);
+
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU
+    attr->ipc_type = MPIDI_IPCI_TYPE__GPU;
+    mpl_err = MPL_gpu_ipc_handle_create(vaddr, &attr->mem_handle.gpu.ipc_handle);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                        "**gpu_ipc_handle_create");
+
+    attr->threshold.send_lmt_sz = MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD;
+#else
+    /* Do not support IPC data transfer */
+    attr->ipc_type = MPIDI_IPCI_TYPE__NONE;
+    attr->threshold.send_lmt_sz = MPIR_AINT_MAX;
+#endif
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_GET_MEM_ATTR);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
+                         MPL_gpu_device_handle_t dev_handle, void **vaddr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
+
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU
+    int mpl_err = MPL_SUCCESS;
+    mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, dev_handle, vaddr);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_map");
+#endif
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_GPU_close_mem(void *vaddr, MPL_gpu_ipc_mem_handle_t ipc_handle)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_CLOSE_MEM);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_CLOSE_MEM);
+
+#ifdef MPIDI_CH4_SHM_ENABLE_GPU
+    int mpl_err = MPL_SUCCESS;
+    mpl_err = MPL_gpu_ipc_handle_unmap(vaddr, ipc_handle);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_unmap");
+#endif
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_CLOSE_MEM);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -3,7 +3,9 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpidimpl.h"
 #include "gpu_pre.h"
+#include "gpu_types.h"
 
 int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPCI_mem_attr_t * attr)
 {
@@ -12,12 +14,17 @@ int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPCI_mem_attr_t * attr)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPC_GET_MEM_ATTR);
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
+    int local_dev_id;
+    MPIDI_GPUI_dev_id_t *tmp;
+
     attr->ipc_type = MPIDI_IPCI_TYPE__GPU;
     mpl_err = MPL_gpu_ipc_handle_create(vaddr, &attr->mem_handle.gpu.ipc_handle);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                         "**gpu_ipc_handle_create");
 
-    MPL_gpu_get_dev_id(attr->gpu_attr.device, &attr->mem_handle.gpu.dev_id);
+    MPL_gpu_get_dev_id(attr->gpu_attr.device, &local_dev_id);
+    HASH_FIND_INT(MPIDI_GPUI_global.local_to_global_map, &local_dev_id, tmp);
+    attr->mem_handle.gpu.global_dev_id = tmp->global_dev_id;
     attr->threshold.send_lmt_sz = MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD;
 #else
     /* Do not support IPC data transfer */
@@ -41,11 +48,14 @@ int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     int mpl_err = MPL_SUCCESS;
-    if (mem_handle.dev_id == -1)
+    if (mem_handle.global_dev_id == -1)
         mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, dev_handle, vaddr);
     else {
         MPL_gpu_device_handle_t remote_dev_handle;
-        MPL_gpu_get_dev_handle(mem_handle.dev_id, &remote_dev_handle);
+        MPIDI_GPUI_dev_id_t *tmp;
+        HASH_FIND_INT(MPIDI_GPUI_global.global_to_local_map, &mem_handle.global_dev_id, tmp);
+
+        MPL_gpu_get_dev_handle(tmp->local_dev_id, &remote_dev_handle);
         mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, remote_dev_handle, vaddr);
     }
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_map");
@@ -58,7 +68,7 @@ int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
     goto fn_exit;
 }
 
-int MPIDI_GPU_close_mem(void *vaddr, MPIDI_GPU_mem_handle_t ipc_handle)
+int MPIDI_GPU_close_mem(void *vaddr, MPIDI_GPU_mem_handle_t handle)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_CLOSE_MEM);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -26,10 +26,11 @@ cvars:
 
 #include "gpu_pre.h"
 
-int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPCI_mem_attr_t * attr);
-int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
-                         MPL_gpu_device_handle_t dev_handle, MPI_Datatype recv_type, void **vaddr);
-int MPIDI_GPU_close_mem(void *vaddr, MPIDI_GPU_mem_handle_t handle);
+int MPIDI_GPU_get_ipc_attr(const void *vaddr, MPIDI_IPCI_ipc_attr_t * ipc_attr);
+int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle,
+                             MPL_gpu_device_handle_t dev_handle,
+                             MPI_Datatype recv_type, void **vaddr);
+int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle);
 int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits);
 int MPIDI_GPU_mpi_finalize_hook(void);
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -24,68 +24,12 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-#include "ch4_impl.h"
 #include "gpu_pre.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPCI_mem_attr_t * attr)
-{
-    int mpi_errno = MPI_SUCCESS, mpl_err = MPL_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_GET_MEM_ATTR);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPC_GET_MEM_ATTR);
-
-#ifdef MPIDI_CH4_SHM_ENABLE_GPU
-    attr->ipc_type = MPIDI_IPCI_TYPE__GPU;
-    mpl_err = MPL_gpu_ipc_handle_create(vaddr, &attr->mem_handle.gpu.ipc_handle);
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                        "**gpu_ipc_handle_create");
-
-    attr->threshold.send_lmt_sz = MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD;
-#else
-    /* Do not support IPC data transfer */
-    attr->ipc_type = MPIDI_IPCI_TYPE__NONE;
-    attr->threshold.send_lmt_sz = MPIR_AINT_MAX;
-#endif
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_GET_MEM_ATTR);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
-                                                  MPL_gpu_device_handle_t dev_handle, void **vaddr)
-{
-    int mpi_errno = MPI_SUCCESS, mpl_err = MPL_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
-
-    mpl_err = MPL_gpu_ipc_handle_map(mem_handle.ipc_handle, dev_handle, vaddr);
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_map");
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_ATTACH_MEM);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_GPU_close_mem(void *vaddr, MPL_gpu_ipc_mem_handle_t ipc_handle)
-{
-    int mpi_errno = MPI_SUCCESS, mpl_err = MPL_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_CLOSE_MEM);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_CLOSE_MEM);
-
-    mpl_err = MPL_gpu_ipc_handle_unmap(vaddr, ipc_handle);
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_ipc_handle_unmap");
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_CLOSE_MEM);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
+int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPCI_mem_attr_t * attr);
+int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
+                         MPL_gpu_device_handle_t dev_handle, void **vaddr);
+int MPIDI_GPU_close_mem(void *vaddr, MPL_gpu_ipc_mem_handle_t ipc_handle);
 int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits);
 int MPIDI_GPU_mpi_finalize_hook(void);
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -28,7 +28,7 @@ cvars:
 
 int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPCI_mem_attr_t * attr);
 int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
-                         MPL_gpu_device_handle_t dev_handle, void **vaddr);
+                         MPL_gpu_device_handle_t dev_handle, MPI_Datatype recv_type, void **vaddr);
 int MPIDI_GPU_close_mem(void *vaddr, MPIDI_GPU_mem_handle_t handle);
 int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits);
 int MPIDI_GPU_mpi_finalize_hook(void);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -29,7 +29,7 @@ cvars:
 int MPIDI_GPU_get_mem_attr(const void *vaddr, MPIDI_IPCI_mem_attr_t * attr);
 int MPIDI_GPU_attach_mem(MPIDI_GPU_mem_handle_t mem_handle,
                          MPL_gpu_device_handle_t dev_handle, void **vaddr);
-int MPIDI_GPU_close_mem(void *vaddr, MPL_gpu_ipc_mem_handle_t ipc_handle);
+int MPIDI_GPU_close_mem(void *vaddr, MPIDI_GPU_mem_handle_t handle);
 int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits);
 int MPIDI_GPU_mpi_finalize_hook(void);
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -10,7 +10,7 @@
 
 typedef struct MPIDI_GPU_mem_handle {
     MPL_gpu_ipc_mem_handle_t ipc_handle;
-    int dev_id;
+    int global_dev_id;
 } MPIDI_GPU_mem_handle_t;
 
 #endif /* GPU_PRE_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -8,9 +8,9 @@
 
 #include "mpl.h"
 
-typedef struct MPIDI_GPU_mem_handle {
+typedef struct MPIDI_GPU_ipc_handle {
     MPL_gpu_ipc_mem_handle_t ipc_handle;
     int global_dev_id;
-} MPIDI_GPU_mem_handle_t;
+} MPIDI_GPU_ipc_handle_t;
 
 #endif /* GPU_PRE_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -6,6 +6,8 @@
 #ifndef GPU_PRE_H_INCLUDED
 #define GPU_PRE_H_INCLUDED
 
+#include "mpl.h"
+
 typedef struct MPIDI_GPU_mem_handle {
     MPL_gpu_ipc_mem_handle_t ipc_handle;
 } MPIDI_GPU_mem_handle_t;

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -10,6 +10,7 @@
 
 typedef struct MPIDI_GPU_mem_handle {
     MPL_gpu_ipc_mem_handle_t ipc_handle;
+    int dev_id;
 } MPIDI_GPU_mem_handle_t;
 
 #endif /* GPU_PRE_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef GPU_TYPES_H_INCLUDED
+#define GPU_TYPES_H_INCLUDED
+
+#include "uthash.h"
+
+typedef struct MPIDI_GPUI_dev_id {
+    int local_dev_id;
+    int global_dev_id;
+    UT_hash_handle hh;
+} MPIDI_GPUI_dev_id_t;
+
+typedef struct {
+    MPIDI_GPUI_dev_id_t *local_to_global_map;
+    MPIDI_GPUI_dev_id_t *global_to_local_map;
+    int **visible_dev_global_id;
+    int *local_ranks;
+    int *local_procs;
+    int initialized;
+} MPIDI_GPUI_global_t;
+
+extern MPIDI_GPUI_global_t MPIDI_GPUI_global;
+
+#endif /* GPU_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/src/ipc_control.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.c
@@ -80,7 +80,7 @@ int MPIDI_IPCI_send_contig_lmt_rts_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
 
         /* Complete IPC receive */
         mpi_errno = MPIDI_IPCI_handle_lmt_recv(slmt_rts_hdr->ipc_type,
-                                               slmt_rts_hdr->mem_handle,
+                                               slmt_rts_hdr->ipc_handle,
                                                slmt_rts_hdr->data_sz, slmt_rts_hdr->sreq_ptr, rreq);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
@@ -100,7 +100,7 @@ int MPIDI_IPCI_send_contig_lmt_rts_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
         /* store IPC internal info */
         MPIDI_SHM_REQUEST(rreq, status) |= MPIDI_SHM_REQ_IPC_SEND_LMT;
         MPIDI_IPCI_REQUEST(rreq, ipc_type) = slmt_rts_hdr->ipc_type;
-        MPIDI_IPCI_REQUEST(rreq, unexp_rreq).mem_handle = slmt_rts_hdr->mem_handle;
+        MPIDI_IPCI_REQUEST(rreq, unexp_rreq).ipc_handle = slmt_rts_hdr->ipc_handle;
         MPIDI_IPCI_REQUEST(rreq, unexp_rreq).data_sz = slmt_rts_hdr->data_sz;
         MPIDI_IPCI_REQUEST(rreq, unexp_rreq).src_lrank = slmt_rts_hdr->src_lrank;
         MPIDI_IPCI_REQUEST(rreq, unexp_rreq).sreq_ptr = slmt_rts_hdr->sreq_ptr;

--- a/src/mpid/ch4/shm/ipc/src/ipc_control.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.c
@@ -81,9 +81,7 @@ int MPIDI_IPCI_send_contig_lmt_rts_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
         /* Complete IPC receive */
         mpi_errno = MPIDI_IPCI_handle_lmt_recv(slmt_rts_hdr->ipc_type,
                                                slmt_rts_hdr->mem_handle,
-                                               slmt_rts_hdr->data_sz,
-                                               slmt_rts_hdr->sreq_ptr,
-                                               slmt_rts_hdr->src_lrank, rreq);
+                                               slmt_rts_hdr->data_sz, slmt_rts_hdr->sreq_ptr, rreq);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* Enqueue unexpected receive request */

--- a/src/mpid/ch4/shm/ipc/src/ipc_mem.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_mem.h
@@ -11,67 +11,6 @@
 #include "../xpmem/xpmem_post.h"
 #include "../gpu/gpu_post.h"
 
-/* Get local memory handle. No-op if the IPC type is NONE. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_get_mem_attr(const void *vaddr,
-                                                     MPIDI_IPCI_mem_attr_t * attr)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_GET_MEM_ATTR);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_GET_MEM_ATTR);
-
-    MPIR_GPU_query_pointer_attr(vaddr, &attr->gpu_attr);
-
-    if (attr->gpu_attr.type == MPL_GPU_POINTER_DEV) {
-        mpi_errno = MPIDI_GPU_get_mem_attr(vaddr, attr);
-        MPIR_ERR_CHECK(mpi_errno);
-    } else {
-        mpi_errno = MPIDI_XPMEM_get_mem_attr(vaddr, attr);
-        MPIR_ERR_CHECK(mpi_errno);
-    }
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_GET_MEM_ATTR);
-    return mpi_errno;
-  fn_fail:
-    attr->ipc_type = MPIDI_IPCI_TYPE__NONE;
-    memset(&attr->mem_handle, 0, sizeof(MPIDI_IPCI_mem_handle_t));
-    goto fn_exit;
-}
-
-/* Attach remote memory handle. Return the local memory segment handle and
- * the mapped virtual address. No-op if the IPC type is NONE. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_attach_mem(MPIDI_IPCI_type_t ipc_type,
-                                                   int node_rank,
-                                                   MPIDI_IPCI_mem_handle_t mem_handle,
-                                                   MPL_gpu_device_handle_t dev_handle, size_t size,
-                                                   void **vaddr)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_ATTACH_MEM);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_ATTACH_MEM);
-
-    switch (ipc_type) {
-        case MPIDI_IPCI_TYPE__XPMEM:
-            mpi_errno = MPIDI_XPMEM_attach_mem(node_rank, mem_handle.xpmem, size, vaddr);
-            break;
-        case MPIDI_IPCI_TYPE__GPU:
-            mpi_errno = MPIDI_GPU_attach_mem(mem_handle.gpu, dev_handle, vaddr);
-            break;
-        case MPIDI_IPCI_TYPE__NONE:
-            /* no-op */
-            break;
-        default:
-            /* Unknown IPC type */
-            MPIR_Assert(0);
-            break;
-    }
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_ATTACH_MEM);
-    return mpi_errno;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_close_mem(MPIDI_IPCI_type_t ipc_type, void *vaddr,
                                                   MPIDI_IPCI_mem_handle_t mem_handle)
 {
@@ -84,7 +23,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_close_mem(MPIDI_IPCI_type_t ipc_type, vo
         case MPIDI_IPCI_TYPE__XPMEM:
             break;
         case MPIDI_IPCI_TYPE__GPU:
-            mpi_errno = MPIDI_GPU_close_mem(vaddr, mem_handle.gpu.ipc_handle);
+            mpi_errno = MPIDI_GPU_close_mem(vaddr, mem_handle.gpu);
             break;
         case MPIDI_IPCI_TYPE__NONE:
             /* noop */

--- a/src/mpid/ch4/shm/ipc/src/ipc_mem.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_mem.h
@@ -11,19 +11,19 @@
 #include "../xpmem/xpmem_post.h"
 #include "../gpu/gpu_post.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_close_mem(MPIDI_IPCI_type_t ipc_type, void *vaddr,
-                                                  MPIDI_IPCI_mem_handle_t mem_handle)
+MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_unmap(MPIDI_IPCI_type_t ipc_type, void *vaddr,
+                                                     MPIDI_IPCI_ipc_handle_t ipc_handle)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_CLOSE_MEM);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_CLOSE_MEM);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_HANDLE_UNMAP);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_HANDLE_UNMAP);
 
     switch (ipc_type) {
         case MPIDI_IPCI_TYPE__XPMEM:
             break;
         case MPIDI_IPCI_TYPE__GPU:
-            mpi_errno = MPIDI_GPU_close_mem(vaddr, mem_handle.gpu);
+            mpi_errno = MPIDI_GPU_ipc_handle_unmap(vaddr, ipc_handle.gpu);
             break;
         case MPIDI_IPCI_TYPE__NONE:
             /* noop */
@@ -34,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_close_mem(MPIDI_IPCI_type_t ipc_type, vo
             break;
     }
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_CLOSE_MEM_HANDLE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_HANDLE_UNMAP);
     return mpi_errno;
 }
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -25,7 +25,7 @@
  * and perform direct data transfer.
  */
 MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Aint count,
-                                                        MPI_Datatype datatype, size_t data_sz,
+                                                        MPI_Datatype datatype, uintptr_t data_sz,
                                                         int rank, int tag, MPIR_Comm * comm,
                                                         int context_offset, MPIDI_av_entry_t * addr,
                                                         MPIDI_IPCI_ipc_attr_t ipc_attr,
@@ -91,7 +91,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
 {
     int mpi_errno = MPI_SUCCESS;
     void *src_buf = NULL;
-    size_t data_sz, recv_data_sz;
+    uintptr_t data_sz, recv_data_sz;
     MPIDI_SHMI_ctrl_hdr_t ack_ctrl_hdr;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_HANDLE_LMT_RECV);

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -118,7 +118,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
             mpi_errno = MPIDI_XPMEM_attach_mem(mem_handle.xpmem, &src_buf);
             break;
         case MPIDI_IPCI_TYPE__GPU:
-            mpi_errno = MPIDI_GPU_attach_mem(mem_handle.gpu, attr.device, &src_buf);
+            mpi_errno =
+                MPIDI_GPU_attach_mem(mem_handle.gpu, attr.device, MPIDIG_REQUEST(rreq, datatype),
+                                     &src_buf);
             break;
         case MPIDI_IPCI_TYPE__NONE:
             /* no-op */

--- a/src/mpid/ch4/shm/ipc/src/ipc_pre.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_pre.h
@@ -12,7 +12,7 @@
 
 /* request extension */
 typedef struct MPIDI_IPC_am_unexp_rreq {
-    MPIDI_IPCI_mem_handle_t mem_handle;
+    MPIDI_IPCI_ipc_handle_t ipc_handle;
     uint64_t data_sz;
     MPIR_Request *sreq_ptr;
     int src_lrank;
@@ -29,7 +29,7 @@ typedef struct MPIDI_IPC_am_request {
 /* ctrl packet header types */
 typedef struct MPIDI_IPC_ctrl_send_contig_lmt_rts {
     MPIDI_IPCI_type_t ipc_type;
-    MPIDI_IPCI_mem_handle_t mem_handle;
+    MPIDI_IPCI_ipc_handle_t ipc_handle;
     uint64_t data_sz;           /* data size in bytes */
     MPIR_Request *sreq_ptr;     /* send request pointer */
     int src_lrank;              /* sender rank on local node */

--- a/src/mpid/ch4/shm/ipc/src/ipc_recv.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_recv.h
@@ -38,9 +38,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_matched_recv(void *buf,
 
         mpi_errno = MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_REQUEST(message, ipc_type),
                                                unexp_rreq->mem_handle,
-                                               unexp_rreq->data_sz,
-                                               unexp_rreq->sreq_ptr, unexp_rreq->src_lrank,
-                                               message);
+                                               unexp_rreq->data_sz, unexp_rreq->sreq_ptr, message);
         MPIR_ERR_CHECK(mpi_errno);
 
         *recvd_flag = true;

--- a/src/mpid/ch4/shm/ipc/src/ipc_recv.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_recv.h
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_matched_recv(void *buf,
         MPIDI_IPC_am_unexp_rreq_t *unexp_rreq = &MPIDI_IPCI_REQUEST(message, unexp_rreq);
 
         mpi_errno = MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_REQUEST(message, ipc_type),
-                                               unexp_rreq->mem_handle,
+                                               unexp_rreq->ipc_handle,
                                                unexp_rreq->data_sz, unexp_rreq->sreq_ptr, message);
         MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -21,7 +21,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_isend(const void *buf, MPI_Aint count
     int mpi_errno = MPI_SUCCESS;
     bool dt_contig;
     MPI_Aint true_lb;
-    size_t data_sz;
+    uintptr_t data_sz;
     void *vaddr;
     MPIDI_IPCI_ipc_attr_t ipc_attr;
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -22,6 +22,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_isend(const void *buf, MPI_Aint count
     bool dt_contig;
     MPI_Aint true_lb;
     size_t data_sz;
+    void *vaddr;
+    MPIDI_IPCI_mem_attr_t attr;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPC_MPI_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPC_MPI_ISEND);
@@ -29,8 +31,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_isend(const void *buf, MPI_Aint count
     MPIDI_Datatype_check_contig_size_lb(datatype, count, dt_contig, data_sz, true_lb);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_IPCI_mem_attr_t attr;
-    MPIDI_IPCI_get_mem_attr((char *) buf + true_lb, &attr);
+
+    vaddr = (char *) buf + true_lb;
+    MPIR_GPU_query_pointer_attr(vaddr, &attr.gpu_attr);
+
+    if (attr.gpu_attr.type == MPL_GPU_POINTER_DEV) {
+        mpi_errno = MPIDI_GPU_get_mem_attr(vaddr, &attr);
+        MPIR_ERR_CHECK(mpi_errno);
+    } else {
+        mpi_errno = MPIDI_XPMEM_get_mem_attr(vaddr, data_sz, &attr);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
     if (rank != comm->rank && attr.ipc_type != MPIDI_IPCI_TYPE__NONE &&
         data_sz >= attr.threshold.send_lmt_sz) {

--- a/src/mpid/ch4/shm/ipc/src/ipc_types.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_types.h
@@ -19,22 +19,22 @@ typedef struct {
 } MPIDI_IPCI_global_t;
 
 /* memory handle definition
- * MPIDI_IPCI_mem_handle_t: local memory handle
- * MPIDI_IPCI_mem_attr_t: local memory attributes including available handle,
+ * MPIDI_IPCI_ipc_handle_t: local memory handle
+ * MPIDI_IPCI_ipc_attr_t: local memory attributes including available handle,
  *                        IPC type, and thresholds */
-typedef union MPIDI_IPCI_mem_handle {
-    MPIDI_XPMEM_mem_handle_t xpmem;
-    MPIDI_GPU_mem_handle_t gpu;
-} MPIDI_IPCI_mem_handle_t;
+typedef union MPIDI_IPCI_ipc_handle {
+    MPIDI_XPMEM_ipc_handle_t xpmem;
+    MPIDI_GPU_ipc_handle_t gpu;
+} MPIDI_IPCI_ipc_handle_t;
 
-typedef struct MPIDI_IPCI_mem_attr {
+typedef struct MPIDI_IPCI_ipc_attr {
     MPIDI_IPCI_type_t ipc_type;
-    MPIDI_IPCI_mem_handle_t mem_handle;
+    MPIDI_IPCI_ipc_handle_t ipc_handle;
     MPL_pointer_attr_t gpu_attr;
     struct {
         size_t send_lmt_sz;
     } threshold;
-} MPIDI_IPCI_mem_attr_t;
+} MPIDI_IPCI_ipc_attr_t;
 
 #ifdef MPL_USE_DBG_LOGGING
 extern MPL_dbg_class MPIDI_IPCI_DBG_GENERAL;

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -169,7 +169,8 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
                      * local GPU device. */
                     mpi_errno =
                         MPIDI_GPU_attach_mem(ipc_shared_table[i].mem_handle.gpu,
-                                             attr.gpu_attr.device, &shared_table[i].shm_base_addr);
+                                             attr.gpu_attr.device, MPI_BYTE,
+                                             &shared_table[i].shm_base_addr);
                     break;
                 case MPIDI_IPCI_TYPE__NONE:
                     /* no-op */

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -53,7 +53,7 @@ typedef struct win_shared_info {
     uint32_t disp_unit;
     size_t size;
     MPIDI_IPCI_type_t ipc_type;
-    MPIDI_IPCI_mem_handle_t mem_handle;
+    MPIDI_IPCI_ipc_handle_t ipc_handle;
 } win_shared_info_t;
 
 int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
@@ -66,7 +66,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
     MPIDIG_win_shared_info_t *shared_table = NULL;
     win_shared_info_t *ipc_shared_table = NULL; /* temporary exchange buffer */
     int *ranks_in_shm_grp = NULL;
-    MPIDI_IPCI_mem_attr_t attr;
+    MPIDI_IPCI_ipc_attr_t ipc_attr;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPC_MPI_WIN_CREATE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPC_MPI_WIN_CREATE_HOOK);
@@ -80,19 +80,19 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
 
     /* Determine IPC type based on buffer type and submodule availability.
      * We always exchange in case any remote buffer can be shared by IPC. */
-    MPIR_GPU_query_pointer_attr(win->base, &attr.gpu_attr);
+    MPIR_GPU_query_pointer_attr(win->base, &ipc_attr.gpu_attr);
 
-    if (attr.gpu_attr.type == MPL_GPU_POINTER_DEV) {
-        mpi_errno = MPIDI_GPU_get_mem_attr(win->base, &attr);
+    if (ipc_attr.gpu_attr.type == MPL_GPU_POINTER_DEV) {
+        mpi_errno = MPIDI_GPU_get_ipc_attr(win->base, &ipc_attr);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
-        mpi_errno = MPIDI_XPMEM_get_mem_attr(win->base, win->size, &attr);
+        mpi_errno = MPIDI_XPMEM_get_ipc_attr(win->base, win->size, &ipc_attr);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* Disable local IPC for zero buffer */
     if (win->size == 0)
-        attr.ipc_type = MPIDI_IPCI_TYPE__NONE;
+        ipc_attr.ipc_type = MPIDI_IPCI_TYPE__NONE;
 
     /* Exchange shared memory region information */
     MPIR_T_PVAR_TIMER_START(RMA, rma_wincreate_allgather);
@@ -114,8 +114,8 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
     memset(&ipc_shared_table[shm_comm_ptr->rank], 0, sizeof(win_shared_info_t));
     ipc_shared_table[shm_comm_ptr->rank].size = win->size;
     ipc_shared_table[shm_comm_ptr->rank].disp_unit = win->disp_unit;
-    ipc_shared_table[shm_comm_ptr->rank].ipc_type = attr.ipc_type;
-    ipc_shared_table[shm_comm_ptr->rank].mem_handle = attr.mem_handle;
+    ipc_shared_table[shm_comm_ptr->rank].ipc_type = ipc_attr.ipc_type;
+    ipc_shared_table[shm_comm_ptr->rank].ipc_handle = ipc_attr.ipc_handle;
 
     mpi_errno = MPIR_Allgather(MPI_IN_PLACE,
                                0,
@@ -161,16 +161,16 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
             switch (ipc_shared_table[i].ipc_type) {
                 case MPIDI_IPCI_TYPE__XPMEM:
                     mpi_errno =
-                        MPIDI_XPMEM_attach_mem(ipc_shared_table[i].mem_handle.xpmem,
-                                               &shared_table[i].shm_base_addr);
+                        MPIDI_XPMEM_ipc_handle_map(ipc_shared_table[i].ipc_handle.xpmem,
+                                                   &shared_table[i].shm_base_addr);
                     break;
                 case MPIDI_IPCI_TYPE__GPU:
                     /* FIXME: remote win buffer should be mapped to each of their corresponding
                      * local GPU device. */
                     mpi_errno =
-                        MPIDI_GPU_attach_mem(ipc_shared_table[i].mem_handle.gpu,
-                                             attr.gpu_attr.device, MPI_BYTE,
-                                             &shared_table[i].shm_base_addr);
+                        MPIDI_GPU_ipc_handle_map(ipc_shared_table[i].ipc_handle.gpu,
+                                                 ipc_attr.gpu_attr.device, MPI_BYTE,
+                                                 &shared_table[i].shm_base_addr);
                     break;
                 case MPIDI_IPCI_TYPE__NONE:
                     /* no-op */

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_mem.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_mem.c
@@ -5,17 +5,17 @@
 #include "xpmem_seg.h"
 #include "xpmem_post.h"
 
-int MPIDI_XPMEM_attach_mem(MPIDI_XPMEM_mem_handle_t mem_handle, void **vaddr)
+int MPIDI_XPMEM_ipc_handle_map(MPIDI_XPMEM_ipc_handle_t handle, void **vaddr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_ATTACH_MEM);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_ATTACH_MEM);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_IPC_HANDLE_MAP);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_IPC_HANDLE_MAP);
 
     mpi_errno =
-        MPIDI_XPMEMI_seg_regist(mem_handle.src_lrank, mem_handle.data_sz,
-                                (void *) mem_handle.src_offset, vaddr,
-                                &MPIDI_XPMEMI_global.segmaps[mem_handle.src_lrank].segcache_ubuf);
+        MPIDI_XPMEMI_seg_regist(handle.src_lrank, handle.data_sz,
+                                (void *) handle.src_offset, vaddr,
+                                &MPIDI_XPMEMI_global.segmaps[handle.src_lrank].segcache_ubuf);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_ATTACH_MEM);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_IPC_HANDLE_MAP);
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_mem.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_mem.c
@@ -5,16 +5,16 @@
 #include "xpmem_seg.h"
 #include "xpmem_post.h"
 
-int MPIDI_XPMEM_attach_mem(int node_rank,
-                           MPIDI_XPMEM_mem_handle_t handle, size_t size, void **vaddr)
+int MPIDI_XPMEM_attach_mem(MPIDI_XPMEM_mem_handle_t mem_handle, void **vaddr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_ATTACH_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_ATTACH_MEM);
 
-    mpi_errno = MPIDI_XPMEMI_seg_regist(node_rank, size, (void *) handle.src_offset,
-                                        vaddr,
-                                        &MPIDI_XPMEMI_global.segmaps[node_rank].segcache_ubuf);
+    mpi_errno =
+        MPIDI_XPMEMI_seg_regist(mem_handle.src_lrank, mem_handle.data_sz,
+                                (void *) mem_handle.src_offset, vaddr,
+                                &MPIDI_XPMEMI_global.segmaps[mem_handle.src_lrank].segcache_ubuf);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_ATTACH_MEM);
     return mpi_errno;

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
@@ -38,34 +38,34 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_mem_attr(const void *vaddr, uintptr_t data_sz,
-                                                      MPIDI_IPCI_mem_attr_t * attr)
+MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_ipc_attr(const void *vaddr, uintptr_t data_sz,
+                                                      MPIDI_IPCI_ipc_attr_t * ipc_attr)
 {
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_GET_MEM_ATTR);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_GET_MEM_ATTR);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_GET_IPC_ATTR);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_GET_IPC_ATTR);
 
-    memset(&attr->mem_handle, 0, sizeof(MPIDI_IPCI_mem_handle_t));
+    memset(&ipc_attr->ipc_handle, 0, sizeof(MPIDI_IPCI_ipc_handle_t));
 
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
-    attr->ipc_type = MPIDI_IPCI_TYPE__XPMEM;
-    attr->mem_handle.xpmem.src_offset = (uint64_t) vaddr;
-    attr->mem_handle.xpmem.data_sz = data_sz;
-    attr->mem_handle.xpmem.src_lrank = MPIR_Process.local_rank;
+    ipc_attr->ipc_type = MPIDI_IPCI_TYPE__XPMEM;
+    ipc_attr->ipc_handle.xpmem.src_offset = (uint64_t) vaddr;
+    ipc_attr->ipc_handle.xpmem.data_sz = data_sz;
+    ipc_attr->ipc_handle.xpmem.src_lrank = MPIR_Process.local_rank;
     if (MPIR_CVAR_CH4_XPMEM_ENABLE)
-        attr->threshold.send_lmt_sz = MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD;
+        ipc_attr->threshold.send_lmt_sz = MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD;
     else
-        attr->threshold.send_lmt_sz = MPIR_AINT_MAX;
+        ipc_attr->threshold.send_lmt_sz = MPIR_AINT_MAX;
 #else
-    attr->ipc_type = MPIDI_IPCI_TYPE__NONE;
-    attr->threshold.send_lmt_sz = MPIR_AINT_MAX;
+    ipc_attr->ipc_type = MPIDI_IPCI_TYPE__NONE;
+    ipc_attr->threshold.send_lmt_sz = MPIR_AINT_MAX;
 #endif
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_GET_MEM_ATTR);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_GET_IPC_ATTR);
     return MPI_SUCCESS;
 }
 
 int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *tag_bits);
 int MPIDI_XPMEM_mpi_finalize_hook(void);
-int MPIDI_XPMEM_attach_mem(MPIDI_XPMEM_mem_handle_t mem_handle, void **vaddr);
+int MPIDI_XPMEM_ipc_handle_map(MPIDI_XPMEM_ipc_handle_t mem_handle, void **vaddr);
 
 #endif /* XPMEM_POST_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
@@ -38,7 +38,7 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_mem_attr(const void *vaddr,
+MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_mem_attr(const void *vaddr, uintptr_t data_sz,
                                                       MPIDI_IPCI_mem_attr_t * attr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_GET_MEM_ATTR);
@@ -49,6 +49,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_mem_attr(const void *vaddr,
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
     attr->ipc_type = MPIDI_IPCI_TYPE__XPMEM;
     attr->mem_handle.xpmem.src_offset = (uint64_t) vaddr;
+    attr->mem_handle.xpmem.data_sz = data_sz;
+    attr->mem_handle.xpmem.src_lrank = MPIR_Process.local_rank;
     if (MPIR_CVAR_CH4_XPMEM_ENABLE)
         attr->threshold.send_lmt_sz = MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD;
     else
@@ -64,7 +66,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_mem_attr(const void *vaddr,
 
 int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *tag_bits);
 int MPIDI_XPMEM_mpi_finalize_hook(void);
-int MPIDI_XPMEM_attach_mem(int node_rank, MPIDI_XPMEM_mem_handle_t handle, size_t size,
-                           void **vaddr);
+int MPIDI_XPMEM_attach_mem(MPIDI_XPMEM_mem_handle_t mem_handle, void **vaddr);
 
 #endif /* XPMEM_POST_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_pre.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_pre.h
@@ -9,6 +9,8 @@
 /* memory handle definition */
 typedef struct {
     uint64_t src_offset;
+    int src_lrank;
+    uintptr_t data_sz;
 } MPIDI_XPMEM_mem_handle_t;
 
 /* request extension definition */

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_pre.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_pre.h
@@ -8,10 +8,10 @@
 
 /* memory handle definition */
 typedef struct {
-    uint64_t src_offset;
+    uintptr_t src_offset;
     int src_lrank;
     uintptr_t data_sz;
-} MPIDI_XPMEM_mem_handle_t;
+} MPIDI_XPMEM_ipc_handle_t;
 
 /* request extension definition */
 typedef struct {

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
@@ -493,7 +493,7 @@ int MPIDI_XPMEMI_segtree_delete_all(MPIDI_XPMEMI_segtree_t * tree)
  *            or a newly created one.
  * - vaddr:   corresponding start address of the remote buffer in local
  *            virtual address space. */
-int MPIDI_XPMEMI_seg_regist(int node_rank, size_t size,
+int MPIDI_XPMEMI_seg_regist(int node_rank, uintptr_t size,
                             void *remote_vaddr, void **vaddr, MPIDI_XPMEMI_segtree_t * segcache)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -517,7 +517,7 @@ int MPIDI_XPMEMI_seg_regist(int node_rank, size_t size,
     seg_low = MPL_ROUND_DOWN_ALIGN((uint64_t) remote_vaddr,
                                    (uint64_t) MPIDI_XPMEMI_global.sys_page_sz);
     offset_diff = (off_t) remote_vaddr - seg_low;
-    seg_size = MPL_ROUND_UP_ALIGN(size + (size_t) offset_diff, MPIDI_XPMEMI_global.sys_page_sz);
+    seg_size = MPL_ROUND_UP_ALIGN(size + (uintptr_t) offset_diff, MPIDI_XPMEMI_global.sys_page_sz);
     seg_high = seg_low + seg_size;
     mpi_errno =
         segtree_do_search_and_insert_safe(segcache, seg_low, seg_high,

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.h
@@ -10,7 +10,7 @@
 
 int MPIDI_XPMEMI_segtree_init(MPIDI_XPMEMI_segtree_t * tree);
 int MPIDI_XPMEMI_segtree_delete_all(MPIDI_XPMEMI_segtree_t * tree);
-int MPIDI_XPMEMI_seg_regist(int node_rank, size_t size,
+int MPIDI_XPMEMI_seg_regist(int node_rank, uintptr_t size,
                             void *remote_vaddr, void **vaddr, MPIDI_XPMEMI_segtree_t * segcache);
 
 #endif /* XPMEM_SEG_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_stub.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_stub.c
@@ -16,7 +16,7 @@ int MPIDI_XPMEM_mpi_finalize_hook(void)
     return MPI_SUCCESS;
 }
 
-int MPIDI_XPMEM_attach_mem(MPIDI_XPMEM_mem_handle_t mem_handle, void **vaddr)
+int MPIDI_XPMEM_ipc_handle_map(MPIDI_XPMEM_ipc_handle_t handle, void **vaddr)
 {
     return MPI_SUCCESS;
 }

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_stub.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_stub.c
@@ -16,8 +16,7 @@ int MPIDI_XPMEM_mpi_finalize_hook(void)
     return MPI_SUCCESS;
 }
 
-int MPIDI_XPMEM_attach_mem(int node_rank, MPIDI_XPMEM_mem_handle_t handle,
-                           size_t size, void **vaddr)
+int MPIDI_XPMEM_attach_mem(MPIDI_XPMEM_mem_handle_t mem_handle, void **vaddr)
 {
     return MPI_SUCCESS;
 }

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -43,10 +43,11 @@ int MPL_gpu_unregister_host(const void *ptr);
 int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device);
 int MPL_gpu_free(void *ptr);
 
-int MPL_gpu_init(void);
+int MPL_gpu_init(int *device_count, int *max_dev_id_ptr);
 int MPL_gpu_finalize(void);
 
 int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id);
 int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle);
+int MPL_gpu_get_global_dev_ids(int *global_ids, int count);
 
 #endif /* ifndef MPL_GPU_H_INCLUDED */

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -46,4 +46,7 @@ int MPL_gpu_free(void *ptr);
 int MPL_gpu_init(void);
 int MPL_gpu_finalize(void);
 
+int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id);
+int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle);
+
 #endif /* ifndef MPL_GPU_H_INCLUDED */

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -54,7 +54,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     curet = cuMemGetAddressRange(&pbase, NULL, (CUdeviceptr) ptr);
     CU_ERR_CHECK(curet);
 
-    ret = cudaIpcGetMemHandle(&ipc_handle->handle, ptr);
+    ret = cudaIpcGetMemHandle(&ipc_handle->handle, (void *) ptr);
     CUDA_ERR_CHECK(ret);
 
     ipc_handle->offset = (uintptr_t) ptr - (uintptr_t) pbase;
@@ -183,5 +183,17 @@ int MPL_gpu_init()
 
 int MPL_gpu_finalize()
 {
+    return MPL_SUCCESS;
+}
+
+int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id)
+{
+    *dev_id = dev_handle;
+    return MPL_SUCCESS;
+}
+
+int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
+{
+    *dev_handle = dev_id;
     return MPL_SUCCESS;
 }

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -75,3 +75,13 @@ int MPL_gpu_finalize()
 {
     return MPL_SUCCESS;
 }
+
+int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id)
+{
+    return MPL_SUCCESS;
+}
+
+int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
+{
+    return MPL_SUCCESS;
+}

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -66,7 +66,7 @@ int MPL_gpu_free(void *ptr)
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_init()
+int MPL_gpu_init(int *device_count, int *max_dev_id_ptr)
 {
     return MPL_SUCCESS;
 }
@@ -82,6 +82,11 @@ int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id)
 }
 
 int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
+{
+    return MPL_SUCCESS;
+}
+
+int MPL_gpu_get_global_dev_ids(int *global_ids, int count)
 {
     return MPL_SUCCESS;
 }

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -19,7 +19,7 @@ int gpu_ze_init_driver();
             goto fn_fail; \
     } while (0)
 
-int MPL_gpu_init()
+int MPL_gpu_init(int *device_count_ptr, int *max_dev_id_ptr)
 {
     int ret_error;
     int device_count;
@@ -33,6 +33,8 @@ int MPL_gpu_init()
     device_handles = MPL_malloc(device_count * sizeof(ze_device_handle_t), MPL_MEM_OTHER);
     ret = zeDeviceGet(global_ze_driver_handle, &device_count, device_handles);
     ZE_ERR_CHECK(ret);
+
+    *max_dev_id_ptr = *device_count_ptr = device_count;
 
   fn_exit:
     return MPL_SUCCESS;
@@ -270,6 +272,13 @@ int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id)
 int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
 {
     *dev_handle = device_handles[dev_id];
+    return MPL_SUCCESS;
+}
+
+int MPL_gpu_get_global_dev_ids(int *global_ids, int count)
+{
+    for (int i = 0; i < count; ++i)
+        global_ids[i] = i;
     return MPL_SUCCESS;
 }
 


### PR DESCRIPTION
## Pull Request Description
This PR provides the following functions:
- add `dev_id` in `ipc_handle` to allow local process map buffer onto remote gpu
- add `MPL_gpu_ipc_handle_get_dev_id` function to retrieve device id of queried `ipc_handle`
- add device id mapping between global and local gpu device in case user export `CUDA_VISIBLE_DEVICES` variable
- add initial determination process of which gpu the remote buffer should map onto based on remote and local data contiguity and density

Two fixup commits are provided:
- rename mem_ definitions, variables and functions to ipc_ style in and below IPC layer
- replace `size_t` with `uintptr_t` type for length/size related variable