### PR TITLE
ch4/ofi: rename vni_src/dst in MPIDI_OFI_av_to_phys

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -402,31 +402,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_av_insert(int vni, int rank, void *addrna
 }
 
 MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_av_to_phys(MPIDI_av_entry_t * av,
-                                                        int vni_src, int vni_dst)
+                                                        int vni_local, int vni_remote)
 {
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         int ep_num = MPIDI_OFI_av_to_ep(&MPIDI_OFI_AV(av));
-        return fi_rx_addr(MPIDI_OFI_AV(av).dest[vni_src][vni_dst], ep_num,
+        return fi_rx_addr(MPIDI_OFI_AV(av).dest[vni_local][vni_remote], ep_num,
                           MPIDI_OFI_MAX_ENDPOINTS_BITS);
     } else {
-        return MPIDI_OFI_AV(av).dest[vni_src][vni_dst];
+        return MPIDI_OFI_AV(av).dest[vni_local][vni_remote];
     }
 #else /* MPIDI_OFI_VNI_USE_SEPCTX */
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        return fi_rx_addr(MPIDI_OFI_AV(av).dest[0][0], vni_dst, MPIDI_OFI_MAX_ENDPOINTS_BITS);
+        return fi_rx_addr(MPIDI_OFI_AV(av).dest[0][0], vni_remote, MPIDI_OFI_MAX_ENDPOINTS_BITS);
     } else {
-        MPIR_Assert(vni_dst == 0);
+        MPIR_Assert(vni_remote == 0);
         return MPIDI_OFI_AV(av).dest[0][0];
     }
 #endif
 }
 
 MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int rank,
-                                                          int vni_src, int vni_dst)
+                                                          int vni_local, int vni_remote)
 {
     MPIDI_av_entry_t *av = MPIDIU_comm_rank_to_av(comm, rank);
-    return MPIDI_OFI_av_to_phys(av, vni_src, vni_dst);
+    return MPIDI_OFI_av_to_phys(av, vni_local, vni_remote);
 }
 
 MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_is_tag_sync(uint64_t match_bits)


### PR DESCRIPTION
## Pull Request Description

Coverity complains:
```
     CID 210895:  API usage errors  (SWAPPED_ARGUMENTS)
     The positions of arguments in the call to "MPIDI_OFI_comm_to_phys" do not match the ordering of the parameters:
* "vni_dst" is passed to "vni_src"
* "vni_src" is passed to "vni_dst"
```

When translating address, vni_local/vni_remote may be more sensible than
vni_src/vni_dst. This should appease coverity.



## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
