### PR TITLE
Apply generic AVL tree to xpmem

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -1495,6 +1495,7 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **xpmem_detach: xpmem_detach failed
 **xpmem_release: xpmem_release failed
 **xpmem_remove: xpmem_remove failed
+**xpmem_segtree_init: xpmem_segtree_init failed
 
 ## GPU related error messages
 **gpu_query_ptr: gpu_query_pointer_attr failed

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
@@ -95,7 +95,7 @@ int MPIDI_XPMEM_mpi_finalize_hook(void)
     for (i = 0; i < MPIR_Process.local_size; i++) {
         /* should be called before xpmem_release
          * MPIDI_XPMEMI_segtree_delete_all will call xpmem_detach */
-        MPIDI_XPMEMI_segtree_delete_all(&MPIDI_XPMEMI_global.segmaps[i].segcache_ubuf);
+        MPL_gavl_tree_free(MPIDI_XPMEMI_global.segmaps[i].segcache_ubuf, MPIDI_XPMEM_seg_free);
         if (MPIDI_XPMEMI_global.segmaps[i].apid != -1) {
             XPMEM_TRACE("finalize: release apid: node_rank %d, 0x%lx\n",
                         i, (uint64_t) MPIDI_XPMEMI_global.segmaps[i].apid);

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_mem.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_mem.c
@@ -14,7 +14,7 @@ int MPIDI_XPMEM_ipc_handle_map(MPIDI_XPMEM_ipc_handle_t handle, void **vaddr)
     mpi_errno =
         MPIDI_XPMEMI_seg_regist(handle.src_lrank, handle.data_sz,
                                 (void *) handle.src_offset, vaddr,
-                                &MPIDI_XPMEMI_global.segmaps[handle.src_lrank].segcache_ubuf);
+                                MPIDI_XPMEMI_global.segmaps[handle.src_lrank].segcache_ubuf);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_IPC_HANDLE_MAP);
     return mpi_errno;

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
@@ -8,469 +8,21 @@
 #include "xpmem_seg.h"
 
 /****************************************/
-/* Segment cache internal routines      */
-/****************************************/
-
-enum {
-    AVL_RIGHT,
-    AVL_LEFT
-};
-
-/* AVL tree is balanced tree, so 64 stack size should be enough to go
- * through all the nodes in the tree in practice. In case it exceeds,
- * we throw an assertion error. This problem can be fixed by using
- * heap memory, but it adds additional overhead. */
-#define MPIDI_XPMEMI_AVL_STACK_SIZE 64
-#define MPIDI_XPMEMI_AVL_DECLARE_STACK(stack, type, size) \
-        const size_t stack##_size = size; \
-        type stack[stack##_size]; \
-        int stack##_sp = 0
-#define MPIDI_XPMEMI_AVL_STACK_PUSH(stack, value) do {           \
-        MPIR_Assert(stack##_sp < MPIDI_XPMEMI_AVL_STACK_SIZE);   \
-        stack[stack##_sp++] = value;                            \
-} while (0)
-#define MPIDI_XPMEMI_AVL_STACK_POP(stack, value) do {   \
-        MPIR_Assert(stack##_sp > 0);                   \
-        value = stack[--stack##_sp];                   \
-} while (0)
-#define MPIDI_XPMEMI_AVL_STACK_EMPTY(stack) (!stack##_sp)
-
-/* Creates a new segment and attaches into local virtual address space. */
-MPL_STATIC_INLINE_PREFIX int seg_do_create(MPIDI_XPMEMI_seg_t ** seg_ptr,
-                                           uint64_t low, uint64_t high, xpmem_apid_t apid)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIDI_XPMEMI_seg_t *seg = NULL;
-    struct xpmem_addr xpmem_addr;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEG_DO_CREATE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEG_DO_CREATE);
-
-    *seg_ptr = (MPIDI_XPMEMI_seg_t *) MPL_malloc(sizeof(MPIDI_XPMEMI_seg_t), MPL_MEM_OTHER);
-    MPIR_ERR_CHKANDJUMP1(!(*seg_ptr), mpi_errno, MPI_ERR_OTHER, "**nomem",
-                         "**nomem %s", "MPIDI_XPMEMI_seg_t");
-    seg = *seg_ptr;
-    seg->low = low;
-    seg->high = high;
-
-    xpmem_addr.apid = apid;
-    xpmem_addr.offset = seg->low;
-    seg->vaddr = xpmem_attach(xpmem_addr, high - low, NULL);
-    /* virtual address or failure(-1) */
-    MPIR_ERR_CHKANDJUMP(seg->vaddr == (void *) -1, mpi_errno, MPI_ERR_OTHER, "**xpmem_attach");
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEG_DO_CREATE);
-    return mpi_errno;
-  fn_fail:
-    MPL_free(seg);
-    goto fn_exit;
-}
-
-/* Detaches and releases a segment. */
-MPL_STATIC_INLINE_PREFIX int seg_do_release(MPIDI_XPMEMI_seg_t * seg)
-{
-    int ret;
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEG_DO_RELEASE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEG_DO_RELEASE);
-
-    ret = xpmem_detach((void *) seg->vaddr);
-    MPIR_ERR_CHKANDJUMP(ret == -1, mpi_errno, MPI_ERR_OTHER, "**xpmem_detach");
-    MPL_free(seg);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEG_DO_RELEASE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int avl_do_update_node_info(MPIDI_XPMEMI_seg_t * node)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_AVL_DO_UPDATE_NODE_INFO);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_AVL_DO_UPDATE_NODE_INFO);
-
-    int lheight = node->left == NULL ? 0 : node->left->height;
-    int rheight = node->right == NULL ? 0 : node->right->height;
-    node->height = (lheight < rheight ? rheight : lheight) + 1;
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_AVL_DO_UPDATE_NODE_INFO);
-    return mpi_errno;
-}
-
-MPL_STATIC_INLINE_PREFIX int avl_do_right_rotation(MPIDI_XPMEMI_seg_t * parent,
-                                                   MPIDI_XPMEMI_seg_t * left_child)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_AVL_DO_RIGHT_ROTATION);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_AVL_DO_RIGHT_ROTATION);
-
-    parent->left = left_child->right;
-    left_child->right = parent;
-
-    left_child->parent = parent->parent;
-    if (left_child->parent != NULL) {
-        if (left_child->parent->left == parent)
-            left_child->parent->left = left_child;
-        else
-            left_child->parent->right = left_child;
-    }
-
-    parent->parent = left_child;
-    if (parent->left != NULL)
-        parent->left->parent = parent;
-
-    mpi_errno = avl_do_update_node_info(parent);
-    MPIR_ERR_CHECK(mpi_errno);
-    mpi_errno = avl_do_update_node_info(left_child);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_AVL_DO_RIGHT_ROTATION);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int avl_do_left_rotation(MPIDI_XPMEMI_seg_t * parent,
-                                                  MPIDI_XPMEMI_seg_t * right_child)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_AVL_DO_LEFT_ROTATION);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_AVL_DO_LEFT_ROTATION);
-
-    parent->right = right_child->left;
-    right_child->left = parent;
-
-    right_child->parent = parent->parent;
-    if (right_child->parent != NULL) {
-        if (right_child->parent->left == parent)
-            right_child->parent->left = right_child;
-        else
-            right_child->parent->right = right_child;
-    }
-
-    parent->parent = right_child;
-    if (parent->right != NULL)
-        parent->right->parent = parent;
-
-    mpi_errno = avl_do_update_node_info(parent);
-    MPIR_ERR_CHECK(mpi_errno);
-    mpi_errno = avl_do_update_node_info(right_child);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_AVL_DO_LEFT_ROTATION);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int avl_do_left_right_rotation(MPIDI_XPMEMI_seg_t * parent,
-                                                        MPIDI_XPMEMI_seg_t * left_child)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_AVL_DO_LEFT_RIGHT_ROTATION);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_AVL_DO_LEFT_RIGHT_ROTATION);
-
-    MPIDI_XPMEMI_seg_t *lr_child = left_child->right;
-    /* Left rotate */
-    mpi_errno = avl_do_left_rotation(left_child, lr_child);
-    MPIR_ERR_CHECK(mpi_errno);
-    /* Right rotate */
-    mpi_errno = avl_do_right_rotation(parent, lr_child);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_AVL_DO_LEFT_RIGHT_ROTATION);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int avl_do_right_left_rotation(MPIDI_XPMEMI_seg_t * parent,
-                                                        MPIDI_XPMEMI_seg_t * right_child)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_AVL_DO_RIGHT_LEFT_ROTATION);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_AVL_DO_RIGHT_LEFT_ROTATION);
-
-    MPIDI_XPMEMI_seg_t *rl_child = right_child->left;
-    mpi_errno = avl_do_right_rotation(right_child, rl_child);
-    MPIR_ERR_CHECK(mpi_errno);
-    mpi_errno = avl_do_left_rotation(parent, rl_child);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_AVL_DO_RIGHT_LEFT_ROTATION);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-/* Create a new segment and initialize tree node attributes */
-MPL_STATIC_INLINE_PREFIX int segtree_do_create_node(uint64_t low,
-                                                    uint64_t high, xpmem_apid_t apid,
-                                                    MPIDI_XPMEMI_seg_t ** seg_ptr)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIDI_XPMEMI_seg_t *seg = NULL;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEGTREE_DO_CREATE_NODE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEGTREE_DO_CREATE_NODE);
-
-    mpi_errno = seg_do_create(seg_ptr, low, high, apid);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    seg = *seg_ptr;
-    seg->height = 1;
-    seg->parent = NULL;
-    seg->left = NULL;
-    seg->right = NULL;
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEGTREE_DO_CREATE_NODE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-/*
-* Threads safe search and insert routine for a specified address range.
-* It first performs binary search to find a matched segment; if it does
-* not find one, then it inserts a new segment into the AVL tree. By combining
-* search and insert into one routine, we need only one top-down traversal.
-* The time complexity is O(logN).
-*
-* Input parameters:
-*  - tree: the segment cache tree.
-*  - low:  low address of searched address range.
-*  - high: high address of searched address range.
-*  - apid: apid of remote process. Used when inserting a new segment.
-*
-* Output parameters:
-*  - seg_ptr: matched or newly inserted segment.
-*  - voffset: offset between low address of the cached segment and the
-*             inputed low address.
-*
-* Search procedure: find a matched segment which includes the entire range
-*  specified by the input low address and high address. If input low address
-*  is smaller than recorded segment, we then search left branch; otherwise,
-*  we search right branch.
-*
-* Insert procedure: create and attach a new segment for the input address range.
-*  We insert it into the tree based on the low address. If low address of the new
-*  segment is smaller than the current segment node in AVL tree, it will be
-*  inserted into left branch; otherwise, it will be inserted into the right branch.
-*  After insertion, we check the height of each sub tree to make sure all of subtrees
-*  still obey the AVL tree requirement (left branch and right branch height difference
-*  cannot exceed 1). If it exceeds the limit, we then adjust the height of tree to
-*  make it balanced again. */
-MPL_STATIC_INLINE_PREFIX int
-segtree_do_search_and_insert_safe(MPIDI_XPMEMI_segtree_t * tree, uint64_t low,
-                                  uint64_t high, xpmem_apid_t apid,
-                                  MPIDI_XPMEMI_seg_t ** seg_ptr, off_t * voffset)
-{
-    int direction;
-    int mpi_errno = MPI_SUCCESS;
-    MPIDI_XPMEMI_seg_t *sub_root = NULL;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEGTREE_DO_SEARCH_AND_INSERT_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEGTREE_DO_SEARCH_AND_INSERT_SAFE);
-
-    MPID_THREAD_CS_ENTER(VCI, tree->lock);
-
-    if (tree->root == NULL) {
-        mpi_errno = segtree_do_create_node(low, high, apid, seg_ptr);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        *voffset = 0;
-        tree->root = *seg_ptr;
-        tree->tree_size = 1;
-    } else {
-        sub_root = tree->root;
-
-        MPIDI_XPMEMI_AVL_DECLARE_STACK(node_stack, MPIDI_XPMEMI_seg_t *,
-                                       MPIDI_XPMEMI_AVL_STACK_SIZE);
-
-        do {
-            if (low < sub_root->low) {
-                /* Insert into left branch */
-                if (sub_root->left != NULL) {
-                    MPIDI_XPMEMI_AVL_STACK_PUSH(node_stack, sub_root);
-                    sub_root = sub_root->left;
-                    continue;
-                } else {
-                    direction = AVL_LEFT;
-                }
-            } else if (high <= sub_root->high) {
-                /* Hit the cache */
-                *seg_ptr = sub_root;
-                /* voffset is the offset between registered virtual address in
-                 * cached segment and the virtual address we actually need. */
-                *voffset = low - sub_root->low;
-                goto fn_exit;
-            } else {
-                /* Insert into right branch */
-                if (sub_root->right != NULL) {
-                    MPIDI_XPMEMI_AVL_STACK_PUSH(node_stack, sub_root);
-                    sub_root = sub_root->right;
-                    continue;
-                } else {
-                    direction = AVL_RIGHT;
-                }
-            }
-
-            mpi_errno = segtree_do_create_node(low, high, apid, seg_ptr);
-            MPIR_ERR_CHECK(mpi_errno);
-
-            if (direction == AVL_LEFT)
-                sub_root->left = *seg_ptr;
-            else
-                sub_root->right = *seg_ptr;
-
-            (*seg_ptr)->parent = sub_root;
-            *voffset = 0;
-            tree->tree_size++;
-
-          stack_recovery:
-            mpi_errno = avl_do_update_node_info(sub_root);
-            MPIR_ERR_CHECK(mpi_errno);
-
-            int lheight = sub_root->left == NULL ? 0 : sub_root->left->height;
-            int rheight = sub_root->right == NULL ? 0 : sub_root->right->height;
-            if (lheight - rheight > 1) {
-                /* left unbalanced */
-                MPIDI_XPMEMI_seg_t *ct_node = sub_root->left;
-                int lct_height = ct_node->left == NULL ? 0 : ct_node->left->height;
-                if (lct_height + 1 == lheight) {
-                    /* Insert into left child of left child */
-                    /* Do right rotation */
-                    mpi_errno = avl_do_right_rotation(sub_root, ct_node);
-                    MPIR_ERR_CHECK(mpi_errno);
-                } else {
-                    /* Insert into right child of left child */
-                    /* Do left-right rotation */
-                    mpi_errno = avl_do_left_right_rotation(sub_root, ct_node);
-                    MPIR_ERR_CHECK(mpi_errno);
-                }
-            } else if (rheight - lheight > 1) {
-                /* right unbalanced */
-                MPIDI_XPMEMI_seg_t *ct_node = sub_root->right;
-                int lct_height = ct_node->left == NULL ? 0 : ct_node->left->height;
-                if (lct_height + 1 == rheight) {
-                    /* Insert into left child of right child */
-                    /* Do right-left rotation */
-                    mpi_errno = avl_do_right_left_rotation(sub_root, ct_node);
-                    MPIR_ERR_CHECK(mpi_errno);
-                } else {
-                    /* Insert into right child of right child */
-                    /* Do left rotation */
-                    mpi_errno = avl_do_left_rotation(sub_root, ct_node);
-                    MPIR_ERR_CHECK(mpi_errno);
-                }
-            }
-
-            if (!MPIDI_XPMEMI_AVL_STACK_EMPTY(node_stack)) {
-                MPIDI_XPMEMI_AVL_STACK_POP(node_stack, sub_root);
-                goto stack_recovery;
-            } else
-                break;
-
-            /* This infinite loop will break in either two cases:
-             * (1) when we search AVL tree and hit the segment cache, it means
-             * no insertion is needed, and we can jump to fn_exit and return cached
-             * segment right away.
-             * (2) when we cannot find cached segment, we need to attach and insert
-             * a new segment into AVL tree; in this case, loop will exit when we
-             * finish insertion and AVL tree height adjustment.  */
-        } while (1);
-
-        while (tree->root->parent != NULL)
-            tree->root = tree->root->parent;
-    }
-
-  fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, tree->lock);
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEGTREE_DO_SEARCH_AND_INSERT_SAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-/****************************************/
 /* Segment cache public routines        */
 /****************************************/
-
 /* Initialize an empty tree for segment cache.
  * It should be called only once for a AVL tree at MPI init.*/
-int MPIDI_XPMEMI_segtree_init(MPIDI_XPMEMI_segtree_t * tree)
+int MPIDI_XPMEMI_segtree_init(MPL_gavl_tree_t * tree)
 {
     int mpi_errno = MPI_SUCCESS, ret;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEGTREE_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEGTREE_INIT);
 
-    tree->root = NULL;
-    tree->tree_size = 0;
-    MPID_Thread_mutex_create(&tree->lock, &ret);
+    ret = MPL_gavl_tree_create(MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE, tree);
+    MPIR_ERR_CHKANDJUMP(ret != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**xpmem_segtree_init");
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEGTREE_INIT);
-    return mpi_errno;
-}
-
-/* Deletes all registered segments in the segment cache.
- * It detaches and frees each segment. */
-int MPIDI_XPMEMI_segtree_delete_all(MPIDI_XPMEMI_segtree_t * tree)
-{
-    uint8_t direction;
-    int mpi_errno = MPI_SUCCESS, ret;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEGTREE_DELETE_ALL);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEGTREE_DELETE_ALL);
-
-    MPIDI_XPMEMI_AVL_DECLARE_STACK(node_stack, MPIDI_XPMEMI_seg_t *, MPIDI_XPMEMI_AVL_STACK_SIZE);
-    MPIDI_XPMEMI_AVL_DECLARE_STACK(direction_stack, uint8_t, MPIDI_XPMEMI_AVL_STACK_SIZE);
-
-    if (tree->tree_size) {
-        MPIDI_XPMEMI_seg_t *node = tree->root;
-        while (1) {
-            /* this delete function will traverse all the segments stored in AVL
-             * tree, and this infinite loop is used to avoid recursive call of
-             * function. It exits when all segments have been deleted (also means
-             * stack is empty). */
-
-            if (node->left != NULL) {
-                MPIDI_XPMEMI_AVL_STACK_PUSH(node_stack, node);
-                /* AVL_LEFT stands for recovering from LEFT. */
-                MPIDI_XPMEMI_AVL_STACK_PUSH(direction_stack, AVL_LEFT);
-                node = node->left;
-                continue;
-            }
-          left_recovery:
-            if (node->right != NULL) {
-                MPIDI_XPMEMI_AVL_STACK_PUSH(node_stack, node);
-                /* AVL_RIGHT stands for recovering from RIGHT. */
-                MPIDI_XPMEMI_AVL_STACK_PUSH(direction_stack, AVL_RIGHT);
-                node = node->right;
-                continue;
-            }
-          right_recovery:
-            mpi_errno = seg_do_release(node);
-            MPIR_ERR_CHECK(mpi_errno);
-            tree->tree_size--;
-            if (!MPIDI_XPMEMI_AVL_STACK_EMPTY(node_stack)) {
-                MPIDI_XPMEMI_AVL_STACK_POP(node_stack, node);
-                MPIDI_XPMEMI_AVL_STACK_POP(direction_stack, direction);
-                if (direction == AVL_RIGHT)
-                    goto right_recovery;
-                else
-                    goto left_recovery;
-            } else
-                break;
-        }
-    }
-
-    MPID_Thread_mutex_destroy(&tree->lock, &ret);
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEGTREE_DELETE_ALL);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEGTREE_INIT);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -494,13 +46,13 @@ int MPIDI_XPMEMI_segtree_delete_all(MPIDI_XPMEMI_segtree_t * tree)
  * - vaddr:   corresponding start address of the remote buffer in local
  *            virtual address space. */
 int MPIDI_XPMEMI_seg_regist(int node_rank, uintptr_t size,
-                            void *remote_vaddr, void **vaddr, MPIDI_XPMEMI_segtree_t * segcache)
+                            void *remote_vaddr, void **vaddr, MPL_gavl_tree_t segcache)
 {
-    int mpi_errno = MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS, mpl_err;
     MPIDI_XPMEMI_segmap_t *segmap = &MPIDI_XPMEMI_global.segmaps[node_rank];
     MPIDI_XPMEMI_seg_t *seg = NULL;
-    off_t offset_diff = 0, voffset = 0;
-    uint64_t seg_low, seg_size, seg_high;
+    uintptr_t seg_low;
+    uintptr_t seg_size;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEG_REGIST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEG_REGIST);
     /* Get apid if it is the first time registered on the local process. */
@@ -516,23 +68,54 @@ int MPIDI_XPMEMI_seg_regist(int node_rank, uintptr_t size,
     /* Search a cached segment or create a new one. Both low and size must be page aligned. */
     seg_low = MPL_ROUND_DOWN_ALIGN((uint64_t) remote_vaddr,
                                    (uint64_t) MPIDI_XPMEMI_global.sys_page_sz);
-    offset_diff = (off_t) remote_vaddr - seg_low;
-    seg_size = MPL_ROUND_UP_ALIGN(size + (uintptr_t) offset_diff, MPIDI_XPMEMI_global.sys_page_sz);
-    seg_high = seg_low + seg_size;
-    mpi_errno =
-        segtree_do_search_and_insert_safe(segcache, seg_low, seg_high,
-                                          segmap->apid, &seg, &voffset);
-    MPIR_ERR_CHECK(mpi_errno);
+    seg_size =
+        MPL_ROUND_UP_ALIGN(size + ((uintptr_t) remote_vaddr - seg_low),
+                           MPIDI_XPMEMI_global.sys_page_sz);
+
+    mpl_err = MPL_gavl_tree_search(segcache, remote_vaddr, size, (void **) &seg);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**mpl_gavl_search");
+
+    if (seg == NULL) {
+        struct xpmem_addr xpmem_addr;
+        void *att_vaddr;
+
+        seg = (MPIDI_XPMEMI_seg_t *) MPL_malloc(sizeof(MPIDI_XPMEMI_seg_t), MPL_MEM_OTHER);
+        MPIR_Assert(seg != NULL);
+
+        xpmem_addr.apid = segmap->apid;
+        xpmem_addr.offset = seg_low;
+        att_vaddr = xpmem_attach(xpmem_addr, seg_size, NULL);
+        MPIR_ERR_CHKANDJUMP(att_vaddr == (void *) -1, mpi_errno, MPI_ERR_OTHER, "**xpmem_attach");
+        seg->remote_align_addr = seg_low;
+        seg->att_vaddr = (uintptr_t) att_vaddr;
+        MPL_gavl_tree_insert(segcache, (void *) seg_low, seg_size, (void *) seg);
+    }
 
     /* return mapped vaddr without round down */
-    *vaddr = (void *) ((off_t) seg->vaddr + offset_diff + voffset);
+    *vaddr = (void *) ((uintptr_t) remote_vaddr - seg->remote_align_addr + seg->att_vaddr);
     XPMEM_TRACE("seg: register segment %p for node_rank %d, apid 0x%lx, "
                 "size 0x%lx->0x%lx, seg->low %p->0x%lx, attached_vaddr %p, vaddr %p\n", seg,
                 node_rank, (uint64_t) segmap->apid, size, seg_size,
-                remote_vaddr, seg->low, seg->vaddr, *vaddr);
+                remote_vaddr, seg_low, (void *) seg->att_vaddr, *vaddr);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEMI_SEG_REGIST);
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+void MPIDI_XPMEM_seg_free(void *seg)
+{
+    MPIDI_XPMEMI_seg_t *seg_ptr = (MPIDI_XPMEMI_seg_t *) seg;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_FREE_SEG);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_FREE_SEG);
+
+    xpmem_detach((void *) seg_ptr->att_vaddr);
+    MPL_free(seg);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_FREE_SEG);
+    return;
   fn_fail:
     goto fn_exit;
 }

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.h
@@ -8,9 +8,9 @@
 
 #include "xpmem_types.h"
 
-int MPIDI_XPMEMI_segtree_init(MPIDI_XPMEMI_segtree_t * tree);
-int MPIDI_XPMEMI_segtree_delete_all(MPIDI_XPMEMI_segtree_t * tree);
+int MPIDI_XPMEMI_segtree_init(MPL_gavl_tree_t * tree);
 int MPIDI_XPMEMI_seg_regist(int node_rank, uintptr_t size,
-                            void *remote_vaddr, void **vaddr, MPIDI_XPMEMI_segtree_t * segcache);
+                            void *remote_vaddr, void **vaddr, MPL_gavl_tree_t segcache);
+void MPIDI_XPMEM_seg_free(void *seg);
 
 #endif /* XPMEM_SEG_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_types.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_types.h
@@ -12,28 +12,14 @@
 #define MPIDI_XPMEMI_PERMIT_VALUE ((void *)0600)
 
 typedef struct MPIDI_XPMEMI_seg {
-    /* AVL-tree internal components start */
-    struct MPIDI_XPMEMI_seg *parent;
-    struct MPIDI_XPMEMI_seg *left;
-    struct MPIDI_XPMEMI_seg *right;
-    uint64_t height;            /* height of this subtree */
-    /* AVL-tree internal components end */
-
-    uint64_t low;               /* page aligned low address of remote seg */
-    uint64_t high;              /* page aligned high address of remote seg */
-    void *vaddr;                /* virtual address attached in current process */
+    uintptr_t remote_align_addr;
+    uintptr_t att_vaddr;
 } MPIDI_XPMEMI_seg_t;
-
-typedef struct MPIDI_XPMEMI_segtree {
-    MPIDI_XPMEMI_seg_t *root;
-    int tree_size;
-    MPID_Thread_mutex_t lock;
-} MPIDI_XPMEMI_segtree_t;
 
 typedef struct {
     xpmem_segid_t remote_segid;
     xpmem_apid_t apid;
-    MPIDI_XPMEMI_segtree_t segcache_ubuf;       /* AVL tree based segment cache for user buffer */
+    MPL_gavl_tree_t segcache_ubuf;      /* AVL tree based segment cache for user buffer */
 } MPIDI_XPMEMI_segmap_t;
 
 typedef struct {

--- a/src/mpl/include/mpl.h
+++ b/src/mpl/include/mpl.h
@@ -29,5 +29,6 @@
 #include "mpl_math.h"
 #include "mpl_proc_mutex.h"
 #include "mpl_gpu.h"
+#include "mpl_gavl.h"
 
 #endif /* MPL_H_INCLUDED */

--- a/src/mpl/include/mpl_gavl.h
+++ b/src/mpl/include/mpl_gavl.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPL_GAVL_H_INCLUDED
+#define MPL_GAVL_H_INCLUDED
+
+typedef void *MPL_gavl_tree_t;
+
+int MPL_gavl_tree_create(int need_thread_safety, MPL_gavl_tree_t * gavl_tree);
+int MPL_gavl_tree_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len,
+                         const void *val);
+int MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len, void **val);
+int MPL_gavl_tree_free(MPL_gavl_tree_t gavl_tree, void (*free_fn) (void *));
+
+#endif /* MPL_GAVL_H_INCLUDED  */

--- a/src/mpl/src/Makefile.mk
+++ b/src/mpl/src/Makefile.mk
@@ -15,3 +15,4 @@ include src/thread/Makefile.mk
 include src/timer/Makefile.mk
 include src/shm/Makefile.mk
 include src/gpu/Makefile.mk
+include src/gavl/Makefile.mk

--- a/src/mpl/src/gavl/Makefile.mk
+++ b/src/mpl/src/gavl/Makefile.mk
@@ -1,0 +1,6 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+lib@MPLLIBNAME@_la_SOURCES += src/gavl/mpl_gavl.c

--- a/src/mpl/src/gavl/mpl_gavl.c
+++ b/src/mpl/src/gavl/mpl_gavl.c
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpl.h"
+#include <assert.h>
+
+#define GAVL_LEFT 0
+#define GAVL_RIGHT 1
+/*
+ * We assume AVL tree height will not exceed 64. AVL tree with 64 height in worst case
+ * can contain 27777890035287 nodes which is far enough for current applications.
+ * The idea to compute worse case nodes is as follows:
+ * In worse case, AVL tree with height h_p should have h_p - 1 height left child and
+ * h_p - 2 height right child; therefore, the worse case nodes N(h_p) = N(h_p - 1) + N(h_p - 2) + 1.
+ * Since we know N(1) = 1 and N(2) = 2, we can use iteration to compute N(64) = 27777890035287.
+ */
+#define MAX_STACK_SIZE 64
+
+typedef struct gavl_tree_node {
+    struct gavl_tree_node *parent;
+    struct gavl_tree_node *left;
+    struct gavl_tree_node *right;
+    long height;
+    long addr;
+    uintptr_t len;
+    const void *val;
+} gavl_tree_node_s;
+
+typedef struct gavl_tree {
+    gavl_tree_node_s *root;
+    uintptr_t valsize;
+    int need_thread_safety;
+    MPL_thread_mutex_t lock;
+} gavl_tree_s;
+
+#define DECLARE_STACK(type, stack) \
+    type stack[MAX_STACK_SIZE];    \
+    int stack##_sp = 0
+
+#define STACK_PUSH(stack, value)             \
+    do {                                     \
+        assert(stack##_sp < MAX_STACK_SIZE); \
+        stack[stack##_sp++] = value;         \
+    } while (0)
+
+#define STACK_POP(stack, value)      \
+    do {                             \
+        assert(stack##_sp > 0);      \
+        value = stack[--stack##_sp]; \
+    } while (0)
+
+#define STACK_EMPTY(stack) (!stack##_sp)
+
+static void gavl_update_node_info(gavl_tree_node_s * node_iptr)
+{
+    int lheight = node_iptr->left == NULL ? 0 : node_iptr->left->height;
+    int rheight = node_iptr->right == NULL ? 0 : node_iptr->right->height;
+    node_iptr->height = (lheight < rheight ? rheight : lheight) + 1;
+    return;
+}
+
+static void gavl_right_rotation(gavl_tree_node_s * parent_ptr, gavl_tree_node_s * lchild)
+{
+    parent_ptr->left = lchild->right;
+    lchild->right = parent_ptr;
+    lchild->parent = parent_ptr->parent;
+    if (lchild->parent != NULL) {
+        if (lchild->parent->left == parent_ptr)
+            lchild->parent->left = lchild;
+        else
+            lchild->parent->right = lchild;
+    }
+
+    parent_ptr->parent = lchild;
+    if (parent_ptr->left != NULL)
+        parent_ptr->left->parent = parent_ptr;
+
+    gavl_update_node_info(parent_ptr);
+    gavl_update_node_info(lchild);
+    return;
+}
+
+static void gavl_left_rotation(gavl_tree_node_s * parent_ptr, gavl_tree_node_s * rchild)
+{
+    parent_ptr->right = rchild->left;
+    rchild->left = parent_ptr;
+    rchild->parent = parent_ptr->parent;
+    if (rchild->parent != NULL) {
+        if (rchild->parent->left == parent_ptr)
+            rchild->parent->left = rchild;
+        else
+            rchild->parent->right = rchild;
+    }
+
+    parent_ptr->parent = rchild;
+    if (parent_ptr->right != NULL)
+        parent_ptr->right->parent = parent_ptr;
+
+    gavl_update_node_info(parent_ptr);
+    gavl_update_node_info(rchild);
+    return;
+}
+
+static void gavl_left_right_rotation(gavl_tree_node_s * parent_ptr, gavl_tree_node_s * lchild)
+{
+    gavl_tree_node_s *rlchild = lchild->right;
+    gavl_left_rotation(lchild, rlchild);
+    gavl_right_rotation(parent_ptr, rlchild);
+    return;
+}
+
+static void gavl_right_left_rotation(gavl_tree_node_s * parent_ptr, gavl_tree_node_s * rchild)
+{
+    gavl_tree_node_s *lrchild = rchild->left;
+    gavl_right_rotation(rchild, lrchild);
+    gavl_left_rotation(parent_ptr, lrchild);
+    return;
+}
+
+MPL_STATIC_INLINE_PREFIX int gavl_cmp_func(long ustart, uintptr_t len, gavl_tree_node_s * tnode)
+{
+    long uend = ustart + len;
+    long tstart = tnode->addr;
+    long tend = tnode->addr + tnode->len;
+
+    if (ustart < tstart)
+        return -1;
+    else if (uend <= tend)
+        return 0;
+    else
+        return 1;
+}
+
+int MPL_gavl_tree_create(int need_thread_safety, MPL_gavl_tree_t * gavl_tree)
+{
+    int mpl_err;
+    gavl_tree_s *gavl_tree_iptr;
+
+    gavl_tree_iptr = (gavl_tree_s *) MPL_malloc(sizeof(gavl_tree_s), MPL_MEM_OTHER);
+    if (gavl_tree_iptr == NULL)
+        return MPL_ERR_SHM_NOMEM;
+
+    if (need_thread_safety) {
+        assert(MPL_THREAD_PACKAGE_NAME != MPL_THREAD_PACKAGE_NONE);
+        MPL_thread_mutex_create(&gavl_tree_iptr->lock, &mpl_err);
+        if (mpl_err != MPL_SUCCESS) {
+            MPL_free(gavl_tree_iptr);
+            return mpl_err;
+        }
+    }
+    gavl_tree_iptr->need_thread_safety = need_thread_safety;
+
+    gavl_tree_iptr->root = NULL;
+    *gavl_tree = (MPL_gavl_tree_t) gavl_tree_iptr;
+    return MPL_SUCCESS;
+}
+
+int MPL_gavl_tree_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len,
+                         const void *val)
+{
+    int mpl_err = MPL_SUCCESS;
+    gavl_tree_node_s *node_ptr;
+    gavl_tree_s *gavl_tree_iptr = (gavl_tree_s *) gavl_tree;
+
+    if (gavl_tree_iptr->need_thread_safety) {
+        MPL_thread_mutex_lock(&gavl_tree_iptr->lock, &mpl_err, MPL_THREAD_PRIO_HIGH);
+        if (mpl_err != MPL_SUCCESS)
+            return mpl_err;
+    }
+
+    node_ptr = (gavl_tree_node_s *) MPL_malloc(sizeof(gavl_tree_node_s), MPL_MEM_OTHER);
+    node_ptr->parent = NULL;
+    node_ptr->left = NULL;
+    node_ptr->right = NULL;
+    node_ptr->height = 1;
+    node_ptr->addr = (long) addr;
+    node_ptr->len = len;
+    node_ptr->val = val;
+
+    if (gavl_tree_iptr->root == NULL)
+        gavl_tree_iptr->root = node_ptr;
+    else {
+        DECLARE_STACK(gavl_tree_node_s *, node_stack);
+        gavl_tree_node_s *cur_node = gavl_tree_iptr->root;
+        int direction;
+        do {
+            int cmp_ret = gavl_cmp_func((long) node_ptr->addr, node_ptr->len, cur_node);
+            if (cmp_ret < 0) {
+                if (cur_node->left != NULL) {
+                    STACK_PUSH(node_stack, cur_node);
+                    cur_node = cur_node->left;
+                    continue;
+                } else
+                    direction = GAVL_LEFT;
+            } else {
+                if (cur_node->right != NULL) {
+                    STACK_PUSH(node_stack, cur_node);
+                    cur_node = cur_node->right;
+                    continue;
+                } else
+                    direction = GAVL_RIGHT;
+            }
+
+            if (direction == GAVL_LEFT)
+                cur_node->left = node_ptr;
+            else
+                cur_node->right = node_ptr;
+            node_ptr->parent = cur_node;
+
+          stack_recovery:
+            gavl_update_node_info(cur_node);
+
+            int lheight = cur_node->left == NULL ? 0 : cur_node->left->height;
+            int rheight = cur_node->right == NULL ? 0 : cur_node->right->height;
+            if (lheight - rheight > 1) {
+                gavl_tree_node_s *lnode = cur_node->left;
+                int llheight = lnode->left == NULL ? 0 : lnode->left->height;
+                if (llheight + 1 == lheight)
+                    gavl_right_rotation(cur_node, lnode);
+                else
+                    gavl_left_right_rotation(cur_node, lnode);
+            } else if (rheight - lheight > 1) {
+                gavl_tree_node_s *rnode = cur_node->right;
+                int rlheight = rnode->left == NULL ? 0 : rnode->left->height;
+                if (rlheight + 1 == rheight)
+                    gavl_right_left_rotation(cur_node, rnode);
+                else
+                    gavl_left_rotation(cur_node, rnode);
+            }
+
+            if (!STACK_EMPTY(node_stack)) {
+                STACK_POP(node_stack, cur_node);
+                goto stack_recovery;
+            } else
+                break;
+        } while (1);
+
+        while (gavl_tree_iptr->root->parent != NULL)
+            gavl_tree_iptr->root = gavl_tree_iptr->root->parent;
+    }
+    if (gavl_tree_iptr->need_thread_safety)
+        MPL_thread_mutex_unlock(&gavl_tree_iptr->lock, &mpl_err);
+
+    return mpl_err;
+}
+
+int MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len, void **val)
+{
+    int mpl_err = MPL_SUCCESS;
+    gavl_tree_node_s *cur_node;
+    gavl_tree_s *gavl_tree_iptr = (gavl_tree_s *) gavl_tree;
+
+    if (gavl_tree_iptr->need_thread_safety) {
+        MPL_thread_mutex_lock(&gavl_tree_iptr->lock, &mpl_err, MPL_THREAD_PRIO_HIGH);
+        if (mpl_err != MPL_SUCCESS)
+            return mpl_err;
+    }
+
+    *val = NULL;
+    cur_node = gavl_tree_iptr->root;
+    while (cur_node) {
+        int cmp_ret = gavl_cmp_func((long) addr, len, cur_node);
+        if (cmp_ret == 0) {
+            *val = (void *) cur_node->val;
+            break;
+        } else if (cmp_ret < 0)
+            cur_node = cur_node->left;
+        else
+            cur_node = cur_node->right;
+    }
+
+    if (gavl_tree_iptr->need_thread_safety)
+        MPL_thread_mutex_unlock(&gavl_tree_iptr->lock, &mpl_err);
+    return mpl_err;
+}
+
+int MPL_gavl_tree_free(MPL_gavl_tree_t gavl_tree, void (*free_fn) (void *))
+{
+    int mpl_err = MPL_SUCCESS;
+    gavl_tree_s *gavl_tree_iptr = (gavl_tree_s *) gavl_tree;
+    gavl_tree_node_s *cur_node = gavl_tree_iptr->root;
+    gavl_tree_node_s *dnode = NULL;
+    while (cur_node) {
+        if (cur_node->left)
+            cur_node = cur_node->left;
+        else if (cur_node->right)
+            cur_node = cur_node->right;
+        else {
+            dnode = cur_node;
+            cur_node = cur_node->parent;
+            if (cur_node) {
+                if (cur_node->left == dnode)
+                    cur_node->left = NULL;
+                else
+                    cur_node->right = NULL;
+            }
+            if (free_fn)
+                free_fn((void *) dnode->val);
+            MPL_free(dnode);
+        }
+    }
+    if (gavl_tree_iptr->need_thread_safety)
+        MPL_thread_mutex_destroy(&gavl_tree_iptr->lock, &mpl_err);
+    MPL_free(gavl_tree_iptr);
+    return mpl_err;
+}


### PR DESCRIPTION
## Pull Request Description
This PR includes two things:
- add generic avl into MPL
- apply generic avl to XPMEM for cache reuse

For AVL tree, it currently contains four basic functions:
- int MPL_gavl_tree_create(int need_thread_safety, MPL_gavl_tree_t *gavl_tree)
- int MPL_gavl_tree_insert(MPL_gavl_tree_t gavl_tree,  const void *addr, size_t len, const void *val)
- int MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, const void *addr, size_t len, void **val)
- int MPL_gavl_tree_free(MPL_gavl_tree_t gavl_tree, void (*free_fn) (void *))

Users should create their own structure to store the values they need; the structure can contain any type of variables. The example of using generic avl tree is as follow:

1. user can create a structure like:
```
typedef struct handle_obj
{
    long handle;
    const void *attach_addr;
    size_t buffer_len;
} handle_obj_t;
```
2. create generic avl tree
```
MPL_gavl_tree_t gavl_tree;
MPL_gavl_tree_create(0, &gavl_tree);
```

3. insert a segment
```
handle_obj_t *obj = malloc(sizeof(handle_obj_t));
obj->handle = 1;
obj->attach_addr = 0x77777777;
obj->buffer_len = 128;
MPL_gavl_tree_insert(gavl_tree, 0xff457810, 128, &obj);
```

4. search a segment
```
handle_obj_t *cached_obj;
MPL_gavl_tree_search(gavl_tree, 0xff457810, 128, &cached_obj);
if(cached_obj)
    process_seg(cached_seg);
```
(Note: handle object will be matched if provided addr and len locates within the cached segment; that is `cached_addr <= addr && len <= cached_len`. If we cannot find matched item, NULL will be returned by function.)

5. free generic avl tree
```
MPL_gavl_tree_free(gavl_tree, free);
```
(Note: user should provide a free function here to free cached values in AVL tree; `NULL` is also an acceptable parameter for stack objects.)