### PR TITLE
test/mpi: Add GPU-only configuration

### DIFF
--- a/test/mpi/Makefile_common.mtest
+++ b/test/mpi/Makefile_common.mtest
@@ -30,7 +30,11 @@ $(top_builddir)/dtpools/src/libdtpools.la:
 	(cd $(top_builddir)/dtpools && $(MAKE))
 
 if HAVE_CUDA
+if GPU_ONLY
+TESTLIST ?= testlist.gpu
+else
 TESTLIST ?= testlist,testlist.dtp,testlist.cvar,testlist.gpu
+endif
 else
 TESTLIST ?= testlist,testlist.dtp,testlist.cvar
 endif

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -279,6 +279,11 @@ AC_ARG_ENABLE(xfail,
 		[Run tests marked for expected failure])],,
 	[enable_xfail=no])
 
+AC_ARG_ENABLE(gpu-only,
+        [AC_HELP_STRING([--enable-gpu-only],
+                [Run only GPU tests])],,
+        [enable_gpu_only=no])
+
 # DTPools test generation
 AC_ARG_WITH(dtpools-datatypes,
     [AC_HELP_STRING([--with-dtpools-datatypes=typelist],
@@ -472,6 +477,19 @@ if test "$enable_xfail" = "yes" ; then
     RUN_XFAIL=true
 fi
 AC_SUBST(RUN_XFAIL)
+
+# GPU only tests
+if test $have_cuda = "no" -a $enable_gpu_only = "yes" ; then
+    AC_MSG_ERROR([GPU only test configuration requires CUDA])
+fi
+gpuonly="#"
+if test $enable_gpu_only = "yes" ; then
+    gpuonly="coll
+pt2pt
+rma"
+fi
+AC_SUBST(gpuonly)
+AM_CONDITIONAL([GPU_ONLY], [test $enable_gpu_only = "yes"])
 
 PAC_LOAD_BASE_CACHE
 PAC_VPATH_CHECK()
@@ -1762,6 +1780,7 @@ AC_OUTPUT(maint/testmerge \
           manual/mpi_t/Makefile \
           perf/Makefile \
           testlist \
+          testlist.gpu \
           cxx/testlist \
 	  cxx/topo/testlist \
           f77/testlist \

--- a/test/mpi/testlist.gpu.in
+++ b/test/mpi/testlist.gpu.in
@@ -1,0 +1,1 @@
+@gpuonly@


### PR DESCRIPTION
## Pull Request Description

Add a configuration option to only run GPU tests. This allows for more
targeted testing of GPU-related changes outside of regular Jenkins
testing.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
