### PR TITLE
progress: extend MPID_Progress_start to allow lock optimization

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -316,12 +316,8 @@ static inline int MPIR_Request_is_persistent(MPIR_Request * req_ptr)
 {
     return (req_ptr->kind == MPIR_REQUEST_KIND__PREQUEST_SEND ||
             req_ptr->kind == MPIR_REQUEST_KIND__PREQUEST_RECV ||
-            req_ptr->kind == MPIR_REQUEST_KIND__PREQUEST_COLL);
-}
-
-static inline int MPIR_Request_is_partitioned(MPIR_Request * req_ptr)
-{
-    return (req_ptr->kind == MPIR_REQUEST_KIND__PART_SEND ||
+            req_ptr->kind == MPIR_REQUEST_KIND__PREQUEST_COLL ||
+            req_ptr->kind == MPIR_REQUEST_KIND__PART_SEND ||
             req_ptr->kind == MPIR_REQUEST_KIND__PART_RECV);
 }
 

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -704,9 +704,6 @@ int MPIR_Testany_impl(int count, MPIR_Request * request_ptrs[],
 int MPIR_Testsome_impl(int incount, MPIR_Request * request_ptrs[],
                        int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]);
 
-int MPIR_Wait_state(MPIR_Request * request_ptr, MPI_Status * status, MPID_Progress_state * state);
-int MPIR_Waitall_state(int count, MPIR_Request * request_ptrs[], MPI_Status array_of_statuses[],
-                       int request_properties, MPID_Progress_state * state);
 int MPIR_Waitany_state(int count, MPIR_Request * request_ptrs[], int *indx, MPI_Status * status,
                        MPID_Progress_state * state);
 int MPIR_Waitsome_state(int incount, MPIR_Request * request_ptrs[],

--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -318,7 +318,7 @@ int MPIR_Test(MPI_Request * request, int *flag, MPI_Status * status)
 
     if (*flag) {
         mpi_errno = MPIR_Request_completion_processing(request_ptr, status);
-        if (!MPIR_Request_is_persistent(request_ptr) && !MPIR_Request_is_partitioned(request_ptr)) {
+        if (!MPIR_Request_is_persistent(request_ptr)) {
             MPIR_Request_free(request_ptr);
             *request = MPI_REQUEST_NULL;
         }
@@ -513,8 +513,7 @@ int MPIR_Testall(int count, MPI_Request array_of_requests[], int *flag,
         for (i = 0; i < count; i++) {
             if (request_ptrs[i] != NULL && MPIR_Request_is_complete(request_ptrs[i])) {
                 MPIR_Request_completion_processing(request_ptrs[i], MPI_STATUS_IGNORE);
-                if (!MPIR_Request_is_persistent(request_ptrs[i]) &&
-                    !MPIR_Request_is_partitioned(request_ptrs[i])) {
+                if (!MPIR_Request_is_persistent(request_ptrs[i])) {
                     MPIR_Request_free(request_ptrs[i]);
                     array_of_requests[i] = MPI_REQUEST_NULL;
                 }
@@ -528,8 +527,7 @@ int MPIR_Testall(int count, MPI_Request array_of_requests[], int *flag,
             if (MPIR_Request_is_complete(request_ptrs[i])) {
                 active_flag = MPIR_Request_is_active(request_ptrs[i]);
                 rc = MPIR_Request_completion_processing(request_ptrs[i], &array_of_statuses[i]);
-                if (!MPIR_Request_is_persistent(request_ptrs[i]) &&
-                    !MPIR_Request_is_partitioned(request_ptrs[i])) {
+                if (!MPIR_Request_is_persistent(request_ptrs[i])) {
                     MPIR_Request_free(request_ptrs[i]);
                     array_of_requests[i] = MPI_REQUEST_NULL;
                 }
@@ -675,8 +673,7 @@ int MPIR_Testany(int count, MPI_Request array_of_requests[], MPIR_Request * requ
 
     if (*indx != MPI_UNDEFINED) {
         mpi_errno = MPIR_Request_completion_processing(request_ptrs[*indx], status);
-        if (!MPIR_Request_is_persistent(request_ptrs[*indx]) &&
-            !MPIR_Request_is_partitioned(request_ptrs[*indx])) {
+        if (!MPIR_Request_is_persistent(request_ptrs[*indx])) {
             MPIR_Request_free(request_ptrs[*indx]);
             array_of_requests[*indx] = MPI_REQUEST_NULL;
         }
@@ -798,8 +795,7 @@ int MPIR_Testsome(int incount, MPI_Request array_of_requests[], MPIR_Request * r
         MPI_Status *status_ptr = (array_of_statuses == MPI_STATUSES_IGNORE) ?
             MPI_STATUS_IGNORE : &array_of_statuses[i];
         int rc = MPIR_Request_completion_processing(request_ptrs[idx], status_ptr);
-        if (!MPIR_Request_is_persistent(request_ptrs[idx]) &&
-            !MPIR_Request_is_partitioned(request_ptrs[idx])) {
+        if (!MPIR_Request_is_persistent(request_ptrs[idx])) {
             MPIR_Request_free(request_ptrs[idx]);
             array_of_requests[idx] = MPI_REQUEST_NULL;
         }
@@ -902,7 +898,7 @@ int MPIR_Wait(MPI_Request * request, MPI_Status * status)
     }
 
     mpi_errno = MPIR_Request_completion_processing(request_ptr, status);
-    if (!MPIR_Request_is_persistent(request_ptr) && !MPIR_Request_is_partitioned(request_ptr)) {
+    if (!MPIR_Request_is_persistent(request_ptr)) {
         MPIR_Request_free(request_ptr);
         *request = MPI_REQUEST_NULL;
     }
@@ -982,8 +978,7 @@ static int requests_completion_processing(int count, MPIR_Request ** request_ptr
             if (request_ptrs[i] == NULL)
                 continue;
             int rc = MPIR_Request_completion_processing(request_ptrs[i], MPI_STATUS_IGNORE);
-            if (!MPIR_Request_is_persistent(request_ptrs[i]) &&
-                !MPIR_Request_is_partitioned(request_ptrs[i])) {
+            if (!MPIR_Request_is_persistent(request_ptrs[i])) {
                 MPIR_Request_free_with_safety(request_ptrs[i], !is_locked);
             }
             if (rc != MPI_SUCCESS) {
@@ -998,8 +993,7 @@ static int requests_completion_processing(int count, MPIR_Request ** request_ptr
         if (request_ptrs[i] == NULL)
             continue;
         int rc = MPIR_Request_completion_processing(request_ptrs[i], &array_of_statuses[i]);
-        if (!MPIR_Request_is_persistent(request_ptrs[i]) &&
-            !MPIR_Request_is_partitioned(request_ptrs[i])) {
+        if (!MPIR_Request_is_persistent(request_ptrs[i])) {
             MPIR_Request_free_with_safety(request_ptrs[i], !is_locked);
         }
 
@@ -1147,8 +1141,7 @@ int MPIR_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of
             }
         } else {
             for (i = ii; i < ii + icount; i++) {
-                if (request_ptrs[i] && !MPIR_Request_is_persistent(request_ptrs[i]) &&
-                    !MPIR_Request_is_partitioned(request_ptrs[i])) {
+                if (request_ptrs[i] && !MPIR_Request_is_persistent(request_ptrs[i])) {
                     array_of_requests[i] = MPI_REQUEST_NULL;
                 }
             }
@@ -1302,8 +1295,7 @@ int MPIR_Waitany(int count, MPI_Request array_of_requests[], MPIR_Request * requ
     }
 
     mpi_errno = MPIR_Request_completion_processing(request_ptrs[*indx], status);
-    if (!MPIR_Request_is_persistent(request_ptrs[*indx]) &&
-        !MPIR_Request_is_partitioned(request_ptrs[*indx])) {
+    if (!MPIR_Request_is_persistent(request_ptrs[*indx])) {
         MPIR_Request_free(request_ptrs[*indx]);
         array_of_requests[*indx] = MPI_REQUEST_NULL;
     }
@@ -1440,8 +1432,7 @@ int MPIR_Waitsome(int incount, MPI_Request array_of_requests[], MPIR_Request * r
         MPI_Status *status_ptr =
             (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
         int rc = MPIR_Request_completion_processing(request_ptrs[idx], status_ptr);
-        if (!MPIR_Request_is_persistent(request_ptrs[idx]) &&
-            !MPIR_Request_is_partitioned(request_ptrs[idx])) {
+        if (!MPIR_Request_is_persistent(request_ptrs[idx])) {
             MPIR_Request_free(request_ptrs[idx]);
             array_of_requests[idx] = MPI_REQUEST_NULL;
         }

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -173,8 +173,10 @@ int MPIDI_CH3_Comm_connect(char * port_name, int root, MPIR_Comm * comm_ptr,
  * Device level progress engine macros
  */
 #define MPID_Progress_start(progress_state_) MPIDI_CH3_Progress_start(progress_state_)
+#define MPID_Progress_start_ex(progress_state_, n_, reqs_, property_) MPIDI_CH3_Progress_start(progress_state_)
 #define MPID_Progress_wait(progress_state_)  MPIDI_CH3_Progress_wait(progress_state_)
 #define MPID_Progress_end(progress_state_)   MPIDI_CH3_Progress_end(progress_state_)
+#define MPID_Progress_locked(progress_state_) 0
 /* This is static inline instead of macro because otherwise MPID_Progress_test will
  * be a chain of macros and therefore can not be used as a callback function */
 static inline int MPID_Progress_test(MPID_Progress_state * state) /* state is unused */

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -813,8 +813,11 @@ int MPID_Win_flush_local_all(MPIR_Win *win);
 int MPID_Win_sync(MPIR_Win *win);
 
 void MPID_Progress_start(MPID_Progress_state * state);
+void MPID_Progress_start_ex(MPID_Progress_state * state, int count, MPIR_Request ** reqs,
+                            int requests_property);
 int MPID_Progress_wait(MPID_Progress_state * state);
 void MPID_Progress_end(MPID_Progress_state * state);
+int MPID_Progress_locked(MPID_Progress_state * state);
 int MPID_Progress_poke(void);
 
 int MPID_Get_processor_name( char *name, int namelen, int *resultlen);

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -55,7 +55,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Improbe(int, int, MPIR_Comm *, int, int *, MPI
 MPL_STATIC_INLINE_PREFIX int MPID_Progress_test(MPID_Progress_state *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Progress_poke(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX void MPID_Progress_start(MPID_Progress_state *) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX void MPID_Progress_start_ex(MPID_Progress_state *, int, MPIR_Request **,
+                                                     int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX void MPID_Progress_end(MPID_Progress_state *) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Progress_locked(MPID_Progress_state *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Progress_wait(MPID_Progress_state *) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Progress_register(int (*progress_fn) (int *), int *id);
 int MPID_Progress_deregister(int id);

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -346,6 +346,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_av_is_local(MPIDI_av_entry_t * av);
 #include "shm_impl.h"
 #endif
 
+/* declare some prototypes to avoid circular dependency */
+MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci_n(int n, MPIR_Request ** reqs,
+                                                       MPID_Progress_state * state);
+
 #include "ch4i_workq.h"
 
 #include "ch4_probe.h"

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -51,6 +51,7 @@ typedef struct {
     int vci_count;              /* number of vcis that need progress */
     int progress_counts[MPIDI_CH4_MAX_VCIS];
     uint8_t vci[MPIDI_CH4_MAX_VCIS];    /* list of vcis that need progress */
+    int is_locked;
 } MPID_Progress_state;
 
 typedef enum {

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -256,6 +256,20 @@ MPL_STATIC_INLINE_PREFIX void MPID_Progress_start(MPID_Progress_state * state)
     return;
 }
 
+/* MPID_Progress_start_ex is an extended version of MPID_Progress_start.
+ * It allows initializing the progress_state with vci informantion and lock optimization */
+MPL_STATIC_INLINE_PREFIX void MPID_Progress_start_ex(MPID_Progress_state * state, int count,
+                                                     MPIR_Request ** reqs, int requests_property)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PROGRESS_START_EX);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_PROGRESS_START_EX);
+
+    MPIDI_progress_state_init(state);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_PROGRESS_START_EX);
+    return;
+}
+
 MPL_STATIC_INLINE_PREFIX void MPID_Progress_end(MPID_Progress_state * state)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PROGRESS_END);
@@ -263,6 +277,11 @@ MPL_STATIC_INLINE_PREFIX void MPID_Progress_end(MPID_Progress_state * state)
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_PROGRESS_END);
     return;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPID_Progress_locked(MPID_Progress_state * state)
+{
+    return 0;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Progress_test(MPID_Progress_state * state)

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -8,6 +8,23 @@
 
 #include "ch4_impl.h"
 
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_CH4_DISABLE_GLOBAL_PROGRESS
+      category    : CH4
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If true, this cvar disables global progress and does per-vci progress only.
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
 /* Global progress (polling every vci) is required for correctness. Currently we adopt the
  * simple approach to do global progress every MPIDI_CH4_PROG_POLL_MASK.
  *
@@ -34,7 +51,8 @@ extern int global_vci_poll_count;
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_do_global_progress(void)
 {
-    if (MPIDI_global.n_vcis == 1 || !MPIDI_global.is_initialized) {
+    if (MPIDI_global.n_vcis == 1 || !MPIDI_global.is_initialized ||
+        MPIR_CVAR_CH4_DISABLE_GLOBAL_PROGRESS) {
         return 0;
     } else {
         global_vci_poll_count++;

--- a/src/mpid/ch4/src/ch4_wait.h
+++ b/src/mpid/ch4/src/ch4_wait.h
@@ -123,20 +123,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Testsome(int incount, MPIR_Request * request_p
 
 MPL_STATIC_INLINE_PREFIX int MPID_Wait(MPIR_Request * request_ptr, MPI_Status * status)
 {
-    MPID_Progress_state progress_state;
-
-    MPIDI_set_progress_vci(request_ptr, &progress_state);
-    return MPIR_Wait_state(request_ptr, status, &progress_state);
+    return MPIR_Wait_impl(request_ptr, status);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Waitall(int count, MPIR_Request * request_ptrs[],
                                           MPI_Status array_of_statuses[], int request_properties)
 {
-    MPID_Progress_state progress_state;
-
-    MPIDI_set_progress_vci_n(count, request_ptrs, &progress_state);
-    return MPIR_Waitall_state(count, request_ptrs, array_of_statuses,
-                              request_properties, &progress_state);
+    return MPIR_Waitall_impl(count, request_ptrs, array_of_statuses, request_properties);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Waitany(int count, MPIR_Request * request_ptrs[],

--- a/src/mpid/ch4/src/ch4_wait.h
+++ b/src/mpid/ch4/src/ch4_wait.h
@@ -36,8 +36,8 @@ MPL_STATIC_INLINE_PREFIX int get_vci_wrapper(MPIR_Request * req)
 MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci(MPIR_Request * req,
                                                      MPID_Progress_state * state)
 {
+    memset(state, 0, sizeof(MPID_Progress_state));
     state->flag = MPIDI_PROGRESS_ALL;   /* TODO: check request is_local/anysource */
-    state->progress_made = 0;
 
     int vci = get_vci_wrapper(req);
 
@@ -49,8 +49,8 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci(MPIR_Request * req,
 MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci_n(int n, MPIR_Request ** reqs,
                                                        MPID_Progress_state * state)
 {
+    memset(state, 0, sizeof(MPID_Progress_state));
     state->flag = MPIDI_PROGRESS_ALL;   /* TODO: check request is_local/anysource */
-    state->progress_made = 0;
 
     int idx = 0;
     for (int i = 0; i < n; i++) {


### PR DESCRIPTION
## Pull Request Description

For high message rate benchmarks, it is critical to reduce extra lock/unlock. This PR adds `MPID_Progress_start_ex` -- an extension to `MPID_Progress_start` -- to embed more information into the `progress_state` variable, allowing the possibility of taking on the per-vci lock between `MPID_Progress_start` and `MPID_Progress_end`. This allows skipping extra per-vci locks during `MPIR_Request_free`.

EDIT: The alternate solution is to add `MPID_Progress_requests`, so ch4 layer can manage/optimize requests internally. This solution is more flexible since all the critical pieces are inside ch4. But it deviates from the existing flow significantly.

[skip warnings]

## Expected Impact
ADI change.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
