### PR TITLE
cvar: add GPU categories

### DIFF
--- a/src/include/mpir_gpu.h
+++ b/src/include/mpir_gpu.h
@@ -11,6 +11,10 @@
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
 
+categories:
+    - name        : GPU
+      description : GPU related cvars
+
 cvars:
     - name        : MPIR_CVAR_ENABLE_GPU
       category    : GPU


### PR DESCRIPTION
## Pull Request Description
GPU category was used by MPIR_CVAR_ENABLE_GPU but not defined. This
patch adds the missing category.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
