### PR TITLE
ch4/ofi: enable multiple vci in collectives

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -198,6 +198,12 @@ struct MPIR_Comm {
      * because context_id is non-sequential and can't be used to identify user-level
      * communicators (due to sub-comms). */
     int seq;
+    /* Certain comm and its offsprings should be restricted to sequence 0 due to
+     * various restrictions. E.g. multiple-vci doesn't support dynamic process,
+     * nor intercomms (even after its merge).
+     */
+    int tainted;
+
 
     int hints[MPIR_COMM_HINT_MAX];      /* Hints to the communicator
                                          * use int array for fast access */

--- a/src/mpi/comm/comm_create.c
+++ b/src/mpi/comm/comm_create.c
@@ -222,6 +222,7 @@ int MPIR_Comm_create_intra(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
         mpi_errno = MPII_Comm_create_map(n, 0, mapping, NULL, mapping_comm, *newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
 
+        (*newcomm_ptr)->tainted = comm_ptr->tainted;
         mpi_errno = MPIR_Comm_commit(*newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
@@ -380,6 +381,7 @@ PMPI_LOCAL int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_p
                                          mapping, remote_mapping, mapping_comm, *newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
 
+        (*newcomm_ptr)->tainted = comm_ptr->tainted;
         mpi_errno = MPIR_Comm_commit(*newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpi/comm/comm_create_group.c
+++ b/src/mpi/comm/comm_create_group.c
@@ -87,6 +87,7 @@ int MPIR_Comm_create_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, int tag
         mpi_errno = MPII_Comm_create_map(n, 0, mapping, NULL, mapping_comm, *newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
 
+        (*newcomm_ptr)->tainted = comm_ptr->tainted;
         mpi_errno = MPIR_Comm_commit(*newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     } else {

--- a/src/mpi/comm/comm_split.c
+++ b/src/mpi/comm/comm_split.c
@@ -369,6 +369,7 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
         }
         MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_COMM_MUTEX(comm_ptr));
 
+        (*newcomm_ptr)->tainted = comm_ptr->tainted;
         mpi_errno = MPIR_Comm_commit(*newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     }

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -627,14 +627,19 @@ static int init_comm_seq(MPIR_Comm * comm)
     if (!HANDLE_IS_BUILTIN(comm->handle)) {
         static int vci_seq = 0;
         vci_seq++;
-        comm->seq = vci_seq;
+
+        int tmp = vci_seq;
+        /* Bcast seq over vci 0 */
+        MPIR_Assert(comm->seq == 0);
 
         /* Every rank need share the same seq from root. NOTE: it is possible for
          * different communicators to have the same seq. It is only used as an
          * opportunistic optimization */
         MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-        mpi_errno = MPIR_Bcast_allcomm_auto(&comm->seq, 1, MPI_INT, 0, comm, &errflag);
+        mpi_errno = MPIR_Bcast_allcomm_auto(&tmp, 1, MPI_INT, 0, comm, &errflag);
         MPIR_ERR_CHECK(mpi_errno);
+
+        comm->seq = tmp;
     }
 
     if (comm->node_comm) {

--- a/src/mpi/comm/intercomm_create.c
+++ b/src/mpi/comm/intercomm_create.c
@@ -130,6 +130,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
     }
     MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_COMM_MUTEX(local_comm_ptr));
 
+    (*new_intercomm_ptr)->tainted = 1;
     mpi_errno = MPIR_Comm_commit(*new_intercomm_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpi/comm/intercomm_merge.c
+++ b/src/mpi/comm/intercomm_merge.c
@@ -143,6 +143,7 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
      * operations within the context id algorithm, since we already
      * have a valid (almost - see comm_create_hook) communicator.
      */
+    (*new_intracomm_ptr)->tainted = 1;
     mpi_errno = MPIR_Comm_commit((*new_intracomm_ptr));
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -172,6 +173,7 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
     mpi_errno = create_and_map(comm_ptr, local_high, (*new_intracomm_ptr));
     MPIR_ERR_CHECK(mpi_errno);
 
+    (*new_intracomm_ptr)->tainted = 1;
     mpi_errno = MPIR_Comm_commit((*new_intracomm_ptr));
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -248,7 +248,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
 /* Common macro used by all MPIDI_NM_mpi_recv routines to facilitate tuning */
 #define MPIDI_OFI_RECV_VNIS(vni_src_, vni_dst_) \
     do { \
-        if (*request != NULL || context_offset != 0) { \
+        if (*request != NULL) { \
             /* workq path  or collectives */ \
             vni_src_ = 0; \
             vni_dst_ = 0; \

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -421,7 +421,7 @@ Input Parameters:
     errflag - the error flag to be passed along with the message
 @*/
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int d_rank, int tag,
+                                                MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,
                                                 MPIDI_av_entry_t * addr,
                                                 MPIR_Request ** request, MPIR_Errflag_t * errflag)
@@ -433,11 +433,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
     /* NOTE: collective use vci 0 and critical section taken at ch4-layer */
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno =
-            MPIDIG_send_coll(buf, count, datatype, d_rank, tag, comm, context_offset, addr, request,
+            MPIDIG_send_coll(buf, count, datatype, rank, tag, comm, context_offset, addr, request,
                              errflag);
     } else {
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-        mpi_errno = MPIDI_OFI_send(buf, count, datatype, d_rank, tag, comm, context_offset,
+        mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm, context_offset,
                                    addr, 0, 0, request, (*request == NULL), 0ULL, *errflag);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -436,10 +436,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
             MPIDIG_send_coll(buf, count, datatype, rank, tag, comm, context_offset, addr, request,
                              errflag);
     } else {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        int vni_src, vni_dst;
+        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm, context_offset,
-                                   addr, 0, 0, request, (*request == NULL), 0ULL, *errflag);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+                                   addr, vni_src, vni_dst, request, (*request == NULL), 0ULL,
+                                   *errflag);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_SEND_COLL);
@@ -530,10 +533,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
             MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
                               request, errflag);
     } else {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        int vni_src, vni_dst;
+        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, 0, 0, request, 0, 0ULL, *errflag);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+                                   context_offset, addr, vni_src, vni_dst, request, 0, 0ULL,
+                                   *errflag);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_ISEND_COLL);


### PR DESCRIPTION
## Pull Request Description

Simply treat collective communication the same as pt2pt communication.
Alternatively, we could add `context_offset` parameter to
`MPIDI_vci_get_src/dst` so we can make more differentiated vci descisions.



<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
