### PR TITLE
test/mpi: Add GPU-only configuration

### DIFF
--- a/test/mpi/Makefile_common.mtest
+++ b/test/mpi/Makefile_common.mtest
@@ -30,14 +30,19 @@ $(top_builddir)/dtpools/src/libdtpools.la:
 	(cd $(top_builddir)/dtpools && $(MAKE))
 
 if HAVE_CUDA
+if GPU_ONLY
+TESTDIRS ?= coll,pt2pt,rma
+TESTLIST ?= testlist.gpu
+else
 TESTLIST ?= testlist,testlist.dtp,testlist.cvar,testlist.gpu
+endif
 else
 TESTLIST ?= testlist,testlist.dtp,testlist.cvar
 endif
 SUMMARY_BASENAME ?= summary
 
 testing:
-	$(top_builddir)/runtests -srcdir=$(srcdir) -tests=$(TESTLIST) \
+	$(top_builddir)/runtests -srcdir=$(srcdir) -tests=$(TESTLIST) -testdirs=$(TESTDIRS) \
 		-mpiexec="${MPIEXEC}" -xmlfile=$(SUMMARY_BASENAME).xml \
 		-tapfile=$(SUMMARY_BASENAME).tap -junitfile=$(SUMMARY_BASENAME).junit.xml
 

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -250,6 +250,11 @@ AC_ARG_ENABLE(xfail,
 		[Run tests marked for expected failure])],,
 	[enable_xfail=no])
 
+AC_ARG_ENABLE(gpu-tests-only,
+        [AC_HELP_STRING([--enable-gpu-tests-only],
+                [Run only GPU tests])],,
+        [enable_gpu_tests_only=no])
+
 # DTPools test generation
 AC_ARG_WITH(dtpools-datatypes,
     [AC_HELP_STRING([--with-dtpools-datatypes=typelist],
@@ -1598,6 +1603,12 @@ AC_SUBST([cuda_LIBS])
 PAC_POP_FLAG([CPPFLAGS])
 PAC_POP_FLAG([LDFLAGS])
 PAC_POP_FLAG([LIBS])
+
+# GPU only tests
+if test $have_cuda = "no" -a $enable_gpu_tests_only = "yes" ; then
+    AC_MSG_ERROR([GPU only test configuration requires CUDA])
+fi
+AM_CONDITIONAL([GPU_ONLY], [test $enable_gpu_tests_only = "yes"])
 
 # TODO: use variables such as has_f77 etc. instead of double use $f77dir etc.
 AM_CONDITIONAL([HAS_F77], [test $f77dir = f77])

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -212,6 +212,7 @@ foreach $_ (@ARGV) {
     elsif (/--?ppn=(\d+)/)  { $ppnMax = $1; }
     elsif (/--?timelimitarg=(.*)/) { $timelimitArg = $1; }
     elsif (/--?tests=(.*)/) { $listfiles = $1; }
+    elsif (/--?testdirs=(.*)/) { $testdirs = $1; }
     elsif (/--?srcdir=(.*)/) { $srcdir = $1; }
     elsif (/--?verbose/) { $verbose = 1; }
     elsif (/--?showprogress/) { $showProgress = 1; }
@@ -279,7 +280,7 @@ foreach $_ (@ARGV) {
     }
     else {
         print STDERR "Unrecognized argument $_\n";
-        print STDERR "runtests [-tests=testfile] [-np=nprocesses] \
+        print STDERR "runtests [-tests=testfile] [-testdirs=dirs] [-np=nprocesses] \
         [-maxnp=max-nprocesses] [-srcdir=location-of-tests] \
         [-ppn=max-proc-per-node] [-ppnarg=string] \
         [-timelimitarg=string] [-xmlfile=filename ] [-tapfile=filename ] \
@@ -315,8 +316,11 @@ if ($listfiles eq "") {
         &ProcessImplicitList;
     }
 }
-elsif (-d $listfiles) { 
-    print STDERR "Testing by directories not yet supported\n";
+elsif ($testdirs ne "") {
+    my @all_testdirs = split /,\s*/, $testdirs;
+    foreach my $_d (@all_testdirs) {
+        &ProcessDir( $_d, $listfiles );
+    }
 }
 else {
     &RunList( $listfiles );
@@ -401,9 +405,8 @@ sub ProcessDir {
     }
 
     print "Processing directory $dir\n" if ($verbose || $debug);
-    chdir $dir;
-    if ($dir =~ /\//) {
-        print STDERR "only direct subdirectories allowed in list files";
+    unless(chdir $dir) {
+        die "Error: Cannot find directory $dir";
     }
     $curdir .= "/$dir";
 


### PR DESCRIPTION
## Pull Request Description

Add a configuration option to only run GPU tests. This allows for more
targeted testing of GPU-related changes outside of regular Jenkins
testing.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
