### PR TITLE
runtests: check sub test directory by default

### DIFF
--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -153,35 +153,6 @@ fi
 
 AC_SUBST(DTP_SWITCH)
 
-# GPU support
-PAC_PUSH_FLAG([CPPFLAGS])
-PAC_PUSH_FLAG([LDFLAGS])
-PAC_PUSH_FLAG([LIBS])
-PAC_SET_HEADER_LIB_PATH([cuda])
-PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cuda=yes],[have_cuda=no])
-cuda_CPPFLAGS=""
-cuda_LDFLAGS=""
-cuda_LIBS=""
-if test "X${have_cuda}" = "Xyes" ; then
-    AC_DEFINE([HAVE_CUDA],[1],[Define if CUDA is available])
-    if test -n "${with_cuda}" ; then
-        cuda_CPPFLAGS="-I${with_cuda}/include"
-        if test -d ${with_cuda}/lib64 ; then
-            cuda_LDFLAGS="-L${with_cuda}/lib64 -L${with_cuda}/lib"
-        else
-            cuda_LDFLAGS="-L${with_cuda}/lib"
-        fi
-        cuda_LIBS="-lcudart"
-    fi
-fi
-AM_CONDITIONAL([HAVE_CUDA],[test "X${have_cuda}" = "Xyes"])
-AC_SUBST([cuda_CPPFLAGS])
-AC_SUBST([cuda_LDFLAGS])
-AC_SUBST([cuda_LIBS])
-PAC_POP_FLAG([CPPFLAGS])
-PAC_POP_FLAG([LDFLAGS])
-PAC_POP_FLAG([LIBS])
-
 AC_ARG_ENABLE(cxx,
 	[AC_HELP_STRING([--enable-cxx],[Turn on C++ tests (default)])],,[enable_cxx=yes])
 
@@ -423,7 +394,7 @@ fi
 
 # errordir is substituted into the testlist file as errors when the
 # tests should check error handling and as a comment (#) otherwise.
-errordir="#"
+errordir="#errors"
 if test "$enable_checkerrors" = "yes" ; then
     errordir=errors
 fi
@@ -432,7 +403,7 @@ AC_SUBST(errordir)
 # The performance tests are not part of the MPI standard
 perfdir="perf"
 if test "$enable_strictmpi" = "yes" -o "$enable_perftest" = "no" ; then
-     perfdir="#"
+     perfdir="#perf"
 fi
 AC_SUBST(perfdir)
 
@@ -454,6 +425,7 @@ AC_SUBST(comm_overlap)
 
 # 
 # Only run the threads tests if multiple is specified
+threadsdir="#threads"
 if test "$enable_threads" = "multiple" -o "$enable_threads" = "runtime" ; then
     threadsdir="threads"
 fi
@@ -513,6 +485,8 @@ AC_ARG_VAR([MPI_NO_SPAWN],[set to "yes" to disable dynamic process tests])
 if test "$enable_spawn" = "yes" -a "$MPI_NO_SPAWN" != "yes" ; then
     spawndir=spawn
     AC_DEFINE(HAVE_MPI_SPAWN,1,[Define if Dynamic Process functionality is available])
+else
+    spawndir="#spawn"
 fi
 AC_SUBST(spawndir)
 
@@ -520,15 +494,15 @@ AC_SUBST(spawndir)
 AC_ARG_VAR([MPI_NO_RMA],[set to "yes" to disable one-sided tests])
 rmadir=rma
 if test "$enable_rma" != yes ; then
-    rmadir="#"
+    rmadir="#rma"
 elif test "$MPI_NO_RMA"  = yes ; then
-    rmadir="#"
+    rmadir="#rma"
 else
     AC_DEFINE(HAVE_MPI_WIN_CREATE,1,[Define if MPI_Win_create is available])
 fi
 AC_SUBST(rmadir)
 
-faultsdir=#
+faultsdir="#faults"
 if test "$enable_checkfaults" = "yes" ; then
     faultsdir=faults
 fi
@@ -904,7 +878,7 @@ if test "$enable_f77" = yes ; then
 fi
 # Simple tests for which other languages we can handle.  
 # Use these only when configuring separate from an MPICH build
-f77dir="#"
+f77dir="#f77"
 AC_SUBST(f77dir)
 buildingF77=no
 if test "$FROM_MPICH" = yes ; then
@@ -1210,7 +1184,7 @@ if test "$enable_fc" = yes ; then
         enable_fc=no
     fi
 fi
-f90dir="#"
+f90dir="#f90"
 AC_SUBST(f90dir)
 # First, see if we have an f90 compiler.  This uses code similar to that
 # in the MPICH top-level configure
@@ -1243,7 +1217,7 @@ if test "$enable_fc" = yes ; then
             FCFLAGS="$FCFLAGS $FCFLAGS_f90"
         ],[
             AC_MSG_WARN([Fortran 90 test being disabled because the $FC compiler does not accept a .f90 extension])
-            f90dir=#
+            f90dir="#f90"
             enable_fc=no
         ])
         AC_LANG_POP([Fortran])
@@ -1332,7 +1306,7 @@ if test "$enable_f08" = "yes" ; then
     PAC_FC_2008_SUPPORT([enable_f08=yes],[enable_f08=no])
 fi
 
-f08dir="#"
+f08dir="#f08"
 AC_SUBST(f08dir)
 # FIXME if $FROM_MPICH is no, we should test build an MPI F08 program
 if test "$enable_f08" = "yes" -a "$FROM_MPICH" = "yes" ; then
@@ -1347,7 +1321,7 @@ if test "$enable_cxx" = yes ; then
     fi
 fi
 # Simple tests for which other languages we can handle
-cxxdir="#"
+cxxdir="#cxx"
 # The C++ interface added support for the Distgraph routines in MPI-2.2,
 # but not all MPI implementations support that.  nocxxdistgraph allows
 # us to detect that and to skip the test when it is not supported.
@@ -1441,7 +1415,7 @@ AC_LANG_C
 LT_INIT()
 
 # IO
-iodir="#"
+iodir="#io"
 if test "$enable_romio" != no ; then
     iodir=io
     AC_DEFINE(HAVE_MPI_IO,1,[Define if MPI-IO (really ROMIO) is included])
@@ -1598,6 +1572,35 @@ else
     # the user will need to determine how to run a program
     AC_PATH_PROG(MPIEXEC,$MPIEXEC_NAME)
 fi
+
+# GPU support
+PAC_PUSH_FLAG([CPPFLAGS])
+PAC_PUSH_FLAG([LDFLAGS])
+PAC_PUSH_FLAG([LIBS])
+PAC_SET_HEADER_LIB_PATH([cuda])
+PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cuda=yes],[have_cuda=no])
+cuda_CPPFLAGS=""
+cuda_LDFLAGS=""
+cuda_LIBS=""
+if test "X${have_cuda}" = "Xyes" ; then
+    AC_DEFINE([HAVE_CUDA],[1],[Define if CUDA is available])
+    if test -n "${with_cuda}" ; then
+        cuda_CPPFLAGS="-I${with_cuda}/include"
+        if test -d ${with_cuda}/lib64 ; then
+            cuda_LDFLAGS="-L${with_cuda}/lib64 -L${with_cuda}/lib"
+        else
+            cuda_LDFLAGS="-L${with_cuda}/lib"
+        fi
+        cuda_LIBS="-lcudart"
+    fi
+fi
+AM_CONDITIONAL([HAVE_CUDA],[test "X${have_cuda}" = "Xyes"])
+AC_SUBST([cuda_CPPFLAGS])
+AC_SUBST([cuda_LDFLAGS])
+AC_SUBST([cuda_LIBS])
+PAC_POP_FLAG([CPPFLAGS])
+PAC_POP_FLAG([LDFLAGS])
+PAC_POP_FLAG([LIBS])
 
 # TODO: use variables such as has_f77 etc. instead of double use $f77dir etc.
 AM_CONDITIONAL([HAS_F77], [test $f77dir = f77])

--- a/test/mpi/errors/testlist.in
+++ b/test/mpi/errors/testlist.in
@@ -11,4 +11,5 @@ topo
 @f77dir@
 @cxxdir@
 @f90dir@
+@f08dir@
 @faultsdir@

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -441,7 +441,7 @@ sub RunList {
         if (! -s "$_f" && -s "$srcdir/$curdir/$_f" ) {
             $listfileSource = "$srcdir/$curdir/$_f";
         }
-        if (!-f $listfileSource && $_f ne "testlist") {
+        if (!-f $listfileSource) {
             # just skip, do not complain missing unless it is "testlist"
             next;
         }

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -432,6 +432,8 @@ sub RunList {
         @TYPES = split ' ', $ENV{"DTP_RUNTIME_TYPES"};
     }
 
+    my $dir_hash = get_subdirs();
+
     # eg: runtests -tests='testlist,testlist.dtp'
     my @all_listfiles = split /,\s*/, $listfile;
     foreach my $_f (@all_listfiles){
@@ -456,6 +458,10 @@ sub RunList {
                 # Too many timeout failures
                 print STDERR "Terminating test because of too many timeout failures\n";
                 last;
+            }
+            # disabled dir
+            if (/^#\s*(\S+)/ and -d $1) {
+                $dir_hash->{$1} = 0;
             }
             # Skip comments
             s/#.*//g;
@@ -594,9 +600,7 @@ sub RunList {
             }
 
             if (-d $programname) {
-                # If a directory, go into the that directory and 
-                # look for a new list file
-                &ProcessDir( $programname, $listfile );
+                $dir_hash->{$programname} = 1;
             }
             else {
                 $g_total_run++;
@@ -630,6 +634,12 @@ sub RunList {
             }
         }
         close( $LIST );
+    }
+
+    foreach my $dir (sort keys %$dir_hash) {
+        if ($dir_hash->{$dir}) {
+            ProcessDir($dir, $listfile);
+        }
     }
 }
 #
@@ -1409,4 +1419,16 @@ sub relese_lock {
         print "Releasing lock [$lockfile]\n";
     }
     close(LOCK);
+}
+
+# collect all subdirs into a hash from current directory
+sub get_subdirs {
+    my %dirs;
+    my @all = glob("*");
+    foreach my $a (@all) {
+        if (-d $a) {
+            $dirs{$a} = 1;
+        }
+    }
+    return \%dirs;
 }

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -304,6 +304,10 @@ else {
     }
 }
 
+if ($listfiles eq "") {
+    $listfiles = $ENV{MPITEST_TESTLIST};
+}
+
 #
 # Process any files
 if ($listfiles eq "") {

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -311,13 +311,7 @@ if ($listfiles eq "") {
 #
 # Process any files
 if ($listfiles eq "") {
-    if ($batchRun) {
-        print STDERR "An implicit list of tests is not permitted in batch mode. See README for more details\n";
-        exit(1);
-    } 
-    else {
-        &ProcessImplicitList;
-    }
+    $listfiles = "testlist";
 }
 elsif (-d $listfiles) { 
     print STDERR "Testing by directories not yet supported\n";
@@ -647,80 +641,6 @@ sub RunList {
     }
 }
 #
-# This routine tries to run all of the files in the current
-# directory
-sub ProcessImplicitList {
-    # The default is to run every file in the current directory.
-    # If there are no built programs, build and run every file
-    # WARNING: This assumes that anything executable should be run as
-    # an MPI test.
-    $found_exec = 0;
-    $found_src  = 0;
-    open (PGMS, "ls -1 |" ) || die "Cannot list directory\n";
-    while (<PGMS>) {
-        s/\r?\n//;
-        $programname = $_;
-        if (-d $programname) { next; }  # Ignore directories
-        if ($programname eq "runtests") { next; } # Ignore self
-        if ($programname eq "checktests") { next; } # Ignore helper
-        if ($programname eq "configure") { next; } # Ignore configure script
-        if ($programname eq "config.status") { next; } # Ignore configure helper
-        if (-x $programname) { $found_exec++; }
-        if ($programname =~ /\.[cf]$/) { $found_src++; } 
-    }
-    close PGMS;
-    
-    my $default_test_opt = {args=>[], envs=>[], mpiexecargs=>[]};
-    if ($found_exec) {
-        print "Found executables\n" if $debug;
-        open (PGMS, "ls -1 |" ) || die "Cannot list programs\n";
-        while (<PGMS>) {
-            # Check for stop file
-            if (-s $stopfile) {
-                # Exit because we found a stopfile
-                print STDERR "Terminating test because stopfile $stopfile found\n";
-                last;
-            }
-            s/\r?\n//;
-            $programname = $_;
-            if (-d $programname) { next; }  # Ignore directories
-            if ($programname eq "runtests") { next; } # Ignore self
-            if (-x $programname) {
-                $g_total_run++;
-                &RunMPIProgram( $programname, $np_default, $default_test_opt);
-            }
-        }
-        close PGMS;
-    }
-    elsif ($found_src) { 
-        print "Found source files\n" if $debug;
-        open (PGMS, "ls -1 *.c |" ) || die "Cannot list programs\n";
-        while (<PGMS>) {
-            if (-s $stopfile) {
-                # Exit because we found a stopfile
-                print STDERR "Terminating test because stopfile $stopfile found\n";
-                last;
-            }
-            s/\r?\n//;
-            $programname = $_;
-            # Skip messages from ls about no files
-            if (! -s $programname) { next; }
-            $programname =~ s/\.c//;
-            $g_total_run++;
-            if (&BuildMPIProgram( $programname, "") == 0) {
-                &RunMPIProgram( $programname, $np_default, $default_test_opt);
-            }
-            else {
-                # We expected to run this program, so failure to build
-                # is an error
-                $found_error = 1;
-                $err_count++;
-            }
-            &CleanUpAfterRun( $programname, $default_test_opt );
-        }
-        close PGMS;
-    }
-}
 # Run the program.  
 # ToDo: Add a way to limit the time that any particular program may run.
 # The arguments are

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -113,8 +113,6 @@ my $junitoutput = 0;
 my $junitfile = '';
 my $junitfullfile = '';
 
-$debug = 1;
-
 $depth = 0;              # This is used to manage multiple open list files
 
 # Build flags
@@ -215,7 +213,6 @@ foreach $_ (@ARGV) {
     elsif (/--?srcdir=(.*)/) { $srcdir = $1; }
     elsif (/--?verbose/) { $verbose = 1; }
     elsif (/--?showprogress/) { $showProgress = 1; }
-    elsif (/--?debug/) { $debug = 1; }
     elsif (/--?batchdir=(.*)/) { $batrundir = $1; }
     elsif (/--?batch/) { $batchRun = 1; }
     elsif (/--?timeoutarg=(.*)/) { $timeoutArgPattern = $1; }
@@ -284,7 +281,7 @@ foreach $_ (@ARGV) {
         [-ppn=max-proc-per-node] [-ppnarg=string] \
         [-timelimitarg=string] [-xmlfile=filename ] [-tapfile=filename ] \
         [-junitfile=filename ] [-noxmlclose] \
-        [-verbose] [-showprogress] [-debug] [-batch]\n";
+        [-verbose] [-showprogress] [-batch]\n";
         exit(1);
     }
 }
@@ -398,7 +395,7 @@ sub ProcessDir {
       $srcdir = "../$srcdir";
     }
 
-    print "Processing directory $dir\n" if ($verbose || $debug);
+    print "Processing directory $dir\n" if ($verbose);
     chdir $dir;
     if ($dir =~ /\//) {
         print STDERR "only direct subdirectories allowed in list files";
@@ -443,7 +440,7 @@ sub RunList {
             # just skip, do not complain missing unless it is "testlist"
             next;
         }
-        print "Looking in $curdir/$_f\n" if $debug;
+        print "Looking in $curdir/$_f\n";
         open( $LIST, "<$listfileSource" ) || die "Could not open $listfileSource\n";
         while (<$LIST>) {
             # Check for stop file


### PR DESCRIPTION
## Pull Request Description
This allows special testlist config inside a sub directory without the
need of modifying upper-level testlist, avoids potential conflict.


## Example usages
* runs `testlist,testlist.dtp,testlist.cvar`:
```
make testing
```
* recurse into directories and run any testlist.cvar that exist
```
TESTLIST=testlist.cvar make testing
```

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## References
Reference discussions in #4645 and #4651

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
