### PR TITLE
Fix gavl tree variables/functions type and naming issue

### DIFF
--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
@@ -95,7 +95,7 @@ int MPIDI_XPMEM_mpi_finalize_hook(void)
     for (i = 0; i < MPIR_Process.local_size; i++) {
         /* should be called before xpmem_release
          * MPIDI_XPMEMI_segtree_delete_all will call xpmem_detach */
-        MPL_gavl_tree_free(MPIDI_XPMEMI_global.segmaps[i].segcache_ubuf, MPIDI_XPMEM_seg_free);
+        MPL_gavl_tree_free(MPIDI_XPMEMI_global.segmaps[i].segcache_ubuf);
         if (MPIDI_XPMEMI_global.segmaps[i].apid != -1) {
             XPMEM_TRACE("finalize: release apid: node_rank %d, 0x%lx\n",
                         i, (uint64_t) MPIDI_XPMEMI_global.segmaps[i].apid);

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
@@ -18,7 +18,7 @@ int MPIDI_XPMEMI_segtree_init(MPL_gavl_tree_t * tree)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEGTREE_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEGTREE_INIT);
 
-    ret = MPL_gavl_tree_create(tree);
+    ret = MPL_gavl_tree_create(MPIDI_XPMEM_seg_free, tree);
     MPIR_ERR_CHKANDJUMP(ret != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**xpmem_segtree_init");
 
   fn_exit:

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
@@ -18,7 +18,7 @@ int MPIDI_XPMEMI_segtree_init(MPL_gavl_tree_t * tree)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEMI_SEGTREE_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEMI_SEGTREE_INIT);
 
-    ret = MPL_gavl_tree_create(MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE, tree);
+    ret = MPL_gavl_tree_create(tree);
     MPIR_ERR_CHKANDJUMP(ret != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**xpmem_segtree_init");
 
   fn_exit:

--- a/src/mpl/include/mpl_gavl.h
+++ b/src/mpl/include/mpl_gavl.h
@@ -8,10 +8,10 @@
 
 typedef void *MPL_gavl_tree_t;
 
-int MPL_gavl_tree_create(MPL_gavl_tree_t * gavl_tree);
+int MPL_gavl_tree_create(void (*free_fn) (void *), MPL_gavl_tree_t * gavl_tree);
 int MPL_gavl_tree_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len,
                          const void *val);
 int MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len, void **val);
-int MPL_gavl_tree_free(MPL_gavl_tree_t gavl_tree, void (*free_fn) (void *));
+int MPL_gavl_tree_free(MPL_gavl_tree_t gavl_tree);
 
 #endif /* MPL_GAVL_H_INCLUDED  */

--- a/src/mpl/include/mpl_gavl.h
+++ b/src/mpl/include/mpl_gavl.h
@@ -8,7 +8,7 @@
 
 typedef void *MPL_gavl_tree_t;
 
-int MPL_gavl_tree_create(int need_thread_safety, MPL_gavl_tree_t * gavl_tree);
+int MPL_gavl_tree_create(MPL_gavl_tree_t * gavl_tree);
 int MPL_gavl_tree_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len,
                          const void *val);
 int MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len, void **val);


### PR DESCRIPTION
## Pull Request Description
This PR provides the following changes:
- move thread-safety check to MPICH
- fix size variable type to `uintptr_t`
- add enumeration SEARCH_LFET, SEARCH_RIGHT, BUFFER_MATCH, NO_BUFFER_MATCH semantics
- change comparison function name to `gavl_subset_cmp_func`
- change gavl tree API to let user pass `free_fn` in `MPL_gavl_tree_create`
