### PR TITLE
pt2pt: only validate datatype if count is nonzero

### DIFF
--- a/src/mpi/pt2pt/bsend.c
+++ b/src/mpi/pt2pt/bsend.c
@@ -123,21 +123,23 @@ int MPI_Bsend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
             /* Validate datatype handle */
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+            if (count > 0) {
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/bsend_init.c
+++ b/src/mpi/pt2pt/bsend_init.c
@@ -92,22 +92,25 @@ int MPI_Bsend_init(const void *buf, int count, MPI_Datatype datatype,
                 goto fn_fail;
 
             MPIR_ERRTEST_COUNT(count, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_SEND_RANK(comm_ptr, dest, mpi_errno);
             MPIR_ERRTEST_SEND_TAG(tag, mpi_errno);
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+            if (count > 0) {
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
+
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
             }
         }
         MPID_END_ERROR_CHECKS;

--- a/src/mpi/pt2pt/ibsend.c
+++ b/src/mpi/pt2pt/ibsend.c
@@ -116,24 +116,26 @@ int MPI_Ibsend(const void *buf, int count, MPI_Datatype datatype, int dest, int 
                 MPIR_ERRTEST_SEND_RANK(comm_ptr, dest, mpi_errno)
             }
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/imrecv.c
+++ b/src/mpi/pt2pt/imrecv.c
@@ -64,7 +64,9 @@ int MPI_Imrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message * messag
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            }
 
             /* TODO more checks may be appropriate */
         }

--- a/src/mpi/pt2pt/irecv.c
+++ b/src/mpi/pt2pt/irecv.c
@@ -94,24 +94,26 @@ int MPI_Irecv(void *buf, int count, MPI_Datatype datatype, int source,
             MPIR_ERRTEST_RECV_TAG(tag, mpi_errno);
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/irsend.c
+++ b/src/mpi/pt2pt/irsend.c
@@ -95,24 +95,26 @@ int MPI_Irsend(const void *buf, int count, MPI_Datatype datatype, int dest, int 
             MPIR_ERRTEST_SEND_TAG(tag, mpi_errno);
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/isend.c
+++ b/src/mpi/pt2pt/isend.c
@@ -93,24 +93,26 @@ int MPI_Isend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
             MPIR_ERRTEST_SEND_TAG(tag, mpi_errno);
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/issend.c
+++ b/src/mpi/pt2pt/issend.c
@@ -94,24 +94,26 @@ int MPI_Issend(const void *buf, int count, MPI_Datatype datatype, int dest, int 
             MPIR_ERRTEST_SEND_TAG(tag, mpi_errno);
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/recv.c
+++ b/src/mpi/pt2pt/recv.c
@@ -102,24 +102,26 @@ int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag,
             MPIR_ERRTEST_RECV_RANK(comm_ptr, source, mpi_errno);
             MPIR_ERRTEST_RECV_TAG(tag, mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/recv_init.c
+++ b/src/mpi/pt2pt/recv_init.c
@@ -97,24 +97,26 @@ int MPI_Recv_init(void *buf, int count, MPI_Datatype datatype, int source,
             MPIR_ERRTEST_RECV_TAG(tag, mpi_errno);
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/rsend.c
+++ b/src/mpi/pt2pt/rsend.c
@@ -89,24 +89,26 @@ int MPI_Rsend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
             MPIR_ERRTEST_SEND_RANK(comm_ptr, dest, mpi_errno);
             MPIR_ERRTEST_SEND_TAG(tag, mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/rsend_init.c
+++ b/src/mpi/pt2pt/rsend_init.c
@@ -97,24 +97,26 @@ int MPI_Rsend_init(const void *buf, int count, MPI_Datatype datatype, int dest,
             MPIR_ERRTEST_SEND_TAG(tag, mpi_errno);
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/send.c
+++ b/src/mpi/pt2pt/send.c
@@ -94,24 +94,26 @@ int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int ta
             MPIR_ERRTEST_SEND_RANK(comm_ptr, dest, mpi_errno);
             MPIR_ERRTEST_SEND_TAG(tag, mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/send_init.c
+++ b/src/mpi/pt2pt/send_init.c
@@ -97,24 +97,26 @@ int MPI_Send_init(const void *buf, int count, MPI_Datatype datatype, int dest,
             MPIR_ERRTEST_SEND_TAG(tag, mpi_errno);
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/sendrecv.c
+++ b/src/mpi/pt2pt/sendrecv.c
@@ -118,37 +118,47 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 MPIR_ERRTEST_RECV_RANK(comm_ptr, source, mpi_errno);
             }
 
-            /* Validate datatype handles */
-            MPIR_ERRTEST_DATATYPE(sendtype, "datatype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "datatype", mpi_errno);
+            if (sendcount > 0) {
+                /* Validate datatype handles */
+                MPIR_ERRTEST_DATATYPE(sendtype, "datatype", mpi_errno);
 
-            /* Validate datatype objects */
-            if (!HANDLE_IS_BUILTIN(sendtype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype objects */
+                if (!HANDLE_IS_BUILTIN(sendtype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(sendtype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-            }
-            if (!HANDLE_IS_BUILTIN(recvtype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                    MPIR_Datatype_get_ptr(sendtype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
 
-                MPIR_Datatype_get_ptr(recvtype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                /* Validate buffers */
+                MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
             }
 
-            /* Validate buffers */
-            MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
-            MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
+            if (recvcount > 0) {
+                /* Validate datatype handles */
+                MPIR_ERRTEST_DATATYPE(recvtype, "datatype", mpi_errno);
+
+                /* Validate datatype objects */
+                if (!HANDLE_IS_BUILTIN(recvtype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
+
+                    MPIR_Datatype_get_ptr(recvtype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffers */
+                MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
+            }
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/sendrecv_rep.c
+++ b/src/mpi/pt2pt/sendrecv_rep.c
@@ -100,24 +100,26 @@ int MPI_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype,
             MPIR_ERRTEST_SEND_RANK(comm_ptr, dest, mpi_errno);
             MPIR_ERRTEST_RECV_RANK(comm_ptr, source, mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/ssend.c
+++ b/src/mpi/pt2pt/ssend.c
@@ -88,24 +88,26 @@ int MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
             MPIR_ERRTEST_SEND_RANK(comm_ptr, dest, mpi_errno);
             MPIR_ERRTEST_SEND_TAG(tag, mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/pt2pt/ssend_init.c
+++ b/src/mpi/pt2pt/ssend_init.c
@@ -94,24 +94,26 @@ int MPI_Ssend_init(const void *buf, int count, MPI_Datatype datatype, int dest,
             MPIR_ERRTEST_SEND_TAG(tag, mpi_errno);
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
 
-            /* Validate datatype handle */
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            if (count > 0) {
+                /* Validate datatype handle */
+                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            /* Validate datatype object */
-            if (!HANDLE_IS_BUILTIN(datatype)) {
-                MPIR_Datatype *datatype_ptr = NULL;
+                /* Validate datatype object */
+                if (!HANDLE_IS_BUILTIN(datatype)) {
+                    MPIR_Datatype *datatype_ptr = NULL;
 
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
+                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
+                    if (mpi_errno)
+                        goto fn_fail;
+                }
+
+                /* Validate buffer */
+                MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
             }
-
-            /* Validate buffer */
-            MPIR_ERRTEST_USERBUFFER(buf, count, datatype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }


### PR DESCRIPTION
## Pull Request Description

Zero sized message is allowed in MPI and we are supposed to ignore its datatype or buffer argument in that case.

Fixes #4659

* [x] fix all send/recv operations
* [ ] add test

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
