### PR TITLE
xfail: a few expected fails in nightly special tests

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -44,6 +44,9 @@
 * * * ch4:ofi * sed -i "s+\(^ibsend .*\)+\1 xfail=ticket0+g" test/mpi/threads/pt2pt/testlist
 * * * ch4:ofi * sed -i "s+\(^large_acc_flush_local .*\)+\1 xfail=issue3251+g" test/mpi/rma/testlist
 ################################################################################
+# misc special build
+nofast * * * * sed -i "s+\(^large_acc_flush_local .*\)+\1 xfail=issue4663+g" test/mpi/rma/testlist
+shmem  * * ch4:ofi * sed -i "s+\(^disconnect3 .*\)+\1 xfail=pr4517+g" test/mpi/rma/testlist
 #ch3:ofi
 * * * ch3:ofi * sed -i  "s+\(^manyget .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
 * * * ch3:ofi * sed -i  "s+\(^manyrma2 .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist


### PR DESCRIPTION
## Pull Request Description
Xfail the failures that we are not going to fix anytime soon so that the
nightly tests can provide clean signals.

I would argue that in principle, any failures in nightly tests that we are not actively fixing should be removed or xfailed, since they only serve to obscure the signals.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
