### PR TITLE
dtpools: replace strncpy with strcpy to suppress warnings

### DIFF
--- a/test/mpi/dtpools/include/dtpools_internal.h
+++ b/test/mpi/dtpools/include/dtpools_internal.h
@@ -101,7 +101,7 @@ extern int DTPI_func_nesting;
             DTPI_FREE(t2_);                                             \
         }                                                               \
         DTPI_ERR_ASSERT(strlen(tmp_) < max_len - cur_len - 1, rc_);     \
-        strncpy(tstr + cur_len, tmp_, strlen(tmp_) + 1);                \
+        strcpy(tstr + cur_len, tmp_);                                   \
         cur_len += strlen(tmp_);                                        \
     } while (0)
 


### PR DESCRIPTION
Using strlen in strncpy is useless and gcc warns:
   '__builtin_strncpy' specified bound depends on the length of the
source argument [-Wstringop-overflow=]

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
