### PR TITLE
ch4/ofi: fix warning about function declaration

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_progress.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.c
@@ -7,9 +7,9 @@
 #include "ofi_impl.h"
 #include "ofi_events.h"
 
-static int handle_deferred_ops();
+static int handle_deferred_ops(void);
 
-static int handle_deferred_ops()
+static int handle_deferred_ops(void)
 {
 
     int mpi_errno = MPI_SUCCESS;


### PR DESCRIPTION
## Pull Request Description

This commit fixes the warning on the function declaration introduced in the GenQ CH4/AM PR.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
