### PR TITLE
ch4: remove mpid_send and friends

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -213,33 +213,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv(void *buf,
-                                             MPI_Aint count,
-                                             MPI_Datatype datatype,
-                                             int rank,
-                                             int tag,
-                                             MPIR_Comm * comm,
-                                             int context_offset, MPI_Status * status,
-                                             MPIR_Request ** request, int is_local)
-{
-    int mpi_errno;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RECV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_RECV);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-
-    mpi_errno =
-        MPIDIG_do_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0ULL);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIDI_REQUEST_SET_LOCAL(*request, is_local, NULL);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_RECV);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
                                                MPI_Aint count,
                                                MPI_Datatype datatype, MPIR_Request * message)

--- a/src/mpid/ch4/generic/am/mpidig_am_send.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_send.h
@@ -114,47 +114,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_send(const void *buf,
-                                             MPI_Aint count,
-                                             MPI_Datatype datatype,
-                                             int rank,
-                                             int tag, MPIR_Comm * comm, int context_offset,
-                                             MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_SEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_SEND);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-
-    mpi_errno =
-        MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                          MPIDIG_AM_SEND_FLAGS_NONE, request, MPIR_ERR_NONE);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_SEND);
-    return mpi_errno;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDIG_send_coll(const void *buf, MPI_Aint count,
-                                              MPI_Datatype datatype, int rank,
-                                              int tag, MPIR_Comm * comm, int context_offset,
-                                              MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                              MPIR_Errflag_t * errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_SEND_COLL);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_COLL);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-
-    mpi_errno =
-        MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                          MPIDIG_AM_SEND_FLAGS_NONE, request, *errflag);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_SEND_COLL);
-    return mpi_errno;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
                                               MPI_Aint count,
                                               MPI_Datatype datatype,
@@ -238,27 +197,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irsend(const void *buf,
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IRSEND);
-    return mpi_errno;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_ssend(const void *buf,
-                                              MPI_Aint count,
-                                              MPI_Datatype datatype,
-                                              int rank,
-                                              int tag, MPIR_Comm * comm, int context_offset,
-                                              MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_SSEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_SSEND);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-
-    mpi_errno =
-        MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                          MPIDIG_AM_SEND_FLAGS_SYNC, request, MPIR_ERR_NONE);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_SSEND);
     return mpi_errno;
 }
 

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -75,16 +75,6 @@ typedef int (*MPIDI_NM_rma_target_cmpl_hook_t) (int rank, MPIR_Win * win);
 typedef int (*MPIDI_NM_rma_target_local_cmpl_hook_t) (int rank, MPIR_Win * win);
 typedef void (*MPIDI_NM_am_request_init_t) (MPIR_Request * req);
 typedef void (*MPIDI_NM_am_request_finalize_t) (MPIR_Request * req);
-typedef int (*MPIDI_NM_mpi_send_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                    int rank, int tag, MPIR_Comm * comm, int context_offset,
-                                    MPIDI_av_entry_t * addr, MPIR_Request ** request);
-typedef int (*MPIDI_NM_send_coll_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                     int rank, int tag, MPIR_Comm * comm, int context_offset,
-                                     MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                     MPIR_Errflag_t * errflag);
-typedef int (*MPIDI_NM_mpi_ssend_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                     int rank, int tag, MPIR_Comm * comm, int context_offset,
-                                     MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_NM_mpi_isend_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                      int rank, int tag, MPIR_Comm * comm, int context_offset,
                                      MPIDI_av_entry_t * addr, MPIR_Request ** request);
@@ -96,10 +86,6 @@ typedef int (*MPIDI_NM_mpi_issend_t) (const void *buf, MPI_Aint count, MPI_Datat
                                       int rank, int tag, MPIR_Comm * comm, int context_offset,
                                       MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_NM_mpi_cancel_send_t) (MPIR_Request * sreq);
-typedef int (*MPIDI_NM_mpi_recv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
-                                    int tag, MPIR_Comm * comm, int context_offset,
-                                    MPIDI_av_entry_t * addr, MPI_Status * status,
-                                    MPIR_Request ** request);
 typedef int (*MPIDI_NM_mpi_irecv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
                                      int tag, MPIR_Comm * comm, int context_offset,
                                      MPIDI_av_entry_t * addr, MPIR_Request ** request,
@@ -416,14 +402,10 @@ typedef struct MPIDI_NM_funcs {
 } MPIDI_NM_funcs_t;
 
 typedef struct MPIDI_NM_native_funcs {
-    MPIDI_NM_mpi_send_t mpi_send;
-    MPIDI_NM_send_coll_t send_coll;
-    MPIDI_NM_mpi_ssend_t mpi_ssend;
     MPIDI_NM_mpi_isend_t mpi_isend;
     MPIDI_NM_isend_coll_t isend_coll;
     MPIDI_NM_mpi_issend_t mpi_issend;
     MPIDI_NM_mpi_cancel_send_t mpi_cancel_send;
-    MPIDI_NM_mpi_recv_t mpi_recv;
     MPIDI_NM_mpi_irecv_t mpi_irecv;
     MPIDI_NM_mpi_imrecv_t mpi_imrecv;
     MPIDI_NM_mpi_cancel_recv_t mpi_cancel_recv;
@@ -592,21 +574,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank,
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request *
                                                            req) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
-                                               MPI_Datatype datatype, int rank, int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr,
-                                               MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                MPIR_Errflag_t * errflag) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,
@@ -623,11 +590,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count
                                                  MPIDI_av_entry_t * addr,
                                                  MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                               int rank, int tag, MPIR_Comm * comm,
-                                               int context_offset, MPIDI_av_entry_t * addr,
-                                               MPI_Status * status,
-                                               MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t * addr,

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
@@ -6,19 +6,6 @@
 #ifndef NETMOD_AM_FALLBACK_RECV_H_INCLUDED
 #define NETMOD_AM_FALLBACK_RECV_H_INCLUDED
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag,
-                                               MPIR_Comm * comm,
-                                               int context_offset, MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request)
-{
-    return MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request,
-                           0);
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
                                                  MPI_Aint count, MPI_Datatype datatype,
                                                  MPIR_Request * message)

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
@@ -14,7 +14,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf,
                                                MPIR_Comm * comm, int context_offset,
                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf,
@@ -25,7 +26,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf,
                                                 MPIR_Comm * comm, int context_offset,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
@@ -56,8 +58,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
                                                 int context_offset, MPIDI_av_entry_t * addr,
                                                 MPIR_Request ** request, MPIR_Errflag_t * errflag)
 {
-    return MPIDIG_send_coll(buf, count, datatype, rank, tag, comm, context_offset, addr, request,
-                            errflag);
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
@@ -6,30 +6,6 @@
 #ifndef NETMOD_AM_FALLBACK_SEND_H_INCLUDED
 #define NETMOD_AM_FALLBACK_SEND_H_INCLUDED
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf,
-                                                MPI_Aint count,
-                                                MPI_Datatype datatype,
-                                                int rank,
-                                                int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
                                                 MPI_Aint count,
                                                 MPI_Datatype datatype,
@@ -50,16 +26,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     return MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm,
-                                                int context_offset, MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request, MPIR_Errflag_t * errflag)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -201,60 +201,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_REQUEST_FINALIZE);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
-                                               MPI_Datatype datatype, int rank, int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_SEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_SEND);
-
-    ret =
-        MPIDI_NM_native_func->mpi_send(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                       request);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SEND);
-    return ret;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request, MPIR_Errflag_t * errflag)
-{
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_SEND_COLL);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_SEND_COLL);
-    ret =
-        MPIDI_NM_native_func->send_coll(buf, count, datatype, rank, tag, comm, context_offset,
-                                        addr, request, errflag);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_SEND_COLL);
-    return ret;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_SSEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_SSEND);
-
-    ret =
-        MPIDI_NM_native_func->mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                        request);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SSEND);
-    return ret;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,
@@ -320,24 +266,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq)
     ret = MPIDI_NM_native_func->mpi_cancel_send(sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_CANCEL_SEND);
-    return ret;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                               int rank, int tag, MPIR_Comm * comm,
-                                               int context_offset, MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request)
-{
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RECV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RECV);
-
-    ret =
-        MPIDI_NM_native_func->mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                       status, request);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_RECV);
     return ret;
 }
 

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -58,14 +58,10 @@ MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_ofi_funcs = {
-    .mpi_send = MPIDI_NM_mpi_send,
-    .send_coll = MPIDI_NM_send_coll,
-    .mpi_ssend = MPIDI_NM_mpi_ssend,
     .mpi_isend = MPIDI_NM_mpi_isend,
     .isend_coll = MPIDI_NM_isend_coll,
     .mpi_issend = MPIDI_NM_mpi_issend,
     .mpi_cancel_send = MPIDI_NM_mpi_cancel_send,
-    .mpi_recv = MPIDI_NM_mpi_recv,
     .mpi_irecv = MPIDI_NM_mpi_irecv,
     .mpi_imrecv = MPIDI_NM_mpi_imrecv,
     .mpi_cancel_recv = MPIDI_NM_mpi_cancel_recv,

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -245,7 +245,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
     goto fn_exit;
 }
 
-/* Common macro used by all MPIDI_NM_mpi_recv routines to facilitate tuning */
+/* Common macro used by all MPIDI_NM_mpi_irecv routines to facilitate tuning */
 #define MPIDI_OFI_RECV_VNIS(vni_src_, vni_dst_) \
     do { \
         if (*request != NULL) { \
@@ -259,19 +259,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         } \
     } while (0)
 
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag,
-                                               MPIR_Comm * comm,
-                                               int context_offset, MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
                                                  MPI_Aint count,

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -269,27 +269,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
                                                int context_offset, MPIDI_av_entry_t * addr,
                                                MPI_Status * status, MPIR_Request ** request)
 {
-    int mpi_errno;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RECV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RECV);
-
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno =
-            MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request,
-                            0);
-    } else {
-        int vni_src, vni_dst;
-        MPIDI_OFI_RECV_VNIS(vni_src, vni_dst);
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_dst).lock);
-        mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, rank, tag, comm,
-                                       context_offset, addr, vni_src, vni_dst, request,
-                                       MPIDI_OFI_ON_HEAP, 0ULL);
-        MPIDI_REQUEST_SET_LOCAL(*request, 0, NULL);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_dst).lock);
-    }
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_RECV);
-    return mpi_errno;
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -379,52 +379,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         } \
     } while (0)
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
-                                               MPI_Datatype datatype, int rank, int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request, MPIR_Errflag_t * errflag)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    int mpi_errno;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_SSEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_SSEND);
-
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno =
-            MPIDIG_mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
-    } else {
-        int vni_src, vni_dst;
-        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
-        mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, vni_src, vni_dst, request, 0,
-                                   MPIDI_OFI_SYNC_SEND, MPIR_ERR_NONE);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
-    }
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SSEND);
-    return mpi_errno;
-}
-
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -384,69 +384,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
                                                MPIR_Comm * comm, int context_offset,
                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    int mpi_errno;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_SEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_SEND);
-
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno =
-            MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
-    } else {
-        int vni_src, vni_dst;
-        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
-        mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, vni_src, vni_dst, request,
-                                   (*request == NULL), 0ULL, MPIR_ERR_NONE);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
-    }
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SEND);
-    return mpi_errno;
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
-/*@
-    MPIDI_NM_send_coll - NM_mpi_send function for collectives which takes an additional error
-    flag argument.
-Input Parameters:
-    buf - starting address of buffer to send
-    count - number of elements to send
-    datatype - data type of each send buffer element
-    dst_rank - rank of destination rank
-    tag - message tag
-    comm - handle to communicator
-    context_offset - offset into context object
-    addr - address vector entry for destination
-    request - handle to request pointer
-    errflag - the error flag to be passed along with the message
-@*/
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,
                                                 MPIDI_av_entry_t * addr,
                                                 MPIR_Request ** request, MPIR_Errflag_t * errflag)
 {
-    int mpi_errno;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_SEND_COLL);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_SEND_COLL);
-
-    /* NOTE: collective use vci 0 and critical section taken at ch4-layer */
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno =
-            MPIDIG_send_coll(buf, count, datatype, rank, tag, comm, context_offset, addr, request,
-                             errflag);
-    } else {
-        int vni_src, vni_dst;
-        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
-        mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm, context_offset,
-                                   addr, vni_src, vni_dst, request, (*request == NULL), 0ULL,
-                                   *errflag);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
-    }
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_SEND_COLL);
-    return mpi_errno;
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,

--- a/src/mpid/ch4/netmod/stubnm/func_table.c
+++ b/src/mpid/ch4/netmod/stubnm/func_table.c
@@ -57,12 +57,9 @@ MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_stubnm_funcs = {
-    .mpi_send = MPIDI_NM_mpi_send,
-    .mpi_ssend = MPIDI_NM_mpi_ssend,
     .mpi_isend = MPIDI_NM_mpi_isend,
     .mpi_issend = MPIDI_NM_mpi_issend,
     .mpi_cancel_send = MPIDI_NM_mpi_cancel_send,
-    .mpi_recv = MPIDI_NM_mpi_recv,
     .mpi_irecv = MPIDI_NM_mpi_irecv,
     .mpi_imrecv = MPIDI_NM_mpi_imrecv,
     .mpi_cancel_recv = MPIDI_NM_mpi_cancel_recv,

--- a/src/mpid/ch4/netmod/stubnm/stubnm_recv.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_recv.h
@@ -8,21 +8,6 @@
 
 #include "stubnm_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag,
-                                               MPIR_Comm * comm,
-                                               int context_offset,
-                                               MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request)
-{
-    int err = MPI_SUCCESS;
-    MPIR_Assert(0);
-    return err;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
                                                  MPI_Aint count, MPI_Datatype datatype,
                                                  MPIR_Request * message)

--- a/src/mpid/ch4/netmod/stubnm/stubnm_send.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_send.h
@@ -8,38 +8,6 @@
 
 #include "stubnm_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    return MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                MPIR_Errflag_t * errflag)
-{
-    return MPIDIG_send_coll(buf, count, datatype, rank, tag, comm, context_offset, addr, request,
-                            errflag);
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf,
-                                                MPI_Aint count,
-                                                MPI_Datatype datatype,
-                                                int rank,
-                                                int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    return MPIDIG_mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
                                                 MPI_Aint count,
                                                 MPI_Datatype datatype,

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -58,14 +58,10 @@ MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_ucx_funcs = {
-    .mpi_send = MPIDI_NM_mpi_send,
-    .send_coll = MPIDI_NM_send_coll,
-    .mpi_ssend = MPIDI_NM_mpi_ssend,
     .mpi_isend = MPIDI_NM_mpi_isend,
     .isend_coll = MPIDI_NM_isend_coll,
     .mpi_issend = MPIDI_NM_mpi_issend,
     .mpi_cancel_send = MPIDI_NM_mpi_cancel_send,
-    .mpi_recv = MPIDI_NM_mpi_recv,
     .mpi_irecv = MPIDI_NM_mpi_irecv,
     .mpi_imrecv = MPIDI_NM_mpi_imrecv,
     .mpi_cancel_recv = MPIDI_NM_mpi_cancel_recv,

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -221,20 +221,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag,
-                                               MPIR_Comm * comm,
-                                               int context_offset,
-                                               MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 MPI_Aint count,
                                                 MPI_Datatype datatype,

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -231,16 +231,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
                                                MPIDI_av_entry_t * addr,
                                                MPI_Status * status, MPIR_Request ** request)
 {
-    int mpi_errno;
-
-    int vni_dst = MPIDI_UCX_get_vni(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_dst).lock);
-    mpi_errno =
-        MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, vni_dst,
-                       request);
-    MPIDI_REQUEST_SET_LOCAL(*request, 0, NULL);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_dst).lock);
-    return mpi_errno;
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -110,32 +110,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
                                                 int context_offset, MPIDI_av_entry_t * addr,
                                                 MPIR_Request ** request, MPIR_Errflag_t * errflag)
 {
-    int mpi_errno = MPI_SUCCESS;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_SEND_COLL);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_SEND_COLL);
-
-    int vni_src = MPIDI_UCX_get_vni(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
-    int vni_dst = MPIDI_UCX_get_vni(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
-
-    switch (*errflag) {
-        case MPIR_ERR_NONE:
-            break;
-        case MPIR_ERR_PROC_FAILED:
-            MPIR_TAG_SET_PROC_FAILURE_BIT(tag);
-            break;
-        default:
-            MPIR_TAG_SET_ERROR_BIT(tag);
-    }
-
-    mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset, addr, request,
-                               vni_src, vni_dst, 0, 0);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_SEND_COLL);
-
-    return mpi_errno;
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf,
@@ -146,16 +122,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf,
                                                MPIR_Comm * comm, int context_offset,
                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    int mpi_errno;
-
-    int vni_src = MPIDI_UCX_get_vni(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
-    int vni_dst = MPIDI_UCX_get_vni(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
-    mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
-                               addr, request, vni_src, vni_dst, 0, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
-
-    return mpi_errno;
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf,
@@ -166,14 +134,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf,
                                                 MPIR_Comm * comm, int context_offset,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    int mpi_errno;
-    int vni_src = MPIDI_UCX_get_vni(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
-    int vni_dst = MPIDI_UCX_get_vni(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
-    mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
-                               addr, request, vni_src, vni_dst, 0, 1);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
-    return mpi_errno;
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -104,40 +104,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm,
-                                                int context_offset, MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request, MPIR_Errflag_t * errflag)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf,
-                                                MPI_Aint count,
-                                                MPI_Datatype datatype,
-                                                int rank,
-                                                int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm * comm, int context_offset,

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -62,21 +62,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_init(MPIR_Request *
                                                         req) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_finalize(MPIR_Request *
                                                             req) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_send_coll(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                 MPIR_Errflag_t * errflag) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIDI_av_entry_t * addr,
-                                                 MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm * comm, int context_offset,
@@ -95,10 +80,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf, MPI_Aint coun
                                                   MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_send(MPIR_Request *
                                                        sreq) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                int rank, int tag, MPIR_Comm * comm,
-                                                int context_offset, MPI_Status * status,
-                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  int rank, int tag, MPIR_Comm * comm,
                                                  int context_offset,

--- a/src/mpid/ch4/shm/posix/posix_recv.h
+++ b/src/mpid/ch4/shm/posix/posix_recv.h
@@ -22,21 +22,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_recv_posted_hook(MPIR_Request * reques
     MPIDI_POSIX_EAGER_RECV_POSTED_HOOK(request, rank, comm);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_recv(void *buf,
-                                                  MPI_Aint count,
-                                                  MPI_Datatype datatype,
-                                                  int rank,
-                                                  int tag,
-                                                  MPIR_Comm * comm,
-                                                  int context_offset, MPI_Status * status,
-                                                  MPIR_Request ** request)
-{
-    int mpi_errno =
-        MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request, 1);
-    MPIDI_POSIX_recv_posted_hook(*request, rank, comm);
-    return mpi_errno;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_imrecv(void *buf, MPI_Aint count,
                                                     MPI_Datatype datatype, MPIR_Request * message)
 {

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -16,33 +16,6 @@
 
 #include "posix_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_send(const void *buf, MPI_Aint count,
-                                                  MPI_Datatype datatype, int rank, int tag,
-                                                  MPIR_Comm * comm, int context_offset,
-                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    return MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_send_coll(const void *buf, MPI_Aint count,
-                                                   MPI_Datatype datatype, int rank, int tag,
-                                                   MPIR_Comm * comm, int context_offset,
-                                                   MPIDI_av_entry_t * addr,
-                                                   MPIR_Request ** request,
-                                                   MPIR_Errflag_t * errflag)
-{
-    return MPIDIG_send_coll(buf, count, datatype, rank, tag, comm, context_offset, addr, request,
-                            errflag);
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ssend(const void *buf, MPI_Aint count,
-                                                   MPI_Datatype datatype, int rank, int tag,
-                                                   MPIR_Comm * comm, int context_offset,
-                                                   MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    return MPIDIG_mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint count,
                                                    MPI_Datatype datatype, int rank, int tag,
                                                    MPIR_Comm * comm, int context_offset,

--- a/src/mpid/ch4/shm/src/shm_am_fallback_recv.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_recv.h
@@ -6,19 +6,6 @@
 #ifndef SHM_AM_FALLBACK_RECV_H_INCLUDED
 #define SHM_AM_FALLBACK_RECV_H_INCLUDED
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf,
-                                                MPI_Aint count,
-                                                MPI_Datatype datatype,
-                                                int rank,
-                                                int tag,
-                                                MPIR_Comm * comm,
-                                                int context_offset, MPI_Status * status,
-                                                MPIR_Request ** request)
-{
-    return MPIDIG_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, status, request,
-                           1);
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf,
                                                   MPI_Aint count, MPI_Datatype datatype,
                                                   MPIR_Request * message)

--- a/src/mpid/ch4/shm/src/shm_am_fallback_send.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_send.h
@@ -6,30 +6,6 @@
 #ifndef SHM_AM_FALLBACK_SEND_H_INCLUDED
 #define SHM_AM_FALLBACK_SEND_H_INCLUDED
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf,
-                                                MPI_Aint count,
-                                                MPI_Datatype datatype,
-                                                int rank,
-                                                int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf,
-                                                 MPI_Aint count,
-                                                 MPI_Datatype datatype,
-                                                 int rank,
-                                                 int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf,
                                                  MPI_Aint count,
                                                  MPI_Datatype datatype,
@@ -50,16 +26,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf,
                                                   MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     return MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_send_coll(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm,
-                                                 int context_offset, MPIDI_av_entry_t * addr,
-                                                 MPIR_Request ** request, MPIR_Errflag_t * errflag)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_isend_coll(const void *buf, MPI_Aint count,

--- a/src/mpid/ch4/shm/src/shm_am_fallback_send.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_send.h
@@ -14,7 +14,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf,
                                                 MPIR_Comm * comm, int context_offset,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf,
@@ -25,7 +26,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf,
                                                  MPIR_Comm * comm, int context_offset,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf,
@@ -56,8 +58,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_send_coll(const void *buf, MPI_Aint count
                                                  int context_offset, MPIDI_av_entry_t * addr,
                                                  MPIR_Request ** request, MPIR_Errflag_t * errflag)
 {
-    return MPIDIG_send_coll(buf, count, datatype, rank, tag, comm, context_offset, addr, request,
-                            errflag);
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_isend_coll(const void *buf, MPI_Aint count,

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -10,34 +10,6 @@
 #include "../ipc/src/shm_inline.h"
 #include "../posix/shm_inline.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_send_coll(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIDI_av_entry_t * addr,
-                                                 MPIR_Request ** request, MPIR_Errflag_t * errflag)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm * comm, int context_offset,
@@ -107,15 +79,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_send(MPIR_Request * sreq)
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_CANCEL_SEND);
     return ret;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                int rank, int tag, MPIR_Comm * comm,
-                                                int context_offset, MPI_Status * status,
-                                                MPIR_Request ** request)
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -15,15 +15,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count,
                                                 MPIR_Comm * comm, int context_offset,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_SEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_SEND);
-
-    ret = MPIDI_SHM_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_SEND);
-    return ret;
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_send_coll(const void *buf, MPI_Aint count,
@@ -32,16 +25,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_send_coll(const void *buf, MPI_Aint count
                                                  MPIDI_av_entry_t * addr,
                                                  MPIR_Request ** request, MPIR_Errflag_t * errflag)
 {
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_SEND_COLL);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_SEND_COLL);
-    ret =
-        MPIDI_POSIX_send_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                              request, errflag);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_SEND_COLL);
-    return ret;
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count,
@@ -49,16 +34,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count
                                                  MPIR_Comm * comm, int context_offset,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_SSEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_SSEND);
-
-    ret =
-        MPIDI_POSIX_mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_SSEND);
-    return ret;
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count,
@@ -137,15 +114,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, MPI_Aint count, MPI_D
                                                 int context_offset, MPI_Status * status,
                                                 MPIR_Request ** request)
 {
-    int ret = MPI_SUCCESS;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_RECV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_RECV);
-
-    ret = MPIDI_SHM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_RECV);
-    return ret;
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,

--- a/src/mpid/ch4/shm/stubshm/stubshm_recv.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_recv.h
@@ -8,24 +8,6 @@
 
 #include "stubshm_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_STUBSHM_mpi_recv(void *buf,
-                                                    MPI_Aint count,
-                                                    MPI_Datatype datatype,
-                                                    int rank,
-                                                    int tag,
-                                                    MPIR_Comm * comm,
-                                                    int context_offset, MPI_Status * status,
-                                                    MPIR_Request ** request)
-{
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_MPI_RECV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_MPI_RECV);
-
-    MPIR_Assert(0);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_STUBSHM_MPI_RECV);
-    return MPI_SUCCESS;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_STUBSHM_mpi_imrecv(void *buf,
                                                       MPI_Aint count,
                                                       MPI_Datatype datatype,

--- a/src/mpid/ch4/shm/stubshm/stubshm_send.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_send.h
@@ -8,26 +8,6 @@
 
 #include "stubshm_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_STUBSHM_mpi_send(const void *buf,
-                                                    MPI_Aint count,
-                                                    MPI_Datatype datatype,
-                                                    int rank,
-                                                    int tag,
-                                                    MPIR_Comm * comm, int context_offset,
-                                                    MPIR_Request ** request)
-{
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_MPI_SEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_MPI_SEND);
-
-    MPIR_Assert(0);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_STUBSHM_MPI_SEND);
-    return MPI_SUCCESS;
-}
-
-
-
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_STUBSHM_irsend(const void *buf,
                                                   MPI_Aint count,
                                                   MPI_Datatype datatype,
@@ -42,23 +22,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_STUBSHM_irsend(const void *buf,
     MPIR_Assert(0);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_STUBSHM_IRSEND);
-    return MPI_SUCCESS;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_STUBSHM_mpi_ssend(const void *buf,
-                                                     MPI_Aint count,
-                                                     MPI_Datatype datatype,
-                                                     int rank,
-                                                     int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIR_Request ** request)
-{
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_MPI_SSEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_MPI_SSEND);
-
-    MPIR_Assert(0);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_STUBSHM_MPI_SSEND);
     return MPI_SUCCESS;
 }
 

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -331,20 +331,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv(void *buf,
                                        int context_offset, MPI_Status * status,
                                        MPIR_Request ** request)
 {
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RECV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RECV);
-
-    MPIDI_av_entry_t *av = (rank == MPI_ANY_SOURCE ? NULL : MPIDIU_comm_rank_to_av(comm, rank));
-    mpi_errno =
-        MPIDI_recv_safe(buf, count, datatype, rank, tag, comm, context_offset, av, status, request);
-
-    MPIR_ERR_CHECK(mpi_errno);
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RECV);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
+    return MPID_Irecv(buf, count, datatype, rank, tag, comm, context_offset, request);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *buf,

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -448,56 +448,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,
-                                       MPI_Aint count,
-                                       MPI_Datatype datatype,
-                                       int rank,
-                                       int tag,
-                                       MPIR_Comm * comm, int context_offset,
-                                       MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIDI_av_entry_t *av = NULL;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_SEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_SEND);
-
-    av = MPIDIU_comm_rank_to_av(comm, rank);
-    mpi_errno = MPIDI_send_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
-
-    MPIR_ERR_CHECK(mpi_errno);
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_SEND);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPID_Send_coll(const void *buf,
-                                            MPI_Aint count,
-                                            MPI_Datatype datatype,
-                                            int rank,
-                                            int tag,
-                                            MPIR_Comm * comm, int context_offset,
-                                            MPIR_Request ** request, MPIR_Errflag_t * errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIDI_av_entry_t *av = NULL;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_SEND_COLL);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_SEND_COLL);
-
-    av = MPIDIU_comm_rank_to_av(comm, rank);
-    mpi_errno = MPIDI_send_coll_safe(buf, count, datatype, rank, tag, comm, context_offset, av,
-                                     request, errflag);
-
-    MPIR_ERR_CHECK(mpi_errno);
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_SEND_COLL);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-
 MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
                                         MPI_Aint count,
                                         MPI_Datatype datatype,
@@ -549,6 +499,27 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend_coll(const void *buf,
     goto fn_exit;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,
+                                       MPI_Aint count,
+                                       MPI_Datatype datatype,
+                                       int rank,
+                                       int tag,
+                                       MPIR_Comm * comm, int context_offset,
+                                       MPIR_Request ** request)
+{
+    return MPID_Isend(buf, count, datatype, rank, tag, comm, context_offset, request);
+}
+
+MPL_STATIC_INLINE_PREFIX int MPID_Send_coll(const void *buf,
+                                            MPI_Aint count,
+                                            MPI_Datatype datatype,
+                                            int rank,
+                                            int tag,
+                                            MPIR_Comm * comm, int context_offset,
+                                            MPIR_Request ** request, MPIR_Errflag_t * errflag)
+{
+    return MPID_Isend_coll(buf, count, datatype, rank, tag, comm, context_offset, request, errflag);
+}
 
 MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *buf,
                                         MPI_Aint count,
@@ -558,26 +529,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *buf,
                                         MPIR_Comm * comm, int context_offset,
                                         MPIR_Request ** request)
 {
-    /*
-     * FIXME: this implementation of MPID_Rsend is identical to that of MPID_Send.
-     * Need to support rsend protocol, i.e., check if receive is posted on the
-     * reveiver side before the send is posted.
-     */
-
-    int mpi_errno = MPI_SUCCESS;
-    MPIDI_av_entry_t *av = NULL;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RSEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RSEND);
-
-    av = MPIDIU_comm_rank_to_av(comm, rank);
-    mpi_errno = MPIDI_send_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
-
-    MPIR_ERR_CHECK(mpi_errno);
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RSEND);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
+    return MPID_Irsend(buf, count, datatype, rank, tag, comm, context_offset, request);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
@@ -619,21 +571,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ssend(const void *buf,
                                         MPIR_Comm * comm, int context_offset,
                                         MPIR_Request ** request)
 {
-    int mpi_errno = MPI_SUCCESS;
-    MPIDI_av_entry_t *av = NULL;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_SSEND);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_SSEND);
-
-    av = MPIDIU_comm_rank_to_av(comm, rank);
-    mpi_errno =
-        MPIDI_ssend_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
-
-    MPIR_ERR_CHECK(mpi_errno);
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_SSEND);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
+    return MPID_Issend(buf, count, datatype, rank, tag, comm, context_offset, request);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Issend(const void *buf,

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -9,84 +9,6 @@
 #include "ch4_impl.h"
 #include "ch4r_proc.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_send_unsafe(const void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * av, MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SEND_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_UNSAFE);
-
-#ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno =
-        MPIDI_NM_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, av, request);
-#else
-    int r;
-    if ((r = MPIDI_av_is_local(av)))
-        mpi_errno =
-            MPIDI_SHM_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, av, request);
-    else
-        mpi_errno =
-            MPIDI_NM_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, av, request);
-    if (mpi_errno == MPI_SUCCESS && *request)
-        MPIDI_REQUEST(*request, is_local) = r;
-#endif
-
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SEND_UNSAFE);
-    return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_unsafe(const void *buf,
-                                                    MPI_Aint count,
-                                                    MPI_Datatype datatype,
-                                                    int rank,
-                                                    int tag,
-                                                    MPIR_Comm * comm, int context_offset,
-                                                    MPIDI_av_entry_t * av, MPIR_Request ** request,
-                                                    MPIR_Errflag_t * errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SEND_COLL_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_COLL_UNSAFE);
-
-#ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno =
-        MPIDI_NM_send_coll(buf, count, datatype, rank, tag, comm, context_offset, av, request,
-                           errflag);
-#else
-    int r;
-    if ((r = MPIDI_av_is_local(av)))
-        mpi_errno =
-            MPIDI_SHM_send_coll(buf, count, datatype, rank, tag, comm, context_offset, av,
-                                request, errflag);
-    else
-        mpi_errno =
-            MPIDI_NM_send_coll(buf, count, datatype, rank, tag, comm, context_offset, av,
-                               request, errflag);
-    if (mpi_errno == MPI_SUCCESS && *request)
-        MPIDI_REQUEST(*request, is_local) = r;
-#endif
-
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SEND_COLL_UNSAFE);
-    return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_isend_unsafe(const void *buf,
                                                 MPI_Aint count,
                                                 MPI_Datatype datatype,
@@ -162,41 +84,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_unsafe(const void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_unsafe(const void *buf,
-                                                MPI_Aint count,
-                                                MPI_Datatype datatype,
-                                                int rank,
-                                                int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * av, MPIR_Request ** req)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SSEND_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SSEND_UNSAFE);
-
-    av = MPIDIU_comm_rank_to_av(comm, rank);
-#ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-#else
-    int r;
-    if ((r = MPIDI_av_is_local(av)))
-        mpi_errno =
-            MPIDI_SHM_mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-    else
-        mpi_errno =
-            MPIDI_NM_mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-
-    if (mpi_errno == MPI_SUCCESS && *req)
-        MPIDI_REQUEST(*req, is_local) = r;
-#endif
-    MPIR_ERR_CHECK(mpi_errno);
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SSEND_UNSAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_issend_unsafe(const void *buf,
                                                  MPI_Aint count,
                                                  MPI_Datatype datatype,
@@ -227,82 +114,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_unsafe(const void *buf,
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISSEND_UNSAFE);
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
-                                             MPI_Aint count,
-                                             MPI_Datatype datatype,
-                                             int rank,
-                                             int tag,
-                                             MPIR_Comm * comm, int context_offset,
-                                             MPIDI_av_entry_t * av, MPIR_Request ** req)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SEND_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    /* NOTE: When WORKQ is enabled, we always enqueue. However, it probably makes sense
-     *       to directly do lightweight send for small message. It is tricky since the
-     *       threshold for lightweight send is controlled by lower layer. It'll be nice
-     *       if the lower layer expose the threshold.
-     */
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_workq_pt2pt_enqueue(SEND, buf, NULL /*recv_buf */ , count, datatype,
-                              rank, tag, comm, context_offset, av,
-                              NULL /*status */ , *req, NULL /*flag */ ,
-                              NULL /*message */ , NULL /*processed */);
-#else
-    *(req) = NULL;
-    mpi_errno = MPIDI_send_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-#endif
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SEND_SAFE);
-    return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
-                                                  MPI_Aint count,
-                                                  MPI_Datatype datatype,
-                                                  int rank,
-                                                  int tag,
-                                                  MPIR_Comm * comm, int context_offset,
-                                                  MPIDI_av_entry_t * av, MPIR_Request ** req,
-                                                  MPIR_Errflag_t * errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SEND_COLL_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_COLL_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_workq_csend_enqueue(CSEND, buf, count, datatype, rank, tag, comm,
-                              context_offset, av, *req, errflag);
-#else
-    *(req) = NULL;
-    mpi_errno = MPIDI_send_coll_unsafe(buf, count, datatype, rank, tag, comm,
-                                       context_offset, av, req, errflag);
-#endif
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SEND_COLL_SAFE);
-    return mpi_errno;
-
   fn_fail:
     goto fn_exit;
 }
@@ -372,41 +183,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISEND_COLL_SAFE);
-    return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
-                                              MPI_Aint count,
-                                              MPI_Datatype datatype,
-                                              int rank,
-                                              int tag,
-                                              MPIR_Comm * comm, int context_offset,
-                                              MPIDI_av_entry_t * av, MPIR_Request ** req)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SSEND_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SSEND_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
-                              rank, tag, comm, context_offset, av,
-                              NULL /*status */ , *req, NULL /*flag */ ,
-                              NULL /*message */ , NULL /*processed */);
-#else
-    *(req) = NULL;
-    mpi_errno = MPIDI_ssend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-#endif
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SSEND_SAFE);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -15,27 +15,15 @@ extern MPIR_Object_alloc_t MPIDI_workq_elemt_mem;
 
 /* Forward declarations of the routines that can be pushed to a work-queue */
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_send_unsafe(const void *, MPI_Aint, MPI_Datatype, int, int,
-                                               MPIR_Comm *, int, MPIDI_av_entry_t *,
-                                               MPIR_Request **);
 MPL_STATIC_INLINE_PREFIX int MPIDI_isend_unsafe(const void *, MPI_Aint, MPI_Datatype, int, int,
-                                                MPIR_Comm *, int, MPIDI_av_entry_t *,
-                                                MPIR_Request **);
-MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_unsafe(const void *, MPI_Aint, MPI_Datatype, int, int,
                                                 MPIR_Comm *, int, MPIDI_av_entry_t *,
                                                 MPIR_Request **);
 MPL_STATIC_INLINE_PREFIX int MPIDI_issend_unsafe(const void *, MPI_Aint, MPI_Datatype, int, int,
                                                  MPIR_Comm *, int, MPIDI_av_entry_t *,
                                                  MPIR_Request **);
-MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_unsafe(const void *, MPI_Aint, MPI_Datatype, int, int,
-                                                    MPIR_Comm *, int, MPIDI_av_entry_t *,
-                                                    MPIR_Request **, MPIR_Errflag_t *);
 MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_unsafe(const void *, MPI_Aint, MPI_Datatype, int, int,
                                                      MPIR_Comm *, int, MPIDI_av_entry_t *,
                                                      MPIR_Request **, MPIR_Errflag_t *);
-MPL_STATIC_INLINE_PREFIX int MPIDI_recv_unsafe(void *, MPI_Aint, MPI_Datatype, int, int,
-                                               MPIR_Comm *, int, MPIDI_av_entry_t *, MPI_Status *,
-                                               MPIR_Request **);
 MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_unsafe(void *, MPI_Aint, MPI_Datatype, int, int,
                                                 MPIR_Comm *, int, MPIDI_av_entry_t *,
                                                 MPIR_Request **);
@@ -286,31 +274,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_el
     MPIR_Assert(workq_elemt != NULL);
 
     switch (workq_elemt->op) {
-        case SEND:{
-                struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_send_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                  wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
         case ISEND:{
                 struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
                 req = wd->request;
                 datatype = wd->datatype;
                 MPIDI_isend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                   wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
-        case SSEND:{
-                struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_ssend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
                                    wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
                 MPIR_Datatype_release_if_not_builtin(datatype);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
@@ -326,17 +294,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_el
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
                 break;
             }
-        case CSEND:{
-                struct MPIDI_workq_csend *wd = &workq_elemt->params.pt2pt.csend;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_send_coll_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                       wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req,
-                                       &(wd->errflag));
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
         case ICSEND:{
                 struct MPIDI_workq_csend *wd = &workq_elemt->params.pt2pt.csend;
                 req = wd->request;
@@ -344,16 +301,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_el
                 MPIDI_isend_coll_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
                                         wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req,
                                         &(wd->errflag));
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
-        case RECV:{
-                struct MPIDI_workq_recv *wd = &workq_elemt->params.pt2pt.recv;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_recv_unsafe(wd->recv_buf, wd->count, wd->datatype, wd->rank, wd->tag,
-                                  wd->comm_ptr, wd->context_offset, wd->addr, wd->status, &req);
                 MPIR_Datatype_release_if_not_builtin(datatype);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
                 break;


### PR DESCRIPTION
## Pull Request Description

There is no actual differences between `MPID_Send` and `MPID_Isend`. Similarly with `MPID_Send_coll`, `MPID_Ssend`,  and `MPID_Recv`. They all can be eliminated.

[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
