### PR TITLE
ch4/ofi: Use GenQ private pool for RMA pack buffers

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -297,6 +297,7 @@ static inline void MPIDI_OFI_load_iov(const void *buffer, int count, MPI_Datatyp
 }
 
 int MPIDI_OFI_issue_deferred_rma(MPIR_Win * win);
+void MPIDI_OFI_complete_chunks(MPIDI_OFI_win_request_t * winreq);
 int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
                             MPI_Datatype origin_datatype, int target_rank,
                             MPI_Aint target_disp, int target_count,
@@ -368,6 +369,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_reque
         }
     }
 
+    MPIDI_OFI_complete_chunks(winreq);
     MPL_free(winreq);
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -349,22 +349,6 @@ MPL_STATIC_INLINE_PREFIX MPIDI_OFI_win_request_t *MPIDI_OFI_win_request_create(v
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_request_t * winreq)
 {
-    if (winreq->rma_type == MPIDI_OFI_GET) {
-        if (winreq->noncontig.get.origin.pack_buffer) {
-            MPI_Aint actual_unpack_bytes;
-            MPIR_Typerep_unpack(winreq->noncontig.get.origin.pack_buffer,
-                                winreq->noncontig.get.origin.pack_size,
-                                winreq->noncontig.get.origin.addr,
-                                winreq->noncontig.get.origin.count,
-                                winreq->noncontig.get.origin.datatype,
-                                winreq->noncontig.get.origin.pack_offset -
-                                winreq->noncontig.get.origin.pack_size, &actual_unpack_bytes);
-            MPIR_Assert(winreq->noncontig.get.origin.pack_size == actual_unpack_bytes);
-            MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.am_pack_buf_pool,
-                                              winreq->noncontig.get.origin.pack_buffer);
-        }
-    }
-
     MPIDI_OFI_complete_chunks(winreq);
     MPL_free(winreq);
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -349,7 +349,8 @@ MPL_STATIC_INLINE_PREFIX MPIDI_OFI_win_request_t *MPIDI_OFI_win_request_create(v
 MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_request_t * winreq)
 {
     if (winreq->rma_type == MPIDI_OFI_PUT)
-        MPL_free(winreq->noncontig.put.origin.pack_buffer);
+        MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.am_pack_buf_pool,
+                                          winreq->noncontig.put.origin.pack_buffer);
 
     if (winreq->rma_type == MPIDI_OFI_GET) {
         if (winreq->noncontig.get.origin.pack_buffer) {
@@ -362,7 +363,8 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_reque
                                 winreq->noncontig.get.origin.pack_offset -
                                 winreq->noncontig.get.origin.pack_size, &actual_unpack_bytes);
             MPIR_Assert(winreq->noncontig.get.origin.pack_size == actual_unpack_bytes);
-            MPL_free(winreq->noncontig.get.origin.pack_buffer);
+            MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.am_pack_buf_pool,
+                                              winreq->noncontig.get.origin.pack_buffer);
         }
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -349,10 +349,6 @@ MPL_STATIC_INLINE_PREFIX MPIDI_OFI_win_request_t *MPIDI_OFI_win_request_create(v
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_request_t * winreq)
 {
-    if (winreq->rma_type == MPIDI_OFI_PUT)
-        MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.am_pack_buf_pool,
-                                          winreq->noncontig.put.origin.pack_buffer);
-
     if (winreq->rma_type == MPIDI_OFI_GET) {
         if (winreq->noncontig.get.origin.pack_buffer) {
             MPI_Aint actual_unpack_bytes;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -410,24 +410,24 @@ int MPIDI_OFI_pack_get(void *origin_addr, int origin_count,
     req->rma_type = MPIDI_OFI_GET;
 
     /* origin */
-    req->noncontig.put.origin.addr = origin_addr;
-    req->noncontig.put.origin.count = origin_count;
-    req->noncontig.put.origin.datatype = origin_datatype;
-    req->noncontig.put.origin.pack_buffer = pack_buffer;
-    req->noncontig.put.origin.pack_offset = 0;
-    req->noncontig.put.origin.pack_size = pack_bytes;
-    req->noncontig.put.origin.total_bytes = origin_bytes;
+    req->noncontig.get.origin.addr = origin_addr;
+    req->noncontig.get.origin.count = origin_count;
+    req->noncontig.get.origin.datatype = origin_datatype;
+    req->noncontig.get.origin.pack_buffer = pack_buffer;
+    req->noncontig.get.origin.pack_offset = 0;
+    req->noncontig.get.origin.pack_size = pack_bytes;
+    req->noncontig.get.origin.total_bytes = origin_bytes;
 
     /* target */
-    req->noncontig.put.target.base = target_base;
-    req->noncontig.put.target.count = target_count;
-    req->noncontig.put.target.datatype = target_datatype;
-    req->noncontig.put.target.iov = target_iov;
-    req->noncontig.put.target.iov_len = target_len;
-    req->noncontig.put.target.iov_offset = 0;
-    req->noncontig.put.target.iov_cur = 0;
-    req->noncontig.put.target.addr = addr;
-    req->noncontig.put.target.key = MPIDI_OFI_winfo_mr_key(win, target_rank);
+    req->noncontig.get.target.base = target_base;
+    req->noncontig.get.target.count = target_count;
+    req->noncontig.get.target.datatype = target_datatype;
+    req->noncontig.get.target.iov = target_iov;
+    req->noncontig.get.target.iov_len = target_len;
+    req->noncontig.get.target.iov_offset = 0;
+    req->noncontig.get.target.iov_cur = 0;
+    req->noncontig.get.target.addr = addr;
+    req->noncontig.get.target.key = MPIDI_OFI_winfo_mr_key(win, target_rank);
 
     mpi_errno = issue_packed_get(win, req);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -28,7 +28,6 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    req->event_id = MPIDI_OFI_EVENT_ABORT;
     req->next = MPIDI_OFI_WIN(win).syncQ;
     MPIDI_OFI_WIN(win).syncQ = req;
     req->sigreq = sigreq;
@@ -319,7 +318,6 @@ int MPIDI_OFI_pack_put(const void *origin_addr, int origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    req->event_id = MPIDI_OFI_EVENT_ABORT;
     req->sigreq = sigreq;
 
     /* allocate target iovecs */
@@ -388,7 +386,6 @@ int MPIDI_OFI_pack_get(void *origin_addr, int origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    req->event_id = MPIDI_OFI_EVENT_ABORT;
     req->sigreq = sigreq;
 
     /* allocate target iovecs */

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -465,8 +465,6 @@ typedef struct MPIDI_OFI_win_request {
                 MPI_Datatype datatype;
                 MPI_Aint total_bytes;
                 MPI_Aint pack_offset;
-                void *pack_buffer;
-                MPI_Aint pack_size;
             } origin;
             struct {
                 void *base;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -445,9 +445,6 @@ enum {
 };
 
 typedef struct MPIDI_OFI_win_request {
-    MPIR_OBJECT_HEADER;
-    struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];       /* fixed field, do not move */
-    int event_id;               /* fixed field, do not move */
     struct MPIDI_OFI_win_request *next;
     struct MPIDI_OFI_win_request *prev;
     int rma_type;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -444,11 +444,19 @@ enum {
     MPIDI_OFI_GET_ACC,
 };
 
+typedef struct MPIDI_OFI_pack_chunk {
+    struct MPIDI_OFI_pack_chunk *next;
+    void *pack_buffer;
+    MPI_Aint unpack_size;
+    MPI_Aint unpack_offset;
+} MPIDI_OFI_pack_chunk;
+
 typedef struct MPIDI_OFI_win_request {
     struct MPIDI_OFI_win_request *next;
     struct MPIDI_OFI_win_request *prev;
     int rma_type;
     MPIR_Request **sigreq;
+    MPIDI_OFI_pack_chunk *chunks;
     union {
         struct {
             struct {

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -486,8 +486,6 @@ typedef struct MPIDI_OFI_win_request {
                 MPI_Datatype datatype;
                 MPI_Aint total_bytes;
                 MPI_Aint pack_offset;
-                void *pack_buffer;
-                MPI_Aint pack_size;
             } origin;
             struct {
                 void *base;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -48,7 +48,6 @@ static inline int MPIDI_OFI_win_do_progress(MPIR_Win * win)
 
         if (MPIDI_OFI_WIN(win).deferredQ) {
             MPIDI_OFI_issue_deferred_rma(win);
-            continue;
         } else {
             /* any/all deferred operations are complete */
             break;


### PR DESCRIPTION
## Pull Request Description

Use GenQ private pool instead of malloc.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Better support for device buffers.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
