### PR TITLE
ROMIO: inside ROMIO, use ADIO_ instead of MPI_

### DIFF
--- a/src/mpi/romio/adio/common/ad_close.c
+++ b/src/mpi/romio/adio/common/ad_close.c
@@ -55,7 +55,7 @@ void ADIO_Close(ADIO_File fd, int *error_code)
     }
 
     if (fd->fortran_handle != -1) {
-        ADIOI_Ftable[fd->fortran_handle] = MPI_FILE_NULL;
+        ADIOI_Ftable[fd->fortran_handle] = ADIO_FILE_NULL;
     }
 
     if (fd->hints)

--- a/src/mpi/romio/adio/common/ad_open.c
+++ b/src/mpi/romio/adio/common/ad_open.c
@@ -15,11 +15,11 @@ static int build_cb_config_list(ADIO_File fd,
                                 MPI_Comm orig_comm, MPI_Comm comm,
                                 int rank, int procs, int *error_code);
 
-MPI_File ADIO_Open(MPI_Comm orig_comm,
-                   MPI_Comm comm, const char *filename, int file_system,
-                   ADIOI_Fns * ops,
-                   int access_mode, ADIO_Offset disp, MPI_Datatype etype,
-                   MPI_Datatype filetype, MPI_Info info, int perm, int *error_code)
+ADIO_File ADIO_Open(MPI_Comm orig_comm,
+                    MPI_Comm comm, const char *filename, int file_system,
+                    ADIOI_Fns * ops,
+                    int access_mode, ADIO_Offset disp, MPI_Datatype etype,
+                    MPI_Datatype filetype, MPI_Info info, int perm, int *error_code)
 {
     MPI_File mpi_fh;
     ADIO_File fd;
@@ -35,12 +35,11 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
     /* obtain MPI_File handle */
     mpi_fh = MPIO_File_create(sizeof(struct ADIOI_FileD));
     if (mpi_fh == MPI_FILE_NULL) {
-        fd = MPI_FILE_NULL;
+        fd = ADIO_FILE_NULL;
         *error_code = MPIO_Err_create_code(*error_code,
                                            MPIR_ERR_RECOVERABLE,
                                            myname, __LINE__, MPI_ERR_OTHER, "**nomem2", 0);
         goto fn_exit;
-
     }
     fd = MPIO_File_resolve(mpi_fh);
 

--- a/src/mpi/romio/adio/common/greq_fns.c
+++ b/src/mpi/romio/adio/common/greq_fns.c
@@ -9,7 +9,7 @@
 /* In cases where nonblocking operation will carry out blocking version,
  * instantiate and complete a generalized request  */
 
-void MPIO_Completed_request_create(MPI_File * fh, MPI_Offset bytes,
+void MPIO_Completed_request_create(ADIO_File * fh, MPI_Offset bytes,
                                    int *error_code, MPI_Request * request)
 {
     MPI_Status *status;

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -364,10 +364,10 @@ typedef struct {
 
 void ADIO_Init(int *argc, char ***argv, int *error_code);
 void ADIO_End(int *error_code);
-MPI_File ADIO_Open(MPI_Comm orig_comm, MPI_Comm comm, const char *filename,
-                   int file_system, ADIOI_Fns * ops,
-                   int access_mode, ADIO_Offset disp, MPI_Datatype etype,
-                   MPI_Datatype filetype, MPI_Info info, int perm, int *error_code);
+ADIO_File ADIO_Open(MPI_Comm orig_comm, MPI_Comm comm, const char *filename,
+                    int file_system, ADIOI_Fns * ops,
+                    int access_mode, ADIO_Offset disp, MPI_Datatype etype,
+                    MPI_Datatype filetype, MPI_Info info, int perm, int *error_code);
 void ADIOI_OpenColl(ADIO_File fd, int rank, int acces_mode, int *error_code);
 void ADIO_ImmediateOpen(ADIO_File fd, int *error_code);
 void ADIO_Close(ADIO_File fd, int *error_code);
@@ -452,17 +452,17 @@ int ADIO_Type_create_darray(int size, int rank, int ndims,
 /* MPI_File management functions (in mpio_file.c) */
 MPI_File MPIO_File_create(int size);
 ADIO_File MPIO_File_resolve(MPI_File mpi_fh);
-void MPIO_File_free(MPI_File * mpi_fh);
+void MPIO_File_free(ADIO_File * fd);
 MPI_File MPIO_File_f2c(MPI_Fint fh);
 MPI_Fint MPIO_File_c2f(MPI_File fh);
 int MPIO_Err_create_code(int lastcode, int fatal, const char fcname[],
                          int line, int error_class, const char generic_msg[],
                          const char specific_msg[], ...);
-int MPIO_Err_return_file(MPI_File mpi_fh, int error_code);
+int MPIO_Err_return_file(ADIO_File adio_fh, int error_code);
 int MPIO_Err_return_comm(MPI_Comm mpi_comm, int error_code);
 
 /* request management helper functions */
-void MPIO_Completed_request_create(MPI_File * fh, MPI_Offset nbytes,
+void MPIO_Completed_request_create(ADIO_File * fd, MPI_Offset nbytes,
                                    int *error_code, MPI_Request * request);
 
 #include "adioi.h"

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -803,7 +803,7 @@ int MPIOI_File_write_all_begin(MPI_File fh, MPI_Offset offset, int file_ptr_type
                                MPI_Aint count, MPI_Datatype datatype, char *myname);
 int MPIOI_File_read_all_end(MPI_File fh, void *buf, char *myname, MPI_Status * status);
 int MPIOI_File_write_all_end(MPI_File fh, const void *buf, char *myname, MPI_Status * status);
-int MPIOI_File_iwrite(MPI_File fh,
+int MPIOI_File_iwrite(ADIO_File adio_fh,
                       MPI_Offset offset,
                       int file_ptr_type,
                       const void *buf,
@@ -813,7 +813,7 @@ int MPIOI_File_iread(MPI_File fh,
                      int file_ptr_type,
                      void *buf,
                      MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Request * request);
-int MPIOI_File_iwrite_all(MPI_File fh,
+int MPIOI_File_iwrite_all(ADIO_File adio_fh,
                           MPI_Offset offset,
                           int file_ptr_type,
                           const void *buf,

--- a/src/mpi/romio/adio/include/adioi_error.h
+++ b/src/mpi/romio/adio/include/adioi_error.h
@@ -19,7 +19,7 @@
                                           myname, __LINE__,             \
                                           MPI_ERR_FILE,                 \
                                           "**iobadfh", 0);              \
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);   \
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);  \
         goto fn_exit;                                                   \
     }
 
@@ -33,7 +33,7 @@
                                               (myname_), __LINE__,      \
                                               MPI_ERR_COMM,             \
                                               "**commnull", 0);         \
-            error_code_ = MPIO_Err_return_file(MPI_FILE_NULL, (error_code_)); \
+            error_code_ = MPIO_Err_return_file(ADIO_FILE_NULL, (error_code_)); \
             goto fn_exit;                                               \
         }                                                               \
     } while (0)

--- a/src/mpi/romio/mpi-io/close.c
+++ b/src/mpi/romio/mpi-io/close.c
@@ -59,7 +59,7 @@ int MPI_File_close(MPI_File * fh)
          * but a race condition in GPFS necessated this.  See ticket #2214 */
         MPI_Barrier((adio_fh)->comm);
         if ((adio_fh)->shared_fp_fd != ADIO_FILE_NULL) {
-            MPI_File *fh_shared = &(adio_fh->shared_fp_fd);
+            ADIO_File *fh_shared = &(adio_fh->shared_fp_fd);
             ADIO_Close((adio_fh)->shared_fp_fd, &error_code);
             MPIO_File_free(fh_shared);
             /* --BEGIN ERROR HANDLING-- */
@@ -74,12 +74,16 @@ int MPI_File_close(MPI_File * fh)
      * somehow inform the MPI library that we no longer hold a reference to any
      * user defined error handler.  We do this by setting the errhandler at this
      * point to MPI_ERRORS_RETURN. */
+#ifdef MPIO_BUILD_PROFILING
     error_code = PMPI_File_set_errhandler(*fh, MPI_ERRORS_RETURN);
+#else
+    error_code = MPI_File_set_errhandler(*fh, MPI_ERRORS_RETURN);
+#endif
     if (error_code != MPI_SUCCESS)
         goto fn_fail;
 
     ADIO_Close(adio_fh, &error_code);
-    MPIO_File_free(fh);
+    MPIO_File_free(&adio_fh);
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS)
         goto fn_fail;

--- a/src/mpi/romio/mpi-io/delete.c
+++ b/src/mpi/romio/mpi-io/delete.c
@@ -62,7 +62,7 @@ int MPI_File_delete(ROMIO_CONST char *filename, MPI_Info info)
          * the error up.  In the PRINT_ERR_MSG case MPI_Abort has already
          * been called as well, so we probably didn't even make it this far.
          */
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
         goto fn_exit;
     }
     /* --END ERROR HANDLING-- */
@@ -82,7 +82,7 @@ int MPI_File_delete(ROMIO_CONST char *filename, MPI_Info info)
     (fsops->ADIOI_xxx_Delete) (filename, &error_code);
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/fsync.c
+++ b/src/mpi/romio/mpi-io/fsync.c
@@ -49,10 +49,10 @@ int MPI_File_sync(MPI_File fh)
     if ((adio_fh == NULL) || ((adio_fh)->cookie != ADIOI_FILE_COOKIE)) {
         error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
                                           myname, __LINE__, MPI_ERR_ARG, "**iobadfh", 0);
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
         goto fn_exit;
     }
-    MPIO_CHECK_WRITABLE(fh, myname, error_code);
+    MPIO_CHECK_WRITABLE(adio_fh, myname, error_code);
     /* --END ERROR HANDLING-- */
 
     ADIO_Flush(adio_fh, &error_code);

--- a/src/mpi/romio/mpi-io/get_errh.c
+++ b/src/mpi/romio/mpi-io/get_errh.c
@@ -49,10 +49,10 @@ int MPI_File_get_errhandler(MPI_File mpi_fh, MPI_Errhandler * errhandler)
     } else {
         fh = MPIO_File_resolve(mpi_fh);
         /* --BEGIN ERROR HANDLING-- */
-        if ((fh <= (MPI_File) 0) || ((fh)->cookie != ADIOI_FILE_COOKIE)) {
+        if ((fh <= (ADIO_File) 0) || ((fh)->cookie != ADIOI_FILE_COOKIE)) {
             error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
                                               myname, __LINE__, MPI_ERR_ARG, "**iobadfh", 0);
-            error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+            error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
             goto fn_exit;
         }
         /* --END ERROR HANDLING-- */

--- a/src/mpi/romio/mpi-io/get_size.c
+++ b/src/mpi/romio/mpi-io/get_size.c
@@ -78,7 +78,7 @@ int MPI_File_get_size(MPI_File fh, MPI_Offset * size)
     return error_code;
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */
-    error_code = MPIO_Err_return_file(fh, error_code);
+    error_code = MPIO_Err_return_file(adio_fh, error_code);
     goto fn_exit;
     /* --END ERROR HANDLING-- */
 }

--- a/src/mpi/romio/mpi-io/glue/default/mpio_err.c
+++ b/src/mpi/romio/mpi-io/glue/default/mpio_err.c
@@ -40,25 +40,21 @@ int MPIO_Err_create_code(int lastcode, int fatal, const char fcname[],
     return error_class;
 }
 
-int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
+int MPIO_Err_return_file(ADIO_File adio_fh, int error_code)
 {
-    ADIO_File adio_fh;
-
-    if (mpi_fh == MPI_FILE_NULL) {
-        if (ADIOI_DFLT_ERR_HANDLER != MPI_ERRORS_RETURN) {
+    if (adio_fh == MPI_FILE_NULL) {
+        if (ADIOI_DFLT_ERR_HANDLER == MPI_ERRORS_ARE_FATAL ||
+            ADIOI_DFLT_ERR_HANDLER != MPI_ERRORS_RETURN) {
             MPI_Abort(MPI_COMM_WORLD, 1);
         } else {
             return error_code;
         }
     }
 
-    adio_fh = MPIO_File_resolve(mpi_fh);
-
-    if (adio_fh->err_handler != MPI_ERRORS_RETURN) {
+    if (adio_fh->err_handler == MPI_ERRORS_ARE_FATAL || adio_fh->err_handler != MPI_ERRORS_RETURN)
         MPI_Abort(MPI_COMM_WORLD, 1);
-    } else {
-        return error_code;
-    }
+
+    return error_code;
 }
 
 int MPIO_Err_return_comm(MPI_Comm mpi_comm, int error_code)

--- a/src/mpi/romio/mpi-io/glue/default/mpio_file.c
+++ b/src/mpi/romio/mpi-io/glue/default/mpio_file.c
@@ -11,7 +11,7 @@
  * of MPI_File structures:
  * - MPIO_File_create(size)
  * - MPIO_File_resolve(mpi_fh)
- * - MPIO_File_free(mpi_fh)
+ * - MPIO_File_free(adio_fh)
  *
  */
 
@@ -25,13 +25,13 @@ MPI_File MPIO_File_create(int size)
 
 ADIO_File MPIO_File_resolve(MPI_File mpi_fh)
 {
-    return mpi_fh;
+    return (ADIO_File) mpi_fh;
 }
 
-void MPIO_File_free(MPI_File * mpi_fh)
+void MPIO_File_free(ADIO_File * adio_fh)
 {
-    ADIOI_Free(*mpi_fh);
-    *mpi_fh = MPI_FILE_NULL;
+    ADIOI_Free(*adio_fh);
+    *adio_fh = ADIO_FILE_NULL;
 }
 
 extern ADIO_File *ADIOI_Ftable;
@@ -54,7 +54,7 @@ MPI_File MPIO_File_f2c(MPI_Fint fh)
         /* there is no way to return an error from MPI_File_f2c */
         return MPI_FILE_NULL;
     }
-    return ADIOI_Ftable[fh];
+    return (MPI_File) ADIOI_Ftable[fh];
 #endif
 }
 
@@ -64,27 +64,28 @@ MPI_Fint MPIO_File_c2f(MPI_File fh)
     return (MPI_Fint) fh;
 #else
     int i;
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
 
     if ((fh == MPI_FILE_NULL) || (fh->cookie != ADIOI_FILE_COOKIE))
         return (MPI_Fint) 0;
     if (!ADIOI_Ftable) {
         ADIOI_Ftable_max = 1024;
-        ADIOI_Ftable = (MPI_File *)
-            ADIOI_Malloc(ADIOI_Ftable_max * sizeof(MPI_File));
+        ADIOI_Ftable = (ADIO_File *)
+            ADIOI_Malloc(ADIOI_Ftable_max * sizeof(ADIO_File));
         ADIOI_Ftable_ptr = 0;   /* 0 can't be used though, because
-                                 * MPI_FILE_NULL=0 */
+                                 * ADIO_FILE_NULL=0 */
         for (i = 0; i < ADIOI_Ftable_max; i++)
-            ADIOI_Ftable[i] = MPI_FILE_NULL;
+            ADIOI_Ftable[i] = ADIO_FILE_NULL;
     }
     if (ADIOI_Ftable_ptr == ADIOI_Ftable_max - 1) {
-        ADIOI_Ftable = (MPI_File *) ADIOI_Realloc(ADIOI_Ftable,
-                                                  (ADIOI_Ftable_max + 1024) * sizeof(MPI_File));
+        ADIOI_Ftable = (ADIO_File *) ADIOI_Realloc(ADIOI_Ftable,
+                                                   (ADIOI_Ftable_max + 1024) * sizeof(ADIO_File));
         for (i = ADIOI_Ftable_max; i < ADIOI_Ftable_max + 1024; i++)
-            ADIOI_Ftable[i] = MPI_FILE_NULL;
+            ADIOI_Ftable[i] = ADIO_FILE_NULL;
         ADIOI_Ftable_max += 1024;
     }
     ADIOI_Ftable_ptr++;
-    ADIOI_Ftable[ADIOI_Ftable_ptr] = fh;
+    ADIOI_Ftable[ADIOI_Ftable_ptr] = adio_fh;
     return (MPI_Fint) ADIOI_Ftable_ptr;
 #endif
 }

--- a/src/mpi/romio/mpi-io/glue/mpich/mpio_err.c
+++ b/src/mpi/romio/mpi-io/glue/mpich/mpio_err.c
@@ -28,7 +28,7 @@ int MPIO_Err_create_code(int lastcode, int fatal, const char fcname[],
     return error_code;
 }
 
-int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
+int MPIO_Err_return_file(ADIO_File adio_fh, int error_code)
 {
     MPI_Errhandler e;
     void (*c_errhandler) (MPI_File *, int *, ...);
@@ -43,14 +43,10 @@ int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
      */
 
     /* First, get the handler and the corresponding function */
-    if (mpi_fh == MPI_FILE_NULL) {
+    if (adio_fh == ADIO_FILE_NULL)
         e = ADIOI_DFLT_ERR_HANDLER;
-    } else {
-        ADIO_File fh;
-
-        fh = MPIO_File_resolve(mpi_fh);
-        e = fh->err_handler;
-    }
+    else
+        e = adio_fh->err_handler;
 
     /* Actually, e is just the value provide by the MPICH routines
      * file_set_errhandler.  This is actually a *pointer* to the
@@ -70,7 +66,7 @@ int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
 
     /* --BEGIN ERROR HANDLING-- */
     if (MPIR_Err_is_fatal(error_code) || kind == 0) {
-        ADIO_File fh = MPIO_File_resolve(mpi_fh);
+        ADIO_File fh = MPIO_File_resolve(adio_fh);
 
         snprintf(error_msg, 4096, "I/O error: ");
         len = (int) strlen(error_msg);
@@ -79,9 +75,9 @@ int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
     }
     /* --END ERROR HANDLING-- */
     else if (kind == 2) {
-        (*c_errhandler) (&mpi_fh, &error_code, 0);
+        (*c_errhandler) (&adio_fh, &error_code, 0);
     } else if (kind == 3) {
-        MPIR_File_call_cxx_errhandler(&mpi_fh, &error_code, c_errhandler);
+        MPIR_File_call_cxx_errhandler(&adio_fh, &error_code, c_errhandler);
     }
 
     /* kind == 1 just returns */

--- a/src/mpi/romio/mpi-io/glue/mpich/mpio_file.c
+++ b/src/mpi/romio/mpi-io/glue/mpich/mpio_file.c
@@ -13,7 +13,7 @@
  * of MPI_File structures:
  * - MPIO_File_create(size)
  * - MPIO_File_resolve(mpi_fh)
- * - MPIO_File_free(mpi_fh)
+ * - MPIO_File_free(adio_fh)
  *
  */
 
@@ -27,13 +27,13 @@ MPI_File MPIO_File_create(int size)
 
 ADIO_File MPIO_File_resolve(MPI_File mpi_fh)
 {
-    return mpi_fh;
+    return (ADIO_File) mpi_fh;
 }
 
-void MPIO_File_free(MPI_File * mpi_fh)
+void MPIO_File_free(ADIO_File * adio_fh)
 {
-    ADIOI_Free(*mpi_fh);
-    *mpi_fh = MPI_FILE_NULL;
+    ADIOI_Free(*adio_fh);
+    *adio_fh = ADIO_FILE_NULL;
 }
 
 MPI_File MPIO_File_f2c(MPI_Fint fh)

--- a/src/mpi/romio/mpi-io/glue/openmpi/mpio_err.c
+++ b/src/mpi/romio/mpi-io/glue/openmpi/mpio_err.c
@@ -39,7 +39,7 @@ int MPIO_Err_create_code(int lastcode, int fatal, const char fcname[],
     return error_class;
 }
 
-int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
+int MPIO_Err_return_file(ADIO_File adio_fh, int error_code)
 {
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/glue/openmpi/mpio_file.c
+++ b/src/mpi/romio/mpi-io/glue/openmpi/mpio_file.c
@@ -13,7 +13,7 @@
  * of MPI_File structures:
  * - MPIO_File_create(size)
  * - MPIO_File_resolve(mpi_fh)
- * - MPIO_File_free(mpi_fh)
+ * - MPIO_File_free(adio_fh)
  *
  */
 
@@ -27,18 +27,21 @@ MPI_File MPIO_File_create(int size)
 
 ADIO_File MPIO_File_resolve(MPI_File mpi_fh)
 {
-    return mpi_fh;
+    return (ADIO_File) mpi_fh;
 }
 
-void MPIO_File_free(MPI_File * mpi_fh)
+void MPIO_File_free(ADIO_File * adio_fh)
 {
-    ADIOI_Free(*mpi_fh);
-    *mpi_fh = MPI_FILE_NULL;
+    ADIOI_Free(*adio_fh);
+    *adio_fh = ADIO_FILE_NULL;
 }
 
 /* these functions aren't needed with the way Open MPI uses ROMIO */
 #if 0
 
+extern ADIO_File *ADIOI_Ftable;
+extern int ADIOI_Ftable_ptr;
+extern int ADIOI_Ftable_max;
 
 MPI_File MPIO_File_f2c(MPI_Fint fh)
 {
@@ -53,9 +56,11 @@ MPI_File MPIO_File_f2c(MPI_Fint fh)
         return MPI_FILE_NULL;
     if ((fh < 0) || (fh > ADIOI_Ftable_ptr)) {
         FPRINTF(stderr, "MPI_File_f2c: Invalid file handle\n");
-        MPI_Abort(MPI_COMM_WORLD, 1);
+        /* MPI_Abort(MPI_COMM_WORLD, 1); */
+        /* there is no way to return an error from MPI_File_f2c */
+        return MPI_FILE_NULL;
     }
-    return ADIOI_Ftable[fh];
+    return (MPI_File) ADIOI_Ftable[fh];
 #endif
 }
 
@@ -65,27 +70,28 @@ MPI_Fint MPIO_File_c2f(MPI_File fh)
     return (MPI_Fint) fh;
 #else
     int i;
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
 
     if ((fh == MPI_FILE_NULL) || (fh->cookie != ADIOI_FILE_COOKIE))
         return (MPI_Fint) 0;
     if (!ADIOI_Ftable) {
         ADIOI_Ftable_max = 1024;
-        ADIOI_Ftable = (MPI_File *)
-            ADIOI_Malloc(ADIOI_Ftable_max * sizeof(MPI_File));
+        ADIOI_Ftable = (ADIO_File *)
+            ADIOI_Malloc(ADIOI_Ftable_max * sizeof(ADIO_File));
         ADIOI_Ftable_ptr = 0;   /* 0 can't be used though, because
-                                 * MPI_FILE_NULL=0 */
+                                 * ADIO_FILE_NULL=0 */
         for (i = 0; i < ADIOI_Ftable_max; i++)
-            ADIOI_Ftable[i] = MPI_FILE_NULL;
+            ADIOI_Ftable[i] = ADIO_FILE_NULL;
     }
     if (ADIOI_Ftable_ptr == ADIOI_Ftable_max - 1) {
-        ADIOI_Ftable = (MPI_File *) ADIOI_Realloc(ADIOI_Ftable,
-                                                  (ADIOI_Ftable_max + 1024) * sizeof(MPI_File));
+        ADIOI_Ftable = (ADIO_File *) ADIOI_Realloc(ADIOI_Ftable,
+                                                   (ADIOI_Ftable_max + 1024) * sizeof(ADIO_File));
         for (i = ADIOI_Ftable_max; i < ADIOI_Ftable_max + 1024; i++)
-            ADIOI_Ftable[i] = MPI_FILE_NULL;
+            ADIOI_Ftable[i] = ADIO_FILE_NULL;
         ADIOI_Ftable_max += 1024;
     }
     ADIOI_Ftable_ptr++;
-    ADIOI_Ftable[ADIOI_Ftable_ptr] = fh;
+    ADIOI_Ftable[ADIOI_Ftable_ptr] = adio_fh;
     return (MPI_Fint) ADIOI_Ftable_ptr;
 #endif
 }

--- a/src/mpi/romio/mpi-io/iread.c
+++ b/src/mpi/romio/mpi-io/iread.c
@@ -72,8 +72,10 @@ int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI
                                   buf, count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+    if (error_code != MPI_SUCCESS) {
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
+    }
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/iread_all.c
+++ b/src/mpi/romio/mpi-io/iread_all.c
@@ -74,7 +74,8 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count,
 
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_return_file(fh, error_code);
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
     }
     /* --END ERROR HANDLING-- */
 
@@ -134,8 +135,6 @@ int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count,
 }
 
 /* Note: MPIOI_File_iread_all also used by MPI_File_iread_at_all */
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_iread_all(MPI_File fh,
                          MPI_Offset offset,
                          int file_ptr_type,
@@ -202,4 +201,3 @@ int MPIOI_File_iread_all(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/iread_at.c
+++ b/src/mpi/romio/mpi-io/iread_at.c
@@ -75,8 +75,10 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_
                                   count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+    if (error_code != MPI_SUCCESS) {
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
+    }
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/iread_atall.c
+++ b/src/mpi/romio/mpi-io/iread_atall.c
@@ -74,8 +74,10 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf,
                                       count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+    if (error_code != MPI_SUCCESS) {
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
+    }
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/iwrite.c
+++ b/src/mpi/romio/mpi-io/iwrite.c
@@ -60,6 +60,7 @@ int MPI_File_iwrite(MPI_File fh, ROMIO_CONST void *buf, int count,
                     MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code = MPI_SUCCESS;
+    ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_IWRITE";
 #ifdef MPI_hpux
     int fl_xmpi;
@@ -68,12 +69,13 @@ int MPI_File_iwrite(MPI_File fh, ROMIO_CONST void *buf, int count,
 #endif /* MPI_hpux */
 
 
-    error_code = MPIOI_File_iwrite(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
+    adio_fh = MPIO_File_resolve(fh);
+    error_code = MPIOI_File_iwrite(adio_fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
                                    buf, count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux
@@ -133,7 +135,7 @@ int MPI_File_iwrite_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
 
 /* prevent multiple definitions of this routine */
 #ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iwrite(MPI_File fh,
+int MPIOI_File_iwrite(ADIO_File adio_fh,
                       MPI_Offset offset,
                       int file_ptr_type,
                       const void *buf,
@@ -143,11 +145,9 @@ int MPIOI_File_iwrite(MPI_File fh,
     MPI_Count datatype_size;
     ADIO_Status status;
     ADIO_Offset off, bufsize;
-    ADIO_File adio_fh;
     MPI_Offset nbytes = 0;
 
     ROMIO_THREAD_CS_ENTER();
-    adio_fh = MPIO_File_resolve(fh);
 
     /* --BEGIN ERROR HANDLING-- */
     MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);

--- a/src/mpi/romio/mpi-io/iwrite_all.c
+++ b/src/mpi/romio/mpi-io/iwrite_all.c
@@ -62,6 +62,7 @@ int MPI_File_iwrite_all(MPI_File fh, ROMIO_CONST void *buf, int count,
                         MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
+    ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_IWRITE_ALL";
 #ifdef MPI_hpux
     int fl_xmpi;
@@ -69,7 +70,9 @@ int MPI_File_iwrite_all(MPI_File fh, ROMIO_CONST void *buf, int count,
     HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEALL, TRDTBLOCK, fh, datatype, count);
 #endif /* MPI_hpux */
 
-    error_code = MPIOI_File_iwrite_all(fh, (MPI_Offset) 0,
+    adio_fh = MPIO_File_resolve(fh);
+
+    error_code = MPIOI_File_iwrite_all(adio_fh, (MPI_Offset) 0,
                                        ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
 
 #ifdef MPI_hpux
@@ -122,9 +125,7 @@ int MPI_File_iwrite_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
 }
 
 /* Note: MPIOI_File_iwrite_all also used by MPI_File_iwrite_at_all */
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iwrite_all(MPI_File fh,
+int MPIOI_File_iwrite_all(ADIO_File adio_fh,
                           MPI_Offset offset,
                           int file_ptr_type,
                           const void *buf,
@@ -133,13 +134,10 @@ int MPIOI_File_iwrite_all(MPI_File fh,
 {
     int error_code;
     MPI_Count datatype_size;
-    ADIO_File adio_fh;
     void *e32buf = NULL;
     const void *xbuf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
-
-    adio_fh = MPIO_File_resolve(fh);
 
     /* --BEGIN ERROR HANDLING-- */
     MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
@@ -187,4 +185,3 @@ int MPIOI_File_iwrite_all(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/iwrite_atall.c
+++ b/src/mpi/romio/mpi-io/iwrite_atall.c
@@ -63,6 +63,7 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf
                            int count, MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
+    ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_IWRITE_AT_ALL";
 #ifdef MPI_hpux
     int fl_xmpi;
@@ -70,7 +71,9 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf
     HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEATALL, TRDTBLOCK, fh, datatype, count);
 #endif /* MPI_hpux */
 
-    error_code = MPIOI_File_iwrite_all(fh, offset, ADIO_EXPLICIT_OFFSET,
+    adio_fh = MPIO_File_resolve(fh);
+
+    error_code = MPIOI_File_iwrite_all(adio_fh, offset, ADIO_EXPLICIT_OFFSET,
                                        buf, count, datatype, myname, request);
 
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/mpir-mpioinit.c
+++ b/src/mpi/romio/mpi-io/mpir-mpioinit.c
@@ -32,12 +32,13 @@ void MPIR_MPIOInit(int *error_code)
             *error_code = MPIO_Err_create_code(MPI_SUCCESS,
                                                MPIR_ERR_RECOVERABLE, myname, __LINE__,
                                                MPI_ERR_OTHER, "**initialized", 0);
-            *error_code = MPIO_Err_return_file(MPI_FILE_NULL, *error_code);
+            *error_code = MPIO_Err_return_file(ADIO_FILE_NULL, *error_code);
             return;
         }
         /* --END ERROR HANDLING-- */
 
-        MPI_Keyval_create(MPI_NULL_COPY_FN, ADIOI_End_call, &ADIO_Init_keyval, (void *) 0);
+        MPI_Comm_create_keyval(MPI_COMM_NULL_COPY_FN, ADIOI_End_call, &ADIO_Init_keyval,
+                               (void *) 0);
 
         /* put a dummy attribute on MPI_COMM_SELF, because we want the delete
          * function to be called when MPI_COMM_SELF is freed. Clarified

--- a/src/mpi/romio/mpi-io/open.c
+++ b/src/mpi/romio/mpi-io/open.c
@@ -58,6 +58,7 @@ int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
     int known_fstype;
     char *tmp;
     MPI_Comm dupcomm = MPI_COMM_NULL;
+    ADIO_File adio_fh;
     ADIOI_Fns *fsops;
     static char myname[] = "MPI_FILE_OPEN";
 #ifdef MPI_hpux
@@ -149,8 +150,8 @@ int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
     }
 /* use default values for disp, etype, filetype */
 
-    *fh = ADIO_Open(comm, dupcomm, filename, file_system, fsops, amode, 0,
-                    MPI_BYTE, MPI_BYTE, info, ADIO_PERM_NULL, &error_code);
+    adio_fh = ADIO_Open(comm, dupcomm, filename, file_system, fsops, amode, 0,
+                        MPI_BYTE, MPI_BYTE, info, ADIO_PERM_NULL, &error_code);
 
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS) {
@@ -158,32 +159,34 @@ int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
     }
     /* --END ERROR HANDLING-- */
 
+    *fh = (MPI_File) adio_fh;
+
     /* if MPI_MODE_SEQUENTIAL requested, file systems cannot do explicit offset
      * or independent file pointer accesses, leaving not much else aside from
      * shared file pointer accesses. */
-    if (!ADIO_Feature((*fh), ADIO_SHARED_FP) && (amode & MPI_MODE_SEQUENTIAL)) {
+    if (!ADIO_Feature((adio_fh), ADIO_SHARED_FP) && (amode & MPI_MODE_SEQUENTIAL)) {
         error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
                                           myname, __LINE__,
                                           MPI_ERR_UNSUPPORTED_OPERATION, "**iosequnsupported", 0);
-        ADIO_Close(*fh, &error_code);
+        ADIO_Close(adio_fh, &error_code);
         goto fn_fail;
     }
 
     /* determine name of file that will hold the shared file pointer */
     /* can't support shared file pointers on a file system that doesn't
      * support file locking. */
-    if ((error_code == MPI_SUCCESS) && ADIO_Feature((*fh), ADIO_SHARED_FP)) {
+    if ((error_code == MPI_SUCCESS) && ADIO_Feature(adio_fh, ADIO_SHARED_FP)) {
         MPI_Comm_rank(dupcomm, &rank);
-        ADIOI_Shfp_fname(*fh, rank, &error_code);
+        ADIOI_Shfp_fname(adio_fh, rank, &error_code);
         if (error_code != MPI_SUCCESS)
             goto fn_fail;
 
         /* if MPI_MODE_APPEND, set the shared file pointer to end of file.
          * indiv. file pointer already set to end of file in ADIO_Open.
          * Here file view is just bytes. */
-        if ((*fh)->access_mode & MPI_MODE_APPEND) {
-            if (rank == (*fh)->hints->ranklist[0])      /* only one person need set the sharedfp */
-                ADIO_Set_shared_fp(*fh, (*fh)->fp_ind, &error_code);
+        if (adio_fh->access_mode & MPI_MODE_APPEND) {
+            if (rank == adio_fh->hints->ranklist[0])    /* only one person need set the sharedfp */
+                ADIO_Set_shared_fp(adio_fh, adio_fh->fp_ind, &error_code);
             MPI_Barrier(dupcomm);
         }
     }
@@ -198,7 +201,7 @@ int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
     /* --BEGIN ERROR HANDLING-- */
     if (dupcomm != MPI_COMM_NULL)
         MPI_Comm_free(&dupcomm);
-    error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+    error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
     goto fn_exit;
     /* --END ERROR HANDLING-- */
 }

--- a/src/mpi/romio/mpi-io/register_datarep.c
+++ b/src/mpi/romio/mpi-io/register_datarep.c
@@ -139,7 +139,7 @@ int MPIOI_Register_datarep(const char *datarep,
         error_code = MPIO_Err_create_code(MPI_SUCCESS,
                                           MPIR_ERR_RECOVERABLE,
                                           myname, __LINE__, MPI_ERR_ARG, "**datarepname", 0);
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
         goto fn_exit;
     }
     /* --END ERROR HANDLING-- */
@@ -157,7 +157,7 @@ int MPIOI_Register_datarep(const char *datarep,
                                               myname, __LINE__,
                                               MPI_ERR_DUP_DATAREP,
                                               "**datarepused", "**datarepused %s", datarep);
-            error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+            error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
             goto fn_exit;
         }
     }
@@ -169,7 +169,7 @@ int MPIOI_Register_datarep(const char *datarep,
                                           myname, __LINE__,
                                           MPI_ERR_CONVERSION, "**drconvnotsupported", 0);
 
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
         goto fn_exit;
     }
 
@@ -178,7 +178,7 @@ int MPIOI_Register_datarep(const char *datarep,
         error_code = MPIO_Err_create_code(MPI_SUCCESS,
                                           MPIR_ERR_RECOVERABLE,
                                           myname, __LINE__, MPI_ERR_ARG, "**datarepextent", 0);
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
         goto fn_exit;
     }
     /* --END ERROR HANDLING-- */

--- a/src/mpi/romio/mpi-io/set_info.c
+++ b/src/mpi/romio/mpi-io/set_info.c
@@ -45,7 +45,7 @@ int MPI_File_set_info(MPI_File fh, MPI_Info info)
 
     /* --BEGIN ERROR HANDLING-- */
     MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_INFO_ALL(info, error_code, fh->comm);
+    MPIO_CHECK_INFO_ALL(info, error_code, adio_fh->comm);
     /* --END ERROR HANDLING-- */
 
     /* set new info */

--- a/src/mpi/romio/mpi-io/set_size.c
+++ b/src/mpi/romio/mpi-io/set_size.c
@@ -60,7 +60,7 @@ int MPI_File_set_size(MPI_File fh, MPI_Offset size)
         error_code = MPIO_Err_return_file(adio_fh, error_code);
         goto fn_exit;
     }
-    MPIO_CHECK_WRITABLE(fh, myname, error_code);
+    MPIO_CHECK_WRITABLE(adio_fh, myname, error_code);
     /* --END ERROR HANDLING-- */
 
     tmp_sz = size;

--- a/src/mpi/romio/mpi-io/set_view.c
+++ b/src/mpi/romio/mpi-io/set_view.c
@@ -179,7 +179,7 @@ int MPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype,
     return error_code;
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */
-    error_code = MPIO_Err_return_file(fh, error_code);
+    error_code = MPIO_Err_return_file(adio_fh, error_code);
     goto fn_exit;
     /* --END ERROR HANDLING-- */
 }


### PR DESCRIPTION
## Pull Request Description

Improve consistent use of file handler.
* use ADIO_File instead of MPI_File, once MPI file handle is translated
  into ADIO file handle. This translation is done through a call to
  MPIO_File_resolve, e.g. adio_fh = MPIO_File_resolve(mpi_fh)
* use constant ADIO_FILE_NULL instead of MPI_FILE_NULL

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

This PR prepares ROMIO to be able to build stand-alone (#6956).
Because `MPI_File` may be defined differently in different MPI implementations,
such as MPICH and OpenMPI, using ADIO_File is more portable.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager