### PR TITLE
ROMIO: Fix Fortran binding

### DIFF
--- a/src/mpi/romio/mpi-io/fortran/closef.c
+++ b/src/mpi/romio/mpi-io/fortran/closef.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_close_(MPI_File *, MPI_Fint *);
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/deletef.c
+++ b/src/mpi/romio/mpi-io/fortran/deletef.c
@@ -56,8 +56,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_delete_(char *FORT_MIXED_LEN_DECL, MP
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/fsyncf.c
+++ b/src/mpi/romio/mpi-io/fortran/fsyncf.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_sync_(MPI_Fint *, MPI_Fint *);
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_amodef.c
+++ b/src/mpi/romio/mpi-io/fortran/get_amodef.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_amode_(MPI_Fint *, MPI_Fint *, MP
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_atomf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_atomf.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_atomicity_(MPI_Fint *, MPI_Fint *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_bytofff.c
+++ b/src/mpi/romio/mpi-io/fortran/get_bytofff.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_byte_offset_(MPI_Fint *, MPI_Offs
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_errhf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_errhf.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_errhandler_(MPI_Fint *, MPI_Fint 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_extentf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_extentf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_type_extent_(MPI_Fint *, MPI_Fint
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,14 @@ void mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Fint * datatype,
 
 void mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Fint * datatype,
                                MPI_Fint * extent, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Fint * datatype,
+                                                     MPI_Fint * extent, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Fint * datatype,
+                                                     MPI_Fint * extent, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -109,20 +115,3 @@ void mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Fint * datatype,
     *ierr = MPI_File_get_type_extent(fh_c, datatype_c, &extent_c);
     *(MPI_Aint *) extent = extent_c;    /* Have to assume it's really an MPI_Aint? */
 }
-
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Datatype * datatype,
-                                                     MPI_Fint * extent, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Datatype * datatype,
-                                                     MPI_Fint * extent, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Aint extent_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_get_type_extent(fh_c, *datatype, &extent_c);
-    *(MPI_Aint *) extent = extent_c;    /* Have to assume it's really an MPI_Aint? */
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/get_groupf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_groupf.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint *, MPI_Group *, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -92,6 +90,12 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint *, MPI_Group *, M
 void mpi_file_get_group_(MPI_Fint * fh, MPI_Fint * group, MPI_Fint * ierr);
 
 void mpi_file_get_group_(MPI_Fint * fh, MPI_Fint * group, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint * fh, MPI_Fint * group, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint * fh, MPI_Fint * group, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Group group_c;
@@ -100,15 +104,3 @@ void mpi_file_get_group_(MPI_Fint * fh, MPI_Fint * group, MPI_Fint * ierr)
     *ierr = MPI_File_get_group(fh_c, &group_c);
     *group = MPI_Group_c2f(group_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint * fh, MPI_Group * group, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint * fh, MPI_Group * group, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_get_group(fh_c, group);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/get_infof.c
+++ b/src/mpi/romio/mpi-io/fortran/get_infof.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_info_(MPI_Fint *, MPI_Fint *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_posn_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_posn_shf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_position_shared_(MPI_Fint *, MPI_
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_posnf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_posnf.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_position_(MPI_Fint *, MPI_Offset 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_sizef.c
+++ b/src/mpi/romio/mpi-io/fortran/get_sizef.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_size_(MPI_Fint *, MPI_Offset *, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_viewf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_viewf.c
@@ -60,8 +60,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_view_(MPI_Fint *, MPI_Offset *, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -106,39 +104,6 @@ void mpi_file_get_view_(MPI_Fint * fh, MPI_Offset * disp, MPI_Fint * etype,
 void mpi_file_get_view_(MPI_Fint * fh, MPI_Offset * disp, MPI_Fint * etype,
                         MPI_Fint * filetype, char *datarep, MPI_Fint * ierr, int str_len)
 {
-    MPI_File fh_c;
-    MPI_Datatype etype_c, filetype_c;
-    int i, tmpreplen;
-    char *tmprep;
-
-    if (datarep <= (char *) 0) {
-        FPRINTF(stderr, "MPI_File_get_view: datarep is an invalid address\n");
-        MPI_Abort(MPI_COMM_WORLD, 1);
-    }
-
-    tmprep = (char *) ADIOI_Malloc((MPI_MAX_DATAREP_STRING + 1) * sizeof(char));
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_get_view(fh_c, disp, &etype_c, &filetype_c, tmprep);
-
-    tmpreplen = strlen(tmprep);
-    if (tmpreplen <= str_len) {
-        ADIOI_Strncpy(datarep, tmprep, tmpreplen);
-
-        /* blank pad the remaining space */
-        for (i = tmpreplen; i < str_len; i++)
-            datarep[i] = ' ';
-    } else {
-        /* not enough space */
-        ADIOI_Strncpy(datarep, tmprep, str_len);
-        /* this should be flagged as an error. */
-        *ierr = MPI_ERR_UNKNOWN;
-    }
-
-    *etype = MPI_Type_c2f(etype_c);
-    *filetype = MPI_Type_c2f(filetype_c);
-    ADIOI_Free(tmprep);
-}
-
 #else
 
 #ifdef _UNICOS
@@ -160,13 +125,12 @@ FORTRAN_API void FORT_CALL mpi_file_get_view_(MPI_Fint * fh, MPI_Offset * disp, 
                                               MPI_Fint * ierr FORT_END_LEN(str_len))
 {
 #endif
+#endif
     MPI_File fh_c;
-    int i, tmpreplen;
     MPI_Datatype etype_c, filetype_c;
-
+    int i, tmpreplen;
     char *tmprep;
 
-/* Initialize the string to all blanks */
     if (datarep <= (char *) 0) {
         FPRINTF(stderr, "MPI_File_get_view: datarep is an invalid address\n");
         MPI_Abort(MPI_COMM_WORLD, 1);
@@ -174,8 +138,6 @@ FORTRAN_API void FORT_CALL mpi_file_get_view_(MPI_Fint * fh, MPI_Offset * disp, 
 
     tmprep = (char *) ADIOI_Malloc((MPI_MAX_DATAREP_STRING + 1) * sizeof(char));
     fh_c = MPI_File_f2c(*fh);
-    etype_c = MPI_Type_f2c(*etype);
-    filetype_c = MPI_Type_f2c(*filetype);
     *ierr = MPI_File_get_view(fh_c, disp, &etype_c, &filetype_c, tmprep);
 
     tmpreplen = strlen(tmprep);
@@ -196,4 +158,3 @@ FORTRAN_API void FORT_CALL mpi_file_get_view_(MPI_Fint * fh, MPI_Offset * disp, 
     *filetype = MPI_Type_c2f(filetype_c);
     ADIOI_Free(tmprep);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/iotestf.c
+++ b/src/mpi/romio/mpi-io/fortran/iotestf.c
@@ -52,8 +52,6 @@ FORTRAN_API void FORT_CALL mpio_test_(MPI_Fint * request, MPI_Fint * flag, MPI_S
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/iowaitf.c
+++ b/src/mpi/romio/mpi-io/fortran/iowaitf.c
@@ -48,8 +48,6 @@ FORTRAN_API void FORT_CALL mpio_wait_(MPI_Fint * request, MPI_Status * status, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/iread_atf.c
+++ b/src/mpi/romio/mpi-io/fortran/iread_atf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iread_at_(MPI_Fint *, MPI_Offset *, v
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,16 @@ void mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                         MPI_Fint * count, MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
+                                              MPI_Fint * count, MPI_Fint * datatype,
+                                              MPI_Fint * request, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
+                                              MPI_Fint * count, MPI_Fint * datatype,
+                                              MPI_Fint * request, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -110,21 +118,3 @@ void mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
-                                              MPI_Fint * count, MPI_Datatype * datatype,
-                                              MPI_Fint * request, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
-                                              MPI_Fint * count, MPI_Datatype * datatype,
-                                              MPI_Fint * request, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iread_at(fh_c, *offset, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/iread_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/iread_shf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iread_shared_(MPI_Fint *, void *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,16 @@ void mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                             MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                  MPI_Fint * datatype, MPI_Fint * request,
+                                                  MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                  MPI_Fint * datatype, MPI_Fint * request,
+                                                  MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -108,21 +116,3 @@ void mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
     *ierr = MPI_File_iread_shared(fh_c, buf, *count, datatype_c, &req_c);
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                  MPI_Datatype * datatype, MPI_Fint * request,
-                                                  MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                  MPI_Datatype * datatype, MPI_Fint * request,
-                                                  MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iread_shared(fh_c, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/ireadf.c
+++ b/src/mpi/romio/mpi-io/fortran/ireadf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iread_(MPI_Fint *, void *, MPI_Fint *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,15 @@ void mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                      MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                           MPI_Fint * datatype, MPI_Fint * request,
+                                           MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                           MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -108,21 +115,3 @@ void mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
     *ierr = MPI_File_iread(fh_c, buf, *count, datatype_c, &req_c);
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                           MPI_Datatype * datatype, MPI_Fint * request,
-                                           MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                           MPI_Datatype * datatype, MPI_Fint * request,
-                                           MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iread(fh_c, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/iwrite_atf.c
+++ b/src/mpi/romio/mpi-io/fortran/iwrite_atf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iwrite_at_(MPI_Fint *, MPI_Offset *, 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -99,6 +97,16 @@ void mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                          MPI_Fint * count, MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
+                                               MPI_Fint * count, MPI_Fint * datatype,
+                                               MPI_Fint * request, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
+                                               MPI_Fint * count, MPI_Fint * datatype,
+                                               MPI_Fint * request, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -110,21 +118,3 @@ void mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
     *ierr = MPI_File_iwrite_at(fh_c, *offset, buf, *count, datatype_c, &req_c);
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
-                                               MPI_Fint * count, MPI_Datatype * datatype,
-                                               MPI_Fint * request, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
-                                               MPI_Fint * count, MPI_Datatype * datatype,
-                                               MPI_Fint * request, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iwrite_at(fh_c, *offset, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/iwrite_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/iwrite_shf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iwrite_shared_(MPI_Fint *, void *, MP
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -97,6 +95,16 @@ void mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                              MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr);
 void mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                              MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                   MPI_Fint * datatype, MPI_Fint * request,
+                                                   MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                   MPI_Fint * datatype, MPI_Fint * request,
+                                                   MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -108,21 +116,3 @@ void mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
     *ierr = MPI_File_iwrite_shared(fh_c, buf, *count, datatype_c, &req_c);
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                   MPI_Datatype * datatype, MPI_Fint * request,
-                                                   MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                   MPI_Datatype * datatype, MPI_Fint * request,
-                                                   MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iwrite_shared(fh_c, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/iwritef.c
+++ b/src/mpi/romio/mpi-io/fortran/iwritef.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iwrite_(MPI_Fint *, void *, MPI_Fint 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,16 @@ void mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                       MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                            MPI_Fint * datatype, MPI_Fint * request,
+                                            MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                            MPI_Fint * datatype, MPI_Fint * request,
+                                            MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -109,21 +117,3 @@ void mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
     *ierr = MPI_File_iwrite(fh_c, buf, *count, datatype_c, &req_c);
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                            MPI_Datatype * datatype, MPI_Fint * request,
-                                            MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                            MPI_Datatype * datatype, MPI_Fint * request,
-                                            MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iwrite(fh_c, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/openf.c
+++ b/src/mpi/romio/mpi-io/fortran/openf.c
@@ -57,11 +57,8 @@ extern FORTRAN_API void FORT_CALL mpi_file_open_(MPI_Fint *, char *FORT_MIXED_LE
 #else
 #pragma _CRI duplicate mpi_file_open_ as pmpi_file_open_
 #endif
-
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -106,6 +103,34 @@ void mpi_file_open_(MPI_Fint * comm, char *filename, MPI_Fint * amode,
 void mpi_file_open_(MPI_Fint * comm, char *filename, MPI_Fint * amode,
                     MPI_Fint * info, MPI_Fint * fh, MPI_Fint * ierr, int str_len)
 {
+#else
+
+#ifdef _UNICOS
+void mpi_file_open_(MPI_Fint * comm, _fcd filename_fcd, MPI_Fint * amode,
+                    MPI_Fint * info, MPI_Fint * fh, MPI_Fint * ierr)
+{
+    char *filename = _fcdtocp(filename_fcd);
+    int str_len = _fcdlen(filename_fcd);
+#else
+/* Prototype to keep compiler happy */
+/*
+FORTRAN_API void FORT_CALL mpi_file_open_(MPI_Comm *comm,char *filename,MPI_Fint *amode,
+            MPI_Fint *info, MPI_Fint *fh, MPI_Fint *ierr, int str_len);
+
+FORTRAN_API void FORT_CALL mpi_file_open_(MPI_Comm *comm,char *filename,MPI_Fint *amode,
+                  MPI_Fint *info, MPI_Fint *fh, MPI_Fint *ierr, int str_len)
+*/
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_open_(MPI_Fint * comm, char *filename FORT_MIXED_LEN_DECL,
+                                          MPI_Fint * amode, MPI_Fint * info, MPI_Fint * fh,
+                                          MPI_Fint * ierr FORT_END_LEN_DECL);
+
+FORTRAN_API void FORT_CALL mpi_file_open_(MPI_Fint * comm, char *filename FORT_MIXED_LEN(str_len),
+                                          MPI_Fint * amode, MPI_Fint * info, MPI_Fint * fh,
+                                          MPI_Fint * ierr FORT_END_LEN(str_len))
+{
+#endif
+#endif
     char *newfname;
     MPI_File fh_c;
     int real_len, i;
@@ -138,62 +163,3 @@ void mpi_file_open_(MPI_Fint * comm, char *filename, MPI_Fint * amode,
     *fh = MPI_File_c2f(fh_c);
     ADIOI_Free(newfname);
 }
-
-#else
-
-#ifdef _UNICOS
-void mpi_file_open_(MPI_Fint * comm, _fcd filename_fcd, MPI_Fint * amode,
-                    MPI_Fint * info, MPI_Fint * fh, MPI_Fint * ierr)
-{
-    char *filename = _fcdtocp(filename_fcd);
-    int str_len = _fcdlen(filename_fcd);
-#else
-/* Prototype to keep compiler happy */
-/*
-FORTRAN_API void FORT_CALL mpi_file_open_(MPI_Comm *comm,char *filename,MPI_Fint *amode,
-            MPI_Fint *info, MPI_Fint *fh, MPI_Fint *ierr, int str_len);
-
-FORTRAN_API void FORT_CALL mpi_file_open_(MPI_Comm *comm,char *filename,MPI_Fint *amode,
-                  MPI_Fint *info, MPI_Fint *fh, MPI_Fint *ierr, int str_len)
-*/
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_open_(MPI_Fint * comm, char *filename FORT_MIXED_LEN_DECL,
-                                          MPI_Fint * amode, MPI_Fint * info, MPI_Fint * fh,
-                                          MPI_Fint * ierr FORT_END_LEN_DECL);
-
-FORTRAN_API void FORT_CALL mpi_file_open_(MPI_Fint * comm, char *filename FORT_MIXED_LEN(str_len),
-                                          MPI_Fint * amode, MPI_Fint * info, MPI_Fint * fh,
-                                          MPI_Fint * ierr FORT_END_LEN(str_len))
-{
-#endif
-    char *newfname;
-    MPI_File fh_c;
-    int real_len, i;
-    MPI_Info info_c;
-
-    info_c = MPI_Info_f2c(*info);
-
-    /* strip trailing blanks */
-    if (filename <= (char *) 0) {
-        FPRINTF(stderr, "MPI_File_open: filename is an invalid address\n");
-        MPI_Abort(MPI_COMM_WORLD, 1);
-    }
-    for (i = str_len - 1; i >= 0; i--)
-        if (filename[i] != ' ')
-            break;
-    if (i < 0) {
-        FPRINTF(stderr, "MPI_File_open: filename is a blank string\n");
-        MPI_Abort(MPI_COMM_WORLD, 1);
-    }
-    real_len = i + 1;
-
-    newfname = (char *) ADIOI_Malloc((real_len + 1) * sizeof(char));
-    ADIOI_Strncpy(newfname, filename, real_len);
-    newfname[real_len] = '\0';
-
-    *ierr = MPI_File_open((MPI_Comm) (*comm), newfname, *amode, info_c, &fh_c);
-
-    *fh = MPI_File_c2f(fh_c);
-    ADIOI_Free(newfname);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/preallocf.c
+++ b/src/mpi/romio/mpi-io/fortran/preallocf.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_preallocate_(MPI_Fint *, MPI_Offset *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/rd_atallbf.c
+++ b/src/mpi/romio/mpi-io/fortran/rd_atallbf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_at_all_begin_(MPI_Fint *, MPI_Of
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_read_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_read_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                  MPI_Fint * count, MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_read_at_all_begin(fh_c, *offset, buf, *count, datatype_c);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_read_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_read_at_all_begin_(MPI_Fint * fh, MPI_Offset
 FORTRAN_API void FORT_CALL mpi_file_read_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset,
                                                        void *buf, MPI_Fint * count,
                                                        MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_at_all_begin(fh_c, *offset, buf, *count, (MPI_Datatype) * datatype);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_read_at_all_begin(fh_c, *offset, buf, *count, datatype_c);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/rd_atallef.c
+++ b/src/mpi/romio/mpi-io/fortran/rd_atallef.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_at_all_end_(MPI_Fint *, void *, 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/read_allbf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_allbf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_all_begin_(MPI_Fint *, void *, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,14 @@ void mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                               MPI_Fint * datatype, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                    MPI_Fint * datatype, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                    MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -107,17 +113,3 @@ void mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_read_all_begin(fh_c, buf, *count, datatype_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                    MPI_Fint * datatype, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                    MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_all_begin(fh_c, buf, *count, (MPI_Datatype) * datatype);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_allef.c
+++ b/src/mpi/romio/mpi-io/fortran/read_allef.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_all_end_(MPI_Fint *, void *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/read_allf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_allf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_all_(MPI_Fint *, void *, MPI_Fin
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_read_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_read_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                         MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_read_all(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_read_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_read_all_(MPI_Fint * fh, void *buf, MPI_Fint
 FORTRAN_API void FORT_CALL mpi_file_read_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                               MPI_Fint * datatype, MPI_Status * status,
                                               MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_all(fh_c, buf, *count, (MPI_Datatype) * datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_read_all(fh_c, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_atallf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_atallf.c
@@ -55,8 +55,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_at_all_(MPI_Fint *, MPI_Offset *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -102,15 +100,6 @@ void mpi_file_read_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 void mpi_file_read_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                            MPI_Fint * count, MPI_Fint * datatype,
                            MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_read_at_all(fh_c, *offset, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_read_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
@@ -120,10 +109,13 @@ FORTRAN_API void FORT_CALL mpi_file_read_at_all_(MPI_Fint * fh, MPI_Offset * off
 FORTRAN_API void FORT_CALL mpi_file_read_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                                  MPI_Fint * count, MPI_Fint * datatype,
                                                  MPI_Status * status, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_at_all(fh_c, *offset, buf, *count, (MPI_Datatype) * datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_read_at_all(fh_c, *offset, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_atf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_atf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_at_(MPI_Fint *, MPI_Offset *, vo
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_read_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_read_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                        MPI_Fint * count, MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_read_at(fh_c, *offset, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_read_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_read_at_(MPI_Fint * fh, MPI_Offset * offset,
 FORTRAN_API void FORT_CALL mpi_file_read_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                              MPI_Fint * count, MPI_Fint * datatype,
                                              MPI_Status * status, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_at(fh_c, *offset, buf, *count, (MPI_Datatype) * datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_read_at(fh_c, *offset, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_ordbf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_ordbf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_ordered_begin_(MPI_Fint *, void 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,14 @@ void mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                   MPI_Fint * datatype, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                        MPI_Fint * datatype, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                        MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -107,17 +113,3 @@ void mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_read_ordered_begin(fh_c, buf, *count, datatype_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                        MPI_Fint * datatype, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                        MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_ordered_begin(fh_c, buf, *count, (MPI_Datatype) * datatype);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_ordef.c
+++ b/src/mpi/romio/mpi-io/fortran/read_ordef.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_ordered_end_(MPI_Fint *, void *,
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/read_ordf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_ordf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_ordered_(MPI_Fint *, void *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_read_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_read_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                             MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_read_ordered(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_read_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_read_ordered_(MPI_Fint * fh, void *buf, MPI_
 FORTRAN_API void FORT_CALL mpi_file_read_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                                   MPI_Fint * datatype, MPI_Status * status,
                                                   MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_ordered(fh_c, buf, *count, (MPI_Datatype) * datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_read_ordered(fh_c, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_shf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_shared_(MPI_Fint *, void *, MPI_
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -97,6 +95,15 @@ void mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                            MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr);
 void mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                            MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                 MPI_Fint * datatype, MPI_Status * status,
+                                                 MPI_Fint * ierr);
+FORTRAN_API void FORT_CALL mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                 MPI_Fint * datatype, MPI_Status * status,
+                                                 MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -106,18 +113,3 @@ void mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_read_shared(fh_c, buf, *count, datatype_c, status);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                 MPI_Fint * datatype, MPI_Status * status,
-                                                 MPI_Fint * ierr);
-FORTRAN_API void FORT_CALL mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                 MPI_Fint * datatype, MPI_Status * status,
-                                                 MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_shared(fh_c, buf, *count, (MPI_Datatype) * datatype, status);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/readf.c
+++ b/src/mpi/romio/mpi-io/fortran/readf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_(MPI_Fint *, void *, MPI_Fint *,
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,15 @@ void mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                     MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                          MPI_Fint * datatype, MPI_Status * status,
+                                          MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                          MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -107,18 +114,3 @@ void mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_read(fh_c, buf, *count, datatype_c, status);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                          MPI_Fint * datatype, MPI_Status * status,
-                                          MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                          MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read(fh_c, buf, *count, (MPI_Datatype) * datatype, status);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/seek_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/seek_shf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_seek_shared_(MPI_Fint *, MPI_Offset *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/seekf.c
+++ b/src/mpi/romio/mpi-io/fortran/seekf.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_seek_(MPI_Fint *, MPI_Offset *, MPI_F
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/set_atomf.c
+++ b/src/mpi/romio/mpi-io/fortran/set_atomf.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_set_atomicity_(MPI_Fint *, MPI_Fint *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/set_errhf.c
+++ b/src/mpi/romio/mpi-io/fortran/set_errhf.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_set_errhandler_(MPI_Fint *, MPI_Fint 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/set_infof.c
+++ b/src/mpi/romio/mpi-io/fortran/set_infof.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_set_info_(MPI_Fint *, MPI_Fint *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/set_sizef.c
+++ b/src/mpi/romio/mpi-io/fortran/set_sizef.c
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_set_size_(MPI_Fint *, MPI_Offset *, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/set_viewf.c
+++ b/src/mpi/romio/mpi-io/fortran/set_viewf.c
@@ -60,8 +60,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_set_view_(MPI_Fint *, MPI_Offset *, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -108,6 +106,29 @@ void mpi_file_set_view_(MPI_Fint * fh, MPI_Offset * disp, MPI_Fint * etype,
                         MPI_Fint * filetype, char *datarep, MPI_Fint * info, MPI_Fint * ierr,
                         int str_len)
 {
+#else
+
+#ifdef _UNICOS
+void mpi_file_set_view_(MPI_Fint * fh, MPI_Offset * disp, MPI_Datatype * etype,
+                        MPI_Datatype * filetype, _fcd datarep_fcd, MPI_Fint * info, MPI_Fint * ierr)
+{
+    char *datarep = _fcdtocp(datarep_fcd);
+    int str_len = _fcdlen(datarep_fcd);
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_set_view_(MPI_Fint * fh, MPI_Offset * disp, MPI_Fint * etype,
+                                              MPI_Fint * filetype,
+                                              char *datarep FORT_MIXED_LEN_DECL, MPI_Fint * info,
+                                              MPI_Fint * ierr FORT_END_LEN_DECL);
+
+FORTRAN_API void FORT_CALL mpi_file_set_view_(MPI_Fint * fh, MPI_Offset * disp, MPI_Fint * etype,
+                                              MPI_Fint * filetype,
+                                              char *datarep FORT_MIXED_LEN(str_len),
+                                              MPI_Fint * info,
+                                              MPI_Fint * ierr FORT_END_LEN(str_len))
+{
+#endif
+#endif
     char *newstr;
     MPI_File fh_c;
     int i, real_len;
@@ -142,58 +163,3 @@ void mpi_file_set_view_(MPI_Fint * fh, MPI_Offset * disp, MPI_Fint * etype,
 
     ADIOI_Free(newstr);
 }
-
-#else
-
-#ifdef _UNICOS
-void mpi_file_set_view_(MPI_Fint * fh, MPI_Offset * disp, MPI_Datatype * etype,
-                        MPI_Datatype * filetype, _fcd datarep_fcd, MPI_Fint * info, MPI_Fint * ierr)
-{
-    char *datarep = _fcdtocp(datarep_fcd);
-    int str_len = _fcdlen(datarep_fcd);
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_set_view_(MPI_Fint * fh, MPI_Offset * disp, MPI_Fint * etype,
-                                              MPI_Fint * filetype,
-                                              char *datarep FORT_MIXED_LEN_DECL, MPI_Fint * info,
-                                              MPI_Fint * ierr FORT_END_LEN_DECL);
-
-FORTRAN_API void FORT_CALL mpi_file_set_view_(MPI_Fint * fh, MPI_Offset * disp, MPI_Fint * etype,
-                                              MPI_Fint * filetype,
-                                              char *datarep FORT_MIXED_LEN(str_len),
-                                              MPI_Fint * info,
-                                              MPI_Fint * ierr FORT_END_LEN(str_len))
-{
-#endif
-    char *newstr;
-    MPI_File fh_c;
-    int i, real_len;
-    MPI_Info info_c;
-
-    info_c = MPI_Info_f2c(*info);
-
-    /* strip trailing blanks in datarep */
-    if (datarep <= (char *) 0) {
-        FPRINTF(stderr, "MPI_File_set_view: datarep is an invalid address\n");
-        MPI_Abort(MPI_COMM_WORLD, 1);
-    }
-    for (i = str_len - 1; i >= 0; i--)
-        if (datarep[i] != ' ')
-            break;
-    if (i < 0) {
-        FPRINTF(stderr, "MPI_File_set_view: datarep is a blank string\n");
-        MPI_Abort(MPI_COMM_WORLD, 1);
-    }
-    real_len = i + 1;
-
-    newstr = (char *) ADIOI_Malloc((real_len + 1) * sizeof(char));
-    ADIOI_Strncpy(newstr, datarep, real_len);
-    newstr[real_len] = '\0';
-
-    fh_c = MPI_File_f2c(*fh);
-
-    *ierr = MPI_File_set_view(fh_c, *disp, *etype, *filetype, newstr, info_c);
-
-    ADIOI_Free(newstr);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/wr_atallbf.c
+++ b/src/mpi/romio/mpi-io/fortran/wr_atallbf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_at_all_begin_(MPI_Fint *, MPI_O
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -99,15 +97,6 @@ void mpi_file_write_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_write_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                   MPI_Fint * count, MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_at_all_begin(fh_c, *offset, buf, *count, datatype_c);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset,
@@ -117,10 +106,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_at_all_begin_(MPI_Fint * fh, MPI_Offse
 FORTRAN_API void FORT_CALL mpi_file_write_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset,
                                                         void *buf, MPI_Fint * count,
                                                         MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_at_all_begin(fh_c, *offset, buf, *count, (MPI_Datatype) * datatype);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_at_all_begin(fh_c, *offset, buf, *count, datatype_c);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/wr_atallef.c
+++ b/src/mpi/romio/mpi-io/fortran/wr_atallef.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_at_all_end_(MPI_Fint *, void *,
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/write_allbf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_allbf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_all_begin_(MPI_Fint *, void *, 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -97,6 +95,13 @@ void mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                MPI_Fint * datatype, MPI_Fint * ierr);
 void mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                MPI_Fint * datatype, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                     MPI_Fint * datatype, MPI_Fint * ierr);
+FORTRAN_API void FORT_CALL mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                     MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -106,16 +111,3 @@ void mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_write_all_begin(fh_c, buf, *count, datatype_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                     MPI_Fint * datatype, MPI_Fint * ierr);
-FORTRAN_API void FORT_CALL mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                     MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_all_begin(fh_c, buf, *count, (MPI_Datatype) * datatype);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_allef.c
+++ b/src/mpi/romio/mpi-io/fortran/write_allef.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_all_end_(MPI_Fint *, void *, MP
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/write_allf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_allf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_all_(MPI_Fint *, void *, MPI_Fi
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_write_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_write_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                          MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_all(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_all_(MPI_Fint * fh, void *buf, MPI_Fin
 FORTRAN_API void FORT_CALL mpi_file_write_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                                MPI_Fint * datatype, MPI_Status * status,
                                                MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_all(fh_c, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_all(fh_c, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_atallf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_atallf.c
@@ -57,8 +57,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_at_all_(MPI_Fint *, MPI_Offset 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -104,15 +102,6 @@ void mpi_file_write_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 void mpi_file_write_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                             MPI_Fint * count, MPI_Fint * datatype,
                             MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_at_all(fh_c, *offset, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
@@ -122,10 +111,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_at_all_(MPI_Fint * fh, MPI_Offset * of
 FORTRAN_API void FORT_CALL mpi_file_write_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                                   MPI_Fint * count, MPI_Fint * datatype,
                                                   MPI_Status * status, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_at_all(fh_c, *offset, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_at_all(fh_c, *offset, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_atf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_atf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_at_(MPI_Fint *, MPI_Offset *, v
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -99,15 +97,6 @@ void mpi_file_write_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_write_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                         MPI_Fint * count, MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_at(fh_c, *offset, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
@@ -117,10 +106,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_at_(MPI_Fint * fh, MPI_Offset * offset
 FORTRAN_API void FORT_CALL mpi_file_write_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                               MPI_Fint * count, MPI_Fint * datatype,
                                               MPI_Status * status, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_at(fh_c, *offset, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_at(fh_c, *offset, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_ordbf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_ordbf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_ordered_begin_(MPI_Fint *, void
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,14 @@ void mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                    MPI_Fint * datatype, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                         MPI_Fint * datatype, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                         MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -107,17 +113,3 @@ void mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_write_ordered_begin(fh_c, buf, *count, datatype_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                         MPI_Fint * datatype, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                         MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_ordered_begin(fh_c, buf, *count, *datatype);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_ordef.c
+++ b/src/mpi/romio/mpi-io/fortran/write_ordef.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_ordered_end_(MPI_Fint *, void *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/write_ordf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_ordf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_ordered_(MPI_Fint *, void *, MP
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_write_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_write_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                              MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_ordered(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_ordered_(MPI_Fint * fh, void *buf, MPI
 FORTRAN_API void FORT_CALL mpi_file_write_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                                    MPI_Fint * datatype, MPI_Status * status,
                                                    MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_ordered(fh_c, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_ordered(fh_c, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_shf.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_shared_(MPI_Fint *, void *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_write_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_write_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                             MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_shared(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_shared_(MPI_Fint * fh, void *buf, MPI_
 FORTRAN_API void FORT_CALL mpi_file_write_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                                   MPI_Fint * datatype, MPI_Status * status,
                                                   MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_shared(fh_c, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_shared(fh_c, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/writef.c
+++ b/src/mpi/romio/mpi-io/fortran/writef.c
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_(MPI_Fint *, void *, MPI_Fint *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_write_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_write_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                      MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_(MPI_Fint * fh, void *buf, MPI_Fint * 
 FORTRAN_API void FORT_CALL mpi_file_write_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                            MPI_Fint * datatype, MPI_Status * status,
                                            MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write(fh_c, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write(fh_c, buf, *count, datatype_c, status);
 }
-#endif


### PR DESCRIPTION
## Pull Request Description
* This PR is for preparing ROMIO to be built stand alone
* Note in current MPICH and OpenMPI settings, if ROMIO is built
  embedded in MPICH or OpenMPI, ROMIO's Fortran binding is skipped.
* Fortran binding need not include header file mpioprof.h
* Use MPI_Fint data type for arguments in Fortran-to-C functions
* Use MPI f2c and c2f functions to convert MPI handles between C and
  Fortran

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
