### PR TITLE
ROMIO: Call function MPIR_Get_node_id only when build within MPICH

### DIFF
--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1593,6 +1593,12 @@ AC_MSG_NOTICE([setting CFLAGS to $CFLAGS])
 AC_MSG_NOTICE([setting USER_CFLAGS to $USER_CFLAGS])
 AC_MSG_NOTICE([setting USER_FFLAGS to $USER_FFLAGS])
 
+# check subroutines when ROMIO is built outside MPICH
+if test "$FROM_MPICH" = no ; then
+   AC_CHECK_FUNCS([MPIR_Get_node_id], [],
+                  [AC_SEARCH_LIBS([MPIR_Get_node_id], [mpi])])
+fi
+
 AC_SUBST(ARCH)
 AC_SUBST(FILE_SYSTEM)
 AC_SUBST(CC)

--- a/src/mpi/romio/mpi-io/mpir_cst_filesys.c
+++ b/src/mpi/romio/mpi-io/mpir_cst_filesys.c
@@ -13,6 +13,9 @@
 #include <dirent.h>
 #endif
 
+#if defined(ROMIO_INSIDE_MPICH) || defined(HAVE_MPIR_GET_NODE_ID)
+extern int MPIR_Get_node_id(MPI_Comm comm, int rank, int *id);
+
 static int comm_split_filesystem_exhaustive(MPI_Comm comm, int key,
                                             const char *dirname, MPI_Comm * newcomm)
 {
@@ -252,3 +255,4 @@ int MPIR_Comm_split_filesystem(MPI_Comm comm, int key, const char *dirname, MPI_
     }
     return mpi_errno;
 }
+#endif


### PR DESCRIPTION
## Pull Request Description
* This PR is for preparing ROMIO to be built stand alone
* Guard the calling to MPIR_Get_node_id() with ROMIO_INSIDE_MPICH, so
  MPIR_Get_node_id() is called only when ROMIO is built embedded in
  MPICH.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
