### PR TITLE
ROMIO: Always build subroutines with prefix MPIOI_File_

### DIFF
--- a/src/mpi/romio/mpi-io/read.c
+++ b/src/mpi/romio/mpi-io/read.c
@@ -225,4 +225,3 @@ int MPIOI_File_read(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read_all.c
+++ b/src/mpi/romio/mpi-io/read_all.c
@@ -116,8 +116,6 @@ int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype da
 }
 
 /* Note: MPIOI_File_read_all also used by MPI_File_read_at_all */
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_read_all(MPI_File fh,
                         MPI_Offset offset,
                         int file_ptr_type,
@@ -184,4 +182,3 @@ int MPIOI_File_read_all(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read_allb.c
+++ b/src/mpi/romio/mpi-io/read_allb.c
@@ -165,4 +165,3 @@ int MPIOI_File_read_all_begin(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read_alle.c
+++ b/src/mpi/romio/mpi-io/read_alle.c
@@ -47,8 +47,6 @@ int MPI_File_read_all_end(MPI_File fh, void *buf, MPI_Status * status)
     return error_code;
 }
 
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_read_all_end(MPI_File fh, void *buf, char *myname, MPI_Status * status)
 {
     int error_code = MPI_SUCCESS;
@@ -82,4 +80,3 @@ int MPIOI_File_read_all_end(MPI_File fh, void *buf, char *myname, MPI_Status * s
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write.c
+++ b/src/mpi/romio/mpi-io/write.c
@@ -224,4 +224,3 @@ int MPIOI_File_write(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write_all.c
+++ b/src/mpi/romio/mpi-io/write_all.c
@@ -178,4 +178,3 @@ int MPIOI_File_write_all(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write_allb.c
+++ b/src/mpi/romio/mpi-io/write_allb.c
@@ -160,4 +160,3 @@ int MPIOI_File_write_all_begin(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write_alle.c
+++ b/src/mpi/romio/mpi-io/write_alle.c
@@ -46,8 +46,6 @@ int MPI_File_write_all_end(MPI_File fh, ROMIO_CONST void *buf, MPI_Status * stat
     return error_code;
 }
 
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write_all_end(MPI_File fh, const void *buf, char *myname, MPI_Status * status)
 {
     int error_code;
@@ -86,4 +84,3 @@ int MPIOI_File_write_all_end(MPI_File fh, const void *buf, char *myname, MPI_Sta
 
     return error_code;
 }
-#endif


### PR DESCRIPTION
## Pull Request Description
* This PR is for preparing ROMIO to be built stand alone
* Subroutines with prefix MPIOI_File_ are used no matter
  MPIO_BUILD_PROFILING is defined or not

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
