### PR TITLE
ROMIO: Call MPIR_Comm_split_filesystem only when build within MPICH

### DIFF
--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -904,8 +904,10 @@ char *ADIOI_Strdup(const char *);
 #define ADIOI_Info_delete(info_,key_str_) \
     MPI_Info_delete((info_),((char*)key_str_))
 
+#ifdef ROMIO_INSIDE_MPICH
 /* the I/O related support for MPI_Comm_split_type */
 int MPIR_Comm_split_filesystem(MPI_Comm comm, int key, const char *dirname, MPI_Comm * newcomm);
+#endif
 
 /* Define attribute as empty if it has no definition */
 #ifndef ATTRIBUTE


### PR DESCRIPTION
## Pull Request Description
* This PR is for preparing ROMIO to be built stand alone
* Guard the calling to MPIR_Comm_split_filesystem() with
  ROMIO_INSIDE_MPICH, so MPIR_Comm_split_filesystem() is called only
  when ROMIO is built embedded in MPICH.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
