### PR TITLE
ROMIO: add --enable-fortran configure option

### DIFF
--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -72,6 +72,7 @@ AH_BOTTOM([
 dnl
 NOF77=0
 NOF90=0
+NOF08=0
 ARCH=""
 arch_IRIX=""
 MPI_IMPL=""
@@ -226,10 +227,6 @@ AC_ARG_ENABLE(aio,[
 ], disable_aio=no)
 AC_ARG_ENABLE(echo,
 [--enable-echo  - Turn on strong echoing. The default is enable=no.] ,set -x)
-AC_ARG_ENABLE(f77,
-[--enable-f77 - Turn on support for Fortran 77 (default)],,enable_f77=yes)
-AC_ARG_ENABLE(f90,
-[--enable-f90 - Turn on support for Fortran 90 (default)],,enable_f90=yes)
 AC_ARG_ENABLE(weak-symbols,
 [--enable-weak-symbols - Turn on support for weak symbols],,enable_weak_symbols=yes)
 AC_ARG_ENABLE(debug,
@@ -244,11 +241,46 @@ dnl
 AC_ARG_WITH(mpi, [
 --with-mpi=path   - Path to installation of MPI (headers, libs, etc)],,)
 dnl
+
+AC_ARG_ENABLE(fortran,
+    [AS_HELP_STRING([--disable-fortran],
+                    [Turn off support for Fortran. @<:@default: enabled@:>@])],
+    [enable_fortran=${enableval}], [enable_fortran=yes])
+AC_ARG_ENABLE(f77,
+    [AS_HELP_STRING([--disable-f77],
+                    [Turn off support for Fortran 77. @<:@default: enabled@:>@])],
+    [enable_f77=${enableval}], [enable_f77=yes])
+AC_ARG_ENABLE(f90,
+    [AS_HELP_STRING([--disable-f90],
+                    [Turn off support for Fortran 90. @<:@default: enabled@:>@])],
+    [enable_f90=${enableval}], [enable_f90=yes])
+AC_ARG_ENABLE(f08,
+    [AS_HELP_STRING([--disable-f08],
+                    [Turn off support for Fortran 2008. @<:@default: enabled@:>@])],
+    [enable_f08=${enableval}], [enable_f08=yes])
+
+if test "x$enable_fortran" = xno ; then
+   if test "x$enable_f77" = yes ; then
+      AC_MSG_WARN([disabling Fortran 77 due to the use of --disable-fortran])
+   fi
+   enable_f77=no
+   if test "x$enable_f90" = yes ; then
+      AC_MSG_WARN([disabling Fortran 90 due to the use of --disable-fortran])
+   fi
+   enable_f90=no
+   if test "x$enable_f08" = yes ; then
+      AC_MSG_WARN([disabling Fortran 2008 due to the use of --disable-fortran])
+   fi
+   enable_f08=no
+fi
 if test "$enable_f77" != "yes" ; then
    NOF77=1
 fi
 if test "$enable_f90" != "yes" ; then
    NOF90=1
+fi
+if test "$enable_f08" != "yes" ; then
+   NOF08=1
 fi
 if test "$enable_debug" = "yes" ; then
     DEBUG=yes
@@ -590,11 +622,11 @@ if test -n "$OFFSET_KIND" -a "A$MPI_OFFSET_KIND1" = "A!" ; then
   MPI_OFFSET_KIND2="        PARAMETER (MPI_OFFSET_KIND=$OFFSET_KIND)"
   MPI_OFFSET_KIND_VAL=$OFFSET_KIND
 else
- if test "$FORTRAN_MPI_OFFSET" = "integer*8" && test "A$MPI_OFFSET_KIND2" = "A!" && test $NOF77 = 0 && test $NOF90 = 0 ; then
+ if test "$FORTRAN_MPI_OFFSET" = "integer*8" && test "A$MPI_OFFSET_KIND2" = "A!" && test $NOF77 = 0 && (test $NOF90 = 0 || test $NOF08 = 0) ; then
    PAC_MPI_OFFSET_KIND
  fi
  #
-  if test "$FORTRAN_MPI_OFFSET" = "integer" && test "A$MPI_OFFSET_KIND2" = "A!" && test $NOF77 = 0 && test $NOF90 = 0 ; then
+  if test "$FORTRAN_MPI_OFFSET" = "integer" && test "A$MPI_OFFSET_KIND2" = "A!" && test $NOF77 = 0 && (test $NOF90 = 0 || test $NOF08 = 0) ; then
    PAC_MPI_OFFSET_KIND_4BYTE
   fi
 fi


### PR DESCRIPTION
## Pull Request Description
Note MPICH configure option --enable-fortran/--disable-fortran is
passed down to ROMIO.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
