### PR TITLE
ROMIO: remove include of mpiof.h in Fortran test programs

### DIFF
--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -184,9 +184,7 @@ MAKE=${MAKE:-"make"}
 # foll. needed for f77 test programs
 F77GETARG="call getarg(i,str)"
 F77IARGC="iargc()"
-F77MPIOINC=""
 FORTRAN_MPI_OFFSET=""
-MPIOF_H_INCLUDED=0
 MPI_OFFSET_KIND1="!"
 MPI_OFFSET_KIND2="!"
 TEST_CC=""
@@ -1299,9 +1297,6 @@ AC_CHECK_DECLS([pwrite])
 ####################################################################
 
 if test -n "$mpi_mpich"; then
-   if test -z "$arch_SX4" ; then
-      MPIOF_H_INCLUDED=1
-   fi
    if test "$FROM_MPICH" = no; then
       AC_DEFINE(NEEDS_MPI_TEST,1,[Define if mpi_test needed])
       AC_DEFINE(MPICH,1,[Define if using MPICH])
@@ -1575,12 +1570,6 @@ AC_SUBST(FILE_SYS_DIRS)
 CFLAGS="$CFLAGS -DHAVE_ROMIOCONF_H"
 #
 
-if test -n "$MPIOF_H_INCLUDED"; then
-   F77MPIOINC=""
-else
-   F77MPIOINC="include 'mpiof.h'"
-fi
-
 AC_MSG_NOTICE([setting SYSDEP_INC to $SYSDEP_INC])
 AC_SUBST(SYSDEP_INC)
 
@@ -1622,7 +1611,6 @@ AC_SUBST(TEST_LIBNAME)
 AC_SUBST(LL)
 AC_SUBST(F77GETARG)
 AC_SUBST(F77IARGC)
-AC_SUBST(F77MPIOINC)
 AC_SUBST(FORTRAN_MPI_OFFSET)
 AC_SUBST(FROM_MPICH)
 AC_SUBST(FROM_LAM)

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1327,8 +1327,8 @@ AC_SUBST(srcdir)
 AC_ARG_VAR([main_top_srcdir],[set by the MPICH configure to indicate the MPICH source root])
 AC_ARG_VAR([main_top_builddir],[set by the MPICH configure to indicate the MPICH build root])
 
-# The main_top_srcdir is the location of the source for the building
-# package.  This is used only as part of the MPICH build, including 
+# The master_top_srcdir is the location of the source for the building
+# package.  This is used only as part of the MPICH build, including
 # the documentation targets mandoc, htmldoc, and latexdoc
 if test -z "$main_top_srcdir" ; then
     if test "$FROM_MPICH" = yes ; then

--- a/src/mpi/romio/test/fcoll_test.f.in
+++ b/src/mpi/romio/test/fcoll_test.f.in
@@ -6,7 +6,6 @@
       implicit none
 
       include 'mpif.h'
-      @F77MPIOINC@
 
 !     Fortran equivalent of coll_test.c
 

--- a/src/mpi/romio/test/fcoll_test.f.in
+++ b/src/mpi/romio/test/fcoll_test.f.in
@@ -1,4 +1,4 @@
-!  
+!
 !     Copyright (C) by Argonne National Laboratory
 !         See COPYRIGHT in top-level directory
 !
@@ -10,7 +10,7 @@
 
 !     Fortran equivalent of coll_test.c
 
-      integer FILESIZE 
+      integer FILESIZE
       parameter (FILESIZE=32*32*32*4)
 
 !     A 32^3 array. For other array sizes, change FILESIZE above and
@@ -21,7 +21,7 @@
 !     back, and checks that the data read is correct.
 
 !     Note that the file access pattern is noncontiguous.
-   
+
       integer newtype, i, ndims, array_of_gsizes(3)
       integer order, intsize, nprocs, j, array_of_distribs(3)
       integer array_of_dargs(3), array_of_psizes(3)
@@ -37,7 +37,7 @@
       call MPI_COMM_SIZE(MPI_COMM_WORLD, nprocs, ierr)
       call MPI_COMM_RANK(MPI_COMM_WORLD, mynod, ierr)
 
-!     process 0 takes the file name as a command-line argument and 
+!     process 0 takes the file name as a command-line argument and
 !     broadcasts it to other processes
 
       if (mynod .eq. 0) then
@@ -59,14 +59,14 @@
          @F77GETARG@
          call MPI_BCAST(str, 1024, MPI_CHARACTER, 0,                    &
      &        MPI_COMM_WORLD, ierr)
-      else 
+      else
          call MPI_BCAST(str, 1024, MPI_CHARACTER, 0,                    &
      &        MPI_COMM_WORLD, ierr)
       end if
 
 
 !     create the distributed array filetype
-    
+
       ndims = 3
       order = MPI_ORDER_FORTRAN
 
@@ -94,12 +94,12 @@
 
       call MPI_TYPE_COMMIT(newtype, ierr)
 
-!     initialize writebuf 
+!     initialize writebuf
 
       call MPI_TYPE_SIZE(newtype, bufcount, ierr)
       call MPI_TYPE_SIZE(MPI_INTEGER, intsize, ierr)
       bufcount = bufcount/intsize
-      do i=1, bufcount 
+      do i=1, bufcount
          writebuf(i) = 1
       end do
 
@@ -130,7 +130,7 @@
       call MPI_FILE_OPEN(MPI_COMM_WORLD, str,                           &
      &     MPI_MODE_CREATE+MPI_MODE_RDWR, MPI_INFO_NULL, fh, ierr)
 
-      disp = 0 
+      disp = 0
       call MPI_FILE_SET_VIEW(fh, disp, MPI_INTEGER, newtype, "native",  &
      &     MPI_INFO_NULL, ierr)
       call MPI_FILE_WRITE_ALL(fh, writebuf, bufcount, MPI_INTEGER,      &
@@ -141,7 +141,7 @@
 
       call MPI_FILE_OPEN(MPI_COMM_WORLD, str,                           &
      &     MPI_MODE_CREATE+MPI_MODE_RDWR, MPI_INFO_NULL, fh, ierr)
- 
+
       call MPI_FILE_SET_VIEW(fh, disp, MPI_INTEGER, newtype, "native",  &
      &     MPI_INFO_NULL, ierr)
       call MPI_FILE_READ_ALL(fh, readbuf, bufcount, MPI_INTEGER,        &
@@ -159,7 +159,7 @@
 
       call MPI_TYPE_FREE(newtype, ierr)
       call MPI_Allreduce( errs, toterrs, 1, MPI_INTEGER, MPI_SUM,       &
-     $     MPI_COMM_WORLD, ierr )  
+     $     MPI_COMM_WORLD, ierr )
       if (mynod .eq. 0) then
         if( toterrs .gt. 0 ) then
            print *, 'Found ', toterrs, ' errors'

--- a/src/mpi/romio/test/fmisc.f.in
+++ b/src/mpi/romio/test/fmisc.f.in
@@ -6,7 +6,6 @@
       implicit none
 
       include 'mpif.h'
-      @F77MPIOINC@
 
 !     Fortran equivalent of misc.c
 !     tests various miscellaneous functions.

--- a/src/mpi/romio/test/fmisc.f.in
+++ b/src/mpi/romio/test/fmisc.f.in
@@ -26,7 +26,7 @@
       call MPI_INIT(ierr)
       call MPI_COMM_RANK(MPI_COMM_WORLD, mynod, ierr)
 
-!     process 0 takes the file name as a command-line argument and 
+!     process 0 takes the file name as a command-line argument and
 !     broadcasts it to other processes
 
       if (mynod .eq. 0) then
@@ -48,7 +48,7 @@
          @F77GETARG@
          call MPI_BCAST(str, 1024, MPI_CHARACTER, 0,                    &
      &        MPI_COMM_WORLD, ierr)
-      else 
+      else
          call MPI_BCAST(str, 1024, MPI_CHARACTER, 0,                    &
      &        MPI_COMM_WORLD, ierr)
       end if
@@ -94,7 +94,7 @@
       call MPI_TYPE_COMMIT(newtype, ierr)
 
       disp = 1000
-      call MPI_FILE_SET_VIEW(fh, disp, MPI_INTEGER, newtype, 'native',  & 
+      call MPI_FILE_SET_VIEW(fh, disp, MPI_INTEGER, newtype, 'native',  &
      &     MPI_INFO_NULL, ierr)
       if (mynod .eq. 0 .and. verbose) then
          print *, ' testing MPI_FILE_GET_VIEW'
@@ -113,7 +113,7 @@
       end if
       offset = 10
       call MPI_FILE_GET_BYTE_OFFSET(fh, offset, disp, ierr)
-      if (disp .ne. 1080) then 
+      if (disp .ne. 1080) then
          errs = errs + 1
          print *, 'byte offset = ', disp, ', should be 1080'
       end if
@@ -133,14 +133,14 @@
          errs = errs + 1
          print *, 'file size = ', filesize, ', should be 1060'
       end if
- 
+
       if (mynod .eq. 0 .and. verbose) then
          print *, ' seeking to eof and testing MPI_FILE_GET_POSITION'
       end if
       offset = 0
       call MPI_FILE_SEEK(fh, offset, MPI_SEEK_END, ierr)
       call MPI_FILE_GET_POSITION(fh, offset, ierr)
-      if (offset .ne. 10) then 
+      if (offset .ne. 10) then
          errs = errs + 1
          print *, 'file pointer posn = ', offset, ', should be 10'
       end if
@@ -162,7 +162,7 @@
       call MPI_FILE_SEEK(fh, offset, MPI_SEEK_CUR, ierr)
       call MPI_FILE_GET_POSITION(fh, offset, ierr)
       call MPI_FILE_GET_BYTE_OFFSET(fh, offset, disp, ierr)
-      if (disp .ne. 1000) then 
+      if (disp .ne. 1000) then
          errs = errs + 1
          print *, 'file pointer posn in bytes = ', disp,                &
      &     ', should be 1000'
@@ -185,7 +185,7 @@
       end if
 
       call MPI_Allreduce( errs, toterrs, 1, MPI_INTEGER, MPI_SUM,       &
-     $     MPI_COMM_WORLD, ierr )  
+     $     MPI_COMM_WORLD, ierr )
       if (mynod .eq. 0) then
         if( toterrs .gt. 0 ) then
            print *, 'Found ', toterrs, ' errors'
@@ -194,8 +194,8 @@
         endif
       endif
 
-      call MPI_TYPE_FREE(newtype, ierr)    
-      call MPI_TYPE_FREE(filetype, ierr)    
+      call MPI_TYPE_FREE(newtype, ierr)
+      call MPI_TYPE_FREE(filetype, ierr)
       call MPI_GROUP_FREE(group, ierr)
       call MPI_FINALIZE(ierr)
 

--- a/src/mpi/romio/test/fperf.f.in
+++ b/src/mpi/romio/test/fperf.f.in
@@ -6,7 +6,6 @@
       implicit none
 
       include 'mpif.h'
-      @F77MPIOINC@
 
 !     Fortran equivalent of perf.c
 

--- a/src/mpi/romio/test/fperf.f.in
+++ b/src/mpi/romio/test/fperf.f.in
@@ -10,7 +10,7 @@
 
 !     Fortran equivalent of perf.c
 
-      integer SIZE 
+      integer SIZE
       parameter (SIZE=1048576*4)
 !     read/write size per node in bytes
 
@@ -30,7 +30,7 @@
       call MPI_COMM_SIZE(MPI_COMM_WORLD, nprocs, ierr)
       call MPI_COMM_RANK(MPI_COMM_WORLD, mynod, ierr)
 
-!     process 0 takes the file name as a command-line argument and 
+!     process 0 takes the file name as a command-line argument and
 !     broadcasts it to other processes
 
       if (mynod .eq. 0) then
@@ -50,11 +50,11 @@
 
          i = i + 1
          @F77GETARG@
-         call MPI_BCAST(str, 1024, MPI_CHARACTER, 0,                    &  
+         call MPI_BCAST(str, 1024, MPI_CHARACTER, 0,                    &
      &        MPI_COMM_WORLD, ierr)
          print *, 'Access size per process = ', SIZE, ' bytes',         &
      &        ', ntimes = ', ntimes
-      else 
+      else
          call MPI_BCAST(str, 1024, MPI_CHARACTER, 0,                    &
      &        MPI_COMM_WORLD, ierr)
       end if
@@ -71,7 +71,7 @@
          stim = MPI_WTIME()
          call MPI_FILE_WRITE(fh, buf, SIZE, MPI_BYTE, status, ierr)
          write_tim = MPI_WTIME() - stim
-  
+
          call MPI_FILE_CLOSE(fh, ierr)
 
          call MPI_BARRIER(MPI_COMM_WORLD, ierr)
@@ -85,7 +85,7 @@
          stim = MPI_WTIME()
          call MPI_FILE_READ(fh, buf, SIZE, MPI_BYTE, status, ierr)
          read_tim = MPI_WTIME() - stim
-  
+
          call MPI_FILE_CLOSE(fh, ierr)
 
          call MPI_ALLREDUCE(write_tim, new_write_tim, 1,                &
@@ -100,7 +100,7 @@
             min_write_tim = new_write_tim
          end if
       end do
-    
+
       if (mynod .eq. 0) then
          read_bw = (SIZE*nprocs*1.0D0)/(min_read_tim*1000000.0D0)
          write_bw = (SIZE*nprocs*1.0D0)/(min_write_tim*1000000.0D0)
@@ -108,14 +108,14 @@
      &        write_bw, ' Mbytes/sec'
          print *, 'Read bandwidth without prior file sync = ',          &
      &        read_bw, ' Mbytes/sec'
-      end if 
+      end if
 
       min_read_tim = 10000000.0D0
       min_write_tim = 10000000.0D0
 
       flag = 0
       do j=1, ntimes
-         call MPI_FILE_OPEN(MPI_COMM_WORLD, str,                        & 
+         call MPI_FILE_OPEN(MPI_COMM_WORLD, str,                        &
      &        MPI_MODE_CREATE+MPI_MODE_RDWR, MPI_INFO_NULL, fh, ierr)
 
          call MPI_FILE_SEEK(fh, offset, MPI_SEEK_SET, ierr)
@@ -125,15 +125,15 @@
          call MPI_FILE_WRITE(fh, buf, SIZE, MPI_BYTE, status, ierr)
          call MPI_FILE_SYNC(fh, ierr)
          write_tim = MPI_WTIME() - stim
-         if (ierr .eq. MPI_ERR_UNKNOWN) then 
+         if (ierr .eq. MPI_ERR_UNKNOWN) then
             flag = 1
          end if
-  
+
          call MPI_FILE_CLOSE(fh, ierr)
 
          call MPI_BARRIER(MPI_COMM_WORLD, ierr)
 
-         call MPI_FILE_OPEN(MPI_COMM_WORLD, str,                        & 
+         call MPI_FILE_OPEN(MPI_COMM_WORLD, str,                        &
      &        MPI_MODE_CREATE+MPI_MODE_RDWR, MPI_INFO_NULL, fh, ierr)
 
          call MPI_FILE_SEEK(fh, offset, MPI_SEEK_SET, ierr)
@@ -142,7 +142,7 @@
          stim = MPI_WTIME()
          call MPI_FILE_READ(fh, buf, SIZE, MPI_BYTE, status, ierr)
          read_tim = MPI_WTIME() - stim
-  
+
          call MPI_FILE_CLOSE(fh, ierr)
 
          call MPI_ALLREDUCE(write_tim, new_write_tim, 1,                &
@@ -158,18 +158,18 @@
          end if
 
       end do
-    
+
       if (mynod .eq. 0) then
          if (flag .eq. 1) then
             print *, 'MPI_FILE_SYNC returns error.'
          else
             read_bw = (SIZE*nprocs*1.0D0)/(min_read_tim*1000000.0D0)
             write_bw = (SIZE*nprocs*1.0D0)/(min_write_tim*1000000.0D0)
-            print *, 'Write bandwidth including file sync = ',          & 
+            print *, 'Write bandwidth including file sync = ',          &
      &           write_bw, ' Mbytes/sec'
             print *, 'Read bandwidth after file sync = ',               &
      &           read_bw, ' Mbytes/sec'
-         end if 
+         end if
       end if
 
       call MPI_FINALIZE(ierr)

--- a/src/mpi/romio/test/pfcoll_test.f.in
+++ b/src/mpi/romio/test/pfcoll_test.f.in
@@ -6,7 +6,6 @@
       implicit none
 
       include 'mpif.h'
-      @F77MPIOINC@
 
 !     This is the same as fcoll_test.f, but uses the PMPI versions
 !     of all functions in order to test the profiling interface.

--- a/src/mpi/romio/test/pfcoll_test.f.in
+++ b/src/mpi/romio/test/pfcoll_test.f.in
@@ -11,7 +11,7 @@
 !     This is the same as fcoll_test.f, but uses the PMPI versions
 !     of all functions in order to test the profiling interface.
 
-      integer FILESIZE 
+      integer FILESIZE
       parameter (FILESIZE=32*32*32*4)
 
 !     A 32^3 array. For other array sizes, change FILESIZE above and
@@ -22,7 +22,7 @@
 !     back, and checks that the data read is correct.
 
 !     Note that the file access pattern is noncontiguous.
-   
+
       integer newtype, i, ndims, array_of_gsizes(3)
       integer order, intsize, nprocs, j, array_of_distribs(3)
       integer array_of_dargs(3), array_of_psizes(3)
@@ -38,7 +38,7 @@
       call PMPI_COMM_SIZE(MPI_COMM_WORLD, nprocs, ierr)
       call PMPI_COMM_RANK(MPI_COMM_WORLD, mynod, ierr)
 
-!     process 0 takes the file name as a command-line argument and 
+!     process 0 takes the file name as a command-line argument and
 !     broadcasts it to other processes
 
       if (mynod .eq. 0) then
@@ -60,14 +60,14 @@
          @F77GETARG@
          call PMPI_BCAST(str, 1024, MPI_CHARACTER, 0,                   &
      &        MPI_COMM_WORLD, ierr)
-      else 
+      else
          call PMPI_BCAST(str, 1024, MPI_CHARACTER, 0,                   &
      &        MPI_COMM_WORLD, ierr)
       end if
 
 
 !     create the distributed array filetype
-    
+
       ndims = 3
       order = MPI_ORDER_FORTRAN
 
@@ -95,12 +95,12 @@
 
       call PMPI_TYPE_COMMIT(newtype, ierr)
 
-!     initialize writebuf 
+!     initialize writebuf
 
       call PMPI_TYPE_SIZE(newtype, bufcount, ierr)
       call PMPI_TYPE_SIZE(MPI_INTEGER, intsize, ierr)
       bufcount = bufcount/intsize
-      do i=1, bufcount 
+      do i=1, bufcount
          writebuf(i) = 1
       end do
 
@@ -131,7 +131,7 @@
       call PMPI_FILE_OPEN(MPI_COMM_WORLD, str,                          &
      &     MPI_MODE_CREATE+MPI_MODE_RDWR, MPI_INFO_NULL, fh, ierr)
 
-      disp = 0 
+      disp = 0
       call PMPI_FILE_SET_VIEW(fh, disp, MPI_INTEGER, newtype, "native", &
      &     MPI_INFO_NULL, ierr)
       call PMPI_FILE_WRITE_ALL(fh, writebuf, bufcount, MPI_INTEGER,     &
@@ -142,7 +142,7 @@
 
       call PMPI_FILE_OPEN(MPI_COMM_WORLD, str,                          &
      &     MPI_MODE_CREATE+MPI_MODE_RDWR, MPI_INFO_NULL, fh, ierr)
- 
+
       call PMPI_FILE_SET_VIEW(fh, disp, MPI_INTEGER, newtype, "native", &
      &     MPI_INFO_NULL, ierr)
       call PMPI_FILE_READ_ALL(fh, readbuf, bufcount, MPI_INTEGER,       &
@@ -160,7 +160,7 @@
 
       call PMPI_TYPE_FREE(newtype, ierr)
       call MPI_Allreduce( errs, toterrs, 1, MPI_INTEGER, MPI_SUM,       &
-     $     MPI_COMM_WORLD, ierr )  
+     $     MPI_COMM_WORLD, ierr )
       if (mynod .eq. 0) then
         if( toterrs .gt. 0 ) then
            print *, 'Found ', toterrs, ' errors'


### PR DESCRIPTION
## Pull Request Description
Header file mpiof.h is obsolete. Remove use of F77MPIOINC.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
