### PR TITLE
ipc noncontig p2p

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am.h
+++ b/src/mpid/ch4/generic/am/mpidig_am.h
@@ -58,6 +58,10 @@ enum {
 
     MPIDI_OFI_INTERNAL_HANDLER_CONTROL,
 
+    /* IPC datatype handle id */
+    MPIDIG_IPC_DATATYPE_REQ,
+    MPIDIG_IPC_DATATYPE_ACK,
+
     MPIDIG_HANDLER_STATIC_MAX
 };
 

--- a/src/mpid/ch4/generic/am/mpidig_am_init.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_init.c
@@ -156,6 +156,8 @@ int MPIDIG_am_init(void)
     MPIDIG_am_reg_cb(MPIDIG_SEND_LONG_ACK, NULL, &MPIDIG_send_long_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_SEND_LONG_LMT,
                      &MPIDIG_send_long_lmt_origin_cb, &MPIDIG_send_long_lmt_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_IPC_DATATYPE_REQ, NULL, &MPIDIG_send_ipc_datatype_req_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_IPC_DATATYPE_ACK, NULL, &MPIDIG_send_ipc_datatype_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_SSEND_REQ, &MPIDIG_send_origin_cb, &MPIDIG_ssend_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_SSEND_ACK,
                      &MPIDIG_ssend_ack_origin_cb, &MPIDIG_ssend_ack_target_msg_cb);

--- a/src/mpid/ch4/shm/ipc/src/Makefile.mk
+++ b/src/mpid/ch4/shm/ipc/src/Makefile.mk
@@ -13,6 +13,7 @@ noinst_HEADERS += src/mpid/ch4/shm/ipc/src/shm_inline.h    \
                   src/mpid/ch4/shm/ipc/src/ipc_mem.h       \
                   src/mpid/ch4/shm/ipc/src/ipc_p2p.h       \
                   src/mpid/ch4/shm/ipc/src/ipc_types.h     \
+                  src/mpid/ch4/shm/ipc/src/ipc_am.h        \
                   src/mpid/ch4/shm/ipc/src/ipc_pre.h
 
 mpi_core_sources += src/mpid/ch4/shm/ipc/src/globals.c     \

--- a/src/mpid/ch4/shm/ipc/src/ipc_am.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_am.h
@@ -11,6 +11,7 @@
 MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_am_recv_rdma_read(void *lmt_msg, size_t recv_data_sz,
                                                          MPIR_Request * rreq)
 {
+    void *flattened_type;
     MPIDI_IPC_ctrl_send_lmt_rts_t *slmt_rts_hdr = (MPIDI_IPC_ctrl_send_lmt_rts_t *) lmt_msg;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPC_AM_RECV_RDMA);
@@ -20,10 +21,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_am_recv_rdma_read(void *lmt_msg, size_t r
     MPIDIG_REQUEST(rreq, tag) = slmt_rts_hdr->tag;
     MPIDIG_REQUEST(rreq, context_id) = slmt_rts_hdr->context_id;
 
+    if (slmt_rts_hdr->flattened_type_size > 0) {
+        flattened_type = slmt_rts_hdr->flattened_type;
+    } else {
+        flattened_type = NULL;
+    }
+
     /* Complete IPC receive */
     mpi_errno = MPIDI_IPCI_handle_lmt_recv(slmt_rts_hdr->ipc_type,
                                            slmt_rts_hdr->ipc_handle,
-                                           slmt_rts_hdr->data_sz, slmt_rts_hdr->sreq_ptr, rreq);
+                                           slmt_rts_hdr->data_sz, slmt_rts_hdr->sreq_ptr,
+                                           flattened_type, rreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPC_AM_RECV_RDMA);
     return mpi_errno;

--- a/src/mpid/ch4/shm/ipc/src/ipc_am.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_am.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef IPC_AM_H_INCLUDED
+#define IPC_AM_H_INCLUDED
+
+#include "ipc_p2p.h"
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_am_recv_rdma_read(void *lmt_msg, size_t recv_data_sz,
+                                                         MPIR_Request * rreq)
+{
+    MPIDI_IPC_ctrl_send_lmt_rts_t *slmt_rts_hdr = (MPIDI_IPC_ctrl_send_lmt_rts_t *) lmt_msg;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPC_AM_RECV_RDMA);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPC_AM_RECV_RDMA);
+
+    MPIDIG_REQUEST(rreq, rank) = slmt_rts_hdr->src_rank;
+    MPIDIG_REQUEST(rreq, tag) = slmt_rts_hdr->tag;
+    MPIDIG_REQUEST(rreq, context_id) = slmt_rts_hdr->context_id;
+
+    /* Complete IPC receive */
+    mpi_errno = MPIDI_IPCI_handle_lmt_recv(slmt_rts_hdr->ipc_type,
+                                           slmt_rts_hdr->ipc_handle,
+                                           slmt_rts_hdr->data_sz, slmt_rts_hdr->sreq_ptr, rreq);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPC_AM_RECV_RDMA);
+    return mpi_errno;
+}
+
+#endif /* IPC_AM_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/src/ipc_control.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.c
@@ -9,13 +9,13 @@
 #include "ipc_recv.h"
 #include "ipc_control.h"
 
-int MPIDI_IPCI_send_contig_lmt_fin_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
+int MPIDI_IPCI_send_lmt_fin_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *sreq = ctrl_hdr->ipc_contig_slmt_fin.req_ptr;
+    MPIR_Request *sreq = ctrl_hdr->ipc_slmt_fin.req_ptr;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT_FIN_CB);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT_FIN_CB);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_SEND_LMT_FIN_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_SEND_LMT_FIN_CB);
 
     IPC_TRACE("send_contig_lmt_fin_cb: complete sreq %p\n", sreq);
 
@@ -23,20 +23,20 @@ int MPIDI_IPCI_send_contig_lmt_fin_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
     MPID_Request_complete(sreq);
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT_FIN_CB);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_SEND_LMT_FIN_CB);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-int MPIDI_IPCI_send_contig_lmt_rts_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
+int MPIDI_IPCI_send_lmt_rts_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIDI_IPC_ctrl_send_contig_lmt_rts_t *slmt_rts_hdr = &ctrl_hdr->ipc_contig_slmt_rts;
+    MPIDI_IPC_ctrl_send_lmt_rts_t *slmt_rts_hdr = &ctrl_hdr->ipc_slmt_rts;
     MPIR_Request *rreq = NULL;
     MPIR_Comm *root_comm;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT_RTS_CB);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT_RTS_CB);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_SEND_LMT_RTS_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_SEND_LMT_RTS_CB);
 
     IPC_TRACE("send_contig_lmt_rts_cb: received data_sz 0x%" PRIu64 ", sreq_ptr 0x%p, "
               "src_lrank %d, match info[src_rank %d, tag %d, context_id 0x%x]\n",
@@ -117,7 +117,7 @@ int MPIDI_IPCI_send_contig_lmt_rts_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
     }
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT_RTS_CB);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_SEND_LMT_RTS_CB);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/shm/ipc/src/ipc_control.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.h
@@ -8,7 +8,7 @@
 
 #include "shm_types.h"
 
-int MPIDI_IPCI_send_contig_lmt_rts_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr);
-int MPIDI_IPCI_send_contig_lmt_fin_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr);
+int MPIDI_IPCI_send_lmt_rts_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr);
+int MPIDI_IPCI_send_lmt_fin_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr);
 
 #endif /* IPC_CONTROL_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/src/ipc_init.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_init.c
@@ -11,8 +11,8 @@
 
 static void register_shm_ctrl_cb(void)
 {
-    MPIDI_SHMI_ctrl_reg_cb(MPIDI_IPC_SEND_CONTIG_LMT_RTS, &MPIDI_IPCI_send_contig_lmt_rts_cb);
-    MPIDI_SHMI_ctrl_reg_cb(MPIDI_IPC_SEND_CONTIG_LMT_FIN, &MPIDI_IPCI_send_contig_lmt_fin_cb);
+    MPIDI_SHMI_ctrl_reg_cb(MPIDI_IPC_SEND_LMT_RTS, &MPIDI_IPCI_send_lmt_rts_cb);
+    MPIDI_SHMI_ctrl_reg_cb(MPIDI_IPC_SEND_LMT_FIN, &MPIDI_IPCI_send_lmt_fin_cb);
 }
 
 int MPIDI_IPC_mpi_init_hook(int rank, int size, int *tag_bits)

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -34,11 +34,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
-    MPIDI_SHMI_ctrl_hdr_t ctrl_hdr;
-    MPIDI_IPC_ctrl_send_lmt_rts_t *slmt_req_hdr = &ctrl_hdr.ipc_slmt_rts;
+    MPIDI_SHMI_ctrl_hdr_t *ctrl_hdr;
+    MPIDI_IPC_ctrl_send_lmt_rts_t *slmt_req_hdr;
+    int flattened_type_size, ctrl_hdr_size, dt_contig;
+    void *flattened_type_ptr;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_SEND_LMT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_SEND_LMT);
+
+    MPIDI_Datatype_check_contig(datatype, dt_contig);
+
+    /* Allocate full memory for control header */
+    if (!MPIR_DATATYPE_IS_PREDEFINED(datatype) && !dt_contig) {
+        MPIR_Datatype_get_flattened(datatype, &flattened_type_ptr, &flattened_type_size);
+    } else {
+        flattened_type_size = 0;
+    }
+
+    ctrl_hdr_size = sizeof(MPIDI_SHMI_ctrl_hdr_t) + flattened_type_size;
+    ctrl_hdr = (MPIDI_SHMI_ctrl_hdr_t *) MPL_malloc(ctrl_hdr_size, MPL_MEM_OTHER);
+    MPIR_Assert(ctrl_hdr);
+
+    slmt_req_hdr = &ctrl_hdr->ipc_slmt_rts;
+    slmt_req_hdr->flattened_type_size = flattened_type_size;
+    if (flattened_type_size)
+        memcpy(slmt_req_hdr->flattened_type, flattened_type_ptr, flattened_type_size);
 
     /* Create send request */
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -74,11 +94,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count
               slmt_req_hdr->context_id);
 
     mpi_errno =
-        MPIDI_SHM_do_ctrl_send(rank, comm, MPIDIG_IPC_DATATYPE_REQ, sizeof(MPIDI_SHMI_ctrl_hdr_t),
-                               &ctrl_hdr, sreq);
+        MPIDI_SHM_do_ctrl_send(rank, comm, MPIDIG_IPC_DATATYPE_REQ, ctrl_hdr_size, &ctrl_hdr, sreq);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
+    MPL_free(ctrl_hdr);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_SEND_LMT);
     return mpi_errno;
   fn_fail:
@@ -95,17 +115,41 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
                                                         MPIDI_IPCI_ipc_handle_t ipc_handle,
                                                         size_t src_data_sz,
                                                         MPIR_Request * sreq_ptr,
-                                                        MPIR_Request * rreq)
+                                                        void *flattened_type, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    void *src_buf = NULL;
+    void *src_buf = NULL, *copy_src_buf;
     uintptr_t data_sz, recv_data_sz;
     MPIDI_SHMI_ctrl_hdr_t ack_ctrl_hdr;
+    MPI_Datatype src_datatype;
+    MPIR_Datatype *src_datatype_ptr;
+    int src_dt_contig, dest_dt_contig, src_true_lb, dest_true_lb;
+    uintptr_t src_dt_size, src_count;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_HANDLE_LMT_RECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_HANDLE_LMT_RECV);
 
-    MPIDI_Datatype_check_size(MPIDIG_REQUEST(rreq, datatype), MPIDIG_REQUEST(rreq, count), data_sz);
+    MPIDI_Datatype_check_contig_size_lb(MPIDIG_REQUEST(rreq, datatype), MPIDIG_REQUEST(rreq, count),
+                                        dest_dt_contig, data_sz, dest_true_lb);
+
+    /* recover src datatype */
+    if (flattened_type) {
+        src_datatype_ptr = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
+        MPIR_Assert(src_datatype_ptr);
+
+        MPIR_Object_set_ref(src_datatype_ptr, 1);
+        MPIR_Typerep_unflatten(src_datatype_ptr, flattened_type);
+        src_datatype = src_datatype_ptr->handle;
+        MPIDI_Datatype_check_contig_size_lb(src_datatype, 1, src_dt_contig, src_dt_size,
+                                            src_true_lb);
+        src_count = src_data_sz / src_dt_size;
+    } else {
+        src_datatype_ptr = NULL;
+        src_datatype = MPI_BYTE;
+        src_dt_contig = 1;
+        src_count = src_data_sz;
+        src_true_lb = 0;
+    }
 
     /* Data truncation checking */
     recv_data_sz = MPL_MIN(src_data_sz, data_sz);
@@ -147,10 +191,60 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
 
     /* Copy data to receive buffer */
     MPI_Aint actual_unpack_bytes;
-    mpi_errno = MPIR_Typerep_unpack((const void *) src_buf, src_data_sz,
-                                    (char *) MPIDIG_REQUEST(rreq, buffer), recv_data_sz,
-                                    MPIDIG_REQUEST(rreq, datatype), 0, &actual_unpack_bytes);
-    MPIR_ERR_CHECK(mpi_errno);
+    MPI_Aint actual_pack_bytes;
+
+    copy_src_buf = (void *) ((uintptr_t) src_buf - src_true_lb);
+    if (!src_dt_contig && dest_dt_contig) {
+        /* source datatype is non-contiguous and destination datatype is contiguous */
+        mpi_errno = MPIR_Typerep_pack(copy_src_buf, src_count, src_datatype,
+                                      0,
+                                      (void *) ((char *) MPIDIG_REQUEST(rreq, buffer) +
+                                                dest_true_lb), recv_data_sz, &actual_pack_bytes);
+        MPIR_ERR_CHECK(mpi_errno);
+        MPIR_Assert(actual_pack_bytes <= recv_data_sz);
+    } else if (src_dt_contig) {
+        /* source datatype is contiguous */
+        mpi_errno =
+            MPIR_Typerep_unpack(((char *) copy_src_buf + src_true_lb),
+                                src_data_sz, MPIDIG_REQUEST(rreq, buffer), MPIDIG_REQUEST(rreq,
+                                                                                          count),
+                                MPIDIG_REQUEST(rreq, datatype), 0, &actual_unpack_bytes);
+        MPIR_ERR_CHECK(mpi_errno);
+        MPIR_Assert(actual_unpack_bytes <= recv_data_sz);
+    } else {
+        /* both datatype are non-contiguous */
+        void *tmp_buf;
+        bool host_buf;
+        int mpl_err;
+
+        if (ipc_type == MPIDI_IPCI_TYPE__XPMEM || attr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
+            attr.type == MPL_GPU_POINTER_REGISTERED_HOST) {
+            tmp_buf = MPL_malloc(recv_data_sz, MPL_MEM_OTHER);
+            host_buf = true;
+        } else {
+            /* both src and dest buffer are on GPU, so tmp buffer should be allocated on GPU as well */
+            mpl_err = MPL_gpu_malloc(&tmp_buf, recv_data_sz, attr.device);
+            MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**nomem");
+            host_buf = false;
+        }
+
+        mpi_errno = MPIR_Typerep_pack(copy_src_buf, src_count, src_datatype,
+                                      0, tmp_buf, recv_data_sz, &actual_pack_bytes);
+        MPIR_ERR_CHECK(mpi_errno);
+        MPIR_Assert(actual_pack_bytes <= recv_data_sz);
+
+        mpi_errno = MPIR_Typerep_unpack(tmp_buf, actual_pack_bytes,
+                                        MPIDIG_REQUEST(rreq, buffer), MPIDIG_REQUEST(rreq, count),
+                                        MPIDIG_REQUEST(rreq, datatype), 0, &actual_unpack_bytes);
+        MPIR_ERR_CHECK(mpi_errno);
+        MPIR_Assert(actual_unpack_bytes <= recv_data_sz);
+
+        if (host_buf) {
+            MPL_free(tmp_buf);
+        } else {
+            MPL_gpu_free(tmp_buf);
+        }
+    }
 
     mpi_errno = MPIDI_IPCI_handle_unmap(ipc_type, src_buf, ipc_handle);
     MPIR_ERR_CHECK(mpi_errno);
@@ -165,6 +259,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
     MPID_Request_complete(rreq);
+
+    if (src_datatype_ptr)
+        MPIR_Datatype_ptr_release(src_datatype_ptr);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_HANDLE_LMT_RECV);

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -24,20 +24,20 @@
  * to the receiver. The receiver will then open the remote memory handle
  * and perform direct data transfer.
  */
-MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Aint count,
-                                                        MPI_Datatype datatype, uintptr_t data_sz,
-                                                        int rank, int tag, MPIR_Comm * comm,
-                                                        int context_offset, MPIDI_av_entry_t * addr,
-                                                        MPIDI_IPCI_ipc_attr_t ipc_attr,
-                                                        MPIR_Request ** request)
+MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count,
+                                                 MPI_Datatype datatype, uintptr_t data_sz,
+                                                 int rank, int tag, MPIR_Comm * comm,
+                                                 int context_offset, MPIDI_av_entry_t * addr,
+                                                 MPIDI_IPCI_ipc_attr_t ipc_attr,
+                                                 MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
     MPIDI_SHMI_ctrl_hdr_t ctrl_hdr;
-    MPIDI_IPC_ctrl_send_contig_lmt_rts_t *slmt_req_hdr = &ctrl_hdr.ipc_contig_slmt_rts;
+    MPIDI_IPC_ctrl_send_lmt_rts_t *slmt_req_hdr = &ctrl_hdr.ipc_slmt_rts;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_SEND_LMT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPCI_SEND_LMT);
 
     /* Create send request */
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -68,15 +68,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
 
     IPC_TRACE("send_contig_lmt: shm ctrl_id %d, data_sz 0x%" PRIu64 ", sreq_ptr 0x%p, "
               "src_lrank %d, match info[dest %d, src_rank %d, tag %d, context_id 0x%x]\n",
-              MPIDI_IPC_SEND_CONTIG_LMT_RTS, slmt_req_hdr->data_sz, slmt_req_hdr->sreq_ptr,
+              MPIDI_IPC_SEND_LMT_RTS, slmt_req_hdr->data_sz, slmt_req_hdr->sreq_ptr,
               slmt_req_hdr->src_lrank, rank, slmt_req_hdr->src_rank, slmt_req_hdr->tag,
               slmt_req_hdr->context_id);
 
-    mpi_errno = MPIDI_SHM_do_ctrl_send(rank, comm, MPIDI_IPC_SEND_CONTIG_LMT_RTS, &ctrl_hdr);
+    mpi_errno = MPIDI_SHM_do_ctrl_send(rank, comm, MPIDI_IPC_SEND_LMT_RTS, &ctrl_hdr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_SEND_CONTIG_LMT);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPCI_SEND_LMT);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -152,12 +152,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
     mpi_errno = MPIDI_IPCI_handle_unmap(ipc_type, src_buf, ipc_handle);
     MPIR_ERR_CHECK(mpi_errno);
 
-    ack_ctrl_hdr.ipc_contig_slmt_fin.ipc_type = ipc_type;
-    ack_ctrl_hdr.ipc_contig_slmt_fin.req_ptr = sreq_ptr;
+    ack_ctrl_hdr.ipc_slmt_fin.ipc_type = ipc_type;
+    ack_ctrl_hdr.ipc_slmt_fin.req_ptr = sreq_ptr;
     mpi_errno = MPIDI_SHM_do_ctrl_send(MPIDIG_REQUEST(rreq, rank),
                                        MPIDIG_context_id_to_comm(MPIDIG_REQUEST
                                                                  (rreq, context_id)),
-                                       MPIDI_IPC_SEND_CONTIG_LMT_FIN, &ack_ctrl_hdr);
+                                       MPIDI_IPC_SEND_LMT_FIN, &ack_ctrl_hdr);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -12,6 +12,7 @@
 #include "ipc_pre.h"
 #include "ipc_types.h"
 #include "ipc_mem.h"
+#include "../posix/posix_am.h"
 
 /* Generic IPC protocols for P2P. */
 
@@ -72,7 +73,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count
               slmt_req_hdr->src_lrank, rank, slmt_req_hdr->src_rank, slmt_req_hdr->tag,
               slmt_req_hdr->context_id);
 
-    mpi_errno = MPIDI_SHM_do_ctrl_send(rank, comm, MPIDI_IPC_SEND_LMT_RTS, &ctrl_hdr);
+    mpi_errno =
+        MPIDI_SHM_do_ctrl_send(rank, comm, MPIDIG_IPC_DATATYPE_REQ, sizeof(MPIDI_SHMI_ctrl_hdr_t),
+                               &ctrl_hdr, sreq);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/shm/ipc/src/ipc_pre.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_pre.h
@@ -16,6 +16,7 @@ typedef struct MPIDI_IPC_am_unexp_rreq {
     uint64_t data_sz;
     MPIR_Request *sreq_ptr;
     int src_lrank;
+    void *flattened_type;
 } MPIDI_IPC_am_unexp_rreq_t;
 
 typedef struct MPIDI_IPC_am_request {
@@ -42,6 +43,10 @@ typedef struct MPIDI_IPC_ctrl_send_lmt_rts {
     int src_rank;
     int tag;
     MPIR_Context_id_t context_id;
+
+    /* flatten type */
+    int flattened_type_size;
+    uint8_t flattened_type[];
 } MPIDI_IPC_ctrl_send_lmt_rts_t;
 
 typedef struct MPIDI_IPC_ctrl_send_lmt_fin {

--- a/src/mpid/ch4/shm/ipc/src/ipc_pre.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_pre.h
@@ -27,7 +27,7 @@ typedef struct MPIDI_IPC_am_request {
 } MPIDI_IPC_am_request_t;
 
 /* ctrl packet header types */
-typedef struct MPIDI_IPC_ctrl_send_contig_lmt_rts {
+typedef struct MPIDI_IPC_ctrl_send_lmt_rts {
     MPIDI_IPCI_type_t ipc_type;
     MPIDI_IPCI_ipc_handle_t ipc_handle;
     uint64_t data_sz;           /* data size in bytes */
@@ -38,11 +38,11 @@ typedef struct MPIDI_IPC_ctrl_send_contig_lmt_rts {
     int src_rank;
     int tag;
     MPIR_Context_id_t context_id;
-} MPIDI_IPC_ctrl_send_contig_lmt_rts_t;
+} MPIDI_IPC_ctrl_send_lmt_rts_t;
 
-typedef struct MPIDI_IPC_ctrl_send_contig_lmt_fin {
+typedef struct MPIDI_IPC_ctrl_send_lmt_fin {
     MPIDI_IPCI_type_t ipc_type;
     MPIR_Request *req_ptr;
-} MPIDI_IPC_ctrl_send_contig_lmt_fin_t;
+} MPIDI_IPC_ctrl_send_lmt_fin_t;
 
 #endif /* IPC_PRE_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/src/ipc_pre.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_pre.h
@@ -23,6 +23,10 @@ typedef struct MPIDI_IPC_am_request {
     union {
         MPIDI_XPMEM_am_request_t xpmem;
     } u;
+    void *ipc_buf;
+    MPI_Aint ipc_count;
+    MPI_Datatype ipc_datatype;
+    MPIR_Request *sreq;
     MPIDI_IPC_am_unexp_rreq_t unexp_rreq;
 } MPIDI_IPC_am_request_t;
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_recv.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_recv.h
@@ -38,9 +38,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_matched_recv(void *buf,
 
         mpi_errno = MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_REQUEST(message, ipc_type),
                                                unexp_rreq->ipc_handle,
-                                               unexp_rreq->data_sz, unexp_rreq->sreq_ptr, message);
+                                               unexp_rreq->data_sz, unexp_rreq->sreq_ptr,
+                                               unexp_rreq->flattened_type, message);
         MPIR_ERR_CHECK(mpi_errno);
 
+        MPL_free(unexp_rreq->flattened_type);
         *recvd_flag = true;
     }
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -45,8 +45,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
     if (rank != comm->rank && ipc_attr.ipc_type != MPIDI_IPCI_TYPE__NONE &&
         data_sz >= ipc_attr.threshold.send_lmt_sz) {
         if (dt_contig) {
-            mpi_errno = MPIDI_IPCI_send_contig_lmt(buf, count, datatype, data_sz, rank, tag, comm,
-                                                   context_offset, addr, ipc_attr, request);
+            mpi_errno = MPIDI_IPCI_send_lmt(buf, count, datatype, data_sz, rank, tag, comm,
+                                            context_offset, addr, ipc_attr, request);
             MPIR_ERR_CHECK(mpi_errno);
             *done = true;
         }

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -138,4 +138,16 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_finalize(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_REQUEST_FINALIZE);
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_recv_rdma_read(void *lmt_msg, size_t recv_data_sz,
+                                                         MPIR_Request * rreq)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_RECV_RDMA);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_RECV_RDMA);
+
+    mpi_errno = MPIDI_IPC_am_recv_rdma_read(lmt_msg, recv_data_sz, rreq);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_RECV_RDMA);
+    return mpi_errno;
+}
 #endif /* SHM_AM_H_INCLUDED */

--- a/src/mpid/ch4/shm/src/shm_control.h
+++ b/src/mpid/ch4/shm/src/shm_control.h
@@ -10,18 +10,45 @@
 #include "../posix/posix_am.h"
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_do_ctrl_send(int rank, MPIR_Comm * comm,
-                                                    int ctrl_id, void *ctrl_hdr)
+                                                    int ctrl_id, MPI_Aint ctrl_hdr_sz,
+                                                    void *ctrl_hdr, MPIR_Request * request)
 {
     int ret;
+    int protocol;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIDIG_IPC_hdr_t ipc_hdr;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_DO_CTRL_SEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_DO_CTRL_SEND);
 
-    ret = MPIDI_POSIX_am_send_hdr(rank, comm, MPIDI_POSIX_AM_HDR_SHM,
-                                  ctrl_id, ctrl_hdr, sizeof(MPIDI_SHMI_ctrl_hdr_t));
+    ipc_hdr.req_ptr = request;
+    mpi_errno =
+        MPIDIG_isend_impl_new(&ctrl_hdr, ctrl_hdr_sz, MPI_BYTE, rank, tag, comm,
+                              context_offset, addr, &request, errflag, ctrl_id, &ipc_hdr,
+                              sizeof(MPIDIG_IPC_hdr_t), protocol);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_DO_CTRL_SEND);
     return ret;
+}
+
+/* This function return bool-type fallback flag to tell caller whether it needs
+ * to fallback to ch4 am based on whether the size can fit in with one cell of posix */
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_query_size_fallback(MPI_Aint size, int handle_id,
+                                                           bool * fallback_flag)
+{
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_FALLBACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_FALLBACK);
+
+    /* FIXME: MPIDIG_IPC_DATATYPE_REQ should be added in MPIDIG_am_check_size_le_eager_limit switch list */
+    if (!MPIDIG_am_check_size_le_eager_limit(size, handle_id, MPIDI_POSIX_am_eager_limit())) {
+        *fallback_flag = false;
+    } else {
+        *fallback_flag = true;
+    }
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_QUERY_FALLBACK);
+    return MPI_SUCCESS;
 }
 
 void MPIDI_SHMI_ctrl_reg_cb(int ctrl_id, MPIDI_SHMI_ctrl_cb cb);

--- a/src/mpid/ch4/shm/src/shm_types.h
+++ b/src/mpid/ch4/shm/src/shm_types.h
@@ -9,14 +9,14 @@
 #include "../ipc/src/ipc_pre.h"
 
 typedef enum {
-    MPIDI_IPC_SEND_CONTIG_LMT_RTS,      /* issued by sender to initialize IPC with contig sbuf */
-    MPIDI_IPC_SEND_CONTIG_LMT_FIN,      /* issued by receiver to notify completion of sender-initialized contig IPC */
+    MPIDI_IPC_SEND_LMT_RTS,     /* issued by sender to initialize IPC with contig sbuf */
+    MPIDI_IPC_SEND_LMT_FIN,     /* issued by receiver to notify completion of sender-initialized contig IPC */
     MPIDI_SHMI_CTRL_IDS_MAX
 } MPIDI_SHMI_ctrl_id_t;
 
 typedef union {
-    MPIDI_IPC_ctrl_send_contig_lmt_rts_t ipc_contig_slmt_rts;
-    MPIDI_IPC_ctrl_send_contig_lmt_fin_t ipc_contig_slmt_fin;
+    MPIDI_IPC_ctrl_send_lmt_rts_t ipc_slmt_rts;
+    MPIDI_IPC_ctrl_send_lmt_fin_t ipc_slmt_fin;
 } MPIDI_SHMI_ctrl_hdr_t;
 
 typedef int (*MPIDI_SHMI_ctrl_cb) (MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr);

--- a/src/mpid/ch4/src/ch4_coll_globals_default.c
+++ b/src/mpid/ch4/src/ch4_coll_globals_default.c
@@ -1,0 +1,259 @@
+#include "coll_algo_params.h"
+#include <mpidimpl.h>
+#include "ch4_impl.h"
+
+/* container traverse function to be implemented  */
+/* e.g. return ((void *) ((char *)container) + sizeof(MPIDIG_coll_algo_generic_container_t)); */
+const void *MPIDI_coll_get_next_container(const void *container)
+{
+    return NULL;
+}
+
+/* Barrier default composition containers initialization*/
+const MPIDI_coll_algo_container_t MPIDI_Barrier_intra_composition_alpha_cnt = {
+    .id = MPIDI_Barrier_intra_composition_alpha_id,
+    .params.ch4_barrier_params.ch4_barrier_alpha = {
+                                                    .node_barrier = MPIDI_COLL_AUTO_SELECT,
+                                                    .roots_barrier = MPIDI_COLL_AUTO_SELECT,
+                                                    .node_bcast = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Barrier_intra_composition_beta_cnt = {
+    .id = MPIDI_Barrier_intra_composition_beta_id,
+    .params.ch4_barrier_params.ch4_barrier_beta = {
+                                                   .barrier = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Barrier_inter_composition_alpha_cnt = {
+    .id = MPIDI_Barrier_inter_composition_alpha_id
+};
+
+/* Bcast default composition containers initialization*/
+const MPIDI_coll_algo_container_t MPIDI_Bcast_intra_composition_alpha_cnt = {
+    .id = MPIDI_Bcast_intra_composition_alpha_id,
+    .params.ch4_bcast_params.ch4_bcast_alpha = {
+                                                .roots_bcast = MPIDI_COLL_AUTO_SELECT,
+                                                .node_bcast = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Bcast_intra_composition_beta_cnt = {
+    .id = MPIDI_Bcast_intra_composition_beta_id,
+    .params.ch4_bcast_params.ch4_bcast_beta = {
+                                               .node_bcast_first = MPIDI_COLL_AUTO_SELECT,
+                                               .roots_bcast = MPIDI_COLL_AUTO_SELECT,
+                                               .node_bcast_second = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Bcast_intra_composition_gamma_cnt = {
+    .id = MPIDI_Bcast_intra_composition_gamma_id,
+    .params.ch4_bcast_params.ch4_bcast_gamma = {
+                                                .bcast = MPIDI_COLL_AUTO_SELECT,
+                                                }
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Bcast_inter_composition_alpha_cnt = {
+    .id = MPIDI_Bcast_inter_composition_alpha_id
+};
+
+/* Reduce default composition containers initialization*/
+const MPIDI_coll_algo_container_t MPIDI_Reduce_intra_composition_alpha_cnt = {
+    .id = MPIDI_Reduce_intra_composition_alpha_id,
+    .params.ch4_reduce_params.ch4_reduce_alpha = {
+                                                  .node_reduce = MPIDI_COLL_AUTO_SELECT,
+                                                  .roots_reduce = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Reduce_intra_composition_beta_cnt = {
+    .id = MPIDI_Reduce_intra_composition_beta_id,
+    .params.ch4_reduce_params.ch4_reduce_beta = {
+                                                 .node_reduce = MPIDI_COLL_AUTO_SELECT,
+                                                 .roots_reduce = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Reduce_intra_composition_gamma_cnt = {
+    .id = MPIDI_Reduce_intra_composition_gamma_id,
+    .params.ch4_reduce_params.ch4_reduce_gamma = {
+                                                  .reduce = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Reduce_inter_composition_alpha_cnt = {
+    .id = MPIDI_Reduce_inter_composition_alpha_id
+};
+
+/* Allreduce default composition containers initialization*/
+const MPIDI_coll_algo_container_t MPIDI_Allreduce_intra_composition_alpha_cnt = {
+    .id = MPIDI_Allreduce_intra_composition_alpha_id,
+    .params.ch4_allreduce_params.ch4_allreduce_alpha = {
+                                                        .node_reduce = MPIDI_COLL_AUTO_SELECT,
+                                                        .roots_allreduce = MPIDI_COLL_AUTO_SELECT,
+                                                        .node_bcast = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Allreduce_intra_composition_beta_cnt = {
+    .id = MPIDI_Allreduce_intra_composition_beta_id,
+    .params.ch4_allreduce_params.ch4_allreduce_beta = {
+                                                       .allreduce = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Allreduce_intra_composition_gamma_cnt = {
+    .id = MPIDI_Allreduce_intra_composition_gamma_id,
+    .params.ch4_allreduce_params.ch4_allreduce_gamma = {
+                                                        .allreduce = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Allreduce_inter_composition_alpha_cnt = {
+    .id = MPIDI_Allreduce_inter_composition_alpha_id
+};
+
+/* Gather default composition containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Gather_intra_composition_alpha_cnt = {
+    .id = MPIDI_Gather_intra_composition_alpha_id,
+    .params.ch4_gather_params.ch4_gather_alpha = {
+                                                  .gather = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Gather_inter_composition_alpha_cnt = {
+    .id = MPIDI_Gather_inter_composition_alpha_id
+};
+
+/* Gatherv default composition containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Gatherv_intra_composition_alpha_cnt = {
+    .id = MPIDI_Gatherv_intra_composition_alpha_id,
+    .params.ch4_gatherv_params.ch4_gatherv_alpha = {
+                                                    .gatherv = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Gatherv_inter_composition_alpha_cnt = {
+    .id = MPIDI_Gatherv_inter_composition_alpha_id
+};
+
+/* Scatter default composition containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Scatter_intra_composition_alpha_cnt = {
+    .id = MPIDI_Scatter_intra_composition_alpha_id,
+    .params.ch4_scatter_params.ch4_scatter_alpha = {
+                                                    .scatter = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Scatter_inter_composition_alpha_cnt = {
+    .id = MPIDI_Scatter_inter_composition_alpha_id
+};
+
+/* Scatterv default composition containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Scatterv_intra_composition_alpha_cnt = {
+    .id = MPIDI_Scatterv_intra_composition_alpha_id,
+    .params.ch4_scatterv_params.ch4_scatterv_alpha = {
+                                                      .scatterv = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Scatterv_inter_composition_alpha_cnt = {
+    .id = MPIDI_Scatterv_inter_composition_alpha_id
+};
+
+/* Alltoall default containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Alltoall_intra_composition_alpha_cnt = {
+    .id = MPIDI_Alltoall_intra_composition_alpha_id,
+    .params.ch4_alltoall_params.ch4_alltoall_alpha = {
+                                                      .alltoall = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Alltoall_inter_composition_alpha_cnt = {
+    .id = MPIDI_Alltoall_inter_composition_alpha_id
+};
+
+/* Alltoallv default containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Alltoallv_intra_composition_alpha_cnt = {
+    .id = MPIDI_Alltoallv_intra_composition_alpha_id,
+    .params.ch4_alltoallv_params.ch4_alltoallv_alpha = {
+                                                        .alltoallv = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Alltoallv_inter_composition_alpha_cnt = {
+    .id = MPIDI_Alltoallv_inter_composition_alpha_id
+};
+
+/* Alltoallw default containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Alltoallw_intra_composition_alpha_cnt = {
+    .id = MPIDI_Alltoallw_intra_composition_alpha_id,
+    .params.ch4_alltoallw_params.ch4_alltoallw_alpha = {
+                                                        .alltoallw = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Alltoallw_inter_composition_alpha_cnt = {
+    .id = MPIDI_Alltoallw_inter_composition_alpha_id
+};
+
+/* Allgather default containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Allgather_intra_composition_alpha_cnt = {
+    .id = MPIDI_Allgather_intra_composition_alpha_id,
+    .params.ch4_allgather_params.ch4_allgather_alpha = {
+                                                        .allgather = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Allgather_inter_composition_alpha_cnt = {
+    .id = MPIDI_Allgather_inter_composition_alpha_id
+};
+
+/* Allgatherv default containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Allgatherv_intra_composition_alpha_cnt = {
+    .id = MPIDI_Allgatherv_intra_composition_alpha_id,
+    .params.ch4_allgatherv_params.ch4_allgatherv_alpha = {
+                                                          .allgatherv = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Allgatherv_inter_composition_alpha_cnt = {
+    .id = MPIDI_Allgatherv_inter_composition_alpha_id
+};
+
+/* Reduce_scatter default composition containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Reduce_scatter_intra_composition_alpha_cnt = {
+    .id = MPIDI_Reduce_scatter_intra_composition_alpha_id,
+    .params.ch4_reduce_scatter_params.ch4_reduce_scatter_alpha = {
+                                                                  .reduce_scatter =
+                                                                  MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Reduce_scatter_inter_composition_alpha_cnt = {
+    .id = MPIDI_Reduce_scatter_inter_composition_alpha_id
+};
+
+/* Reduce_scatter_block default composition containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Reduce_scatter_block_intra_composition_alpha_cnt = {
+    .id = MPIDI_Reduce_scatter_block_intra_composition_alpha_id,
+    .params.ch4_reduce_scatter_block_params.ch4_reduce_scatter_block_alpha = {
+                                                                              .reduce_scatter_block
+                                                                              =
+                                                                              MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Reduce_scatter_block_inter_composition_alpha_cnt = {
+    .id = MPIDI_Reduce_scatter_block_inter_composition_alpha_id
+};
+
+/* Scan default containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Scan_intra_composition_alpha_cnt = {
+    .id = MPIDI_Scan_intra_composition_alpha_id,
+    .params.ch4_scan_params.ch4_scan_alpha = {
+                                              .node_scan = MPIDI_COLL_AUTO_SELECT,
+                                              .roots_scan = MPIDI_COLL_AUTO_SELECT,
+                                              .node_bcast = MPIDI_COLL_AUTO_SELECT}
+};
+
+const MPIDI_coll_algo_container_t MPIDI_Scan_intra_composition_beta_cnt = {
+    .id = MPIDI_Scan_intra_composition_beta_id,
+    .params.ch4_scan_params.ch4_scan_beta = {
+                                             .scan = MPIDI_COLL_AUTO_SELECT}
+};
+
+/* Exscan default containers initialization */
+const MPIDI_coll_algo_container_t MPIDI_Exscan_intra_composition_alpha_cnt = {
+    .id = MPIDI_Exscan_intra_composition_alpha_id,
+    .params.ch4_exscan_params.ch4_exscan_alpha = {
+                                                  .exscan = MPIDI_COLL_AUTO_SELECT}
+};
+
+/* *INDENT-OFF* */
+#include "../netmod/ofi/ofi_coll_globals_default.c"
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+#include "../shm/posix/posix_coll_globals_default.c"
+#endif
+/* *INDENT-ON* */

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -62,6 +62,10 @@ enum {
     MPIDIG_ACC_SRCBUF_PACKED = 1
 };
 
+typedef struct MPIDIG_IPC_hdr {
+    MPIR_Request *sreq_ptr;
+} MPIDIG_IPC_hdr_t;
+
 typedef struct MPIDIG_hdr_t {
     int src_rank;
     int tag;


### PR DESCRIPTION
## Pull Request Description
This PR implements non-contiguous point-to-point communication in IPC layer.
Two main changes are made:
- add `MPIDI_SHM_do_large_ctrl_send` function to support large/dynamic-size control header transmission
- implement non-contiguous data transmission which is done as follows:
    - if !src_dt_contig && dest_dt_contig, pack src data to destination buffer
    - else if src_dt_contig, unpack src data to destination buffer
    - else if both are non-contig, allocate tmp buffer with chunk size min(`MPIR_CVAR_CH4_IPC_NON_CONTIG_CHUNK_SIZE`, data_sz) and copy is performed chunk by chunk; that is we first pack src data to tmp buffer, and then unpack tmp buffer to destination buffer until the last chunk.

## EDIT -- by Hui
Do we need to worry about sending datatypes that its flattened size can't fit into eager limit (typically > 10KB)? If we ignore the case for those datatypes -- very fragmented and very uncommon, thus less need to optimize -- then we can easily support non-contig datatypes by simply append flattened datatype after the lmt RTS header. Much of the complications proposed by this PR can be avoided.

## Expected Impact
## Author Checklist
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand