### PR TITLE
ch4: fixed improper MPI_WTIME_IS_GLOBAL initialization

### DIFF
--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -618,7 +618,6 @@ int MPID_Init(int requested, int *provided)
     MPIR_Comm_fns = &MPIDI_global.MPIR_Comm_fns_store;
 
     MPIR_Process.attrs.appnum = appnum;
-    MPIR_Process.attrs.wtime_is_global = 1;
     MPIR_Process.attrs.io = MPI_ANY_SOURCE;
 
     destroy_init_comm(&init_comm);


### PR DESCRIPTION
## Pull Request Description
Fixed improper MPI_WTIME_IS_GLOBAL initialization during CH4 init.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
