### PR TITLE
ch4/ofi: fallback to MPIDIG for dynamic window

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -274,7 +274,7 @@ static inline int MPIDI_NM_mpi_put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_PUT);
     int mpi_errno = MPI_SUCCESS;
 
-    if (!MPIDI_OFI_ENABLE_RMA) {
+    if (!MPIDI_OFI_ENABLE_RMA || win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
         mpi_errno = MPIDIG_mpi_put(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win);
         goto fn_exit;
@@ -432,7 +432,7 @@ static inline int MPIDI_NM_mpi_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_GET);
 
-    if (!MPIDI_OFI_ENABLE_RMA) {
+    if (!MPIDI_OFI_ENABLE_RMA || win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
         mpi_errno = MPIDIG_mpi_get(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win);
         goto fn_exit;
@@ -462,7 +462,7 @@ static inline int MPIDI_NM_mpi_rput(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RPUT);
     int mpi_errno = MPI_SUCCESS;
 
-    if (!MPIDI_OFI_ENABLE_RMA) {
+    if (!MPIDI_OFI_ENABLE_RMA || win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
         mpi_errno = MPIDIG_mpi_rput(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_disp, target_count, target_datatype, win, request);
         goto fn_exit;
@@ -508,9 +508,11 @@ static inline int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS) {
-        mpi_errno = MPIDIG_mpi_compare_and_swap(origin_addr, compare_addr, result_addr, datatype,
-                                                target_rank, target_disp, win);
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
+           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+        mpi_errno =
+            MPIDIG_mpi_compare_and_swap(origin_addr, compare_addr, result_addr, datatype,
+                                        target_rank, target_disp, win);
         goto fn_exit;
     }
 
@@ -721,10 +723,11 @@ static inline int MPIDI_NM_mpi_raccumulate(const void *origin_addr,
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS) {
-        mpi_errno = MPIDIG_mpi_raccumulate(origin_addr, origin_count, origin_datatype, target_rank,
-                                           target_disp, target_count, target_datatype, op, win,
-                                           request);
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
+           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+        mpi_errno =
+            MPIDIG_mpi_raccumulate(origin_addr, origin_count, origin_datatype, target_rank,
+                                   target_disp, target_count, target_datatype, op, win, request);
         goto fn_exit;
     }
 
@@ -766,11 +769,12 @@ static inline int MPIDI_NM_mpi_rget_accumulate(const void *origin_addr,
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS) {
-        mpi_errno = MPIDIG_mpi_rget_accumulate(origin_addr, origin_count, origin_datatype,
-                                               result_addr, result_count, result_datatype,
-                                               target_rank, target_disp, target_count,
-                                               target_datatype, op, win, request);
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
+           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+        mpi_errno =
+            MPIDIG_mpi_rget_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
+                                       result_count, result_datatype, target_rank, target_disp,
+                                       target_count, target_datatype, op, win, request);
         goto fn_exit;
     }
 
@@ -813,9 +817,11 @@ static inline int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS) {
-        mpi_errno = MPIDIG_mpi_fetch_and_op(origin_addr, result_addr, datatype, target_rank,
-                                            target_disp, op, win);
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
+           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+        mpi_errno =
+            MPIDIG_mpi_fetch_and_op(origin_addr, result_addr, datatype, target_rank, target_disp,
+                                    op, win);
         goto fn_exit;
     }
 
@@ -907,7 +913,7 @@ static inline int MPIDI_NM_mpi_rget(void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RGET);
     int mpi_errno = MPI_SUCCESS;
 
-    if (!MPIDI_OFI_ENABLE_RMA) {
+    if (!MPIDI_OFI_ENABLE_RMA || win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
         mpi_errno = MPIDIG_mpi_rget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_disp, target_count, target_datatype, win, request);
         goto fn_exit;
@@ -950,11 +956,12 @@ static inline int MPIDI_NM_mpi_get_accumulate(const void *origin_addr,
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS) {
-        mpi_errno = MPIDIG_mpi_get_accumulate(origin_addr, origin_count, origin_datatype,
-                                              result_addr, result_count, result_datatype,
-                                              target_rank, target_disp, target_count,
-                                              target_datatype, op, win);
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
+           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+        mpi_errno =
+            MPIDIG_mpi_get_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
+                                      result_count, result_datatype, target_rank, target_disp,
+                                      target_count, target_datatype, op, win);
         goto fn_exit;
     }
 
@@ -990,9 +997,11 @@ static inline int MPIDI_NM_mpi_accumulate(const void *origin_addr,
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS) {
-        mpi_errno = MPIDIG_mpi_accumulate(origin_addr, origin_count, origin_datatype, target_rank,
-                                          target_disp, target_count, target_datatype, op, win);
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
+           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+        mpi_errno =
+            MPIDIG_mpi_accumulate(origin_addr, origin_count, origin_datatype, target_rank,
+                                  target_disp, target_count, target_datatype, op, win);
         goto fn_exit;
     }
 


### PR DESCRIPTION
## Pull Request Description

When dynamic window is created, we assume a base of 0 and disp_unit of
one. However, it is not clear whether calling `fi_mr_reg` on NULL address
is allowed and even when it is allowed, it is probably achieving
nothing. For correctness, we skip the memory registration for dynamic
window and fall back to active message for RMA operations.

TODO: add optimization to register each attached memory. We can
synchronize the mr_keys either via `symm_attach` hints (which require
collective MPI_Win_attach) or communicate key inside epoch
synchronization (which also require a hint that user won't detach memory
inside the epoch.

[skip warnings]


## Reference
Cherry picked from #4705 

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
