### PR TITLE
mpl: Fix an IFS-related configure script error

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -80,7 +80,10 @@ AC_ARG_ENABLE(g,
 # enable-g
 # strip off multiple options, separated by commas
 PAC_PUSH_FLAG(IFS)
-IFS=","
+# Change IFS to process enable_g values; save for use after AC_MSG_WARN
+# below to provide single point of maintenance
+enable_g_IFS=","
+IFS="$enable_g_IFS"
 for option in $enable_g ; do
     case "$option" in
 	 log)
@@ -100,7 +103,12 @@ for option in $enable_g ; do
 	 ;;
 
 	 *)
+	 # Default IFS required by AC_MSG_WARN
+	 PAC_POP_FLAG(IFS)
 	 AC_MSG_WARN([Unknown value $option for enable-g])
+	 # Restore previous IFS to process any remaining enable_g values
+	 PAC_PUSH_FLAG(IFS)
+	 IFS="$enable_g_IFS"
 	 ;;
     esac
 done


### PR DESCRIPTION
## Pull Request Description

In the case where someone specifies `--enable-g=debug` (say) a warning is triggered in `mpl/configure`. However, since `IFS=","` at that point, two cryptic shell errors are produced instead. This PR temporarily pops `IFS` to allow the warnings to succeed. Ideally one would also filter-out `enable_g` flags understood at the higher level but not here before `mpl/configure` is invoked, but I believe that is a policy decision beyond the purview of a first-time contributor.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Minor: none beyond fixing the described problem.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
