### PR TITLE
ch4/ofi: Make pack buffer pool independent of active messages

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.c
@@ -54,7 +54,7 @@ int MPIDI_OFI_deferred_am_isend_issue(MPIDI_OFI_deferred_am_isend_req_t * dreq)
          *       (2) Pipeline allocation for low-density datatypes; */
         if (dreq->am_hdr_sz + dreq->data_sz + sizeof(MPIDI_OFI_am_header_t) <=
             MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE) {
-            mpi_errno = MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.am_pack_buf_pool,
+            mpi_errno = MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.pack_buf_pool,
                                                            (void **) &send_buf);
             if (send_buf == NULL) {
                 /* no buffer available, suppress error and exit */

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -416,8 +416,7 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
         /* TODO: (1) Skip packing for high-density datatypes;
          *       (2) Pipeline allocation for low-density datatypes; */
         if (data_lt_eager_threshold) {
-            MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.am_pack_buf_pool,
-                                               (void **) &send_buf);
+            MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.pack_buf_pool, (void **) &send_buf);
             if (send_buf == NULL) {
                 mpi_errno = MPIDI_OFI_deferred_am_isend_enqueue(rank, comm, handler_id, am_hdr_sz,
                                                                 buf, count, datatype, sreq,

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -536,7 +536,7 @@ static int am_isend_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
             break;
     }
 
-    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.am_pack_buf_pool,
+    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.pack_buf_pool,
                                       MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer));
     MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer) = NULL;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -41,7 +41,7 @@ void MPIDI_OFI_complete_chunks(MPIDI_OFI_win_request_t * winreq)
         }
 
         MPIDI_OFI_pack_chunk *next = chunk->next;
-        MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.am_pack_buf_pool, chunk->pack_buffer);
+        MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.pack_buf_pool, chunk->pack_buffer);
         MPL_free(chunk);
         chunk = next;
     }
@@ -193,7 +193,7 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
     int j = req->noncontig.put.target.iov_cur;
     size_t msg_len;
     while (req->noncontig.put.origin.pack_offset < req->noncontig.put.origin.total_bytes) {
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.am_pack_buf_pool, &pack_buffer);
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.pack_buf_pool, &pack_buffer);
         if (pack_buffer == NULL)
             break;
 
@@ -280,7 +280,7 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
     int j = req->noncontig.get.target.iov_cur;
     size_t msg_len;
     while (req->noncontig.get.origin.pack_offset < req->noncontig.get.origin.total_bytes) {
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.am_pack_buf_pool, &pack_buffer);
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.pack_buf_pool, &pack_buffer);
         if (pack_buffer == NULL)
             break;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -375,7 +375,6 @@ typedef struct {
     void *am_bufs[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
     MPIDI_OFI_am_repost_request_t am_reqs[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
     MPIDU_genq_private_pool_t am_hdr_buf_pool;
-    MPIDU_genq_private_pool_t am_pack_buf_pool;
     MPL_atomic_int_t am_inflight_inject_emus;
     MPL_atomic_int_t am_inflight_rma_send_mrs;
     /* Sequence number trackers for active messages */
@@ -383,6 +382,9 @@ typedef struct {
     void *am_recv_seq_tracker;
     /* Queue (utlist) to store early-arrival active messages */
     MPIDI_OFI_am_unordered_msg_t *am_unordered_msgs;
+
+    /* Pack buffers for various communication */
+    MPIDU_genq_private_pool_t pack_buf_pool;
 
     /* Completion queue buffering */
     MPIDI_OFI_cq_buff_entry_t cq_buffered_static_list[MPIDI_OFI_NUM_CQ_BUFFERED];


### PR DESCRIPTION
## Pull Request Description

Pack buffers from this pool are utilized in RMA code. Rename the pool
and associated CVARs to be independent of actives messages. Move
init/finalize outside of AM conditionals.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
