### PR TITLE
mpl/config: fix extra MPL_ prefix in AC_DEFINE

### DIFF
--- a/confdb/aclocal_shm.m4
+++ b/confdb/aclocal_shm.m4
@@ -46,4 +46,11 @@ if test "$with_shared_memory" = auto -o "$with_shared_memory" = sysv; then
         AC_MSG_ERROR([cannot support shared memory:  sysv shared memory functions functions not found])
     fi
 fi
+if test "$with_shared_memory" = nt ; then
+    AC_DEFINE(USE_NT_SHM,1,[Define if use Windows shared memory])
+fi
+
+if test "$with_shared_memory" = "auto" ; then
+    AC_MSG_ERROR([cannot support shared memory:  need either sysv shared memory functions or mmap in order to support shared memory])
+fi
 ])

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -947,7 +947,7 @@ PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have
 PAC_CHECK_HEADER_LIB([cuda.h],[cuda],[cuMemGetAddressRange],[have_cuda=yes],[have_cuda=no])
 if test "X${have_cudart}" = "Xyes" -a \
     "X${have_cuda}" = "Xyes" ; then
-    AC_DEFINE([MPL_HAVE_CUDA],[1],[Define if CUDA is available])
+    AC_DEFINE([HAVE_CUDA],[1],[Define if CUDA is available])
 fi
 AM_CONDITIONAL([MPL_HAVE_CUDA],[test "X${have_cudart}" = "Xyes" -a "X${have_cuda}" = "Xyes"])
 
@@ -959,7 +959,7 @@ PAC_CHECK_HEADER_LIB([level_zero/ze_api.h],[ze_loader],[zeInit],[have_ze=yes],[h
 PAC_CHECK_HEADER_LIB([CL/cl.h],[OpenCL],[clGetPlatformIDs],[have_cl=yes],[have_cl=no])
 if test "X${have_ze}" = "Xyes" -a \
     "X${have_cl}" = "Xyes" ; then
-    AC_DEFINE([MPL_HAVE_ZE],[1],[Define if ZE is available])
+    AC_DEFINE([HAVE_ZE],[1],[Define if ZE is available])
 fi
 AM_CONDITIONAL([MPL_HAVE_ZE],[test "X${have_ze}" = "Xyes" -a "X${have_cl}" = "Xyes"])
 

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -919,21 +919,6 @@ AC_CHECK_FUNCS(getpid)
 dnl Check for shm
 PAC_ARG_SHARED_MEMORY
 
-case $with_shared_memory in
-    sysv)
-        AC_DEFINE(MPL_USE_SYSV_SHM,1,[Define if use SYSV shared memory])
-        ;;
-    mmap)
-        AC_DEFINE(MPL_USE_MMAP_SHM,1,[Define if use MMAP shared memory])
-        ;;
-    nt)
-        AC_DEFINE(MPL_USE_NT_SHM,1,[Define if use Windows shared memory])
-        ;;
-    *)
-        AC_MSG_ERROR([cannot support shared memory:  need either sysv shared memory functions or mmap in order to support shared memory])
-esac
-
-
 #######################################################################
 ## END OF SHM CODE
 #######################################################################


### PR DESCRIPTION
## Pull Request Description
Fix a wrong usage of `PAC_ARG_SHARED_MEMORY`. It both tests the availability and defines the macro, so we shouldn't define the macro again; worse, define it inconsistently.

The MPL_ prefix in the cofig macros are added by `AC_CONFIG_COMMANDS([prefix-config],...)`. While the script is smart enough not to double add the prefix, it is better to avoid it for consistency reason.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
