### PR TITLE
test/mpi: Fix bugs in GPU tests

### DIFF
--- a/test/mpi/coll/bcast.c
+++ b/test/mpi/coll/bcast.c
@@ -93,13 +93,13 @@ int main(int argc, char *argv[])
                 assert(buf);
 
                 if (rank == root) {
-                    err = DTP_obj_buf_init(obj, buf, 0, 1, count);
+                    err = DTP_obj_buf_init(obj, buf_h, 0, 1, count);
                     if (err != DTP_SUCCESS) {
                         errs++;
                         break;
                     }
                 } else {
-                    err = DTP_obj_buf_init(obj, buf, -1, -1, count);
+                    err = DTP_obj_buf_init(obj, buf_h, -1, -1, count);
                     if (err != DTP_SUCCESS) {
                         errs++;
                         break;
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
                 }
 
                 MTestCopyContent(buf, buf_h, obj.DTP_bufsize, memtype);
-                err = DTP_obj_buf_check(obj, buf, 0, 1, count);
+                err = DTP_obj_buf_check(obj, buf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {
                     errs++;
                     if (errs < 10) {

--- a/test/mpi/pt2pt/sendrecv1.c
+++ b/test/mpi/pt2pt/sendrecv1.c
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
                 }
 
                 MTestCopyContent(recvbuf, recvbuf_h, recv_obj.DTP_bufsize, recvmem);
-                err = DTP_obj_buf_check(recv_obj, recvbuf, 0, 1, count[0]);
+                err = DTP_obj_buf_check(recv_obj, recvbuf_h, 0, 1, count[0]);
                 if (err != DTP_SUCCESS) {
                     if (errs < 10) {
                         char *recv_desc, *send_desc;

--- a/test/mpi/rma/fence.c
+++ b/test/mpi/rma/fence.c
@@ -46,13 +46,13 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
 
     if (rank == target) {
 #if defined(USE_GET)
-        err = DTP_obj_buf_init(target_obj, targetbuf, 0, 1, count);
+        err = DTP_obj_buf_init(target_obj, targetbuf_h, 0, 1, count);
         if (err != DTP_SUCCESS) {
             return ++errs;
         }
         MTestCopyContent(targetbuf_h, targetbuf, maxbufsize, targetmem);
 #elif defined(USE_PUT)
-        err = DTP_obj_buf_init(target_obj, targetbuf, -1, -1, count);
+        err = DTP_obj_buf_init(target_obj, targetbuf_h, -1, -1, count);
         if (err != DTP_SUCCESS) {
             return ++errs;
         }

--- a/test/mpi/rma/lock_x_dt.c
+++ b/test/mpi/rma/lock_x_dt.c
@@ -200,7 +200,7 @@ static int run_test(MPI_Comm comm, MPI_Win win, DTP_obj_s orig_obj, void *origbu
              * origins might receive the value that has already been
              * overwritten by other origins */
             MTestCopyContent(resultbuf, resultbuf_h, result_obj.DTP_bufsize, resultmem);
-            err = DTP_obj_buf_check(result_obj, resultbuf, 1, 2, count);
+            err = DTP_obj_buf_check(result_obj, resultbuf_h, 1, 2, count);
             if (err != DTP_SUCCESS)
                 errs++;
 #endif


### PR DESCRIPTION
## Pull Request Description

Fix instances where data buffers were not initialized or checked in
host memory. This resulted in segfaults at runtime when trying to
read/write inaccessible memory regions.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Ensures all GPU tests are usable.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
