### PR TITLE
config: Improve error message for gfortran 10

### DIFF
--- a/confdb/aclocal_f77.m4
+++ b/confdb/aclocal_f77.m4
@@ -1441,7 +1441,7 @@ if test "X$pac_cv_prog_f77_mismatched_args" = X ; then
 	# The best solution is to turn off errors on particular routines
 	# if that isn't possible (e.g., too many of them), then
 	# just try arguments that turn off all checking
-	for flags in ifelse($2,yes,,"-wmismatch=foo1") "-mismatch" ; do
+	for flags in ifelse($2,yes,,"-wmismatch=foo1") "-mismatch" "-fallow-argument-mismatch" ; do
             testok=no
             FFLAGS="$FFLAGS $flags"
             AC_COMPILE_IFELSE([


### PR DESCRIPTION
## Pull Request Description

Add -fallow-argument-mismatch to the list of options to try when test
support for mismatched function arguments in Fortran. This provides
more useful error output the user.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Better error message at configure time.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
