### PR TITLE
ch4: fix intercomm MPI_Probe

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -41,7 +41,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
         rreq = &r;
     }
 
-    match_bits = MPIDI_OFI_init_recvtag(&mask_bits, comm->context_id + context_offset, tag);
+    match_bits = MPIDI_OFI_init_recvtag(&mask_bits, comm->recvcontext_id + context_offset, tag);
 
     MPIDI_OFI_REQUEST(rreq, event_id) = MPIDI_OFI_EVENT_PEEK;
     MPIDI_OFI_REQUEST(rreq, util_id) = MPIDI_OFI_PEEK_START;

--- a/src/mpid/ch4/src/ch4r_probe.h
+++ b/src/mpid/ch4/src/ch4r_probe.h
@@ -18,11 +18,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IPROBE);
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
-    root_comm = MPIDIG_context_id_to_comm(comm->context_id);
+    MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
+    root_comm = MPIDIG_context_id_to_comm(context_id);
 
     /* MPIDI_CS_ENTER(); */
-    unexp_req = MPIDIG_find_unexp(source, tag, root_comm->recvcontext_id + context_offset,
-                                  &MPIDIG_COMM(root_comm, unexp_list));
+    unexp_req = MPIDIG_find_unexp(source, tag, context_id, &MPIDIG_COMM(root_comm, unexp_list));
 
     if (unexp_req) {
         *flag = 1;
@@ -54,11 +54,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IMPROBE);
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
-    root_comm = MPIDIG_context_id_to_comm(comm->context_id);
+    MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
+    root_comm = MPIDIG_context_id_to_comm(context_id);
 
     /* MPIDI_CS_ENTER(); */
-    unexp_req = MPIDIG_dequeue_unexp(source, tag, root_comm->recvcontext_id + context_offset,
-                                     &MPIDIG_COMM(root_comm, unexp_list));
+    unexp_req = MPIDIG_dequeue_unexp(source, tag, context_id, &MPIDIG_COMM(root_comm, unexp_list));
 
     if (unexp_req) {
         *flag = 1;

--- a/test/mpi/include/mpitest.h
+++ b/test/mpi/include/mpitest.h
@@ -32,6 +32,8 @@ void MTestGetDbgInfo(int *dbgflag, int *verbose);
 
 int MTestGetIntracomm(MPI_Comm *, int);
 int MTestGetIntracommGeneral(MPI_Comm *, int, int);
+void MTestGetIntercomm_start(void);
+void MTestGetIntercomm_finish(void);
 int MTestGetIntercomm(MPI_Comm *, int *, int);
 int MTestGetComm(MPI_Comm *, int);
 int MTestTestIntercomm(MPI_Comm intercomm);

--- a/test/mpi/include/mpitest.h
+++ b/test/mpi/include/mpitest.h
@@ -32,8 +32,6 @@ void MTestGetDbgInfo(int *dbgflag, int *verbose);
 
 int MTestGetIntracomm(MPI_Comm *, int);
 int MTestGetIntracommGeneral(MPI_Comm *, int, int);
-void MTestGetIntercomm_start(void);
-void MTestGetIntercomm_finish(void);
 int MTestGetIntercomm(MPI_Comm *, int *, int);
 int MTestGetComm(MPI_Comm *, int);
 int MTestTestIntercomm(MPI_Comm intercomm);
@@ -42,6 +40,7 @@ int MTestTestComm(MPI_Comm comm);
 const char *MTestGetIntracommName(void);
 const char *MTestGetIntercommName(void);
 void MTestFreeComm(MPI_Comm *);
+void MTestCommRandomize(void);
 
 int MTestSpawnPossible(int *);
 

--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -29,6 +29,7 @@ noinst_PROGRAMS =  \
     bsendfrag      \
     bsendpending   \
     icsend         \
+    icprobe        \
     rqstatus       \
     rqfreeb        \
     greq1          \

--- a/test/mpi/pt2pt/icprobe.c
+++ b/test/mpi/pt2pt/icprobe.c
@@ -20,6 +20,7 @@ int main(int argc, char *argv[])
 
     MTest_Init(&argc, &argv);
 
+    MTestGetIntercomm_start();
     while (MTestGetIntercomm(&comm, &leftGroup, 4)) {
         if (comm == MPI_COMM_NULL)
             continue;
@@ -65,6 +66,7 @@ int main(int argc, char *argv[])
         }
         MTestFreeComm(&comm);
     }
+    MTestGetIntercomm_finish();
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/pt2pt/icprobe.c
+++ b/test/mpi/pt2pt/icprobe.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include "mpitest.h"
+
+/*
+static char MTEST_Descrip[] = "Simple test of intercommunicator send and receive";
+*/
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    int leftGroup, buf, rank, remote_size, i;
+    MPI_Comm comm;
+    MPI_Status status;
+
+    MTest_Init(&argc, &argv);
+
+    while (MTestGetIntercomm(&comm, &leftGroup, 4)) {
+        if (comm == MPI_COMM_NULL)
+            continue;
+
+        if (leftGroup) {
+            MPI_Comm_rank(comm, &rank);
+            buf = rank;
+            MPI_Send(&buf, 1, MPI_INT, 0, 0, comm);
+        } else {
+            MPI_Comm_remote_size(comm, &remote_size);
+            MPI_Comm_rank(comm, &rank);
+            if (rank == 0) {
+                for (i = 0; i < remote_size; i++) {
+                    buf = -1;
+                    MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, comm, &status);
+                    MPI_Recv(&buf, 1, MPI_INT, status.MPI_SOURCE, status.MPI_TAG, comm, &status);
+                    if (buf != status.MPI_SOURCE) {
+                        errs++;
+                        fprintf(stderr, "buf = %d, should be %d\n", buf, status.MPI_SOURCE);
+                    }
+                }
+            }
+        }
+        /* Now, reverse it and send back */
+        if (!leftGroup) {
+            MPI_Comm_rank(comm, &rank);
+            buf = rank;
+            MPI_Send(&buf, 1, MPI_INT, 0, 0, comm);
+        } else {
+            MPI_Comm_remote_size(comm, &remote_size);
+            MPI_Comm_rank(comm, &rank);
+            if (rank == 0) {
+                for (i = 0; i < remote_size; i++) {
+                    buf = -1;
+                    MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, comm, &status);
+                    MPI_Recv(&buf, 1, MPI_INT, status.MPI_SOURCE, status.MPI_TAG, comm, &status);
+                    if (buf != status.MPI_SOURCE) {
+                        errs++;
+                        fprintf(stderr, "buf = %d, should be %d\n", buf, status.MPI_SOURCE);
+                    }
+                }
+            }
+        }
+        MTestFreeComm(&comm);
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/pt2pt/icprobe.c
+++ b/test/mpi/pt2pt/icprobe.c
@@ -20,7 +20,14 @@ int main(int argc, char *argv[])
 
     MTest_Init(&argc, &argv);
 
-    MTestGetIntercomm_start();
+    int do_randomize;
+    MTestArgList *head = MTestArgListCreate(argc, argv);
+    do_randomize = MTestArgListGetInt_with_default(head, "randomize", 0);
+    MTestArgListDestroy(head);
+
+    if (do_randomize) {
+        MTestCommRandomize();
+    }
     while (MTestGetIntercomm(&comm, &leftGroup, 4)) {
         if (comm == MPI_COMM_NULL)
             continue;
@@ -66,7 +73,6 @@ int main(int argc, char *argv[])
         }
         MTestFreeComm(&comm);
     }
-    MTestGetIntercomm_finish();
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/pt2pt/icsend.c
+++ b/test/mpi/pt2pt/icsend.c
@@ -20,6 +20,7 @@ int main(int argc, char *argv[])
 
     MTest_Init(&argc, &argv);
 
+    MTestGetIntercomm_start();
     while (MTestGetIntercomm(&comm, &leftGroup, 4)) {
         if (comm == MPI_COMM_NULL)
             continue;
@@ -63,6 +64,7 @@ int main(int argc, char *argv[])
         }
         MTestFreeComm(&comm);
     }
+    MTestGetIntercomm_finish();
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/pt2pt/icsend.c
+++ b/test/mpi/pt2pt/icsend.c
@@ -20,7 +20,14 @@ int main(int argc, char *argv[])
 
     MTest_Init(&argc, &argv);
 
-    MTestGetIntercomm_start();
+    int do_randomize;
+    MTestArgList *head = MTestArgListCreate(argc, argv);
+    do_randomize = MTestArgListGetInt_with_default(head, "randomize", 0);
+    MTestArgListDestroy(head);
+
+    if (do_randomize) {
+        MTestCommRandomize();
+    }
     while (MTestGetIntercomm(&comm, &leftGroup, 4)) {
         if (comm == MPI_COMM_NULL)
             continue;
@@ -64,7 +71,6 @@ int main(int argc, char *argv[])
         }
         MTestFreeComm(&comm);
     }
-    MTestGetIntercomm_finish();
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -17,7 +17,9 @@ issendselfcancel 1 xfail=ticket2276
 isendirecv 10
 bsendfrag 2
 icsend 4
+icsend 4 arg=-randomize=1
 icprobe 4
+icprobe 4 arg=-randomize=1
 rqstatus 2
 rqfreeb 4
 greq1 1

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -17,6 +17,7 @@ issendselfcancel 1 xfail=ticket2276
 isendirecv 10
 bsendfrag 2
 icsend 4
+icprobe 4
 rqstatus 2
 rqfreeb 4
 greq1 1

--- a/test/mpi/util/mtest.c
+++ b/test/mpi/util/mtest.c
@@ -1022,6 +1022,33 @@ void MTestFreeComm(MPI_Comm * comm)
     }
 }
 
+/* Directly calling MTestGetIntercomm maybe insufficient since all the processes
+ * may end up with the same context_id even between different groups of the intercomm.
+ * Radomize it by duplicate MPI_Comm_self different times */
+
+#define MAX_COMM_SELF_DUPS 4
+static MPI_Comm comm_self_dups[MAX_COMM_SELF_DUPS];
+static int num_self_dups;
+
+void MTestGetIntercomm_start(void)
+{
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    srand(rank);
+
+    num_self_dups = rand() % MAX_COMM_SELF_DUPS;
+    for (int i = 0; i < num_self_dups; i++) {
+        MPI_Comm_dup(MPI_COMM_SELF, &comm_self_dups[i]);
+    }
+}
+
+void MTestGetIntercomm_finish(void)
+{
+    for (int i = 0; i < num_self_dups; i++) {
+        MPI_Comm_free(&comm_self_dups[i]);
+    }
+}
+
 /* ------------------------------------------------------------------------ */
 void MTestPrintError(int errcode)
 {

--- a/test/mpi/util/mtest.c
+++ b/test/mpi/util/mtest.c
@@ -178,6 +178,7 @@ void MTest_Init(int *argc, char ***argv)
 #endif
 }
 
+static void MTestCommRandomize_cleanup(void);
 /*
   Finalize MTest.  errs is the number of errors on the calling process;
   this routine will write the total number of errors over all of MPI_COMM_WORLD
@@ -206,6 +207,8 @@ void MTest_Finalize(int errs)
     if (usageOutput)
         MTestResourceSummary(stdout);
 
+    /* Clean up any comms from MTestCommRandomize() */
+    MTestCommRandomize_cleanup();
 
     /* Clean up any persistent objects that we allocated */
     MTestRMACleanup();
@@ -1028,9 +1031,9 @@ void MTestFreeComm(MPI_Comm * comm)
 
 #define MAX_COMM_SELF_DUPS 4
 static MPI_Comm comm_self_dups[MAX_COMM_SELF_DUPS];
-static int num_self_dups;
+static int num_self_dups = 0;
 
-void MTestGetIntercomm_start(void)
+void MTestCommRandomize(void)
 {
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -1042,7 +1045,7 @@ void MTestGetIntercomm_start(void)
     }
 }
 
-void MTestGetIntercomm_finish(void)
+static void MTestCommRandomize_cleanup(void)
 {
     for (int i = 0; i < num_self_dups; i++) {
         MPI_Comm_free(&comm_self_dups[i]);


### PR DESCRIPTION
## Pull Request Description

There are bugs in ch4 MPI_Probe code. However, our current tests either didn't directly test intercomm MPI_Probe or insufficient in manifesting the bug. The way we generate intercom by splitting MPI_COMM_WORLD always results in same context_id for different groups of the intercomm. This PR adds the test to test intercomm MPI_Probe, and enhances the tests by adding functions to randomize the context_id. After verifying the current bugs, this PR fixes them.

Thanks @thananon for the bug report.

[skip warnings]

## Expected Impact

Fixes #4730
## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
