### PR TITLE
mpi/coll: Improve staging of GPU data

### DIFF
--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -33,7 +33,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     MPIR_CHKLMEM_DECL(1);
 
     if (((sendcount == 0) && (sendbuf != MPI_IN_PLACE)) || (recvcount == 0))
-        return MPI_SUCCESS;
+        goto fn_exit;
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -31,7 +31,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     int curr_cnt, dst;
     MPL_pointer_attr_t attr;
 
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_COLL_CHKLMEM_DECL(1);
 
     if (((sendcount == 0) && (sendbuf != MPI_IN_PLACE)) || (recvcount == 0))
         goto fn_exit;
@@ -44,11 +44,8 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
 
     /* allocate a temporary buffer of the same size as recvbuf. */
     MPL_gpu_query_pointer_attr(recvbuf, &attr);
-    if (attr.type == MPL_GPU_POINTER_DEV)
-        MPL_gpu_malloc((void **) &tmp_buf, recvcount * comm_size * recvtype_sz, attr.device);
-    else
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, recvcount * comm_size * recvtype_sz, mpi_errno,
-                            "tmp_buf", MPL_MEM_BUFFER);
+    MPIR_COLL_CHKLMEM_MALLOC(tmp_buf, recvcount * comm_size * recvtype_sz, attr, mpi_errno,
+                             "tmp_buf", MPL_MEM_BUFFER);
 
     /* copy local data to the top of tmp_buf */
     if (sendbuf != MPI_IN_PLACE) {
@@ -125,9 +122,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     }
 
   fn_exit:
-    if (attr.type == MPL_GPU_POINTER_DEV)
-        MPL_gpu_free(tmp_buf);
-    MPIR_CHKLMEM_FREEALL();
+    MPIR_COLL_CHKLMEM_FREEALL();
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;
     else if (*errflag != MPIR_ERR_NONE)

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -35,7 +35,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     int dst, total_count;
     void *tmp_buf;
     MPL_pointer_attr_t attr;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_COLL_CHKLMEM_DECL(1);
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -53,11 +53,8 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);
 
     MPL_gpu_query_pointer_attr(recvbuf, &attr);
-    if (attr.type == MPL_GPU_POINTER_DEV)
-        MPL_gpu_malloc((void **) &tmp_buf, total_count * recvtype_sz, attr.device);
-    else
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, total_count * recvtype_sz, mpi_errno, "tmp_buf",
-                            MPL_MEM_BUFFER);
+    MPIR_COLL_CHKLMEM_MALLOC(tmp_buf, total_count * recvtype_sz, attr, mpi_errno, "tmp_buf",
+                             MPL_MEM_BUFFER);
 
     /* copy local data to the top of tmp_buf */
     if (sendbuf != MPI_IN_PLACE) {
@@ -150,9 +147,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     }
 
   fn_exit:
-    if (attr.type == MPL_GPU_POINTER_DEV)
-        MPL_gpu_free(tmp_buf);
-    MPIR_CHKLMEM_FREEALL();
+    MPIR_COLL_CHKLMEM_FREEALL();
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;
     else if (*errflag != MPIR_ERR_NONE)

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -38,7 +38,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
     int mask, dst_tree_root, my_tree_root, position,
         send_offset, recv_offset, nprocs_completed, k, offset, tmp_mask, tree_root;
     MPL_pointer_attr_t attr;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_COLL_CHKLMEM_DECL(1);
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -61,11 +61,8 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);
 
     MPL_gpu_query_pointer_attr(recvbuf, &attr);
-    if (attr.type == MPL_GPU_POINTER_DEV)
-        MPL_gpu_malloc((void **) &tmp_buf, total_count * recvtype_sz, attr.device);
-    else
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *,
-                            total_count * recvtype_sz, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+    MPIR_COLL_CHKLMEM_MALLOC(tmp_buf, total_count * recvtype_sz, attr, mpi_errno, "tmp_buf",
+                             MPL_MEM_BUFFER);
 
     /* copy local data into right location in tmp_buf */
     position = 0;
@@ -251,9 +248,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
     }
 
   fn_exit:
-    if (attr.type == MPL_GPU_POINTER_DEV)
-        MPL_gpu_free(tmp_buf);
-    MPIR_CHKLMEM_FREEALL();
+    MPIR_COLL_CHKLMEM_FREEALL();
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;
     else if (*errflag != MPIR_ERR_NONE)

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -126,10 +126,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
         pof2 *= 2;
     }
 
-    /* Rotate blocks in recvbuf upwards by (rank + 1) blocks. Need
-     * a temporary buffer of the same size as recvbuf. */
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, pack_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
-
+    /* Rotate blocks in recvbuf upwards by (rank + 1) blocks */
     mpi_errno = MPIR_Localcopy((char *) recvbuf + (rank + 1) * recvcount * recvtype_extent,
                                (comm_size - rank - 1) * recvcount, recvtype, tmp_buf,
                                (comm_size - rank - 1) * recvcount * recvtype_sz, MPI_BYTE);

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -32,7 +32,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
     MPL_pointer_attr_t attr;
     MPI_Aint type_size;
     void *tmp_buf = NULL;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_COLL_CHKLMEM_DECL(1);
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -55,11 +55,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
 
     if (!is_contig) {
         MPL_gpu_query_pointer_attr(buffer, &attr);
-        if (attr.type == MPL_GPU_POINTER_DEV) {
-            MPL_gpu_malloc((void **) &tmp_buf, nbytes, attr.device);
-        } else {
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
-        }
+        MPIR_COLL_CHKLMEM_MALLOC(tmp_buf, nbytes, attr, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {
@@ -176,9 +172,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
     }
 
   fn_exit:
-    if (tmp_buf && attr.type == MPL_GPU_POINTER_DEV)
-        MPL_gpu_free(tmp_buf);
-    MPIR_CHKLMEM_FREEALL();
+    MPIR_COLL_CHKLMEM_FREEALL();
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -40,12 +40,13 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     int scatter_size;
     MPI_Aint curr_size, recv_size = 0;
     int j, k, i, tmp_mask, is_contig;
+    MPL_pointer_attr_t attr;
     MPI_Aint type_size, nbytes = 0;
     int relative_dst, dst_tree_root, my_tree_root, send_offset;
     int recv_offset, tree_root, nprocs_completed, offset;
     MPIR_CHKLMEM_DECL(1);
     MPI_Aint true_extent, true_lb;
-    void *tmp_buf;
+    void *tmp_buf = NULL;
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -79,7 +80,12 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
         tmp_buf = (char *) buffer + true_lb;
     } else {
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+        MPL_gpu_query_pointer_attr(buffer, &attr);
+        if (attr.type == MPL_GPU_POINTER_DEV) {
+            MPL_gpu_malloc((void **) &tmp_buf, nbytes, attr.device);
+        } else {
+            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+        }
 
         if (rank == root) {
             mpi_errno = MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE);
@@ -279,6 +285,8 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     }
 
   fn_exit:
+    if (tmp_buf && attr.type == MPL_GPU_POINTER_DEV)
+        MPL_gpu_free(tmp_buf);
     MPIR_CHKLMEM_FREEALL();
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno_ret)

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -39,7 +39,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
     MPI_Aint recvd_size, curr_size = 0;
     MPI_Status status;
     MPI_Aint true_extent, true_lb;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_COLL_CHKLMEM_DECL(1);
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -67,11 +67,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
         tmp_buf = (char *) buffer + true_lb;
     } else {
         MPL_gpu_query_pointer_attr(buffer, &attr);
-        if (attr.type == MPL_GPU_POINTER_DEV) {
-            MPL_gpu_malloc((void **) &tmp_buf, nbytes, attr.device);
-        } else {
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
-        }
+        MPIR_COLL_CHKLMEM_MALLOC(tmp_buf, nbytes, attr, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         if (rank == root) {
             mpi_errno = MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE);
@@ -156,9 +152,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
     }
 
   fn_exit:
-    if (tmp_buf && attr.type == MPL_GPU_POINTER_DEV)
-        MPL_gpu_free(tmp_buf);
-    MPIR_CHKLMEM_FREEALL();
+    MPIR_COLL_CHKLMEM_FREEALL();
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -59,7 +59,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype 
     MPI_Datatype types[2], tmp_type;
     int copy_offset = 0, copy_blks = 0;
     MPL_pointer_attr_t attr;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_COLL_CHKLMEM_DECL(1);
 
 
     comm_size = comm_ptr->local_size;
@@ -111,8 +111,8 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype 
         if (attr.type == MPL_GPU_POINTER_DEV)
             MPL_gpu_malloc((void **) &tmp_buf, tmp_buf_size, attr.device);
         else
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf",
-                                MPL_MEM_BUFFER);
+            MPIR_COLL_CHKLMEM_MALLOC(tmp_buf, tmp_buf_size, attr, mpi_errno, "tmp_buf",
+                                     MPL_MEM_BUFFER);
     }
 
     if (rank == root) {
@@ -315,9 +315,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype 
     }
 
   fn_exit:
-    if (attr.type == MPL_GPU_POINTER_DEV)
-        MPL_gpu_free(tmp_buf);
-    MPIR_CHKLMEM_FREEALL();
+    MPIR_COLL_CHKLMEM_FREEALL();
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;
     else if (*errflag != MPIR_ERR_NONE)


### PR DESCRIPTION
## Pull Request Description

When staging user data to and from GPUs, allocate temporary buffers on
the GPU to minimize data movement. This commit addresses blocking data
movement collectives.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
