### PR TITLE
ch4/workq: create upper-layer workq request

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -67,6 +67,7 @@ typedef enum MPIR_Request_kind_t {
     MPIR_REQUEST_KIND__COLL,
     MPIR_REQUEST_KIND__MPROBE,  /* see NOTE-R1 */
     MPIR_REQUEST_KIND__RMA,
+    MPIR_REQUEST_KIND__WORKQ,
     MPIR_REQUEST_KIND__LAST
 #ifdef MPID_REQUEST_KIND_DECL
         , MPID_REQUEST_KIND_DECL
@@ -204,6 +205,12 @@ struct MPIR_Request {
             /* Persistent requests have their own "real" requests */
             struct MPIR_Request *real_request;
         } persist;              /* kind : MPID_PREQUEST_SEND or MPID_PREQUEST_RECV */
+        struct {
+#if defined HAVE_DEBUGGER_SUPPORT
+            struct MPIR_Sendq *dbg_next;
+#endif
+            struct MPIR_Request *real_request;
+        } workq;                /* kind : MPIR_REQUEST_KIND__WORKQ */
     } u;
 
     /* Other, device-specific information */

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -297,6 +297,13 @@ static inline int MPIR_Request_is_persistent(MPIR_Request * req_ptr)
             req_ptr->kind == MPIR_REQUEST_KIND__PREQUEST_RECV);
 }
 
+static inline int MPIR_Request_is_persistent_workq(MPIR_Request * req_ptr)
+{
+    return (MPIR_Request_is_persistent(req_ptr) &&
+            req_ptr->u.persist.real_request &&
+            req_ptr->u.persist.real_request->kind == MPIR_REQUEST_KIND__WORKQ);
+}
+
 /* Return whether a request is active.
  * A persistent request and the handle to it are "inactive"
  * if the request is not associated with any ongoing communication.

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -42,6 +42,8 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
+/* Add MPIR_REQUEST_KIND__WORKQ */
+
 /* NOTE-R1: MPIR_REQUEST_KIND__MPROBE signifies that this is a request created by
  * MPI_Mprobe or MPI_Improbe.  Since we use MPI_Request objects as our
  * MPI_Message objects, we use this separate kind in order to provide stronger

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -504,6 +504,19 @@ MPL_STATIC_INLINE_PREFIX void MPIR_Request_free(MPIR_Request * req)
     MPIR_Request_free_with_safety(req, 1);
 }
 
+/* On completion, transfer status from real_request back to workq request
+ * for regular completion processing */
+static inline void MPIR_workq_request_completion(MPIR_Request * req)
+{
+    MPIR_Assert(req->kind == MPIR_REQUEST_KIND__WORKQ);
+
+    MPIR_Request *real_req = req->u.workq.real_request;
+    MPIR_Assert(real_req != NULL);
+    req->kind = real_req->kind;
+    req->status = real_req->status;
+    MPIR_Request_free_safe(real_req);
+}
+
 /* Requests that are not created inside device (general requests, nonblocking collective
  * requests such as sched, gentran, hcoll) should call MPIR_Request_complete.
  * MPID_Request_complete are called inside device critical section, therefore, potentially

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -64,6 +64,11 @@ int MPIC_Wait(MPIR_Request * request_ptr, MPIR_Errflag_t * errflag)
     mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* collapse workq request */
+    if (request_ptr->kind == MPIR_REQUEST_KIND__WORKQ) {
+        MPIR_workq_request_completion(request_ptr);
+    }
+
     if (request_ptr->kind == MPIR_REQUEST_KIND__RECV)
         MPIR_Process_status(&request_ptr->status, errflag);
 

--- a/src/mpi/pt2pt/recv.c
+++ b/src/mpi/pt2pt/recv.c
@@ -149,6 +149,11 @@ int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag,
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
+    /* collapse workq request */
+    if (request_ptr->kind == MPIR_REQUEST_KIND__WORKQ) {
+        MPIR_workq_request_completion(request_ptr);
+    }
+
     mpi_errno = request_ptr->status.MPI_ERROR;
     MPIR_Request_extract_status(request_ptr, status);
     MPIR_Request_free(request_ptr);

--- a/src/mpi/pt2pt/rsend.c
+++ b/src/mpi/pt2pt/rsend.c
@@ -133,6 +133,11 @@ int MPI_Rsend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
     mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* collapse workq request */
+    if (request_ptr->kind == MPIR_REQUEST_KIND__WORKQ) {
+        MPIR_workq_request_completion(request_ptr);
+    }
+
     mpi_errno = request_ptr->status.MPI_ERROR;
     MPIR_Request_free(request_ptr);
 

--- a/src/mpi/pt2pt/send.c
+++ b/src/mpi/pt2pt/send.c
@@ -136,6 +136,11 @@ int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int ta
     mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* collapse workq request */
+    if (request_ptr->kind == MPIR_REQUEST_KIND__WORKQ) {
+        MPIR_workq_request_completion(request_ptr);
+    }
+
     mpi_errno = request_ptr->status.MPI_ERROR;
     MPIR_Request_free(request_ptr);
 

--- a/src/mpi/pt2pt/sendrecv.c
+++ b/src/mpi/pt2pt/sendrecv.c
@@ -216,6 +216,14 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         MPID_Progress_end(&progress_state);
     }
 
+    if (sreq->kind == MPIR_REQUEST_KIND__WORKQ) {
+        MPIR_workq_request_completion(sreq);
+    }
+
+    if (rreq->kind == MPIR_REQUEST_KIND__WORKQ) {
+        MPIR_workq_request_completion(rreq);
+    }
+
     mpi_errno = rreq->status.MPI_ERROR;
     MPIR_Request_extract_status(rreq, status);
     MPIR_Request_free(rreq);

--- a/src/mpi/pt2pt/sendrecv_rep.c
+++ b/src/mpi/pt2pt/sendrecv_rep.c
@@ -189,6 +189,15 @@ int MPI_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype,
         mpi_errno = MPID_Wait(sreq, MPI_STATUS_IGNORE);
         MPIR_ERR_CHECK(mpi_errno);
 
+        /* collapse workq request */
+        if (sreq->kind == MPIR_REQUEST_KIND__WORKQ) {
+            MPIR_workq_request_completion(sreq);
+        }
+
+        if (rreq->kind == MPIR_REQUEST_KIND__WORKQ) {
+            MPIR_workq_request_completion(rreq);
+        }
+
         if (status != MPI_STATUS_IGNORE) {
             *status = rreq->status;
         }

--- a/src/mpi/pt2pt/ssend.c
+++ b/src/mpi/pt2pt/ssend.c
@@ -132,6 +132,11 @@ int MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
     mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* collapse workq request */
+    if (request_ptr->kind == MPIR_REQUEST_KIND__WORKQ) {
+        MPIR_workq_request_completion(request_ptr);
+    }
+
     mpi_errno = request_ptr->status.MPI_ERROR;
     MPIR_Request_free(request_ptr);
 

--- a/src/mpi/request/cancel.c
+++ b/src/mpi/request/cancel.c
@@ -100,6 +100,13 @@ int MPIR_Cancel(MPIR_Request * request_ptr)
                 break;
             }
 
+        case MPIR_REQUEST_KIND__WORKQ:
+            /* This is a hack to avoid adding a netmod API. We'll handle the workq case
+             * inside MPID_Cancel_send. */
+            mpi_errno = MPID_Cancel_send(request_ptr);
+            MPIR_ERR_CHECK(mpi_errno);
+            break;
+
             /* --BEGIN ERROR HANDLING-- */
         default:
             {

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -64,6 +64,14 @@ int MPIR_Request_completion_processing(MPIR_Request * request_ptr, MPI_Status * 
     int mpi_errno = MPI_SUCCESS;
     int rc;
 
+    /* first, collapse workq request */
+    if (request_ptr->kind == MPIR_REQUEST_KIND__WORKQ) {
+        MPIR_workq_request_completion(request_ptr);
+    } else if (MPIR_Request_is_persistent_workq(request_ptr)) {
+        MPIR_workq_request_completion(request_ptr->u.persist.real_request);
+    }
+
+    /* normal request completion */
     switch (request_ptr->kind) {
         case MPIR_REQUEST_KIND__SEND:
             {

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -254,6 +254,16 @@ int MPIR_Request_get_error(MPIR_Request * request_ptr)
                 break;
             }
 
+        case MPIR_REQUEST_KIND__WORKQ:
+            {
+                if (request_ptr->u.workq.real_request != NULL) {
+                    mpi_errno = request_ptr->u.workq.real_request->status.MPI_ERROR;
+                } else {
+                    mpi_errno = request_ptr->status.MPI_ERROR;
+                }
+                break;
+            }
+
         default:
             {
                 /* --BEGIN ERROR HANDLING-- */

--- a/src/mpi/request/request_free.c
+++ b/src/mpi/request/request_free.c
@@ -148,6 +148,11 @@ int MPI_Request_free(MPI_Request * request)
                 break;
             }
 
+        case MPIR_REQUEST_KIND__WORKQ:
+            {
+                break;
+            }
+
             /* --BEGIN ERROR HANDLING-- */
         default:
             {

--- a/src/mpi/request/request_get_status.c
+++ b/src/mpi/request/request_get_status.c
@@ -111,6 +111,13 @@ int MPI_Request_get_status(MPI_Request request, int *flag, MPI_Status * status)
     }
 
     if (MPIR_Request_is_complete(request_ptr)) {
+        /* first, collapse workq request */
+        if (request_ptr->kind == MPIR_REQUEST_KIND__WORKQ) {
+            MPIR_workq_request_completion(request_ptr);
+        } else if (MPIR_Request_is_persistent_workq(request_ptr)) {
+            MPIR_workq_request_completion(request_ptr->u.persist.real_request);
+        }
+
         switch (request_ptr->kind) {
             case MPIR_REQUEST_KIND__SEND:
                 {

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -73,27 +73,25 @@ int MPIR_Wait(MPI_Request * request, MPI_Status * status)
     MPIR_Request_get_ptr(*request, request_ptr);
     MPIR_Assert(request_ptr != NULL);
 
-    if (!MPIR_Request_is_complete(request_ptr)) {
-        /* If this is an anysource request including a communicator with
-         * anysource disabled, convert the call to an MPI_Test instead so we
-         * don't get stuck in the progress engine. */
-        if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptr))) {
-            mpi_errno = MPIR_Test(request, &active_flag, status);
-            goto fn_exit;
-        }
+    /* If this is an anysource request including a communicator with
+     * anysource disabled, convert the call to an MPI_Test instead so we
+     * don't get stuck in the progress engine. */
+    if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptr))) {
+        mpi_errno = MPIR_Test(request, &active_flag, status);
+        goto fn_exit;
+    }
 
-        if (MPIR_Request_has_poll_fn(request_ptr)) {
-            while (!MPIR_Request_is_complete(request_ptr)) {
-                mpi_errno = MPIR_Grequest_poll(request_ptr, status);
-                MPIR_ERR_CHECK(mpi_errno);
-
-                /* Avoid blocking other threads since I am inside an infinite loop */
-                MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-            }
-        } else {
-            mpi_errno = MPID_Wait(request_ptr, status);
+    if (MPIR_Request_has_poll_fn(request_ptr)) {
+        while (!MPIR_Request_is_complete(request_ptr)) {
+            mpi_errno = MPIR_Grequest_poll(request_ptr, status);
             MPIR_ERR_CHECK(mpi_errno);
+
+            /* Avoid blocking other threads since I am inside an infinite loop */
+            MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
         }
+    } else {
+        mpi_errno = MPID_Wait(request_ptr, status);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     mpi_errno = MPIR_Request_completion_processing(request_ptr, status);

--- a/src/mpid/ch4/generic/am/mpidig_am_send.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_send.h
@@ -93,14 +93,10 @@ static inline int MPIDIG_do_eager_send(const void *buf, MPI_Aint count, MPI_Data
                                        MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *sreq = *request;
+    MPIR_Request *sreq;
 
-    if (sreq == NULL) {
-        sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
-        MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    } else {
-        MPIDIG_request_init(sreq, MPIR_REQUEST_KIND__SEND);
-    }
+    sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
+    MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
     *request = sreq;
 
@@ -141,14 +137,10 @@ static inline int MPIDIG_do_ssend(const void *buf, MPI_Aint count, MPI_Datatype 
                                   MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS, c;
-    MPIR_Request *sreq = *request;
+    MPIR_Request *sreq;
 
-    if (sreq == NULL) {
-        sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
-        MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    } else {
-        MPIDIG_request_init(sreq, MPIR_REQUEST_KIND__SEND);
-    }
+    sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
+    MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
     *request = sreq;
 
@@ -195,14 +187,10 @@ static inline int MPIDIG_do_rndv_send(const void *buf, MPI_Aint count, MPI_Datat
                                       MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *sreq = *request;
+    MPIR_Request *sreq;
 
-    if (sreq == NULL) {
-        sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
-        MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    } else {
-        MPIDIG_request_init(sreq, MPIR_REQUEST_KIND__SEND);
-    }
+    sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
+    MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
     *request = sreq;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -627,11 +627,6 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     MPIR_Assert(num_vnis == 1 || MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS);
 #endif
 
-    /* WorkQ only works with single vni for now */
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIR_Assert(num_vnis == 1);
-#endif
-
     MPIDI_OFI_global.num_vnis = num_vnis;
 
     /* Create MPIDI_OFI_global.ctx[0] first  */

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -98,14 +98,7 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
     origin_iov = MPL_malloc(sizeof(struct iovec) * origin_len, MPL_MEM_RMA);
 
     if (sigreq) {
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-        if (*sigreq) {
-            MPIR_Request_add_ref(*sigreq);
-        } else
-#endif
-        {
-            MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
-        }
+        MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
         flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
     } else {
         flags = FI_DELIVERY_COMPLETE;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -185,14 +185,7 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
     /* large contiguous messages */
     if (origin_contig && target_contig) {
         if (sigreq) {
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-            if (*sigreq) {
-                MPIR_Request_add_ref(*sigreq);
-            } else
-#endif
-            {
-                MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
-            }
+            MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
             flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
         } else {
             flags = FI_DELIVERY_COMPLETE;
@@ -341,14 +334,7 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
         offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
         if (sigreq) {
             if (sigreq) {
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-                if (*sigreq) {
-                    MPIR_Request_add_ref(*sigreq);
-                } else
-#endif
-                {
-                    MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
-                }
+                MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
                 flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
             } else {
                 flags = FI_DELIVERY_COMPLETE;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -353,8 +353,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
              * lightweight_send. */
             MPL_gpu_free_host(send_buf);
         }
-        if (!noreq) {
+        if (noreq) {
             *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
+        } else {
+            mpi_errno = MPID_Request_complete(*request);
         }
     } else {
         mpi_errno = MPIDI_OFI_send_normal(buf, count, datatype, cq_data, dst_rank, tag, comm,

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -315,7 +315,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
                                             int dst_rank, int tag, MPIR_Comm * comm,
                                             int context_offset, MPIDI_av_entry_t * addr,
                                             int vni_src, int vni_dst,
-                                            MPIR_Request ** request, int noreq,
+                                            MPIR_Request ** request,
                                             uint64_t syncflag, MPIR_Errflag_t err_flag)
 {
     int dt_contig, mpi_errno;
@@ -353,7 +353,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
              * lightweight_send. */
             MPL_gpu_free_host(send_buf);
         }
-        if (noreq) {
+        if (*request == NULL) {
             *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
         } else {
             mpi_errno = MPID_Request_complete(*request);
@@ -399,7 +399,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, vni_src, vni_dst, request,
-                                   (*request == NULL), 0ULL, MPIR_ERR_NONE);
+                                   0ULL, MPIR_ERR_NONE);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }
 
@@ -442,8 +442,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
         MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm, context_offset,
-                                   addr, vni_src, vni_dst, request, (*request == NULL), 0ULL,
-                                   *errflag);
+                                   addr, vni_src, vni_dst, request, 0ULL, *errflag);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }
 
@@ -468,7 +467,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
         MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, vni_src, vni_dst, request, 0,
+                                   context_offset, addr, vni_src, vni_dst, request,
                                    MPIDI_OFI_SYNC_SEND, MPIR_ERR_NONE);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }
@@ -496,7 +495,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, vni_src, vni_dst,
-                                   request, 0, 0ULL, MPIR_ERR_NONE);
+                                   request, 0ULL, MPIR_ERR_NONE);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }
 
@@ -539,8 +538,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
         MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, vni_src, vni_dst, request, 0, 0ULL,
-                                   *errflag);
+                                   context_offset, addr, vni_src, vni_dst, request, 0ULL, *errflag);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }
 
@@ -565,7 +563,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count
         MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, vni_src, vni_dst, request, 0,
+                                   context_offset, addr, vni_src, vni_dst, request,
                                    MPIDI_OFI_SYNC_SEND, MPIR_ERR_NONE);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -356,6 +356,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         if (*request == NULL) {
             *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
         } else {
+            MPIR_Request_add_ref(*request);
             mpi_errno = MPID_Request_complete(*request);
         }
     } else {

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -24,7 +24,7 @@ int MPIDI_OFI_retry_progress()
     /* We do not call progress on hooks form netmod level
      * because it is not reentrant safe.
      */
-    return MPID_Progress_test(NULL);
+    return MPIDI_Progress_test(MPIDI_PROGRESS_SHM | MPIDI_PROGRESS_NM);
 }
 
 typedef struct MPIDI_OFI_mr_key_allocator_t {

--- a/src/mpid/ch4/src/Makefile.mk
+++ b/src/mpid/ch4/src/Makefile.mk
@@ -22,6 +22,8 @@ noinst_HEADERS += src/mpid/ch4/src/ch4_comm.h     \
                   src/mpid/ch4/src/ch4r_init.h    \
                   src/mpid/ch4/src/ch4r_proc.h    \
                   src/mpid/ch4/src/ch4i_comm.h    \
+                  src/mpid/ch4/src/ch4i_workq.h   \
+                  src/mpid/ch4/src/ch4i_workq_types.h \
                   src/mpid/ch4/src/ch4r_recvq.h   \
                   src/mpid/ch4/src/ch4r_recv.h    \
                   src/mpid/ch4/src/ch4r_callbacks.h     \
@@ -37,6 +39,7 @@ mpi_core_sources += src/mpid/ch4/src/ch4_globals.c        \
                     src/mpid/ch4/src/ch4_progress.c       \
                     src/mpid/ch4/src/ch4_win.c            \
                     src/mpid/ch4/src/ch4i_comm.c          \
+                    src/mpid/ch4/src/ch4i_workq_progress.c \
                     src/mpid/ch4/src/ch4r_init.c          \
                     src/mpid/ch4/src/ch4r_proc.c          \
                     src/mpid/ch4/src/ch4r_recvq.c         \

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -571,6 +571,10 @@ int MPID_Init(int requested, int *provided)
         MPIR_Assert(MPIDI_global.n_vcis <= MPIDI_CH4_MAX_VCIS);
         MPIR_Assert(MPIDI_global.n_vcis <= MPIR_REQUEST_NUM_POOLS);
     }
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    /* workq does not work with multiple vci */
+    MPIR_Assert(MPIDI_global.n_vcis == 1);
+#endif
 
     for (int i = 0; i < MPIDI_global.n_vcis; i++) {
         MPID_Thread_mutex_create(&MPIDI_VCI(i).lock, &err);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -232,6 +232,8 @@ static int choose_netmod(void)
  */
 /* TODO: move them to ch4i_workq_init.c. */
 
+MPID_Thread_mutex_t MPIDI_workq_lock;
+
 static const char *get_mt_model_name(int mt);
 static void print_runtime_configurations(void);
 static int parse_mt_model(const char *name);
@@ -537,6 +539,9 @@ int MPID_Init(int requested, int *provided)
     MPIR_Assert(err == 0);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_Thread_mutex_create(&MPIDI_workq_lock, &err);
+    MPIR_Assert(err == 0);
+
     mpi_errno = set_runtime_configurations();
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -752,6 +757,11 @@ int MPID_Finalize(void)
         MPID_Thread_mutex_destroy(&MPIDI_VCI(i).lock, &err);
         MPIR_Assert(err == 0);
     }
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_Thread_mutex_destroy(&MPIDI_workq_lock, &err);
+    MPIR_Assert(err == 0);
+#endif
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_FINALIZE);

--- a/src/mpid/ch4/src/ch4_probe.h
+++ b/src/mpid/ch4/src/ch4_probe.h
@@ -100,9 +100,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_safe(int source,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPROBE_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
     mpi_errno = MPIDI_iprobe_unsafe(source, tag, comm, context_offset, av, flag, status);
     MPIR_ERR_CHECK(mpi_errno);
@@ -127,9 +126,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_improbe_safe(int source,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMPROBE_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
     mpi_errno = MPIDI_improbe_unsafe(source, tag, comm, context_offset, av, flag, message, status);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/src/ch4_progress.c
+++ b/src/mpid/ch4/src/ch4_progress.c
@@ -78,8 +78,10 @@ static int progress_test(MPID_Progress_state * state, int wait)
     /* todo: progress unexp_list */
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    mpi_errno = MPIDI_workq_vci_progress();
-    MPIR_ERR_CHECK(mpi_errno);
+    if (state->flag & MPIDI_PROGRESS_WORKQ) {
+        mpi_errno = MPIDI_workq_vci_progress();
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 #endif
 
     if (do_global_progress()) {

--- a/src/mpid/ch4/src/ch4_progress.c
+++ b/src/mpid/ch4/src/ch4_progress.c
@@ -219,12 +219,6 @@ int MPID_Progress_wait(MPID_Progress_state * state)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PROGRESS_WAIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_PROGRESS_WAIT);
 
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    mpi_errno = MPID_Progress_test(state);
-    MPIR_ERR_CHECK(mpi_errno);
-    MPIDI_PROGRESS_YIELD();
-
-#else
     state->progress_made = 0;
     while (1) {
         mpi_errno = progress_test(state, 1);
@@ -235,7 +229,6 @@ int MPID_Progress_wait(MPID_Progress_state * state)
         MPIDI_PROGRESS_YIELD();
     }
 
-#endif
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_PROGRESS_WAIT);
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -272,15 +272,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMRECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIR_Request *request = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT(request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(IMRECV, NULL /*send_buf */ , buf, count, datatype,
                               0 /*rank */ , 0 /*tag */ , NULL /*comm */ ,
                               0 /*context_offset */ , NULL /*av */ ,
-                              NULL /*status */ , request, NULL /*flag */ ,
+                              NULL /*status */ , message, NULL /*flag */ ,
                               &message, NULL /*processed */);
 #else
     mpi_errno = MPIDI_imrecv_unsafe(buf, count, datatype, message);

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -472,6 +472,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Cancel_recv(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_CANCEL_RECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_CANCEL_RECV);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    /* this is silly: izem queue doesn't have iter and delete interface
+     * so we can't simply delete from work queue. Progress and have the
+     * request posted before we cancel.
+     */
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     mpi_errno = MPIDI_cancel_recv_safe(rreq);
 
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -209,7 +209,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
                                           status, req, NULL /*flag */ , NULL /*message */ ,
                                           NULL /*processed */);
 #else
-    *(req) = NULL;
     mpi_errno = MPIDI_recv_unsafe(buf, count, datatype, rank, tag, comm,
                                   context_offset, av, status, req);
 #endif
@@ -238,7 +237,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
                                           NULL /*message */ ,
                                           NULL /*processed */);
 #else
-    *(req) = NULL;
     mpi_errno = MPIDI_irecv_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
 #endif
 

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -204,27 +204,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_workq_pt2pt_enqueue(RECV, NULL /*send_buf */ , buf, count, datatype,
-                              rank, tag, comm, context_offset, av,
-                              status, *req, NULL /*flag */ , NULL /*message */ ,
-                              NULL /*processed */);
+    mpi_errno = MPIDI_workq_pt2pt_enqueue(RECV, NULL /*send_buf */ , buf, count, datatype,
+                                          rank, tag, comm, context_offset, av,
+                                          status, req, NULL /*flag */ , NULL /*message */ ,
+                                          NULL /*processed */);
 #else
     *(req) = NULL;
     mpi_errno = MPIDI_recv_unsafe(buf, count, datatype, rank, tag, comm,
                                   context_offset, av, status, req);
 #endif
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RECV_SAFE);
     return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
@@ -241,26 +232,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IRECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_workq_pt2pt_enqueue(IRECV, NULL /*send_buf */ , buf, count, datatype,
-                              rank, tag, comm, context_offset, av,
-                              NULL /*status */ , *req, NULL /*flag */ , NULL /*message */ ,
-                              NULL /*processed */);
+    mpi_errno = MPIDI_workq_pt2pt_enqueue(IRECV, NULL /*send_buf */ , buf, count, datatype,
+                                          rank, tag, comm, context_offset, av,
+                                          NULL /*status */ , req, NULL /*flag */ ,
+                                          NULL /*message */ ,
+                                          NULL /*processed */);
 #else
     *(req) = NULL;
     mpi_errno = MPIDI_irecv_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
 #endif
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IRECV_SAFE);
     return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
@@ -272,11 +255,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMRECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_pt2pt_enqueue(IMRECV, NULL /*send_buf */ , buf, count, datatype,
-                              0 /*rank */ , 0 /*tag */ , NULL /*comm */ ,
-                              0 /*context_offset */ , NULL /*av */ ,
-                              NULL /*status */ , message, NULL /*flag */ ,
-                              &message, NULL /*processed */);
+    mpi_errno = MPIDI_workq_pt2pt_enqueue(IMRECV, NULL /*send_buf */ , buf, count, datatype,
+                                          0 /*rank */ , 0 /*tag */ , NULL /*comm */ ,
+                                          0 /*context_offset */ , NULL /*av */ ,
+                                          NULL /*status */ , NULL /*req */ , NULL /*flag */ ,
+                                          &message, NULL /*processed */);
 #else
     mpi_errno = MPIDI_imrecv_unsafe(buf, count, datatype, message);
 #endif

--- a/src/mpid/ch4/src/ch4_rma.h
+++ b/src/mpid/ch4/src/ch4_rma.h
@@ -468,10 +468,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno = MPIDI_accumulate_unsafe(origin_addr, origin_count, origin_datatype, target_rank,
                                         target_disp, target_count, target_datatype, op, win);
@@ -498,10 +499,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_safe(const void *origin_addr
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_COMPARE_AND_SWAP_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_COMPARE_AND_SWAP_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno =
         MPIDI_compare_and_swap_unsafe(origin_addr, compare_addr, result_addr, datatype,
@@ -533,10 +535,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno = MPIDI_raccumulate_unsafe(origin_addr, origin_count, origin_datatype, target_rank,
                                          target_disp, target_count, target_datatype, op, win,
@@ -569,10 +572,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_ACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_ACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno =
         MPIDI_rget_accumulate_unsafe(origin_addr, origin_count, origin_datatype, result_addr,
@@ -601,10 +605,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_FETCH_AND_OP_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_FETCH_AND_OP_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno = MPIDI_fetch_and_op_unsafe(origin_addr, result_addr, datatype, target_rank,
                                           target_disp, op, win);
@@ -633,10 +638,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_safe(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno =
         MPIDI_rget_unsafe(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
@@ -666,10 +672,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rput_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RPUT_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RPUT_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno =
         MPIDI_rput_unsafe(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
@@ -702,10 +709,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     mpi_errno = MPIDI_get_accumulate_unsafe(origin_addr, origin_count, origin_datatype, result_addr,
                                             result_count, result_datatype, target_rank, target_disp,

--- a/src/mpid/ch4/src/ch4_rma.h
+++ b/src/mpid/ch4/src/ch4_rma.h
@@ -400,11 +400,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_put_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PUT_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
-    MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
-    MPIDI_workq_rma_enqueue(PUT, origin_addr, origin_count, origin_datatype, NULL, NULL, 0,
-                            MPI_DATATYPE_NULL, target_rank, target_disp, target_count,
-                            target_datatype, MPI_OP_NULL, win, NULL, NULL);
+    mpi_errno =
+        MPIDI_workq_rma_enqueue(PUT, origin_addr, origin_count, origin_datatype, NULL, NULL, 0,
+                                MPI_DATATYPE_NULL, target_rank, target_disp, target_count,
+                                target_datatype, MPI_OP_NULL, win, NULL, NULL);
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDI_put_unsafe(origin_addr, origin_count, origin_datatype,
@@ -433,13 +433,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_safe(void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
-    MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
     /* For MPI_Get, "origin" has to be passed to the "result" parameter
      * field, because `origin_addr` is declared as `const void *`. */
-    MPIDI_workq_rma_enqueue(GET, NULL, origin_count, origin_datatype, NULL, origin_addr, 0,
-                            MPI_DATATYPE_NULL, target_rank, target_disp, target_count,
-                            target_datatype, MPI_OP_NULL, win, NULL, NULL);
+    mpi_errno =
+        MPIDI_workq_rma_enqueue(GET, NULL, origin_count, origin_datatype, NULL, origin_addr, 0,
+                                MPI_DATATYPE_NULL, target_rank, target_disp, target_count,
+                                target_datatype, MPI_OP_NULL, win, NULL, NULL);
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDI_get_unsafe(origin_addr, origin_count, origin_datatype,

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -249,26 +249,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
      *       threshold for lightweight send is controlled by lower layer. It'll be nice
      *       if the lower layer expose the threshold.
      */
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_workq_pt2pt_enqueue(SEND, buf, NULL /*recv_buf */ , count, datatype,
-                              rank, tag, comm, context_offset, av,
-                              NULL /*status */ , *req, NULL /*flag */ ,
-                              NULL /*message */ , NULL /*processed */);
+    mpi_errno = MPIDI_workq_pt2pt_enqueue(SEND, buf, NULL /*recv_buf */ , count, datatype,
+                                          rank, tag, comm, context_offset, av,
+                                          NULL /*status */ , req, NULL /*flag */ ,
+                                          NULL /*message */ , NULL /*processed */);
 #else
     *(req) = NULL;
     mpi_errno = MPIDI_send_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
 #endif
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SEND_SAFE);
     return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
@@ -286,25 +277,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_COLL_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_workq_csend_enqueue(CSEND, buf, count, datatype, rank, tag, comm,
-                              context_offset, av, *req, errflag);
+    mpi_errno = MPIDI_workq_csend_enqueue(CSEND, buf, count, datatype, rank, tag, comm,
+                                          context_offset, av, req, errflag);
 #else
     *(req) = NULL;
     mpi_errno = MPIDI_send_coll_unsafe(buf, count, datatype, rank, tag, comm,
                                        context_offset, av, req, errflag);
 #endif
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SEND_COLL_SAFE);
     return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
@@ -320,26 +302,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_workq_pt2pt_enqueue(ISEND, buf, NULL /*recv_buf */ , count, datatype,
-                              rank, tag, comm, context_offset, av,
-                              NULL /*status */ , *req, NULL /*flag */ ,
-                              NULL /*message */ , NULL /*processed */);
+    mpi_errno = MPIDI_workq_pt2pt_enqueue(ISEND, buf, NULL /*recv_buf */ , count, datatype,
+                                          rank, tag, comm, context_offset, av,
+                                          NULL /*status */ , req, NULL /*flag */ ,
+                                          NULL /*message */ , NULL /*processed */);
 #else
     *(req) = NULL;
     mpi_errno = MPIDI_isend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
 #endif
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISEND_SAFE);
     return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
@@ -357,25 +330,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISEND_COLL_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_workq_csend_enqueue(ICSEND, buf, count, datatype, rank, tag, comm,
-                              context_offset, av, *req, errflag);
+    mpi_errno = MPIDI_workq_csend_enqueue(ICSEND, buf, count, datatype, rank, tag, comm,
+                                          context_offset, av, req, errflag);
 #else
     *(req) = NULL;
     mpi_errno = MPIDI_isend_coll_unsafe(buf, count, datatype, rank, tag, comm,
                                         context_offset, av, req, errflag);
 #endif
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISEND_COLL_SAFE);
     return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
@@ -391,26 +355,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SSEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
-                              rank, tag, comm, context_offset, av,
-                              NULL /*status */ , *req, NULL /*flag */ ,
-                              NULL /*message */ , NULL /*processed */);
+    mpi_errno = MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
+                                          rank, tag, comm, context_offset, av,
+                                          NULL /*status */ , req, NULL /*flag */ ,
+                                          NULL /*message */ , NULL /*processed */);
 #else
     *(req) = NULL;
     mpi_errno = MPIDI_ssend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
 #endif
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SSEND_SAFE);
     return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
@@ -426,26 +381,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISSEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
-                              rank, tag, comm, context_offset, av,
-                              NULL /*status */ , *req, NULL /*flag */ ,
-                              NULL /*message */ , NULL /*processed */);
+    mpi_errno = MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
+                                          rank, tag, comm, context_offset, av,
+                                          NULL /*status */ , req, NULL /*flag */ ,
+                                          NULL /*message */ , NULL /*processed */);
 #else
     *(req) = NULL;
     mpi_errno = MPIDI_issend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
 #endif
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISSEND_SAFE);
     return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -254,7 +254,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
                                           NULL /*status */ , req, NULL /*flag */ ,
                                           NULL /*message */ , NULL /*processed */);
 #else
-    *(req) = NULL;
     mpi_errno = MPIDI_send_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
 #endif
 
@@ -280,7 +279,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
     mpi_errno = MPIDI_workq_csend_enqueue(CSEND, buf, count, datatype, rank, tag, comm,
                                           context_offset, av, req, errflag);
 #else
-    *(req) = NULL;
     mpi_errno = MPIDI_send_coll_unsafe(buf, count, datatype, rank, tag, comm,
                                        context_offset, av, req, errflag);
 #endif
@@ -307,7 +305,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
                                           NULL /*status */ , req, NULL /*flag */ ,
                                           NULL /*message */ , NULL /*processed */);
 #else
-    *(req) = NULL;
     mpi_errno = MPIDI_isend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
 #endif
 
@@ -333,7 +330,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
     mpi_errno = MPIDI_workq_csend_enqueue(ICSEND, buf, count, datatype, rank, tag, comm,
                                           context_offset, av, req, errflag);
 #else
-    *(req) = NULL;
     mpi_errno = MPIDI_isend_coll_unsafe(buf, count, datatype, rank, tag, comm,
                                         context_offset, av, req, errflag);
 #endif
@@ -360,7 +356,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
                                           NULL /*status */ , req, NULL /*flag */ ,
                                           NULL /*message */ , NULL /*processed */);
 #else
-    *(req) = NULL;
     mpi_errno = MPIDI_ssend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
 #endif
 
@@ -386,7 +381,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
                                           NULL /*status */ , req, NULL /*flag */ ,
                                           NULL /*message */ , NULL /*processed */);
 #else
-    *(req) = NULL;
     mpi_errno = MPIDI_issend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
 #endif
 

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -37,8 +37,9 @@ enum {
 #define MPIDI_PROGRESS_HOOKS  (1)
 #define MPIDI_PROGRESS_NM     (1<<1)
 #define MPIDI_PROGRESS_SHM    (1<<2)
+#define MPIDI_PROGRESS_WORKQ  (1<<3)
 
-#define MPIDI_PROGRESS_ALL (MPIDI_PROGRESS_HOOKS|MPIDI_PROGRESS_NM|MPIDI_PROGRESS_SHM)
+#define MPIDI_PROGRESS_ALL 0xff
 
 enum {
     MPIDIG_EPOTYPE_NONE = 0,          /**< No epoch in affect */

--- a/src/mpid/ch4/src/ch4_win.h
+++ b/src/mpid/ch4/src/ch4_win.h
@@ -15,8 +15,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_start(MPIR_Group * group, int assert, MPIR
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_START);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_START);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_start(group, assert, win);
@@ -40,8 +43,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_complete(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_COMPLETE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_COMPLETE);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_complete(win);
@@ -65,8 +71,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_post(MPIR_Group * group, int assert, MPIR_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_POST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_POST);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_post(group, assert, win);
@@ -90,8 +99,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_wait(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_WAIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_WAIT);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_wait(win);
@@ -116,8 +128,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_test(MPIR_Win * win, int *flag)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_TEST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_TEST);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_test(win, flag);
@@ -141,8 +156,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock(int lock_type, int rank, int assert, 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_LOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_LOCK);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_lock(lock_type, rank, assert, win, NULL);
@@ -166,8 +184,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_UNLOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_UNLOCK);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_unlock(rank, win, NULL);
@@ -191,8 +212,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_fence(int assert, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FENCE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FENCE);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_fence(assert, win);
@@ -216,8 +240,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_LOCAL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH_LOCAL);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush_local(rank, win, NULL);
@@ -263,8 +290,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush(rank, win, NULL);
@@ -288,8 +318,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_LOCAL_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH_LOCAL_ALL);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush_local_all(win);
@@ -313,8 +346,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_UNLOCK_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_UNLOCK_ALL);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_unlock_all(win);
@@ -338,8 +374,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_sync(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_SYNC);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_SYNC);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_sync(win);
@@ -363,8 +402,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH_ALL);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush_all(win);
@@ -388,8 +430,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock_all(int assert, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_LOCK_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_LOCK_ALL);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    mpi_errno = MPIDI_workq_vci_progress();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_lock_all(assert, win);

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -9,6 +9,9 @@
 #include "ch4i_workq_types.h"
 #include <utlist.h>
 
+int MPIDI_workq_vci_progress_unsafe(void);
+int MPIDI_workq_vci_progress(void);
+
 #if defined(MPIDI_CH4_USE_WORK_QUEUES)
 extern struct MPIDI_workq_elemt MPIDI_workq_elemt_direct[MPIDI_WORKQ_ELEMT_PREALLOC];
 extern MPIR_Object_alloc_t MPIDI_workq_elemt_mem;
@@ -277,186 +280,11 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_release_pt2pt_elemt(MPIDI_workq_elemt_
     MPIR_Request_free(req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *req;
-    MPI_Datatype datatype, origin_datatype, target_datatype;
-
-    MPIR_Assert(workq_elemt != NULL);
-
-    switch (workq_elemt->op) {
-        case SEND:{
-                struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_send_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                  wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
-        case ISEND:{
-                struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_isend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                   wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
-        case SSEND:{
-                struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_ssend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                   wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
-        case ISSEND:{
-                struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_issend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                    wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
-        case CSEND:{
-                struct MPIDI_workq_csend *wd = &workq_elemt->params.pt2pt.csend;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_send_coll_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                       wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req,
-                                       &(wd->errflag));
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
-        case ICSEND:{
-                struct MPIDI_workq_csend *wd = &workq_elemt->params.pt2pt.csend;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_isend_coll_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                        wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req,
-                                        &(wd->errflag));
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
-        case RECV:{
-                struct MPIDI_workq_recv *wd = &workq_elemt->params.pt2pt.recv;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_recv_unsafe(wd->recv_buf, wd->count, wd->datatype, wd->rank, wd->tag,
-                                  wd->comm_ptr, wd->context_offset, wd->addr, wd->status, &req);
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
-        case IRECV:{
-                struct MPIDI_workq_irecv *wd = &workq_elemt->params.pt2pt.irecv;
-                req = wd->request;
-                datatype = wd->datatype;
-                MPIDI_irecv_unsafe(wd->recv_buf, wd->count, wd->datatype, wd->rank, wd->tag,
-                                   wd->comm_ptr, wd->context_offset, wd->addr, &req);
-                MPIR_Datatype_release_if_not_builtin(datatype);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
-        case IMRECV:{
-                struct MPIDI_workq_imrecv *wd = &workq_elemt->params.pt2pt.imrecv;
-                datatype = wd->datatype;
-                MPIDI_imrecv_unsafe(wd->buf, wd->count, wd->datatype, *wd->message);
-                MPIR_Datatype_release_if_not_builtin(datatype);
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-                if (!MPIDI_REQUEST(*wd->message, is_local))
-#endif
-                    MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
-                break;
-            }
-        case PUT:{
-                struct MPIDI_workq_put *wd = &workq_elemt->params.rma.put;
-                origin_datatype = wd->origin_datatype;
-                target_datatype = wd->target_datatype;
-                MPIDI_put_unsafe(wd->origin_addr, wd->origin_count, wd->origin_datatype,
-                                 wd->target_rank, wd->target_disp,
-                                 wd->target_count, wd->target_datatype, wd->win_ptr);
-                MPIR_Datatype_release_if_not_builtin(origin_datatype);
-                MPIR_Datatype_release_if_not_builtin(target_datatype);
-                MPIDI_workq_elemt_free(workq_elemt);
-                break;
-            }
-        case GET:{
-                struct MPIDI_workq_get *wd = &workq_elemt->params.rma.get;
-                origin_datatype = wd->origin_datatype;
-                target_datatype = wd->target_datatype;
-                MPIDI_get_unsafe(wd->origin_addr, wd->origin_count, wd->origin_datatype,
-                                 wd->target_rank, wd->target_disp,
-                                 wd->target_count, wd->target_datatype, wd->win_ptr);
-                MPIR_Datatype_release_if_not_builtin(origin_datatype);
-                MPIR_Datatype_release_if_not_builtin(target_datatype);
-                MPIDI_workq_elemt_free(workq_elemt);
-                break;
-            }
-        default:
-            mpi_errno = MPI_ERR_OTHER;
-            goto fn_fail;
-    }
-
-  fn_fail:
-    return mpi_errno;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_workq_vci_progress_unsafe(void)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIDI_workq_elemt_t *workq_elemt = NULL;
-
-    MPIDI_workq_dequeue(&MPIDI_global.workqueue, (void **) &workq_elemt);
-    while (workq_elemt != NULL) {
-        mpi_errno = MPIDI_workq_dispatch(workq_elemt);
-        if (mpi_errno != MPI_SUCCESS)
-            goto fn_fail;
-        MPIDI_workq_dequeue(&MPIDI_global.workqueue, (void **) &workq_elemt);
-    }
-
-  fn_fail:
-    return mpi_errno;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_workq_vci_progress(void)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-
-    mpi_errno = MPIDI_workq_vci_progress_unsafe();
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-  fn_fail:
-    return mpi_errno;
-}
-
 #else /* #if defined(MPIDI_CH4_USE_WORK_QUEUES) */
 #define MPIDI_workq_pt2pt_enqueue(...)
 #define MPIDI_workq_rma_enqueue(...)
 #define MPIDI_workq_csend_enqueue(...)
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_workq_vci_progress_unsafe(void)
-{
-    return MPI_SUCCESS;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_workq_vci_progress(void)
-{
-    return MPI_SUCCESS;
-}
 #endif /* #if defined(MPIDI_CH4_USE_WORK_QUEUES) */
 
 #endif /* CH4I_WORKQ_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -169,8 +169,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_pt2pt_enqueue(MPIDI_workq_op_t op,
                 wd->buf = recv_buf;
                 wd->count = count;
                 wd->datatype = datatype;
-                wd->message = message;
-                wd->request = request;
+                wd->message = *message;
                 break;
             }
         default:

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -16,6 +16,8 @@ int MPIDI_workq_vci_progress(void);
 extern struct MPIDI_workq_elemt MPIDI_workq_elemt_direct[MPIDI_WORKQ_ELEMT_PREALLOC];
 extern MPIR_Object_alloc_t MPIDI_workq_elemt_mem;
 
+extern MPID_Thread_mutex_t MPIDI_workq_lock;
+
 /* Forward declarations of the routines that can be pushed to a work-queue */
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_send_unsafe(const void *, MPI_Aint, MPI_Datatype, int, int,
@@ -175,7 +177,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_pt2pt_enqueue(MPIDI_workq_op_t op,
             MPIR_Assert(0);
     }
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_workq_lock);
     MPIDI_workq_enqueue(&MPIDI_global.workqueue, pt2pt_elemt);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_workq_lock);
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_workq_csend_enqueue(MPIDI_workq_op_t op,
@@ -212,7 +216,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_csend_enqueue(MPIDI_workq_op_t op,
     wd->request = request;
     wd->errflag = *errflag;
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_workq_lock);
     MPIDI_workq_enqueue(&MPIDI_global.workqueue, pt2pt_elemt);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_workq_lock);
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_workq_rma_enqueue(MPIDI_workq_op_t op,
@@ -270,7 +276,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_rma_enqueue(MPIDI_workq_op_t op,
         default:
             MPIR_Assert(0);
     }
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_workq_lock);
     MPIDI_workq_enqueue(&MPIDI_global.workqueue, rma_elemt);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_workq_lock);
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_workq_release_pt2pt_elemt(MPIDI_workq_elemt_t * workq_elemt)

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -80,6 +80,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_pt2pt_enqueue(MPIDI_workq_op_t op,
     MPIR_Assert(request != NULL);
 
     MPIR_Request_add_ref(request);
+    if (op != IMRECV) {
+        MPIR_Comm_add_ref(comm_ptr);
+    }
     pt2pt_elemt = &request->dev.ch4.command;
     pt2pt_elemt->op = op;
     pt2pt_elemt->processed = processed;
@@ -200,6 +203,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_csend_enqueue(MPIDI_workq_op_t op,
     MPIR_Assert(op == CSEND || op == ICSEND);
 
     MPIR_Request_add_ref(request);
+    MPIR_Comm_add_ref(comm_ptr);
     pt2pt_elemt = &request->dev.ch4.command;
     pt2pt_elemt->op = op;
 

--- a/src/mpid/ch4/src/ch4i_workq_progress.c
+++ b/src/mpid/ch4/src/ch4i_workq_progress.c
@@ -111,6 +111,7 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
                 break;
             }
         case PUT:{
+                MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
                 struct MPIDI_workq_put *wd = &workq_elemt->params.rma.put;
                 origin_datatype = wd->origin_datatype;
                 target_datatype = wd->target_datatype;
@@ -120,9 +121,11 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
                 MPIR_Datatype_release_if_not_builtin(origin_datatype);
                 MPIR_Datatype_release_if_not_builtin(target_datatype);
                 MPIDI_workq_elemt_free(workq_elemt);
+                MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
                 break;
             }
         case GET:{
+                MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
                 struct MPIDI_workq_get *wd = &workq_elemt->params.rma.get;
                 origin_datatype = wd->origin_datatype;
                 target_datatype = wd->target_datatype;
@@ -132,6 +135,7 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
                 MPIR_Datatype_release_if_not_builtin(origin_datatype);
                 MPIR_Datatype_release_if_not_builtin(target_datatype);
                 MPIDI_workq_elemt_free(workq_elemt);
+                MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
                 break;
             }
         default:
@@ -164,11 +168,8 @@ int MPIDI_workq_vci_progress(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-
     mpi_errno = MPIDI_workq_vci_progress_unsafe();
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
   fn_fail:
     return mpi_errno;
 }

--- a/src/mpid/ch4/src/ch4i_workq_progress.c
+++ b/src/mpid/ch4/src/ch4i_workq_progress.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+
+#if defined(MPIDI_CH4_USE_WORK_QUEUES)
+
+static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Request *req;
+    MPI_Datatype datatype, origin_datatype, target_datatype;
+
+    MPIR_Assert(workq_elemt != NULL);
+
+    switch (workq_elemt->op) {
+        case SEND:{
+                struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
+                req = wd->request;
+                datatype = wd->datatype;
+                MPIDI_send_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
+                                  wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
+                MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
+                break;
+            }
+        case ISEND:{
+                struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
+                req = wd->request;
+                datatype = wd->datatype;
+                MPIDI_isend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
+                                   wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
+                MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
+                break;
+            }
+        case SSEND:{
+                struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
+                req = wd->request;
+                datatype = wd->datatype;
+                MPIDI_ssend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
+                                   wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
+                MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
+                break;
+            }
+        case ISSEND:{
+                struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
+                req = wd->request;
+                datatype = wd->datatype;
+                MPIDI_issend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
+                                    wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
+                MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
+                break;
+            }
+        case CSEND:{
+                struct MPIDI_workq_csend *wd = &workq_elemt->params.pt2pt.csend;
+                req = wd->request;
+                datatype = wd->datatype;
+                MPIDI_send_coll_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
+                                       wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req,
+                                       &(wd->errflag));
+                MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
+                break;
+            }
+        case ICSEND:{
+                struct MPIDI_workq_csend *wd = &workq_elemt->params.pt2pt.csend;
+                req = wd->request;
+                datatype = wd->datatype;
+                MPIDI_isend_coll_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
+                                        wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req,
+                                        &(wd->errflag));
+                MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
+                break;
+            }
+        case RECV:{
+                struct MPIDI_workq_recv *wd = &workq_elemt->params.pt2pt.recv;
+                req = wd->request;
+                datatype = wd->datatype;
+                MPIDI_recv_unsafe(wd->recv_buf, wd->count, wd->datatype, wd->rank, wd->tag,
+                                  wd->comm_ptr, wd->context_offset, wd->addr, wd->status, &req);
+                MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
+                break;
+            }
+        case IRECV:{
+                struct MPIDI_workq_irecv *wd = &workq_elemt->params.pt2pt.irecv;
+                req = wd->request;
+                datatype = wd->datatype;
+                MPIDI_irecv_unsafe(wd->recv_buf, wd->count, wd->datatype, wd->rank, wd->tag,
+                                   wd->comm_ptr, wd->context_offset, wd->addr, &req);
+                MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
+                break;
+            }
+        case IMRECV:{
+                struct MPIDI_workq_imrecv *wd = &workq_elemt->params.pt2pt.imrecv;
+                datatype = wd->datatype;
+                MPIDI_imrecv_unsafe(wd->buf, wd->count, wd->datatype, *wd->message);
+                MPIR_Datatype_release_if_not_builtin(datatype);
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+                if (!MPIDI_REQUEST(*wd->message, is_local))
+#endif
+                    MPIDI_workq_release_pt2pt_elemt(workq_elemt);
+                MPIDI_workq_release_pt2pt_elemt(workq_elemt);
+                break;
+            }
+        case PUT:{
+                struct MPIDI_workq_put *wd = &workq_elemt->params.rma.put;
+                origin_datatype = wd->origin_datatype;
+                target_datatype = wd->target_datatype;
+                MPIDI_put_unsafe(wd->origin_addr, wd->origin_count, wd->origin_datatype,
+                                 wd->target_rank, wd->target_disp,
+                                 wd->target_count, wd->target_datatype, wd->win_ptr);
+                MPIR_Datatype_release_if_not_builtin(origin_datatype);
+                MPIR_Datatype_release_if_not_builtin(target_datatype);
+                MPIDI_workq_elemt_free(workq_elemt);
+                break;
+            }
+        case GET:{
+                struct MPIDI_workq_get *wd = &workq_elemt->params.rma.get;
+                origin_datatype = wd->origin_datatype;
+                target_datatype = wd->target_datatype;
+                MPIDI_get_unsafe(wd->origin_addr, wd->origin_count, wd->origin_datatype,
+                                 wd->target_rank, wd->target_disp,
+                                 wd->target_count, wd->target_datatype, wd->win_ptr);
+                MPIR_Datatype_release_if_not_builtin(origin_datatype);
+                MPIR_Datatype_release_if_not_builtin(target_datatype);
+                MPIDI_workq_elemt_free(workq_elemt);
+                break;
+            }
+        default:
+            mpi_errno = MPI_ERR_OTHER;
+            goto fn_fail;
+    }
+
+  fn_fail:
+    return mpi_errno;
+}
+
+int MPIDI_workq_vci_progress_unsafe(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIDI_workq_elemt_t *workq_elemt = NULL;
+
+    MPIDI_workq_dequeue(&MPIDI_global.workqueue, (void **) &workq_elemt);
+    while (workq_elemt != NULL) {
+        mpi_errno = MPIDI_workq_dispatch(workq_elemt);
+        if (mpi_errno != MPI_SUCCESS)
+            goto fn_fail;
+        MPIDI_workq_dequeue(&MPIDI_global.workqueue, (void **) &workq_elemt);
+    }
+
+  fn_fail:
+    return mpi_errno;
+}
+
+int MPIDI_workq_vci_progress(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+
+    mpi_errno = MPIDI_workq_vci_progress_unsafe();
+
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+  fn_fail:
+    return mpi_errno;
+}
+
+#else /* #if defined(MPIDI_CH4_USE_WORK_QUEUES) */
+
+int MPIDI_workq_vci_progress_unsafe(void)
+{
+    return MPI_SUCCESS;
+}
+
+int MPIDI_workq_vci_progress(void)
+{
+    return MPI_SUCCESS;
+}
+
+#endif /* #if defined(MPIDI_CH4_USE_WORK_QUEUES) */

--- a/src/mpid/ch4/src/ch4i_workq_progress.c
+++ b/src/mpid/ch4/src/ch4i_workq_progress.c
@@ -103,12 +103,7 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
         case IMRECV:{
                 struct MPIDI_workq_imrecv *wd = &workq_elemt->params.pt2pt.imrecv;
                 datatype = wd->datatype;
-                MPIDI_imrecv_unsafe(wd->buf, wd->count, wd->datatype, *wd->message);
-                MPIR_Datatype_release_if_not_builtin(datatype);
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-                if (!MPIDI_REQUEST(*wd->message, is_local))
-#endif
-                    MPIDI_workq_release_pt2pt_elemt(workq_elemt);
+                MPIDI_imrecv_unsafe(wd->buf, wd->count, wd->datatype, wd->message);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
                 break;
             }

--- a/src/mpid/ch4/src/ch4i_workq_progress.c
+++ b/src/mpid/ch4/src/ch4i_workq_progress.c
@@ -25,6 +25,7 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
                 MPIDI_send_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
                                   wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
                 MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
                 break;
             }
@@ -35,6 +36,7 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
                 MPIDI_isend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
                                    wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
                 MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
                 break;
             }
@@ -45,6 +47,7 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
                 MPIDI_ssend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
                                    wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
                 MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
                 break;
             }
@@ -55,6 +58,7 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
                 MPIDI_issend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
                                     wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
                 MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
                 break;
             }
@@ -66,6 +70,7 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
                                        wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req,
                                        &(wd->errflag));
                 MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
                 break;
             }
@@ -77,6 +82,7 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
                                         wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req,
                                         &(wd->errflag));
                 MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
                 break;
             }
@@ -87,6 +93,7 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
                 MPIDI_recv_unsafe(wd->recv_buf, wd->count, wd->datatype, wd->rank, wd->tag,
                                   wd->comm_ptr, wd->context_offset, wd->addr, wd->status, &req);
                 MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
                 break;
             }
@@ -97,6 +104,7 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
                 MPIDI_irecv_unsafe(wd->recv_buf, wd->count, wd->datatype, wd->rank, wd->tag,
                                    wd->comm_ptr, wd->context_offset, wd->addr, &req);
                 MPIR_Datatype_release_if_not_builtin(datatype);
+                MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
                 break;
             }

--- a/src/mpid/ch4/src/ch4i_workq_progress.c
+++ b/src/mpid/ch4/src/ch4i_workq_progress.c
@@ -7,6 +7,8 @@
 
 #if defined(MPIDI_CH4_USE_WORK_QUEUES)
 
+extern MPID_Thread_mutex_t MPIDI_workq_lock;
+
 static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -168,7 +170,11 @@ int MPIDI_workq_vci_progress(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_workq_lock);
+
     mpi_errno = MPIDI_workq_vci_progress_unsafe();
+
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_workq_lock);
 
   fn_fail:
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4i_workq_progress.c
+++ b/src/mpid/ch4/src/ch4i_workq_progress.c
@@ -12,7 +12,6 @@ extern MPID_Thread_mutex_t MPIDI_workq_lock;
 static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *req;
     MPI_Datatype datatype, origin_datatype, target_datatype;
 
     MPIR_Assert(workq_elemt != NULL);
@@ -20,10 +19,12 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
     switch (workq_elemt->op) {
         case SEND:{
                 struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
-                req = wd->request;
                 datatype = wd->datatype;
                 MPIDI_send_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                  wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
+                                  wd->tag, wd->comm_ptr, wd->context_offset, wd->addr,
+                                  &(wd->request->u.workq.real_request));
+                wd->request->status.MPI_ERROR = MPI_SUCCESS;
+                wd->request->cc_ptr = &wd->request->u.workq.real_request->cc;
                 MPIR_Datatype_release_if_not_builtin(datatype);
                 MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
@@ -31,10 +32,12 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
             }
         case ISEND:{
                 struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
-                req = wd->request;
                 datatype = wd->datatype;
                 MPIDI_isend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                   wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
+                                   wd->tag, wd->comm_ptr, wd->context_offset, wd->addr,
+                                   &(wd->request->u.workq.real_request));
+                wd->request->status.MPI_ERROR = MPI_SUCCESS;
+                wd->request->cc_ptr = &wd->request->u.workq.real_request->cc;
                 MPIR_Datatype_release_if_not_builtin(datatype);
                 MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
@@ -42,10 +45,12 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
             }
         case SSEND:{
                 struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
-                req = wd->request;
                 datatype = wd->datatype;
                 MPIDI_ssend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                   wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
+                                   wd->tag, wd->comm_ptr, wd->context_offset, wd->addr,
+                                   &(wd->request->u.workq.real_request));
+                wd->request->status.MPI_ERROR = MPI_SUCCESS;
+                wd->request->cc_ptr = &wd->request->u.workq.real_request->cc;
                 MPIR_Datatype_release_if_not_builtin(datatype);
                 MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
@@ -53,10 +58,12 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
             }
         case ISSEND:{
                 struct MPIDI_workq_send *wd = &workq_elemt->params.pt2pt.send;
-                req = wd->request;
                 datatype = wd->datatype;
                 MPIDI_issend_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                    wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req);
+                                    wd->tag, wd->comm_ptr, wd->context_offset, wd->addr,
+                                    &(wd->request->u.workq.real_request));
+                wd->request->status.MPI_ERROR = MPI_SUCCESS;
+                wd->request->cc_ptr = &wd->request->u.workq.real_request->cc;
                 MPIR_Datatype_release_if_not_builtin(datatype);
                 MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
@@ -64,11 +71,12 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
             }
         case CSEND:{
                 struct MPIDI_workq_csend *wd = &workq_elemt->params.pt2pt.csend;
-                req = wd->request;
                 datatype = wd->datatype;
                 MPIDI_send_coll_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                       wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req,
-                                       &(wd->errflag));
+                                       wd->tag, wd->comm_ptr, wd->context_offset, wd->addr,
+                                       &(wd->request->u.workq.real_request), &(wd->errflag));
+                wd->request->status.MPI_ERROR = MPI_SUCCESS;
+                wd->request->cc_ptr = &wd->request->u.workq.real_request->cc;
                 MPIR_Datatype_release_if_not_builtin(datatype);
                 MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
@@ -76,11 +84,12 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
             }
         case ICSEND:{
                 struct MPIDI_workq_csend *wd = &workq_elemt->params.pt2pt.csend;
-                req = wd->request;
                 datatype = wd->datatype;
                 MPIDI_isend_coll_unsafe(wd->send_buf, wd->count, wd->datatype, wd->rank,
-                                        wd->tag, wd->comm_ptr, wd->context_offset, wd->addr, &req,
-                                        &(wd->errflag));
+                                        wd->tag, wd->comm_ptr, wd->context_offset, wd->addr,
+                                        &(wd->request->u.workq.real_request), &(wd->errflag));
+                wd->request->status.MPI_ERROR = MPI_SUCCESS;
+                wd->request->cc_ptr = &wd->request->u.workq.real_request->cc;
                 MPIR_Datatype_release_if_not_builtin(datatype);
                 MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
@@ -88,10 +97,12 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
             }
         case RECV:{
                 struct MPIDI_workq_recv *wd = &workq_elemt->params.pt2pt.recv;
-                req = wd->request;
                 datatype = wd->datatype;
                 MPIDI_recv_unsafe(wd->recv_buf, wd->count, wd->datatype, wd->rank, wd->tag,
-                                  wd->comm_ptr, wd->context_offset, wd->addr, wd->status, &req);
+                                  wd->comm_ptr, wd->context_offset, wd->addr, wd->status,
+                                  &(wd->request->u.workq.real_request));
+                wd->request->status.MPI_ERROR = MPI_SUCCESS;
+                wd->request->cc_ptr = &wd->request->u.workq.real_request->cc;
                 MPIR_Datatype_release_if_not_builtin(datatype);
                 MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);
@@ -99,10 +110,12 @@ static int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
             }
         case IRECV:{
                 struct MPIDI_workq_irecv *wd = &workq_elemt->params.pt2pt.irecv;
-                req = wd->request;
                 datatype = wd->datatype;
                 MPIDI_irecv_unsafe(wd->recv_buf, wd->count, wd->datatype, wd->rank, wd->tag,
-                                   wd->comm_ptr, wd->context_offset, wd->addr, &req);
+                                   wd->comm_ptr, wd->context_offset, wd->addr,
+                                   &(wd->request->u.workq.real_request));
+                wd->request->status.MPI_ERROR = MPI_SUCCESS;
+                wd->request->cc_ptr = &wd->request->u.workq.real_request->cc;
                 MPIR_Datatype_release_if_not_builtin(datatype);
                 MPIR_Comm_release(wd->comm_ptr);
                 MPIDI_workq_release_pt2pt_elemt(workq_elemt);

--- a/src/mpid/ch4/src/ch4i_workq_types.h
+++ b/src/mpid/ch4/src/ch4i_workq_types.h
@@ -146,8 +146,7 @@ typedef struct MPIDI_workq_elemt {
                 void *buf;
                 MPI_Aint count;
                 MPI_Datatype datatype;
-                MPIR_Request **message;
-                MPIR_Request *request;
+                MPIR_Request *message;
             } imrecv;
         } pt2pt;
         union {

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -887,6 +887,9 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
             switch (e->type) {
                 case MPIDU_SCHED_ENTRY_SEND:
                     if (e->u.send.sreq != NULL && MPIR_Request_is_complete(e->u.send.sreq)) {
+                        if (e->u.send.sreq->kind == MPIR_REQUEST_KIND__WORKQ) {
+                            MPIR_workq_request_completion(e->u.send.sreq);
+                        }
                         MPL_DBG_MSG_FMT(MPIR_DBG_COMM, VERBOSE,
                                         (MPL_DBG_FDEST, "completed SEND entry %d, sreq=%p\n",
                                          (int) i, e->u.send.sreq));
@@ -902,6 +905,9 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
                     break;
                 case MPIDU_SCHED_ENTRY_RECV:
                     if (e->u.recv.rreq != NULL && MPIR_Request_is_complete(e->u.recv.rreq)) {
+                        if (e->u.recv.rreq->kind == MPIR_REQUEST_KIND__WORKQ) {
+                            MPIR_workq_request_completion(e->u.recv.rreq);
+                        }
                         MPL_DBG_MSG_FMT(MPIR_DBG_COMM, VERBOSE,
                                         (MPL_DBG_FDEST, "completed RECV entry %d, rreq=%p\n",
                                          (int) i, e->u.recv.rreq));


### PR DESCRIPTION
## Pull Request Description

[NOTE] this PR is based on #4694. The actual commits of this PR starts at `request: add MPIR_REQUEST_KIND__WORKQ`.

The current workq works by creating request at ch4-layer and then later pass down to shmmod/netmod layer at workq dispatch time. This is undesirable. For one, all netmod/shmmod implementation need deal with both the possibility of creating new request or using an existing request. When using an existing request, we have to always be careful that the same request may be concurrently progressed. This brings much complexity that is difficult to maintain. For two, creating requests at ch4-layer restricts the flexibility of netmod or shmmod deciding vci and all solutions will bring further complications.

In this PR, we implement the workq request as a pseudo request, very similar to how persistent request currently works. With pseudo request, netmod/shmmod layers will have full freedom in creating and progressing their own requests. The upper layer only need atomic access to the `cc_ptr` that is to be linked at workq dispatch time.


[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
