### PR TITLE
ch4/posix: fix checking for am_hdr_sz

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_am_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_am_impl.h
@@ -51,24 +51,23 @@ static inline int MPIDI_POSIX_am_init_req_hdr(const void *am_hdr,
         req_hdr->am_hdr_sz = am_hdr_sz;
 
         req_hdr->pack_buffer = NULL;
-
     }
 
     /* If the header is larger than what we'd preallocated, get rid of the preallocated buffer and
      * create a new one of the correct size. */
-    if (am_hdr_sz > req_hdr->am_hdr_sz) {
+    if (am_hdr_sz > MPIDI_POSIX_MAX_AM_HDR_SIZE) {
         if (req_hdr->am_hdr != &req_hdr->am_hdr_buf[0])
             MPL_free(req_hdr->am_hdr);
 
         req_hdr->am_hdr = MPL_malloc(am_hdr_sz, MPL_MEM_SHM);
         MPIR_ERR_CHKANDJUMP(!(req_hdr->am_hdr), mpi_errno, MPI_ERR_OTHER, "**nomem");
+        req_hdr->am_hdr_sz = am_hdr_sz;
     }
 
     if (am_hdr) {
         MPIR_Typerep_copy(req_hdr->am_hdr, am_hdr, am_hdr_sz);
     }
 
-    req_hdr->am_hdr_sz = am_hdr_sz;
     *req_hdr_ptr = req_hdr;
 
   fn_exit:


### PR DESCRIPTION
The posix req_hdr need to do a malloc if the am_hdr is larger than the
preallocated space from the pool. This checking was comparing against
the am_hdr_sz stored in the req_hdr which originally set to
MPIDI_POSIX_MAX_AM_HDR_SIZE.

A previous commit 69900d68bf2d changed the setting to the actual
am_hdr_sz which makes the following `am_hdr_sz > req_hdr->am_hdr_sz`
always false and cause faliure in RMA (which relies on large am_hdr_sz
handling in the isendv case). Also, in original code, the
req_hdr->am_hdr_sz was set to the actual am_hdr_sz later in this
function, so commit 69900d68bf2d is seemingly unnecessary.

This commit fixes the failure caused by 69900d68bf2d by fixing the
aforemention comparison to `am_hdr_sz > MPIDI_POSIX_MAX_AM_HDR_SIZE`. I
think it is better to keep 69900d68bf2d and apply this commit as it
results in reliable code---comparison will work without relying some
variable being set in a certain way.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
