### PR TITLE
ch4: move the vci lock to device layer for RMA

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -224,17 +224,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
 
     /* small contiguous messages */
     if (origin_contig && target_contig && (origin_bytes <= MPIDI_OFI_global.max_buffered_write)) {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         MPIDI_OFI_win_cntr_incr(win);
         MPIDI_OFI_CALL_RETRY(fi_inject_write(MPIDI_OFI_WIN(win).ep,
                                              (char *) origin_addr + origin_true_lb, target_bytes,
                                              MPIDI_OFI_av_to_phys(addr, 0, 0),
                                              target_mr.addr + target_true_lb,
                                              target_mr.mr_key), 0, rdma_inject_write, FALSE);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         goto null_op_exit;
     }
 
     /* large contiguous messages */
     if (origin_contig && target_contig) {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         if (sigreq) {
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
             if (*sigreq) {
@@ -265,6 +268,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), 0, rdma_write, FALSE);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         goto fn_exit;
     }
 
@@ -275,18 +279,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
 
     if (origin_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno =
             MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_count, target_datatype, target_mr, win, addr,
                                     MPIDI_OFI_PUT, sigreq);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         goto fn_exit;
     }
 
     if (origin_density < MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno =
             MPIDI_OFI_pack_put(origin_addr, origin_count, origin_datatype, target_rank,
                                target_count, target_datatype, target_mr, win, addr, sigreq);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         goto fn_exit;
     }
 
@@ -398,6 +406,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
 
     /* contiguous messages */
     if (origin_contig && target_contig) {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         if (sigreq) {
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
             if (*sigreq) {
@@ -428,6 +437,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), 0, rdma_write, FALSE);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         goto fn_exit;
     }
 
@@ -438,18 +448,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
 
     if (origin_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno =
             MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_count, target_datatype, target_mr, win, addr,
                                     MPIDI_OFI_GET, sigreq);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         goto fn_exit;
     }
 
     if (origin_density < MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno =
             MPIDI_OFI_pack_get(origin_addr, origin_count, origin_datatype, target_rank,
                                target_count, target_datatype, target_mr, win, addr, sigreq);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         goto fn_exit;
     }
 
@@ -636,10 +650,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     msg.op = fi_op;
     msg.context = NULL;
     msg.data = 0;
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     MPIDI_OFI_win_cntr_incr(win);
     MPIDI_OFI_CALL_RETRY(fi_compare_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg,
                                               &comparev, NULL, 1, &resultv, NULL, 1, 0), 0,
                          atomicto, FALSE);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_COMPARE_AND_SWAP);
     return mpi_errno;
@@ -648,7 +664,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
   am_fallback:
     /* Wait for OFI cas to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPIDI_OFI_win_do_progress(win);
+    MPIDI_OFI_win_do_progress(win, 0);
     return MPIDIG_mpi_compare_and_swap(origin_addr, compare_addr, result_addr, datatype,
                                        target_rank, target_disp, win);
 }
@@ -721,6 +737,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         /* Ensure completion of outstanding AMs for atomicity. */
         MPIDIG_wait_am_acc(win, target_rank);
 
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         uint64_t flags;
         if (sigreq) {
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
@@ -761,13 +778,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
                              rdma_atomicto, FALSE);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         goto fn_exit;
     }
 
   am_fallback:
     /* Wait for OFI acc to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPIDI_OFI_win_do_progress(win);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPIDI_OFI_win_do_progress(win, 0);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     if (sigreq)
         mpi_errno = MPIDIG_mpi_raccumulate(origin_addr, origin_count, origin_datatype, target_rank,
                                            target_disp, target_count, target_datatype, op, win,
@@ -859,6 +879,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         /* Ensure completion of outstanding AMs for atomicity. */
         MPIDIG_wait_am_acc(win, target_rank);
 
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         uint64_t flags;
         if (sigreq) {
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
@@ -901,13 +922,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
                                                 NULL, 1, flags), 0 /*vci */ , rdma_readfrom, FALSE);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         goto fn_exit;
     }
 
   am_fallback:
     /* Wait for OFI getacc to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPIDI_OFI_win_do_progress(win);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPIDI_OFI_win_do_progress(win, 0);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     if (sigreq)
         mpi_errno =
             MPIDIG_mpi_rget_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
@@ -1121,9 +1145,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     msg.op = fi_op;
     msg.context = NULL;
     msg.data = 0;
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     MPIDI_OFI_win_cntr_incr(win);
     MPIDI_OFI_CALL_RETRY(fi_fetch_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg, &resultv,
                                             NULL, 1, 0), 0, rdma_readfrom, FALSE);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_FETCH_AND_OP);
@@ -1133,7 +1159,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
   am_fallback:
     /* Wait for OFI fetch_and_op to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPIDI_OFI_win_do_progress(win);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPIDI_OFI_win_do_progress(win, 0);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     return MPIDIG_mpi_fetch_and_op(origin_addr, result_addr, datatype, target_rank, target_disp, op,
                                    win);
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -11,7 +11,7 @@
 /*
  * Blocking progress function to complete outstanding RMA operations on the input window.
  */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win)
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win, int vni)
 {
     int mpi_errno = MPI_SUCCESS;
     int itercount = 0;
@@ -30,7 +30,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win)
 
         while (tcount > donecount) {
             MPIR_Assert(donecount <= tcount);
-            MPIDI_OFI_PROGRESS(0);
+            MPIDI_OFI_PROGRESS(vni);
             /* rma issued_cntr may be updated during MPIDI_OFI_PROGRESS if active messages
              * arrive and trigger RDMA calls, so we need to update it after progress call */
             tcount = *MPIDI_OFI_WIN(win).issued_cntr;
@@ -78,7 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win)
 /* If the OFI provider does not have automatic progress, check to see if the progress engine should
  * be manually triggered to keep performance from suffering when doing large, non-continuguous
  * transfers. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_trigger_rma_progress(MPIR_Win * win)
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_trigger_rma_progress(MPIR_Win * win, int vni)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -87,7 +87,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_trigger_rma_progress(MPIR_Win * win)
 
     if (!MPIDI_OFI_ENABLE_DATA_AUTO_PROGRESS && MPIR_CVAR_CH4_OFI_RMA_PROGRESS_INTERVAL != -1) {
         if (MPIDI_OFI_WIN(win).progress_counter % MPIR_CVAR_CH4_OFI_RMA_PROGRESS_INTERVAL == 0) {
-            MPIDI_OFI_win_do_progress(win);
+            MPIDI_OFI_win_do_progress(win, vni);
             MPIDI_OFI_WIN(win).progress_counter = 1;
         }
         MPIDI_OFI_WIN(win).progress_counter++;
@@ -317,7 +317,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        mpi_errno = MPIDI_OFI_win_do_progress(win);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -335,7 +335,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_LOCAL_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        mpi_errno = MPIDI_OFI_win_do_progress(win);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -354,7 +354,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank ATTRIBUTE((u
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        mpi_errno = MPIDI_OFI_win_do_progress(win);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -373,7 +373,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank ATTRIB
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_LOCAL_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        mpi_errno = MPIDI_OFI_win_do_progress(win);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -317,7 +317,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -335,7 +337,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_LOCAL_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -354,7 +358,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank ATTRIBUTE((u
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -373,7 +379,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank ATTRIB
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_LOCAL_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -153,6 +153,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_RMA_WIN_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_CMPL_HOOK);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     if ((MPIDI_WIN(win, winattr) & MPIDI_WINATTR_NM_REACHABLE) && MPIDI_UCX_win_need_flush(win)) {
         ucs_status_t ucp_status;
@@ -163,6 +164,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
     }
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_RMA_WIN_CMPL_HOOK);
     return mpi_errno;
   fn_fail:
@@ -174,6 +176,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_RMA_WIN_LOCAL_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_LOCAL_CMPL_HOOK);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     if ((MPIDI_WIN(win, winattr) & MPIDI_WINATTR_NM_REACHABLE) &&
         MPIDI_UCX_win_need_flush_local(win)) {
@@ -189,6 +192,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
     }
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_RMA_WIN_LOCAL_CMPL_HOOK);
     return mpi_errno;
   fn_fail:
@@ -200,6 +204,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank, MPIR_Win * 
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_RMA_TARGET_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_CMPL_HOOK);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     if (MPIDI_UCX_is_reachable_target(rank, win, MPIDI_WIN(win, winattr)) &&
         /* including cases where FLUSH_LOCAL or FLUSH is set */
@@ -214,6 +219,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank, MPIR_Win * 
     }
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_RMA_TARGET_CMPL_HOOK);
     return mpi_errno;
   fn_fail:
@@ -225,6 +231,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_RMA_TARGET_LOCAL_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_LOCAL_CMPL_HOOK);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     if (MPIDI_UCX_is_reachable_target(rank, win, MPIDI_WIN(win, winattr)) &&
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync == MPIDI_UCX_WIN_SYNC_FLUSH_LOCAL) {
@@ -241,6 +248,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
     }
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_RMA_TARGET_LOCAL_CMPL_HOOK);
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -12,6 +12,7 @@
 #include "ch4r_proc.h"
 
 int MPIDI_Progress_test(int flags);
+int MPIDI_progress_test_vci(int vci);
 int MPIDIG_get_context_index(uint64_t context_id);
 uint64_t MPIDIG_generate_win_id(MPIR_Comm * comm_ptr);
 
@@ -437,55 +438,28 @@ MPL_STATIC_INLINE_PREFIX int MPIDIU_valid_group_rank(MPIR_Comm * comm, int rank,
     return ret;
 }
 
-/* TODO: Several unbounded loops call this macro. One way to avoid holding the
- * ALLFUNC_MUTEX lock forever is to insert YIELD in each loop. We choose to
- * insert it here for simplicity, but this might not be the best place. One
- * needs to investigate the appropriate place to yield the lock. */
-/* NOTE: Taking off VCI lock is necessary to avoid recursive locking and allow
- * more granular per-vci locks */
-/* TODO: MPIDI_global.vci_lock probably will be changed into granular generic lock
+/* Following progress macros are currently used by window synchronization calls.
+ *
+ * CAUTION: the macro uses MPIR_ERR_CHECK, be careful of it escaping the
+ * critical section.
+ *
+ * NOTE: when used in a loop, we insert a yield of global lock to prevent
+ * blocking other progress (under global granularity).
  */
 
-#define MPIDIU_PROGRESS()                                   \
-    do {                                                        \
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock); \
-        mpi_errno = MPID_Progress_test(NULL);                       \
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock); \
-        MPIR_ERR_CHECK(mpi_errno);  \
+#define MPIDIU_PROGRESS_WHILE(cond, vci)         \
+    while (cond) {                          \
+        mpi_errno = MPIDI_progress_test_vci(vci);   \
+        MPIR_ERR_CHECK(mpi_errno); \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
-    } while (0)
+    }
 
-/* Optimized versions to avoid exessive locking/unlocking */
-/* FIXME: use inline function rather macros for cleaner semantics */
-
-#define MPIDIU_PROGRESS_WHILE(cond)         \
-    do {                                        \
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock); \
-        while (cond) {                          \
-            mpi_errno = MPID_Progress_test(NULL);   \
-            if (mpi_errno) break;               \
-            MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
-        } \
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock); \
-        MPIR_ERR_CHECK(mpi_errno);              \
-    } while (0)
-
-/* This macro is refactored for original code that progress in a do-while loop
- * NOTE: it's already inside the progress lock and it is calling progress again.
- *       To avoid recursive locking, we yield the lock here.
- * TODO: Can we consolidate with previous macro? Double check the reasoning.
- */
-#define MPIDIU_PROGRESS_DO_WHILE(cond) \
-    do {                                        \
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock); \
-        do {                          \
-            mpi_errno = MPID_Progress_test(NULL);   \
-            if (mpi_errno) break;               \
-            MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
-        } while (cond); \
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock); \
-        MPIR_ERR_CHECK(mpi_errno);              \
-    } while (0)
+#define MPIDIU_PROGRESS_DO_WHILE(cond, vci) \
+    do { \
+        mpi_errno = MPIDI_progress_test_vci(vci); \
+        MPIR_ERR_CHECK(mpi_errno); \
+        MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
+    } while (cond)
 
 #ifdef HAVE_ERROR_CHECKING
 #define MPIDIG_EPOCH_CHECK_SYNC(win, mpi_errno, stmt)               \

--- a/src/mpid/ch4/src/ch4_probe.h
+++ b/src/mpid/ch4/src/ch4_probe.h
@@ -9,14 +9,19 @@
 #include "ch4r_proc.h"
 #include "ch4_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_unsafe(int source,
-                                                 int tag, MPIR_Comm * comm, int context_offset,
-                                                 MPIDI_av_entry_t * av, int *flag,
-                                                 MPI_Status * status)
+MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe(int source,
+                                          int tag, MPIR_Comm * comm, int context_offset,
+                                          MPIDI_av_entry_t * av, int *flag, MPI_Status * status)
 {
-    int mpi_errno;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPROBE_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPROBE_UNSAFE);
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPROBE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPROBE);
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPIDI_workq_vci_progress_unsafe();
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+#endif
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_iprobe(source, tag, comm, context_offset, av, flag, status);
@@ -35,26 +40,32 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_unsafe(int source,
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPROBE_UNSAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPROBE);
     return mpi_errno;
+
   fn_fail:
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_improbe_unsafe(int source,
-                                                  int tag, MPIR_Comm * comm,
-                                                  int context_offset,
-                                                  MPIDI_av_entry_t * av,
-                                                  int *flag, MPIR_Request ** message,
-                                                  MPI_Status * status)
+MPL_STATIC_INLINE_PREFIX int MPIDI_improbe(int source,
+                                           int tag, MPIR_Comm * comm,
+                                           int context_offset,
+                                           MPIDI_av_entry_t * av,
+                                           int *flag, MPIR_Request ** message, MPI_Status * status)
 {
-#ifdef MPIDI_CH4_DIRECT_NETMOD
-    return MPIDI_NM_mpi_improbe(source, tag, comm, context_offset, av, flag, message, status);
-#else
     int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IMPROBE_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMPROBE_UNSAFE);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IMPROBE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMPROBE);
 
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPIDI_workq_vci_progress_unsafe();
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+#endif
+
+#ifdef MPIDI_CH4_DIRECT_NETMOD
+    mpi_errno = MPIDI_NM_mpi_improbe(source, tag, comm, context_offset, av, flag, message, status);
+#else
     if (unlikely(source == MPI_ANY_SOURCE)) {
         mpi_errno = MPIDI_SHM_mpi_improbe(source, tag, comm, context_offset, flag, message, status);
         MPIR_ERR_CHECK(mpi_errno);
@@ -80,62 +91,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_improbe_unsafe(int source,
         if (*flag)
             MPIDI_REQUEST(*message, is_local) = 0;
     }
+#endif
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IMPROBE_UNSAFE);
-    return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
-#endif
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_safe(int source,
-                                               int tag, MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * av, int *flag,
-                                               MPI_Status * status)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPROBE_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPROBE_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-#endif
-    mpi_errno = MPIDI_iprobe_unsafe(source, tag, comm, context_offset, av, flag, status);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPROBE_SAFE);
-    return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_improbe_safe(int source,
-                                                int tag, MPIR_Comm * comm,
-                                                int context_offset,
-                                                MPIDI_av_entry_t * av,
-                                                int *flag, MPIR_Request ** message,
-                                                MPI_Status * status)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IMPROBE_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMPROBE_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-#endif
-    mpi_errno = MPIDI_improbe_unsafe(source, tag, comm, context_offset, av, flag, message, status);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IMPROBE_SAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IMPROBE);
     return mpi_errno;
 
   fn_fail:
@@ -152,7 +111,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Probe(int source,
 
     MPIDI_av_entry_t *av = (source == MPI_ANY_SOURCE ? NULL : MPIDIU_comm_rank_to_av(comm, source));
     while (!flag) {
-        mpi_errno = MPIDI_iprobe_safe(source, tag, comm, context_offset, av, &flag, status);
+        mpi_errno = MPIDI_iprobe(source, tag, comm, context_offset, av, &flag, status);
         MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPID_Progress_test(NULL);
@@ -180,8 +139,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mprobe(int source,
 
     MPIDI_av_entry_t *av = (source == MPI_ANY_SOURCE ? NULL : MPIDIU_comm_rank_to_av(comm, source));
     while (!flag) {
-        mpi_errno =
-            MPIDI_improbe_safe(source, tag, comm, context_offset, av, &flag, message, status);
+        mpi_errno = MPIDI_improbe(source, tag, comm, context_offset, av, &flag, message, status);
         MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPID_Progress_test(NULL);
@@ -208,7 +166,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Improbe(int source,
     *flag = 0;
     MPIDI_av_entry_t *av = (source == MPI_ANY_SOURCE ? NULL : MPIDIU_comm_rank_to_av(comm, source));
 
-    mpi_errno = MPIDI_improbe_safe(source, tag, comm, context_offset, av, flag, message, status);
+    mpi_errno = MPIDI_improbe(source, tag, comm, context_offset, av, flag, message, status);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (!*flag) {
@@ -236,7 +194,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iprobe(int source,
     *flag = 0;
     MPIDI_av_entry_t *av = (source == MPI_ANY_SOURCE ? NULL : MPIDIU_comm_rank_to_av(comm, source));
 
-    mpi_errno = MPIDI_iprobe_safe(source, tag, comm, context_offset, av, flag, status);
+    mpi_errno = MPIDI_iprobe(source, tag, comm, context_offset, av, flag, status);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (!*flag) {

--- a/src/mpid/ch4/src/ch4_progress.c
+++ b/src/mpid/ch4/src/ch4_progress.c
@@ -25,7 +25,7 @@ static int global_vci_poll_count = 0;
 MPL_STATIC_INLINE_PREFIX int do_global_progress(void)
 {
     if (MPIDI_global.n_vcis == 1) {
-        return 1;
+        return 0;
     } else {
         global_vci_poll_count++;
         return ((global_vci_poll_count & POLL_MASK) == 0);

--- a/src/mpid/ch4/src/ch4_rma.h
+++ b/src/mpid/ch4/src/ch4_rma.h
@@ -462,10 +462,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_put_safe(const void *origin_addr,
                             MPI_DATATYPE_NULL, target_rank, target_disp, target_count,
                             target_datatype, MPI_OP_NULL, win, NULL, NULL);
 #else
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDI_put_unsafe(origin_addr, origin_count, origin_datatype,
                                  target_rank, target_disp, target_count, target_datatype, win);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
@@ -497,10 +495,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_safe(void *origin_addr,
                             MPI_DATATYPE_NULL, target_rank, target_disp, target_count,
                             target_datatype, MPI_OP_NULL, win, NULL, NULL);
 #else
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDI_get_unsafe(origin_addr, origin_count, origin_datatype,
                                  target_rank, target_disp, target_count, target_datatype, win);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
@@ -524,16 +520,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 #endif
 
     mpi_errno = MPIDI_accumulate_unsafe(origin_addr, origin_count, origin_datatype, target_rank,
                                         target_disp, target_count, target_datatype, op, win);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -554,17 +546,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_safe(const void *origin_addr
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_COMPARE_AND_SWAP_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_COMPARE_AND_SWAP_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 #endif
 
     mpi_errno =
         MPIDI_compare_and_swap_unsafe(origin_addr, compare_addr, result_addr, datatype,
                                       target_rank, target_disp, win);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -589,17 +577,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 #endif
 
     mpi_errno = MPIDI_raccumulate_unsafe(origin_addr, origin_count, origin_datatype, target_rank,
                                          target_disp, target_count, target_datatype, op, win,
                                          request);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
@@ -625,18 +609,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_ACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_ACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 #endif
 
     mpi_errno =
         MPIDI_rget_accumulate_unsafe(origin_addr, origin_count, origin_datatype, result_addr,
                                      result_count, result_datatype, target_rank, target_disp,
                                      target_count, target_datatype, op, win, request);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -657,16 +637,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_FETCH_AND_OP_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_FETCH_AND_OP_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 #endif
 
     mpi_errno = MPIDI_fetch_and_op_unsafe(origin_addr, result_addr, datatype, target_rank,
                                           target_disp, op, win);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -689,17 +665,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_safe(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 #endif
 
     mpi_errno =
         MPIDI_rget_unsafe(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                           target_count, target_datatype, win, request);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -722,17 +694,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rput_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RPUT_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RPUT_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 #endif
 
     mpi_errno =
         MPIDI_rput_unsafe(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                           target_count, target_datatype, win, request);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -758,17 +726,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 #endif
 
     mpi_errno = MPIDI_get_accumulate_unsafe(origin_addr, origin_count, origin_datatype, result_addr,
                                             result_count, result_datatype, target_rank, target_disp,
                                             target_count, target_datatype, op, win);
-
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_rma.h
+++ b/src/mpid/ch4/src/ch4_rma.h
@@ -26,20 +26,27 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_dbg_dump_winattr(MPIDI_winattr_t winattr)
 #endif
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_put_unsafe(const void *origin_addr,
-                                              int origin_count,
-                                              MPI_Datatype origin_datatype,
-                                              int target_rank,
-                                              MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
-                                              MPIR_Win * win)
+MPL_STATIC_INLINE_PREFIX int MPIDI_put(const void *origin_addr,
+                                       int origin_count,
+                                       MPI_Datatype origin_datatype,
+                                       int target_rank,
+                                       MPI_Aint target_disp,
+                                       int target_count, MPI_Datatype target_datatype,
+                                       MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PUT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PUT);
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
+    MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
+    MPIDI_workq_rma_enqueue(PUT, origin_addr, origin_count, origin_datatype, NULL, NULL, 0,
+                            MPI_DATATYPE_NULL, target_rank, target_disp, target_count,
+                            target_datatype, MPI_OP_NULL, win, NULL, NULL);
+#else
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PUT_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PUT_UNSAFE);
-
     MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -59,27 +66,38 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_put_unsafe(const void *origin_addr,
                                      av, winattr);
 #endif
     MPIR_ERR_CHECK(mpi_errno);
+#endif
+
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PUT_UNSAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PUT);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_get_unsafe(void *origin_addr,
-                                              int origin_count,
-                                              MPI_Datatype origin_datatype,
-                                              int target_rank,
-                                              MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
-                                              MPIR_Win * win)
+MPL_STATIC_INLINE_PREFIX int MPIDI_get(void *origin_addr,
+                                       int origin_count,
+                                       MPI_Datatype origin_datatype,
+                                       int target_rank,
+                                       MPI_Aint target_disp,
+                                       int target_count, MPI_Datatype target_datatype,
+                                       MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET);
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
+    MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
+    /* For MPI_Get, "origin" has to be passed to the "result" parameter
+     * field, because `origin_addr` is declared as `const void *`. */
+    MPIDI_workq_rma_enqueue(GET, NULL, origin_count, origin_datatype, NULL, origin_addr, 0,
+                            MPI_DATATYPE_NULL, target_rank, target_disp, target_count,
+                            target_datatype, MPI_OP_NULL, win, NULL, NULL);
+#else
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_UNSAFE);
-
     MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -99,28 +117,34 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_unsafe(void *origin_addr,
                                      av, winattr);
 #endif
     MPIR_ERR_CHECK(mpi_errno);
+#endif
+
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_UNSAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_unsafe(const void *origin_addr,
-                                                     int origin_count,
-                                                     MPI_Datatype origin_datatype,
-                                                     int target_rank,
-                                                     MPI_Aint target_disp,
-                                                     int target_count,
-                                                     MPI_Datatype target_datatype, MPI_Op op,
-                                                     MPIR_Win * win)
+MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate(const void *origin_addr,
+                                              int origin_count,
+                                              MPI_Datatype origin_datatype,
+                                              int target_rank,
+                                              MPI_Aint target_disp,
+                                              int target_count,
+                                              MPI_Datatype target_datatype, MPI_Op op,
+                                              MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACCUMULATE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACCUMULATE);
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPIDI_workq_vci_progress();
+#endif
+
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACCUMULATE_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACCUMULATE_UNSAFE);
-
     MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -140,26 +164,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_unsafe(const void *origin_addr,
                                             target_datatype, op, win, av, winattr);
 #endif
     MPIR_ERR_CHECK(mpi_errno);
+
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ACCUMULATE_UNSAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ACCUMULATE);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_unsafe(const void *origin_addr,
-                                                           const void *compare_addr,
-                                                           void *result_addr,
-                                                           MPI_Datatype datatype,
-                                                           int target_rank, MPI_Aint target_disp,
-                                                           MPIR_Win * win)
+MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap(const void *origin_addr,
+                                                    const void *compare_addr,
+                                                    void *result_addr,
+                                                    MPI_Datatype datatype,
+                                                    int target_rank, MPI_Aint target_disp,
+                                                    MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_COMPARE_AND_SWAP);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_COMPARE_AND_SWAP);
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPIDI_workq_vci_progress();
+#endif
+
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_COMPARE_AND_SWAP_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_COMPARE_AND_SWAP_UNSAFE);
-
     MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -178,30 +207,34 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_unsafe(const void *origin_ad
                                                   winattr);
 #endif
     MPIR_ERR_CHECK(mpi_errno);
+
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_COMPARE_AND_SWAP_UNSAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_COMPARE_AND_SWAP);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_unsafe(const void *origin_addr,
-                                                      int origin_count,
-                                                      MPI_Datatype origin_datatype,
-                                                      int target_rank,
-                                                      MPI_Aint target_disp,
-                                                      int target_count,
-                                                      MPI_Datatype target_datatype,
-                                                      MPI_Op op, MPIR_Win * win,
-                                                      MPIR_Request ** request)
+MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate(const void *origin_addr,
+                                               int origin_count,
+                                               MPI_Datatype origin_datatype,
+                                               int target_rank,
+                                               MPI_Aint target_disp,
+                                               int target_count,
+                                               MPI_Datatype target_datatype,
+                                               MPI_Op op, MPIR_Win * win, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RACCUMULATE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RACCUMULATE);
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPIDI_workq_vci_progress();
+#endif
+
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RACCUMULATE_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RACCUMULATE_UNSAFE);
-
     MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -222,31 +255,35 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_unsafe(const void *origin_addr,
 #endif
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RACCUMULATE_UNSAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RACCUMULATE);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_unsafe(const void *origin_addr,
-                                                          int origin_count,
-                                                          MPI_Datatype origin_datatype,
-                                                          void *result_addr,
-                                                          int result_count,
-                                                          MPI_Datatype result_datatype,
-                                                          int target_rank,
-                                                          MPI_Aint target_disp,
-                                                          int target_count,
-                                                          MPI_Datatype target_datatype,
-                                                          MPI_Op op, MPIR_Win * win,
-                                                          MPIR_Request ** request)
+MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate(const void *origin_addr,
+                                                   int origin_count,
+                                                   MPI_Datatype origin_datatype,
+                                                   void *result_addr,
+                                                   int result_count,
+                                                   MPI_Datatype result_datatype,
+                                                   int target_rank,
+                                                   MPI_Aint target_disp,
+                                                   int target_count,
+                                                   MPI_Datatype target_datatype,
+                                                   MPI_Op op, MPIR_Win * win,
+                                                   MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_ACCUMULATE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_ACCUMULATE);
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPIDI_workq_vci_progress();
+#endif
+
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_ACCUMULATE_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_ACCUMULATE_UNSAFE);
-
     MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -269,26 +306,30 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_unsafe(const void *origin_add
                                                  target_datatype, op, win, av, winattr, request);
 #endif
     MPIR_ERR_CHECK(mpi_errno);
+
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RGET_ACCUMULATE_UNSAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RGET_ACCUMULATE);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_unsafe(const void *origin_addr,
-                                                       void *result_addr,
-                                                       MPI_Datatype datatype,
-                                                       int target_rank,
-                                                       MPI_Aint target_disp, MPI_Op op,
-                                                       MPIR_Win * win)
+MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op(const void *origin_addr,
+                                                void *result_addr,
+                                                MPI_Datatype datatype,
+                                                int target_rank,
+                                                MPI_Aint target_disp, MPI_Op op, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_FETCH_AND_OP);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_FETCH_AND_OP);
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPIDI_workq_vci_progress();
+#endif
+
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_FETCH_AND_OP_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_FETCH_AND_OP_UNSAFE);
-
     MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -307,28 +348,33 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_unsafe(const void *origin_addr,
                                               winattr);
 #endif
     MPIR_ERR_CHECK(mpi_errno);
+
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_FETCH_AND_OP_UNSAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_FETCH_AND_OP);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_rget_unsafe(void *origin_addr,
-                                               int origin_count,
-                                               MPI_Datatype origin_datatype,
-                                               int target_rank,
-                                               MPI_Aint target_disp,
-                                               int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win,
-                                               MPIR_Request ** request)
+MPL_STATIC_INLINE_PREFIX int MPIDI_rget(void *origin_addr,
+                                        int origin_count,
+                                        MPI_Datatype origin_datatype,
+                                        int target_rank,
+                                        MPI_Aint target_disp,
+                                        int target_count,
+                                        MPI_Datatype target_datatype, MPIR_Win * win,
+                                        MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET);
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPIDI_workq_vci_progress();
+#endif
+
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_UNSAFE);
-
     MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -348,28 +394,33 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_unsafe(void *origin_addr,
                                       target_datatype, win, av, winattr, request);
 #endif
     MPIR_ERR_CHECK(mpi_errno);
+
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RGET_UNSAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RGET);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_rput_unsafe(const void *origin_addr,
-                                               int origin_count,
-                                               MPI_Datatype origin_datatype,
-                                               int target_rank,
-                                               MPI_Aint target_disp,
-                                               int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win,
-                                               MPIR_Request ** request)
+MPL_STATIC_INLINE_PREFIX int MPIDI_rput(const void *origin_addr,
+                                        int origin_count,
+                                        MPI_Datatype origin_datatype,
+                                        int target_rank,
+                                        MPI_Aint target_disp,
+                                        int target_count,
+                                        MPI_Datatype target_datatype, MPIR_Win * win,
+                                        MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RPUT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RPUT);
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPIDI_workq_vci_progress();
+#endif
+
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RPUT_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RPUT_UNSAFE);
-
     MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -389,31 +440,36 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rput_unsafe(const void *origin_addr,
                                       target_datatype, win, av, winattr, request);
 #endif
     MPIR_ERR_CHECK(mpi_errno);
+
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RPUT_UNSAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RPUT);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_unsafe(const void *origin_addr,
-                                                         int origin_count,
-                                                         MPI_Datatype origin_datatype,
-                                                         void *result_addr,
-                                                         int result_count,
-                                                         MPI_Datatype result_datatype,
-                                                         int target_rank,
-                                                         MPI_Aint target_disp,
-                                                         int target_count,
-                                                         MPI_Datatype target_datatype, MPI_Op op,
-                                                         MPIR_Win * win)
+MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate(const void *origin_addr,
+                                                  int origin_count,
+                                                  MPI_Datatype origin_datatype,
+                                                  void *result_addr,
+                                                  int result_count,
+                                                  MPI_Datatype result_datatype,
+                                                  int target_rank,
+                                                  MPI_Aint target_disp,
+                                                  int target_count,
+                                                  MPI_Datatype target_datatype, MPI_Op op,
+                                                  MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACCUMULATE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACCUMULATE);
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPIDI_workq_vci_progress();
+#endif
+
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACCUMULATE_UNSAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACCUMULATE_UNSAFE);
-
     MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -436,307 +492,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_unsafe(const void *origin_addr
                                                 target_datatype, op, win, av, winattr);
 #endif
     MPIR_ERR_CHECK(mpi_errno);
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_ACCUMULATE_UNSAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_put_safe(const void *origin_addr,
-                                            int origin_count,
-                                            MPI_Datatype origin_datatype,
-                                            int target_rank,
-                                            MPI_Aint target_disp,
-                                            int target_count, MPI_Datatype target_datatype,
-                                            MPIR_Win * win)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PUT_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PUT_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
-    MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
-    MPIDI_workq_rma_enqueue(PUT, origin_addr, origin_count, origin_datatype, NULL, NULL, 0,
-                            MPI_DATATYPE_NULL, target_rank, target_disp, target_count,
-                            target_datatype, MPI_OP_NULL, win, NULL, NULL);
-#else
-    mpi_errno = MPIDI_put_unsafe(origin_addr, origin_count, origin_datatype,
-                                 target_rank, target_disp, target_count, target_datatype, win);
-    MPIR_ERR_CHECK(mpi_errno);
-#endif
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PUT_SAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_get_safe(void *origin_addr,
-                                            int origin_count,
-                                            MPI_Datatype origin_datatype,
-                                            int target_rank,
-                                            MPI_Aint target_disp,
-                                            int target_count, MPI_Datatype target_datatype,
-                                            MPIR_Win * win)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
-    MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
-    /* For MPI_Get, "origin" has to be passed to the "result" parameter
-     * field, because `origin_addr` is declared as `const void *`. */
-    MPIDI_workq_rma_enqueue(GET, NULL, origin_count, origin_datatype, NULL, origin_addr, 0,
-                            MPI_DATATYPE_NULL, target_rank, target_disp, target_count,
-                            target_datatype, MPI_OP_NULL, win, NULL, NULL);
-#else
-    mpi_errno = MPIDI_get_unsafe(origin_addr, origin_count, origin_datatype,
-                                 target_rank, target_disp, target_count, target_datatype, win);
-    MPIR_ERR_CHECK(mpi_errno);
-#endif
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_SAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_safe(const void *origin_addr,
-                                                   int origin_count,
-                                                   MPI_Datatype origin_datatype,
-                                                   int target_rank,
-                                                   MPI_Aint target_disp,
-                                                   int target_count,
-                                                   MPI_Datatype target_datatype, MPI_Op op,
-                                                   MPIR_Win * win)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACCUMULATE_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACCUMULATE_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress();
-#endif
-
-    mpi_errno = MPIDI_accumulate_unsafe(origin_addr, origin_count, origin_datatype, target_rank,
-                                        target_disp, target_count, target_datatype, op, win);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ACCUMULATE_SAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_safe(const void *origin_addr,
-                                                         const void *compare_addr,
-                                                         void *result_addr,
-                                                         MPI_Datatype datatype,
-                                                         int target_rank, MPI_Aint target_disp,
-                                                         MPIR_Win * win)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_COMPARE_AND_SWAP_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_COMPARE_AND_SWAP_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress();
-#endif
-
-    mpi_errno =
-        MPIDI_compare_and_swap_unsafe(origin_addr, compare_addr, result_addr, datatype,
-                                      target_rank, target_disp, win);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_COMPARE_AND_SWAP_SAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_safe(const void *origin_addr,
-                                                    int origin_count,
-                                                    MPI_Datatype origin_datatype,
-                                                    int target_rank,
-                                                    MPI_Aint target_disp,
-                                                    int target_count,
-                                                    MPI_Datatype target_datatype,
-                                                    MPI_Op op, MPIR_Win * win,
-                                                    MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress();
-#endif
-
-    mpi_errno = MPIDI_raccumulate_unsafe(origin_addr, origin_count, origin_datatype, target_rank,
-                                         target_disp, target_count, target_datatype, op, win,
-                                         request);
-    MPIR_ERR_CHECK(mpi_errno);
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_safe(const void *origin_addr,
-                                                        int origin_count,
-                                                        MPI_Datatype origin_datatype,
-                                                        void *result_addr,
-                                                        int result_count,
-                                                        MPI_Datatype result_datatype,
-                                                        int target_rank,
-                                                        MPI_Aint target_disp,
-                                                        int target_count,
-                                                        MPI_Datatype target_datatype,
-                                                        MPI_Op op, MPIR_Win * win,
-                                                        MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_ACCUMULATE_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_ACCUMULATE_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress();
-#endif
-
-    mpi_errno =
-        MPIDI_rget_accumulate_unsafe(origin_addr, origin_count, origin_datatype, result_addr,
-                                     result_count, result_datatype, target_rank, target_disp,
-                                     target_count, target_datatype, op, win, request);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RGET_ACCUMULATE_SAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_safe(const void *origin_addr,
-                                                     void *result_addr,
-                                                     MPI_Datatype datatype,
-                                                     int target_rank,
-                                                     MPI_Aint target_disp, MPI_Op op,
-                                                     MPIR_Win * win)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_FETCH_AND_OP_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_FETCH_AND_OP_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress();
-#endif
-
-    mpi_errno = MPIDI_fetch_and_op_unsafe(origin_addr, result_addr, datatype, target_rank,
-                                          target_disp, op, win);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_FETCH_AND_OP_SAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_rget_safe(void *origin_addr,
-                                             int origin_count,
-                                             MPI_Datatype origin_datatype,
-                                             int target_rank,
-                                             MPI_Aint target_disp,
-                                             int target_count,
-                                             MPI_Datatype target_datatype, MPIR_Win * win,
-                                             MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress();
-#endif
-
-    mpi_errno =
-        MPIDI_rget_unsafe(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
-                          target_count, target_datatype, win, request);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RGET_SAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_rput_safe(const void *origin_addr,
-                                             int origin_count,
-                                             MPI_Datatype origin_datatype,
-                                             int target_rank,
-                                             MPI_Aint target_disp,
-                                             int target_count,
-                                             MPI_Datatype target_datatype, MPIR_Win * win,
-                                             MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RPUT_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RPUT_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress();
-#endif
-
-    mpi_errno =
-        MPIDI_rput_unsafe(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
-                          target_count, target_datatype, win, request);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RPUT_SAFE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_safe(const void *origin_addr,
-                                                       int origin_count,
-                                                       MPI_Datatype origin_datatype,
-                                                       void *result_addr,
-                                                       int result_count,
-                                                       MPI_Datatype result_datatype,
-                                                       int target_rank,
-                                                       MPI_Aint target_disp,
-                                                       int target_count,
-                                                       MPI_Datatype target_datatype, MPI_Op op,
-                                                       MPIR_Win * win)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACCUMULATE_SAFE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACCUMULATE_SAFE);
-
-#ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIDI_workq_vci_progress();
-#endif
-
-    mpi_errno = MPIDI_get_accumulate_unsafe(origin_addr, origin_count, origin_datatype, result_addr,
-                                            result_count, result_datatype, target_rank, target_disp,
-                                            target_count, target_datatype, op, win);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_ACCUMULATE_SAFE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_ACCUMULATE);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -755,8 +513,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_PUT);
 
-    mpi_errno = MPIDI_put_safe(origin_addr, origin_count, origin_datatype,
-                               target_rank, target_disp, target_count, target_datatype, win);
+    mpi_errno = MPIDI_put(origin_addr, origin_count, origin_datatype,
+                          target_rank, target_disp, target_count, target_datatype, win);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_PUT);
@@ -777,8 +535,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_GET);
 
-    mpi_errno = MPIDI_get_safe(origin_addr, origin_count, origin_datatype,
-                               target_rank, target_disp, target_count, target_datatype, win);
+    mpi_errno = MPIDI_get(origin_addr, origin_count, origin_datatype,
+                          target_rank, target_disp, target_count, target_datatype, win);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_GET);
@@ -800,8 +558,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_ACCUMULATE);
 
-    mpi_errno = MPIDI_accumulate_safe(origin_addr, origin_count, origin_datatype, target_rank,
-                                      target_disp, target_count, target_datatype, op, win);
+    mpi_errno = MPIDI_accumulate(origin_addr, origin_count, origin_datatype, target_rank,
+                                 target_disp, target_count, target_datatype, op, win);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_ACCUMULATE);
@@ -821,8 +579,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Compare_and_swap(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMPARE_AND_SWAP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMPARE_AND_SWAP);
 
-    mpi_errno = MPIDI_compare_and_swap_safe(origin_addr, compare_addr, result_addr,
-                                            datatype, target_rank, target_disp, win);
+    mpi_errno = MPIDI_compare_and_swap(origin_addr, compare_addr, result_addr,
+                                       datatype, target_rank, target_disp, win);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_COMPARE_AND_SWAP);
@@ -844,9 +602,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Raccumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RACCUMULATE);
 
-    mpi_errno = MPIDI_raccumulate_safe(origin_addr, origin_count, origin_datatype, target_rank,
-                                       target_disp, target_count, target_datatype, op, win,
-                                       request);
+    mpi_errno = MPIDI_raccumulate(origin_addr, origin_count, origin_datatype, target_rank,
+                                  target_disp, target_count, target_datatype, op, win, request);
 
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
@@ -873,9 +630,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rget_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RGET_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RGET_ACCUMULATE);
 
-    mpi_errno = MPIDI_rget_accumulate_safe(origin_addr, origin_count, origin_datatype, result_addr,
-                                           result_count, result_datatype, target_rank, target_disp,
-                                           target_count, target_datatype, op, win, request);
+    mpi_errno = MPIDI_rget_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
+                                      result_count, result_datatype, target_rank, target_disp,
+                                      target_count, target_datatype, op, win, request);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RGET_ACCUMULATE);
@@ -894,8 +651,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Fetch_and_op(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_FETCH_AND_OP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_FETCH_AND_OP);
 
-    mpi_errno = MPIDI_fetch_and_op_safe(origin_addr, result_addr,
-                                        datatype, target_rank, target_disp, op, win);
+    mpi_errno = MPIDI_fetch_and_op(origin_addr, result_addr,
+                                   datatype, target_rank, target_disp, op, win);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_FETCH_AND_OP);
@@ -918,8 +675,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rget(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RGET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RGET);
 
-    mpi_errno = MPIDI_rget_safe(origin_addr, origin_count, origin_datatype, target_rank,
-                                target_disp, target_count, target_datatype, win, request);
+    mpi_errno = MPIDI_rget(origin_addr, origin_count, origin_datatype, target_rank,
+                           target_disp, target_count, target_datatype, win, request);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RGET);
@@ -942,8 +699,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rput(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RPUT);
 
 
-    mpi_errno = MPIDI_rput_safe(origin_addr, origin_count, origin_datatype, target_rank,
-                                target_disp, target_count, target_datatype, win, request);
+    mpi_errno = MPIDI_rput(origin_addr, origin_count, origin_datatype, target_rank,
+                           target_disp, target_count, target_datatype, win, request);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RPUT);
@@ -968,9 +725,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_GET_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_GET_ACCUMULATE);
 
-    mpi_errno = MPIDI_get_accumulate_safe(origin_addr, origin_count, origin_datatype,
-                                          result_addr, result_count, result_datatype, target_rank,
-                                          target_disp, target_count, target_datatype, op, win);
+    mpi_errno = MPIDI_get_accumulate(origin_addr, origin_count, origin_datatype,
+                                     result_addr, result_count, result_datatype, target_rank,
+                                     target_disp, target_count, target_datatype, op, win);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_GET_ACCUMULATE);

--- a/src/mpid/ch4/src/ch4_win.h
+++ b/src/mpid/ch4/src/ch4_win.h
@@ -15,8 +15,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_start(MPIR_Group * group, int assert, MPIR
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_START);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_START);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_start(group, assert, win);
@@ -27,7 +26,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_start(MPIR_Group * group, int assert, MPIR
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_START);
     return mpi_errno;
   fn_fail:
@@ -40,8 +38,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_complete(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_COMPLETE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_COMPLETE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_complete(win);
@@ -52,7 +49,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_complete(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_COMPLETE);
     return mpi_errno;
   fn_fail:
@@ -65,8 +61,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_post(MPIR_Group * group, int assert, MPIR_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_POST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_POST);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_post(group, assert, win);
@@ -77,7 +72,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_post(MPIR_Group * group, int assert, MPIR_
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_POST);
     return mpi_errno;
   fn_fail:
@@ -90,8 +84,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_wait(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_WAIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_WAIT);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_wait(win);
@@ -102,7 +95,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_wait(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_WAIT);
     return mpi_errno;
   fn_fail:
@@ -116,8 +108,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_test(MPIR_Win * win, int *flag)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_TEST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_TEST);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_test(win, flag);
@@ -128,7 +119,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_test(MPIR_Win * win, int *flag)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_TEST);
     return mpi_errno;
   fn_fail:
@@ -141,8 +131,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock(int lock_type, int rank, int assert, 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_LOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_LOCK);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_lock(lock_type, rank, assert, win, NULL);
@@ -153,7 +142,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock(int lock_type, int rank, int assert, 
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_LOCK);
     return mpi_errno;
   fn_fail:
@@ -166,8 +154,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_UNLOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_UNLOCK);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_unlock(rank, win, NULL);
@@ -178,7 +165,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock(int rank, MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_UNLOCK);
     return mpi_errno;
   fn_fail:
@@ -191,8 +177,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_fence(int assert, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FENCE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FENCE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_fence(assert, win);
@@ -203,7 +188,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_fence(int assert, MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_FENCE);
     return mpi_errno;
   fn_fail:
@@ -216,8 +200,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_LOCAL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH_LOCAL);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush_local(rank, win, NULL);
@@ -228,7 +211,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local(int rank, MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_FLUSH_LOCAL);
     return mpi_errno;
   fn_fail:
@@ -263,8 +245,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush(rank, win, NULL);
@@ -275,7 +256,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush(int rank, MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_FLUSH);
     return mpi_errno;
   fn_fail:
@@ -288,8 +268,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_LOCAL_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH_LOCAL_ALL);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush_local_all(win);
@@ -300,7 +279,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local_all(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_FLUSH_LOCAL_ALL);
     return mpi_errno;
   fn_fail:
@@ -313,8 +291,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_UNLOCK_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_UNLOCK_ALL);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_unlock_all(win);
@@ -325,7 +302,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock_all(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_UNLOCK_ALL);
     return mpi_errno;
   fn_fail:
@@ -338,8 +314,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_sync(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_SYNC);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_SYNC);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_sync(win);
@@ -350,7 +325,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_sync(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_SYNC);
     return mpi_errno;
   fn_fail:
@@ -363,8 +337,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH_ALL);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush_all(win);
@@ -375,7 +348,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_all(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_FLUSH_ALL);
     return mpi_errno;
   fn_fail:
@@ -388,8 +360,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock_all(int assert, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_LOCK_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_LOCK_ALL);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_workq_vci_progress_unsafe();
+    MPIDI_workq_vci_progress();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_lock_all(assert, win);
@@ -400,7 +371,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock_all(int assert, MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_LOCK_ALL);
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -28,10 +28,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_unsafe(void *, MPI_Aint, MPI_Datatype, 
                                                 MPIR_Comm *, int, MPIDI_av_entry_t *,
                                                 MPIR_Request **);
 MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_unsafe(void *, MPI_Aint, MPI_Datatype, MPIR_Request *);
-MPL_STATIC_INLINE_PREFIX int MPIDI_put_unsafe(const void *, int, MPI_Datatype, int, MPI_Aint, int,
-                                              MPI_Datatype, MPIR_Win *);
-MPL_STATIC_INLINE_PREFIX int MPIDI_get_unsafe(void *, int, MPI_Datatype, int, MPI_Aint, int,
-                                              MPI_Datatype, MPIR_Win *);
+MPL_STATIC_INLINE_PREFIX int MPIDI_put(const void *, int, MPI_Datatype, int, MPI_Aint, int,
+                                       MPI_Datatype, MPIR_Win *);
+MPL_STATIC_INLINE_PREFIX int MPIDI_get(void *, int, MPI_Datatype, int, MPI_Aint, int,
+                                       MPI_Datatype, MPIR_Win *);
 MPL_STATIC_INLINE_PREFIX struct MPIDI_workq_elemt *MPIDI_workq_elemt_create(void)
 {
     return MPIR_Handle_obj_alloc(&MPIDI_workq_elemt_mem);
@@ -331,9 +331,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_el
                 struct MPIDI_workq_put *wd = &workq_elemt->params.rma.put;
                 origin_datatype = wd->origin_datatype;
                 target_datatype = wd->target_datatype;
-                MPIDI_put_unsafe(wd->origin_addr, wd->origin_count, wd->origin_datatype,
-                                 wd->target_rank, wd->target_disp,
-                                 wd->target_count, wd->target_datatype, wd->win_ptr);
+                MPIDI_put(wd->origin_addr, wd->origin_count, wd->origin_datatype,
+                          wd->target_rank, wd->target_disp,
+                          wd->target_count, wd->target_datatype, wd->win_ptr);
                 MPIR_Datatype_release_if_not_builtin(origin_datatype);
                 MPIR_Datatype_release_if_not_builtin(target_datatype);
                 MPIDI_workq_elemt_free(workq_elemt);
@@ -343,9 +343,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_el
                 struct MPIDI_workq_get *wd = &workq_elemt->params.rma.get;
                 origin_datatype = wd->origin_datatype;
                 target_datatype = wd->target_datatype;
-                MPIDI_get_unsafe(wd->origin_addr, wd->origin_count, wd->origin_datatype,
-                                 wd->target_rank, wd->target_disp,
-                                 wd->target_count, wd->target_datatype, wd->win_ptr);
+                MPIDI_get(wd->origin_addr, wd->origin_count, wd->origin_datatype,
+                          wd->target_rank, wd->target_disp,
+                          wd->target_count, wd->target_datatype, wd->win_ptr);
                 MPIR_Datatype_release_if_not_builtin(origin_datatype);
                 MPIR_Datatype_release_if_not_builtin(target_datatype);
                 MPIDI_workq_elemt_free(workq_elemt);

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -680,8 +680,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_put(const void *origin_addr, int origin_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_PUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_PUT);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_do_put(origin_addr, origin_count, origin_datatype,
                               target_rank, target_disp, target_count, target_datatype, win, NULL);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -702,8 +704,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rput(const void *origin_addr, int origin
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RPUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_RPUT);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_do_put(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                               target_count, target_datatype, win, &sreq);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -723,8 +727,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_get(void *origin_addr, int origin_count,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_GET);
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_do_get(origin_addr, origin_count, origin_datatype,
                               target_rank, target_disp, target_count, target_datatype, win, NULL);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -745,8 +752,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rget(void *origin_addr, int origin_count
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RGET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_RGET);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_do_get(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                               target_count, target_datatype, win, &sreq);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -769,8 +778,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_raccumulate(const void *origin_addr, int
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_RACCUMULATE);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_do_accumulate(origin_addr, origin_count, origin_datatype, target_rank,
                                      target_disp, target_count, target_datatype, op, win, &sreq);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -791,9 +802,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_accumulate(const void *origin_addr, int 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_ACCUMULATE);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_do_accumulate(origin_addr, origin_count, origin_datatype,
                                      target_rank, target_disp, target_count, target_datatype, op,
                                      win, NULL);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -819,9 +832,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rget_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RGET_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_RGET_ACCUMULATE);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_do_get_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
                                          result_count, result_datatype, target_rank, target_disp,
                                          target_count, target_datatype, op, win, &sreq);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -846,10 +861,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_get_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_GET_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_GET_ACCUMULATE);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_do_get_accumulate(origin_addr, origin_count, origin_datatype,
                                          result_addr, result_count, result_datatype,
                                          target_rank, target_disp, target_count, target_datatype,
                                          op, win, NULL);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -873,6 +890,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_COMPARE_AND_SWAP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_COMPARE_AND_SWAP);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
 
@@ -920,6 +938,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
     }
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_COMPARE_AND_SWAP);
     return mpi_errno;
   fn_fail:
@@ -935,8 +954,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_fetch_and_op(const void *origin_addr, vo
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_FETCH_AND_OP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_FETCH_AND_OP);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_mpi_get_accumulate(origin_addr, 1, datatype, result_addr, 1, datatype,
                                           target_rank, target_disp, 1, datatype, op, win);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_FETCH_AND_OP);

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -135,6 +135,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_start(MPIR_Group * group, int assert
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_START);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_START);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     MPIDIG_ACCESS_EPOCH_CHECK_NONE(win, mpi_errno, goto fn_fail);
 
@@ -153,6 +154,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_start(MPIR_Group * group, int assert
     MPIDIG_WIN(win, sync).access_epoch_type = MPIDIG_EPOTYPE_START;
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_START);
     return mpi_errno;
   fn_fail:
@@ -166,6 +168,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_complete(MPIR_Win * win)
     int win_grp_idx, peer;
     MPIR_Group *group;
     int *ranks_in_win_grp = NULL;
+    int need_unlock = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_COMPLETE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_COMPLETE);
@@ -183,6 +186,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_complete(MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    need_unlock = 1;
 
     msg.win_id = MPIDIG_WIN(win, win_id);
     msg.origin_rank = win->comm_ptr->rank;
@@ -226,6 +232,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_complete(MPIR_Win * win)
   fn_exit:
     MPL_free(ranks_in_win_grp);
 
+    if (need_unlock) {
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_COMPLETE);
     return mpi_errno;
   fn_fail:
@@ -241,6 +250,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_post(MPIR_Group * group, int assert,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_POST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_POST);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     MPIDIG_EXPOSURE_EPOCH_CHECK_NONE(win, mpi_errno, goto fn_fail);
 
@@ -286,6 +296,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_post(MPIR_Group * group, int assert,
   fn_exit:
     MPL_free(ranks_in_win_grp);
 
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_POST);
     return mpi_errno;
   fn_fail:
@@ -299,6 +310,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_wait(MPIR_Win * win)
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_WAIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_WAIT);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     MPIDIG_EXPOSURE_EPOCH_CHECK(win, MPIDIG_EPOTYPE_POST, mpi_errno, goto fn_fail);
     group = MPIDIG_WIN(win, sync).pw.group;
@@ -310,6 +322,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_wait(MPIR_Win * win)
     MPIDIG_WIN(win, sync).exposure_epoch_type = MPIDIG_EPOTYPE_NONE;
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_WAIT);
     return mpi_errno;
   fn_fail:
@@ -322,6 +335,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_test(MPIR_Win * win, int *flag)
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_TEST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_TEST);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     MPIDIG_EXPOSURE_EPOCH_CHECK(win, MPIDIG_EPOTYPE_POST, mpi_errno, goto fn_fail);
 
@@ -342,6 +356,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_test(MPIR_Win * win, int *flag)
     }
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_TEST);
     return mpi_errno;
   fn_fail:
@@ -356,6 +371,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock(int lock_type, int rank, int as
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_LOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_LOCK);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     MPIDIG_LOCK_EPOCH_CHECK_NONE(win, rank, mpi_errno, goto fn_fail);
 
@@ -397,6 +413,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock(int lock_type, int rank, int as
     MPIDIG_WIN(win, sync).lock.count++;
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_LOCK);
     return mpi_errno;
   fn_fail:
@@ -408,6 +425,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
     int mpi_errno = MPI_SUCCESS;
     unsigned unlocked;
     MPIDIG_win_cntrl_msg_t msg;
+    int need_unlock = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_UNLOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_UNLOCK);
@@ -433,6 +451,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_target_cmpl_hook(rank, win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    need_unlock = 1;
 
     /* Ensure completion of AM operations */
     MPIDIU_PROGRESS_DO_WHILE(MPIR_cc_get(target_ptr->remote_cmpl_cnts) != 0 ||
@@ -477,6 +498,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
     }
 
   fn_exit:
+    if (need_unlock) {
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_UNLOCK);
     return mpi_errno;
   fn_fail:
@@ -488,6 +512,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    int need_unlock = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_FENCE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_FENCE);
 
@@ -501,6 +526,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    need_unlock = 1;
 
     /* Ensure completion of AM operations */
     MPIDIU_PROGRESS_DO_WHILE(MPIR_cc_get(MPIDIG_WIN(win, local_cmpl_cnts)) != 0 ||
@@ -523,10 +551,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
      * In VCI granularity, individual send/recv/wait operations will take
      * the VCI lock internally. */
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    need_unlock = 0;
     mpi_errno = MPIR_Barrier(win->comm_ptr, &errflag);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
   fn_exit:
+    if (need_unlock) {
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_FENCE);
     return mpi_errno;
   fn_fail:
@@ -582,6 +613,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_shared_query(MPIR_Win * win, int ran
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    int need_unlock = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_FLUSH);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_FLUSH);
 
@@ -596,6 +628,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_target_cmpl_hook(rank, win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    need_unlock = 1;
 
     /* Ensure completion of AM operations issued to the target.
      * If target object is not created (e.g., when all operations issued
@@ -613,6 +648,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
                           poll_once-- > 0, 0);
 
   fn_exit:
+    if (need_unlock) {
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_FLUSH);
     return mpi_errno;
   fn_fail:
@@ -622,6 +660,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    int need_unlock = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_FLUSH_LOCAL_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_FLUSH_LOCAL_ALL);
 
@@ -636,6 +675,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    need_unlock = 1;
+
     /* Ensure completion of AM operations */
 
     /* FIXME: now we simply set per-target counters for lockall in case
@@ -646,6 +688,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
                           0);
 
   fn_exit:
+    if (need_unlock) {
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_FLUSH_LOCAL_ALL);
     return mpi_errno;
   fn_fail:
@@ -655,6 +700,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    int need_unlock = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_UNLOCK_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_UNLOCK_ALL);
     int i;
@@ -671,6 +717,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    need_unlock = 1;
 
     /* Ensure completion of AM operations */
 
@@ -711,6 +760,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
     MPIDIG_WIN(win, sync).assert_mode = 0;
 
   fn_exit:
+    if (need_unlock) {
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_UNLOCK_ALL);
     return mpi_errno;
   fn_fail:
@@ -720,6 +772,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    int need_unlock = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_FLUSH_LOCAL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_FLUSH_LOCAL);
 
@@ -735,6 +788,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    need_unlock = 1;
     /* Ensure completion of AM operations issued to the target.
      * If target object is not created (e.g., when all operations issued
      * to the target were via shm and in lockall), we also need trigger
@@ -750,6 +805,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win
                            poll_once-- > 0), 0);
 
   fn_exit:
+    if (need_unlock) {
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_FLUSH_LOCAL);
     return mpi_errno;
   fn_fail:
@@ -775,6 +833,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_sync(MPIR_Win * win)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_all(MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    int need_unlock = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_FLUSH_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_FLUSH_ALL);
 
@@ -789,6 +848,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_all(MPIR_Win * win)
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    need_unlock = 1;
+
     /* Ensure completion of AM operations */
 
     /* FIXME: now we simply set per-target counters for lockall in case
@@ -799,6 +861,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_all(MPIR_Win * win)
                           0);
 
   fn_exit:
+    if (need_unlock) {
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_FLUSH_ALL);
     return mpi_errno;
   fn_fail:
@@ -811,6 +876,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock_all(int assert, MPIR_Win * win)
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_LOCK_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_LOCK_ALL);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     MPIDIG_ACCESS_EPOCH_CHECK_NONE(win, mpi_errno, goto fn_fail);
 
@@ -851,6 +917,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock_all(int assert, MPIR_Win * win)
     MPIDIG_WIN(win, sync).access_epoch_type = MPIDIG_EPOTYPE_LOCK_ALL;
 
   fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_LOCK_ALL);
     return mpi_errno;
   fn_fail:


### PR DESCRIPTION
## Pull Request Description

To prepare for multi-vci RMA, we first need move the ch4-layer locks down so each component can implement its own multi-vci scheme independently.

[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
