### PR TITLE
mpl: fix dbg log getting lost during init

### DIFF
--- a/src/mpl/src/dbg/mpl_dbg.c
+++ b/src/mpl/src/dbg/mpl_dbg.c
@@ -537,6 +537,9 @@ int MPL_dbg_init(int wnum, int wrank)
 
     dbg_initialized = DBG_INITIALIZED;
 
+    /* updating dbg_initialized may alter where dbg_fp is stored, set it again */
+    set_fp(dbg_fp);
+
   fn_exit:
     return MPL_SUCCESS;
   fn_fail:


### PR DESCRIPTION

## Pull Request Description

This fixes the loss of log before MPL_dbg_init, broken since PR #4288.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->
[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
