### PR TITLE
ch4/ucx: enable multiple vni for UCX rma operations

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -94,6 +94,7 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
      * and remote windows (at least now). If win_create is used, the key cannot be unpackt -
      * then we need our fallback-solution */
 
+    int vni = MPIDI_UCX_get_win_vni(win);
     bool all_reachable = true;
     for (i = 0; i < comm_ptr->local_size; i++) {
         /* Skip unmapped remote region. */
@@ -103,7 +104,7 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
             continue;
         }
 
-        status = ucp_ep_rkey_unpack(MPIDI_UCX_COMM_TO_EP(comm_ptr, i, 0, 0),
+        status = ucp_ep_rkey_unpack(MPIDI_UCX_WIN_TO_EP(win, i, vni),
                                     &rkey_recv_buff[recv_disps[i]],
                                     &(MPIDI_UCX_WIN_INFO(win, i).rkey));
         if (status == UCS_ERR_UNREACHABLE) {

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -153,18 +153,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_RMA_WIN_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_CMPL_HOOK);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     if ((MPIDI_WIN(win, winattr) & MPIDI_WINATTR_NM_REACHABLE) && MPIDI_UCX_win_need_flush(win)) {
         ucs_status_t ucp_status;
-        /* maybe we just flush all eps here? More efficient for smaller communicators... */
-        ucp_status = MPIDI_UCX_flush(0);
+        int vni = MPIDI_UCX_get_win_vni(win);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
+        ucp_status = MPIDI_UCX_flush(vni);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         MPIDI_UCX_CHK_STATUS(ucp_status);
         MPIDI_UCX_win_unset_sync(win);
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_RMA_WIN_CMPL_HOOK);
     return mpi_errno;
   fn_fail:
@@ -176,7 +176,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_RMA_WIN_LOCAL_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_LOCAL_CMPL_HOOK);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     if ((MPIDI_WIN(win, winattr) & MPIDI_WINATTR_NM_REACHABLE) &&
         MPIDI_UCX_win_need_flush_local(win)) {
@@ -184,7 +183,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
 
         /* currently, UCP does not support local flush, so we have to call
          * a global flush. This is not good for performance - but OK for now */
-        ucp_status = MPIDI_UCX_flush(0);
+        int vni = MPIDI_UCX_get_win_vni(win);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
+        ucp_status = MPIDI_UCX_flush(vni);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         MPIDI_UCX_CHK_STATUS(ucp_status);
 
         /* TODO: should set to FLUSH after replace with real local flush. */
@@ -192,7 +194,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_RMA_WIN_LOCAL_CMPL_HOOK);
     return mpi_errno;
   fn_fail:
@@ -204,22 +205,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank, MPIR_Win * 
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_RMA_TARGET_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_CMPL_HOOK);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     if (MPIDI_UCX_is_reachable_target(rank, win, MPIDI_WIN(win, winattr)) &&
         /* including cases where FLUSH_LOCAL or FLUSH is set */
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync >= MPIDI_UCX_WIN_SYNC_FLUSH_LOCAL) {
 
         ucs_status_t ucp_status;
-        ucp_ep_h ep = MPIDI_UCX_COMM_TO_EP(win->comm_ptr, rank, 0, 0);
+        int vni = MPIDI_UCX_get_win_vni(win);
+        ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni);
         /* only flush the endpoint */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         ucp_status = ucp_ep_flush(ep);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         MPIDI_UCX_CHK_STATUS(ucp_status);
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync = MPIDI_UCX_WIN_SYNC_UNSET;
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_RMA_TARGET_CMPL_HOOK);
     return mpi_errno;
   fn_fail:
@@ -231,16 +233,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_RMA_TARGET_LOCAL_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_LOCAL_CMPL_HOOK);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     if (MPIDI_UCX_is_reachable_target(rank, win, MPIDI_WIN(win, winattr)) &&
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync == MPIDI_UCX_WIN_SYNC_FLUSH_LOCAL) {
         ucs_status_t ucp_status;
 
-        ucp_ep_h ep = MPIDI_UCX_COMM_TO_EP(win->comm_ptr, rank, 0, 0);
+        int vni = MPIDI_UCX_get_win_vni(win);
+        ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni);
         /* currently, UCP does not support local flush, so we have to call
          * a global flush. This is not good for performance - but OK for now */
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         ucp_status = ucp_ep_flush(ep);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         MPIDI_UCX_CHK_STATUS(ucp_status);
 
         /* TODO: should set to FLUSH after replace with real local flush. */
@@ -248,7 +252,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_RMA_TARGET_LOCAL_CMPL_HOOK);
     return mpi_errno;
   fn_fail:


### PR DESCRIPTION
## Pull Request Description

Enable the multiple vni for ucx operations.

NOTE: this PR is based on PR #4746 . Only the last *4* commits belong to this PR and the last 3 probably should be squashed to ensure integrety.
<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->
[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
