### PR TITLE
ch4/ucx: initialize status when recv immediately completes

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -24,10 +24,13 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_recv_cmpl_cb(void *request, ucs_status_t
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_UCX_RECV_CMPL_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_RECV_CMPL_CB);
 
-    if (ucp_request->req)
+    if (ucp_request->req) {
         rreq = ucp_request->req;
-    else
+    } else {
         rreq = MPL_malloc(sizeof(MPIR_Request), MPL_MEM_OTHER);
+        rreq->status.MPI_ERROR = MPI_SUCCESS;
+        MPIR_STATUS_SET_CANCEL_BIT(rreq->status, FALSE);
+    }
 
     if (unlikely(status == UCS_ERR_CANCELED)) {
         MPIR_STATUS_SET_CANCEL_BIT(rreq->status, TRUE);


### PR DESCRIPTION

## Pull Request Description
When we allocate status, need make sure it is initialized or some
garbage field may leak in.

This fixes the occasional test failure: `./pt2pt/rcancle 2`

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->
[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
