### PR TITLE
ch4/ofi: Fix misc 32-bit errors

### DIFF
--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -537,8 +537,9 @@ static void MPIR_Bsend_take_buffer(MPII_Bsend_data_t * p, size_t size)
     /* Compute the remaining size.  This must include any padding
      * that must be added to make the new block properly aligned */
     alloc_size = size;
-    if (alloc_size & 0x7)
-        alloc_size += (8 - (alloc_size & 0x7));
+    if (alloc_size & (MAX_ALIGNMENT - 1)) {
+        alloc_size += (MAX_ALIGNMENT - (alloc_size & (MAX_ALIGNMENT - 1)));
+    }
     /* alloc_size is the amount of space (out of size) that we will
      * allocate for this buffer. */
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -169,9 +169,9 @@ static int recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq, int ev
         MPI_Count elements;
 
         /* Check to see if there are any bytes that don't fit into the datatype basic elements */
-        MPIR_Get_elements_x_impl(((MPI_Count *) & count), MPIDI_OFI_REQUEST(rreq, datatype),
-                                 &elements);
-        if (count)
+        MPI_Count count_x = count;      /* need a MPI_Count variable (consider 32-bit OS) */
+        MPIR_Get_elements_x_impl(&count_x, MPIDI_OFI_REQUEST(rreq, datatype), &elements);
+        if (count_x)
             MPIR_ERR_SET(rreq->status.MPI_ERROR, MPI_ERR_TYPE, "**dtypemismatch");
 
         MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.nopack));

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -567,8 +567,8 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     /* FI_MULTI_RECV may pack the message at lesser alignment, copy the header
      * when that's the case */
 #define MAX_HDR_SIZE 256        /* need accommodate MPIDI_AMTYPE_LMT_REQ */
-    char temp[MAX_HDR_SIZE] MPL_ATTR_ALIGNED(8);
-    if ((intptr_t) am_hdr & 0x7) {
+    char temp[MAX_HDR_SIZE] MPL_ATTR_ALIGNED(MAX_ALIGNMENT);
+    if ((intptr_t) am_hdr & (MAX_ALIGNMENT - 1)) {
         int temp_size = MAX_HDR_SIZE;
         if (temp_size > wc->len) {
             temp_size = wc->len;
@@ -576,7 +576,7 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
         memcpy(temp, wc->buf, temp_size);
         am_hdr = (void *) temp;
         /* confirm it (in case MPL_ATTR_ALIGNED didn't work) */
-        MPIR_Assert(((intptr_t) am_hdr & 0x7) == 0);
+        MPIR_Assert(((intptr_t) am_hdr & (MAX_ALIGNMENT - 1)) == 0);
     }
 #endif
 

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -49,9 +49,9 @@ int MPIDI_POSIX_iqueue_init(int rank, int size)
     transport->num_cells = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_NUM_CELLS;
     transport->size_of_cell = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE;
 
-    /* ensure 8-byte alignment for payload */
-    MPIR_Assert((MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE & 0x7) == 0);
-    MPIR_Assert((sizeof(MPIDI_POSIX_eager_iqueue_cell_t) & 0x7) == 0);
+    /* ensure max alignment for payload */
+    MPIR_Assert((MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE & (MAX_ALIGNMENT - 1)) == 0);
+    MPIR_Assert((sizeof(MPIDI_POSIX_eager_iqueue_cell_t) & (MAX_ALIGNMENT - 1)) == 0);
 
     mpi_errno = MPIDU_genq_shmem_pool_create_unsafe(transport->size_of_cell, transport->num_cells,
                                                     MPIDI_POSIX_global.num_local,

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -49,6 +49,10 @@ int MPIDI_POSIX_iqueue_init(int rank, int size)
     transport->num_cells = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_NUM_CELLS;
     transport->size_of_cell = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE;
 
+    /* ensure 8-byte alignment for payload */
+    MPIR_Assert((MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE & 0x7) == 0);
+    MPIR_Assert((sizeof(MPIDI_POSIX_eager_iqueue_cell_t) & 0x7) == 0);
+
     mpi_errno = MPIDU_genq_shmem_pool_create_unsafe(transport->size_of_cell, transport->num_cells,
                                                     MPIDI_POSIX_global.num_local,
                                                     MPIDI_POSIX_global.my_local_rank,

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -140,15 +140,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
         send_buf = (uint8_t *) curr_sreq_hdr->pack_buffer;
     }
 
-    static char padding[8];     /* in case we need pad to alignment */
+    static char padding[MAX_ALIGNMENT]; /* in case we need pad to alignment */
     iov_left[0].iov_base = (void *) am_hdr;
     iov_left[0].iov_len = am_hdr_sz;
     iov_num_left = 1;
     if (data_sz > 0) {
-        if (am_hdr_sz & 7) {
-            /* need padding to ensure minimum alignment of 8 */
+        if (am_hdr_sz & (MAX_ALIGNMENT - 1)) {
+            /* need padding to ensure maximum alignment (typically 16 on x86-64) */
             iov_left[1].iov_base = (void *) padding;
-            iov_left[1].iov_len = 8 - (am_hdr_sz & 7);
+            iov_left[1].iov_len = MAX_ALIGNMENT - (am_hdr_sz & (MAX_ALIGNMENT - 1));
             msg_hdr.am_hdr_sz += iov_left[1].iov_len;
             iov_num_left++;
         }

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -52,18 +52,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, 
     curr_sreq_hdr->iov_num = iov_num_left;
     curr_sreq_hdr->iov_ptr = curr_sreq_hdr->iov;
 
-    /* If we haven't made it through the header yet, make sure we include it in the iovec */
-    if (iov_num_left == 2) {
+    if (iov_num_left == 1 && data_sz > 0) {
+        /* this is the payload */
+        curr_sreq_hdr->iov[0] = iov_left_ptr[0];
+    } else {
+        /* the first iov is am_hdr, now points to curr_sreq_hdr */
         curr_sreq_hdr->iov[0].iov_base = curr_sreq_hdr->am_hdr;
         curr_sreq_hdr->iov[0].iov_len = curr_sreq_hdr->am_hdr_sz;
-
-        curr_sreq_hdr->iov[1] = iov_left_ptr[1];
-    } else if (iov_num_left == 1) {
-        if (data_sz == 0) {
-            curr_sreq_hdr->iov[0].iov_base = curr_sreq_hdr->am_hdr;
-            curr_sreq_hdr->iov[0].iov_len = curr_sreq_hdr->am_hdr_sz;
-        } else {
-            curr_sreq_hdr->iov[0] = iov_left_ptr[0];
+        /* copy the rest */
+        for (int i = 1; i < iov_num_left; i++) {
+            curr_sreq_hdr->iov[i] = iov_left_ptr[i];
         }
     }
 
@@ -99,7 +97,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
     MPIDI_POSIX_am_header_t *msg_hdr_p = &msg_hdr;
     MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = NULL;
     const int grank = MPIDIU_rank_to_lpid(rank, comm);
-    struct iovec iov_left[2];
+    struct iovec iov_left[MPIDI_POSIX_MAX_IOV_NUM];
     struct iovec *iov_left_ptr;
     size_t iov_num_left;
 
@@ -142,19 +140,24 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
         send_buf = (uint8_t *) curr_sreq_hdr->pack_buffer;
     }
 
+    static char padding[8];     /* in case we need pad to alignment */
     iov_left[0].iov_base = (void *) am_hdr;
     iov_left[0].iov_len = am_hdr_sz;
-    iov_left[1].iov_base = (void *) send_buf;
-    iov_left[1].iov_len = data_sz;
+    iov_num_left = 1;
+    if (data_sz > 0) {
+        if (am_hdr_sz & 7) {
+            /* need padding to ensure minimum alignment of 8 */
+            iov_left[1].iov_base = (void *) padding;
+            iov_left[1].iov_len = 8 - (am_hdr_sz & 7);
+            msg_hdr.am_hdr_sz += iov_left[1].iov_len;
+            iov_num_left++;
+        }
+        iov_left[iov_num_left].iov_base = (void *) send_buf;
+        iov_left[iov_num_left].iov_len = data_sz;
+        iov_num_left++;
+    }
 
     iov_left_ptr = iov_left;
-
-    iov_num_left = 2;
-
-    /* If there's no data to send, the second iov can be empty and doesn't need to be transfered. */
-    if (data_sz == 0) {
-        iov_num_left = 1;
-    }
 
     /* If we already have messages in the postponed queue, this one will probably also end up being
      * queued so save some cycles and do it now. */

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -17,7 +17,7 @@
 #define MPIDI_POSIX_AM_DATA_SZ_BITS     (48)
 
 #define MPIDI_POSIX_AM_MSG_HEADER_SIZE  (sizeof(MPIDI_POSIX_am_header_t))
-#define MPIDI_POSIX_MAX_IOV_NUM         (2)
+#define MPIDI_POSIX_MAX_IOV_NUM         (3)     /* am_hdr, [padding], payload */
 
 typedef enum {
     MPIDI_POSIX_AM_HDR_SHM = 0, /* SHM internal AM header */


### PR DESCRIPTION
## Pull Request Description

* Pointer conversion of different type is dangerous for a reason. Adding a cast suppresses warning, but doesn't fix it.
* In POSIX am send, pad after am header to ensure payload alignment


[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
