### PR TITLE
ch4/ofi: enable multiple vni for OFI RMA operations

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -328,7 +328,7 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
         int vni_local = vni_dst;
         int vni_remote = vni_src;
 
-        MPIDI_OFI_cntr_incr();
+        MPIDI_OFI_cntr_incr(vni_local);
         MPIDI_OFI_CALL_RETRY(fi_read(MPIDI_OFI_global.ctx[vni_local].tx,        /* endpoint     */
                                      (void *) ((uintptr_t) recv_elem->wc.buf + recv_elem->cur_offset),  /* local buffer */
                                      bytesToGet,        /* bytes        */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -40,6 +40,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_vni(int flag, MPIR_Comm * comm_ptr,
 #endif
 }
 
+/* for RMA, vni need be persistent with window */
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_win_vni(MPIR_Win * win)
+{
+    int win_idx = 0;
+    return MPIDI_get_vci(SRC_VCI_FROM_SENDER, win->comm_ptr, 0, 0, win_idx) %
+        MPIDI_OFI_global.num_vnis;
+}
+
 /*
  * Helper routines and macros for request completion
  */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -225,9 +225,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_cntr_incr(MPIR_Win * win)
     (*MPIDI_OFI_WIN(win).issued_cntr)++;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr()
+MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr(int vni)
 {
-    MPIDI_OFI_global.rma_issued_cntr++;
+    MPIDI_OFI_global.ctx[vni].rma_issued_cntr++;
 }
 
 /* Externs:  see util.c for definition */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1041,6 +1041,10 @@ static int create_vni_context(int vni)
         MPIDI_OFI_global.ctx[0].av = av;
         MPIDI_OFI_global.ctx[0].rma_cmpl_cntr = rma_cmpl_cntr;
         MPIDI_OFI_global.ctx[0].ep = ep;
+    } else {
+        /* non-zero vni share most fields with vni 0, copy them
+         * so we don't have to switch during runtime */
+        MPIDI_OFI_global.ctx[vni] = MPIDI_OFI_global.ctx[0];
     }
     MPIDI_OFI_global.ctx[vni].cq = cq;
     MPIDI_OFI_global.ctx[vni].tx = tx;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -929,7 +929,6 @@ static int create_sep_tx(struct fid_ep *ep, int idx, struct fid_ep **p_tx,
                          struct fid_cq *cq, struct fid_cntr *cntr);
 static int create_sep_rx(struct fid_ep *ep, int idx, struct fid_ep **p_rx, struct fid_cq *cq);
 static int try_open_shared_av(struct fid_domain *domain, struct fid_av **p_av);
-static int create_rma_stx_ctx(struct fid_domain *domain, struct fid_stx **p_rma_stx_ctx);
 
 static int create_vni_context(int vni)
 {
@@ -1051,14 +1050,6 @@ static int create_vni_context(int vni)
     MPIDI_OFI_global.ctx[vni].rx = rx;
 #endif
 
-    /* ------------------------------------------------------------------------ */
-    /* Construct:  Shared TX Context for RMA                                    */
-    /* ------------------------------------------------------------------------ */
-    if (vni == 0) {
-        mpi_errno = create_rma_stx_ctx(domain, &MPIDI_OFI_global.rma_stx_ctx);
-        MPIR_ERR_CHECK(mpi_errno);
-    }
-
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_CREATE_VNI_CONTEXT);
     return mpi_errno;
@@ -1126,19 +1117,18 @@ static int destroy_vni_context(int vni)
         MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].domain->fid), domainclose);
     }
 #endif
-    if (vni == 0) {
-        /* Close RMA scalable EP. */
-        if (MPIDI_OFI_global.rma_sep) {
-            /* All transmit contexts on RMA must be closed. */
-            MPIR_Assert(utarray_len(MPIDI_OFI_global.rma_sep_idx_array) ==
-                        MPIDI_OFI_global.max_rma_sep_tx_cnt);
-            utarray_free(MPIDI_OFI_global.rma_sep_idx_array);
-            MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.rma_sep->fid), epclose);
-        }
+    /* Close RMA scalable EP. */
+    if (MPIDI_OFI_global.ctx[vni].rma_sep) {
+        /* All transmit contexts on RMA must be closed. */
+        MPIR_Assert(utarray_len(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array) ==
+                    MPIDI_OFI_global.max_rma_sep_tx_cnt);
+        utarray_free(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].rma_sep->fid), epclose);
+    }
 
-        if (MPIDI_OFI_global.rma_stx_ctx != NULL) {
-            MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.rma_stx_ctx->fid), stx_ctx_close);
-        }
+    /* Close RMA shared context */
+    if (MPIDI_OFI_global.ctx[vni].rma_stx_ctx != NULL) {
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].rma_stx_ctx->fid), stx_ctx_close);
     }
 
   fn_exit:
@@ -1317,34 +1307,6 @@ static int try_open_shared_av(struct fid_domain *domain, struct fid_av **p_av)
         return 0;
     }
 #endif
-}
-
-static int create_rma_stx_ctx(struct fid_domain *domain, struct fid_stx **p_rma_stx_ctx)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    if (MPIDI_OFI_ENABLE_SHARED_CONTEXTS) {
-        int ret;
-        struct fi_tx_attr tx_attr;
-        memset(&tx_attr, 0, sizeof(tx_attr));
-        /* A shared transmit context’s attributes must be a union of all associated
-         * endpoints' transmit capabilities. */
-        tx_attr.caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC;
-        tx_attr.msg_order = FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
-        tx_attr.op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
-        MPIDI_OFI_CALL_RETURN(fi_stx_context(domain, &tx_attr, p_rma_stx_ctx, NULL), ret);
-        if (ret < 0) {
-            MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        "Failed to create shared TX context for RMA, "
-                        "falling back to global EP/counter scheme");
-            *p_rma_stx_ctx = NULL;
-        }
-    }
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 static int open_fabric(void)

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -992,6 +992,7 @@ static int create_vni_context(int vni)
     MPIDI_OFI_global.ctx[vni].domain = domain;
     MPIDI_OFI_global.ctx[vni].av = av;
     MPIDI_OFI_global.ctx[vni].rma_cmpl_cntr = rma_cmpl_cntr;
+    MPIDI_OFI_global.ctx[vni].rma_issued_cntr = 0;
     MPIDI_OFI_global.ctx[vni].ep = ep;
     MPIDI_OFI_global.ctx[vni].cq = cq;
     MPIDI_OFI_global.ctx[vni].tx = tx;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -927,8 +927,7 @@ static int create_vni_domain(struct fid_domain **p_domain, struct fid_av **p_av,
 static int create_cq(struct fid_domain *domain, struct fid_cq **p_cq);
 static int create_sep_tx(struct fid_ep *ep, int idx, struct fid_ep **p_tx,
                          struct fid_cq *cq, struct fid_cntr *cntr);
-static int create_sep_rx(struct fid_ep *ep, int idx, struct fid_ep **p_rx,
-                         struct fid_cq *cq, struct fid_cntr *cntr);
+static int create_sep_rx(struct fid_ep *ep, int idx, struct fid_ep **p_rx, struct fid_cq *cq);
 static int try_open_shared_av(struct fid_domain *domain, struct fid_av **p_av);
 static int create_rma_stx_ctx(struct fid_domain *domain, struct fid_stx **p_rma_stx_ctx);
 
@@ -978,7 +977,7 @@ static int create_vni_context(int vni)
 
         mpi_errno = create_sep_tx(ep, 0, &tx, cq, rma_cmpl_cntr);
         MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno = create_sep_rx(ep, 0, &rx, cq, rma_cmpl_cntr);
+        mpi_errno = create_sep_rx(ep, 0, &rx, cq);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         MPIDI_OFI_CALL(fi_endpoint(domain, prov_use, &ep, NULL), ep);
@@ -1030,7 +1029,7 @@ static int create_vni_context(int vni)
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         mpi_errno = create_sep_tx(ep, vni, &tx, cq, rma_cmpl_cntr);
         MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno = create_sep_rx(ep, vni, &rx, cq, rma_cmpl_cntr);
+        mpi_errno = create_sep_rx(ep, vni, &rx, cq);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         tx = ep;
@@ -1245,8 +1244,7 @@ static int create_sep_tx(struct fid_ep *ep, int idx, struct fid_ep **p_tx,
     goto fn_exit;
 }
 
-static int create_sep_rx(struct fid_ep *ep, int idx, struct fid_ep **p_rx,
-                         struct fid_cq *cq, struct fid_cntr *cntr)
+static int create_sep_rx(struct fid_ep *ep, int idx, struct fid_ep **p_rx, struct fid_cq *cq)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -215,6 +215,7 @@ typedef struct {
     struct fid_ep *ep;          /* EP with counter & completion */
     int sep_tx_idx;             /* transmit context index for scalable EP,
                                  * -1 means using non scalable EP. */
+    int vni;
     uint64_t *issued_cntr;
     uint64_t issued_cntr_v;     /* main body of an issued counter,
                                  * if we are to use per-window counter */

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -198,6 +198,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
     MPIDI_Datatype_check_contig_size_extent_lb(target_datatype, target_count, target_contig,
                                                target_bytes, target_extent, target_true_lb);
 
+    int vni = MPIDI_OFI_WIN(win).vni;
+
     /* zero-byte messages */
     if (unlikely(origin_bytes == 0))
         goto null_op_exit;
@@ -224,20 +226,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
 
     /* small contiguous messages */
     if (origin_contig && target_contig && (origin_bytes <= MPIDI_OFI_global.max_buffered_write)) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         MPIDI_OFI_win_cntr_incr(win);
         MPIDI_OFI_CALL_RETRY(fi_inject_write(MPIDI_OFI_WIN(win).ep,
                                              (char *) origin_addr + origin_true_lb, target_bytes,
-                                             MPIDI_OFI_av_to_phys(addr, 0, 0),
+                                             MPIDI_OFI_av_to_phys(addr, vni, vni),
                                              target_mr.addr + target_true_lb,
                                              target_mr.mr_key), 0, rdma_inject_write, FALSE);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         goto null_op_exit;
     }
 
     /* large contiguous messages */
     if (origin_contig && target_contig) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         if (sigreq) {
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
             if (*sigreq) {
@@ -252,7 +254,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
             flags = FI_DELIVERY_COMPLETE;
         }
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, 0, 0);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, vni, vni);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -268,7 +270,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), 0, rdma_write, FALSE);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         goto fn_exit;
     }
 
@@ -279,22 +281,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
 
     if (origin_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         mpi_errno =
             MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_count, target_datatype, target_mr, win, addr,
                                     MPIDI_OFI_PUT, sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         goto fn_exit;
     }
 
     if (origin_density < MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         mpi_errno =
             MPIDI_OFI_pack_put(origin_addr, origin_count, origin_datatype, target_rank,
                                target_count, target_datatype, target_mr, win, addr, sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         goto fn_exit;
     }
 
@@ -381,6 +383,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
     MPIDI_Datatype_check_contig_size_extent_lb(target_datatype, target_count, target_contig,
                                                target_bytes, target_extent, target_true_lb);
 
+    int vni = MPIDI_OFI_WIN(win).vni;
+
     /* zero-byte messages */
     if (unlikely(target_bytes == 0))
         goto null_op_exit;
@@ -406,7 +410,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
 
     /* contiguous messages */
     if (origin_contig && target_contig) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         if (sigreq) {
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
             if (*sigreq) {
@@ -423,7 +427,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         msg.desc = NULL;
         msg.msg_iov = &iov;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, 0, 0);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, vni, vni);
         msg.rma_iov = &riov;
         msg.rma_iov_count = 1;
         msg.context = NULL;
@@ -437,7 +441,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), 0, rdma_write, FALSE);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         goto fn_exit;
     }
 
@@ -448,22 +452,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
 
     if (origin_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         mpi_errno =
             MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_count, target_datatype, target_mr, win, addr,
                                     MPIDI_OFI_GET, sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         goto fn_exit;
     }
 
     if (origin_density < MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         mpi_errno =
             MPIDI_OFI_pack_get(origin_addr, origin_count, origin_datatype, target_rank,
                                target_count, target_datatype, target_mr, win, addr, sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         goto fn_exit;
     }
 
@@ -576,6 +580,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     struct fi_rma_ioc targetv;
     struct fi_msg_atomic msg;
 
+    int vni = MPIDI_OFI_WIN(win).vni;
+
     if (
 #ifndef MPIDI_CH4_DIRECT_NETMOD
            /* We have to disable network-based atomics in auto mode.
@@ -643,19 +649,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av, 0, 0);
+    msg.addr = MPIDI_OFI_av_to_phys(av, vni, vni);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;
     msg.op = fi_op;
     msg.context = NULL;
     msg.data = 0;
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
     MPIDI_OFI_win_cntr_incr(win);
     MPIDI_OFI_CALL_RETRY(fi_compare_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg,
                                               &comparev, NULL, 1, &resultv, NULL, 1, 0), 0,
                          atomicto, FALSE);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_COMPARE_AND_SWAP);
     return mpi_errno;
@@ -664,7 +671,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
   am_fallback:
     /* Wait for OFI cas to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPIDI_OFI_win_do_progress(win, 0);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
+    MPIDI_OFI_win_do_progress(win, vni);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
     return MPIDIG_mpi_compare_and_swap(origin_addr, compare_addr, result_addr, datatype,
                                        target_rank, target_disp, win);
 }
@@ -697,6 +706,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
                                                target_bytes, target_extent, target_true_lb);
     if (origin_bytes == 0)
         goto null_op_exit;
+
+    int vni = MPIDI_OFI_WIN(win).vni;
 
     /* prepare remote addr and mr key.
      * Continue native path only when all segments are in the same registered memory region */
@@ -737,7 +748,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         /* Ensure completion of outstanding AMs for atomicity. */
         MPIDIG_wait_am_acc(win, target_rank);
 
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         uint64_t flags;
         if (sigreq) {
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
@@ -766,7 +777,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         msg.msg_iov = &originv;
         msg.desc = NULL;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, 0, 0);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, vni, vni);
         msg.rma_iov = &targetv;
         msg.rma_iov_count = 1;
         msg.datatype = fi_dt;
@@ -778,16 +789,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
                              rdma_atomicto, FALSE);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         goto fn_exit;
     }
 
   am_fallback:
     /* Wait for OFI acc to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_OFI_win_do_progress(win, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
+    MPIDI_OFI_win_do_progress(win, vni);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
     if (sigreq)
         mpi_errno = MPIDIG_mpi_raccumulate(origin_addr, origin_count, origin_datatype, target_rank,
                                            target_disp, target_count, target_datatype, op, win,
@@ -840,6 +851,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
     if (target_bytes == 0)
         goto null_op_exit;
 
+    int vni = MPIDI_OFI_WIN(win).vni;
+
     /* contiguous messages */
     if (origin_contig && target_contig && result_contig) {
         /* prepare remote addr and mr key.
@@ -879,7 +892,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         /* Ensure completion of outstanding AMs for atomicity. */
         MPIDIG_wait_am_acc(win, target_rank);
 
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         uint64_t flags;
         if (sigreq) {
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
@@ -910,7 +923,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         msg.msg_iov = &originv;
         msg.desc = NULL;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, 0, 0);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, vni, vni);
         msg.rma_iov = &targetv;
         msg.rma_iov_count = 1;
         msg.datatype = fi_dt;
@@ -922,16 +935,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
                                                 NULL, 1, flags), 0 /*vci */ , rdma_readfrom, FALSE);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         goto fn_exit;
     }
 
   am_fallback:
     /* Wait for OFI getacc to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_OFI_win_do_progress(win, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
+    MPIDI_OFI_win_do_progress(win, vni);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
     if (sigreq)
         mpi_errno =
             MPIDIG_mpi_rget_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
@@ -1077,6 +1090,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_FETCH_AND_OP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_FETCH_AND_OP);
 
+    int vni = MPIDI_OFI_WIN(win).vni;
+
     if (
 #ifndef MPIDI_CH4_DIRECT_NETMOD
            /* We have to disable network-based atomics in auto mode.
@@ -1138,18 +1153,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av, 0, 0);
+    msg.addr = MPIDI_OFI_av_to_phys(av, vni, vni);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;
     msg.op = fi_op;
     msg.context = NULL;
     msg.data = 0;
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
     MPIDI_OFI_win_cntr_incr(win);
     MPIDI_OFI_CALL_RETRY(fi_fetch_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg, &resultv,
                                             NULL, 1, 0), 0, rdma_readfrom, FALSE);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_FETCH_AND_OP);
@@ -1159,9 +1175,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
   am_fallback:
     /* Wait for OFI fetch_and_op to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIDI_OFI_win_do_progress(win, 0);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
+    MPIDI_OFI_win_do_progress(win, vni);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
     return MPIDIG_mpi_fetch_and_op(origin_addr, result_addr, datatype, target_rank, target_disp, op,
                                    win);
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -225,6 +225,7 @@ typedef struct {
     struct fid_av *av;
     struct fid_ep *ep;
     struct fid_cntr *rma_cmpl_cntr;
+    uint64_t rma_issued_cntr;
 
     struct fid_ep *tx;
     struct fid_ep *rx;
@@ -330,7 +331,6 @@ typedef struct {
 
     /* Window/RMA Globals */
     void *win_map;
-    uint64_t rma_issued_cntr;
     /* OFI atomics limitation of each pair of <dtype, op> returned by the
      * OFI provider at MPI initialization.*/
     MPIDI_OFI_atomic_valid_t win_op_table[MPIR_DATATYPE_N_PREDEFINED][MPIDIG_ACCU_NUM_OP];

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -226,6 +226,11 @@ typedef struct {
     struct fid_ep *ep;
     struct fid_cntr *rma_cmpl_cntr;
     uint64_t rma_issued_cntr;
+    /* rma using shared TX context */
+    struct fid_stx *rma_stx_ctx;
+    /* rma using dedicated scalable EP */
+    struct fid_ep *rma_sep;
+    UT_array *rma_sep_idx_array;        /* Array of available indexes of transmit contexts on sep */
 
     struct fid_ep *tx;
     struct fid_ep *rx;
@@ -301,9 +306,6 @@ typedef struct {
     struct fi_info *prov_use;
     struct fid_fabric *fabric;
 
-    struct fid_stx *rma_stx_ctx;        /* shared TX context for RMA */
-    struct fid_ep *rma_sep;     /* dedicated scalable EP for RMA */
-
     int got_named_av;
 
     /* Queryable limits */
@@ -334,7 +336,6 @@ typedef struct {
     /* OFI atomics limitation of each pair of <dtype, op> returned by the
      * OFI provider at MPI initialization.*/
     MPIDI_OFI_atomic_valid_t win_op_table[MPIR_DATATYPE_N_PREDEFINED][MPIDIG_ACCU_NUM_OP];
-    UT_array *rma_sep_idx_array;        /* Array of available indexes of transmit contexts on sep */
 
     /* Active Message Globals */
     struct iovec am_iov[MPIDI_OFI_MAX_NUM_AM_BUFFERS];

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -236,10 +236,8 @@ static int win_set_per_win_sync(MPIR_Win * win)
     memset(&cntr_attr, 0, sizeof(cntr_attr));
     cntr_attr.events = FI_CNTR_EVENTS_COMP;
     cntr_attr.wait_obj = FI_WAIT_UNSPEC;
-    MPIDI_OFI_CALL_RETURN(fi_cntr_open(MPIDI_OFI_global.ctx[0].domain,  /* In:  Domain Object */
-                                       &cntr_attr,      /* In:  Configuration object */
-                                       &MPIDI_OFI_WIN(win).cmpl_cntr,   /* Out: Counter Object */
-                                       NULL), ret);     /* Context: counter events   */
+    MPIDI_OFI_CALL_RETURN(fi_cntr_open(MPIDI_OFI_global.ctx[MPIDI_OFI_WIN(win).vni].domain,
+                                       &cntr_attr, &MPIDI_OFI_WIN(win).cmpl_cntr, NULL), ret);
     if (ret < 0) {
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE, "Failed to open completion counter.\n");
         mpi_errno = MPIDI_OFI_ENAVAIL;
@@ -288,52 +286,53 @@ static int win_init_sep(MPIR_Win * win)
     finfo = fi_dupinfo(MPIDI_OFI_global.prov_use);
     MPIR_Assert(finfo);
 
+    int vni = MPIDI_OFI_WIN(win).vni;
+
     /* Initialize scalable EP when first window is created. */
-    if (MPIDI_OFI_global.rma_sep == NULL) {
-        /* Specify number of transmit context according user input and provider limit. */
+    if (MPIDI_OFI_global.ctx[vni].rma_sep == NULL) {
+        /* NOTE: if MPIDI_OFI_VNI_USE_SEPCTX, we could share rma_stx_ctx across vnis */
+
         MPIDI_OFI_global.max_rma_sep_tx_cnt =
             MPL_MIN(MPIDI_OFI_global.prov_use->domain_attr->max_ep_tx_ctx,
                     MPIR_CVAR_CH4_OFI_MAX_RMA_SEP_CTX);
         finfo->ep_attr->tx_ctx_cnt = MPIDI_OFI_global.max_rma_sep_tx_cnt;
 
-        MPIDI_OFI_CALL_RETURN(fi_scalable_ep
-                              (MPIDI_OFI_global.ctx[0].domain, finfo, &MPIDI_OFI_global.rma_sep,
-                               NULL), ret);
+        MPIDI_OFI_CALL_RETURN(fi_scalable_ep(MPIDI_OFI_global.ctx[vni].domain, finfo,
+                                             &MPIDI_OFI_global.ctx[vni].rma_sep, NULL), ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE, "Failed to create scalable endpoint.\n");
-            MPIDI_OFI_global.rma_sep = NULL;
+            MPIDI_OFI_global.ctx[vni].rma_sep = NULL;
             mpi_errno = MPIDI_OFI_ENAVAIL;
             goto fn_fail;
         }
 
-        MPIDI_OFI_CALL_RETURN(fi_scalable_ep_bind
-                              (MPIDI_OFI_global.rma_sep, &(MPIDI_OFI_global.ctx[0].av->fid), 0),
-                              ret);
+        MPIDI_OFI_CALL_RETURN(fi_scalable_ep_bind(MPIDI_OFI_global.ctx[vni].rma_sep,
+                                                  &(MPIDI_OFI_global.ctx[vni].av->fid), 0), ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         "Failed to bind scalable endpoint to address vector.\n");
-            MPIDI_OFI_global.rma_sep = NULL;
+            MPIDI_OFI_global.ctx[vni].rma_sep = NULL;
             mpi_errno = MPIDI_OFI_ENAVAIL;
             goto fn_fail;
         }
 
         /* Allocate and initilize tx index array. */
-        utarray_new(MPIDI_OFI_global.rma_sep_idx_array, &ut_int_icd, MPL_MEM_RMA);
+        utarray_new(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array, &ut_int_icd, MPL_MEM_RMA);
         for (i = 0; i < MPIDI_OFI_global.max_rma_sep_tx_cnt; i++) {
-            utarray_push_back(MPIDI_OFI_global.rma_sep_idx_array, &i, MPL_MEM_RMA);
+            utarray_push_back(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array, &i, MPL_MEM_RMA);
         }
     }
     /* Set per window transmit attributes. */
     set_rma_fi_info(win, finfo);
     /* Get available transmit context index. */
-    int *idx = (int *) utarray_back(MPIDI_OFI_global.rma_sep_idx_array);
+    int *idx = (int *) utarray_back(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array);
     if (idx == NULL) {
         mpi_errno = MPIDI_OFI_ENAVAIL;
         goto fn_fail;
     }
     /* Retrieve transmit context on scalable EP. */
     MPIDI_OFI_CALL_RETURN(fi_tx_context
-                          (MPIDI_OFI_global.rma_sep, *idx, finfo->tx_attr,
+                          (MPIDI_OFI_global.ctx[vni].rma_sep, *idx, finfo->tx_attr,
                            &(MPIDI_OFI_WIN(win).ep), NULL), ret);
     if (ret < 0) {
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -344,10 +343,10 @@ static int win_init_sep(MPIR_Win * win)
 
     MPIDI_OFI_WIN(win).sep_tx_idx = *idx;
     /* Pop this index out of reserving array. */
-    utarray_pop_back(MPIDI_OFI_global.rma_sep_idx_array);
+    utarray_pop_back(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array);
 
     MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep,
-                                     &MPIDI_OFI_global.ctx[0].cq->fid,
+                                     &MPIDI_OFI_global.ctx[vni].cq->fid,
                                      FI_TRANSMIT | FI_SELECTIVE_COMPLETION), ret);
     if (ret < 0) {
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -379,8 +378,8 @@ static int win_init_sep(MPIR_Win * win)
   fn_fail:
     if (MPIDI_OFI_WIN(win).sep_tx_idx != -1) {
         /* Push tx idx back into available pool. */
-        utarray_push_back(MPIDI_OFI_global.rma_sep_idx_array, &MPIDI_OFI_WIN(win).sep_tx_idx,
-                          MPL_MEM_RMA);
+        utarray_push_back(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array,
+                          &MPIDI_OFI_WIN(win).sep_tx_idx, MPL_MEM_RMA);
         MPIDI_OFI_WIN(win).sep_tx_idx = -1;
     }
     if (MPIDI_OFI_WIN(win).ep != NULL) {
@@ -413,6 +412,30 @@ static int win_init_stx(MPIR_Win * win)
     finfo = fi_dupinfo(MPIDI_OFI_global.prov_use);
     MPIR_Assert(finfo);
 
+    int vni = MPIDI_OFI_WIN(win).vni;
+
+    /* Initialize rma shared context when first window is created. */
+    if (MPIDI_OFI_global.ctx[vni].rma_stx_ctx == NULL) {
+        /* NOTE: if MPIDI_OFI_VNI_USE_SEPCTX, we could share rma_stx_ctx across vnis */
+
+        struct fi_tx_attr tx_attr;
+        memset(&tx_attr, 0, sizeof(tx_attr));
+        /* A shared transmit context’s attributes must be a union of all associated
+         * endpoints' transmit capabilities. */
+        tx_attr.caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC;
+        tx_attr.msg_order = FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
+        tx_attr.op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
+        MPIDI_OFI_CALL_RETURN(fi_stx_context(MPIDI_OFI_global.ctx[vni].domain, &tx_attr,
+                                             &MPIDI_OFI_global.ctx[vni].rma_stx_ctx, NULL), ret);
+        if (ret < 0) {
+            MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                        "Failed to create RMA shared TX context.\n");
+            MPIDI_OFI_global.ctx[vni].rma_stx_ctx = NULL;
+            mpi_errno = MPIDI_OFI_ENAVAIL;
+            goto fn_fail;
+        }
+    }
+
     /* Set per window transmit attributes. */
     set_rma_fi_info(win, finfo);
     /* Still need to take out rx capabilities for shared context. */
@@ -420,7 +443,7 @@ static int win_init_stx(MPIR_Win * win)
 
     finfo->ep_attr->tx_ctx_cnt = FI_SHARED_CONTEXT;     /* Request a shared context */
     finfo->ep_attr->rx_ctx_cnt = 0;     /* We don't need RX contexts */
-    MPIDI_OFI_CALL_RETURN(fi_endpoint(MPIDI_OFI_global.ctx[0].domain,
+    MPIDI_OFI_CALL_RETURN(fi_endpoint(MPIDI_OFI_global.ctx[vni].domain,
                                       finfo, &MPIDI_OFI_WIN(win).ep, NULL), ret);
     if (ret < 0) {
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -432,8 +455,8 @@ static int win_init_stx(MPIR_Win * win)
 
     if (win_set_per_win_sync(win) == MPI_SUCCESS) {
         have_per_win_cntr = true;
-        MPIDI_OFI_CALL_RETURN(fi_ep_bind
-                              (MPIDI_OFI_WIN(win).ep, &MPIDI_OFI_global.rma_stx_ctx->fid, 0), ret);
+        MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep,
+                                         &MPIDI_OFI_global.ctx[vni].rma_stx_ctx->fid, 0), ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         "Failed to bind endpoint to shared transmit contxt.\n");
@@ -442,7 +465,7 @@ static int win_init_stx(MPIR_Win * win)
         }
 
         MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep,
-                                         &MPIDI_OFI_global.ctx[0].cq->fid,
+                                         &MPIDI_OFI_global.ctx[vni].cq->fid,
                                          FI_TRANSMIT | FI_SELECTIVE_COMPLETION), ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -452,7 +475,7 @@ static int win_init_stx(MPIR_Win * win)
         }
 
         MPIDI_OFI_CALL_RETURN(fi_ep_bind
-                              (MPIDI_OFI_WIN(win).ep, &MPIDI_OFI_global.ctx[0].av->fid, 0), ret);
+                              (MPIDI_OFI_WIN(win).ep, &MPIDI_OFI_global.ctx[vni].av->fid, 0), ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         "Failed to bind endpoint to address vector.\n");
@@ -494,9 +517,10 @@ static int win_init_global(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_WIN_INIT_GLOBAL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_WIN_INIT_GLOBAL);
 
-    MPIDI_OFI_WIN(win).ep = MPIDI_OFI_global.ctx[0].tx;
-    MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_OFI_global.ctx[0].rma_cmpl_cntr;
-    MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_OFI_global.rma_issued_cntr;
+    int vni = MPIDI_OFI_WIN(win).vni;
+    MPIDI_OFI_WIN(win).ep = MPIDI_OFI_global.ctx[vni].tx;
+    MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_OFI_global.ctx[vni].rma_cmpl_cntr;
+    MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_OFI_global.ctx[vni].rma_issued_cntr;
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_WIN_INIT_GLOBAL);
 
@@ -526,6 +550,12 @@ static int win_init(MPIR_Win * win)
 
     MPIDI_OFI_WIN(win).sep_tx_idx = -1; /* By default, -1 means not using scalable EP. */
     MPIDI_OFI_WIN(win).progress_counter = 1;
+
+    /* Assign vni to window.
+     * NOTE: we could assign vni per epoch, then we need run `win_init_{sep,stx,global}`
+     * at start of every epoch.
+     */
+    MPIDI_OFI_WIN(win).vni = MPIDI_OFI_get_win_vni(win);
 
     /* First, try to enable scalable EP. */
     if (MPIR_CVAR_CH4_OFI_ENABLE_SCALABLE_ENDPOINTS && MPIR_CVAR_CH4_OFI_MAX_RMA_SEP_CTX > 0) {
@@ -983,16 +1013,17 @@ int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_WIN_FREE_HOOK);
 
     if (MPIDI_OFI_ENABLE_RMA) {
+        int vni = MPIDI_OFI_WIN(win).vni;
         MPIDI_OFI_mr_key_free(MPIDI_OFI_COLL_MR_KEY, MPIDI_OFI_WIN(win).win_id);
         MPIDIU_map_erase(MPIDI_OFI_global.win_map, MPIDI_OFI_WIN(win).win_id);
         /* For scalable EP: push transmit context index back into available pool. */
         if (MPIDI_OFI_WIN(win).sep_tx_idx != -1) {
-            utarray_push_back(MPIDI_OFI_global.rma_sep_idx_array, &(MPIDI_OFI_WIN(win).sep_tx_idx),
-                              MPL_MEM_RMA);
+            utarray_push_back(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array,
+                              &(MPIDI_OFI_WIN(win).sep_tx_idx), MPL_MEM_RMA);
         }
-        if (MPIDI_OFI_WIN(win).ep != MPIDI_OFI_global.ctx[0].tx)
+        if (MPIDI_OFI_WIN(win).ep != MPIDI_OFI_global.ctx[vni].tx)
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).ep->fid), epclose);
-        if (MPIDI_OFI_WIN(win).cmpl_cntr != MPIDI_OFI_global.ctx[0].rma_cmpl_cntr)
+        if (MPIDI_OFI_WIN(win).cmpl_cntr != MPIDI_OFI_global.ctx[vni].rma_cmpl_cntr)
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).cmpl_cntr->fid), cntrclose);
         if (MPIDI_OFI_WIN(win).mr)
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).mr->fid), mr_unreg);

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -134,6 +134,9 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
         MPIDI_OFI_WIN(win).mr_key = 0;
     }
 
+    /* we need register mr on the correct domain for the vni */
+    int vni = MPIDI_OFI_get_win_vni(win);
+
     /* Register the allocated win buffer or MPI_BOTTOM (NULL) for dynamic win.
      * It is clear that we cannot register NULL when FI_MR_ALLOCATED is set, thus
      * we skip trial and return immediately. When FI_MR_ALLOCATED is not set, however,
@@ -148,7 +151,7 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
         if (MPIR_GPU_query_pointer_is_dev(base))
             rc = -1;
         else
-            MPIDI_OFI_CALL_RETURN(fi_mr_reg(MPIDI_OFI_global.ctx[0].domain,     /* In:  Domain Object */
+            MPIDI_OFI_CALL_RETURN(fi_mr_reg(MPIDI_OFI_global.ctx[vni].domain,   /* In:  Domain Object */
                                             base,       /* In:  Lower memory address */
                                             win->size,  /* In:  Length              */
                                             FI_REMOTE_READ | FI_REMOTE_WRITE,   /* In:  Expose MR for read  */

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -317,9 +317,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-        mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        int vni = MPIDI_OFI_WIN(win).vni;
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -337,9 +338,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_LOCAL_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-        mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        int vni = MPIDI_OFI_WIN(win).vni;
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -358,9 +360,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank ATTRIBUTE((u
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-        mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        int vni = MPIDI_OFI_WIN(win).vni;
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -379,9 +382,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank ATTRIB
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_LOCAL_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-        mpi_errno = MPIDI_OFI_win_do_progress(win, 0);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        int vni = MPIDI_OFI_WIN(win).vni;
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 


### PR DESCRIPTION
## Pull Request Description
Enable the multiple vni for ucx operations.

NOTE: this PR is based on PR #4746 . The commits start at "ch4/ofi: add MPIDI_OFI_get_win_vni"
[skip warnings]
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
