### PR TITLE
ch4/ofi: always try fi_mr_reg and then decide whether to fallback

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -249,7 +249,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
     MPL_atomic_fetch_add_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs, 1);
 
     if (MPIDI_OFI_ENABLE_MR_PROV_KEY) {
-        /* MR_BASIC */
         lmt_info->rma_key = fi_mr_key(MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr));
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -173,12 +173,8 @@ struct MPIDI_OFI_win_hint;
 /* Stores per-rank information for RMA */
 typedef struct {
     int32_t disp_unit;
-    /* For MR_BASIC mode we need to store an MR key and a base address of the target window */
-    /* TODO - Ideally, we'd like to not have these fields compiled in if not
-     * using MR_BASIC. In practice, doing so makes the code very complex
-     * elsewhere for very little payoff. */
-    uint64_t mr_key;
-    uintptr_t base;
+    uint64_t mr_key;            /* needed if MPIDI_OFI_ENABLE_MR_PROV_KEY (target mr_key may be different) */
+    uintptr_t base;             /* needed if MPIDI_OFI_ENABLE_MR_VIRT_ADDRESS (need to calc target addr) */
 } MPIDI_OFI_win_targetinfo_t;
 
 typedef struct {

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -275,7 +275,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_PUT);
     int mpi_errno = MPI_SUCCESS;
 
-    if (!MPIDI_OFI_ENABLE_RMA || win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+    if (!MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_WIN(win).mr) {
         mpi_errno = MPIDIG_mpi_put(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win);
         goto fn_exit;
@@ -434,7 +434,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_GET);
 
-    if (!MPIDI_OFI_ENABLE_RMA || win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+    if (!MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_WIN(win).mr) {
         mpi_errno = MPIDIG_mpi_get(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win);
         goto fn_exit;
@@ -465,7 +465,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rput(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RPUT);
     int mpi_errno = MPI_SUCCESS;
 
-    if (!MPIDI_OFI_ENABLE_RMA || win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+    if (!MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_WIN(win).mr) {
         mpi_errno = MPIDIG_mpi_rput(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_disp, target_count, target_datatype, win, request);
         goto fn_exit;
@@ -511,8 +511,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS || !MPIDI_OFI_WIN(win).mr) {
         mpi_errno =
             MPIDIG_mpi_compare_and_swap(origin_addr, compare_addr, result_addr, datatype,
                                         target_rank, target_disp, win);
@@ -729,8 +728,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr,
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS || !MPIDI_OFI_WIN(win).mr) {
         mpi_errno =
             MPIDIG_mpi_raccumulate(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, op, win, request);
@@ -776,8 +774,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget_accumulate(const void *origin_add
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS || !MPIDI_OFI_WIN(win).mr) {
         mpi_errno =
             MPIDIG_mpi_rget_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
                                        result_count, result_datatype, target_rank, target_disp,
@@ -824,8 +821,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS || !MPIDI_OFI_WIN(win).mr) {
         mpi_errno =
             MPIDIG_mpi_fetch_and_op(origin_addr, result_addr, datatype, target_rank, target_disp,
                                     op, win);
@@ -921,7 +917,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RGET);
     int mpi_errno = MPI_SUCCESS;
 
-    if (!MPIDI_OFI_ENABLE_RMA || win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+    if (!MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_WIN(win).mr) {
         mpi_errno = MPIDIG_mpi_rget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_disp, target_count, target_datatype, win, request);
         goto fn_exit;
@@ -964,8 +960,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS || !MPIDI_OFI_WIN(win).mr) {
         mpi_errno =
             MPIDIG_mpi_get_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
                                       result_count, result_datatype, target_rank, target_disp,
@@ -1005,8 +1000,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_accumulate(const void *origin_addr,
             * via network thus we can safely use network-based atomics. */
            !MPIDIG_WIN(win, info_args).disable_shm_accumulate ||
 #endif
-           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+           !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS || !MPIDI_OFI_WIN(win).mr) {
         mpi_errno =
             MPIDIG_mpi_accumulate(origin_addr, origin_count, origin_datatype, target_rank,
                                   target_disp, target_count, target_datatype, op, win);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -274,7 +274,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                        MPL_MEM_BUFFER);
 
         if (MPIDI_OFI_ENABLE_MR_PROV_KEY) {
-            /* MR_BASIC */
             ctrl.rma_key = fi_mr_key(huge_send_mr);
         }
 


### PR DESCRIPTION
## Pull Request Description

Previous PR https://github.com/pmodels/mpich/pull/4708 forced all dynamic windows to fallback due to the concern that it's not clear that we can register NULL address. However, since at least some providers, for example `psm2`, does support registering NULL address, and we should try to use the native path whenever we can.

This PR is a second approach to do this properly. We'll try to `fi_mr_reg` the address, and check for results. If it fails (I expect any decent providers should at least tell us whether there is an issue or not), then, and only then, we force the fallback.


<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->
[skip warnings]
## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
