### PR TITLE
coll/gpu: Add GPU fallback paths and testing for reduce, allreduce

### DIFF
--- a/src/mpi/coll/allreduce/allreduce.c
+++ b/src/mpi/coll/allreduce/allreduce.c
@@ -246,6 +246,15 @@ int MPIR_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype d
                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
+    void *in_recvbuf = recvbuf;
+    void *host_sendbuf;
+    void *host_recvbuf;
+
+    MPIR_Coll_host_buffer_alloc(sendbuf, recvbuf, count, datatype, &host_sendbuf, &host_recvbuf);
+    if (host_sendbuf)
+        sendbuf = host_sendbuf;
+    if (host_recvbuf)
+        recvbuf = host_recvbuf;
 
     if ((MPIR_CVAR_DEVICE_COLLECTIVES == MPIR_CVAR_DEVICE_COLLECTIVES_all) ||
         ((MPIR_CVAR_DEVICE_COLLECTIVES == MPIR_CVAR_DEVICE_COLLECTIVES_percoll) &&
@@ -254,6 +263,14 @@ int MPIR_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype d
     } else {
         mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
     }
+
+    /* Copy out data from host recv buffer to GPU buffer after allreduce is complete. */
+    if (host_recvbuf) {
+        recvbuf = in_recvbuf;
+        MPIR_Localcopy(host_recvbuf, count, datatype, recvbuf, count, datatype);
+    }
+
+    MPIR_Coll_host_buffer_free(host_sendbuf, host_recvbuf);
 
     return mpi_errno;
 }

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -100,4 +100,9 @@ int MPII_Coll_finalize(void);
             MPIR_ERR_POP(mpi_errno);                                    \
     } while (0)
 
+/* functions for supporting GPU buffers in reduce collectives */
+void MPIR_Coll_host_buffer_alloc(const void *sendbuf, const void *recvbuf, MPI_Aint count,
+                                 MPI_Datatype datatype, void **host_sendbuf, void **host_recvbuf);
+void MPIR_Coll_host_buffer_free(void *host_sendbuf, void *host_recvbuf);
+
 #endif /* COLL_IMPL_H_INCLUDED */

--- a/test/mpi/coll/allred.c
+++ b/test/mpi/coll/allred.c
@@ -18,6 +18,7 @@
 #endif
 
 int count, size, rank;
+mtest_mem_type_e memtype;
 int errs;
 
 struct int_test {
@@ -58,9 +59,10 @@ struct double_test {
 
 /* calloc to avoid spurious valgrind warnings when "type" has padding bytes */
 #define DECL_MALLOC_IN_OUT_SOL(type)            \
-    type *in, *out, *sol;                       \
-    in  = (type *) calloc(count, sizeof(type)); \
-    out = (type *) calloc(count, sizeof(type)); \
+    type *in, *out, *sol; /*allocated on host*/ \
+    void *in_d, *out_d; /*allocated on device*/ \
+    MTestAlloc(count * sizeof(type), memtype, ((void **)&in), &in_d, 1);  \
+    MTestAlloc(count * sizeof(type), memtype, ((void **)&out), &out_d, 1);\
     sol = (type *) calloc(count, sizeof(type));
 
 #define SET_INDEX_CONST(arr, val)               \
@@ -103,7 +105,9 @@ struct double_test {
             fprintf(stderr, "(%d) Error for type %s and op %s\n",       \
                     rank, name, mpi_op2str(mpi_op));                    \
         }                                                               \
-        free(in); free(out); free(sol);                                 \
+        MTestFree(memtype, in, in_d);                                   \
+        MTestFree(memtype, out, out_d);                                 \
+        free(sol);                                                      \
     } while (0)
 
 /* The logic on the error check on MPI_Allreduce assumes that all
@@ -112,10 +116,12 @@ struct double_test {
    (and motivated this addition, as some versions of the IBM MPI
    failed in just this way).
 */
-#define ALLREDUCE_AND_FREE(mpi_type, mpi_op, in, out, sol)              \
+#define ALLREDUCE_AND_FREE(type, mpi_type, mpi_op, in, out, sol)        \
     {                                                                   \
         int i, rc, lerrcnt = 0;						\
-        rc = MPI_Allreduce(in, out, count, mpi_type, mpi_op, MPI_COMM_WORLD); \
+        MTestCopyContent(in, in_d, count * sizeof(type),  memtype);     \
+        rc = MPI_Allreduce(in_d, out_d, count, mpi_type, mpi_op, MPI_COMM_WORLD); \
+        MTestCopyContent(out_d, out, count * sizeof(type), memtype);    \
         if (rc) { lerrcnt++; errs++; MTestPrintError(rc); }             \
         else {                                                          \
             for (i = 0; i < count; i++) {                               \
@@ -128,10 +134,12 @@ struct double_test {
         ERROR_CHECK_AND_FREE(lerrcnt, mpi_type, mpi_op);                \
     }
 
-#define STRUCT_ALLREDUCE_AND_FREE(mpi_type, mpi_op, in, out, sol)       \
+#define STRUCT_ALLREDUCE_AND_FREE(type, mpi_type, mpi_op, in, out, sol) \
     {                                                                   \
         int i, rc, lerrcnt = 0;						\
-        rc = MPI_Allreduce(in, out, count, mpi_type, mpi_op, MPI_COMM_WORLD); \
+        MTestCopyContent(in, in_d, count * sizeof(type),  memtype);     \
+        rc = MPI_Allreduce(in_d, out_d, count, mpi_type, mpi_op, MPI_COMM_WORLD); \
+        MTestCopyContent(out_d, out, count * sizeof(type), memtype);    \
         if (rc) { lerrcnt++; errs++; MTestPrintError(rc); }             \
         else {                                                          \
             for (i = 0; i < count; i++) {                               \
@@ -164,7 +172,7 @@ struct double_test {
         SET_INDEX_SUM(in, 0);                                   \
         SET_INDEX_FACTOR(sol, size);                            \
         SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(mpi_type, MPI_SUM, in, out, sol);    \
+        ALLREDUCE_AND_FREE(type, mpi_type, MPI_SUM, in, out, sol);    \
     }
 
 #define prod_test1(type, mpi_type)                              \
@@ -173,7 +181,7 @@ struct double_test {
         SET_INDEX_SUM(in, 0);                                   \
         SET_INDEX_POWER(sol, size);                             \
         SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(mpi_type, MPI_PROD, in, out, sol);   \
+        ALLREDUCE_AND_FREE(type, mpi_type, MPI_PROD, in, out, sol);   \
     }
 
 #define max_test1(type, mpi_type)                               \
@@ -182,7 +190,7 @@ struct double_test {
         SET_INDEX_SUM(in, rank);                                \
         SET_INDEX_SUM(sol, size - 1);                           \
         SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(mpi_type, MPI_MAX, in, out, sol);    \
+        ALLREDUCE_AND_FREE(type, mpi_type, MPI_MAX, in, out, sol);    \
     }
 
 #define min_test1(type, mpi_type)                               \
@@ -191,7 +199,7 @@ struct double_test {
         SET_INDEX_SUM(in, rank);                                \
         SET_INDEX_SUM(sol, 0);                                  \
         SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(mpi_type, MPI_MIN, in, out, sol);    \
+        ALLREDUCE_AND_FREE(type, mpi_type, MPI_MIN, in, out, sol);    \
     }
 
 #define const_test(type, mpi_type, mpi_op, val1, val2, val3)    \
@@ -200,7 +208,7 @@ struct double_test {
         SET_INDEX_CONST(in, (val1));                            \
         SET_INDEX_CONST(sol, (val2));                           \
         SET_INDEX_CONST(out, (val3));                           \
-        ALLREDUCE_AND_FREE(mpi_type, mpi_op, in, out, sol);     \
+        ALLREDUCE_AND_FREE(type, mpi_type, mpi_op, in, out, sol);     \
     }
 
 #define lor_test1(type, mpi_type)                                       \
@@ -237,7 +245,7 @@ struct double_test {
         }                                                       \
         SET_INDEX_SUM(sol, 0);                                  \
         SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(mpi_type, MPI_BAND, in, out, sol);   \
+        ALLREDUCE_AND_FREE(type, mpi_type, MPI_BAND, in, out, sol);   \
     }
 
 #define band_test2(type, mpi_type)                              \
@@ -251,7 +259,7 @@ struct double_test {
         }                                                       \
         SET_INDEX_CONST(sol, 0);                                \
         SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(mpi_type, MPI_BAND, in, out, sol);   \
+        ALLREDUCE_AND_FREE(type, mpi_type, MPI_BAND, in, out, sol);   \
     }
 
 #define maxloc_test(type, mpi_type)                                     \
@@ -263,7 +271,7 @@ struct double_test {
         SET_INDEX_STRUCT_CONST(sol, size - 1, b);                       \
         SET_INDEX_STRUCT_CONST(out, 0, a);                              \
         SET_INDEX_STRUCT_CONST(out, -1, b);                             \
-        STRUCT_ALLREDUCE_AND_FREE(mpi_type, MPI_MAXLOC, in, out, sol);  \
+        STRUCT_ALLREDUCE_AND_FREE(type, mpi_type, MPI_MAXLOC, in, out, sol);  \
     }
 
 #define minloc_test(type, mpi_type)                                     \
@@ -275,7 +283,7 @@ struct double_test {
         SET_INDEX_STRUCT_CONST(sol, 0, b);                              \
         SET_INDEX_STRUCT_CONST(out, 0, a);                              \
         SET_INDEX_STRUCT_CONST(out, -1, b);                             \
-        STRUCT_ALLREDUCE_AND_FREE(mpi_type, MPI_MINLOC, in, out, sol);  \
+        STRUCT_ALLREDUCE_AND_FREE(type, mpi_type, MPI_MINLOC, in, out, sol);  \
     }
 
 #if MTEST_HAVE_MIN_MPI_VERSION(2,2)
@@ -376,6 +384,7 @@ struct double_test {
 int main(int argc, char **argv)
 {
     MTest_Init(&argc, &argv);
+    MTestArgList *head = MTestArgListCreate(argc, argv);
 
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -393,13 +402,19 @@ int main(int argc, char **argv)
     /* Allow an argument to override the count.
      * Note that the product tests may fail if the count is very large.
      */
-    if (argc >= 2) {
-        count = atoi(argv[1]);
-        if (count <= 0) {
-            fprintf(stderr, "Invalid count argument %s\n", argv[1]);
-            MPI_Abort(MPI_COMM_WORLD, 1);
-        }
+    count = MTestArgListGetInt(head, "count");
+
+    if (count <= 0) {
+        fprintf(stderr, "Invalid count argument %d\n", count);
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
+
+    if (rank % 2 == 0)
+        memtype = MTestArgListGetMemType(head, "evenmemtype");
+    else
+        memtype = MTestArgListGetMemType(head, "oddmemtype");
+
+    MTestArgListDestroy(head);
 
     test_types_set2(sum, 1);
     test_types_set2(prod, 1);

--- a/test/mpi/coll/allred2.c
+++ b/test/mpi/coll/allred2.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
         MPI_Comm_rank(comm, &rank);
 
         for (count = 1; count < 65000; count = count * 2) {
-            MTestAlloc(count * sizeof(int), memtype, &buf_h, &buf);
+            MTestAlloc(count * sizeof(int), memtype, &buf_h, &buf, 0);
 
             set_buf(rank, count, buf_h);
             MTestCopyContent(buf_h, buf, count * sizeof(int), memtype);

--- a/test/mpi/coll/allred2.c
+++ b/test/mpi/coll/allred2.c
@@ -12,39 +12,66 @@
 static char MTEST_Descrip[] = "Test MPI_Allreduce with MPI_IN_PLACE";
 */
 
+void set_buf(int rank, int count, int *buf)
+{
+    int i;
+    for (i = 0; i < count; i++) {
+        int val = rank + i;
+        buf[i] = val;
+    }
+}
+
+void check_buf(int size, int count, int *errs, int *buf)
+{
+    int i;
+    for (i = 0; i < count; i++) {
+        int result = i * size + (size * (size - 1)) / 2;
+        if (buf[i] != result) {
+            (*errs)++;
+            if ((*errs) < 10) {
+                fprintf(stderr, "buf[%d] = %d expected %d\n", i, buf[i], result);
+            }
+        }
+    }
+}
+
 int main(int argc, char *argv[])
 {
     int errs = 0;
-    int rank, size;
+    int rank, size, i;
     int minsize = 2, count;
     MPI_Comm comm;
-    int *buf, i;
+    void *buf_h, *buf;
+    mtest_mem_type_e memtype;
 
     MTest_Init(&argc, &argv);
+    MTestArgList *head = MTestArgListCreate(argc, argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank % 2 == 0)
+        memtype = MTestArgListGetMemType(head, "evenmemtype");
+    else
+        memtype = MTestArgListGetMemType(head, "oddmemtype");
 
     while (MTestGetIntracommGeneral(&comm, minsize, 1)) {
         if (comm == MPI_COMM_NULL)
             continue;
+
         MPI_Comm_size(comm, &size);
         MPI_Comm_rank(comm, &rank);
 
         for (count = 1; count < 65000; count = count * 2) {
-            /* Contiguous data */
-            buf = (int *) malloc(count * sizeof(int));
-            for (i = 0; i < count; i++)
-                buf[i] = rank + i;
+            MTestAlloc(count * sizeof(int), memtype, &buf_h, &buf);
+
+            set_buf(rank, count, buf_h);
+            MTestCopyContent(buf_h, buf, count * sizeof(int), memtype);
+
             MPI_Allreduce(MPI_IN_PLACE, buf, count, MPI_INT, MPI_SUM, comm);
-            /* Check the results */
-            for (i = 0; i < count; i++) {
-                int result = i * size + (size * (size - 1)) / 2;
-                if (buf[i] != result) {
-                    errs++;
-                    if (errs < 10) {
-                        fprintf(stderr, "buf[%d] = %d expected %d\n", i, buf[i], result);
-                    }
-                }
-            }
-            free(buf);
+
+            MTestCopyContent(buf, buf_h, count * sizeof(int), memtype);
+            check_buf(size, count, &errs, buf_h);
+
+            MTestFree(memtype, buf_h, buf);
         }
         MTestFreeComm(&comm);
     }

--- a/test/mpi/coll/bcast.c
+++ b/test/mpi/coll/bcast.c
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
                     break;
                 }
 
-                MTestAlloc(obj.DTP_bufsize, memtype, &buf_h, &buf);
+                MTestAlloc(obj.DTP_bufsize, memtype, &buf_h, &buf, 0);
                 assert(buf);
 
                 if (rank == root) {

--- a/test/mpi/coll/reduce.c
+++ b/test/mpi/coll/reduce.c
@@ -12,15 +12,53 @@
 static char MTEST_Descrip[] = "A simple test of Reduce with all choices of root process";
 */
 
+void set_send_buf(int count, int *buf)
+{
+    int i;
+    for (i = 0; i < count; i++) {
+        buf[i] = i;
+    }
+}
+
+void set_recv_buf(int count, int *buf)
+{
+    int i;
+    for (i = 0; i < count; i++) {
+        buf[i] = -1;
+    }
+}
+
+void check_buf(int rank, int size, int count, int *errs, int *buf)
+{
+    int i;
+    for (i = 0; i < count; i++) {
+        int result = i * size;
+        if (buf[i] != result) {
+            (*errs)++;
+            if ((*errs) < 10) {
+                fprintf(stderr, "buf[%d] = %d expected %d\n", i, buf[i], result);
+            }
+        }
+    }
+}
+
 int main(int argc, char *argv[])
 {
     int errs = 0;
-    int rank, size, root;
-    int *sendbuf, *recvbuf, i;
+    int rank, size, root, i;
+    void *sendbuf, *recvbuf, *sendbuf_h, *recvbuf_h;
     int minsize = 2, count;
     MPI_Comm comm;
+    mtest_mem_type_e memtype;
 
     MTest_Init(&argc, &argv);
+    MTestArgList *head = MTestArgListCreate(argc, argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank % 2 == 0)
+        memtype = MTestArgListGetMemType(head, "evenmemtype");
+    else
+        memtype = MTestArgListGetMemType(head, "oddmemtype");
 
     while (MTestGetIntracommGeneral(&comm, minsize, 1)) {
         if (comm == MPI_COMM_NULL)
@@ -30,24 +68,24 @@ int main(int argc, char *argv[])
         MPI_Comm_size(comm, &size);
 
         for (count = 1; count < 130000; count = count * 2) {
-            sendbuf = (int *) malloc(count * sizeof(int));
-            recvbuf = (int *) malloc(count * sizeof(int));
+            MTestAlloc(count * sizeof(int), memtype, &recvbuf_h, &recvbuf);
+            MTestAlloc(count * sizeof(int), memtype, &sendbuf_h, &sendbuf);
+
             for (root = 0; root < size; root++) {
-                for (i = 0; i < count; i++)
-                    sendbuf[i] = i;
-                for (i = 0; i < count; i++)
-                    recvbuf[i] = -1;
+                set_send_buf(count, sendbuf_h);
+                set_recv_buf(count, recvbuf_h);
+                MTestCopyContent(sendbuf_h, sendbuf, count * sizeof(int), memtype);
+                MTestCopyContent(recvbuf_h, recvbuf, count * sizeof(int), memtype);
+
                 MPI_Reduce(sendbuf, recvbuf, count, MPI_INT, MPI_SUM, root, comm);
+                MTestCopyContent(recvbuf, recvbuf_h, count * sizeof(int), memtype);
+
                 if (rank == root) {
-                    for (i = 0; i < count; i++) {
-                        if (recvbuf[i] != i * size) {
-                            errs++;
-                        }
-                    }
+                    check_buf(rank, size, count, &errs, recvbuf_h);
                 }
             }
-            free(sendbuf);
-            free(recvbuf);
+            MTestFree(memtype, sendbuf_h, sendbuf);
+            MTestFree(memtype, recvbuf_h, recvbuf);
         }
         MTestFreeComm(&comm);
     }

--- a/test/mpi/coll/reduce.c
+++ b/test/mpi/coll/reduce.c
@@ -68,8 +68,8 @@ int main(int argc, char *argv[])
         MPI_Comm_size(comm, &size);
 
         for (count = 1; count < 130000; count = count * 2) {
-            MTestAlloc(count * sizeof(int), memtype, &recvbuf_h, &recvbuf);
-            MTestAlloc(count * sizeof(int), memtype, &sendbuf_h, &sendbuf);
+            MTestAlloc(count * sizeof(int), memtype, &recvbuf_h, &recvbuf, 0);
+            MTestAlloc(count * sizeof(int), memtype, &sendbuf_h, &sendbuf, 0);
 
             for (root = 0; root < size; root++) {
                 set_send_buf(count, sendbuf_h);

--- a/test/mpi/coll/testlist.in
+++ b/test/mpi/coll/testlist.in
@@ -1,6 +1,6 @@
-allred 4
-allred 7
-allred 4 arg=100
+allred 4 arg=-count=10
+allred 7 arg=-count=10
+allred 4 arg=-count=100
 allredmany 4
 allred2 4
 allred3 10

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -267,6 +267,7 @@ AC_ARG_WITH(dtpools-datatypes,
 dtp_args="--with-dtpools-datatypes=${with_dtpools_datatypes}"
 
 AC_CONFIG_COMMANDS([gentests],[$srcdir/maint/gentests_dtp.sh $dtp_args],[dtp_args="$dtp_args"])
+AC_CONFIG_COMMANDS([gputests],[$srcdir/maint/generate_gpu_tests.sh])
 #Test collectives algorithms with CVARs
 AC_CONFIG_COMMANDS([collcvartests],[$srcdir/maint/test_coll_algos.sh])
 

--- a/test/mpi/include/mtest_common.h
+++ b/test/mpi/include/mtest_common.h
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 
 typedef enum {
     MTEST_MEM_TYPE__UNSET,
@@ -31,7 +32,8 @@ long MTestArgListGetLong_with_default(MTestArgList * head, const char *arg, long
 mtest_mem_type_e MTestArgListGetMemType(MTestArgList * head, const char *arg);
 void MTestArgListDestroy(MTestArgList * head);
 
-void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devicebuf);
+void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devicebuf,
+                bool is_calloc);
 void MTestFree(mtest_mem_type_e type, void *hostbuf, void *devicebuf);
 void MTestCopyContent(const void *sbuf, void *dbuf, size_t size, mtest_mem_type_e type);
 void MTest_finalize_gpu();

--- a/test/mpi/maint/generate_gpu_tests.sh
+++ b/test/mpi/maint/generate_gpu_tests.sh
@@ -1,0 +1,61 @@
+#! /bin/sh
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+# Generate testlist.gpu for cases not covered under gentests-dtop.sh
+# and test_coll_algos.sh
+# Reads input from the input file in format "testpath/testname:procs"
+# and creates test combinations for (host, device) and (device, device).
+
+srcdir=`dirname $0`
+builddir=$PWD
+
+while read -r line ; do
+    if [ ! `echo $line | cut -c 1` = "#" ] ; then
+        # the line is not a comment
+        pathname=`echo $line | cut -f1 -d':'`
+        procs=`echo $line | cut -f2 -d':'`
+        other_args=""
+    else
+        # the line is a comment
+        continue
+    fi
+
+    if [ -z "$pathname" ] ; then
+        echo "No pathname found"
+        exit 1
+    elif [ -z "$procs" ] ; then
+        echo "$pathname has no proc count specified"
+        exit 1
+    fi
+
+    # get test directory and name
+    testdir=`dirname $pathname`
+    testname=`basename $pathname`
+
+    # if this is the first test in this directory, create a new
+    # testlist.gpu
+    found=0
+    for dir in $dirs ; do
+        if test "$testdir" = "$dir" ; then
+            found=1
+        fi
+    done
+    if test "$found" = "0" ; then
+        dirs="$dirs $testdir"
+        printf "" >> ${builddir}/${testdir}/testlist.gpu
+    fi
+
+    # prepare extra args
+    for arg in $args ; do
+        other_args="$other_args arg=$arg"
+    done
+
+    printf "generating tests for: ${testname}... "
+    echo "${testname} $procs arg=-evenmemtype=host arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
+    echo "${testname} $procs arg=-evenmemtype=reg_host arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
+    echo "${testname} $procs arg=-evenmemtype=device arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
+
+done < ${srcdir}/gpu-test-config.txt

--- a/test/mpi/maint/generate_gpu_tests.sh
+++ b/test/mpi/maint/generate_gpu_tests.sh
@@ -17,6 +17,7 @@ while read -r line ; do
         # the line is not a comment
         pathname=`echo $line | cut -f1 -d':'`
         procs=`echo $line | cut -f2 -d':'`
+        count=`echo $line | cut -f3 -d':'`
         other_args=""
     else
         # the line is a comment
@@ -54,8 +55,14 @@ while read -r line ; do
     done
 
     printf "generating tests for: ${testname}... "
-    echo "${testname} $procs arg=-evenmemtype=host arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
-    echo "${testname} $procs arg=-evenmemtype=reg_host arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
-    echo "${testname} $procs arg=-evenmemtype=device arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
-
+    if [ ${testname} == 'allred' ]
+    then
+        echo "${testname} $procs arg=-count=$count arg=-evenmemtype=host arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
+        echo "${testname} $procs arg=-count=$count arg=-evenmemtype=reg_host arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
+        echo "${testname} $procs arg=-count=$count arg=-evenmemtype=device arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
+    else
+        echo "${testname} $procs arg=-evenmemtype=host arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
+        echo "${testname} $procs arg=-evenmemtype=reg_host arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
+        echo "${testname} $procs arg=-evenmemtype=device arg=-oddmemtype=device" >> ${builddir}/${testdir}/testlist.gpu
+    fi
 done < ${srcdir}/gpu-test-config.txt

--- a/test/mpi/maint/gpu-test-config.txt
+++ b/test/mpi/maint/gpu-test-config.txt
@@ -1,7 +1,10 @@
 #This file is used by autogen.sh to generate multiple binary files for datatype testing.
 # Every line must have the format:
 #
-# <test pathname>:<procs#>
+# <test pathname>:<procs#>:<count>
+coll/allred:4:10
+coll/allred:4:100
+coll/allred:7:10
 coll/allred2:4
 coll/reduce:5
 coll/reduce:10

--- a/test/mpi/maint/gpu-test-config.txt
+++ b/test/mpi/maint/gpu-test-config.txt
@@ -3,3 +3,5 @@
 #
 # <test pathname>:<procs#>
 coll/allred2:4
+coll/reduce:5
+coll/reduce:10

--- a/test/mpi/maint/gpu-test-config.txt
+++ b/test/mpi/maint/gpu-test-config.txt
@@ -1,0 +1,5 @@
+#This file is used by autogen.sh to generate multiple binary files for datatype testing.
+# Every line must have the format:
+#
+# <test pathname>:<procs#>
+coll/allred2:4

--- a/test/mpi/maint/test_coll_algos.sh
+++ b/test/mpi/maint/test_coll_algos.sh
@@ -125,8 +125,8 @@ for algo_name in ${algo_names}; do
                     env="${env} env=MPIR_CVAR_IALLREDUCE_TREE_TYPE=${tree_type} env=MPIR_CVAR_IALLREDUCE_TREE_PIPELINE_CHUNK_SIZE=4096"
                     env="${env} env=MPIR_CVAR_IALLREDUCE_TREE_KVAL=${kval}"
 
-                    echo "allred 4 arg=100 ${env}" >> ${testlist_cvar}
-                    echo "allred 7 ${env}" >> ${testlist_cvar}
+                    echo "allred 4 arg=-count=100 ${env}" >> ${testlist_cvar}
+                    echo "allred 7 arg=-count=10 ${env}" >> ${testlist_cvar}
                     echo "allredmany 4 ${env}" >> ${testlist_cvar}
                     echo "allred2 4 ${env}" >> ${testlist_cvar}
                     echo "allred3 10 ${env}" >> ${testlist_cvar}
@@ -141,8 +141,8 @@ for algo_name in ${algo_names}; do
                 env="${testing_env} env=MPIR_CVAR_IALLREDUCE_INTRA_ALGORITHM=${algo_name}"
                 env="${env} env=MPIR_CVAR_IALLREDUCE_RECEXCH_KVAL=${kval}"
 
-                echo "allred 4 arg=100 ${env}" >> ${testlist_cvar}
-                echo "allred 7 ${env}" >> ${testlist_cvar}
+                echo "allred 4 arg=-count=100 ${env}" >> ${testlist_cvar}
+                echo "allred 7 arg=-count=10 ${env}" >> ${testlist_cvar}
                 echo "allredmany 4 ${env}" >> ${testlist_cvar}
                 echo "allred2 4 ${env}" >> ${testlist_cvar}
                 echo "allred3 10 ${env}" >> ${testlist_cvar}
@@ -157,8 +157,8 @@ for algo_name in ${algo_names}; do
         #set the environment
         env="${testing_env} env=MPIR_CVAR_IALLREDUCE_INTRA_ALGORITHM=${algo_name}"
 
-        echo "allred 4 arg=100 ${env}" >> ${testlist_cvar}
-        echo "allred 7 ${env}" >> ${testlist_cvar}
+        echo "allred 4 arg=-count=100 ${env}" >> ${testlist_cvar}
+        echo "allred 7 arg=-count=10 ${env}" >> ${testlist_cvar}
         echo "allredmany 4 ${env}" >> ${testlist_cvar}
         echo "allred2 4 ${env}" >> ${testlist_cvar}
         echo "allred3 10 ${env}" >> ${testlist_cvar}
@@ -689,7 +689,7 @@ for buf_size in ${buffer_sizes}; do
         env="${testing_env} env=MPIR_CVAR_REDUCE_INTRANODE_BUFFER_TOTAL_SIZE=${buf_size}"
         env="${env} env=MPIR_CVAR_REDUCE_INTRANODE_TREE_KVAL=${kval}"
 
-        echo "allred 4 ${env}" >> ${testlist_cvar}
+        echo "allred 4 arg=-count=10 ${env}" >> ${testlist_cvar}
         echo "allred2 4 ${env}" >> ${testlist_cvar}
         env=""
     done

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
                 maxmsg = MAXMSG;
 
             if (rank == source) {
-                MTestAlloc(send_obj.DTP_bufsize, sendmem, &sendbuf_h, &sendbuf);
+                MTestAlloc(send_obj.DTP_bufsize, sendmem, &sendbuf_h, &sendbuf, 0);
                 assert(sendbuf && sendbuf_h);
 
                 err = DTP_obj_buf_init(send_obj, sendbuf_h, 0, 1, count[0]);
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
 
                 MTestFree(sendmem, sendbuf_h, sendbuf);
             } else if (rank == dest) {
-                MTestAlloc(recv_obj.DTP_bufsize, recvmem, &recvbuf_h, &recvbuf);
+                MTestAlloc(recv_obj.DTP_bufsize, recvmem, &recvbuf_h, &recvbuf, 0);
                 assert(recvbuf && recvbuf_h);
 
                 recvcount = recv_obj.DTP_type_count;

--- a/test/mpi/pt2pt/sendrecv1.c
+++ b/test/mpi/pt2pt/sendrecv1.c
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
             }
 
             if (rank == source) {
-                MTestAlloc(send_obj.DTP_bufsize, sendmem, &sendbuf_h, &sendbuf);
+                MTestAlloc(send_obj.DTP_bufsize, sendmem, &sendbuf_h, &sendbuf, 0);
                 assert(sendbuf && sendbuf_h);
 
                 err = DTP_obj_buf_init(send_obj, sendbuf_h, 0, 1, count[0]);
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 
                 MTestFree(sendmem, sendbuf_h, sendbuf);
             } else if (rank == dest) {
-                MTestAlloc(recv_obj.DTP_bufsize, recvmem, &recvbuf_h, &recvbuf);
+                MTestAlloc(recv_obj.DTP_bufsize, recvmem, &recvbuf_h, &recvbuf, 0);
                 assert(recvbuf && recvbuf_h);
 
                 err = DTP_obj_buf_init(recv_obj, recvbuf_h, -1, -1, count[0]);

--- a/test/mpi/pt2pt/sendself.c
+++ b/test/mpi/pt2pt/sendself.c
@@ -73,10 +73,10 @@ int main(int argc, char *argv[])
             errs++;
         }
 
-        MTestAlloc(send_obj.DTP_bufsize, sendmem, &sendbuf_h, &sendbuf);
+        MTestAlloc(send_obj.DTP_bufsize, sendmem, &sendbuf_h, &sendbuf, 0);
         assert(sendbuf && sendbuf_h);
 
-        MTestAlloc(recv_obj.DTP_bufsize, recvmem, &recvbuf_h, &recvbuf);
+        MTestAlloc(recv_obj.DTP_bufsize, recvmem, &recvbuf_h, &recvbuf, 0);
         assert(recvbuf && recvbuf_h);
 
         err = DTP_obj_buf_init(send_obj, sendbuf_h, 0, 1, count[0]);

--- a/test/mpi/rma/accfence1.c
+++ b/test/mpi/rma/accfence1.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
         goto fn_exit;
     }
 
-    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
+    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf, 0);
     assert(targetbuf && targetbuf_h);
 
     /* The following illustrates the use of the routines to
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
             MPI_Win_fence(0, win);
 
             if (rank == orig) {
-                MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
+                MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf, 0);
                 assert(origbuf && origbuf_h);
 
                 err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);

--- a/test/mpi/rma/accpscw1.c
+++ b/test/mpi/rma/accpscw1.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
         goto fn_exit;
     }
 
-    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
+    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf, 0);
     assert(targetbuf && targetbuf_h);
 
     /* The following illustrates the use of the routines to
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
             targettype = target_obj.DTP_datatype;
 
             if (rank == orig) {
-                MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
+                MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf, 0);
                 assert(origbuf && origbuf_h);
 
                 err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);

--- a/test/mpi/rma/epochtest.c
+++ b/test/mpi/rma/epochtest.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
         extent = 1;
     }
 
-    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
+    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf, 0);
     assert(targetbuf && targetbuf_h);
 
     while (MTestGetIntracommGeneral(&comm, minsize, 1)) {
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
                 break;
             }
 
-            MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
+            MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf, 0);
             assert(origbuf && origbuf_h);
 
             err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);

--- a/test/mpi/rma/fence.c
+++ b/test/mpi/rma/fence.c
@@ -77,7 +77,7 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
         }
 #endif
     } else if (rank == orig) {
-        MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
+        MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf, 0);
         assert(origbuf && origbuf_h);
 
 #if defined(USE_GET)
@@ -211,7 +211,7 @@ int main(int argc, char *argv[])
         goto fn_exit;
     }
 
-    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
+    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf, 0);
     assert(targetbuf && targetbuf_h);
 
     /* The following illustrates the use of the routines to

--- a/test/mpi/rma/lock_x_dt.c
+++ b/test/mpi/rma/lock_x_dt.c
@@ -108,7 +108,7 @@ static int run_test(MPI_Comm comm, MPI_Win win, DTP_obj_s orig_obj, void *origbu
      * second one informs the origin that the target is done
      * checking. */
     if (rank == orig) {
-        MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
+        MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf, 0);
         assert(origbuf && origbuf_h);
 
         err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);
@@ -140,7 +140,7 @@ static int run_test(MPI_Comm comm, MPI_Win win, DTP_obj_s orig_obj, void *origbu
                                targettype, MPI_REPLACE, win);
             }
         } else {
-            MTestAlloc(result_obj.DTP_bufsize, resultmem, &resultbuf_h, &resultbuf);
+            MTestAlloc(result_obj.DTP_bufsize, resultmem, &resultbuf_h, &resultbuf, 0);
             assert(resultbuf && resultbuf_h);
 
 #if !defined(MULTI_ORIGIN) && !defined(MULTI_TARGET)
@@ -274,7 +274,7 @@ int main(int argc, char *argv[])
         goto fn_exit;
     }
 
-    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
+    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf, 0);
     assert(targetbuf && targetbuf_h);
 
     while (MTestGetIntracommGeneral(&comm, minsize, 1)) {

--- a/test/mpi/rma/putpscw1.c
+++ b/test/mpi/rma/putpscw1.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
         extent = 1;
     }
 
-    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf);
+    MTestAlloc(maxbufsize, targetmem, &targetbuf_h, &targetbuf, 0);
     assert(targetbuf && targetbuf_h);
 
     /* The following illustrates the use of the routines to
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
             MPI_Win_set_errhandler(win, MPI_ERRORS_RETURN);
 
             if (rank == orig) {
-                MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf);
+                MTestAlloc(orig_obj.DTP_bufsize, origmem, &origbuf_h, &origbuf, 0);
                 assert(origbuf && origbuf_h);
 
                 err = DTP_obj_buf_init(orig_obj, origbuf_h, 0, 1, count);


### PR DESCRIPTION
## Pull Request Description
Enables testing of MPI_Reduce and MPI_Allreduce with GPU buffers. 
- Adds fallback path in reduce and allreduce when the buffers are in GPU.
- Enables testing with GPU buffers in allred.c, allred2.c and reduce.c.  Other tests had user operations so we did not modify those.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
