### PR TITLE
ch4/generic: use send_hdr_reply for sending SSEND_ACK

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_init.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_init.c
@@ -156,8 +156,7 @@ int MPIDIG_am_init(void)
     MPIDIG_am_reg_cb(MPIDIG_SEND_LONG_ACK, NULL, &MPIDIG_send_long_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_SEND_LONG_LMT,
                      &MPIDIG_send_long_lmt_origin_cb, &MPIDIG_send_long_lmt_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_SSEND_ACK,
-                     &MPIDIG_ssend_ack_origin_cb, &MPIDIG_ssend_ack_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_SSEND_ACK, NULL, &MPIDIG_ssend_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_PUT_REQ, &MPIDIG_put_origin_cb, &MPIDIG_put_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_PUT_ACK, NULL, &MPIDIG_put_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_GET_REQ, &MPIDIG_get_origin_cb, &MPIDIG_get_target_msg_cb);

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -288,17 +288,6 @@ int MPIDIG_send_long_lmt_origin_cb(MPIR_Request * sreq)
     return mpi_errno;
 }
 
-int MPIDIG_ssend_ack_origin_cb(MPIR_Request * req)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_SSEND_ACK_ORIGIN_CB);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SSEND_ACK_ORIGIN_CB);
-    MPID_Request_complete(req);
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_SSEND_ACK_ORIGIN_CB);
-    return mpi_errno;
-}
-
-
 int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
                               int is_local, int is_async, MPIR_Request ** req)
 {

--- a/src/mpid/ch4/src/ch4r_recv.h
+++ b/src/mpid/ch4/src/ch4r_recv.h
@@ -10,26 +10,25 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDIG_reply_ssend(MPIR_Request * rreq)
 {
-    int mpi_errno = MPI_SUCCESS, c;
+    int mpi_errno = MPI_SUCCESS;
     MPIDIG_ssend_ack_msg_t ack_msg;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_REPLY_SSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_REPLY_SSEND);
-    MPIR_cc_incr(rreq->cc_ptr, &c);
     ack_msg.sreq_ptr = MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(rreq, context_id),
-                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK, &ack_msg,
-                                     sizeof(ack_msg), NULL, 0, MPI_DATATYPE_NULL, rreq);
+            MPIDI_SHM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
+                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK, &ack_msg,
+                                        sizeof(ack_msg));
     else
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_isend_reply(MPIDIG_REQUEST(rreq, context_id),
-                                    MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK, &ack_msg,
-                                    sizeof(ack_msg), NULL, 0, MPI_DATATYPE_NULL, rreq);
+            MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
+                                       MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK, &ack_msg,
+                                       sizeof(ack_msg));
     }
 
     MPIR_ERR_CHECK(mpi_errno);


### PR DESCRIPTION
The message carries no data. Just use send_hdr_reply for simplicity.

## Pull Request Description

I step on this problem that the SSEND ACK is sent using am_isend_reply rather than am_send_hdr_reply. Since there is no data being sent, it should just do a header send.

As a result of this change, the origin callback is unnecessary now.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
