### PR TITLE
Misc size limit fix

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -117,9 +117,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void)
     size_t max_shortsend = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE -
         (sizeof(MPIDI_OFI_am_header_t) + sizeof(MPIDI_OFI_lmt_msg_payload_t));
     /* Maximum payload size representable by MPIDI_OFI_am_header_t::am_hdr_sz field */
-    size_t max_representable = (1 << MPIDI_OFI_AM_HDR_SZ_BITS) - 1;
-
-    return MPL_MIN(max_shortsend, max_representable);
+    return MPL_MIN(max_shortsend, MPIDI_OFI_MAX_AM_HDR_SIZE);
 }
 
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_limit(void)

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -85,10 +85,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_am_clear_request(MPIR_Request * sreq)
     if (!req_hdr)
         goto fn_exit;
 
-    if (req_hdr->am_hdr != &req_hdr->am_hdr_buf[0]) {
-        MPL_free(req_hdr->am_hdr);
-    }
-
     MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.am_hdr_buf_pool, req_hdr);
     MPIDI_OFI_AMREQUEST(sreq, req_hdr) = NULL;
 
@@ -116,15 +112,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_init_request(const void *am_hdr,
         req_hdr->am_hdr_sz = am_hdr_sz;
     } else {
         req_hdr = MPIDI_OFI_AMREQUEST(sreq, req_hdr);
-    }
-
-    if (am_hdr_sz > req_hdr->am_hdr_sz) {
-        if (req_hdr->am_hdr != &req_hdr->am_hdr_buf[0])
-            MPL_free(req_hdr->am_hdr);
-
-        req_hdr->am_hdr = MPL_malloc(am_hdr_sz, MPL_MEM_BUFFER);
-        MPIR_Assert(req_hdr->am_hdr);
-        req_hdr->am_hdr_sz = am_hdr_sz;
     }
 
     if (am_hdr) {

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -676,6 +676,8 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
         /* Maximum possible message size for short message send (=eager send)
          * See MPIDI_OFI_do_am_isend for short/long switching logic */
         MPIR_Assert(MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE <= MPIDI_OFI_global.max_msg_size);
+        MPL_COMPILE_TIME_ASSERT(sizeof(MPIDI_OFI_am_request_header_t)
+                                < MPIDI_OFI_AM_HDR_POOL_CELL_SIZE);
         mpi_errno =
             MPIDU_genq_private_pool_create_unsafe(MPIDI_OFI_AM_HDR_POOL_CELL_SIZE,
                                                   MPIDI_OFI_AM_HDR_POOL_NUM_CELLS_PER_CHUNK,

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -24,7 +24,7 @@
 #define MPIDI_OFI_VNI_USE_SEPCTX       1
 #endif
 
-#define MPIDI_OFI_MAX_AM_HDR_SIZE    128
+#define MPIDI_OFI_MAX_AM_HDR_SIZE      ((1 << MPIDI_OFI_AM_HDR_SZ_BITS) - 1)
 #define MPIDI_OFI_AM_HANDLER_ID_BITS   8
 #define MPIDI_OFI_AM_TYPE_BITS         8
 #define MPIDI_OFI_AM_HDR_SZ_BITS       8

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -282,10 +282,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_hdr_max_sz(void)
     size_t max_shortsend = MPIDI_POSIX_eager_payload_limit();
 
     /* Maximum payload size representable by MPIDI_POSIX_am_header_t::am_hdr_sz field */
-
-    size_t max_representable = (1 << MPIDI_POSIX_AM_HDR_SZ_BITS) - 1;
-
-    return MPL_MIN(max_shortsend, max_representable);
+    return MPL_MIN(max_shortsend, MPIDI_POSIX_MAX_AM_HDR_SIZE);
 }
 
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_eager_limit(void)

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -287,7 +287,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_hdr_max_sz(void)
 
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_eager_limit(void)
 {
-    return MPIDI_POSIX_eager_payload_limit();
+    return MPIDI_POSIX_eager_payload_limit() - MAX_ALIGNMENT;
 }
 
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_eager_buf_limit(void)

--- a/src/mpid/ch4/shm/posix/posix_am_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_am_impl.h
@@ -17,9 +17,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_release_req_hdr(MPIDI_POSIX_am_reque
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_RELEASE_REQ_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_RELEASE_REQ_HDR);
 
-    if ((*req_hdr_ptr)->am_hdr != &(*req_hdr_ptr)->am_hdr_buf[0]) {
-        MPL_free((*req_hdr_ptr)->am_hdr);
-    }
 #ifndef POSIX_AM_REQUEST_INLINE
     MPIDU_genq_private_pool_free_cell(MPIDI_POSIX_global.am_hdr_buf_pool, (*req_hdr_ptr));
 #endif
@@ -52,17 +49,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_init_req_hdr(const void *am_hdr,
         req_hdr->am_hdr_sz = am_hdr_sz;
 
         req_hdr->pack_buffer = NULL;
-    }
-
-    /* If the header is larger than what we'd preallocated, get rid of the preallocated buffer and
-     * create a new one of the correct size. */
-    if (am_hdr_sz > MPIDI_POSIX_MAX_AM_HDR_SIZE) {
-        if (req_hdr->am_hdr != &req_hdr->am_hdr_buf[0])
-            MPL_free(req_hdr->am_hdr);
-
-        req_hdr->am_hdr = MPL_malloc(am_hdr_sz, MPL_MEM_SHM);
-        MPIR_ERR_CHKANDJUMP(!(req_hdr->am_hdr), mpi_errno, MPI_ERR_OTHER, "**nomem");
-        req_hdr->am_hdr_sz = am_hdr_sz;
     }
 
     if (am_hdr) {

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -132,6 +132,8 @@ int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *tag_bits)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_MPI_INIT_HOOK);
 
+    MPL_COMPILE_TIME_ASSERT(sizeof(MPIDI_POSIX_am_request_header_t)
+                            < MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE);
     mpi_errno = MPIDU_genq_private_pool_create_unsafe(MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE,
                                                       MPIDI_POSIX_AM_HDR_POOL_NUM_CELLS_PER_CHUNK,
                                                       MPIDI_POSIX_AM_HDR_POOL_MAX_NUM_CELLS,

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -9,7 +9,7 @@
 #include <mpi.h>
 #include "release_gather_types.h"
 
-#define MPIDI_POSIX_MAX_AM_HDR_SIZE     (32)
+#define MPIDI_POSIX_MAX_AM_HDR_SIZE     ((1 << MPIDI_POSIX_AM_HDR_SZ_BITS) - 1)
 
 #define MPIDI_POSIX_AM_KIND_BITS  (1)   /* 0 or 1 */
 #define MPIDI_POSIX_AM_HANDLER_ID_BITS  (7)     /* up to 64 */


### PR DESCRIPTION
## Pull Request Description

This is mainly related to how we define the `MPIDI_OFI/POSIX_MAX_AM_HDR_SZ`. This size controls how much am_hdr buffer is allocated inline in the am_request_header_t of OFI and POSIX. The current value is smaller than what is representable by the am_hdr_sz bits (8 bits total) in the OFI/POSIX am msg header. So when the am_hdr_sz is larger than this macro, we will malloc a buffer and use it for am_hdr rather than using what is inline of the request header.

Since the request header is allocated from a pool of 1KB cells. I don't think it makes much sense to keep the inline am_hdr buffer to be small. So this PR just change it to the maximum representable size.

Another change is to account for the possible padding size when calculating eager limit for POSIX. 

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
