### PR TITLE
ch4/ofi: fix ofi progress bug

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -30,7 +30,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win)
 
         while (tcount > donecount) {
             MPIR_Assert(donecount <= tcount);
-            MPIDI_OFI_PROGRESS(0);
             donecount = fi_cntr_read(MPIDI_OFI_WIN(win).cmpl_cntr);
             itercount++;
 


### PR DESCRIPTION
Bug Description:
In MPIDI_OFI_win_do_progress function, we have 
```
while (1) {
        tcount = *MPIDI_OFI_WIN(win).issued_cntr;
        donecount = fi_cntr_read(MPIDI_OFI_WIN(win).cmpl_cntr);
        while(tcount > donecount){
               MPIDI_OFI_PROGRESS(0);
               donecount = fi_cntr_read(MPIDI_OFI_WIN(win).cmpl_cntr);
        }
}
```
The issue of this code is  when calling MPIDI_OFI_win_do_progress, we should only check whether issued and done rma operations is equal without calling `MPIDI_OFI_PROGRESS(0);`. If we call `MPIDI_OFI_PROGRESS(0);`, we may receive an active message which can increase issue count. Main branch didn't update tcount timely, so it would cause an abnormal exit from this function and incomplete rma operations.

Solution:
- delete `MPIDI_OFI_PROGRESS(0);`

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
