### PR TITLE
Setup recv async in callback function

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -367,7 +367,6 @@ MPL_STATIC_INLINE_PREFIX void do_long_am_recv_unpack(MPI_Aint in_data_sz, MPIR_R
                                                      MPIDI_OFI_lmt_msg_payload_t * lmt_msg)
 {
     MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_type) = MPIDI_OFI_AM_LMT_UNPACK;
-    MPIDIG_recv_setup(rreq);
 
     MPI_Aint pack_size = 100 * 1024;
     if (pack_size > MPIDI_OFI_global.max_msg_size) {

--- a/src/mpid/ch4/shm/posix/posix_progress.c
+++ b/src/mpid/ch4/shm/posix/posix_progress.c
@@ -93,9 +93,6 @@ static int progress_recv(int blocking)
             MPIDI_POSIX_EAGER_RECV_COMPLETED_HOOK(rreq);
             goto fn_exit;
         } else {
-            /* prepare for asynchronous transfer */
-            MPIDIG_recv_setup(rreq);
-
             MPIR_Assert(MPIDI_POSIX_global.active_rreq[transaction.src_grank] == NULL);
             MPIDI_POSIX_global.active_rreq[transaction.src_grank] = rreq;
         }

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -405,6 +405,7 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
     MPIDIG_recv_type_init(in_data_sz, rreq);
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -529,8 +530,10 @@ int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void *data,
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    if (is_async)
+    if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = NULL;
+    }
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_SEND_LONG_REQ_TARGET_MSG_CB);
@@ -559,6 +562,7 @@ int MPIDIG_send_long_lmt_target_msg_cb(int handler_id, void *am_hdr, void *data,
     MPIDIG_recv_type_init(in_data_sz, rreq);
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -1180,6 +1180,7 @@ int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, M
     MPIDIG_recv_type_init(in_data_sz, rreq);
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -1212,6 +1213,7 @@ int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = cswap_ack_target_cmpl_cb;
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -1342,6 +1344,7 @@ int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint 
     }
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -1397,6 +1400,7 @@ int MPIDIG_put_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Ai
     MPIDIG_REQUEST(rreq, req->preq.flattened_dt) = flattened_dt;
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -1611,6 +1615,7 @@ int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_
     MPIDIG_recv_type_init(in_data_sz, rreq);
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -1642,6 +1647,7 @@ int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = acc_target_cmpl_cb;
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -1670,6 +1676,7 @@ int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = get_acc_target_cmpl_cb;
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -1729,6 +1736,7 @@ int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Ain
     MPIDIG_recv_init(1, in_data_sz, p_data, data_sz * 2, rreq);
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -1805,6 +1813,7 @@ int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint 
     }
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -1894,6 +1903,7 @@ int MPIDIG_acc_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Ai
 #endif
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -1982,6 +1992,7 @@ int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint 
     }
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);
@@ -2021,6 +2032,7 @@ int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_A
     MPIDIG_recv_type_init(in_data_sz, rreq);
 
     if (is_async) {
+        MPIDIG_recv_setup(rreq);
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);


### PR DESCRIPTION
## Pull Request Description

The async recv setup should be called inside the target callback function when async is requested by the caller of the callback. But we are not doing that. Instead the current code had the caller of the callback to do the setup step, which is error prone and breaking the abstraction. Returning an async rreq without setup step is essentially returning a bad request.

This PR move all the necessary MPIDIG_recv_setup into the callback functions that setup requests.

This is a prereq for the AM PIPELINE.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
