### PR TITLE
Refactoring the NM/SHM interface for taking protocol information

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am.h
+++ b/src/mpid/ch4/generic/am/mpidig_am.h
@@ -61,6 +61,10 @@ enum {
     MPIDIG_HANDLER_STATIC_MAX
 };
 
+enum {
+    MPIDIG_AM_PROTOCOL__SEND_ALL
+};
+
 typedef int (*MPIDIG_am_target_cmpl_cb) (MPIR_Request * req);
 typedef int (*MPIDIG_am_origin_cb) (MPIR_Request * req);
 

--- a/src/mpid/ch4/generic/am/mpidig_am_comm_abort.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_comm_abort.c
@@ -51,7 +51,8 @@ int MPIDIG_am_comm_abort(MPIR_Comm * comm, int exit_code)
 
         /* FIXME: only NM? */
         mpi_errno = MPIDI_NM_am_isend(dest, comm, MPIDIG_COMM_ABORT, &am_hdr,
-                                      sizeof(am_hdr), NULL, 0, MPI_INT, sreq);
+                                      sizeof(am_hdr), NULL, 0, MPI_INT, sreq,
+                                      MPIDIG_AM_PROTOCOL__SEND_ALL);
         if (mpi_errno)
             continue;
         else

--- a/src/mpid/ch4/generic/am/mpidig_am_send.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_send.h
@@ -122,12 +122,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_eager_send(const void *buf, MPI_Aint coun
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_av_is_local(addr)) {
         mpi_errno = MPIDI_SHM_am_isend(rank, comm, MPIDIG_SEND, &am_hdr, sizeof(am_hdr),
-                                       buf, count, datatype, sreq);
+                                       buf, count, datatype, sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     } else
 #endif
     {
         mpi_errno = MPIDI_NM_am_isend(rank, comm, MPIDIG_SEND, &am_hdr, sizeof(am_hdr),
-                                      buf, count, datatype, sreq);
+                                      buf, count, datatype, sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     }
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -38,19 +38,23 @@ typedef int (*MPIDI_NM_am_send_hdr_t) (int rank, MPIR_Comm * comm, int handler_i
                                        const void *am_hdr, size_t am_hdr_sz);
 typedef int (*MPIDI_NM_am_isend_t) (int rank, MPIR_Comm * comm, int handler_id, const void *am_hdr,
                                     size_t am_hdr_sz, const void *data, MPI_Count count,
-                                    MPI_Datatype datatype, MPIR_Request * sreq);
+                                    MPI_Datatype datatype, MPIR_Request * sreq, uint8_t protocol);
 typedef int (*MPIDI_NM_am_isendv_t) (int rank, MPIR_Comm * comm, int handler_id,
                                      struct iovec * am_hdrs, size_t iov_len, const void *data,
-                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq);
+                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq,
+                                     uint8_t protocol);
 typedef int (*MPIDI_NM_am_send_hdr_reply_t) (MPIR_Context_id_t context_id, int src_rank,
                                              int handler_id, const void *am_hdr, size_t am_hdr_sz);
 typedef int (*MPIDI_NM_am_isend_reply_t) (MPIR_Context_id_t context_id, int src_rank,
                                           int handler_id, const void *am_hdr, size_t am_hdr_sz,
                                           const void *data, MPI_Count count, MPI_Datatype datatype,
-                                          MPIR_Request * sreq);
+                                          MPIR_Request * sreq, uint8_t protocol);
 typedef size_t(*MPIDI_NM_am_hdr_max_sz_t) (void);
 typedef size_t(*MPIDI_NM_am_eager_limit_t) (void);
 typedef size_t(*MPIDI_NM_am_eager_buf_limit_t) (void);
+typedef int (*MPIDI_NM_am_choose_protocol_t) (const void *buf, MPI_Count count,
+                                              MPI_Datatype datatype, size_t am_ext_sz,
+                                              int handler_id);
 typedef int (*MPIDI_NM_comm_get_lpid_t) (MPIR_Comm * comm_ptr, int idx, int *lpid_ptr,
                                          bool is_remote);
 typedef int (*MPIDI_NM_get_local_upids_t) (MPIR_Comm * comm, size_t ** local_upid_size,
@@ -408,6 +412,7 @@ typedef struct MPIDI_NM_funcs {
     MPIDI_NM_am_hdr_max_sz_t am_hdr_max_sz;
     MPIDI_NM_am_eager_limit_t am_eager_limit;
     MPIDI_NM_am_eager_buf_limit_t am_eager_buf_limit;
+    MPIDI_NM_am_choose_protocol_t am_choose_protocol;
 } MPIDI_NM_funcs_t;
 
 typedef struct MPIDI_NM_native_funcs {
@@ -541,13 +546,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, in
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                const void *am_hdr, size_t am_hdr_sz,
                                                const void *data, MPI_Count count,
-                                               MPI_Datatype datatype,
-                                               MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                               MPI_Datatype datatype, MPIR_Request * sreq,
+                                               uint8_t protocol) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                 struct iovec *am_hdrs, size_t iov_len,
                                                 const void *data, MPI_Count count,
                                                 MPI_Datatype datatype,
-                                                MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Request * sreq, uint8_t protocol)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
                                                         int handler_id, const void *am_hdr,
                                                         size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
@@ -555,10 +561,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      int handler_id, const void *am_hdr,
                                                      size_t am_hdr_sz, const void *data,
                                                      MPI_Count count, MPI_Datatype datatype,
-                                                     MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Request * sreq, uint8_t protocol)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_limit(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_buf_limit(void) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX uint8_t MPIDI_NM_am_choose_protocol(const void *buf, MPI_Count count,
+                                                             MPI_Datatype datatype,
+                                                             size_t am_ext_sz, int handler_id)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                     int *lpid_ptr,
                                                     bool is_remote) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -28,7 +28,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, in
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                const void *am_hdr, size_t am_hdr_sz,
                                                const void *data, MPI_Count count,
-                                               MPI_Datatype datatype, MPIR_Request * sreq)
+                                               MPI_Datatype datatype, MPIR_Request * sreq,
+                                               uint8_t protocol)
 {
     int ret;
 
@@ -36,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int h
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND);
 
     ret = MPIDI_NM_func->am_isend(rank, comm, handler_id, am_hdr, am_hdr_sz, data, count, datatype,
-                                  sreq);
+                                  sreq, protocol);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISEND);
     return ret;
@@ -45,7 +46,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int h
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                 struct iovec *am_hdrs, size_t iov_len,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq)
+                                                MPI_Datatype datatype, MPIR_Request * sreq,
+                                                uint8_t protocol)
 {
     int ret;
 
@@ -53,7 +55,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISENDV);
 
     ret = MPIDI_NM_func->am_isendv(rank, comm, handler_id, am_hdrs, iov_len, data, count, datatype,
-                                   sreq);
+                                   sreq, protocol);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISENDV);
     return ret;
@@ -78,7 +80,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      int handler_id, const void *am_hdr,
                                                      size_t am_hdr_sz, const void *data,
                                                      MPI_Count count, MPI_Datatype datatype,
-                                                     MPIR_Request * sreq)
+                                                     MPIR_Request * sreq, uint8_t protocol)
 {
     int ret;
 
@@ -86,7 +88,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
 
     ret = MPIDI_NM_func->am_isend_reply(context_id, src_rank, handler_id, am_hdr, am_hdr_sz, data,
-                                        count, datatype, sreq);
+                                        count, datatype, sreq, protocol);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
     return ret;
@@ -113,6 +115,13 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_limit(void)
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_buf_limit(void)
 {
     return MPIDI_NM_func->am_eager_buf_limit();
+}
+
+MPL_STATIC_INLINE_PREFIX uint8_t MPIDI_NM_am_choose_protocol(const void *buf, MPI_Count count,
+                                                             MPI_Datatype datatype,
+                                                             size_t am_ext_sz, int handler_id)
+{
+    return MPIDI_NM_func->am_choose_protocol(buf, count, datatype, am_ext_sz, handler_id);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -54,7 +54,8 @@ MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     .am_isend_reply = MPIDI_NM_am_isend_reply,
     .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
     .am_eager_limit = MPIDI_NM_am_eager_limit,
-    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit
+    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit,
+    .am_choose_protocol = MPIDI_NM_am_choose_protocol
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_ofi_funcs = {

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -29,7 +29,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                size_t am_hdr_sz,
                                                const void *data,
                                                MPI_Count count, MPI_Datatype datatype,
-                                               MPIR_Request * sreq)
+                                               MPIR_Request * sreq, uint8_t protocol)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_ISEND);
@@ -49,7 +49,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
                                                 size_t iov_len,
                                                 const void *data,
                                                 MPI_Count count, MPI_Datatype datatype,
-                                                MPIR_Request * sreq)
+                                                MPIR_Request * sreq, uint8_t protocol)
 {
     int mpi_errno = MPI_SUCCESS, is_allocated;
     size_t am_hdr_sz = 0, i;
@@ -98,7 +98,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      size_t am_hdr_sz,
                                                      const void *data,
                                                      MPI_Count count,
-                                                     MPI_Datatype datatype, MPIR_Request * sreq)
+                                                     MPI_Datatype datatype, MPIR_Request * sreq,
+                                                     uint8_t protocol)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
@@ -169,6 +170,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     return mpi_errno;
   fn_fail:
     goto fn_exit;
+}
+
+MPL_STATIC_INLINE_PREFIX uint8_t MPIDI_NM_am_choose_protocol(const void *buf, MPI_Count count,
+                                                             MPI_Datatype datatype,
+                                                             size_t am_ext_sz, int handler_id)
+{
+    uint8_t protocol = 0;
+
+    MPIR_Assert(0);
+
+    return protocol;
 }
 
 #endif /* OFI_AM_H_INCLUDED */

--- a/src/mpid/ch4/netmod/stubnm/func_table.c
+++ b/src/mpid/ch4/netmod/stubnm/func_table.c
@@ -53,7 +53,8 @@ MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     .am_isend_reply = MPIDI_NM_am_isend_reply,
     .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
     .am_eager_limit = MPIDI_NM_am_eager_limit,
-    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit
+    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit,
+    .am_choose_protocol = MPIDI_NM_am_choose_protocol
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_stubnm_funcs = {

--- a/src/mpid/ch4/netmod/stubnm/stubnm_am.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_am.h
@@ -15,7 +15,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                size_t am_hdr_sz,
                                                const void *data,
                                                MPI_Count count, MPI_Datatype datatype,
-                                               MPIR_Request * sreq)
+                                               MPIR_Request * sreq, uint8_t protocol)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
@@ -28,7 +28,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
                                                 size_t iov_len,
                                                 const void *data,
                                                 MPI_Count count, MPI_Datatype datatype,
-                                                MPIR_Request * sreq)
+                                                MPIR_Request * sreq, uint8_t protocol)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
@@ -40,7 +40,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      size_t am_hdr_sz,
                                                      const void *data,
                                                      MPI_Count count,
-                                                     MPI_Datatype datatype, MPIR_Request * sreq)
+                                                     MPI_Datatype datatype, MPIR_Request * sreq,
+                                                     uint8_t protocol)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
@@ -79,6 +80,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
+}
+
+MPL_STATIC_INLINE_PREFIX uint8_t MPIDI_NM_am_choose_protocol(const void *buf, MPI_Count count,
+                                                             MPI_Datatype datatype,
+                                                             size_t am_ext_sz, int handler_id)
+{
+    uint8_t protocol = 0;
+
+    MPIR_Assert(0);
+
+    return protocol;
 }
 
 #endif /* STUBNM_AM_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -54,7 +54,8 @@ MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     .am_isend_reply = MPIDI_NM_am_isend_reply,
     .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
     .am_eager_limit = MPIDI_NM_am_eager_limit,
-    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit
+    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit,
+    .am_choose_protocol = MPIDI_NM_am_choose_protocol
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_ucx_funcs = {

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -47,7 +47,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                size_t am_hdr_sz,
                                                const void *data,
                                                MPI_Count count, MPI_Datatype datatype,
-                                               MPIR_Request * sreq)
+                                               MPIR_Request * sreq, uint8_t protocol)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request;
@@ -114,7 +114,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
                                                 size_t iov_len,
                                                 const void *data,
                                                 MPI_Count count, MPI_Datatype datatype,
-                                                MPIR_Request * sreq)
+                                                MPIR_Request * sreq, uin8_t protocol)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t am_hdr_sz = 0, i;
@@ -190,7 +190,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      const void *am_hdr,
                                                      size_t am_hdr_sz,
                                                      const void *data, MPI_Count count,
-                                                     MPI_Datatype datatype, MPIR_Request * sreq)
+                                                     MPI_Datatype datatype, MPIR_Request * sreq,
+                                                     uint8_t protocol)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request;
@@ -409,6 +410,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     return mpi_errno;
   fn_fail:
     goto fn_exit;
+}
+
+MPL_STATIC_INLINE_PREFIX uint8_t MPIDI_NM_am_choose_protocol(const void *buf, MPI_Count count,
+                                                             MPI_Datatype datatype,
+                                                             size_t am_ext_sz, int handler_id)
+{
+    uint8_t protocol = 0;
+
+    MPIR_Assert(0);
+
+    return protocol;
 }
 
 #endif /* UCX_AM_H_INCLUDED */

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -27,12 +27,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int 
                                                 const void *am_hdr, size_t am_hdr_sz,
                                                 const void *data, MPI_Count count,
                                                 MPI_Datatype datatype,
-                                                MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Request * sreq, uint8_t protocol)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                  struct iovec *am_hdrs, size_t iov_len,
                                                  const void *data, MPI_Count count,
                                                  MPI_Datatype datatype,
-                                                 MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPIR_Request * sreq, uint8_t protocol)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
                                                          int handler_id, const void *am_hdr,
                                                          size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
@@ -40,10 +42,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_
                                                       int handler_id, const void *am_hdr,
                                                       size_t am_hdr_sz, const void *data,
                                                       MPI_Count count, MPI_Datatype datatype,
-                                                      MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Request * sreq, uint8_t protocol)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_eager_limit(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_eager_buf_limit(void) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX uint8_t MPIDI_SHM_am_choose_protocol(const void *buf, MPI_Count count,
+                                                              MPI_Datatype datatype,
+                                                              size_t am_ext_sz, int handler_id)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                      int *lpid_ptr,
                                                      bool is_remote) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -84,7 +84,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
                                                   size_t am_hdr_sz,
                                                   const void *data,
                                                   MPI_Count count,
-                                                  MPI_Datatype datatype, MPIR_Request * sreq)
+                                                  MPI_Datatype datatype, MPIR_Request * sreq,
+                                                  uint8_t protocol)
 {
     int mpi_errno = MPI_SUCCESS;
     int result = MPIDI_POSIX_OK;
@@ -207,7 +208,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
                                                    size_t iov_len,
                                                    const void *data,
                                                    MPI_Count count,
-                                                   MPI_Datatype datatype, MPIR_Request * sreq)
+                                                   MPI_Datatype datatype, MPIR_Request * sreq,
+                                                   uint8_t protocol)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_allocated;
@@ -241,7 +243,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
     }
 
     mpi_errno = MPIDI_POSIX_am_isend(rank, comm, kind, handler_id, am_hdr_buf, am_hdr_sz,
-                                     data, count, datatype, sreq);
+                                     data, count, datatype, sreq, protocol);
 
     if (is_allocated)
         MPL_free(am_hdr_buf);
@@ -260,7 +262,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(MPIR_Context_id_t contex
                                                         size_t am_hdr_sz,
                                                         const void *data,
                                                         MPI_Count count,
-                                                        MPI_Datatype datatype, MPIR_Request * sreq)
+                                                        MPI_Datatype datatype, MPIR_Request * sreq,
+                                                        uint8_t protocol)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -268,7 +271,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(MPIR_Context_id_t contex
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_ISEND_REPLY);
 
     mpi_errno = MPIDI_POSIX_am_isend(src_rank, MPIDIG_context_id_to_comm(context_id), kind,
-                                     handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq);
+                                     handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq,
+                                     protocol);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_AM_ISEND_REPLY);
 
@@ -403,6 +407,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr_reply(MPIR_Context_id_t con
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR_REPLY);
 
     return mpi_errno;
+}
+
+MPL_STATIC_INLINE_PREFIX uint8_t MPIDI_POSIX_am_choose_protocol(const void *buf, MPI_Count count,
+                                                                MPI_Datatype datatype,
+                                                                size_t am_ext_sz, int handler_id)
+{
+    uint8_t protocol = 0;
+
+    MPIR_Assert(0);
+
+    return protocol;
 }
 
 #endif /* POSIX_AM_H_INCLUDED */

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -29,7 +29,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                 const void *am_hdr, size_t am_hdr_sz,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq)
+                                                MPI_Datatype datatype, MPIR_Request * sreq,
+                                                uint8_t protocol)
 {
     int ret;
 
@@ -37,7 +38,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_ISEND);
 
     ret = MPIDI_POSIX_am_isend(rank, comm, MPIDI_POSIX_AM_HDR_CH4, handler_id, am_hdr,
-                               am_hdr_sz, data, count, datatype, sreq);
+                               am_hdr_sz, data, count, datatype, sreq, protocol);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_ISEND);
     return ret;
@@ -46,7 +47,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                  struct iovec *am_hdrs, size_t iov_len,
                                                  const void *data, MPI_Count count,
-                                                 MPI_Datatype datatype, MPIR_Request * sreq)
+                                                 MPI_Datatype datatype, MPIR_Request * sreq,
+                                                 uint8_t protocol)
 {
     int ret;
 
@@ -54,7 +56,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_ISENDV);
 
     ret = MPIDI_POSIX_am_isendv(rank, comm, MPIDI_POSIX_AM_HDR_CH4, handler_id, am_hdrs,
-                                iov_len, data, count, datatype, sreq);
+                                iov_len, data, count, datatype, sreq, protocol);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_ISENDV);
     return ret;
@@ -80,7 +82,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_
                                                       int src_rank, int handler_id,
                                                       const void *am_hdr, size_t am_hdr_sz,
                                                       const void *data, MPI_Count count,
-                                                      MPI_Datatype datatype, MPIR_Request * sreq)
+                                                      MPI_Datatype datatype, MPIR_Request * sreq,
+                                                      uint8_t protocol)
 {
     int ret;
 
@@ -88,7 +91,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_ISEND_REPLY);
 
     ret = MPIDI_POSIX_am_isend_reply(context_id, src_rank, MPIDI_POSIX_AM_HDR_CH4,
-                                     handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq);
+                                     handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq,
+                                     protocol);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_ISEND_REPLY);
     return ret;
@@ -136,6 +140,13 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_finalize(MPIR_Request * req)
     MPIDI_POSIX_am_request_finalize(req);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_REQUEST_FINALIZE);
+}
+
+MPL_STATIC_INLINE_PREFIX uint8_t MPIDI_SHM_am_choose_protocol(const void *buf, MPI_Count count,
+                                                              MPI_Datatype datatype,
+                                                              size_t am_ext_sz, int handler_id)
+{
+    return MPIDI_POSIX_am_choose_protocol(buf, count, datatype, am_ext_sz, handler_id);
 }
 
 #endif /* SHM_AM_H_INCLUDED */

--- a/src/mpid/ch4/shm/stubshm/stubshm_am.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_am.h
@@ -15,7 +15,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_STUBSHM_am_isend(int rank,
                                                     size_t am_hdr_sz,
                                                     const void *data,
                                                     MPI_Count count,
-                                                    MPI_Datatype datatype, MPIR_Request * sreq)
+                                                    MPI_Datatype datatype, MPIR_Request * sreq,
+                                                    uint8_t protocol)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_AM_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_AM_ISEND);
@@ -33,7 +34,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_STUBSHM_am_isendv(int rank,
                                                      size_t iov_len,
                                                      const void *data,
                                                      MPI_Count count,
-                                                     MPI_Datatype datatype, MPIR_Request * sreq)
+                                                     MPI_Datatype datatype, MPIR_Request * sreq,
+                                                     uint8_t protocol)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_AM_ISENDV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_AM_ISENDV);
@@ -49,7 +51,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_STUBSHM_am_isend_reply(MPIR_Context_id_t cont
                                                           const void *am_hdr, size_t am_hdr_sz,
                                                           const void *data, MPI_Count count,
                                                           MPI_Datatype datatype,
-                                                          MPIR_Request * sreq)
+                                                          MPIR_Request * sreq, uint8_t protocol)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_AM_ISEND_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_AM_ISEND_REPLY);
@@ -108,6 +110,17 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_STUBSHM_am_eager_buf_limit(void)
 {
     MPIR_Assert(0);
     return 0;
+}
+
+MPL_STATIC_INLINE_PREFIX uint8_t MPIDI_STUBSHM_am_choose_protocol(const void *buf, MPI_Count count,
+                                                                  MPI_Datatype datatype,
+                                                                  size_t am_ext_sz, int handler_id)
+{
+    uint8_t protocol = 0;
+
+    MPIR_Assert(0);
+
+    return protocol;
 }
 
 #endif /* STUBSHM_AM_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -613,7 +613,8 @@ int MPIDIG_send_long_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
                                      &send_hdr, sizeof(send_hdr),
                                      MPIDIG_REQUEST(sreq, req->lreq).src_buf,
                                      MPIDIG_REQUEST(sreq, req->lreq).count,
-                                     MPIDIG_REQUEST(sreq, req->lreq).datatype, sreq);
+                                     MPIDIG_REQUEST(sreq, req->lreq).datatype, sreq,
+                                     MPIDIG_AM_PROTOCOL__SEND_ALL);
     else
 #endif
     {
@@ -623,7 +624,8 @@ int MPIDIG_send_long_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
                                     &send_hdr, sizeof(send_hdr),
                                     MPIDIG_REQUEST(sreq, req->lreq).src_buf,
                                     MPIDIG_REQUEST(sreq, req->lreq).count,
-                                    MPIDIG_REQUEST(sreq, req->lreq).datatype, sreq);
+                                    MPIDIG_REQUEST(sreq, req->lreq).datatype, sreq,
+                                    MPIDIG_AM_PROTOCOL__SEND_ALL);
     }
 
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -99,13 +99,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
         if (is_local)
             mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_PUT_REQ,
                                            &am_hdr, sizeof(am_hdr), origin_addr,
-                                           origin_count, origin_datatype, sreq);
+                                           origin_count, origin_datatype, sreq,
+                                           MPIDIG_AM_PROTOCOL__SEND_ALL);
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDIG_PUT_REQ,
                                           &am_hdr, sizeof(am_hdr), origin_addr,
-                                          origin_count, origin_datatype, sreq);
+                                          origin_count, origin_datatype, sreq,
+                                          MPIDIG_AM_PROTOCOL__SEND_ALL);
         }
 
         MPIR_ERR_CHECK(mpi_errno);
@@ -134,13 +136,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
         if (is_local)
             mpi_errno = MPIDI_SHM_am_isendv(target_rank, win->comm_ptr, MPIDIG_PUT_REQ,
                                             am_iov, 2, origin_addr, origin_count,
-                                            origin_datatype, sreq);
+                                            origin_datatype, sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_isendv(target_rank, win->comm_ptr, MPIDIG_PUT_REQ,
                                            am_iov, 2, origin_addr, origin_count,
-                                           origin_datatype, sreq);
+                                           origin_datatype, sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
         }
     } else {
         MPIDIG_REQUEST(sreq, req->preq.origin_addr) = (void *) origin_addr;
@@ -152,13 +154,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
         if (is_local)
             mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_PUT_DT_REQ,
                                            &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                           am_iov[1].iov_len, MPI_BYTE, sreq);
+                                           am_iov[1].iov_len, MPI_BYTE, sreq,
+                                           MPIDIG_AM_PROTOCOL__SEND_ALL);
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDIG_PUT_DT_REQ,
                                           &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                          am_iov[1].iov_len, MPI_BYTE, sreq);
+                                          am_iov[1].iov_len, MPI_BYTE, sreq,
+                                          MPIDIG_AM_PROTOCOL__SEND_ALL);
         }
     }
     MPIR_ERR_CHECK(mpi_errno);
@@ -262,13 +266,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
         if (is_local)
             mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr,
                                            MPIDIG_GET_REQ, &am_hdr, sizeof(am_hdr),
-                                           NULL, 0, MPI_DATATYPE_NULL, sreq);
+                                           NULL, 0, MPI_DATATYPE_NULL, sreq,
+                                           MPIDIG_AM_PROTOCOL__SEND_ALL);
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr,
                                           MPIDIG_GET_REQ, &am_hdr, sizeof(am_hdr),
-                                          NULL, 0, MPI_DATATYPE_NULL, sreq);
+                                          NULL, 0, MPI_DATATYPE_NULL, sreq,
+                                          MPIDIG_AM_PROTOCOL__SEND_ALL);
         }
 
         MPIR_ERR_CHECK(mpi_errno);
@@ -285,13 +291,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
     if (is_local)
         mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_REQ,
                                        &am_hdr, sizeof(am_hdr), flattened_dt,
-                                       flattened_sz, MPI_BYTE, sreq);
+                                       flattened_sz, MPI_BYTE, sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     else
 #endif
     {
         mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_REQ,
                                       &am_hdr, sizeof(am_hdr), flattened_dt,
-                                      flattened_sz, MPI_BYTE, sreq);
+                                      flattened_sz, MPI_BYTE, sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -396,14 +402,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
             mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_ACC_REQ,
                                            &am_hdr, sizeof(am_hdr), origin_addr,
                                            (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                           sreq);
+                                           sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDIG_ACC_REQ,
                                           &am_hdr, sizeof(am_hdr), origin_addr,
                                           (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                          sreq);
+                                          sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
         }
 
         MPIR_ERR_CHECK(mpi_errno);
@@ -433,14 +439,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
             mpi_errno = MPIDI_SHM_am_isendv(target_rank, win->comm_ptr, MPIDIG_ACC_REQ,
                                             am_iov, 2, origin_addr,
                                             (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                            sreq);
+                                            sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_isendv(target_rank, win->comm_ptr, MPIDIG_ACC_REQ,
                                            am_iov, 2, origin_addr,
                                            (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                           sreq);
+                                           sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
         }
     } else {
         MPIDIG_REQUEST(sreq, req->areq.origin_addr) = (void *) origin_addr;
@@ -452,13 +458,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
         if (is_local)
             mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_ACC_DT_REQ,
                                            &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                           am_iov[1].iov_len, MPI_BYTE, sreq);
+                                           am_iov[1].iov_len, MPI_BYTE, sreq,
+                                           MPIDIG_AM_PROTOCOL__SEND_ALL);
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDIG_ACC_DT_REQ,
                                           &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                          am_iov[1].iov_len, MPI_BYTE, sreq);
+                                          am_iov[1].iov_len, MPI_BYTE, sreq,
+                                          MPIDIG_AM_PROTOCOL__SEND_ALL);
         }
     }
     MPIR_ERR_CHECK(mpi_errno);
@@ -586,14 +594,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
             mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_ACC_REQ,
                                            &am_hdr, sizeof(am_hdr), origin_addr,
                                            (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                           sreq);
+                                           sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_ACC_REQ,
                                           &am_hdr, sizeof(am_hdr), origin_addr,
                                           (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                          sreq);
+                                          sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
         }
 
         MPIR_ERR_CHECK(mpi_errno);
@@ -623,14 +631,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
             mpi_errno = MPIDI_SHM_am_isendv(target_rank, win->comm_ptr, MPIDIG_GET_ACC_REQ,
                                             am_iov, 2, origin_addr,
                                             (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                            sreq);
+                                            sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_isendv(target_rank, win->comm_ptr, MPIDIG_GET_ACC_REQ,
                                            am_iov, 2, origin_addr,
                                            (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                           sreq);
+                                           sreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
         }
     } else {
         MPIDIG_REQUEST(sreq, req->areq.origin_addr) = (void *) origin_addr;
@@ -642,13 +650,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
         if (is_local)
             mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_ACC_DT_REQ,
                                            &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                           am_iov[1].iov_len, MPI_BYTE, sreq);
+                                           am_iov[1].iov_len, MPI_BYTE, sreq,
+                                           MPIDIG_AM_PROTOCOL__SEND_ALL);
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_ACC_DT_REQ,
                                           &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                          am_iov[1].iov_len, MPI_BYTE, sreq);
+                                          am_iov[1].iov_len, MPI_BYTE, sreq,
+                                          MPIDIG_AM_PROTOCOL__SEND_ALL);
         }
     }
     MPIR_ERR_CHECK(mpi_errno);
@@ -911,12 +921,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_rank_is_local(target_rank, win->comm_ptr))
         mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_CSWAP_REQ,
-                                       &am_hdr, sizeof(am_hdr), (char *) p_data, 2, datatype, sreq);
+                                       &am_hdr, sizeof(am_hdr), (char *) p_data, 2, datatype, sreq,
+                                       MPIDIG_AM_PROTOCOL__SEND_ALL);
     else
 #endif
     {
         mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDIG_CSWAP_REQ,
-                                      &am_hdr, sizeof(am_hdr), (char *) p_data, 2, datatype, sreq);
+                                      &am_hdr, sizeof(am_hdr), (char *) p_data, 2, datatype, sreq,
+                                      MPIDIG_AM_PROTOCOL__SEND_ALL);
     }
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -276,7 +276,8 @@ static int ack_cswap(MPIR_Request * rreq)
                                      (MPIDIG_REQUEST(rreq, req->creq.win_ptr)),
                                      MPIDIG_REQUEST(rreq, rank), MPIDIG_CSWAP_ACK, &ack_msg,
                                      sizeof(ack_msg), result_addr, 1,
-                                     MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
+                                     MPIDIG_REQUEST(rreq, req->creq.datatype), rreq,
+                                     MPIDIG_AM_PROTOCOL__SEND_ALL);
     else
 #endif
     {
@@ -285,7 +286,8 @@ static int ack_cswap(MPIR_Request * rreq)
                                     (MPIDIG_REQUEST(rreq, req->creq.win_ptr)),
                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_CSWAP_ACK, &ack_msg,
                                     sizeof(ack_msg), result_addr, 1,
-                                    MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
+                                    MPIDIG_REQUEST(rreq, req->creq.datatype), rreq,
+                                    MPIDIG_AM_PROTOCOL__SEND_ALL);
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -349,7 +351,8 @@ static int ack_get_acc(MPIR_Request * rreq)
                                      MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_ACK,
                                      &ack_msg, sizeof(ack_msg),
                                      MPIDIG_REQUEST(rreq, req->areq.data),
-                                     MPIDIG_REQUEST(rreq, req->areq.data_sz), MPI_BYTE, rreq);
+                                     MPIDIG_REQUEST(rreq, req->areq.data_sz), MPI_BYTE, rreq,
+                                     MPIDIG_AM_PROTOCOL__SEND_ALL);
     else
 #endif
     {
@@ -359,7 +362,8 @@ static int ack_get_acc(MPIR_Request * rreq)
                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_ACK,
                                     &ack_msg, sizeof(ack_msg),
                                     MPIDIG_REQUEST(rreq, req->areq.data),
-                                    MPIDIG_REQUEST(rreq, req->areq.data_sz), MPI_BYTE, rreq);
+                                    MPIDIG_REQUEST(rreq, req->areq.data_sz), MPI_BYTE, rreq,
+                                    MPIDIG_AM_PROTOCOL__SEND_ALL);
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -751,7 +755,8 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
                                                  MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
                                                  (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
                                                  MPIDIG_REQUEST(rreq, req->greq.count),
-                                                 MPIDIG_REQUEST(rreq, req->greq.datatype), rreq);
+                                                 MPIDIG_REQUEST(rreq, req->greq.datatype), rreq,
+                                                 MPIDIG_AM_PROTOCOL__SEND_ALL);
         else
 #endif
         {
@@ -759,7 +764,8 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
                                                 MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
                                                 (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
                                                 MPIDIG_REQUEST(rreq, req->greq.count),
-                                                MPIDIG_REQUEST(rreq, req->greq.datatype), rreq);
+                                                MPIDIG_REQUEST(rreq, req->greq.datatype), rreq,
+                                                MPIDIG_AM_PROTOCOL__SEND_ALL);
         }
 
         MPID_Request_complete(rreq);
@@ -784,7 +790,7 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
                                              MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
                                              MPIDIG_REQUEST(rreq, req->greq.addr),
                                              MPIDIG_REQUEST(rreq, req->greq.count), dt->handle,
-                                             rreq);
+                                             rreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     else
 #endif
     {
@@ -792,7 +798,7 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
                                             MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
                                             MPIDIG_REQUEST(rreq, req->greq.addr),
                                             MPIDIG_REQUEST(rreq, req->greq.count), dt->handle,
-                                            rreq);
+                                            rreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     }
 
     MPID_Request_complete(rreq);
@@ -1439,7 +1445,7 @@ int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
                                              MPIDIG_REQUEST(origin_req, req->preq.origin_addr),
                                              MPIDIG_REQUEST(origin_req, req->preq.origin_count),
                                              MPIDIG_REQUEST(origin_req, req->preq.origin_datatype),
-                                             rreq);
+                                             rreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     else
 #endif
     {
@@ -1449,7 +1455,7 @@ int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
                                             MPIDIG_REQUEST(origin_req, req->preq.origin_addr),
                                             MPIDIG_REQUEST(origin_req, req->preq.origin_count),
                                             MPIDIG_REQUEST(origin_req, req->preq.origin_datatype),
-                                            rreq);
+                                            rreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -1495,7 +1501,7 @@ int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_count),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
-                                             rreq);
+                                             rreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     else
 #endif
     {
@@ -1506,7 +1512,7 @@ int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_count),
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
-                                            rreq);
+                                            rreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -1553,7 +1559,7 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_count),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
-                                             rreq);
+                                             rreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     else
 #endif
     {
@@ -1564,7 +1570,7 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_count),
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
-                                            rreq);
+                                            rreq, MPIDIG_AM_PROTOCOL__SEND_ALL);
     }
 
     MPIR_ERR_CHECK(mpi_errno);


### PR DESCRIPTION
## Pull Request Description

Just separating the interface change commits from the main PIPELINE PR. The goal is adding the protocol info when doing isend of AM message so that NM/SHM can make different arrangement of sending data.

Added a simple SEND_ALL protocol name for building it. This is basically what we do today---let NM/SHM send all stuff and don't care about the protocol.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
