### PR TITLE
ch4/posix: allocate req cache for local-only and fix request header allocation

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager_transaction.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager_transaction.h
@@ -17,7 +17,7 @@ typedef struct MPIDI_POSIX_eager_recv_transaction {
     void *payload;
     size_t payload_sz;          /* 2GB limit */
 
-    int src_grank;
+    int src_local_rank;
 
     /* Private */
 

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
@@ -25,7 +25,7 @@ MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t * transaction)
     MPIDU_genq_shmem_queue_dequeue(transport->my_terminal, (void **) &cell);
 
     if (cell) {
-        transaction->src_grank = MPIDI_POSIX_global.local_procs[cell->from];
+        transaction->src_local_rank = cell->from;
         transaction->payload = MPIDI_POSIX_EAGER_IQUEUE_CELL_PAYLOAD(cell);
         transaction->payload_sz = cell->payload_size;
 

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -21,7 +21,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, 
                                                             size_t iov_num_left, size_t data_sz,
                                                             MPIR_Request * sreq)
 {
-    MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = NULL;
+    MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = MPIDI_POSIX_AMREQUEST(sreq, req_hdr);
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_ENQUEUE_REQUEST);
@@ -103,6 +103,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_ISEND);
+
+    MPIDI_POSIX_AMREQUEST(sreq, req_hdr) = NULL;
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
 

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -162,11 +162,11 @@ int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *tag_bits)
     /* This is used to track messages that the eager submodule was not ready to send. */
     MPIDI_POSIX_global.postponed_queue = NULL;
 
-    MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_global.active_rreq,
-                        MPIR_Request **,
-                        size * sizeof(MPIR_Request *), mpi_errno, "active recv req", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_global.active_rreq, MPIR_Request **,
+                        MPIR_Process.local_size * sizeof(MPIR_Request *), mpi_errno,
+                        "active recv req", MPL_MEM_SHM);
 
-    for (i = 0; i < size; i++) {
+    for (i = 0; i < MPIR_Process.local_size; i++) {
         MPIDI_POSIX_global.active_rreq[i] = NULL;
     }
 

--- a/src/mpid/ch4/shm/posix/posix_progress.c
+++ b/src/mpid/ch4/shm/posix/posix_progress.c
@@ -56,7 +56,7 @@ static int progress_recv(int blocking)
 
     if (!msg_hdr) {
         /* Fragment handling. Set currently active recv request */
-        rreq = MPIDI_POSIX_global.active_rreq[transaction.src_grank];
+        rreq = MPIDI_POSIX_global.active_rreq[transaction.src_local_rank];
     } else {
         /* First segment */
         am_hdr = payload;
@@ -96,14 +96,14 @@ static int progress_recv(int blocking)
             /* prepare for asynchronous transfer */
             MPIDIG_recv_setup(rreq);
 
-            MPIR_Assert(MPIDI_POSIX_global.active_rreq[transaction.src_grank] == NULL);
-            MPIDI_POSIX_global.active_rreq[transaction.src_grank] = rreq;
+            MPIR_Assert(MPIDI_POSIX_global.active_rreq[transaction.src_local_rank] == NULL);
+            MPIDI_POSIX_global.active_rreq[transaction.src_local_rank] = rreq;
         }
     }
 
     int is_done = MPIDIG_recv_copy_seg(payload, payload_left, rreq);
     if (is_done) {
-        MPIDI_POSIX_global.active_rreq[transaction.src_grank] = NULL;
+        MPIDI_POSIX_global.active_rreq[transaction.src_local_rank] = NULL;
         MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
     }
 


### PR DESCRIPTION
## Pull Request Description

For POSIX, the request cache array only needs to contain the local ranks. Allocating the array with the size of comm world is wasteful. The first commit fixes this by changing the array allocation and handling at eager module level to return src local rank.

POSIX is always reallocating the request header for enqueue request. The second commit fit is by checking if the request header already exists. Only allocate new request header when there is none.
## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
