### PR TITLE
ch4/generic: refactoring RNDV to merge receiver side logic

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am.h
+++ b/src/mpid/ch4/generic/am/mpidig_am.h
@@ -9,13 +9,11 @@
 #define MPIDI_AM_HANDLERS_MAX (64)
 
 enum {
-    MPIDIG_SEND = 0,            /* Eager send */
+    MPIDIG_SEND = 0,
 
-    MPIDIG_SEND_LONG_REQ,       /* Rendezvous send RTS (request to send) */
-    MPIDIG_SEND_LONG_ACK,       /* Rendezvous send CTS (clear to send) */
-    MPIDIG_SEND_LONG_LMT,       /* Rendezvous send LMT */
+    MPIDIG_SEND_CTS,    /* CTS (clear to send) for send message */
+    MPIDIG_SEND_DATA,   /* data for send message */
 
-    MPIDIG_SSEND_REQ,
     MPIDIG_SSEND_ACK,
 
     MPIDIG_PUT_REQ,

--- a/src/mpid/ch4/generic/am/mpidig_am_init.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_init.c
@@ -152,10 +152,10 @@ int MPIDIG_am_init(void)
     MPIR_Assert(MPIDIG_HANDLER_STATIC_MAX <= MPIDI_AM_HANDLERS_MAX);
 
     MPIDIG_am_reg_cb(MPIDIG_SEND, &MPIDIG_send_origin_cb, &MPIDIG_send_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_SEND_LONG_REQ, NULL, &MPIDIG_send_long_req_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_SEND_LONG_ACK, NULL, &MPIDIG_send_long_ack_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_SEND_LONG_LMT,
-                     &MPIDIG_send_long_lmt_origin_cb, &MPIDIG_send_long_lmt_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_SEND_CTS, NULL, &MPIDIG_send_cts_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_SEND_DATA,
+                     &MPIDIG_send_data_origin_cb, &MPIDIG_send_data_target_msg_cb);
+
     MPIDIG_am_reg_cb(MPIDIG_SSEND_ACK, NULL, &MPIDIG_ssend_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_PUT_REQ, &MPIDIG_put_origin_cb, &MPIDIG_put_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_PUT_ACK, NULL, &MPIDIG_put_ack_target_msg_cb);

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -88,13 +88,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexpected(void *buf, MPI_Aint count,
     }
 
     MPIDIG_REQUEST(rreq, req->status) &= ~MPIDIG_REQ_UNEXPECTED;
-    if (MPIDIG_REQUEST(rreq, count) <= MPIR_CVAR_CH4_AM_PACK_BUFFER_SIZE) {
-        /* unexp pack buf is MPI_BYTE type, count == data size */
-        MPIDU_genq_private_pool_free_cell(MPIDI_global.unexp_pack_buf_pool,
-                                          MPIDIG_REQUEST(rreq, buffer));
-    } else {
-        MPL_gpu_free_host(MPIDIG_REQUEST(rreq, buffer));
-    }
+    MPIDU_genq_private_pool_free_cell(MPIDI_global.unexp_pack_buf_pool,
+                                      MPIDIG_REQUEST(rreq, buffer));
 
     rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, rank);
     rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, tag);

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -70,7 +70,7 @@ typedef enum {
 #define MPIDIG_REQ_UNEXP_CLAIMED  (0x1 << 4)
 #define MPIDIG_REQ_RCV_NON_CONTIG (0x1 << 5)
 #define MPIDIG_REQ_MATCHED (0x1 << 6)
-#define MPIDIG_REQ_LONG_RTS (0x1 << 7)
+#define MPIDIG_REQ_RTS (0x1 << 7)
 #define MPIDIG_REQ_IN_PROGRESS (0x1 << 8)
 
 #define MPIDI_PARENT_PORT_KVSKEY "PARENT_ROOT_PORT_NAME"
@@ -78,18 +78,12 @@ typedef enum {
 
 typedef struct MPIDIG_sreq_t {
     /* persistent send fields */
-    char dummy;                 /* some compilers (suncc) does not like empty struct */
-} MPIDIG_sreq_t;
-
-typedef struct MPIDIG_lreq_t {
-    /* Long send fields */
     const void *src_buf;
     MPI_Count count;
     MPI_Datatype datatype;
     int rank;
-    int tag;
     MPIR_Context_id_t context_id;
-} MPIDIG_lreq_t;
+} MPIDIG_sreq_t;
 
 typedef struct MPIDIG_rreq_t {
     /* mrecv fields */
@@ -176,7 +170,6 @@ typedef struct MPIDIG_req_async {
 typedef struct MPIDIG_req_ext_t {
     union {
         MPIDIG_sreq_t sreq;
-        MPIDIG_lreq_t lreq;
         MPIDIG_rreq_t rreq;
         MPIDIG_put_req_t preq;
         MPIDIG_get_req_t greq;

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -81,11 +81,6 @@ typedef struct MPIDIG_send_data_msg_t {
     MPIR_Request *rreq_ptr;
 } MPIDIG_send_data_msg_t;
 
-typedef struct MPIDIG_ssend_req_msg_t {
-    MPIDIG_hdr_t hdr;
-    MPIR_Request *sreq_ptr;
-} MPIDIG_ssend_req_msg_t;
-
 typedef struct MPIDIG_ssend_ack_msg_t {
     MPIR_Request *sreq_ptr;
 } MPIDIG_ssend_ack_msg_t;

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -69,21 +69,22 @@ typedef struct MPIDIG_hdr_t {
     int error_bits;
     uint8_t flags;
     MPIR_Request *sreq_ptr;
+    size_t data_sz;
 } MPIDIG_hdr_t;
 
-typedef struct MPIDIG_send_long_req_msg_t {
-    MPIDIG_hdr_t hdr;
-    size_t data_sz;             /* Message size in bytes */
-} MPIDIG_send_long_req_msg_t;
-
-typedef struct MPIDIG_send_long_ack_msg_t {
+typedef struct MPIDIG_send_cts_msg_t {
     MPIR_Request *sreq_ptr;
     MPIR_Request *rreq_ptr;
-} MPIDIG_send_long_ack_msg_t;
+} MPIDIG_send_cts_msg_t;
 
-typedef struct MPIDIG_send_long_lmt_msg_t {
+typedef struct MPIDIG_send_data_msg_t {
     MPIR_Request *rreq_ptr;
-} MPIDIG_send_long_lmt_msg_t;
+} MPIDIG_send_data_msg_t;
+
+typedef struct MPIDIG_ssend_req_msg_t {
+    MPIDIG_hdr_t hdr;
+    MPIR_Request *sreq_ptr;
+} MPIDIG_ssend_req_msg_t;
 
 typedef struct MPIDIG_ssend_ack_msg_t {
     MPIR_Request *sreq_ptr;

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -10,27 +10,34 @@
 static int handle_unexp_cmpl(MPIR_Request * rreq);
 static int recv_target_cmpl_cb(MPIR_Request * rreq);
 
-int MPIDIG_do_long_ack(MPIR_Request * rreq)
+int MPIDIG_do_cts(MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIDIG_send_long_ack_msg_t am_hdr;
+    MPIDIG_send_cts_msg_t am_hdr;
     am_hdr.sreq_ptr = (MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr));
     am_hdr.rreq_ptr = rreq;
     MPIR_Assert((void *) am_hdr.sreq_ptr != NULL);
 
-    int rank = MPIDIG_REQUEST(rreq, rank);
-    MPIR_Comm *comm = MPIDIG_context_id_to_comm(MPIDIG_REQUEST(rreq, context_id));
+    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    (MPL_DBG_FDEST, "do cts req %p handle=0x%x", rreq, rreq->handle));
+
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_ACK, &am_hdr, sizeof(am_hdr));
+    mpi_errno = MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
+                                           MPIDIG_REQUEST(rreq, rank), MPIDIG_SEND_CTS, &am_hdr,
+                                           sizeof(am_hdr));
 #else
     if (MPIDI_REQUEST(rreq, is_local)) {
-        mpi_errno = MPIDI_SHM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_ACK,
-                                          &am_hdr, sizeof(am_hdr));
+        mpi_errno = MPIDI_SHM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
+                                                MPIDIG_REQUEST(rreq, rank),
+                                                MPIDIG_SEND_CTS, &am_hdr, sizeof(am_hdr));
     } else {
-        mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_ACK, &am_hdr, sizeof(am_hdr));
+        mpi_errno = MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
+                                               MPIDIG_REQUEST(rreq, rank),
+                                               MPIDIG_SEND_CTS, &am_hdr, sizeof(am_hdr));
     }
 #endif
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -221,6 +228,9 @@ static int recv_target_cmpl_cb(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_RECV_TARGET_CMPL_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_RECV_TARGET_CMPL_CB);
 
+    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    (MPL_DBG_FDEST, "req %p handle=0x%x", rreq, rreq->handle));
+
     /* Check if this request is supposed to complete next or if it should be delayed. */
     if (!MPIDIG_check_cmpl_order(rreq))
         return mpi_errno;
@@ -245,7 +255,7 @@ static int recv_target_cmpl_cb(MPIR_Request * rreq)
 #endif
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
-    if ((MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_LONG_RTS) &&
+    if ((MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_RTS) &&
         MPIDIG_REQUEST(rreq, req->rreq.match_req) != NULL) {
         /* This block is executed only when the receive is enqueued (handoff) &&
          * receive was matched with an unexpected long RTS message.
@@ -277,14 +287,14 @@ int MPIDIG_send_origin_cb(MPIR_Request * sreq)
     return mpi_errno;
 }
 
-int MPIDIG_send_long_lmt_origin_cb(MPIR_Request * sreq)
+int MPIDIG_send_data_origin_cb(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_SEND_LONG_LMT_ORIGIN_CB);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_LONG_LMT_ORIGIN_CB);
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, req->lreq).datatype);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_SEND_DATA_ORIGIN_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_DATA_ORIGIN_CB);
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, req->sreq).datatype);
     MPID_Request_complete(sreq);
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_SEND_LONG_LMT_ORIGIN_CB);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_SEND_DATA_ORIGIN_CB);
     return mpi_errno;
 }
 
@@ -299,6 +309,8 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_SEND_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_TARGET_MSG_CB);
+    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    (MPL_DBG_FDEST, "HDR: data_sz=%ld, flags=0x%X", hdr->data_sz, hdr->flags));
     root_comm = MPIDIG_context_id_to_comm(hdr->context_id);
     if (root_comm) {
       root_comm_retry:
@@ -326,7 +338,10 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
     if (rreq == NULL) {
         rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2);
         MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+        /* for unexpected message, always recv as MPI_BYTE into unexpected buffer. They will be
+         * set to the recv side datatype and count when it is matched */
         MPIDIG_REQUEST(rreq, datatype) = MPI_BYTE;
+        MPIDIG_REQUEST(rreq, count) = hdr->data_sz;
         if (in_data_sz) {
             if (in_data_sz <= MPIR_CVAR_CH4_AM_PACK_BUFFER_SIZE) {
                 mpi_errno =
@@ -335,16 +350,23 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
                 MPL_gpu_malloc_host(&pack_buf, in_data_sz);
             }
             MPIDIG_REQUEST(rreq, buffer) = pack_buf;
-            MPIDIG_REQUEST(rreq, count) = in_data_sz;
         } else {
             MPIDIG_REQUEST(rreq, buffer) = NULL;
-            MPIDIG_REQUEST(rreq, count) = 0;
         }
         MPIDIG_REQUEST(rreq, rank) = hdr->src_rank;
         MPIDIG_REQUEST(rreq, tag) = hdr->tag;
         MPIDIG_REQUEST(rreq, context_id) = hdr->context_id;
-        MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_BUSY;
+
         MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_UNEXPECTED;
+        if (hdr->flags & MPIDIG_AM_SEND_FLAGS_RTS) {
+            /* this is unexpected RNDV */
+            MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = hdr->sreq_ptr;
+            MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_RTS;
+            MPIDIG_REQUEST(rreq, req->rreq.match_req) = NULL;
+        } else {
+            /* this is unexpected EAGER */
+            MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_BUSY;
+        }
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
@@ -382,6 +404,9 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
         }
         MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
     } else {
+        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                        (MPL_DBG_FDEST, "posted req %p handle=0x%x", rreq, rreq->handle));
+
         /* rreq != NULL <=> root_comm != NULL */
         MPIR_Assert(root_comm);
         /* Decrement the refcnt when popping a request out from posted_list */
@@ -389,6 +414,14 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
         MPIDIG_REQUEST(rreq, rank) = hdr->src_rank;
         MPIDIG_REQUEST(rreq, tag) = hdr->tag;
         MPIDIG_REQUEST(rreq, context_id) = hdr->context_id;
+
+        if (hdr->flags & MPIDIG_AM_SEND_FLAGS_RTS) {
+            /* this is expected RNDV, init a special recv into unexp buffer */
+            MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = hdr->sreq_ptr;
+            MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_RTS;
+            MPIDIG_REQUEST(rreq, req->rreq.match_req) = NULL;
+            MPIDIG_do_cts(rreq);
+        }
     }
 
     if (hdr->flags & MPIDIG_AM_SEND_FLAGS_SYNC) {
@@ -400,15 +433,27 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
     MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_IN_PROGRESS;
 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = recv_target_cmpl_cb;
-    MPIDIG_REQUEST(rreq, req->seq_no) = MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
-
-    MPIDIG_recv_type_init(in_data_sz, rreq);
+    if (!(hdr->flags & MPIDIG_AM_SEND_FLAGS_RTS)) {
+        MPIDIG_REQUEST(rreq, req->seq_no) =
+            MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
+        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                        (MPL_DBG_FDEST, "seq_no: me=%" PRIu64 " exp=%" PRIu64,
+                         MPIDIG_REQUEST(rreq, req->seq_no),
+                         MPL_atomic_load_uint64(&MPIDI_global.exp_seq_no)));
+        MPIDIG_recv_type_init(hdr->data_sz, rreq);
+    }
 
     if (is_async) {
-        *req = rreq;
+        if (hdr->flags & MPIDIG_AM_SEND_FLAGS_RTS) {
+            *req = NULL;
+        } else {
+            *req = rreq;
+        }
     } else {
-        MPIDIG_recv_copy(data, rreq);
-        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+        if (!(hdr->flags & MPIDIG_AM_SEND_FLAGS_RTS)) {
+            MPIDIG_recv_copy(data, rreq);
+            MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+        }
     }
 
   fn_exit:
@@ -418,144 +463,24 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
     goto fn_exit;
 }
 
-int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                       MPI_Aint in_data_sz, int is_local, int is_async,
-                                       MPIR_Request ** req)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *rreq = NULL;
-    MPIR_Comm *root_comm;
-    MPIDIG_hdr_t *hdr = (MPIDIG_hdr_t *) am_hdr;
-    MPIDIG_send_long_req_msg_t *lreq_hdr = (MPIDIG_send_long_req_msg_t *) am_hdr;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_SEND_LONG_REQ_TARGET_MSG_CB);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_LONG_REQ_TARGET_MSG_CB);
-
-    root_comm = MPIDIG_context_id_to_comm(hdr->context_id);
-  root_comm_retry:
-    if (root_comm) {
-        /* MPIDI_CS_ENTER(); */
-        while (TRUE) {
-            rreq = MPIDIG_dequeue_posted(hdr->src_rank, hdr->tag, hdr->context_id,
-                                         is_local, &MPIDIG_COMM(root_comm, posted_list));
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-            if (rreq) {
-                int is_cancelled;
-                mpi_errno = MPIDI_anysrc_try_cancel_partner(rreq, &is_cancelled);
-                MPIR_ERR_CHECK(mpi_errno);
-                if (!is_cancelled) {
-                    MPIR_Comm_release(root_comm);       /* -1 for posted_list */
-                    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
-                    continue;
-                }
-            }
-#endif /* MPIDI_CH4_DIRECT_NETMOD */
-            break;
-        }
-        /* MPIDI_CS_EXIT(); */
-    }
-
-    if (rreq == NULL) {
-        rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2);
-        MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-
-        MPIDIG_REQUEST(rreq, buffer) = NULL;
-        MPIDIG_REQUEST(rreq, datatype) = MPI_BYTE;
-        MPIDIG_REQUEST(rreq, count) = lreq_hdr->data_sz;
-        MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_LONG_RTS;
-        MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = hdr->sreq_ptr;
-        MPIDIG_REQUEST(rreq, rank) = hdr->src_rank;
-        MPIDIG_REQUEST(rreq, tag) = hdr->tag;
-        MPIDIG_REQUEST(rreq, context_id) = hdr->context_id;
-        MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_IN_PROGRESS;
-        MPIDIG_REQUEST(rreq, req->rreq.match_req) = NULL;
-
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        MPIDI_REQUEST(rreq, is_local) = is_local;
-#endif
-
-        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
-        if (root_comm) {
-            MPIR_Comm_add_ref(root_comm);
-            MPIDIG_enqueue_unexp(rreq, &MPIDIG_COMM(root_comm, unexp_list));
-        } else {
-            MPIR_Comm *root_comm_again;
-            /* This branch means that last time we checked, there was no communicator
-             * associated with the arriving message.
-             * In a multi-threaded environment, it is possible that the communicator
-             * has been created since we checked root_comm last time.
-             * If that is the case, the new message must be put into a queue in
-             * the new communicator. Otherwise that message will be lost forever.
-             * Here that strategy is to query root_comm again, and if found,
-             * simply re-execute the per-communicator enqueue logic above. */
-            root_comm_again = MPIDIG_context_id_to_comm(hdr->context_id);
-            if (unlikely(root_comm_again != NULL)) {
-                MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
-                if (MPIDIG_REQUEST(rreq, count) <= MPIR_CVAR_CH4_AM_PACK_BUFFER_SIZE) {
-                    /* unexp pack buf is MPI_BYTE type, count == data size */
-                    MPIDU_genq_private_pool_free_cell(MPIDI_global.unexp_pack_buf_pool,
-                                                      MPIDIG_REQUEST(rreq, buffer));
-                } else {
-                    MPL_gpu_free_host(MPIDIG_REQUEST(rreq, buffer));
-                }
-                MPIR_Request_free_unsafe(rreq);
-                MPID_Request_complete(rreq);
-                rreq = NULL;
-                root_comm = root_comm_again;
-                goto root_comm_retry;
-            }
-            MPIDIG_enqueue_unexp(rreq,
-                                 MPIDIG_context_id_to_uelist(MPIDIG_REQUEST(rreq, context_id)));
-        }
-        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
-    } else {
-        /* Matching receive was posted */
-        rreq->comm = root_comm;
-        /* NOTE: we are skipping MPIR_Comm_release for taking off posted_list since we are holding
-         * the reference to root_comm in the rreq. We need to hold on to this reference so the comm
-         * may remain valid by the time we send ack (using the comm).
-         */
-        MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_LONG_RTS;
-        MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = hdr->sreq_ptr;
-        MPIDIG_REQUEST(rreq, rank) = hdr->src_rank;
-        MPIDIG_REQUEST(rreq, tag) = hdr->tag;
-        MPIDIG_REQUEST(rreq, context_id) = hdr->context_id;
-        MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_IN_PROGRESS;
-        /* Mark `match_req` as NULL so that we know nothing else to complete when
-         * `unexp_req` finally completes. (See MPIDI_recv_target_cmpl_cb) */
-        MPIDIG_REQUEST(rreq, req->rreq.match_req) = NULL;
-
-        mpi_errno = MPIDIG_do_long_ack(rreq);
-        MPIR_ERR_CHECK(mpi_errno);
-    }
-
-    if (is_async)
-        *req = NULL;
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_SEND_LONG_REQ_TARGET_MSG_CB);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-int MPIDIG_send_long_lmt_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                       MPI_Aint in_data_sz, int is_local, int is_async,
-                                       MPIR_Request ** req)
+int MPIDIG_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                   int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
-    MPIDIG_send_long_lmt_msg_t *lmt_hdr = (MPIDIG_send_long_lmt_msg_t *) am_hdr;
+    MPIDIG_send_data_msg_t *seg_hdr = (MPIDIG_send_data_msg_t *) am_hdr;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_SEND_LONG_LMT_TARGET_MSG_CB);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_LONG_LMT_TARGET_MSG_CB);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_SEND_DATA_TARGET_MSG_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_DATA_TARGET_MSG_CB);
 
-    rreq = (MPIR_Request *) lmt_hdr->rreq_ptr;
+    rreq = (MPIR_Request *) seg_hdr->rreq_ptr;
     MPIR_Assert(rreq);
 
-    MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = recv_target_cmpl_cb;
     MPIDIG_REQUEST(rreq, req->seq_no) = MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
-
+    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    (MPL_DBG_FDEST, "seq_no: me=%" PRIu64 " exp=%" PRIu64,
+                     MPIDIG_REQUEST(rreq, req->seq_no),
+                     MPL_atomic_load_uint64(&MPIDI_global.exp_seq_no)));
     MPIDIG_recv_type_init(in_data_sz, rreq);
 
     if (is_async) {
@@ -565,8 +490,7 @@ int MPIDIG_send_long_lmt_target_msg_cb(int handler_id, void *am_hdr, void *data,
         MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
     }
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_SEND_LONG_LMT_TARGET_MSG_CB);
-
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_SEND_DATA_TARGET_MSG_CB);
     return mpi_errno;
 }
 
@@ -589,46 +513,48 @@ int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI
     return mpi_errno;
 }
 
-int MPIDIG_send_long_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                       MPI_Aint in_data_sz, int is_local, int is_async,
-                                       MPIR_Request ** req)
+int MPIDIG_send_cts_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                  int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;
-    MPIDIG_send_long_ack_msg_t *msg_hdr = (MPIDIG_send_long_ack_msg_t *) am_hdr;
-    MPIDIG_send_long_lmt_msg_t send_hdr;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_SEND_LONG_ACK_TARGET_MSG_CB);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_LONG_ACK_TARGET_MSG_CB);
+    MPIDIG_send_cts_msg_t *msg_hdr = (MPIDIG_send_cts_msg_t *) am_hdr;
+    MPIDIG_send_data_msg_t send_hdr;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_SEND_CTS_TARGET_MSG_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_CTS_TARGET_MSG_CB);
 
     sreq = (MPIR_Request *) msg_hdr->sreq_ptr;
     MPIR_Assert(sreq != NULL);
+
+    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    (MPL_DBG_FDEST, "got cts req handle=0x%x", sreq->handle));
 
     /* Start the main data transfer */
     send_hdr.rreq_ptr = msg_hdr->rreq_ptr;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(sreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(sreq, req->lreq).context_id,
-                                     MPIDIG_REQUEST(sreq, rank), MPIDIG_SEND_LONG_LMT,
+            MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(sreq, req->sreq).context_id,
+                                     MPIDIG_REQUEST(sreq, rank), MPIDIG_SEND_DATA,
                                      &send_hdr, sizeof(send_hdr),
-                                     MPIDIG_REQUEST(sreq, req->lreq).src_buf,
-                                     MPIDIG_REQUEST(sreq, req->lreq).count,
-                                     MPIDIG_REQUEST(sreq, req->lreq).datatype, sreq);
+                                     MPIDIG_REQUEST(sreq, req->sreq).src_buf,
+                                     MPIDIG_REQUEST(sreq, req->sreq).count,
+                                     MPIDIG_REQUEST(sreq, req->sreq).datatype, sreq);
     else
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_isend_reply(MPIDIG_REQUEST(sreq, req->lreq).context_id,
-                                    MPIDIG_REQUEST(sreq, rank), MPIDIG_SEND_LONG_LMT,
+            MPIDI_NM_am_isend_reply(MPIDIG_REQUEST(sreq, req->sreq).context_id,
+                                    MPIDIG_REQUEST(sreq, rank), MPIDIG_SEND_DATA,
                                     &send_hdr, sizeof(send_hdr),
-                                    MPIDIG_REQUEST(sreq, req->lreq).src_buf,
-                                    MPIDIG_REQUEST(sreq, req->lreq).count,
-                                    MPIDIG_REQUEST(sreq, req->lreq).datatype, sreq);
+                                    MPIDIG_REQUEST(sreq, req->sreq).src_buf,
+                                    MPIDIG_REQUEST(sreq, req->sreq).count,
+                                    MPIDIG_REQUEST(sreq, req->sreq).datatype, sreq);
     }
 
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_SEND_LONG_ACK_TARGET_MSG_CB);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_SEND_CTS_TARGET_MSG_CB);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -13,25 +13,20 @@
 
 #include "mpidig_am.h"
 
-int MPIDIG_do_long_ack(MPIR_Request * rreq);
+int MPIDIG_do_cts(MPIR_Request * rreq);
 int MPIDIG_check_cmpl_order(MPIR_Request * req);
 void MPIDIG_progress_compl_list(void);
 int MPIDIG_send_origin_cb(MPIR_Request * sreq);
-int MPIDIG_send_long_lmt_origin_cb(MPIR_Request * sreq);
+int MPIDIG_send_data_origin_cb(MPIR_Request * sreq);
 int MPIDIG_ssend_ack_origin_cb(MPIR_Request * req);
 int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
                               int is_local, int is_async, MPIR_Request ** req);
-int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                       MPI_Aint in_data_sz, int is_local, int is_async,
-                                       MPIR_Request ** req);
-int MPIDIG_send_long_lmt_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                       MPI_Aint in_data_sz, int is_local, int is_async,
-                                       MPIR_Request ** req);
+int MPIDIG_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                   int is_local, int is_async, MPIR_Request ** req);
 int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
                                    MPI_Aint p_data_sz, int is_local, int is_async,
                                    MPIR_Request ** req);
-int MPIDIG_send_long_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                       MPI_Aint p_data_sz, int is_local, int is_async,
-                                       MPIR_Request ** req);
+int MPIDIG_send_cts_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint p_data_sz,
+                                  int is_local, int is_async, MPIR_Request ** req);
 
 #endif /* CH4R_CALLBACKS_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_recv.h
+++ b/src/mpid/ch4/src/ch4r_recv.h
@@ -96,13 +96,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexp_mrecv(MPIR_Request * rreq)
         MPIR_Typerep_copy((char *) buf + dt_true_lb, MPIDIG_REQUEST(rreq, buffer), nbytes);
     }
 
-    if (MPIDIG_REQUEST(rreq, count) <= MPIR_CVAR_CH4_AM_PACK_BUFFER_SIZE) {
-        /* unexp pack buf is MPI_BYTE type, count == data size */
-        MPIDU_genq_private_pool_free_cell(MPIDI_global.unexp_pack_buf_pool,
-                                          MPIDIG_REQUEST(rreq, buffer));
-    } else {
-        MPL_gpu_free_host(MPIDIG_REQUEST(rreq, buffer));
-    }
+    MPIDU_genq_private_pool_free_cell(MPIDI_global.unexp_pack_buf_pool,
+                                      MPIDIG_REQUEST(rreq, buffer));
     rreq->kind = MPIR_REQUEST_KIND__RECV;
 
     if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_PEER_SSEND) {


### PR DESCRIPTION
Remove `MPIDIG_SEND_LONG_REQ` and related callbacks as they are
redundant. Now long message send using `MPIDIG_SEND` as well.

Renaming related handler name as general data CTS and SEG.

Merge eager/rndv send functions. The request allocation and message init
part the same. RNDV just have some extra work to save send information
which can be put in a branch.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
