### PR TITLE
ch4/generic: remove CVAR for overriding eager limit

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_send.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_send.h
@@ -8,25 +8,6 @@
 
 #include "ch4_impl.h"
 
-/*
-=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
-
-cvars:
-    - name        : MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE
-      category    : CH4
-      type        : int
-      default     : -1
-      class       : device
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_LOCAL
-      description : >-
-        If set to positive number, this cvar controls the message size at which CH4 switches from eager to rendezvous mode.
-        If the number is negative, underlying netmod or shmmod automatically uses an optimal number depending on
-        the underlying fabric or shared memory architecture.
-
-=== END_MPI_T_CVAR_INFO_BLOCK ===
-*/
-
 #define MPIDIG_AM_SEND_HDR_SIZE  sizeof(MPIDIG_hdr_t)
 #define MPIDIG_AM_SEND_FLAGS_NONE (0)
 #define MPIDIG_AM_SEND_FLAGS_SYNC (1)
@@ -34,10 +15,6 @@ cvars:
 
 MPL_STATIC_INLINE_PREFIX int MPIDIG_eager_limit(int is_local)
 {
-    if (MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE > 0) {
-        return MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE;
-    }
-
     int thresh;
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     thresh = MPIDI_NM_am_eager_limit();

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -24,9 +24,9 @@ rqstatus 2
 rqfreeb 4
 greq1 1
 probe_unexp 4
-probe_unexp 4 env=MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE=16384
+probe_unexp 4 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
 probenull 1
-probenull 1 env=MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE=16384
+probenull 1 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
 # For testing, scancel will run with 1 process as well
 scancel 2 xfail=ticket2266 xfail=ticket2270
 scancel2 2 xfail=ticket2266 xfail=ticket2270


### PR DESCRIPTION
The CVAR was introduced in 6ce1a20b3ec19. The
reason was OFI socket provide essentially has a unlimited eager limit
which results in the AM RNDV path untested. OFI now has a provide
independent eager limit of 16 KB. Therefore, the AM RNDV path will be
tested without setting this CVAR.

This commit also removes the test that uses this CVAR.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
