### PR TITLE
ch4/ofi: remove unordered message management in am path

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -9,83 +9,6 @@
 #include "ofi_am_impl.h"
 #include "mpidu_genq.h"
 
-MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_get_next_recv_seqno(fi_addr_t addr)
-{
-    uint64_t id = addr;
-    void *r;
-
-    r = MPIDIU_map_lookup(MPIDI_OFI_global.am_recv_seq_tracker, id);
-    if (r == MPIDIU_MAP_NOT_FOUND) {
-        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        (MPL_DBG_FDEST, "First time adding recv seqno addr=%" PRIx64 "\n", addr));
-        MPIDIU_map_set(MPIDI_OFI_global.am_recv_seq_tracker, id, 0, MPL_MEM_OTHER);
-        return 0;
-    } else {
-        return (uint16_t) (uintptr_t) r;
-    }
-}
-
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_am_set_next_recv_seqno(fi_addr_t addr, uint16_t seqno)
-{
-    uint64_t id = addr;
-
-    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                    (MPL_DBG_FDEST, "Next recv seqno=%d addr=%" PRIx64 "\n", seqno, addr));
-
-    MPIDIU_map_update(MPIDI_OFI_global.am_recv_seq_tracker, id, (void *) (uintptr_t) seqno,
-                      MPL_MEM_OTHER);
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_enqueue_unordered_msg(const MPIDI_OFI_am_header_t *
-                                                                am_hdr)
-{
-    MPIDI_OFI_am_unordered_msg_t *uo_msg;
-    size_t uo_msg_len, packet_len;
-    /* Essentially, uo_msg_len == packet_len + sizeof(next,prev pointers) */
-
-    uo_msg_len = sizeof(*uo_msg) + am_hdr->am_hdr_sz + am_hdr->data_sz;
-
-    /* Allocate a new memory region to store this unordered message.
-     * We are doing this because the original am_hdr comes from FI_MULTI_RECV
-     * buffer, which may be reused soon by OFI. */
-    uo_msg = MPL_malloc(uo_msg_len, MPL_MEM_BUFFER);
-    if (uo_msg == NULL)
-        return MPI_ERR_NO_MEM;
-
-    packet_len = sizeof(*am_hdr) + am_hdr->am_hdr_sz + am_hdr->data_sz;
-    MPIR_Memcpy(&uo_msg->am_hdr, am_hdr, packet_len);
-
-    DL_APPEND(MPIDI_OFI_global.am_unordered_msgs, uo_msg);
-
-    return MPI_SUCCESS;
-}
-
-/* Find and dequeue a message that matches (comm, src_rank, seqno), then return it.
- * Caller must free the returned pointer. */
-MPL_STATIC_INLINE_PREFIX MPIDI_OFI_am_unordered_msg_t
-    * MPIDI_OFI_am_claim_unordered_msg(fi_addr_t addr, uint16_t seqno)
-{
-    MPIDI_OFI_am_unordered_msg_t *uo_msg;
-
-    /* Future optimization note:
-     * Currently we are doing linear search every time, assuming that the number of items
-     * in the queue is extremely small.
-     * If it's not the case, we should consider using better data structure and algorithm
-     * to look up. */
-    DL_FOREACH(MPIDI_OFI_global.am_unordered_msgs, uo_msg) {
-        if (uo_msg->am_hdr.fi_src_addr == addr && uo_msg->am_hdr.seqno == seqno) {
-            MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, TERSE,
-                            (MPL_DBG_FDEST,
-                             "Found unordered message in the queue: addr=%" PRIx64 ", seqno=%d\n",
-                             addr, seqno));
-            DL_DELETE(MPIDI_OFI_global.am_unordered_msgs, uo_msg);
-            return uo_msg;
-        }
-    }
-
-    return NULL;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_short_am(MPIDI_OFI_am_header_t * msg_hdr,
                                                        void *am_hdr, void *p_data)
 {
@@ -297,7 +220,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_ack(int rank, int context_id,
     msg.hdr.am_hdr_sz = sizeof(msg.pyld);
     msg.hdr.data_sz = 0;
     msg.hdr.am_type = am_type;
-    msg.hdr.seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank);
     msg.hdr.fi_src_addr
         = MPIDI_OFI_comm_to_phys(MPIR_Process.comm_world, MPIR_Process.comm_world->rank, 0, 0);
     msg.pyld.sreq_ptr = sreq_ptr;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -555,9 +555,6 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *am_hdr;
-    MPIDI_OFI_am_unordered_msg_t *uo_msg = NULL;
-    fi_addr_t fi_src_addr;
-    uint16_t expected_seqno, next_seqno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_AM_RECV_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_AM_RECV_EVENT);
 
@@ -580,26 +577,9 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     }
 #endif
 
-    expected_seqno = MPIDI_OFI_am_get_next_recv_seqno(am_hdr->fi_src_addr);
-    if (am_hdr->seqno != expected_seqno) {
-        /* This message came earlier than the one that we were expecting.
-         * Put it in the queue to process it later. */
-        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, TERSE,
-                        (MPL_DBG_FDEST,
-                         "Expected seqno=%d but got %d (am_type=%d addr=%" PRIx64 "). "
-                         "Enqueueing it to the queue.\n",
-                         expected_seqno, am_hdr->seqno, am_hdr->am_type, am_hdr->fi_src_addr));
-        mpi_errno = MPIDI_OFI_am_enqueue_unordered_msg(am_hdr);
-        MPIR_ERR_CHECK(mpi_errno);
-        goto fn_exit;
-    }
-
     /* Received an expected message */
-  repeat:
-    fi_src_addr = am_hdr->fi_src_addr;
-    next_seqno = am_hdr->seqno + 1;
-
     void *p_data;
+  repeat:
     switch (am_hdr->am_type) {
         case MPIDI_AMTYPE_SHORT_HDR:
             mpi_errno = MPIDI_OFI_handle_short_am_hdr(am_hdr, am_hdr + 1 /* payload */);
@@ -634,20 +614,6 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
         default:
             MPIR_Assert(0);
     }
-
-    /* For the first iteration (=in case we can process the message just received
-     * from OFI immediately), uo_msg is NULL, so freeing it is no-op.
-     * Otherwise, free it here before getting another uo_msg. */
-    MPL_free(uo_msg);
-
-    /* See if we can process other messages in the queue */
-    if ((uo_msg = MPIDI_OFI_am_claim_unordered_msg(fi_src_addr, next_seqno)) != NULL) {
-        am_hdr = &uo_msg->am_hdr;
-        goto repeat;
-    }
-
-    /* Record the next expected sequence number from fi_src_addr */
-    MPIDI_OFI_am_set_next_recv_seqno(fi_src_addr, next_seqno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_AM_RECV_EVENT);

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -75,8 +75,6 @@ typedef struct MPIDI_OFI_am_header_t {
     uint64_t am_type:MPIDI_OFI_AM_TYPE_BITS;
     uint64_t am_hdr_sz:MPIDI_OFI_AM_HDR_SZ_BITS;
     uint64_t data_sz:MPIDI_OFI_AM_DATA_SZ_BITS;
-    uint16_t seqno;             /* Sequence number of this message.
-                                 * Number is unique to (fi_src_addr, fi_dest_addr) pair. */
     fi_addr_t fi_src_addr;      /* OFI address of the sender */
 } MPIDI_OFI_am_header_t;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -294,7 +294,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
                              vni_local, tsenddata, FALSE /* eagain */);
         ctrl.type = MPIDI_OFI_CTRL_HUGE;
-        ctrl.seqno = 0;
         ctrl.tag = tag;
         ctrl.vni_src = vni_src;
         ctrl.vni_dst = vni_dst;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -417,7 +417,6 @@ typedef struct {
 
 typedef struct {
     int16_t type;
-    int16_t seqno;
     int origin_rank;
     MPIR_Request *ackreq;
     uintptr_t send_buf;


### PR DESCRIPTION
## Pull Request Description
It is not clear whether we need handle am message ordering inside OFI. 

The mechanism was added in https://github.com/pmodels/mpich/pull/3133. The cited reason is ch4 am layer expect ordered completion. This is suspicious. In general, even when the messages are processed in order, due to possibility of asynchronous completion (e.g. RDMA), ch4-layer should not expect in-order completion. 

In fact, in the pt2pt path, ch4 checks completion order:
https://github.com/pmodels/mpich/blob/0f6e8376ef63c2cf636501c9f54d52ded75321d2/src/mpid/ch4/src/ch4r_callbacks.c#L48-L71

There are similar order enforcing code for RMA paths as well.

[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
