### PR TITLE
autogen: add libtool patch for NVIDIA HPC compilers

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -990,6 +990,7 @@ if [ "$do_build_configure" = "yes" ] ; then
                 flang_patch_requires_rebuild=no
                 arm_patch_requires_rebuild=no
                 ibm_patch_requires_rebuild=no
+                nvc_patch_requires_rebuild=no
                 sys_lib_dlsearch_path_patch_requires_rebuild=no
                 echo_n "Patching libtool.m4 for system dynamic library search path..."
                 patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/sys_lib_dlsearch_path_spec.patch
@@ -1052,10 +1053,21 @@ if [ "$do_build_configure" = "yes" ] ; then
                     else
                         echo "failed"
                     fi
+                    echo_n "Patching libtool.m4 for compatibility with NVIDIA HPC compilers..."
+                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/nv-compiler.patch
+                    if [ $? -eq 0 ] ; then
+                        nvc_patch_requires_rebuild=yes
+                        # Remove possible leftovers, which don't imply a failure
+                        rm -f $amdir/confdb/libtool.m4.orig
+                        echo "done"
+                    else
+                        echo "failed"
+                    fi
                 fi
 
                 if [ $ifort_patch_requires_rebuild = "yes" ] || [ $oracle_patch_requires_rebuild = "yes" ] \
                     || [ $arm_patch_requires_rebuild = "yes" ] || [ $ibm_patch_requires_rebuild = "yes" ] \
+                    || [ $nvc_patch_requires_rebuild = "yes" ] \
                     || [ $sys_lib_dlsearch_path_patch_requires_rebuild = "yes" ] || [ $flang_patch_requires_rebuild = "yes" ]; then
                     # Rebuild configure
                     (cd $amdir && $autoconf -f) || exit 1

--- a/maint/patches/optional/confdb/nv-compiler.patch
+++ b/maint/patches/optional/confdb/nv-compiler.patch
@@ -1,0 +1,61 @@
+--- /home/flyxian/libtool.m4	2020-09-15 21:38:52.847054276 -0500
++++ confdb/libtool.m4	2020-09-16 00:55:57.103309019 -0500
+@@ -4445,8 +4445,8 @@
+ 	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
+ 	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
+ 	    ;;
+-	  pgCC* | pgcpp*)
+-	    # Portland Group C++ compiler
++	  pgCC* | pgcpp* | pgc++* | nvc++* )
++	    # NVIDIA HPC C++ Compiler
+ 	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
+ 	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fpic'
+ 	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
+@@ -4788,9 +4788,8 @@
+ 	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
+ 	_LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
+ 	;;
+-      pgcc* | pgf77* | pgf90* | pgf95* | pgfortran*)
+-        # Portland Group compilers (*not* the Pentium gcc compiler,
+-	# which looks to be a dead project)
++      pgcc* | pgf77* | pgf90* | pgf95* | pgfortran* | nvc | nvfortran* )
++        # NVIDIA HPC Compilers
+ 	_LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
+ 	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-fpic'
+ 	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
+@@ -4834,7 +4833,7 @@
+ 	  _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
+ 	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
+ 	  ;;
+-	*Portland\ Group*)
++	*Portland\ Group* | *NVIDIA\ Compilers* | *PGI\ Compilers*)
+ 	  _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
+ 	  _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fpic'
+ 	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
+@@ -5262,12 +5261,12 @@
+ 	tmp_addflag=' $pic_flag'
+ 	tmp_sharedflag='-shared'
+ 	case $cc_basename,$host_cpu in
+-        pgcc*)				# Portland Group C compiler
++        pgcc* | nvc )				# NVIDIA HPC C++ compiler
+ 	  _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  tmp_addflag=' $pic_flag'
+ 	  ;;
+-	pgf77* | pgf90* | pgf95* | pgfortran*)
+-					# Portland Group f77 and f90 compilers
++	pgf77* | pgf90* | pgf95* | pgfortran* | nvfortran* )
++					# NVIDIA HPC Fortran Compilers
+ 	  _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  tmp_addflag=' $pic_flag -Mnomain' ;;
+ 	ecc*,ia64* | icc*,ia64*)	# Intel C compiler on ia64
+@@ -7068,8 +7067,8 @@
+ 	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl--export-dynamic'
+ 	    _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive$convenience $wl--no-whole-archive'
+ 	    ;;
+-          pgCC* | pgcpp*)
+-            # Portland Group C++ compiler
++          pgCC* | pgcpp* | pgc++* | nvc++* )
++            # NVIDIA HPC C++ compiler
+ 	    case `$CC -V` in
+ 	    *pgCC\ [[1-5]].* | *pgcpp\ [[1-5]].*)
+ 	      _LT_TAGVAR(prelink_cmds, $1)='tpldir=Template.dir~


### PR DESCRIPTION
NVIDIA HPC compilers add nvc, nvc++, nvfortran in addition to the PGI
compiler binary names. This patch fixes libtool for them.

The changes are based on https://www.mail-archive.com/libtool-patches@gnu.org/msg07391.html

This should address #4787 

The only problem right now is we don't have NV HPC compilers on our Jenkins so we cannot test them.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
