### PR TITLE
ch4/rma: enable native RMA for dynamic window

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -450,6 +450,8 @@ typedef enum {
     MPIDI_WINATTR_NM_REACHABLE = 16,    /* whether a netmod may reach the window. Set by netmod at win init.
                                          * It only indicates whether the win type is supported. Per-target check
                                          * may be required separately. */
+    MPIDI_WINATTR_NM_DYNAMIC_MR = 32,   /* whether the memory region is registered dynamically. Valid only for
+                                         * dynamic window. Set by netmod. */
     MPIDI_WINATTR_LAST_BIT
 } MPIDI_winattr_bit_t;
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -335,6 +335,7 @@ typedef struct MPIDIG_win_info_args_t {
     MPI_Aint accumulate_max_bytes;      /* Non-negative integer, -1 (unlimited) by default.
                                          * TODO: can be set to win_size.*/
     bool disable_shm_accumulate;        /* false by default. */
+    bool coll_attach;           /* false by default. Valid only for dynamic window */
 
     /* alloc_shm: MPICH specific hint (same in CH3).
      * If true, MPICH will try to use shared memory routines for the window.

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -301,18 +301,18 @@ int MPIDI_OFI_issue_deferred_rma(MPIR_Win * win);
 void MPIDI_OFI_complete_chunks(MPIDI_OFI_win_request_t * winreq);
 int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
                             MPI_Datatype origin_datatype, int target_rank,
-                            MPI_Aint target_disp, int target_count,
-                            MPI_Datatype target_datatype, MPIR_Win * win,
+                            int target_count, MPI_Datatype target_datatype,
+                            MPIDI_OFI_target_mr_t target_mr, MPIR_Win * win,
                             MPIDI_av_entry_t * addr, int rma_type, MPIR_Request ** sigreq);
 int MPIDI_OFI_pack_put(const void *origin_addr, int origin_count,
                        MPI_Datatype origin_datatype, int target_rank,
-                       MPI_Aint target_disp, int target_count,
-                       MPI_Datatype target_datatype, MPIR_Win * win,
+                       int target_count, MPI_Datatype target_datatype,
+                       MPIDI_OFI_target_mr_t target_mr, MPIR_Win * win,
                        MPIDI_av_entry_t * addr, MPIR_Request ** sigreq);
 int MPIDI_OFI_pack_get(void *origin_addr, int origin_count,
                        MPI_Datatype origin_datatype, int target_rank,
-                       MPI_Aint target_disp, int target_count,
-                       MPI_Datatype target_datatype, MPIR_Win * win,
+                       int target_count, MPI_Datatype target_datatype,
+                       MPIDI_OFI_target_mr_t target_mr, MPIR_Win * win,
                        MPIDI_av_entry_t * addr, MPIR_Request ** sigreq);
 
 /* Common Utility functions used by the

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -222,6 +222,10 @@ typedef struct {
     struct MPIDI_OFI_win_request *deferredQ;
     MPIDI_OFI_win_targetinfo_t *winfo;
 
+    MPL_gavl_tree_t *dwin_target_mrs;   /* MR key and address pairs registered to remote processes.
+                                         * One AVL tree per process. */
+    MPL_gavl_tree_t dwin_mrs;   /* Single AVL tree to store locally attached MRs */
+
     /* Accumulate related info. The struct internally uses MPIDI_OFI_DT_SIZES
      * defined in ofi_types.h to allocate the max_count array. The struct
      * size is unknown when we load ofi_pre.h, thus we only set a pointer here. */

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -122,6 +122,51 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_QUERY_ACC_ATOMIC_SUPPORT);
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_prepare_target_mr(int target_rank,
+                                                          MPI_Aint target_disp,
+                                                          size_t target_extent,
+                                                          MPI_Aint target_true_lb, MPIR_Win * win,
+                                                          MPIDI_winattr_t winattr,
+                                                          MPIDI_OFI_target_mr_t * target_mr)
+{
+    size_t offset;
+
+    if (winattr & MPIDI_WINATTR_NM_DYNAMIC_MR) {
+        /* Special path for dynamic window with per-attach memory registration. */
+        offset = target_disp;   /* dynamic win is always with disp_unit=1 */
+        void *target_mr_found = NULL;
+        uint64_t target_addr = (uint64_t) MPI_BOTTOM + offset;
+        /* Return valid node only when [target_addr:target_extent] matches within a
+         * single region. If it crosses two regions, NULL is returned. */
+        MPL_gavl_tree_search(MPIDI_OFI_WIN(win).dwin_target_mrs[target_rank],
+                             (const void *) target_addr, target_extent, &target_mr_found);
+
+        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                        (MPL_DBG_FDEST, "target_mr found %d addr 0x%lx, extent 0x%lx",
+                         target_mr_found ? 1 : 0, target_addr, target_extent));
+
+        if (target_mr_found) {
+            if (MPIDI_OFI_ENABLE_MR_VIRT_ADDRESS) {
+                target_mr->addr = target_addr;
+            } else {
+                /* Unlikely hit this path. It happens only when provider is without
+                 * FI_VIRT_ADDRESS but fails to register MPI_BOTTOM at win creation time */
+                target_mr->addr = target_addr - ((MPIDI_OFI_target_mr_t *) target_mr_found)->addr;
+            }
+            target_mr->mr_key = ((MPIDI_OFI_target_mr_t *) target_mr_found)->mr_key;
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
+        target_mr->addr = MPIDI_OFI_winfo_base(win, target_rank) + offset;
+        target_mr->mr_key = MPIDI_OFI_winfo_mr_key(win, target_rank);
+
+        return true;    /* always found */
+    }
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
                                               int origin_count,
                                               MPI_Datatype origin_datatype,
@@ -133,11 +178,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
                                               MPIDI_winattr_t winattr, MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t offset;
     uint64_t flags;
     struct fi_msg_rma msg;
     int target_contig, origin_contig;
-    size_t target_bytes, origin_bytes;
+    size_t target_bytes, origin_bytes, target_extent;
     MPI_Aint origin_true_lb, target_true_lb;
     struct iovec iov;
     struct fi_rma_iov riov;
@@ -147,11 +191,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
 
-    MPIDI_Datatype_check_origin_target_contig_size_lb(origin_datatype, target_datatype,
-                                                      origin_count, target_count,
-                                                      origin_contig, target_contig,
-                                                      origin_bytes, target_bytes,
-                                                      origin_true_lb, target_true_lb);
+    MPIDI_Datatype_check_contig_size_lb(origin_datatype, origin_count, origin_contig,
+                                        origin_bytes, origin_true_lb);
+    MPIDI_Datatype_check_contig_size_extent_lb(target_datatype, target_count, target_contig,
+                                               target_bytes, target_extent, target_true_lb);
 
     MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
 
@@ -161,7 +204,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
 
     /* self messages */
     if (target_rank == MPIDIU_win_comm_rank(win, winattr)) {
-        offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
+        size_t offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
         mpi_errno = MPIR_Localcopy(origin_addr,
                                    origin_count,
                                    origin_datatype,
@@ -169,18 +212,24 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         goto null_op_exit;
     }
 
+    /* prepare remote addr and mr key.
+     * Continue native path only when all segments are in the same registered memory region */
+    bool target_mr_found;
+    MPIDI_OFI_target_mr_t target_mr;
+    target_mr_found = MPIDI_OFI_prepare_target_mr(target_rank,
+                                                  target_disp, target_extent, target_true_lb,
+                                                  win, winattr, &target_mr);
+    if (unlikely(!target_mr_found))
+        goto am_fallback;
+
     /* small contiguous messages */
     if (origin_contig && target_contig && (origin_bytes <= MPIDI_OFI_global.max_buffered_write)) {
         MPIDI_OFI_win_cntr_incr(win);
         MPIDI_OFI_CALL_RETRY(fi_inject_write(MPIDI_OFI_WIN(win).ep,
                                              (char *) origin_addr + origin_true_lb, target_bytes,
                                              MPIDI_OFI_av_to_phys(addr, 0, 0),
-                                             (uint64_t) MPIDI_OFI_winfo_base(win, target_rank)
-                                             + target_disp * MPIDI_OFI_winfo_disp_unit(win,
-                                                                                       target_rank)
-                                             + target_true_lb, MPIDI_OFI_winfo_mr_key(win,
-                                                                                      target_rank)),
-                             0, rdma_inject_write, FALSE);
+                                             target_mr.addr + target_true_lb,
+                                             target_mr.mr_key), 0, rdma_inject_write, FALSE);
         goto null_op_exit;
     }
 
@@ -199,7 +248,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         } else {
             flags = FI_DELIVERY_COMPLETE;
         }
-        offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
         msg.desc = NULL;
         msg.addr = MPIDI_OFI_av_to_phys(addr, 0, 0);
         msg.context = NULL;
@@ -210,9 +258,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         msg.rma_iov_count = 1;
         iov.iov_base = (char *) origin_addr + origin_true_lb;
         iov.iov_len = target_bytes;
-        riov.addr = (uint64_t) (MPIDI_OFI_winfo_base(win, target_rank) + offset + target_true_lb);
+        riov.addr = target_mr.addr + target_true_lb;
         riov.len = target_bytes;
-        riov.key = MPIDI_OFI_winfo_mr_key(win, target_rank);
+        riov.key = target_mr.mr_key;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
         MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), 0, rdma_write, FALSE);
         /* Complete signal request to inform completion to user. */
@@ -229,7 +277,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
         mpi_errno =
             MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
-                                    target_disp, target_count, target_datatype, win, addr,
+                                    target_count, target_datatype, target_mr, win, addr,
                                     MPIDI_OFI_PUT, sigreq);
         goto fn_exit;
     }
@@ -238,10 +286,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
         mpi_errno =
             MPIDI_OFI_pack_put(origin_addr, origin_count, origin_datatype, target_rank,
-                               target_disp, target_count, target_datatype, win, addr, sigreq);
+                               target_count, target_datatype, target_mr, win, addr, sigreq);
         goto fn_exit;
     }
 
+  am_fallback:
     if (sigreq)
         mpi_errno =
             MPIDIG_mpi_rput(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
@@ -306,12 +355,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
                                               MPIDI_winattr_t winattr, MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t offset;
     uint64_t flags;
     struct fi_msg_rma msg;
     int origin_contig, target_contig;
     MPI_Aint origin_true_lb, target_true_lb;
-    size_t origin_bytes, target_bytes;
+    size_t origin_bytes, target_bytes, target_extent;
     struct fi_rma_iov riov;
     struct iovec iov;
 
@@ -320,11 +368,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
 
-    MPIDI_Datatype_check_origin_target_contig_size_lb(origin_datatype, target_datatype,
-                                                      origin_count, target_count,
-                                                      origin_contig, target_contig,
-                                                      origin_bytes, target_bytes,
-                                                      origin_true_lb, target_true_lb);
+    MPIDI_Datatype_check_contig_size_lb(origin_datatype, origin_count, origin_contig,
+                                        origin_bytes, origin_true_lb);
+    MPIDI_Datatype_check_contig_size_extent_lb(target_datatype, target_count, target_contig,
+                                               target_bytes, target_extent, target_true_lb);
 
     MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
 
@@ -334,16 +381,25 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
 
     /* self messages */
     if (target_rank == MPIDIU_win_comm_rank(win, winattr)) {
-        offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
+        size_t offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
         mpi_errno = MPIR_Localcopy((char *) win->base + offset,
                                    target_count,
                                    target_datatype, origin_addr, origin_count, origin_datatype);
         goto null_op_exit;
     }
 
+    /* prepare remote addr and mr key.
+     * Continue native path only when all segments are in the same registered memory region */
+    bool target_mr_found;
+    MPIDI_OFI_target_mr_t target_mr;
+    target_mr_found = MPIDI_OFI_prepare_target_mr(target_rank,
+                                                  target_disp, target_extent, target_true_lb,
+                                                  win, winattr, &target_mr);
+    if (unlikely(!target_mr_found))
+        goto am_fallback;
+
     /* contiguous messages */
     if (origin_contig && target_contig) {
-        offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
         if (sigreq) {
             if (sigreq) {
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
@@ -371,9 +427,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         msg.data = 0;
         iov.iov_base = (char *) origin_addr + origin_true_lb;
         iov.iov_len = target_bytes;
-        riov.addr = (uint64_t) (MPIDI_OFI_winfo_base(win, target_rank) + offset + target_true_lb);
+        riov.addr = target_mr.addr + target_true_lb;
         riov.len = target_bytes;
-        riov.key = MPIDI_OFI_winfo_mr_key(win, target_rank);
+        riov.key = target_mr.mr_key;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
         MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), 0, rdma_write, FALSE);
         /* Complete signal request to inform completion to user. */
@@ -390,7 +446,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
         mpi_errno =
             MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
-                                    target_disp, target_count, target_datatype, win, addr,
+                                    target_count, target_datatype, target_mr, win, addr,
                                     MPIDI_OFI_GET, sigreq);
         goto fn_exit;
     }
@@ -399,10 +455,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
         mpi_errno =
             MPIDI_OFI_pack_get(origin_addr, origin_count, origin_datatype, target_rank,
-                               target_disp, target_count, target_datatype, win, addr, sigreq);
+                               target_count, target_datatype, target_mr, win, addr, sigreq);
         goto fn_exit;
     }
 
+  am_fallback:
     if (sigreq)
         mpi_errno =
             MPIDIG_mpi_rget(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
@@ -500,9 +557,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     int mpi_errno = MPI_SUCCESS;
     enum fi_op fi_op;
     enum fi_datatype fi_dt;
-    size_t offset, max_count, max_size, dt_size, bytes;
+    size_t max_count, max_size, dt_size, bytes;
     MPI_Aint true_lb;
-    void *buffer, *tbuffer, *rbuffer;
+    void *buffer, *rbuffer;
     struct fi_ioc originv;
     struct fi_ioc resultv;
     struct fi_ioc comparev;
@@ -530,17 +587,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_COMPARE_AND_SWAP);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-
-    offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
-
     MPIDI_Datatype_check_size_lb(datatype, 1, bytes, true_lb);
 
     if (bytes == 0)
         goto fn_exit;
 
+    /* prepare remote addr and mr key.
+     * Continue native path only when all segments are in the same registered memory region */
+    bool target_mr_found;
+    MPIDI_OFI_target_mr_t target_mr;
+    target_mr_found = MPIDI_OFI_prepare_target_mr(target_rank, target_disp, bytes, 0,
+                                                  win, winattr, &target_mr);
+    if (unlikely(!target_mr_found))
+        goto am_fallback;
+
     buffer = (char *) origin_addr + true_lb;
     rbuffer = (char *) result_addr + true_lb;
-    tbuffer = (void *) (MPIDI_OFI_winfo_base(win, target_rank) + offset);
 
     MPIDI_OFI_query_acc_atomic_support(datatype, MPIDI_OFI_QUERY_COMPARE_ATOMIC_COUNT, MPI_OP_NULL,
                                        win, winattr, &fi_dt, &fi_op, &max_count, &dt_size);
@@ -562,9 +624,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     resultv.count = 1;
     comparev.addr = (void *) compare_addr;
     comparev.count = 1;
-    targetv.addr = (uint64_t) (uintptr_t) tbuffer;
+    targetv.addr = target_mr.addr;
     targetv.count = 1;
-    targetv.key = MPIDI_OFI_winfo_mr_key(win, target_rank);;
+    targetv.key = target_mr.mr_key;
 
     msg.msg_iov = &originv;
     msg.desc = NULL;
@@ -815,9 +877,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     int mpi_errno = MPI_SUCCESS;
     enum fi_op fi_op;
     enum fi_datatype fi_dt;
-    size_t offset, max_count, max_size, dt_size, bytes;
+    size_t max_count, max_size, dt_size, bytes;
     MPI_Aint true_lb ATTRIBUTE((unused));
-    void *buffer, *tbuffer, *rbuffer;
+    void *buffer, *rbuffer;
     struct fi_ioc originv;
     struct fi_ioc resultv;
     struct fi_rma_ioc targetv;
@@ -843,16 +905,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     }
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-
-    offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
-
     MPIDI_Datatype_check_size_lb(datatype, 1, bytes, true_lb);
     if (bytes == 0)
         goto fn_exit;
 
+    /* prepare remote addr and mr key.
+     * Continue native path only when all segments are in the same registered memory region */
+    bool target_mr_found;
+    MPIDI_OFI_target_mr_t target_mr;
+    target_mr_found = MPIDI_OFI_prepare_target_mr(target_rank, target_disp, bytes, 0,
+                                                  win, winattr, &target_mr);
+    if (unlikely(!target_mr_found))
+        goto am_fallback;
+
     buffer = (char *) origin_addr;      /* ignore true_lb, which should be always zero */
     rbuffer = (char *) result_addr;
-    tbuffer = (void *) (MPIDI_OFI_winfo_base(win, target_rank) + offset);
 
     MPIDI_OFI_query_acc_atomic_support(datatype, MPIDI_OFI_QUERY_FETCH_ATOMIC_COUNT,
                                        op, win, winattr, &fi_dt, &fi_op, &max_count, &dt_size);
@@ -877,9 +944,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     originv.count = 1;
     resultv.addr = (void *) rbuffer;
     resultv.count = 1;
-    targetv.addr = (uint64_t) (uintptr_t) tbuffer;
+    targetv.addr = target_mr.addr;
     targetv.count = 1;
-    targetv.key = MPIDI_OFI_winfo_mr_key(win, target_rank);
+    targetv.key = target_mr.mr_key;
 
     msg.msg_iov = &originv;
     msg.desc = NULL;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -119,6 +119,10 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt
     if (winattr & MPIDI_WINATTR_ACCU_SAME_OP_NO_OP)
         *count = (size_t) MPIDI_OFI_WIN(win).acc_hint->dtypes_max_count[dt_index];
 
+    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    (MPL_DBG_FDEST, "Query atomics support: max_count 0x%lx, dtsize 0x%lx", *count,
+                     *dtsize));
+
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_QUERY_ACC_ATOMIC_SUPPORT);
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -515,6 +515,13 @@ typedef struct {
     MPIR_Request *parent;       /* Parent request           */
 } MPIDI_OFI_chunk_request;
 
+typedef struct MPIDI_OFI_target_mr {
+    uint64_t addr;              /* Unlikely used. Needed for calculating relative offset
+                                 * only when FI_MR_VIRT_ADDRESS is off but registration with MPI_BOTTOM fails
+                                 * at win creation. However, we always store it for code simplicity. */
+    uint64_t mr_key;
+} MPIDI_OFI_target_mr_t;
+
 typedef struct MPIDI_OFI_huge_recv {
     char pad[MPIDI_REQUEST_HDR_SIZE];
     struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];       /* fixed field, do not move */

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -189,27 +189,40 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
         MPIDI_OFI_WIN(win).mr_key = 0;
     }
 
-    /* It is unclear whether we can register NULL and what that means even in the case
-     * we can. So until there is clear documentation, we take the conservative measure
-     * and do not register a NULL base. */
+    /* Register the allocated win buffer or MPI_BOTTOM (NULL) for dynamic win.
+     * It is clear that we cannot register NULL when FI_MR_ALLOCATED is set, thus
+     * we skip trial and return immediately. When FI_MR_ALLOCATED is not set, however,
+     * it lacks documentation defining whether the provider can accept NULL and whether
+     * it means registration of the entire virtual address space, although we have observed
+     * successful use in existing providers. Thus, we take a try here. */
 
-    /* Implication for dynamic window: since we are not registering mr here, we currently
-     * always fall-back to active messages for dynamic window. In any way, dynamic window
-     * probably will need per-attachment registration and a mechanism for dynamic
-     * synchronization to work with direct RMA. That is difficult without extra sematics or
-     * hints, unfortunately. Until then, we fall back. */
-
-    if (base) {
-        MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.ctx[0].domain,        /* In:  Domain Object */
-                                 base,  /* In:  Lower memory address */
-                                 win->size,     /* In:  Length              */
-                                 FI_REMOTE_READ | FI_REMOTE_WRITE,      /* In:  Expose MR for read  */
-                                 0ULL,  /* In:  offset(not used)    */
-                                 MPIDI_OFI_WIN(win).mr_key,     /* In:  requested key       */
-                                 0ULL,  /* In:  flags               */
-                                 &MPIDI_OFI_WIN(win).mr,        /* Out: memregion object    */
-                                 NULL), mr_reg);        /* In:  context             */
+    int rc = 0, allrc = 0;
+    MPIDI_OFI_WIN(win).mr = NULL;
+    if (base || (win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC && !MPIDI_OFI_ENABLE_MR_ALLOCATED)) {
+        MPIDI_OFI_CALL_RETURN(fi_mr_reg(MPIDI_OFI_global.ctx[0].domain, /* In:  Domain Object */
+                                        base,   /* In:  Lower memory address */
+                                        win->size,      /* In:  Length              */
+                                        FI_REMOTE_READ | FI_REMOTE_WRITE,       /* In:  Expose MR for read  */
+                                        0ULL,   /* In:  offset(not used)    */
+                                        MPIDI_OFI_WIN(win).mr_key,      /* In:  requested key       */
+                                        0ULL,   /* In:  flags               */
+                                        &MPIDI_OFI_WIN(win).mr, /* Out: memregion object    */
+                                        NULL), rc);     /* In:  context             */
+    } else if (win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+        goto fn_exit;
     }
+
+    /* Check if any process fails to register. If so, release local MR and force AM path. */
+    MPIR_Allreduce(&rc, &allrc, 1, MPI_INT, MPI_MIN, comm_ptr, &errflag);
+    if (allrc < 0) {
+        if (rc >= 0 && MPIDI_OFI_WIN(win).mr)
+            MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).mr->fid), fi_close);
+        MPIDI_OFI_WIN(win).mr = NULL;
+        goto fn_exit;
+    } else {
+        MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_NM_REACHABLE;  /* enable NM native RMA */
+    }
+
     MPIDI_OFI_WIN(win).winfo = MPL_malloc(sizeof(*winfo) * comm_ptr->local_size, MPL_MEM_RMA);
 
     winfo = MPIDI_OFI_WIN(win).winfo;
@@ -579,6 +592,37 @@ static int win_init(MPIR_Win * win)
     return mpi_errno;
 }
 
+/* Callback of MPL_gavl_tree_create to delete local registered MR for dynamic window */
+static void dwin_close_mr(void *obj)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_DWIN_CLOSE_MR);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_DWIN_CLOSE_MR);
+
+    /* Close local MR */
+    struct fid_mr *mr = (struct fid_mr *) obj;
+    if (mr) {
+        int ret;
+        MPIDI_OFI_CALL_RETURN(fi_close(&mr->fid), ret);
+        MPIR_Assert(ret >= 0);
+    }
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_DWIN_CLOSE_MR);
+    return;
+}
+
+/* Callback of MPL_gavl_tree_create to delete remote registered MR for dynamic window */
+static void dwin_free_target_mr(void *obj)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_DWIN_FREE_TARGET_MEM);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_DWIN_FREE_TARGET_MEM);
+
+    /* Free cached buffer for remote MR */
+    MPL_free(obj);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_DWIN_FREE_TARGET_MEM);
+    return;
+}
+
 int MPIDI_OFI_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info)
 {
     int mpi_errno;
@@ -708,8 +752,6 @@ int MPIDI_OFI_mpi_win_create_hook(MPIR_Win * win)
         mpi_errno = win_allgather(win, win->base, win->disp_unit);
         if (mpi_errno != MPI_SUCCESS)
             goto fn_fail;
-
-        MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_NM_REACHABLE;
     }
 
   fn_exit:
@@ -733,8 +775,6 @@ int MPIDI_OFI_mpi_win_allocate_hook(MPIR_Win * win)
 
         mpi_errno = win_allgather(win, win->base, win->disp_unit);
         MPIR_ERR_CHECK(mpi_errno);
-
-        MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_NM_REACHABLE;
     }
 
   fn_exit:
@@ -758,8 +798,6 @@ int MPIDI_OFI_mpi_win_allocate_shared_hook(MPIR_Win * win)
 
         mpi_errno = win_allgather(win, win->base, win->disp_unit);
         MPIR_ERR_CHECK(mpi_errno);
-
-        MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_NM_REACHABLE;
     }
 
   fn_exit:
@@ -776,6 +814,8 @@ int MPIDI_OFI_mpi_win_create_dynamic_hook(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_WIN_CREATE_DYNAMIC_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_WIN_CREATE_DYNAMIC_HOOK);
 
+    MPIR_CHKPMEM_DECL(1);
+
     /* This hook is called by CH4 generic call after CH4 initialization */
     if (MPIDI_OFI_ENABLE_RMA) {
         /* FIXME: should the OFI specific size be stored inside OFI rather
@@ -788,14 +828,49 @@ int MPIDI_OFI_mpi_win_create_dynamic_hook(MPIR_Win * win)
 
         mpi_errno = win_allgather(win, win->base, win->disp_unit);
         MPIR_ERR_CHECK(mpi_errno);
+
+        /* Initialize memory region storage for per-attach memory registration
+         * if MR is not successfully registered here and all attach calls are collective */
+        if (!MPIDI_OFI_WIN(win).mr && MPIDIG_WIN(win, info_args).coll_attach) {
+            /* Initialize AVL tree for local registered region */
+            int mpl_err = MPL_SUCCESS;
+            mpl_err = MPL_gavl_tree_create(dwin_close_mr, &MPIDI_OFI_WIN(win).dwin_mrs);
+            MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                "**mpl_gavl_create");
+
+            /* Initialize AVL trees for remote registered regions */
+            MPIR_CHKPMEM_MALLOC(MPIDI_OFI_WIN(win).dwin_target_mrs, MPL_gavl_tree_t *,
+                                sizeof(MPL_gavl_tree_t) * win->comm_ptr->local_size, mpi_errno,
+                                "AVL tree for remote dynamic win memory regions", MPL_MEM_RMA);
+            int i;
+            for (i = 0; i < win->comm_ptr->local_size; i++) {
+                mpl_err = MPL_gavl_tree_create(dwin_free_target_mr,
+                                               &MPIDI_OFI_WIN(win).dwin_target_mrs[i]);
+                MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                    "**mpl_gavl_create");
+            }
+
+            /* Enable native RMA for now. Will be disabled if any registration fails at attach. */
+            MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_NM_REACHABLE;
+            MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_NM_DYNAMIC_MR;
+        }
     }
+
+    MPIR_CHKPMEM_COMMIT();
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_MPI_WIN_CREATE_DYNAMIC_HOOK);
     return mpi_errno;
   fn_fail:
+    MPIR_CHKPMEM_REAP();
     goto fn_exit;
 }
+
+typedef struct dwin_target_mr {
+    uint64_t mr_key;
+    uintptr_t size;
+    const void *base;
+} dwin_target_mr_t;
 
 int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
 {
@@ -803,10 +878,86 @@ int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_WIN_ATTACH_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_WIN_ATTACH_HOOK);
 
-    /* Do nothing */
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Comm *comm_ptr = win->comm_ptr;
+    dwin_target_mr_t *target_mrs;
+    int mpl_err = MPL_SUCCESS, i;
 
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_WIN_ATTACH_HOOK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_WIN_ATTACH_HOOK);
+
+    MPIR_CHKLMEM_DECL(1);
+
+    if (!MPIDI_OFI_ENABLE_RMA || MPIDI_OFI_WIN(win).mr || !MPIDIG_WIN(win, info_args).coll_attach)
+        goto fn_exit;
+
+    uint64_t requested_key = 0ULL;
+    if (!MPIDI_OFI_ENABLE_MR_PROV_KEY)
+        requested_key = MPIDI_OFI_mr_key_alloc();
+
+    int rc = 0, allrc = 0;
+    struct fid_mr *mr = NULL;
+    MPIDI_OFI_CALL_RETURN(fi_mr_reg(MPIDI_OFI_global.ctx[0].domain,     /* In:  Domain Object */
+                                    base,       /* In:  Lower memory address */
+                                    size,       /* In:  Length              */
+                                    FI_REMOTE_READ | FI_REMOTE_WRITE,   /* In:  Expose MR for read  */
+                                    0ULL,       /* In:  offset(not used)    */
+                                    requested_key,      /* In:  requested key */
+                                    0ULL,       /* In:  flags               */
+                                    &mr,        /* Out: memregion object    */
+                                    NULL), rc); /* In:  context             */
+
+    /* Check if any process fails to register. If so, release local MR and force AM path. */
+    MPIR_Allreduce(&rc, &allrc, 1, MPI_INT, MPI_MIN, comm_ptr, &errflag);
+    if (allrc < 0) {
+        if (rc >= 0)
+            MPIDI_OFI_CALL(fi_close(&mr->fid), fi_close);
+        MPIDI_WIN(win, winattr) &= ~MPIDI_WINATTR_NM_REACHABLE; /* disable native RMA */
+        goto fn_exit;
+    }
+
+    /* Local MR is searched only at win_detach */
+    mpl_err = MPL_gavl_tree_insert(MPIDI_OFI_WIN(win).dwin_mrs, (const void *) base,
+                                   (uintptr_t) size, (const void *) mr);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**mpl_gavl_insert");
+
+    MPIR_CHKLMEM_MALLOC(target_mrs, dwin_target_mr_t *,
+                        sizeof(dwin_target_mr_t) * comm_ptr->local_size,
+                        mpi_errno, "temp buffer for dynamic win remote memory regions",
+                        MPL_MEM_RMA);
+
+    /* Exchange remote MR across all processes because "coll_attach" info ensures
+     * that all processes collectively call attach. */
+    target_mrs[comm_ptr->rank].mr_key = fi_mr_key(mr);
+    target_mrs[comm_ptr->rank].base = (const void *) base;
+    target_mrs[comm_ptr->rank].size = (uintptr_t) size;
+    mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0,
+                               MPI_DATATYPE_NULL,
+                               target_mrs, sizeof(dwin_target_mr_t), MPI_BYTE, comm_ptr, &errflag);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* Insert each remote MR which will be searched when issuing an RMA operation
+     * and deleted at win_detach or win_free */
+    for (i = 0; i < comm_ptr->local_size; i++) {
+        MPIDI_OFI_target_mr_t *target_mr =
+            (MPIDI_OFI_target_mr_t *) MPL_malloc(sizeof(MPIDI_OFI_target_mr_t), MPL_MEM_RMA);
+        MPIR_Assert(target_mr);
+        /* Store addr only for calculating offset when !MPIDI_OFI_ENABLE_MR_VIRT_ADDRESS */
+        target_mr->addr = (uint64_t) target_mrs[i].base;
+        target_mr->mr_key = target_mrs[i].mr_key;
+
+        mpl_err = MPL_gavl_tree_insert(MPIDI_OFI_WIN(win).dwin_target_mrs[i],
+                                       target_mrs[i].base, target_mrs[i].size,
+                                       (const void *) target_mr);
+        MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**mpl_gavl_insert");
+    }
+
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_MPI_WIN_ATTACH_HOOK);
+    MPIR_CHKLMEM_FREEALL();
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 int MPIDI_OFI_mpi_win_detach_hook(MPIR_Win * win, const void *base)
@@ -815,10 +966,49 @@ int MPIDI_OFI_mpi_win_detach_hook(MPIR_Win * win, const void *base)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_WIN_DETACH_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_WIN_DETACH_HOOK);
 
-    /* Do nothing */
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Comm *comm_ptr = win->comm_ptr;
+    const void **target_bases;
+    int mpl_err = MPL_SUCCESS, i;
 
+    MPIR_CHKLMEM_DECL(1);
+
+    if (!MPIDI_OFI_ENABLE_RMA || MPIDI_OFI_WIN(win).mr || !MPIDIG_WIN(win, info_args).coll_attach)
+        goto fn_exit;
+
+    /* Search and delete local MR. MR may not be found if the registration fails
+     * at attach. However, we don't distinguish them for code simplicity. */
+    mpl_err = MPL_gavl_tree_delete_start_addr(MPIDI_OFI_WIN(win).dwin_mrs, (const void *) base);
+    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                        "**mpl_gavl_delete_start_addr");
+
+    /* Notify remote processes to delete their local cached MR key */
+    MPIR_CHKLMEM_MALLOC(target_bases, const void **,
+                        sizeof(const void *) * comm_ptr->local_size,
+                        mpi_errno, "temp buffer for dynamic win remote memory regions",
+                        MPL_MEM_RMA);
+
+    /* Exchange remote MR across all processes because "coll_attach" info ensures
+     * that all processes collectively call detach. */
+    target_bases[comm_ptr->rank] = base;
+    mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                               target_bases, sizeof(const void *), MPI_BYTE, comm_ptr, &errflag);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* Search and delete each remote MR */
+    for (i = 0; i < comm_ptr->local_size; i++) {
+        mpl_err = MPL_gavl_tree_delete_start_addr(MPIDI_OFI_WIN(win).dwin_target_mrs[i],
+                                                  (const void *) target_bases[i]);
+        MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                            "**mpl_gavl_delete_start_addr");
+    }
+
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_MPI_WIN_DETACH_HOOK);
+    MPIR_CHKLMEM_FREEALL();
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win)
@@ -845,6 +1035,17 @@ int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win)
         MPIDI_OFI_WIN(win).winfo = NULL;
         MPL_free(MPIDI_OFI_WIN(win).acc_hint);
         MPIDI_OFI_WIN(win).acc_hint = NULL;
+
+        /* Free storage of per-attach memory regions for dynamic window */
+        if (win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC &&
+            !MPIDI_OFI_WIN(win).mr && MPIDIG_WIN(win, info_args).coll_attach) {
+            int i;
+            for (i = 0; i < win->comm_ptr->local_size; i++)
+                MPL_gavl_tree_destory(MPIDI_OFI_WIN(win).dwin_target_mrs[i]);
+            MPL_free(MPIDI_OFI_WIN(win).dwin_target_mrs);
+            MPL_gavl_tree_destory(MPIDI_OFI_WIN(win).dwin_mrs);
+        }
+
     }
     /* This hook is called by CH4 generic call before CH4 finalization */
 

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -338,6 +338,28 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
         }                                                  \
     } while (0)
 
+#define MPIDI_Datatype_check_contig_size_extent_lb(datatype_,count_,   \
+                                                   dt_contig_out_,     \
+                                                   data_sz_out_,       \
+                                                   dt_extent_out_,     \
+                                                   dt_true_lb_)        \
+    do {                                                        \
+        if (IS_BUILTIN(datatype_)) {                            \
+            (dt_contig_out_) = TRUE;                            \
+            (data_sz_out_) = (size_t)(count_) * MPIR_Datatype_get_basic_size(datatype_);  \
+            (dt_extent_out_) = (data_sz_out_);                  \
+            (dt_true_lb_) = 0;                                  \
+        } else {                                                \
+            MPIR_Datatype *dt_ptr_;                             \
+            MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));      \
+            MPIR_Assert(dt_ptr_);                               \
+            (dt_contig_out_) = (dt_ptr_)->is_contig;            \
+            (data_sz_out_) = (size_t)(count_) * (dt_ptr_)->size;    \
+            (dt_extent_out_) = (size_t)(count_) * (dt_ptr_)->extent;\
+            (dt_true_lb_) = (dt_ptr_)->true_lb;                 \
+        }                                                       \
+    } while (0)
+
 /* Check both origin|target buffers' size. */
 #define MPIDI_Datatype_check_origin_target_size(o_datatype_, t_datatype_,         \
                                                 o_count_, t_count_,               \

--- a/src/mpid/ch4/src/ch4_rma.h
+++ b/src/mpid/ch4/src/ch4_rma.h
@@ -8,6 +8,24 @@
 
 #include "ch4_impl.h"
 
+MPL_STATIC_INLINE_PREFIX void MPIDI_dbg_dump_winattr(MPIDI_winattr_t winattr)
+{
+#ifndef CHECK_WINATTR
+#define CHECK_WINATTR(attr, flag) ((attr) & flag ? 1 : 0)
+
+    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    (MPL_DBG_FDEST, "winattr=0x%x (DIRECT_INTRA_COMM %d, SHM_ALLOCATED %d,"
+                     "ACCU_NO_SHM %d, ACCU_SAME_OP_NO_OP %d, NM_REACHABLE %d, NM_DYNAMIC_MR %d)",
+                     winattr, CHECK_WINATTR(winattr, MPIDI_WINATTR_DIRECT_INTRA_COMM),
+                     CHECK_WINATTR(winattr, MPIDI_WINATTR_SHM_ALLOCATED),
+                     CHECK_WINATTR(winattr, MPIDI_WINATTR_ACCU_NO_SHM),
+                     CHECK_WINATTR(winattr, MPIDI_WINATTR_ACCU_SAME_OP_NO_OP),
+                     CHECK_WINATTR(winattr, MPIDI_WINATTR_NM_REACHABLE),
+                     CHECK_WINATTR(winattr, MPIDI_WINATTR_NM_DYNAMIC_MR)));
+#undef CHECK_WINATTR
+#endif
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_put_unsafe(const void *origin_addr,
                                               int origin_count,
                                               MPI_Datatype origin_datatype,
@@ -21,6 +39,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_put_unsafe(const void *origin_addr,
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PUT_UNSAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PUT_UNSAFE);
+
+    MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_put(origin_addr, origin_count, origin_datatype,
@@ -59,6 +79,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_unsafe(void *origin_addr,
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_UNSAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_UNSAFE);
+
+    MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_get(origin_addr, origin_count, origin_datatype,
@@ -99,6 +121,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_unsafe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACCUMULATE_UNSAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACCUMULATE_UNSAFE);
 
+    MPIDI_dbg_dump_winattr(winattr);
+
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_accumulate(origin_addr, origin_count, origin_datatype,
                                         target_rank, target_disp, target_count,
@@ -135,6 +159,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_unsafe(const void *origin_ad
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_COMPARE_AND_SWAP_UNSAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_COMPARE_AND_SWAP_UNSAFE);
+
+    MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_compare_and_swap(origin_addr, compare_addr, result_addr,
@@ -175,6 +201,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_unsafe(const void *origin_addr,
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RACCUMULATE_UNSAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RACCUMULATE_UNSAFE);
+
+    MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_raccumulate(origin_addr, origin_count, origin_datatype,
@@ -219,6 +247,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_unsafe(const void *origin_add
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_ACCUMULATE_UNSAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_ACCUMULATE_UNSAFE);
 
+    MPIDI_dbg_dump_winattr(winattr);
+
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_rget_accumulate(origin_addr, origin_count, origin_datatype,
                                              result_addr, result_count, result_datatype,
@@ -259,6 +289,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_unsafe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_FETCH_AND_OP_UNSAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_FETCH_AND_OP_UNSAFE);
 
+    MPIDI_dbg_dump_winattr(winattr);
+
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_fetch_and_op(origin_addr, result_addr,
                                           datatype, target_rank, target_disp, op, win, av, winattr);
@@ -296,6 +328,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_unsafe(void *origin_addr,
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_UNSAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_UNSAFE);
+
+    MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_rget(origin_addr, origin_count, origin_datatype,
@@ -335,6 +369,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rput_unsafe(const void *origin_addr,
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RPUT_UNSAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RPUT_UNSAFE);
+
+    MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_rput(origin_addr, origin_count, origin_datatype,
@@ -377,6 +413,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_unsafe(const void *origin_addr
     MPIDI_av_entry_t *av = MPIDIU_win_rank_to_av(win, target_rank, winattr);
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACCUMULATE_UNSAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACCUMULATE_UNSAFE);
+
+    MPIDI_dbg_dump_winattr(winattr);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_get_accumulate(origin_addr, origin_count, origin_datatype,

--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -661,7 +661,8 @@ int MPIDIG_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info)
     mpi_errno = win_set_info(win, info, FALSE /* is_init */);
     MPIR_ERR_CHECK(mpi_errno);
 
-    update_winattr_after_set_info(win);
+    /* Do not update winattr except for info set at window creation.
+     * Because it will change RMA's behavior which requires collective synchronization. */
 
     mpi_errno = MPIR_Barrier(win->comm_ptr, &errflag);
   fn_exit:

--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -247,6 +247,11 @@ static int win_set_info(MPIR_Win * win, MPIR_Info * info, bool is_init)
                 MPIDIG_WIN(win, info_args).disable_shm_accumulate = true;
             else
                 MPIDIG_WIN(win, info_args).disable_shm_accumulate = false;
+        } else if (is_init && !strcmp(curr_ptr->key, "coll_attach")) {
+            if (!strcmp(curr_ptr->value, "true"))
+                MPIDIG_WIN(win, info_args).coll_attach = true;
+            else
+                MPIDIG_WIN(win, info_args).coll_attach = false;
         }
       next:
         curr_ptr = curr_ptr->next;
@@ -322,6 +327,7 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
     MPIDIG_WIN(win, info_args).accumulate_noncontig_dtype = true;
     MPIDIG_WIN(win, info_args).accumulate_max_bytes = -1;
     MPIDIG_WIN(win, info_args).disable_shm_accumulate = false;
+    MPIDIG_WIN(win, info_args).coll_attach = false;
 
     if ((info != NULL) && ((int *) info != (int *) MPI_INFO_NULL)) {
         mpi_errno = win_set_info(win, info, TRUE /* is_init */);
@@ -773,6 +779,12 @@ int MPIDIG_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "disable_shm_accumulate", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "disable_shm_accumulate", "false");
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (MPIDIG_WIN(win, info_args).coll_attach)
+        mpi_errno = MPIR_Info_set_impl(*info_p_p, "coll_attach", "true");
+    else
+        mpi_errno = MPIR_Info_set_impl(*info_p_p, "coll_attach", "false");
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/test/mpi/rma/Makefile.am
+++ b/test/mpi/rma/Makefile.am
@@ -81,6 +81,8 @@ noinst_PROGRAMS =          \
     window_creation        \
     window_allocation      \
     window_noncontig_allocation  \
+    window_attach                   \
+    window_attach_collattach        \
     win_flavors            \
     win_shared             \
     win_shared_noncontig   \
@@ -425,3 +427,6 @@ win_dynamic_acc_collattach_SOURCES = win_dynamic_acc.c
 
 aint_collattach_CPPFLAGS = -DUSE_INFO_COLL_ATTACH $(AM_CPPFLAGS)
 aint_collattach_SOURCES = aint.c
+
+window_attach_collattach_CPPFLAGS = -DUSE_INFO_COLL_ATTACH $(AM_CPPFLAGS)
+window_attach_collattach_SOURCES = window_attach.c

--- a/test/mpi/rma/Makefile.am
+++ b/test/mpi/rma/Makefile.am
@@ -94,6 +94,8 @@ noinst_PROGRAMS =          \
     win_large_shm          \
     win_dynamic_acc        \
     win_dynamic_acc_collattach \
+    win_dynamic_rma_flush_get             \
+    win_dynamic_rma_flush_get_collattach  \
     get_acc_local          \
     compare_and_swap       \
     linked_list            \
@@ -424,6 +426,9 @@ putpscw1_SOURCES = putpscw1.c
 
 win_dynamic_acc_collattach_CPPFLAGS = -DUSE_INFO_COLL_ATTACH $(AM_CPPFLAGS)
 win_dynamic_acc_collattach_SOURCES = win_dynamic_acc.c
+
+win_dynamic_rma_flush_get_collattach_CPPFLAGS = -DUSE_INFO_COLL_ATTACH $(AM_CPPFLAGS)
+win_dynamic_rma_flush_get_collattach_SOURCES = win_dynamic_rma_flush_get.c
 
 aint_collattach_CPPFLAGS = -DUSE_INFO_COLL_ATTACH $(AM_CPPFLAGS)
 aint_collattach_SOURCES = aint.c

--- a/test/mpi/rma/Makefile.am
+++ b/test/mpi/rma/Makefile.am
@@ -91,6 +91,7 @@ noinst_PROGRAMS =          \
     win_zero               \
     win_large_shm          \
     win_dynamic_acc        \
+    win_dynamic_acc_collattach \
     get_acc_local          \
     compare_and_swap       \
     linked_list            \
@@ -201,7 +202,8 @@ noinst_PROGRAMS =          \
     putpscw1
 
 if BUILD_MPIX_TESTS
-noinst_PROGRAMS += aint
+noinst_PROGRAMS += aint   \
+                   aint_collattach
 endif
 
 atomic_get_short_int_SOURCES      = atomic_get.c
@@ -417,3 +419,9 @@ lockall_dt_flushlocalall_SOURCES = lock_x_dt.c
 
 putpscw1_CPPFLAGS = $(AM_CPPFLAGS)
 putpscw1_SOURCES = putpscw1.c
+
+win_dynamic_acc_collattach_CPPFLAGS = -DUSE_INFO_COLL_ATTACH $(AM_CPPFLAGS)
+win_dynamic_acc_collattach_SOURCES = win_dynamic_acc.c
+
+aint_collattach_CPPFLAGS = -DUSE_INFO_COLL_ATTACH $(AM_CPPFLAGS)
+aint_collattach_SOURCES = aint.c

--- a/test/mpi/rma/aint.c
+++ b/test/mpi/rma/aint.c
@@ -47,8 +47,18 @@ int main(int argc, char **argv)
     /* Exchange bases */
     MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, bases, 1, MPI_AINT, MPI_COMM_WORLD);
 
-    MPI_Win_create_dynamic(MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+    MPI_Info info = MPI_INFO_NULL;
+#ifdef USE_INFO_COLL_ATTACH
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "coll_attach", "true");
+#endif
+
+    MPI_Win_create_dynamic(info, MPI_COMM_WORLD, &win);
     MPI_Win_attach(win, array, sizeof(int) * 1024);
+
+#ifdef USE_INFO_COLL_ATTACH
+    MPI_Info_free(&info);
+#endif
 
     /* Do MPI_Aint addressing arithmetic */
     if (rank == 0) {

--- a/test/mpi/rma/testlist.in
+++ b/test/mpi/rma/testlist.in
@@ -145,6 +145,22 @@ manyget 2 timeLimit=300
 derived_acc_flush_local 3
 large_acc_flush_local 3
 large_small_acc 2
+win_dynamic_rma_flush_get 2 arg=-count=4096 arg=-op=put
+win_dynamic_rma_flush_get 2 arg=-count=4096 arg=-op=acc
+win_dynamic_rma_flush_get 2 arg=-count=4096 arg=-op=gacc
+win_dynamic_rma_flush_get 2 arg=-count=1 arg=-op=fop
+win_dynamic_rma_flush_get 2 arg=-count=1 arg=-op=cas
+win_dynamic_rma_flush_get 2 arg=-count=9216 arg=-op=put
+win_dynamic_rma_flush_get 2 arg=-count=9216 arg=-op=acc
+win_dynamic_rma_flush_get 2 arg=-count=9216 arg=-op=gacc
+win_dynamic_rma_flush_get_collattach 2 arg=-count=4096 arg=-op=put
+win_dynamic_rma_flush_get_collattach 2 arg=-count=4096 arg=-op=acc
+win_dynamic_rma_flush_get_collattach 2 arg=-count=4096 arg=-op=gacc
+win_dynamic_rma_flush_get_collattach 2 arg=-count=1 arg=-op=fop
+win_dynamic_rma_flush_get_collattach 2 arg=-count=1 arg=-op=cas
+win_dynamic_rma_flush_get_collattach 2 arg=-count=9216 arg=-op=put
+win_dynamic_rma_flush_get_collattach 2 arg=-count=9216 arg=-op=acc
+win_dynamic_rma_flush_get_collattach 2 arg=-count=9216 arg=-op=gacc
 win_shared_put_flush_load 3
 win_shared_acc_flush_load 3
 win_shared_gacc_flush_load 3

--- a/test/mpi/rma/testlist.in
+++ b/test/mpi/rma/testlist.in
@@ -62,6 +62,8 @@ strided_getacc_indexed_shared 4
 window_creation 2
 window_allocation 4
 window_noncontig_allocation 4
+window_attach 4
+window_attach_collattach 4
 contention_put 4
 contention_putget 4
 put_base 2

--- a/test/mpi/rma/testlist.in
+++ b/test/mpi/rma/testlist.in
@@ -80,6 +80,7 @@ win_zero 4
 @largetest@win_large_shm 4
 @largetest@win_large_shm 3
 win_dynamic_acc 4
+win_dynamic_acc_collattach 4
 get_acc_local 1
 linked_list 4
 linked_list_fop 4
@@ -135,6 +136,7 @@ atomic_get_float_int 3 timeLimit=300
 atomic_get_double_int 3 timeLimit=300
 atomic_get_long_double_int 3 timeLimit=300
 aint 2
+aint_collattach 2
 acc_pairtype 2
 acc_pairtype_shm 2
 manyget 2 timeLimit=300

--- a/test/mpi/rma/win_dynamic_acc.c
+++ b/test/mpi/rma/win_dynamic_acc.c
@@ -34,7 +34,18 @@ int main(int argc, char **argv)
 
     MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, val_ptrs, 1, MPI_AINT, MPI_COMM_WORLD);
 
-    MPI_Win_create_dynamic(MPI_INFO_NULL, MPI_COMM_WORLD, &dyn_win);
+    MPI_Info info = MPI_INFO_NULL;
+#ifdef USE_INFO_COLL_ATTACH
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "coll_attach", "true");
+#endif
+
+    MPI_Win_create_dynamic(info, MPI_COMM_WORLD, &dyn_win);
+
+#ifdef USE_INFO_COLL_ATTACH
+    MPI_Info_free(&info);
+#endif
+
     MPI_Win_attach(dyn_win, &val, sizeof(int));
 
     for (i = 0; i < iter; i++) {

--- a/test/mpi/rma/win_dynamic_rma_flush_get.c
+++ b/test/mpi/rma/win_dynamic_rma_flush_get.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mpi.h>
+#include "mpitest.h"
+
+/* This test checks RMA operations that access to dynamic window with multiple attached regions.
+ * It generates separate tests for each RMA operation type accessing to a single remote region,
+ * and for Put, Accumulate, Get_accumulate accessing to two remote regions within a single operation.
+ * Each test uses Get to check results.*/
+#define MPI_DATATYPE MPI_INT
+#define DATATYPE int
+#define DATATYPE_FORMAT "%d"
+
+#define ITER 10
+#define MEM_CNT 8192
+#define MAX_RMA_CNT (MEM_CNT * 2)
+
+static DATATYPE mem_region[MAX_RMA_CNT];
+static MPI_Win dyn_win = MPI_WIN_NULL;
+static MPI_Aint *mem_ptrs = NULL;
+static int rank = -1, nprocs = 0;
+static int rma_cnt = 4096;      /* only touch the first regions */
+
+static DATATYPE local_buf[MAX_RMA_CNT], check_buf[MAX_RMA_CNT], result_buf[MAX_RMA_CNT],
+    compare_buf[MAX_RMA_CNT];
+
+#define error_print(str,...) {                        \
+            fprintf(stderr, str, ## __VA_ARGS__);     \
+            fflush(stderr);                           \
+        }
+
+enum rma_op {
+    TEST_PUT,
+    TEST_ACC,
+    TEST_GACC,
+    TEST_FOP,
+    TEST_CAS,
+    TEST_NUM_OP
+};
+
+static enum rma_op op = TEST_PUT;
+
+/* Define operation name for error message */
+const char *rma_names[TEST_NUM_OP] = {
+    "Put",
+    "Accumulate",
+    "Get_accumulate",
+    "Fetch_and_op",
+    "Compare_and_swap"
+};
+
+/* Issue functions for different RMA operations */
+static inline void issue_rma_op(int dst, MPI_Aint target_disp)
+{
+    switch (op) {
+        case TEST_PUT:
+            MPI_Put(local_buf, rma_cnt, MPI_DATATYPE, dst, target_disp, rma_cnt, MPI_DATATYPE,
+                    dyn_win);
+            break;
+        case TEST_ACC:
+            MPI_Accumulate(local_buf, rma_cnt, MPI_DATATYPE, dst, target_disp, rma_cnt,
+                           MPI_DATATYPE, MPI_REPLACE, dyn_win);
+            break;
+        case TEST_GACC:
+            MPI_Get_accumulate(local_buf, rma_cnt, MPI_DATATYPE, result_buf, rma_cnt, MPI_DATATYPE,
+                               dst, target_disp, rma_cnt, MPI_DATATYPE, MPI_REPLACE, dyn_win);
+            break;
+        case TEST_FOP:
+            MPI_Fetch_and_op(local_buf, result_buf, MPI_DATATYPE, dst, target_disp, MPI_REPLACE,
+                             dyn_win);
+            break;
+        case TEST_CAS:
+            MPI_Compare_and_swap(local_buf, compare_buf, result_buf, MPI_DATATYPE, dst, target_disp,
+                                 dyn_win);
+            break;
+        default:
+            MPI_Abort(MPI_COMM_WORLD, -1);      /* Invalid op */
+            break;
+    }
+}
+
+static void set_iteration_data(int x)
+{
+    int i;
+    for (i = 0; i < rma_cnt; i++)
+        local_buf[i] = rank + i + x;
+
+    if (op == TEST_CAS) {
+        /* Need equals to remote window's value */
+        if (x == 0)
+            compare_buf[0] = 0;
+        else
+            compare_buf[0] = rank + x - 1;
+    }
+
+    memset(check_buf, 0, sizeof(check_buf));
+}
+
+static int check_iteration_data(int x)
+{
+    int i, errs = 0;
+    for (i = 0; i < rma_cnt; i++) {
+        if (check_buf[i] != rank + i + x) {     /* always replace */
+            error_print("rank %d (iter %d) - check %s, got buf[%d] = "
+                        DATATYPE_FORMAT ", expected " DATATYPE_FORMAT "\n", rank, x,
+                        rma_names[op], i, check_buf[i], rank + i + x);
+            errs++;
+        }
+    }
+    return errs;
+}
+
+static int run_test(void)
+{
+    int errors = 0;
+    int i, x;
+    int dst = 0;
+    MPI_Aint target_disp = 0;
+
+    dst = (rank + 1) % nprocs;
+
+    /* reset window buffer */
+    MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, dyn_win);
+    memset(mem_region, 0, sizeof(DATATYPE) * MEM_CNT * 2);
+    MPI_Win_unlock(rank, dyn_win);
+
+    /* start RMA access */
+    MPI_Win_lock_all(0, dyn_win);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    target_disp = mem_ptrs[dst * 2];
+
+    for (x = 0; x < ITER; x++) {
+        set_iteration_data(x);
+
+        issue_rma_op(dst, target_disp);
+        MPI_Win_flush(dst, dyn_win);
+
+        MPI_Get(check_buf, rma_cnt, MPI_DATATYPE, dst, target_disp, rma_cnt, MPI_DATATYPE, dyn_win);
+        MPI_Win_flush(dst, dyn_win);
+
+        errors += check_iteration_data(x);
+    }
+
+    MPI_Win_unlock_all(dyn_win);
+
+    return errors;
+}
+
+static void init_window(void)
+{
+    mem_ptrs = malloc(nprocs * 2 * sizeof(MPI_Aint));
+
+    MPI_Get_address(&mem_region[0], &mem_ptrs[rank * 2]);
+    MPI_Get_address(&mem_region[MEM_CNT], &mem_ptrs[rank * 2 + 1]);
+
+    MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, mem_ptrs, 2, MPI_AINT, MPI_COMM_WORLD);
+
+    MPI_Info info = MPI_INFO_NULL;
+#ifdef USE_INFO_COLL_ATTACH
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "coll_attach", "true");
+#endif
+
+    MPI_Win_create_dynamic(info, MPI_COMM_WORLD, &dyn_win);
+    MPI_Win_attach(dyn_win, &mem_region[0], sizeof(DATATYPE) * MEM_CNT);
+    MPI_Win_attach(dyn_win, &mem_region[MEM_CNT], sizeof(DATATYPE) * MEM_CNT);
+
+#ifdef USE_INFO_COLL_ATTACH
+    MPI_Info_free(&info);
+#endif
+}
+
+static void destroy_windows(void)
+{
+    MPI_Win_detach(dyn_win, &mem_region[0]);
+    MPI_Win_detach(dyn_win, &mem_region[MEM_CNT]);
+    MPI_Win_free(&dyn_win);
+}
+
+int main(int argc, char *argv[])
+{
+    int errors = 0, all_errors = 0;
+    char *op_str = NULL;
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+
+    /* Processing input arguments */
+    MTestArgList *head = MTestArgListCreate(argc, argv);
+    rma_cnt = MTestArgListGetInt(head, "count");
+    op_str = MTestArgListGetString(head, "op");
+
+    if (rma_cnt < 0 || rma_cnt >= MAX_RMA_CNT) {
+        if (rank == 0)
+            error_print("Invalid input: rma_cnt = %d but valid range is [0, %d]\n",
+                        rma_cnt, MAX_RMA_CNT);
+        errors++;
+        goto exit;
+    }
+
+    if (!strncmp(op_str, "put", strlen("put"))) {
+        op = TEST_PUT;
+    } else if (!strncmp(op_str, "acc", strlen("acc"))) {
+        op = TEST_ACC;
+    } else if (!strncmp(op_str, "gacc", strlen("gacc"))) {
+        op = TEST_GACC;
+    } else if (!strncmp(op_str, "fop", strlen("fop"))) {
+        op = TEST_FOP;
+    } else if (!strncmp(op_str, "cas", strlen("cas"))) {
+        op = TEST_CAS;
+    } else {
+        if (rank == 0)
+            error_print("Invalid op: op = %s but valid option is one of put,acc,gacc,fop,cas\n",
+                        op_str);
+        errors++;
+        goto exit;
+    }
+
+    MTestArgListDestroy(head);
+
+    /* Force cnt be 1 for FOP and CAS */
+    if (op == TEST_FOP || op == TEST_CAS)
+        rma_cnt = 1;
+
+    init_window();
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    errors = run_test();
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    destroy_windows();
+
+  exit:
+    MTest_Finalize(errors);
+    return MTestReturnValue(all_errors);
+}

--- a/test/mpi/rma/window_attach.c
+++ b/test/mpi/rma/window_attach.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <mpi.h>
+#include "mpitest.h"
+
+#define DATA_NELTS  1000
+#define NUM_WIN     1000
+#define DATA_SZ     (DATA_NELTS*sizeof(int))
+
+int main(int argc, char **argv)
+{
+    int rank, nproc, i;
+    void *base_ptrs[NUM_WIN];
+    MPI_Win window;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+
+    if (rank == 0)
+        MTestPrintfMsg(1, "Starting MPI dynamic window attach test with %d processes\n", nproc);
+
+    MPI_Info info = MPI_INFO_NULL;
+#ifdef USE_INFO_COLL_ATTACH
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "coll_attach", "true");
+#endif
+    MPI_Win_create_dynamic(info, MPI_COMM_WORLD, &window);
+#ifdef USE_INFO_COLL_ATTACH
+    MPI_Info_free(&info);
+#endif
+
+    for (i = 0; i < NUM_WIN; i++) {
+        MPI_Alloc_mem(DATA_SZ, MPI_INFO_NULL, &base_ptrs[i]);
+        if (rank == 0)
+            MTestPrintfMsg(1, " + Attaching segment %d to window\n", i);
+        MPI_Win_attach(window, base_ptrs[i], DATA_SZ);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    for (i = 0; i < NUM_WIN; i++) {
+        if (rank == 0)
+            MTestPrintfMsg(1, " + Detaching segment %d to window\n", i);
+        MPI_Win_detach(window, base_ptrs[i]);
+        MPI_Free_mem(base_ptrs[i]);
+    }
+
+    MPI_Win_free(&window);
+    MTest_Finalize(0);
+
+    return 0;
+}


### PR DESCRIPTION
## Pull Request Description

For dynamic window, we always fallback to ch4 active message in current main branch. However, it can be optimized by using native RMA in certain situations. This PR implements it and improves the MPICH test suite for more dynamic window tests.

This patch enables native RMA through three steps:
1. Instead of always skip fi_mr_reg when base is NULL at window creation, try register if FI_MR_ALLOCATED is not set. If it successes, native RMA can be enabled as it registers the entire virtual address space.

2. If FI_MR_ALLOCATED is set, we have to register only the allocated buffers. For dynamic windows, we can register it and collectively exchange the mr_keys if coll_attach hint is set.

3. At RMA issuing path, we check whether a remote mr_key can be found to cover the entire range of target buffer(disp:disp+extent). If yes, we can leverage native RMA/atomics; otherwise, we fallback to AM path. This ensure correctness for operations that access to multiple attached segments.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
