### PR TITLE
ch4/am: fix async overwrite in MPIDIG_get_accumulate

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_recv_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv_utils.h
@@ -22,7 +22,7 @@
 /* caching recv buffer information */
 MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_type_init(MPI_Aint in_data_sz, MPIR_Request * rreq)
 {
-    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async.recv));
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->recv_async));
     p->recv_type = MPIDIG_RECV_DATATYPE;
     p->in_data_sz = in_data_sz;
 
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_type_init(MPI_Aint in_data_sz, MPIR_Re
 MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_init(int is_contig, MPI_Aint in_data_sz,
                                                void *data, MPI_Aint data_sz, MPIR_Request * rreq)
 {
-    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async.recv));
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->recv_async));
     p->in_data_sz = in_data_sz;
     if (is_contig) {
         p->recv_type = MPIDIG_RECV_CONTIG;
@@ -65,7 +65,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_convert_datatype(MPIR_Request * rreq);
 MPL_STATIC_INLINE_PREFIX void MPIDIG_get_recv_data(int *is_contig, void **p_data,
                                                    MPI_Aint * p_data_sz, MPIR_Request * rreq)
 {
-    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async.recv));
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->recv_async));
     if (p->recv_type == MPIDIG_RECV_DATATYPE) {
         MPIDIG_convert_datatype(rreq);
         MPIR_Assert(p->recv_type == MPIDIG_RECV_CONTIG || p->recv_type == MPIDIG_RECV_IOV);
@@ -85,7 +85,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_get_recv_data(int *is_contig, void **p_data
 /* Sometime the transport just need info to make algorithm choice */
 MPL_STATIC_INLINE_PREFIX int MPIDIG_get_recv_iov_count(MPIR_Request * rreq)
 {
-    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async.recv));
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->recv_async));
     if (p->recv_type == MPIDIG_RECV_DATATYPE) {
         MPI_Aint num_iov;
         MPIR_Typerep_iov_len(MPIDIG_REQUEST(rreq, count), MPIDIG_REQUEST(rreq, datatype),
@@ -102,7 +102,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_get_recv_iov_count(MPIR_Request * rreq)
 /* TODO: if transport flag callback, synchronous copy can/should be done inside the callback */
 MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_copy(void *in_data, MPIR_Request * rreq)
 {
-    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async.recv));
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->recv_async));
     MPI_Aint in_data_sz = p->in_data_sz;
     if (in_data_sz == 0) {
         /* otherwise if recv size = 0, it is at least a truncation error */
@@ -164,7 +164,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_copy(void *in_data, MPIR_Request * rre
 /* setup for asynchronous multi-segment data transfer (ref posix_progress) */
 MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_setup(MPIR_Request * rreq)
 {
-    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async.recv));
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->recv_async));
     p->offset = 0;
     if (p->recv_type == MPIDIG_RECV_DATATYPE) {
         /* it's ready, rreq status to be set */
@@ -200,7 +200,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_setup(MPIR_Request * rreq)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_recv_copy_seg(void *payload, MPI_Aint payload_sz,
                                                   MPIR_Request * rreq)
 {
-    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async.recv));
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->recv_async));
     p->in_data_sz -= payload_sz;
 
     if (rreq->status.MPI_ERROR) {
@@ -270,7 +270,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_convert_datatype(MPIR_Request * rreq)
     MPIDI_Datatype_get_info(MPIDIG_REQUEST(rreq, count), MPIDIG_REQUEST(rreq, datatype),
                             dt_contig, data_sz, dt_ptr, dt_true_lb);
 
-    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async.recv));
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->recv_async));
     if (dt_contig) {
         p->recv_type = MPIDIG_RECV_CONTIG;
         p->iov_one.iov_base = (char *) MPIDIG_REQUEST(rreq, buffer) + dt_true_lb;

--- a/src/mpid/ch4/generic/am/mpidig_am_send_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_send_utils.h
@@ -14,7 +14,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_am_send_async_init(MPIR_Request * sreq, MPI
                                                         MPI_Aint data_sz)
 {
     int c;
-    MPIDIG_sreq_async_t *send_async = &MPIDIG_REQUEST(sreq, req->async.send);
+    MPIDIG_sreq_async_t *send_async = &MPIDIG_REQUEST(sreq, req->send_async);
     send_async->datatype = datatype;
     send_async->data_sz_left = data_sz;
     send_async->offset = 0;
@@ -32,24 +32,24 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_am_send_async_init(MPIR_Request * sreq, MPI
 
 MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDIG_am_send_async_get_data_sz_left(MPIR_Request * sreq)
 {
-    return MPIDIG_REQUEST(sreq, req->async.send).data_sz_left;
+    return MPIDIG_REQUEST(sreq, req->send_async).data_sz_left;
 }
 
 MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDIG_am_send_async_get_offset(MPIR_Request * sreq)
 {
-    return MPIDIG_REQUEST(sreq, req->async.send).offset;
+    return MPIDIG_REQUEST(sreq, req->send_async).offset;
 }
 
 MPL_STATIC_INLINE_PREFIX bool MPIDIG_am_send_async_is_done(MPIR_Request * sreq)
 {
-    return MPIDIG_REQUEST(sreq, req->async.send).data_sz_left == 0;
+    return MPIDIG_REQUEST(sreq, req->send_async).data_sz_left == 0;
 }
 
 /* indicating one segment is issued, update counter with actual send_size */
 MPL_STATIC_INLINE_PREFIX void MPIDIG_am_send_async_issue_seg(MPIR_Request * sreq,
                                                              MPI_Aint send_size)
 {
-    MPIDIG_sreq_async_t *send_async = &MPIDIG_REQUEST(sreq, req->async.send);
+    MPIDIG_sreq_async_t *send_async = &MPIDIG_REQUEST(sreq, req->send_async);
     send_async->data_sz_left -= send_size;
     MPIR_Assert(send_async->data_sz_left >= 0);
     send_async->offset += send_size;
@@ -68,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_am_send_async_issue_seg(MPIR_Request * sreq
 MPL_STATIC_INLINE_PREFIX bool MPIDIG_am_send_async_finish_seg(MPIR_Request * sreq)
 {
     bool is_done = false;
-    MPIDIG_sreq_async_t *send_async = &MPIDIG_REQUEST(sreq, req->async.send);
+    MPIDIG_sreq_async_t *send_async = &MPIDIG_REQUEST(sreq, req->send_async);
     send_async->seg_completed += 1;
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     (MPL_DBG_FDEST,

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -185,10 +185,8 @@ typedef struct MPIDIG_req_ext_t {
         MPIDIG_acc_req_t areq;
     };
 
-    union {
-        MPIDIG_rreq_async_t recv;
-        MPIDIG_sreq_async_t send;
-    } async;
+    MPIDIG_rreq_async_t recv_async;
+    MPIDIG_sreq_async_t send_async;
     struct iovec *iov;
     MPIDIG_req_cmpl_cb target_cmpl_cb;
     uint64_t seq_no;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -418,7 +418,7 @@ MPL_STATIC_INLINE_PREFIX void do_long_am_recv_unpack(MPI_Aint in_data_sz, MPIR_R
     p->src_offset = lmt_msg->src_offset;
     MPL_gpu_malloc_host(&p->unpack_buffer, pack_size);
 
-    MPI_Aint remain = MPIDIG_REQUEST(rreq, req->async.recv).in_data_sz;
+    MPI_Aint remain = MPIDIG_REQUEST(rreq, req->recv_async).in_data_sz;
     p->pack_size = pack_size;
     if (p->pack_size > remain) {
         p->pack_size = remain;
@@ -432,8 +432,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_lmt_unpack_event(MPIR_Request * rreq)
 {
     MPIDI_OFI_lmt_unpack_t *p = &MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_u.unpack);
     int ret = MPIDIG_recv_copy_seg(p->unpack_buffer, p->pack_size, rreq);
-    MPI_Aint remain = MPIDIG_REQUEST(rreq, req->async.recv).in_data_sz;
-    MPI_Aint offset = MPIDIG_REQUEST(rreq, req->async.recv).offset;
+    MPI_Aint remain = MPIDIG_REQUEST(rreq, req->recv_async).in_data_sz;
+    MPI_Aint offset = MPIDIG_REQUEST(rreq, req->recv_async).offset;
 
     if (!ret && remain) {
         /* more to go */


### PR DESCRIPTION
## Pull Request Description

Send and recv async structure should not share a union becuase for AM
get accumulate, the same request is used for sending and receiving. The
receiving operation would overwrite the send async data.

Here is the case of how it happens, the ACK of GET_ACC may come back
before the sending is locally completed. This is possible if the send is
pipelined, the data on segments may have arrived on target process but
those segments are still waiting for local completion. Since the target
process already have the data, it will proceed with accumulate and send
back the ACK data. When using OFI netmod, the cq_read may return the
event for the incoming ACK data before the local completion of pipeline
send, therefore triggers the GET_ACC_ACK callback to init the request
for receiving by setting the recv async structure which overwrite the
send async structure that is still needed for the local completion of
sends.

## Reference
Bug introduced in PR #4739 
Jenkins tests with intermittent failures: : https://github.com/pmodels/mpich/pull/4798#issuecomment-697079208

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
