### PR TITLE
ch4: Adding data_sz to am_hdr and stop transport from sending total data size

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -109,6 +109,7 @@ typedef struct MPIDIG_put_req_t {
     MPI_Datatype origin_datatype;
     void *target_addr;
     MPI_Datatype target_datatype;
+    MPI_Aint origin_data_sz;
 } MPIDIG_put_req_t;
 
 typedef struct MPIDIG_get_req_t {

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -28,7 +28,8 @@
 #define MPIDI_OFI_AM_HANDLER_ID_BITS   8
 #define MPIDI_OFI_AM_TYPE_BITS         8
 #define MPIDI_OFI_AM_HDR_SZ_BITS       8
-#define MPIDI_OFI_AM_DATA_SZ_BITS     48
+#define MPIDI_OFI_AM_PAYLOAD_SZ_BITS  24
+#define MPIDI_OFI_AM_SEQ_NO_BITS      16
 #define MPIDI_OFI_AM_RANK_BITS        32
 #define MPIDI_OFI_AM_MSG_HEADER_SIZE (sizeof(MPIDI_OFI_am_header_t))
 
@@ -70,6 +71,7 @@ typedef struct {
     MPIR_Request *sreq_ptr;
     uint64_t am_hdr_src;
     uint64_t rma_key;
+    MPI_Aint reg_sz;
 } MPIDI_OFI_lmt_msg_payload_t;
 
 typedef struct {
@@ -80,10 +82,12 @@ typedef struct MPIDI_OFI_am_header_t {
     uint64_t handler_id:MPIDI_OFI_AM_HANDLER_ID_BITS;
     uint64_t am_type:MPIDI_OFI_AM_TYPE_BITS;
     uint64_t am_hdr_sz:MPIDI_OFI_AM_HDR_SZ_BITS;
-    uint64_t data_sz:MPIDI_OFI_AM_DATA_SZ_BITS;
-    int32_t seg_sz;             /* size of current pipeline segment */
-    uint16_t seqno;             /* Sequence number of this message.
-                                 * Number is unique to (fi_src_addr, fi_dest_addr) pair. */
+    uint64_t payload_sz:MPIDI_OFI_AM_PAYLOAD_SZ_BITS;   /* data size on this OFI message. This
+                                                         * could be the size of a pipeline segment
+                                                         * */
+    uint16_t seqno:MPIDI_OFI_AM_SEQ_NO_BITS;    /* Sequence number of this message.
+                                                 * Number is unique to (fi_src_addr,
+                                                 * fi_dest_addr) pair. */
     fi_addr_t fi_src_addr;      /* OFI address of the sender */
 } MPIDI_OFI_am_header_t;
 

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -14,7 +14,8 @@
 #define MPIDI_POSIX_AM_KIND_BITS  (1)   /* 0 or 1 */
 #define MPIDI_POSIX_AM_HANDLER_ID_BITS  (7)     /* up to 64 */
 #define MPIDI_POSIX_AM_HDR_SZ_BITS      (8)
-#define MPIDI_POSIX_AM_DATA_SZ_BITS     (48)
+#define MPIDI_POSIX_AM_TYPE_BITS     (8)
+#define MPIDI_POSIX_AM_UNUSED_BITS     (40)
 
 #define MPIDI_POSIX_AM_MSG_HEADER_SIZE  (sizeof(MPIDI_POSIX_am_header_t))
 #define MPIDI_POSIX_MAX_IOV_NUM         (3)     /* am_hdr, [padding], payload */
@@ -29,6 +30,12 @@ typedef enum {
     MPIDI_POSIX_EAGER_RECV_POSTED_HOOK_STATE_REGISTERED,
     MPIDI_POSIX_EAGER_RECV_POSTED_HOOK_STATE_FINALIZED
 } MPIDI_POSIX_EAGER_recv_posted_hook_state_t;
+
+typedef enum {
+    MPIDI_POSIX_AM_TYPE__HDR,
+    MPIDI_POSIX_AM_TYPE__SHORT,
+    MPIDI_POSIX_AM_TYPE__PIPELINE
+} MPIDI_POSIX_am_type_t;
 
 struct MPIR_Request;
 
@@ -61,7 +68,8 @@ typedef struct MPIDI_POSIX_am_header {
     MPIDI_POSIX_am_header_kind_t kind:MPIDI_POSIX_AM_KIND_BITS;
     uint32_t handler_id:MPIDI_POSIX_AM_HANDLER_ID_BITS;
     uint64_t am_hdr_sz:MPIDI_POSIX_AM_HDR_SZ_BITS;
-    uint64_t data_sz:MPIDI_POSIX_AM_DATA_SZ_BITS;
+    uint64_t am_type:MPIDI_POSIX_AM_TYPE_BITS;
+    uint64_t unused:MPIDI_POSIX_AM_UNUSED_BITS;
 } MPIDI_POSIX_am_header_t;
 
 typedef struct MPIDI_POSIX_am_request_header {

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -100,6 +100,7 @@ typedef struct MPIDIG_put_msg_t {
     MPI_Aint target_datatype;
     MPI_Aint target_true_lb;
     int flattened_sz;
+    MPI_Aint origin_data_sz;
 } MPIDIG_put_msg_t;
 
 typedef struct MPIDIG_put_dt_ack_msg_t {
@@ -133,6 +134,7 @@ typedef struct MPIDIG_get_msg_t {
 
 typedef struct MPIDIG_get_ack_msg_t {
     MPIR_Request *greq_ptr;
+    MPI_Aint target_data_sz;
 } MPIDIG_get_ack_msg_t;
 
 typedef struct MPIDIG_cswap_req_msg_t {
@@ -157,7 +159,7 @@ typedef struct MPIDIG_acc_req_msg_t {
     MPI_Datatype target_datatype;
     MPI_Op op;
     MPI_Aint target_disp;
-    uint64_t result_data_sz;
+    MPI_Aint result_data_sz;
     int n_iov;
     int flattened_sz;
 } MPIDIG_acc_req_msg_t;

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -83,6 +83,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
     }
     am_hdr.preq_ptr = sreq;
     am_hdr.win_id = MPIDIG_WIN(win, win_id);
+    am_hdr.origin_data_sz = origin_data_sz;
 
     /* Increase local and remote completion counters and set the local completion
      * counter in request, thus it can be decreased at request completion. */


### PR DESCRIPTION
## Pull Request Description

The first commit adds data_sz which represents the total data size in a CH4 AM message into the am_hdr. This allows CH4 to have a reliable way to get the message size without relying on the transport to provide the total data size. Note the receiver might need to store the data_sz inside the request in the some usecases (RMA or SEND RNDV).

The second commit removes the total data size field from the ofi message header and replaced it with a payload size. This payload size only describes how much data is in the current message. For pipeline, this would be the segment size. For RDMA read this will be zero as it only send lmt_info. The lmt_info is added with a `data_sz`, but this is just temporary for the current implementation and will be removed once the ZCOPY support is added.

The third commit removes the total data size field from the POSIX message header. Since POSIX was using this field to determined whether a message is short or pipelined, we need to add an `am_type` after removing it.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
