### PR TITLE
config: unify behaviors in configuring external libraries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,12 +3,12 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
-ACLOCAL_AMFLAGS = -I confdb -I modules/hwloc/config
+ACLOCAL_AMFLAGS = -I confdb
 
 # automake requires that we initialize variables to something, even just empty,
 # before appending to them with "+="
-AM_CFLAGS = @VISIBILITY_CFLAGS@ @HWLOC_EMBEDDED_CFLAGS@
-AM_CPPFLAGS = @HWLOC_EMBEDDED_CPPFLAGS@
+AM_CFLAGS = @VISIBILITY_CFLAGS@
+AM_CPPFLAGS =
 AM_FFLAGS =
 AM_FCFLAGS =
 include_HEADERS =
@@ -49,7 +49,7 @@ pkgconfigdir = @pkgconfigdir@
 errnames_txt_files = 
 
 external_subdirs = @mplsrcdir@ @zmsrcdir@ @hwlocsrcdir@ @jsonsrcdir@ @yaksasrcdir@
-external_ldflags = @mpllibdir@ @zmlibdir@ @hwloclibdir@ @netloclibdir@ @yaksalibdir@
+external_ldflags = @mpllibdir@ @zmlibdir@ @yaksalibdir@
 external_libs = @WRAPPER_LIBS@
 mpi_convenience_libs =
 pmpi_convenience_libs = @mpllib@ @zmlib@ @hwloclib@ @jsonlib@ @yaksalib@

--- a/confdb/aclocal_libs.m4
+++ b/confdb/aclocal_libs.m4
@@ -79,12 +79,20 @@ dnl macro (or equivalent logic) to be used before this macro is used.
 AC_DEFUN([PAC_CHECK_HEADER_LIB],[
     failure=no
     AC_CHECK_HEADER([$1],,failure=yes)
+    PAC_PUSH_FLAG(LIBS)
     AC_CHECK_LIB($2,$3,,failure=yes)
+    PAC_POP_FLAG(LIBS)
     if test "$failure" = "no" ; then
        $4
     else
        $5
     fi
+])
+
+dnl PAC_LIBS_ADD(libname)
+dnl Explicitly add -llibname to LIBS or WRAPPER_LIBS
+AC_DEFUN([PAC_LIBS_ADD], [
+    m4_ifdef([use_wrapper_flags],[PAC_APPEND_FLAG([$1],[WRAPPER_LIBS])],[PAC_APPEND_FLAG([$1],[LIBS])])
 ])
 
 dnl PAC_CHECK_HEADER_LIB_FATAL(with_option, header.h, libname, function)

--- a/confdb/aclocal_libs.m4
+++ b/confdb/aclocal_libs.m4
@@ -1,16 +1,25 @@
+dnl PAC_WITH_LIB_HELP_STRING(with_option)
+dnl internal macro for PAC_SET_HEADER_LIB_PATH
+AC_DEFUN([PAC_WITH_LIB_HELP_STRING], [
+    [specify path where $1 include directory and lib directory can be found.
+     Having this option explicitly requires the library. When PATH is not given,
+     it checks the library from system paths.]
+    m4_ifdef([$1_embedded_dir], [Pass "embedded" to force use of embedded version.])
+])
 
-dnl PAC_SET_HEADER_LIB_PATH(with_option,[default_path])
+dnl PAC_SET_HEADER_LIB_PATH(with_option)
 dnl This macro looks for the --with-xxx=, --with-xxx-include and --with-xxx-lib=
 dnl options and sets the library and include paths.
+dnl
+dnl If the library has an embedded version, m4_define xxx_embedded_dir to allow
+dnl embedded options.
 dnl
 dnl TODO as written, this macro cannot handle a "with_option" arg that has "-"
 dnl characters in it.  Use AS_TR_SH (and possibly AS_VAR_* macros) to handle
 dnl this case if it ever arises.
 AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
-    AC_ARG_WITH([$1],
-                [AC_HELP_STRING([--with-$1=[[PATH]]],
-                                [specify path where $1 include directory and lib directory can be found])],,
-                [with_$1=$2])
+    AC_ARG_WITH([$1], [AC_HELP_STRING([--with-$1=[[PATH]]],PAC_WITH_LIB_HELP_STRING($1))])
+
     AC_ARG_WITH([$1-include],
                 [AC_HELP_STRING([--with-$1-include=PATH],
                                 [specify path where $1 include directory can be found])],
@@ -32,6 +41,14 @@ AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
     # Now append -I/-L args to CPPFLAGS/LDFLAGS, with more specific options
     # taking priority
 
+    case "${with_$1}" in
+        embedded)
+            m4_ifndef([$1_embedded_dir],[AC_MSG_ERROR([embedded $1 is requested but we do not have the embedded version])])
+            ;;
+        yes|no)
+            # skip
+            ;;
+        *)
     AS_IF([test -n "${with_$1_include}"],
           [PAC_APPEND_FLAG([-I${with_$1_include}],[CPPFLAGS])],
           [AS_IF([test -n "${with_$1}"],
@@ -44,9 +61,11 @@ AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
                  dnl we are on a 32-bit host that happens to have both lib dirs available?
                  [PAC_APPEND_FLAG([-L${with_$1}/lib],[LDFLAGS])
                   AS_IF([test -d "${with_$1}/lib64"],
-		        [PAC_APPEND_FLAG([-L${with_$1}/lib64],[LDFLAGS])])
+                       [PAC_APPEND_FLAG([-L${with_$1}/lib64],[LDFLAGS])])
                  ])
           ])
+            ;;
+    esac
 ])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1003,21 +1003,15 @@ AC_ARG_VAR([MPLLIBNAME],[can be used to override the name of the MPL library (de
 MPLLIBNAME=${MPLLIBNAME:-"mpl"}
 export MPLLIBNAME
 AC_SUBST(MPLLIBNAME)
-AC_ARG_WITH([mpl-prefix],
-            [AS_HELP_STRING([[--with-mpl-prefix[=DIR]]],
-                            [use the MPL library installed in DIR,
-                             rather than the one included in src/mpl.  Pass
-                             "embedded" to force usage of the MPL source
-                             distributed with MPICH.])],
-            [],dnl action-if-given
-            [with_mpl_prefix=embedded]) dnl action-if-not-given
 mplsrcdir=""
 AC_SUBST([mplsrcdir])
 mpllibdir=""
 AC_SUBST([mpllibdir])
 mpllib=""
 AC_SUBST([mpllib])
-if test "$with_mpl_prefix" = "embedded" ; then
+m4_define([mpl_embedded_dir],[src/mpl])
+PAC_CHECK_HEADER_LIB_EXPLICIT([mpl],[mplconfig.h],[$MPLLIBNAME],[mpl_str_get_int_arg])
+if test "$with_mpl" = "embedded" ; then
     # no need for libtool versioning when embedding MPL
     mpl_subdir_args="--disable-versioning --enable-embedded"
     PAC_CONFIG_SUBDIR_ARGS([src/mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
@@ -1026,15 +1020,6 @@ if test "$with_mpl_prefix" = "embedded" ; then
 
     mplsrcdir="src/mpl"
     mpllib="src/mpl/lib${MPLLIBNAME}.la"
-else
-    # The user specified an already-installed MPL; just sanity check, don't
-    # subconfigure it
-    AS_IF([test -s "${with_mpl_prefix}/include/mplconfig.h"],
-          [:],[AC_MSG_ERROR([the MPL installation in "${with_mpl_prefix}" appears broken])])
-    PAC_APPEND_FLAG([-I${with_mpl_prefix}/include],[CPPFLAGS])
-    PAC_PREPEND_FLAG([-l${MPLLIBNAME}],[WRAPPER_LIBS])
-    PAC_APPEND_FLAG([-L${with_mpl_prefix}/lib],[WRAPPER_LDFLAGS])
-    mpllibdir="-L${with_mpl_prefix}/lib"
 fi
 
 # Izem
@@ -1048,16 +1033,6 @@ AC_ARG_VAR([ZMLIBNAME],[can be used to override the name of the Izem library (de
 ZMLIBNAME=${ZMLIBNAME:-"zm"}
 export ZMLIBNAME
 AC_SUBST(ZMLIBNAME)
-AC_ARG_WITH([zm-prefix],
-[  --with-zm-prefix@<:@=ARG@:>@
-                          specify the Izem library to use. No argument implies "yes".
-                          Accepted values for ARG are:
-                          yes|embedded - use the embedded Izem
-                          system       - search system paths for an Izem installation
-                          no           - disable Izem
-                          <PATH>       - use the Izem at PATH],,
-[with_zm_prefix=no])
-
 zmsrcdir=""
 AC_SUBST([zmsrcdir])
 zmlibdir=""
@@ -1065,8 +1040,10 @@ AC_SUBST([zmlibdir])
 zmlib=""
 AC_SUBST([zmlib])
 
+m4_define([zm_embedded_dir],[modules/izem])
+PAC_CHECK_HEADER_LIB_EXPLICIT([zm],[lock/zm_ticket.h],[$ZMLIBNAME],[zm_ticket_init])
 if test "$enable_izem_queue" != "no" && test "$enable_izem_queue" != "none"; then
-    if test "$with_zm_prefix" = "yes" || test "$with_zm_prefix" = "embedded"; then
+    if test "$with_zm" = "embedded" ; then
         if test -e "${use_top_srcdir}/modules/izem" ; then
             zm_subdir_args="--enable-embedded"
             PAC_CONFIG_SUBDIR_ARGS([modules/izem],[$zm_subdir_args],[],[AC_MSG_ERROR(Izem configure failed)])
@@ -1077,45 +1054,6 @@ if test "$enable_izem_queue" != "no" && test "$enable_izem_queue" != "none"; the
         else
             AC_MSG_WARN([Attempted to use the embedded Izem source tree in "modules/izem", but it is missing.  Configuration or compilation may fail later.])
         fi
-    elif test "$with_zm_prefix" = "system"; then
-        # check if an Izem installation exists on this system
-        PAC_PUSH_FLAG([LIBS])
-        PAC_PREPEND_FLAG([-l${ZMLIBNAME}],[LIBS])
-        AC_LINK_IFELSE([AC_LANG_PROGRAM([#include "lock/zm_ticket.h"
-                                        ],
-                                        [zm_ticket_t lock;
-                                         zm_ticket_init(&lock);
-                                         zm_ticket_acquire(&lock);
-                                         zm_ticket_release(&lock);])],
-                       [AC_MSG_ERROR([No usable Izem installation was found on this system])],
-                       [PAC_PREPEND_FLAG([-l${ZMLIBNAME}],[WRAPPER_LIBS])])
-        PAC_POP_FLAG([LIBS])
-    elif test "$with_zm_prefix" = "no"; then
-        AC_MSG_ERROR([Izem features were requested with --enable-izem but Izem was disabled.])
-    else
-        # The user specified an already-installed Izem; just sanity check, don't
-        # subconfigure it
-
-        AS_IF([test -s "${with_zm_prefix}/include/lock/zm_lock.h" -a -s "${with_zm_prefix}/include/cond/zm_cond.h"],
-              [:],[AC_MSG_ERROR([Izem headers at "${with_zm_prefix}/include" are missing])])
-        PAC_APPEND_FLAG([-I${with_zm_prefix}/include],[CPPFLAGS])
-
-        PAC_PUSH_FLAG([LIBS])
-        PAC_PUSH_FLAG([LDFLAGS])
-        PAC_PREPEND_FLAG([-l${ZMLIBNAME}],[LIBS])
-        PAC_APPEND_FLAG([-L${with_zm_prefix}/lib],[LDFLAGS])
-        AC_LINK_IFELSE([AC_LANG_PROGRAM([#include "lock/zm_ticket.h"
-                                        ],
-                                        [zm_ticket_t lock;
-                                         zm_ticket_init(&lock);
-                                         zm_ticket_acquire(&lock);
-                                         zm_ticket_release(&lock);])],
-                       [],[AC_MSG_ERROR([The Izem installation at "${with_zm_prefix}" seems broken])])
-        PAC_POP_FLAG([LIBS])
-        PAC_POP_FLAG([LDFLAGS])
-        PAC_APPEND_FLAG([-L${with_zm_prefix}/lib],[WRAPPER_LDFLAGS])
-        PAC_PREPEND_FLAG([-l${ZMLIBNAME}],[WRAPPER_LIBS])
-        zmlibdir="-L${with_zm_prefix}/lib"
     fi
 fi
 
@@ -1170,6 +1108,7 @@ hwloclib=""
 AC_SUBST([hwloclib])
 
 m4_define([hwloc_embedded_dir],[modules/hwloc])
+dnl minor difference from e.g. mpl and zm -- we'll prioritize system hwloc by default
 PAC_CHECK_HEADER_LIB_OPTIONAL([hwloc],[hwloc.h],[hwloc],[hwloc_topology_set_pid])
 PAC_CHECK_HEADER_LIB_OPTIONAL([netloc],[netloc.h],[netloc],[netloc_get_all_host_nodes])
 if test "$pac_have_hwloc" = "no" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -271,6 +271,10 @@ PAC_PREFIX_ALL_FLAGS(USER)
 # added to the MPICH wrappers (mpicc and friends) as well.
 PAC_PREFIX_ALL_FLAGS(WRAPPER)
 
+# confdb routines are used in multiple components. Let the macros know
+# whether WRAPPER FLAGS are used.
+m4_define([use_wrapper_flags], [1])
+
 # MPICH_MPIx_FLAGS are used by mpicc and friends.  They are like
 # WRAPPER flags, but these are provided by the user.
 AC_SUBST(MPICH_MPICC_CPPFLAGS)
@@ -1616,10 +1620,8 @@ if test -n "${with_pmix}" -a "${with_pmix}" != "no" ; then
     if test "${device_name}" != "ch4" ; then
         AC_MSG_ERROR([$device_name does not support PMIx])
     fi
-    PAC_PUSH_FLAG([LIBS])
     PAC_CHECK_HEADER_LIB_FATAL(pmix, pmix.h, pmix, PMIx_Init)
-    PAC_APPEND_FLAG([-lpmix],[WRAPPER_LIBS])
-    PAC_POP_FLAG([LIBS])
+    PAC_LIBS_ADD([-lpmix])
     AC_DEFINE(USE_PMIX_API, 1, [Define if PMIx API must be used])
 fi
 
@@ -4778,10 +4780,8 @@ fi
 AC_ARG_ENABLE(checkpointing,
     [AC_HELP_STRING([--enable-checkpointing], [Enable application checkpointing])],
     [ if test "$enableval" != "no" ; then
-	PAC_PUSH_FLAG([LIBS])
 	PAC_CHECK_HEADER_LIB_FATAL(blcr, libcr.h, cr, cr_init)
-	PAC_APPEND_FLAG([-lcr],[WRAPPER_LIBS])
-	PAC_POP_FLAG([LIBS])
+	PAC_LIBS_ADD([-lcr])
         AC_DEFINE(ENABLE_CHECKPOINTING,1,[Application checkpointing enabled])
       fi ],
 )

--- a/configure.ac
+++ b/configure.ac
@@ -1613,15 +1613,14 @@ else
     # Make device_name available to subdirs
 fi
 
-if test -n "${with_pmix}" -a "${with_pmix}" != "no" ; then
+PAC_CHECK_HEADER_LIB_EXPLICIT(pmix, pmix.h, pmix, PMIx_Init)
+if test "$pac_have_pmix" = "yes" ; then
     # disable built-in PMI and process managers
     with_pmi="no"
     with_pm="no"
     if test "${device_name}" != "ch4" ; then
         AC_MSG_ERROR([$device_name does not support PMIx])
     fi
-    PAC_CHECK_HEADER_LIB_FATAL(pmix, pmix.h, pmix, PMIx_Init)
-    PAC_LIBS_ADD([-lpmix])
     AC_DEFINE(USE_PMIX_API, 1, [Define if PMIx API must be used])
 fi
 
@@ -4781,7 +4780,6 @@ AC_ARG_ENABLE(checkpointing,
     [AC_HELP_STRING([--enable-checkpointing], [Enable application checkpointing])],
     [ if test "$enableval" != "no" ; then
 	PAC_CHECK_HEADER_LIB_FATAL(blcr, libcr.h, cr, cr_init)
-	PAC_LIBS_ADD([-lcr])
         AC_DEFINE(ENABLE_CHECKPOINTING,1,[Application checkpointing enabled])
       fi ],
 )

--- a/configure.ac
+++ b/configure.ac
@@ -1162,105 +1162,38 @@ PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/json-c],[CPPFLAGS])
 PAC_APPEND_FLAG([-I${main_top_builddir}/modules/json-c],[CPPFLAGS])
 
 # ----------------------------------------------------------------------------
-# HWLOC
+# HWLOC / NETLOC
 # ----------------------------------------------------------------------------
-# Allow the user to override the hwloc location (from embedded to user
-# or system path)
-PAC_CHECK_PREFIX(hwloc)
 hwlocsrcdir=""
 AC_SUBST([hwlocsrcdir])
-hwloclibdir=""
-AC_SUBST([hwloclibdir])
 hwloclib=""
 AC_SUBST([hwloclib])
 
-if test "$with_hwloc_prefix" = "no" ; then
-   have_hwloc=no
-elif test "$with_hwloc_prefix" = "embedded" ; then
-   # Disable visibility when setting up hwloc
-   PAC_PUSH_FLAG([enable_visibility])
-   enable_visibility=no;
-   HWLOC_SETUP_CORE([modules/hwloc],[have_hwloc=yes],[have_hwloc=no],[1])
-   if test "$have_hwloc" = "yes" ; then
-      hwlocsrcdir="modules/hwloc"
-      hwloclib="$HWLOC_EMBEDDED_LDADD"
-      PAC_PREPEND_FLAG([$HWLOC_EMBEDDED_LIBS], [WRAPPER_LIBS])
-      PAC_APPEND_FLAG([$HWLOC_EMBEDDED_LDFLAGS], [WRAPPER_LDFLAGS])
-      # if possible, do not expose hwloc symbols in libmpi.so
-      PAC_PREPEND_FLAG([$VISIBILITY_CFLAGS], [HWLOC_CFLAGS])
-   fi
-   PAC_POP_FLAG([enable_visibility])
-else
-   AC_CHECK_HEADERS([hwloc.h])
-   PAC_PUSH_FLAG([LIBS])
-   # hwloc_topology_set_pid was added in hwloc-1.0.0, which is our
-   # minimum required version
-   AC_CHECK_LIB([hwloc],[hwloc_topology_set_pid])
-   PAC_POP_FLAG([LIBS])
-   AC_MSG_CHECKING([if non-embedded hwloc works])
-   if test "$ac_cv_header_hwloc_h" = "yes" -a "$ac_cv_lib_hwloc_hwloc_topology_set_pid" = "yes" ; then
-      have_hwloc=yes
-      PAC_PREPEND_FLAG([-lhwloc], [WRAPPER_LIBS])
-   else
-      have_hwloc=no
-   fi
-   AC_MSG_RESULT([$have_hwloc])
-
-   # FIXME: Disable hwloc on Cygwin for now. The hwloc package,
-   # atleast as of 1.0.2, does not install correctly on Cygwin
-   AS_CASE([$host], [*-*-cygwin], [have_hwloc=no])
-
-   if test "$have_hwloc" = "yes" ; then
-      if test -d ${with_hwloc_prefix}/lib64 ; then
-         PAC_APPEND_FLAG([-L${with_hwloc_prefix}/lib64],[WRAPPER_LDFLAGS])
-      else
-         PAC_APPEND_FLAG([-L${with_hwloc_prefix}/lib],[WRAPPER_LDFLAGS])
-      fi
-   fi
+m4_define([hwloc_embedded_dir],[modules/hwloc])
+PAC_CHECK_HEADER_LIB_OPTIONAL([hwloc],[hwloc.h],[hwloc],[hwloc_topology_set_pid])
+PAC_CHECK_HEADER_LIB_OPTIONAL([netloc],[netloc.h],[netloc],[netloc_get_all_host_nodes])
+if test "$pac_have_hwloc" = "no" ; then
+    with_hwloc=embedded
+    pac_have_hwloc=yes
+    dnl TODO: check and configure embedded netloc
 fi
 
-if test "$have_hwloc" = "yes" ; then
-   AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
+if test "$with_hwloc" = "embedded" ; then
+    PAC_PUSH_FLAG([CFLAGS])
+    CFLAGS="$VISIBILITY_CFLAGS"
+    PAC_CONFIG_SUBDIR_ARGS([modules/hwloc], [--enable-embedded-mode --disable-visibility],[], [AC_MSG_ERROR(embedded hwloc configure failed)])
+    PAC_POP_FLAG([CFLAGS])
+    hwlocsrcdir="${main_top_builddir}/modules/hwloc"
+    hwloclib="${main_top_builddir}/modules/hwloc/hwloc/libhwloc_embedded.la"
+    PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/hwloc/include],[CPPFLAGS])
+    PAC_APPEND_FLAG([-I${main_top_builddir}/modules/hwloc/include],[CPPFLAGS])
 fi
 
-HWLOC_DO_AM_CONDITIONALS
-
-# ----------------------------------------------------------------------------
-# NETLOC
-# ----------------------------------------------------------------------------
-AC_ARG_WITH([netloc-prefix],
-            [AS_HELP_STRING([[--with-netloc-prefix[=DIR]]],
-                            [use the NETLOC library installed in DIR]) or system to use the system library], [],
-                            [with_netloc_prefix=no])
-
-netloclibdir=""
-AC_SUBST([netloclibdir])
-
-if test "$have_hwloc" = "yes" ; then
-    if test "${with_netloc_prefix}" != "no" ; then
-        if test "${with_netloc_prefix}" != "system"; then
-            # The user specified an already-installed Netloc; just sanity check,
-            # don't subconfigure it
-            AS_IF([test -s "${with_netloc_prefix}/include/netloc.h"],
-              [:],[AC_MSG_ERROR([the Netloc installation in "${with_netloc_prefix}" appears broken])])
-            PAC_APPEND_FLAG([-I${with_netloc_prefix}/include],[CPPFLAGS])
-            PAC_APPEND_FLAG([-I${with_netloc_prefix}/include],[CFLAGS])
-            PAC_PREPEND_FLAG([-lnetloc],[WRAPPER_LIBS])
-            if test -d ${with_netloc_prefix}/lib64 ; then
-                PAC_APPEND_FLAG([-L${with_netloc_prefix}/lib64],[WRAPPER_LDFLAGS])
-                netloclibdir="-L${with_netloc_prefix}/lib64"
-            else
-                PAC_APPEND_FLAG([-L${with_netloc_prefix}/lib],[WRAPPER_LDFLAGS])
-                netloclibdir="-L${with_netloc_prefix}/lib"
-            fi
-       else
-           AC_LINK_IFELSE([AC_LANG_PROGRAM([#include "netloc.h"
-                                   ],
-                                   [])],
-                          [AC_MSG_ERROR([the Netloc installation seems to be added from system path])], [])
-       fi
-       AC_DEFINE(HAVE_NETLOC,1,[Define if netloc is available in either user specified path or in system path])
-    fi
+if test "$pac_have_hwloc" = "yes" ; then
+    AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
+fi
+if test "$pac_have_netloc" = "yes" ; then
+    AC_DEFINE(HAVE_NETLOC,1,[Define if netloc is available])
 fi
 
 # ----------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -829,7 +829,6 @@ export LIBS
 export MPILIBNAME
 export PMPILIBNAME
 export OPALIBNAME
-export MPLLIBNAME
 # ----------------------------------------------------------------------------
 # with-device
 #
@@ -999,28 +998,22 @@ if test "$enable_extended_context_bits" = "yes" ; then
 fi
 
 # MPL
-AC_ARG_VAR([MPLLIBNAME],[can be used to override the name of the MPL library (default: "mpl")])
-MPLLIBNAME=${MPLLIBNAME:-"mpl"}
-export MPLLIBNAME
-AC_SUBST(MPLLIBNAME)
 mplsrcdir=""
 AC_SUBST([mplsrcdir])
 mpllibdir=""
 AC_SUBST([mpllibdir])
 mpllib=""
 AC_SUBST([mpllib])
-m4_define([mpl_embedded_dir],[src/mpl])
-PAC_CHECK_HEADER_LIB_EXPLICIT([mpl],[mplconfig.h],[$MPLLIBNAME],[mpl_str_get_int_arg])
-if test "$with_mpl" = "embedded" ; then
-    # no need for libtool versioning when embedding MPL
-    mpl_subdir_args="--disable-versioning --enable-embedded"
-    PAC_CONFIG_SUBDIR_ARGS([src/mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
-    PAC_APPEND_FLAG([-I${main_top_builddir}/src/mpl/include], [CPPFLAGS])
-    PAC_APPEND_FLAG([-I${use_top_srcdir}/src/mpl/include], [CPPFLAGS])
 
-    mplsrcdir="src/mpl"
-    mpllib="src/mpl/lib${MPLLIBNAME}.la"
-fi
+# NOTE: we only support embedded mpl now
+# no need for libtool versioning when embedding MPL
+mpl_subdir_args="--disable-versioning --enable-embedded"
+PAC_CONFIG_SUBDIR_ARGS([src/mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
+PAC_APPEND_FLAG([-I${main_top_builddir}/src/mpl/include], [CPPFLAGS])
+PAC_APPEND_FLAG([-I${use_top_srcdir}/src/mpl/include], [CPPFLAGS])
+
+mplsrcdir="src/mpl"
+mpllib="src/mpl/libmpl.la"
 
 # Izem
 

--- a/src/mpi/datatype/typerep/src/subconfigure.m4
+++ b/src/mpi/datatype/typerep/src/subconfigure.m4
@@ -35,15 +35,6 @@ AC_ARG_VAR([YAKSALIBNAME],[can be used to override the name of the YAKSA library
 YAKSALIBNAME=${YAKSALIBNAME:-"yaksa"}
 export YAKSALIBNAME
 AC_SUBST(YAKSALIBNAME)
-AC_ARG_WITH([yaksa-prefix],
-            [AS_HELP_STRING([[--with-yaksa-prefix[=DIR]]],
-                            [use the YAKSA library installed in DIR,
-                             rather than the one included in modules/yaksa.  Pass
-                             "embedded" to force usage of the YAKSA source
-                             distributed with MPICH.])],
-            [],dnl action-if-given
-            [with_yaksa_prefix=embedded]) dnl action-if-not-given
-
 yaksasrcdir=""
 AC_SUBST([yaksasrcdir])
 yaksalibdir=""
@@ -52,7 +43,9 @@ yaksalib=""
 AC_SUBST([yaksalib])
 
 AM_COND_IF([BUILD_YAKSA_ENGINE], [
-if test "$with_yaksa_prefix" = "embedded" ; then
+m4_define([yaksa_embedded_dir],[modules/yaksa])
+PAC_CHECK_HEADER_LIB_EXPLICIT([yaksa],[yaksa_config.h],[$YAKSALIBNAME],[yaksa_init])
+if test "$with_yaksa" = "embedded" ; then
     PAC_PUSH_ALL_FLAGS()
     PAC_RESET_ALL_FLAGS()
     # no need for libtool versioning when embedding YAKSA
@@ -64,15 +57,6 @@ if test "$with_yaksa_prefix" = "embedded" ; then
 
     yaksasrcdir="modules/yaksa"
     yaksalib="modules/yaksa/lib${YAKSALIBNAME}.la"
-else
-    # The user specified an already-installed YAKSA; just sanity check, don't
-    # subconfigure it
-    AS_IF([test -s "${with_yaksa_prefix}/include/yaksa.h"],
-          [:],[AC_MSG_ERROR([the YAKSA installation in "${with_yaksa_prefix}" appears broken])])
-    PAC_APPEND_FLAG([-I${with_yaksa_prefix}/include],[CPPFLAGS])
-    PAC_PREPEND_FLAG([-l${YAKSALIBNAME}],[WRAPPER_LIBS])
-    PAC_APPEND_FLAG([-L${with_yaksa_prefix}/lib],[WRAPPER_LDFLAGS])
-    yaksalibdir="-L${with_yaksa_prefix}/lib"
 fi
 ])
 

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/subconfigure.m4
@@ -14,10 +14,7 @@ AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
 AM_COND_IF([BUILD_NEMESIS_NETMOD_OFI],[
     AC_MSG_NOTICE([RUNNING CONFIGURE FOR ch3:nemesis:ofi])
 
-    PAC_PUSH_FLAG(LIBS)
     PAC_CHECK_HEADER_LIB_FATAL(ofi, rdma/fabric.h, fabric, fi_getinfo)
-    PAC_APPEND_FLAG([-lfabric],[WRAPPER_LIBS])
-    PAC_POP_FLAG(LIBS)
 
     AC_DEFINE([ENABLE_COMM_OVERRIDES], 1, [define to add per-vc function pointers to override send and recv functions])
 ])dnl end AM_COND_IF(BUILD_NEMESIS_NETMOD_OFI,...)

--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -36,11 +36,6 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
     ofilib=""
     AC_SUBST([ofilib])
 
-    ofi_embedded=""
-    if test $have_libfabric = no ; then
-        ofi_embedded="yes"
-    fi
-
     runtime_capabilities="no"
     no_providers="no"
     # $netmod_args - contains the OFI provider
@@ -263,7 +258,11 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         esac
     fi
 
-    if test "${ofi_embedded}" = "yes" ; then
+    if test "$pac_have_libfabric" = "no" ; then
+        with_libfabric=embedded
+    fi
+    if test "$with_libfabric" = "embedded" ; then
+        ofi_embedded="yes"
         AC_MSG_NOTICE([CH4 OFI Netmod:  Using an embedded libfabric])
         ofi_subdir_args="--enable-embedded"
 
@@ -314,7 +313,7 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         ofilib="modules/libfabric/src/libfabric.la"
     else
         AC_MSG_NOTICE([CH4 OFI Netmod:  Using an external libfabric])
-        PAC_APPEND_FLAG([-lfabric],[WRAPPER_LIBS])
+        PAC_LIBS_ADD([-lfabric])
     fi
 
     # check for libfabric depedence libs

--- a/src/mpid/ch4/netmod/ucx/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ucx/subconfigure.m4
@@ -26,12 +26,10 @@ AM_COND_IF([BUILD_CH4_NETMOD_UCX],[
     ucxlib=""
     AC_SUBST([ucxlib])
 
-    ucx_embedded=""
-    if test $have_ucx = no ; then
-        ucx_embedded="yes"
+    if test "$pac_have_ucx" = "no" ; then
+        with_ucx=embedded
     fi
-    
-    if test "${ucx_embedded}" = "yes" ; then
+    if test "$with_ucx" = "embedded" ; then
         PAC_PUSH_ALL_FLAGS()
         PAC_RESET_ALL_FLAGS()
         PAC_CONFIG_SUBDIR_ARGS([modules/ucx],[--disable-static --enable-embedded --with-java=no],[],[AC_MSG_ERROR(ucx configure failed)])
@@ -46,8 +44,9 @@ AM_COND_IF([BUILD_CH4_NETMOD_UCX],[
         have_ucp_put_nb=yes
         have_ucp_get_nb=yes
     else
-        PAC_APPEND_FLAG([-lucp -lucs],[WRAPPER_LIBS])
-
+        dnl PAC_PROBE_HEADER_LIB must've been successful
+        AC_MSG_NOTICE([CH4 UCX Netmod:  Using an external ucx])
+        PAC_LIBS_ADD([-lucp -lucs])
         # ucp_put_nb and ucp_get_nb are added only from ucx 1.4.
         PAC_CHECK_HEADER_LIB([ucp/api/ucp.h],[ucp],[ucp_put_nb], [have_ucp_put_nb=yes], [have_ucp_put_nb=no])
         PAC_CHECK_HEADER_LIB([ucp/api/ucp.h],[ucp],[ucp_get_nb], [have_ucp_get_nb=yes], [have_ucp_get_nb=no])

--- a/src/mpid/ch4/shm/ipc/xpmem/subconfigure.m4
+++ b/src/mpid/ch4/shm/ipc/xpmem/subconfigure.m4
@@ -15,12 +15,8 @@ AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
 AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
     AM_COND_IF([BUILD_SHM_IPC_XPMEM],[
         AC_MSG_NOTICE([RUNNING CONFIGURE FOR ch4:shm:xpmem])
-
-        PAC_SET_HEADER_LIB_PATH(xpmem)
-        PAC_PUSH_FLAG(LIBS)
-        PAC_CHECK_HEADER_LIB([xpmem.h],[xpmem],[xpmem_make],[have_xpmem=yes],[have_xpmem=no])
-        if test "${have_xpmem}" = "yes" ; then
-            PAC_APPEND_FLAG([-lxpmem],[WRAPPER_LIBS])
+        PAC_CHECK_HEADER_LIB_OPTIONAL([xpmem],[xpmem.h],[xpmem],[xpmem_make])
+        if test "$pac_have_xpmem" = "yes" ; then
             AC_DEFINE(MPIDI_CH4_SHM_ENABLE_XPMEM, 1, [Enable XPMEM shared memory submodule in CH4])
             if test "${build_ch4_shm_ipc_xpmem}" = "auto" ; then
                 AC_DEFINE([MPIDI_CH4_SHM_XPMEM_ALLOW_SILENT_FALLBACK],[1],
@@ -29,8 +25,7 @@ AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
         elif test "$build_ch4_shm_ipc_xpmem" = "yes" ; then
             AC_MSG_ERROR(['xpmem.h or libxpmem library not found.'])
         fi
-        PAC_POP_FLAG(LIBS)
-        AM_CONDITIONAL([BUILD_SHM_IPC_XPMEM],[test "$have_xpmem" = "yes"])
+        AM_CONDITIONAL([BUILD_SHM_IPC_XPMEM],[test "$pac_have_xpmem" = "yes"])
     ])dnl end AM_COND_IF(BUILD_SHM_IPC_XPMEM,...)
 ])dnl end _BODY
 

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -13,25 +13,11 @@ AM_CONDITIONAL([BUILD_CH4],[test "$device_name" = "ch4"])
 AM_COND_IF([BUILD_CH4],[
 AC_MSG_NOTICE([RUNNING PREREQ FOR CH4 DEVICE])
 
-# check availability of libfabric
-if test x"$with_libfabric" != x"embedded" ; then
-    PAC_SET_HEADER_LIB_PATH(libfabric)
-    PAC_PUSH_FLAG(LIBS)
-    PAC_CHECK_HEADER_LIB([rdma/fabric.h], [fabric], [fi_getinfo], [have_libfabric=yes], [have_libfabric=no])
-    PAC_POP_FLAG(LIBS)
-else
-    have_libfabric=no
-fi
-
-# check availability of ucx
-if test x"$with_ucx" != x"embedded" ; then
-    PAC_SET_HEADER_LIB_PATH(ucx)
-    PAC_PUSH_FLAG(LIBS)
-    PAC_CHECK_HEADER_LIB([ucp/api/ucp.h], [ucp], [ucp_config_read], [have_ucx=yes], [have_ucx=no])
-    PAC_POP_FLAG(LIBS)
-else
-    have_ucx=no
-fi
+# check availability of libfabric, ucx (for purpose of setting default)
+m4_define([libfabric_embedded_dir],[modules/libfabric])
+m4_define([ucx_embedded_dir],[modules/ucx])
+PAC_PROBE_HEADER_LIB(libfabric,[rdma/fabric.h], [fabric], [fi_getinfo])
+PAC_PROBE_HEADER_LIB(ucx,[ucp/api/ucp.h], [ucp], [ucp_config_read])
 
 # the CH4 device depends on the common NBC scheduler code
 build_mpid_common_sched=yes

--- a/src/mpid/common/hcoll/subconfigure.m4
+++ b/src/mpid/common/hcoll/subconfigure.m4
@@ -1,18 +1,8 @@
 [#] start of __file__
 
 AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
-	PAC_SET_HEADER_LIB_PATH(hcoll)
-	PAC_PUSH_FLAG(LIBS)
-	PAC_CHECK_HEADER_LIB([hcoll/api/hcoll_api.h],[hcoll],[hcoll_init],[have_hcoll=yes],[have_hcoll=no])
-	if test "${with_hcoll}" = "no" ; then
-	   have_hcoll=no;
-	elif test "${have_hcoll}" = "yes" ; then
-	   PAC_APPEND_FLAG([-lhcoll],[WRAPPER_LIBS])
-	elif test -n "${with_hcoll}" -o -n "${with_hcoll_lib}" -o -n "${with_hcoll_include}" ; then
-	   AC_MSG_ERROR(['hcoll/api/hcoll_api.h or libhcoll library not found.'])
-	fi
-	PAC_POP_FLAG(LIBS)
-	AM_CONDITIONAL([BUILD_HCOLL],[test "$have_hcoll" = "yes"])
+    PAC_CHECK_HEADER_LIB_OPTIONAL(hcoll,[hcoll/api/hcoll_api.h],[hcoll],[hcoll_init])
+    AM_CONDITIONAL([BUILD_HCOLL],[test "$pac_have_hcoll" = "yes"])
 ])dnl end PREREQ
 
 AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -982,26 +982,27 @@ AC_SUBST(libmpl_so_versionflags)
 #######################################################################
 have_gpu="no"
 # Check CUDA availability
-PAC_SET_HEADER_LIB_PATH([cuda])
-PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cudart=yes],[have_cudart=no])
-PAC_CHECK_HEADER_LIB([cuda.h],[cuda],[cuMemGetAddressRange],[have_cuda=yes],[have_cuda=no])
-if test "X${have_cudart}" = "Xyes" -a \
-    "X${have_cuda}" = "Xyes" ; then
+PAC_CHECK_HEADER_LIB_OPTIONAL([cuda],[cuda_runtime_api.h],[cudart],[cudaStreamSynchronize])
+if test "$pac_have_cuda" = "yes" ; then
+    # also require -lcuda (in addition to -lcudart)
+    PAC_CHECK_HEADER_LIB([cuda.h],[cuda],[cuMemGetAddressRange], pac_have_cuda=yes, pac_have_cuda=no)
+fi
+if test "X${pac_have_cuda}" = "Xyes" ; then
+    PAC_LIBS_ADD(-lcuda)
     AC_DEFINE([HAVE_CUDA],[1],[Define if CUDA is available])
     have_gpu="yes"
 fi
-AM_CONDITIONAL([MPL_HAVE_CUDA],[test "X${have_cudart}" = "Xyes" -a "X${have_cuda}" = "Xyes"])
+AM_CONDITIONAL([MPL_HAVE_CUDA],[test "X${pac_have_cuda}" = "Xyes"])
 
 if test "$have_gpu" = "no" ; then
     # Check Level Zero availability when no other GPU library is available
-    PAC_SET_HEADER_LIB_PATH([ze])
-    PAC_CHECK_HEADER_LIB([level_zero/ze_api.h],[ze_loader],[zeInit],[have_ze=yes],[have_ze=no])
-    if test "X${have_ze}" = "Xyes" ; then
+    PAC_CHECK_HEADER_LIB_OPTIONAL([ze],[level_zero/ze_api.h],[ze_loader],[zeInit])
+    if test "X${pac_have_ze}" = "Xyes" ; then
         AC_DEFINE([HAVE_ZE],[1],[Define if ZE is available])
         have_gpu="yes"
     fi
 fi
-AM_CONDITIONAL([MPL_HAVE_ZE],[test "X${have_ze}" = "Xyes"])
+AM_CONDITIONAL([MPL_HAVE_ZE],[test "X${pac_have_ze}" = "Xyes"])
 #######################################################################
 ## END OF GPU CODE
 #######################################################################

--- a/src/pm/hydra/Makefile.am
+++ b/src/pm/hydra/Makefile.am
@@ -3,11 +3,11 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
-external_subdirs = @mpl_srcdir@
-external_dist_subdirs = @mpl_dist_srcdir@
-external_includes = @mpl_includedir@
-external_ldflags = @mpl_libdir@
-external_libs = @mpl_lib@ @WRAPPER_LIBS@
+external_subdirs = @mpl_srcdir@ @hwloc_srcdir@
+external_dist_subdirs = @mpl_dist_srcdir@ @hwloc_srcdir@
+external_includes = @mpl_includedir@ @hwloc_includedir@
+external_ldflags =
+external_libs = @mpl_lib@ @hwloc_lib@ @WRAPPER_LIBS@
 
 bin_PROGRAMS =
 noinst_HEADERS =
@@ -16,7 +16,7 @@ EXTRA_DIST =
 SUFFIXES =
 doc1_src_txt =
 
-ACLOCAL_AMFLAGS = -I confdb -I tools/topo/hwloc/hwloc/config
+ACLOCAL_AMFLAGS = -I confdb
 AM_CPPFLAGS = -I$(top_srcdir)/include $(external_includes)
 AM_CFLAGS =
 

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -11,9 +11,6 @@ AC_INIT([Hydra], MPICH_VERSION_m4)
 AC_CONFIG_AUX_DIR(confdb)
 AC_CONFIG_MACRO_DIR(confdb)
 
-# needed by hwloc in embedded mode.  Must come very early to avoid
-# bizarre expansion ordering warnings
-AC_CANONICAL_TARGET
 AC_ARG_PROGRAM
 
 dnl must come before LT_INIT, which AC_REQUIREs AC_PROG_CC
@@ -25,15 +22,6 @@ AM_PROG_CC_C_O
 # also needed by hwloc in embedded mode, must also come early for expansion
 # ordering reasons
 AC_USE_SYSTEM_EXTENSIONS
-
-# Define -D_DARWIN_C_SOURCE on OS/X to ensure that hwloc will build even if we
-# are building under MPICH with --enable-strict that defined _POSIX_C_SOURCE.
-# Some standard Darwin headers don't build correctly under a strict posix
-# environment.
-AS_CASE([$host],
-    [*-*-darwin*], [PAC_APPEND_FLAG([-D_DARWIN_C_SOURCE],[CPPFLAGS])]
-)
-
 
 AM_INIT_AUTOMAKE([-Wall -Wno-portability-recursive -Werror foreign 1.12.3 subdir-objects])
 
@@ -142,25 +130,17 @@ AC_SUBST([mpl_srcdir])
 AC_SUBST(mpl_dist_srcdir)
 mpl_includedir=""
 AC_SUBST([mpl_includedir])
-mpl_libdir=""
-AC_SUBST([mpl_libdir])
 mpl_lib=""
 AC_SUBST([mpl_lib])
-if test "$with_mpl_prefix" = "embedded" ; then
+m4_define([mpl_embedded_dir],[mpl])
+PAC_CHECK_HEADER_LIB_EXPLICIT([mpl],[mplconfig.h],[$MPLLIBNAME],[mpl_str_get_int_arg])
+if test "$with_mpl" = "embedded" ; then
     mpl_srcdir="mpl"
     mpl_dist_srcdir="mpl"
     mpl_lib="mpl/lib${MPLLIBNAME}.la"
     mpl_subdir_args="--disable-versioning --enable-embedded"
     PAC_CONFIG_SUBDIR_ARGS([mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
     mpl_includedir='-I$(top_builddir)/mpl/include -I$(top_srcdir)/mpl/include'
-else
-    # The user specified an already-installed MPL; just sanity check, don't
-    # subconfigure it
-    AS_IF([test -s "${with_mpl_prefix}/include/mplconfig.h"],
-          [:],[AC_MSG_ERROR([the MPL installation in "${with_mpl_prefix}" appears broken])])
-    mpl_includedir="-I${with_mpl_prefix}/include"
-    mpl_libdir="-L${with_mpl_prefix}/lib"
-    mpl_lib="-l${MPLLIBNAME}"
 fi
 
 # Documentation
@@ -398,13 +378,6 @@ AC_MSG_RESULT($hydra_ui)
 AC_SUBST(hydra_ui)
 AM_CONDITIONAL([hydra_ui_mpich], [test $hydra_ui = "mpich"])
 
-
-#########################################################################
-# System hwloc
-#########################################################################
-PAC_CHECK_PREFIX(hwloc)
-
-
 #########################################################################
 # Processor Topology
 #########################################################################
@@ -416,33 +389,32 @@ AC_MSG_RESULT([$hydra_topolib_list])
 
 hydra_topolibs="`echo $hydra_topolib_list | sed -e 's/:/ /g' -e 's/,/ /g'`"
 
-have_hwloc=no
+hwloc_srcdir=""
+hwloc_includedir=""
+hwloc_lib=""
+AC_SUBST([hwloc_srcdir])
+AC_SUBST([hwloc_includedir])
+AC_SUBST([hwloc_lib])
+
 for hydra_topolib in ${hydra_topolibs}; do
     case "$hydra_topolib" in
 	hwloc)
-		if test "$with_hwloc_prefix" = "embedded" ; then
-		   HWLOC_SETUP_CORE([tools/topo/hwloc/hwloc],[have_hwloc=yes],[have_hwloc=no],[1])
-		   # Only build hwloc in embedded mode
-		   if test "$have_hwloc" = "yes" ; then
-		      hydra_use_embedded_hwloc=yes
-		   fi
-                else
-                    AC_CHECK_HEADERS([hwloc.h])
-                    # hwloc_topology_set_pid was added in hwloc-1.0.0, which is our minimum
-                    # required version
-                    AC_CHECK_LIB([hwloc],[hwloc_topology_set_pid])
-                    AC_MSG_CHECKING([if non-embedded hwloc works])
-                    if test "$ac_cv_header_hwloc_h" = "yes" -a "$ac_cv_lib_hwloc_hwloc_topology_set_pid" = "yes" ; then
-                        have_hwloc=yes
-                    fi
-                    AC_MSG_RESULT([$have_hwloc])
+                m4_define([hwloc_embedded_dir],[tools/topo/hwloc/hwloc])
+                PAC_CHECK_HEADER_LIB_OPTIONAL([hwloc],[hwloc.h],[hwloc],[hwloc_topology_set_pid])
+                if test "$pac_have_hwloc" = "no" ; then
+                    with_hwloc=embedded
+                    pac_have_hwloc=yes
+                fi
+		if test "$with_hwloc" = "embedded" ; then
+                    hydra_use_embedded_hwloc=yes
+                    PAC_CONFIG_SUBDIR_ARGS([tools/topo/hwloc/hwloc], [--enable-embedded-mode --disable-visibility],[], [AC_MSG_ERROR(embedded hwloc configure failed)])
+                    dnl Note that single quote is intentional to pass the variable as is
+                    hwloc_srcdir="tools/topo/hwloc/hwloc"
+                    hwloc_includedir='-I${srcdir}/${hwloc_srcdir}/include -I${builddir}/${hwloc_srcdir}/include'
+                    hwloc_lib='${builddir}/${hwloc_srcdir}/hwloc/libhwloc_embedded.la'
                 fi
 
-                # FIXME: Disable hwloc on Cygwin for now. The hwloc package, atleast as of 1.0.2,
-                # does not install correctly on Cygwin
-                AS_CASE([$host], [*-*-cygwin], [have_hwloc=no])
-
-		if test "$have_hwloc" = "yes" ; then
+		if test "$pac_have_hwloc" = "yes" ; then
 		   AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
 		   available_topolibs="$available_topolibs hwloc"
 		fi
@@ -472,9 +444,7 @@ else
    AC_DEFINE(HYDRA_DEFAULT_TOPOLIB,NULL,[Default processor topology library])
 fi
 
-HWLOC_DO_AM_CONDITIONALS
-AM_CONDITIONAL([HYDRA_HAVE_HWLOC], [test "${have_hwloc}" = "yes"])
-AM_CONDITIONAL([HYDRA_USE_EMBEDDED_HWLOC], [test "${hydra_use_embedded_hwloc}" = "yes"])
+AM_CONDITIONAL([HYDRA_HAVE_HWLOC], [test "${pac_have_hwloc}" = "yes"])
 
 AC_MSG_CHECKING([available processor topology libraries])
 AC_MSG_RESULT([$available_topolibs])

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -287,14 +287,9 @@ for hydra_bss_name in ${hydra_bss_names}; do
 	pbs)
 		hydra_bss_external=true
 		# Check if TM library support is available
-		PAC_SET_HEADER_LIB_PATH(pbs)
-		PAC_PUSH_FLAG(LIBS)
-		PAC_CHECK_HEADER_LIB(tm.h, torque, tm_init, have_pbs_launcher=yes,
-					   have_pbs_launcher=no)
-		PAC_POP_FLAG(LIBS)
-                if test "$have_pbs_launcher" = "yes" ; then
+		PAC_CHECK_HEADER_LIB_OPTIONAL(pbs, tm.h, torque, tm_init)
+                if test "$pac_have_pbs" = "yes" ; then
 		    available_launchers="$available_launchers pbs"
-		    PAC_APPEND_FLAG([-ltorque],[WRAPPER_LIBS])
                 fi
 		available_rmks="$available_rmks pbs"
 		;;
@@ -326,10 +321,10 @@ if test "$hydra_bss_persist" ; then
 fi
 
 ## Launchers
-if test "$have_pbs_launcher" = "yes" ; then
+if test "$pac_have_pbs" = "yes" ; then
    AC_DEFINE(HAVE_TM_H, 1, [Define if tm.h and library are usable.])
 fi
-AM_CONDITIONAL([hydra_pbs_launcher], [test "$have_pbs_launcher" = "yes"])
+AM_CONDITIONAL([hydra_pbs_launcher], [test "$pac_have_pbs" = "yes"])
 
 tmp_list=
 for hydra_launcher in ${available_launchers} ; do
@@ -488,9 +483,8 @@ AC_MSG_RESULT([$available_topolibs])
 # Slurm hostlist parsing
 #########################################################################
 AC_CHECK_HEADERS(slurm/slurm.h)
-AC_CHECK_LIB([slurm],[slurm_hostlist_create],have_libslurm=yes)
-if test "$have_libslurm" = "yes" -a "$ac_cv_header_slurm_slurm_h" = "yes" ; then
-    PAC_PREPEND_FLAG([-lslurm],[LIBS])
+PAC_CHECK_HEADER_LIB_OPTIONAL([libslurm],[slurm/slurm.h],[slurm],[slurm_hostlist_create])
+if test "$pac_have_libslurm" = "yes" ; then
     AC_DEFINE(HAVE_LIBSLURM,1,[Define if libslurm is available])
 fi
 

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -50,6 +50,9 @@ WRAPPER_LIBS=""
 export WRAPPER_LIBS
 AC_SUBST(WRAPPER_LIBS)
 
+# let confdb macro know that we are using WRAPPER FLAGS
+m4_define([use_wrapper_flags], [1])
+
 PAC_ARG_STRICT
 
 # Look for perl.  The absolute path of perl is required in hydra-doxygen.cfg.

--- a/src/pm/hydra/tools/topo/hwloc/Makefile.mk
+++ b/src/pm/hydra/tools/topo/hwloc/Makefile.mk
@@ -6,13 +6,3 @@
 libhydra_la_SOURCES += tools/topo/hwloc/topo_hwloc.c
 
 noinst_HEADERS += tools/topo/hwloc/topo_hwloc.h
-
-if HYDRA_USE_EMBEDDED_HWLOC
-AM_CPPFLAGS += @HWLOC_EMBEDDED_CPPFLAGS@
-AM_CFLAGS += @HWLOC_EMBEDDED_CFLAGS@
-
-# Append hwloc to the external subdirs, so it gets built first
-external_subdirs += tools/topo/hwloc/hwloc
-external_dist_subdirs += tools/topo/hwloc/hwloc
-external_libs += @HWLOC_EMBEDDED_LDADD@ @HWLOC_EMBEDDED_LIBS@
-endif

--- a/src/pm/hydra2/configure.ac
+++ b/src/pm/hydra2/configure.ac
@@ -50,6 +50,9 @@ WRAPPER_LIBS=""
 export WRAPPER_LIBS
 AC_SUBST(WRAPPER_LIBS)
 
+# let confdb macro know that we are using WRAPPER FLAGS
+m4_define([use_wrapper_flags], [1])
+
 PAC_ARG_STRICT
 
 # Look for perl.  The absolute path of perl is required in hydra-doxygen.cfg.

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -730,15 +730,14 @@ PAC_PUSH_FLAG([LDFLAGS])
 PAC_PUSH_FLAG([LIBS])
 
 # Check CUDA availability
-PAC_SET_HEADER_LIB_PATH([cuda])
-PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cuda=yes],[have_cuda=no])
+PAC_CHECK_HEADER_LIB_OPTIONAL([cuda],[cuda_runtime_api.h],[cudart],[cudaStreamSynchronize])
 cuda_CPPFLAGS=""
 cuda_LDFLAGS=""
 cuda_LIBS=""
-if test "X${have_cuda}" = "Xyes" ; then
+if test "X${pac_have_cuda}" = "Xyes" ; then
     AC_DEFINE([HAVE_CUDA],[1],[Define if CUDA is available])
     have_gpu="yes"
-    if test -n "${with_cuda}" ; then
+    if test -n "${with_cuda}" -a "$with_cuda" != "no" ; then
         cuda_CPPFLAGS="-I${with_cuda}/include"
         if test -d ${with_cuda}/lib64 ; then
             cuda_LDFLAGS="-L${with_cuda}/lib64 -L${with_cuda}/lib"
@@ -748,22 +747,21 @@ if test "X${have_cuda}" = "Xyes" ; then
         cuda_LIBS="-lcudart"
     fi
 fi
-AM_CONDITIONAL([HAVE_CUDA],[test "X${have_cuda}" = "Xyes"])
+AM_CONDITIONAL([HAVE_CUDA],[test "X${pac_have_cuda}" = "Xyes"])
 AC_SUBST([cuda_CPPFLAGS])
 AC_SUBST([cuda_LDFLAGS])
 AC_SUBST([cuda_LIBS])
 
 if test "$have_gpu" = "no" ; then
     # Check Level Zero availability when no other GPU library is available
-    PAC_SET_HEADER_LIB_PATH([ze])
-    PAC_CHECK_HEADER_LIB([level_zero/ze_api.h],[ze_loader],[zeInit],[have_ze=yes],[have_ze=no])
+    PAC_CHECK_HEADER_LIB_OPTIONAL([ze],[level_zero/ze_api.h],[ze_loader],[zeInit])
     ze_CPPFLAGS=""
     ze_LDFLAGS=""
     ze_LIBS=""
-    if test "X${have_ze}" = "Xyes" ; then
+    if test "X${pac_have_ze}" = "Xyes" ; then
         AC_DEFINE([HAVE_ZE],[1],[Define if ZE is available])
         have_gpu="yes"
-        if test -n "${with_ze}" ; then
+        if test -n "${with_ze}" -a "$with_ze" != "no" ; then
             ze_CPPFLAGS="-I${with_ze}/include"
             if test -d ${with_ze}/lib64 ; then
                 ze_LDFLAGS="-L${with_ze}/lib64 -L${with_ze}/lib"
@@ -777,7 +775,7 @@ if test "$have_gpu" = "no" ; then
     AC_SUBST([ze_LDFLAGS])
     AC_SUBST([ze_LIBS])
 fi
-AM_CONDITIONAL([HAVE_ZE],[test "X${have_ze}" = "Xyes"])
+AM_CONDITIONAL([HAVE_ZE],[test "X${pac_have_ze}" = "Xyes"])
 
 PAC_POP_FLAG([CPPFLAGS])
 PAC_POP_FLAG([LDFLAGS])

--- a/test/mpi/util/mtest_common.c
+++ b/test/mpi/util/mtest_common.c
@@ -369,7 +369,7 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
         device_id %= ndevices;
     } else if (type == MTEST_MEM_TYPE__SHARED) {
         cudaSetDevice(device_id);
-        cudaMallocManaged(devicebuf, size);
+        cudaMallocManaged(devicebuf, size, cudaMemAttachGlobal);
         if (hostbuf)
             *hostbuf = *devicebuf;
 #endif


### PR DESCRIPTION
## Pull Request Description
This is a reopen of PR #4369 with updates. Fixes issue #4807.

This PR adds a set of `PAC_CHECK_HEADER_LIB_XXX` macros to unify the syntax and behaviors of configuring external libraries.

[skip warnings]

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
