### PR TITLE
mpir & ch4/rma: enhance mpir datatype and op to simplify RMA atomics info (prereq of RMA progress optimization)

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -12,6 +12,8 @@
  * here. */
 /* FIXME: I will fix this by refactor the current datatype code out-of configure.ac */
 #define MPIR_DATATYPE_N_BUILTIN 71
+#define MPIR_DATATYPE_PAIRTYPE 5
+#define MPIR_DATATYPE_N_PREDEFINED (MPIR_DATATYPE_N_BUILTIN + MPIR_DATATYPE_PAIRTYPE)
 
 #ifndef MPIR_DATATYPE_PREALLOC
 #define MPIR_DATATYPE_PREALLOC 8
@@ -144,6 +146,7 @@ struct MPIR_Datatype {
 extern MPIR_Datatype MPIR_Datatype_builtin[MPIR_DATATYPE_N_BUILTIN];
 extern MPIR_Datatype MPIR_Datatype_direct[];
 extern MPIR_Object_alloc_t MPIR_Datatype_mem;
+extern MPI_Datatype MPIR_Datatype_index_to_predefined[MPIR_DATATYPE_N_PREDEFINED];
 
 void MPIR_Datatype_free(MPIR_Datatype * ptr);
 void MPIR_Datatype_get_flattened(MPI_Datatype type, void **flattened, int *flattened_sz);
@@ -462,6 +465,35 @@ static inline int MPIR_Datatype_set_contents(MPIR_Datatype * new_dtp,
     }
 
     return MPI_SUCCESS;
+}
+
+MPL_STATIC_INLINE_PREFIX MPI_Datatype MPIR_Datatype_predefined_get_type(uint32_t index)
+{
+    MPIR_Assert(index < MPIR_DATATYPE_N_PREDEFINED);
+    return MPIR_Datatype_index_to_predefined[index];
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIR_Datatype_predefined_get_index(MPI_Datatype datatype)
+{
+    int dtype_index = 0;
+    switch (HANDLE_GET_KIND(datatype)) {
+        case HANDLE_KIND_BUILTIN:
+            /* Predefined builtin index mask for dtype. See MPIR_Datatype_get_ptr. */
+            dtype_index = datatype & 0x000000ff;
+            MPIR_Assert(dtype_index < MPIR_DATATYPE_N_BUILTIN);
+            break;
+        case HANDLE_KIND_DIRECT:
+            /* pairtype */
+            dtype_index = HANDLE_INDEX(datatype) + MPIR_DATATYPE_N_BUILTIN;
+            MPIR_Assert(dtype_index < MPIR_DATATYPE_N_BUILTIN + MPIR_DATATYPE_N_BUILTIN);
+            break;
+        default:
+            /* should be called only by builtin or pairtype */
+            MPIR_Assert(HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN ||
+                        HANDLE_GET_KIND(datatype) == HANDLE_KIND_DIRECT);
+            break;
+    }
+    return dtype_index;
 }
 
 /* contents accessor functions */

--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -12,8 +12,6 @@
  * here. */
 /* FIXME: I will fix this by refactor the current datatype code out-of configure.ac */
 #define MPIR_DATATYPE_N_BUILTIN 71
-#define MPIR_DTYPE_BEGINNING  0
-#define MPIR_DTYPE_END       -1
 
 #ifndef MPIR_DATATYPE_PREALLOC
 #define MPIR_DATATYPE_PREALLOC 8

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -106,7 +106,7 @@ typedef struct MPIR_Op {
      MPID_DEV_OP_DECL
 #endif
 } MPIR_Op;
-#define MPIR_OP_N_BUILTIN 15
+#define MPIR_OP_N_BUILTIN 14
 extern MPIR_Op MPIR_Op_builtin[MPIR_OP_N_BUILTIN];
 extern MPIR_Op MPIR_Op_direct[];
 extern MPIR_Object_alloc_t MPIR_Op_mem;

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -177,7 +177,6 @@ int MPIR_NO_OP_check_dtype(MPI_Datatype);
         }                                                \
     } while (0)                                          \
 
-#define MPIR_PREDEF_OP_COUNT 14
 extern MPI_User_function *MPIR_Op_table[];
 
 typedef int (MPIR_Op_check_dtype_fn) (MPI_Datatype);

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -126,6 +126,21 @@ extern MPIR_Object_alloc_t MPIR_Op_mem;
         }                                                \
     } while (0)
 
+
+/* Query index of builtin op */
+MPL_STATIC_INLINE_PREFIX int MPIR_Op_builtin_get_index(MPI_Op op)
+{
+    MPIR_Assert(HANDLE_IS_BUILTIN(op));
+    return (0x000000ff & op) - 1;       /* index 1 to 14 in handle. */
+}
+
+/* Query builtin op by using index (from 0 to MPIR_OP_N_BUILTIN-1) */
+MPL_STATIC_INLINE_PREFIX MPI_Op MPIR_Op_builtin_get_op(int index)
+{
+    MPIR_Assert(index >= 0 && index < MPIR_OP_N_BUILTIN);
+    return (MPI_Op) (0x58000000 | (index + 1)); /* index 1 to 14 in handle */
+}
+
 void MPIR_MAXF(void *, void *, int *, MPI_Datatype *);
 void MPIR_MINF(void *, void *, int *, MPI_Datatype *);
 void MPIR_SUM(void *, void *, int *, MPI_Datatype *);

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -141,6 +141,9 @@ MPL_STATIC_INLINE_PREFIX MPI_Op MPIR_Op_builtin_get_op(int index)
     return (MPI_Op) (0x58000000 | (index + 1)); /* index 1 to 14 in handle */
 }
 
+MPI_Datatype MPIR_Op_builtin_search_by_shortname(const char *short_name);
+const char *MPIR_Op_builtin_get_shortname(MPI_Op op);
+
 void MPIR_MAXF(void *, void *, int *, MPI_Datatype *);
 void MPIR_MINF(void *, void *, int *, MPI_Datatype *);
 void MPIR_SUM(void *, void *, int *, MPI_Datatype *);

--- a/src/mpi/coll/op/Makefile.mk
+++ b/src/mpi/coll/op/Makefile.mk
@@ -12,6 +12,7 @@ mpi_sources +=                     \
     src/mpi/coll/op/op_commutative.c
 
 mpi_core_sources += \
+    src/mpi/coll/op/oputil.c         \
     src/mpi/coll/op/opsum.c          \
     src/mpi/coll/op/opmax.c          \
     src/mpi/coll/op/opmin.c          \

--- a/src/mpi/coll/op/oputil.c
+++ b/src/mpi/coll/op/oputil.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+typedef struct op_name {
+    MPI_Op op;
+    const char *short_name;     /* used in info */
+} op_name_t;
+
+static op_name_t mpi_ops[] = {
+    {MPI_MAX, "max"},
+    {MPI_MIN, "min"},
+    {MPI_SUM, "sum"},
+    {MPI_PROD, "prod"},
+    {MPI_LAND, "land"},
+    {MPI_BAND, "band"},
+    {MPI_LOR, "lor"},
+    {MPI_BOR, "bor"},
+    {MPI_LXOR, "lxor"},
+    {MPI_BXOR, "bxor"},
+    {MPI_MINLOC, "minloc"},
+    {MPI_MAXLOC, "maxloc"},
+    {MPI_REPLACE, "replace"},
+    {MPI_NO_OP, "no_op"}
+};
+
+MPI_Datatype MPIR_Op_builtin_search_by_shortname(const char *short_name)
+{
+    int i;
+    MPI_Op op = MPI_OP_NULL;
+    for (i = 0; i < sizeof(mpi_ops) / sizeof(op_name_t); i++) {
+        if (!strcmp(mpi_ops[i].short_name, short_name))
+            op = mpi_ops[i].op;
+    }
+    return op;
+}
+
+const char *MPIR_Op_builtin_get_shortname(MPI_Op op)
+{
+    int i;
+    MPIR_Assert(HANDLE_IS_BUILTIN(op));
+    for (i = 0; i < sizeof(mpi_ops) / sizeof(op_name_t); i++) {
+        if (mpi_ops[i].op == op)
+            return mpi_ops[i].short_name;
+    }
+    return "";
+}

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -298,25 +298,7 @@ typedef enum {
     MPIDIG_ACCU_SAME_OP_NO_OP
 } MPIDIG_win_info_accumulate_ops;
 
-typedef enum {
-    MPIDIG_ACCU_OP_SHIFT_FIRST = 0,
-    MPIDIG_ACCU_MAX_SHIFT = 0,  /* 1<<0 */
-    MPIDIG_ACCU_MIN_SHIFT = 1,
-    MPIDIG_ACCU_SUM_SHIFT = 2,
-    MPIDIG_ACCU_PROD_SHIFT = 3,
-    MPIDIG_ACCU_MAXLOC_SHIFT = 4,
-    MPIDIG_ACCU_MINLOC_SHIFT = 5,
-    MPIDIG_ACCU_BAND_SHIFT = 6,
-    MPIDIG_ACCU_BOR_SHIFT = 7,
-    MPIDIG_ACCU_BXOR_SHIFT = 8,
-    MPIDIG_ACCU_LAND_SHIFT = 9,
-    MPIDIG_ACCU_LOR_SHIFT = 10,
-    MPIDIG_ACCU_LXOR_SHIFT = 11,
-    MPIDIG_ACCU_REPLACE_SHIFT = 12,
-    MPIDIG_ACCU_NO_OP_SHIFT = 13,       /* atomic get */
-    MPIDIG_ACCU_CSWAP_SHIFT = 14,
-    MPIDIG_ACCU_OP_SHIFT_LAST
-} MPIDIG_win_info_accu_op_shift_t;
+#define MPIDIG_ACCU_NUM_OP (MPIR_OP_N_BUILTIN + 1)      /* builtin reduce op + cswap */
 
 typedef struct MPIDIG_win_info_args_t {
     int no_locks;
@@ -328,7 +310,7 @@ typedef struct MPIDIG_win_info_args_t {
 
     /* hints to tradeoff atomicity support */
     uint32_t which_accumulate_ops;      /* Arbitrary combination of {1<<max|1<<min|1<<sum|...}
-                                         * with bit shift defined in MPIDIG_win_info_accu_op_shift_t.
+                                         * with bit shift defined by op index (0<=index<MPIDIG_ACCU_NUM_OP).
                                          * any_op and none are two special values.
                                          * any_op by default. */
     bool accumulate_noncontig_dtype;    /* true by default. */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -25,18 +25,6 @@
 
 #define MPIDI_OFI_WIN(win)     ((win)->dev.netmod.ofi)
 
-/* Get op index.
- * TODO: OP_NULL is the oddball. Change configure to table this correctly */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_mpi_acc_op_index(int op)
-{
-    int op_index;
-    if (op == MPI_OP_NULL)
-        op_index = MPIDI_OFI_OP_SIZES - 1;
-    else
-        op_index = (0x000000FFU & op) - 1;
-    return op_index;
-}
-
 int MPIDI_OFI_progress(int vci, int blocking);
 
 /* vni mapping */

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -227,7 +227,7 @@ typedef struct {
                                          * One AVL tree per process. */
     MPL_gavl_tree_t dwin_mrs;   /* Single AVL tree to store locally attached MRs */
 
-    /* Accumulate related info. The struct internally uses MPIDI_OFI_DT_SIZES
+    /* Accumulate related info. The struct internally uses MPIR_DATATYPE_N_PREDEFINED
      * defined in ofi_types.h to allocate the max_count array. The struct
      * size is unknown when we load ofi_pre.h, thus we only set a pointer here. */
     struct MPIDI_OFI_win_acc_hint *acc_hint;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -70,9 +70,8 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt
     dt_index = MPIR_Datatype_predefined_get_index(dt);
     MPIR_Assert(dt_index < MPIR_DATATYPE_N_PREDEFINED);
 
-    op_index = MPIDI_OFI_get_mpi_acc_op_index(op);
-    MPIR_Assert(op_index >= 0);
-    MPIR_Assert(op_index < MPIDI_OFI_OP_SIZES);
+    op_index = MPIDIU_win_acc_op_get_index(op);
+    MPIR_Assert(op_index < MPIDIG_ACCU_NUM_OP);
 
     *fi_dt = (enum fi_datatype) MPIDI_OFI_global.win_op_table[dt_index][op_index].dt;
     *fi_op = (enum fi_op) MPIDI_OFI_global.win_op_table[dt_index][op_index].op;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -62,16 +62,14 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt
                                                                  MPI_Aint * count,
                                                                  MPI_Aint * dtsize)
 {
-    MPIR_Datatype *dt_ptr;
     int op_index, dt_index;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_QUERY_ACC_ATOMIC_SUPPORT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_QUERY_ACC_ATOMIC_SUPPORT);
 
-    MPIR_Datatype_get_ptr(dt, dt_ptr);
-    MPIR_Assert(dt_ptr != NULL);
+    dt_index = MPIR_Datatype_predefined_get_index(dt);
+    MPIR_Assert(dt_index < MPIR_DATATYPE_N_PREDEFINED);
 
-    dt_index = MPIDI_OFI_DATATYPE(dt_ptr).index;
     op_index = MPIDI_OFI_get_mpi_acc_op_index(op);
     MPIR_Assert(op_index >= 0);
     MPIR_Assert(op_index < MPIDI_OFI_OP_SIZES);

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -107,13 +107,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 #endif
 
 
-#ifdef HAVE_FORTRAN_BINDING
-/* number of basic types defined in mpi.h */
-/* FIXME: should be defined in mpi.h or mpir_datatype.h and avoid magic number here */
-#define MPIDI_OFI_DT_SIZES 61
-#else
-#define MPIDI_OFI_DT_SIZES 40
-#endif
 #define MPIDI_OFI_OP_SIZES 15
 
 #define MPIDI_OFI_THREAD_UTIL_MUTEX     MPIDI_OFI_global.mutexes[0].m
@@ -129,7 +122,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 #define MPIDI_OFI_REQUEST(req,field)       ((req)->dev.ch4.netmod.ofi.field)
 #define MPIDI_OFI_AV(av)                   ((av)->netmod.ofi)
 
-#define MPIDI_OFI_DATATYPE(dt)   ((dt)->dev.netmod.ofi)
 #define MPIDI_OFI_COMM(comm)     ((comm)->dev.ch4.netmod.ofi)
 
 #define MPIDI_OFI_NUM_CQ_ENTRIES 8
@@ -343,7 +335,7 @@ typedef struct {
     uint64_t rma_issued_cntr;
     /* OFI atomics limitation of each pair of <dtype, op> returned by the
      * OFI provider at MPI initialization.*/
-    MPIDI_OFI_atomic_valid_t win_op_table[MPIDI_OFI_DT_SIZES][MPIDI_OFI_OP_SIZES];
+    MPIDI_OFI_atomic_valid_t win_op_table[MPIR_DATATYPE_N_PREDEFINED][MPIDI_OFI_OP_SIZES];
     UT_array *rma_sep_idx_array;        /* Array of available indexes of transmit contexts on sep */
 
     /* Active Message Globals */
@@ -390,10 +382,6 @@ typedef struct {
 } MPIDI_OFI_global_t;
 
 typedef struct {
-    uint32_t index;
-} MPIDI_OFI_datatype_t;
-
-typedef struct {
     int16_t type;
     int16_t seqno;
     int origin_rank;
@@ -408,12 +396,12 @@ typedef struct {
 } MPIDI_OFI_send_control_t;
 
 typedef struct MPIDI_OFI_win_acc_hint {
-    uint64_t dtypes_max_count[MPIDI_OFI_DT_SIZES];      /* translate CH4 which_accumulate_ops hints to
-                                                         * atomicity support of all OFI datatypes. A datatype
-                                                         * is supported only when all enabled ops are valid atomic
-                                                         * provided by the OFI provider (recored in MPIDI_OFI_global.win_op_table).
-                                                         * Invalid <dtype, op> defined in MPI standard are excluded.
-                                                         * This structure is prepared at window creation time. */
+    uint64_t dtypes_max_count[MPIR_DATATYPE_N_PREDEFINED];      /* translate CH4 which_accumulate_ops hints to
+                                                                 * atomicity support of all OFI datatypes. A datatype
+                                                                 * is supported only when all enabled ops are valid atomic
+                                                                 * provided by the OFI provider (recored in MPIDI_OFI_global.win_op_table).
+                                                                 * Invalid <dtype, op> defined in MPI standard are excluded.
+                                                                 * This structure is prepared at window creation time. */
 } MPIDI_OFI_win_acc_hint_t;
 
 enum {

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -106,9 +106,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 #endif
 #endif
 
-
-#define MPIDI_OFI_OP_SIZES 15
-
 #define MPIDI_OFI_THREAD_UTIL_MUTEX     MPIDI_OFI_global.mutexes[0].m
 #define MPIDI_OFI_THREAD_PROGRESS_MUTEX MPIDI_OFI_global.mutexes[1].m
 #define MPIDI_OFI_THREAD_FI_MUTEX       MPIDI_OFI_global.mutexes[2].m
@@ -335,7 +332,7 @@ typedef struct {
     uint64_t rma_issued_cntr;
     /* OFI atomics limitation of each pair of <dtype, op> returned by the
      * OFI provider at MPI initialization.*/
-    MPIDI_OFI_atomic_valid_t win_op_table[MPIR_DATATYPE_N_PREDEFINED][MPIDI_OFI_OP_SIZES];
+    MPIDI_OFI_atomic_valid_t win_op_table[MPIR_DATATYPE_N_PREDEFINED][MPIDIG_ACCU_NUM_OP];
     UT_array *rma_sep_idx_array;        /* Array of available indexes of transmit contexts on sep */
 
     /* Active Message Globals */

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -7,7 +7,6 @@
 #include "ofi_impl.h"
 #include "ofi_noinline.h"
 
-static int accu_op_hint_get_index(MPIDIG_win_info_accu_op_shift_t hint_shift);
 static void load_acc_hint(MPIR_Win * win);
 static void set_rma_fi_info(MPIR_Win * win, struct fi_info *finfo);
 static int win_allgather(MPIR_Win * win, void *base, int disp_unit);
@@ -17,66 +16,9 @@ static int win_init_stx(MPIR_Win * win);
 static int win_init_global(MPIR_Win * win);
 static int win_init(MPIR_Win * win);
 
-static int accu_op_hint_get_index(MPIDIG_win_info_accu_op_shift_t hint_shift)
-{
-    int op_index = 0;
-    switch (hint_shift) {
-        case MPIDIG_ACCU_MAX_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_MAX);
-            break;
-        case MPIDIG_ACCU_MIN_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_MIN);
-            break;
-        case MPIDIG_ACCU_SUM_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_SUM);
-            break;
-        case MPIDIG_ACCU_PROD_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_PROD);
-            break;
-        case MPIDIG_ACCU_MAXLOC_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_MAXLOC);
-            break;
-        case MPIDIG_ACCU_MINLOC_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_MINLOC);
-            break;
-        case MPIDIG_ACCU_BAND_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_BAND);
-            break;
-        case MPIDIG_ACCU_BOR_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_BOR);
-            break;
-        case MPIDIG_ACCU_BXOR_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_BXOR);
-            break;
-        case MPIDIG_ACCU_LAND_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_LAND);
-            break;
-        case MPIDIG_ACCU_LOR_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_LOR);
-            break;
-        case MPIDIG_ACCU_LXOR_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_LXOR);
-            break;
-        case MPIDIG_ACCU_REPLACE_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_REPLACE);
-            break;
-        case MPIDIG_ACCU_NO_OP_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_NO_OP);
-            break;
-        case MPIDIG_ACCU_CSWAP_SHIFT:
-            op_index = MPIDI_OFI_get_mpi_acc_op_index(MPI_OP_NULL);
-            break;
-        default:
-            MPIR_Assert(hint_shift < MPIDIG_ACCU_OP_SHIFT_LAST);
-            break;
-    }
-    return op_index;
-}
-
 static void load_acc_hint(MPIR_Win * win)
 {
     int op_index = 0, i;
-    MPIDIG_win_info_accu_op_shift_t hint_shift = MPIDIG_ACCU_OP_SHIFT_FIRST;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_LOAD_ACC_HINT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_LOAD_ACC_HINT);
@@ -99,22 +41,21 @@ static void load_acc_hint(MPIR_Win * win)
         if (dt == MPI_DATATYPE_NULL)
             continue;   /* skip disabled datatype */
 
-        for (hint_shift = MPIDIG_ACCU_OP_SHIFT_FIRST; hint_shift < MPIDIG_ACCU_OP_SHIFT_LAST;
-             hint_shift++) {
+        for (op_index = 0; op_index < MPIDIG_ACCU_NUM_OP; op_index++) {
             uint64_t max_count = 0;
             /* Calculate the max count of all possible atomics if this op is enabled.
              * If the op is disabled for the datatype, the max counts are set to 0 (see util.c).*/
-            if (MPIDIG_WIN(win, info_args).which_accumulate_ops & (1 << hint_shift)) {
-                op_index = accu_op_hint_get_index(hint_shift);
+            if (MPIDIG_WIN(win, info_args).which_accumulate_ops & (1 << op_index)) {
+                MPI_Op op = MPIDIU_win_acc_get_op(op_index);
 
                 /* Invalid <datatype, op> pairs should be excluded as it is never used in a
                  * correct program (e.g., <double, MAXLOC>).*/
                 if (!MPIDI_OFI_global.win_op_table[i][op_index].mpi_acc_valid)
                     continue;
 
-                if (hint_shift == MPIDIG_ACCU_NO_OP_SHIFT)      /* atomic get */
+                if (op == MPI_NO_OP)    /* atomic get */
                     max_count = MPIDI_OFI_global.win_op_table[i][op_index].max_fetch_atomic_count;
-                else if (hint_shift == MPIDIG_ACCU_CSWAP_SHIFT) /* compare and swap */
+                else if (op == MPI_OP_NULL)     /* compare and swap */
                     max_count = MPIDI_OFI_global.win_op_table[i][op_index].max_compare_atomic_count;
                 else    /* atomic write and fetch_and_write */
                     max_count = MPL_MIN(MPIDI_OFI_global.win_op_table[i][op_index].max_atomic_count,

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -91,9 +91,13 @@ static void load_acc_hint(MPIR_Win * win)
     /* We translate the atomic op hints to max count allowed for all possible atomics with each
      * datatype. We do not need more specific info (e.g., <datatype, op>, because any process may use
      * the op with accumulate or get_accumulate.*/
-    for (i = 0; i < MPIDI_OFI_DT_SIZES; i++) {
+    for (i = 0; i < MPIR_DATATYPE_N_PREDEFINED; i++) {
         MPIDI_OFI_WIN(win).acc_hint->dtypes_max_count[i] = 0;
         bool first_valid_op = true;
+
+        MPI_Datatype dt = MPIR_Datatype_predefined_get_type(i);
+        if (dt == MPI_DATATYPE_NULL)
+            continue;   /* skip disabled datatype */
 
         for (hint_shift = MPIDIG_ACCU_OP_SHIFT_FIRST; hint_shift < MPIDIG_ACCU_OP_SHIFT_LAST;
              hint_shift++) {
@@ -559,7 +563,6 @@ static int win_init(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_WIN_INIT);
 
     MPL_COMPILE_TIME_ASSERT(sizeof(MPIDI_Devwin_t) >= sizeof(MPIDI_OFI_win_t));
-    MPL_COMPILE_TIME_ASSERT(sizeof(MPIDI_Devdt_t) >= sizeof(MPIDI_OFI_datatype_t));
 
     memset(&MPIDI_OFI_WIN(win), 0, sizeof(MPIDI_OFI_win_t));
 

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -399,13 +399,6 @@ static int mpi_to_ofi(MPI_Datatype dt, enum fi_datatype *fi_dt, MPI_Op op, enum 
     return -1;
 }
 
-static MPI_Op mpi_ops[] = {
-    MPI_MAX, MPI_MIN, MPI_SUM, MPI_PROD,
-    MPI_LAND, MPI_BAND, MPI_LOR, MPI_BOR,
-    MPI_LXOR, MPI_BXOR, MPI_MINLOC, MPI_MAXLOC,
-    MPI_REPLACE, MPI_NO_OP, MPI_OP_NULL,
-};
-
 #define _TBL MPIDI_OFI_global.win_op_table[i][j]
 #define CHECK_ATOMIC(fcn,field1,field2)            \
   atomic_count = 0;                                \
@@ -452,11 +445,12 @@ static void create_dt_map()
         if (dt == MPI_DATATYPE_NULL)
             continue;
 
-        for (j = 0; j < MPIDI_OFI_OP_SIZES; j++) {
+        for (j = 0; j < MPIDIG_ACCU_NUM_OP; j++) {
+            MPI_Op op = MPIDIU_win_acc_get_op(j);
             enum fi_datatype fi_dt = (enum fi_datatype) -1;
             enum fi_op fi_op = (enum fi_op) -1;
 
-            mpi_to_ofi(dt, &fi_dt, mpi_ops[j], &fi_op);
+            mpi_to_ofi(dt, &fi_dt, op, &fi_op);
             MPIR_Assert(fi_dt != (enum fi_datatype) -1);
             MPIR_Assert(fi_op != (enum fi_op) -1);
             _TBL.dt = fi_dt;
@@ -465,7 +459,7 @@ static void create_dt_map()
             _TBL.max_atomic_count = 0;
             _TBL.max_fetch_atomic_count = 0;
             _TBL.max_compare_atomic_count = 0;
-            _TBL.mpi_acc_valid = check_mpi_acc_valid(dt, mpi_ops[j]);
+            _TBL.mpi_acc_valid = check_mpi_acc_valid(dt, op);
             ssize_t ret;
             size_t atomic_count;
 

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -399,34 +399,6 @@ static int mpi_to_ofi(MPI_Datatype dt, enum fi_datatype *fi_dt, MPI_Op op, enum 
     return -1;
 }
 
-static MPI_Datatype mpi_dtypes[] = {
-    MPI_CHAR, MPI_UNSIGNED_CHAR, MPI_SIGNED_CHAR, MPI_BYTE,
-    MPI_WCHAR, MPI_SHORT, MPI_UNSIGNED_SHORT, MPI_INT,
-    MPI_UNSIGNED, MPI_LONG, MPI_UNSIGNED_LONG, MPI_FLOAT,
-    MPI_DOUBLE, MPI_LONG_DOUBLE, MPI_LONG_LONG, MPI_UNSIGNED_LONG_LONG,
-    MPI_PACKED, MPI_LB, MPI_UB, MPI_2INT,
-
-    MPI_INT8_T, MPI_INT16_T, MPI_INT32_T,
-    MPI_INT64_T, MPI_UINT8_T, MPI_UINT16_T,
-    MPI_UINT32_T, MPI_UINT64_T, MPI_C_BOOL,
-    MPI_C_FLOAT_COMPLEX, MPI_C_DOUBLE_COMPLEX, MPI_C_LONG_DOUBLE_COMPLEX,
-    /* address/offset/count types */
-    MPI_AINT, MPI_OFFSET, MPI_COUNT,
-    /* Fortran types */
-#ifdef HAVE_FORTRAN_BINDING
-    MPI_COMPLEX, MPI_DOUBLE_COMPLEX, MPI_LOGICAL, MPI_REAL,
-    MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_2INTEGER,
-    MPI_2REAL, MPI_2DOUBLE_PRECISION, MPI_CHARACTER,
-    MPI_REAL4, MPI_REAL8, MPI_REAL16, MPI_COMPLEX8, MPI_COMPLEX16,
-    MPI_COMPLEX32, MPI_INTEGER1, MPI_INTEGER2, MPI_INTEGER4, MPI_INTEGER8,
-    MPI_INTEGER16,
-#endif
-    MPI_FLOAT_INT, MPI_DOUBLE_INT,
-    MPI_LONG_INT, MPI_SHORT_INT,
-    MPI_LONG_DOUBLE_INT,
-    (MPI_Datatype) - 1,
-};
-
 static MPI_Op mpi_ops[] = {
     MPI_MAX, MPI_MIN, MPI_SUM, MPI_PROD,
     MPI_LAND, MPI_BAND, MPI_LOR, MPI_BOR,
@@ -470,11 +442,21 @@ static void create_dt_map()
      * enabled call fo fi_atomic*** may crash */
     MPIR_Assert(MPIDI_OFI_ENABLE_ATOMICS);
 
-    for (i = 0; i < MPIDI_OFI_DT_SIZES; i++)
+    memset(MPIDI_OFI_global.win_op_table, 0, sizeof(MPIDI_OFI_global.win_op_table));
+
+    for (i = 0; i < MPIR_DATATYPE_N_PREDEFINED; i++) {
+        MPI_Datatype dt = MPIR_Datatype_predefined_get_type(i);
+
+        /* MPICH sets predefined datatype handles to MPI_DATATYPE_NULL if they are not
+         * supported on the target platform. Skip it. */
+        if (dt == MPI_DATATYPE_NULL)
+            continue;
+
         for (j = 0; j < MPIDI_OFI_OP_SIZES; j++) {
             enum fi_datatype fi_dt = (enum fi_datatype) -1;
             enum fi_op fi_op = (enum fi_op) -1;
-            mpi_to_ofi(mpi_dtypes[i], &fi_dt, mpi_ops[j], &fi_op);
+
+            mpi_to_ofi(dt, &fi_dt, mpi_ops[j], &fi_op);
             MPIR_Assert(fi_dt != (enum fi_datatype) -1);
             MPIR_Assert(fi_op != (enum fi_op) -1);
             _TBL.dt = fi_dt;
@@ -483,7 +465,7 @@ static void create_dt_map()
             _TBL.max_atomic_count = 0;
             _TBL.max_fetch_atomic_count = 0;
             _TBL.max_compare_atomic_count = 0;
-            _TBL.mpi_acc_valid = check_mpi_acc_valid(mpi_dtypes[i], mpi_ops[j]);
+            _TBL.mpi_acc_valid = check_mpi_acc_valid(dt, mpi_ops[j]);
             ssize_t ret;
             size_t atomic_count;
 
@@ -495,98 +477,11 @@ static void create_dt_map()
                 _TBL.dtsize = dtsize[fi_dt];
             }
         }
-}
-
-static void add_index(MPI_Datatype datatype, int *idx)
-{
-    /* MPICH sets predefined datatype handles to MPI_DATATYPE_NULL if they are not supported
-     * on the target platform */
-    if (datatype != MPI_DATATYPE_NULL) {
-        MPIR_Datatype *dt_ptr;
-        MPIR_Datatype_get_ptr(datatype, dt_ptr);
-        MPIDI_OFI_DATATYPE(dt_ptr).index = *idx;
     }
-    (*idx)++;
 }
 
 void MPIDI_OFI_index_datatypes()
 {
-    int idx = 0;
-
-    add_index(MPI_CHAR, &idx);
-    add_index(MPI_UNSIGNED_CHAR, &idx);
-    add_index(MPI_SIGNED_CHAR, &idx);
-    add_index(MPI_BYTE, &idx);
-    add_index(MPI_WCHAR, &idx);
-    add_index(MPI_SHORT, &idx);
-    add_index(MPI_UNSIGNED_SHORT, &idx);
-    add_index(MPI_INT, &idx);
-    add_index(MPI_UNSIGNED, &idx);
-    add_index(MPI_LONG, &idx);  /* count=10 */
-    add_index(MPI_UNSIGNED_LONG, &idx);
-    add_index(MPI_FLOAT, &idx);
-    add_index(MPI_DOUBLE, &idx);
-    add_index(MPI_LONG_DOUBLE, &idx);
-    add_index(MPI_LONG_LONG, &idx);
-    add_index(MPI_UNSIGNED_LONG_LONG, &idx);
-    add_index(MPI_PACKED, &idx);
-    add_index(MPI_LB, &idx);
-    add_index(MPI_UB, &idx);
-    add_index(MPI_2INT, &idx);  /* count=20 */
-
-    /* C99 types */
-    add_index(MPI_INT8_T, &idx);
-    add_index(MPI_INT16_T, &idx);
-    add_index(MPI_INT32_T, &idx);
-    add_index(MPI_INT64_T, &idx);
-    add_index(MPI_UINT8_T, &idx);
-    add_index(MPI_UINT16_T, &idx);
-    add_index(MPI_UINT32_T, &idx);
-    add_index(MPI_UINT64_T, &idx);
-    add_index(MPI_C_BOOL, &idx);
-    add_index(MPI_C_FLOAT_COMPLEX, &idx);       /* count=30 */
-    add_index(MPI_C_DOUBLE_COMPLEX, &idx);
-    add_index(MPI_C_LONG_DOUBLE_COMPLEX, &idx);
-
-    /* address/offset/count types */
-    add_index(MPI_AINT, &idx);
-    add_index(MPI_OFFSET, &idx);
-    add_index(MPI_COUNT, &idx); /* count=35 */
-
-    /* Fortran types (count=23) */
-#ifdef HAVE_FORTRAN_BINDING
-    add_index(MPI_COMPLEX, &idx);
-    add_index(MPI_DOUBLE_COMPLEX, &idx);
-    add_index(MPI_LOGICAL, &idx);
-    add_index(MPI_REAL, &idx);
-    add_index(MPI_DOUBLE_PRECISION, &idx);      /* count=40 */
-    add_index(MPI_INTEGER, &idx);
-    add_index(MPI_2INTEGER, &idx);
-    add_index(MPI_2REAL, &idx);
-    add_index(MPI_2DOUBLE_PRECISION, &idx);
-    add_index(MPI_CHARACTER, &idx);
-    add_index(MPI_REAL4, &idx);
-    add_index(MPI_REAL8, &idx);
-    add_index(MPI_REAL16, &idx);        /* count=50 */
-    add_index(MPI_COMPLEX8, &idx);
-    add_index(MPI_COMPLEX16, &idx);
-    add_index(MPI_COMPLEX32, &idx);
-    add_index(MPI_INTEGER1, &idx);
-    add_index(MPI_INTEGER2, &idx);
-    add_index(MPI_INTEGER4, &idx);
-    add_index(MPI_INTEGER8, &idx);
-    add_index(MPI_INTEGER16, &idx);
-
-#endif
-    add_index(MPI_FLOAT_INT, &idx);
-    add_index(MPI_DOUBLE_INT, &idx);    /* count=60 */
-    add_index(MPI_LONG_INT, &idx);
-    add_index(MPI_SHORT_INT, &idx);
-    add_index(MPI_LONG_DOUBLE_INT, &idx);
-
-    /* check if static dt_size is correct */
-    MPIR_Assert(MPIDI_OFI_DT_SIZES == idx);
-
     /* do not generate map when atomics are not enabled */
     if (MPIDI_OFI_ENABLE_ATOMICS)
         create_dt_map();

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -771,6 +771,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_check_all_targets_remote_completed(MPIR
     int rank = 0;
 
     *allcompleted = 1;
+    if (!MPIDIG_WIN(win, targets))
+        return;
+
     MPIDIG_win_target_t *target_ptr = NULL;
     for (rank = 0; rank < win->comm_ptr->local_size; rank++) {
         target_ptr = MPIDIG_win_target_find(win, rank);
@@ -790,6 +793,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_check_all_targets_local_completed(MPIR_
     int rank = 0;
 
     *allcompleted = 1;
+    if (!MPIDIG_WIN(win, targets))
+        return;
+
     MPIDIG_win_target_t *target_ptr = NULL;
     for (rank = 0; rank < win->comm_ptr->local_size; rank++) {
         target_ptr = MPIDIG_win_target_find(win, rank);
@@ -809,6 +815,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_check_group_local_completed(MPIR_Win * 
     int i = 0;
 
     *allcompleted = 1;
+    if (!MPIDIG_WIN(win, targets))
+        return;
+
     MPIDIG_win_target_t *target_ptr = NULL;
     for (i = 0; i < grp_siz; i++) {
         int rank = ranks_in_win_grp[i];

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -1125,4 +1125,25 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_compute_acc_op(void *source_buf, int source_
     return mpi_errno;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDIU_win_acc_op_get_index(MPI_Op op)
+{
+    if (op == MPI_OP_NULL) {
+        /* Builtin index is from 0 to MPIR_OP_N_BUILTIN-1.
+         * Thus use MPIR_OP_N_BUILTIN as index for special OP_NULL as RMA cswap */
+        return MPIR_OP_N_BUILTIN;
+    } else {
+        return MPIR_Op_builtin_get_index(op);
+    }
+}
+
+MPL_STATIC_INLINE_PREFIX MPI_Op MPIDIU_win_acc_get_op(int index)
+{
+    if (index == MPIR_OP_N_BUILTIN) {
+        /* Builtin index is from 0 to MPIR_OP_N_BUILTIN-1.
+         * Thus use MPIR_OP_N_BUILTIN as index for special OP_NULL as RMA cswap */
+        return MPI_OP_NULL;
+    } else {
+        return MPIR_Op_builtin_get_op(index);
+    }
+}
 #endif /* CH4_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -35,11 +35,10 @@ static void parse_info_accu_ops_str(const char *str, uint32_t * ops_ptr)
         *ops_ptr = 0;
         return;
     } else if (!strncmp(value, "any_op", strlen("any_op"))) {
-        MPIDIG_win_info_accu_op_shift_t op_shift;
         /* add all ops */
-        for (op_shift = MPIDIG_ACCU_OP_SHIFT_FIRST; op_shift < MPIDIG_ACCU_OP_SHIFT_LAST;
-             op_shift++)
-            ops |= (1 << op_shift);
+        int op_index;
+        for (op_index = 0; op_index < MPIDIG_ACCU_NUM_OP; op_index++)
+            ops |= (1 << op_index);
         *ops_ptr = ops;
         return;
     }
@@ -49,36 +48,36 @@ static void parse_info_accu_ops_str(const char *str, uint32_t * ops_ptr)
 
         /* traverse op list (exclude null and last) and add the op if set */
         if (!strncmp(token, "max", strlen("max")))
-            ops |= (1 << MPIDIG_ACCU_MAX_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_MAX));
         else if (!strncmp(token, "min", strlen("min")))
-            ops |= (1 << MPIDIG_ACCU_MIN_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_MIN));
         else if (!strncmp(token, "sum", strlen("sum")))
-            ops |= (1 << MPIDIG_ACCU_SUM_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_SUM));
         else if (!strncmp(token, "prod", strlen("prod")))
-            ops |= (1 << MPIDIG_ACCU_PROD_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_PROD));
         else if (!strncmp(token, "maxloc", strlen("maxloc")))
-            ops |= (1 << MPIDIG_ACCU_MAXLOC_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_MAXLOC));
         else if (!strncmp(token, "minloc", strlen("minloc")))
-            ops |= (1 << MPIDIG_ACCU_MINLOC_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_MINLOC));
         else if (!strncmp(token, "band", strlen("band")))
-            ops |= (1 << MPIDIG_ACCU_BAND_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_BAND));
         else if (!strncmp(token, "bor", strlen("bor")))
-            ops |= (1 << MPIDIG_ACCU_BOR_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_BOR));
         else if (!strncmp(token, "bxor", strlen("bxor")))
-            ops |= (1 << MPIDIG_ACCU_BXOR_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_BXOR));
         else if (!strncmp(token, "land", strlen("land")))
-            ops |= (1 << MPIDIG_ACCU_LAND_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_LAND));
         else if (!strncmp(token, "lor", strlen("lor")))
-            ops |= (1 << MPIDIG_ACCU_LOR_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_LOR));
         else if (!strncmp(token, "lxor", strlen("lxor")))
-            ops |= (1 << MPIDIG_ACCU_LXOR_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_LXOR));
         else if (!strncmp(token, "replace", strlen("replace")))
-            ops |= (1 << MPIDIG_ACCU_REPLACE_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_REPLACE));
         else if (!strncmp(token, "no_op", strlen("no_op")))
-            ops |= (1 << MPIDIG_ACCU_NO_OP_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_NO_OP));
         else if (!strncmp(token, "cswap", strlen("cswap")) ||
                  !strncmp(token, "compare_and_swap", strlen("compare_and_swap")))
-            ops |= (1 << MPIDIG_ACCU_CSWAP_SHIFT);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(MPI_OP_NULL));     /* no cswap OP, thus use special OP_NULL */
 
         token = (char *) strtok_r(NULL, ",", &savePtr);
     }
@@ -95,35 +94,35 @@ static void get_info_accu_ops_str(uint32_t val, char *buf, size_t maxlen)
     MPIR_Assert(maxlen >= strlen("max,min,sum,prod,maxloc,minloc,band,bor,"
                                  "bxor,land,lor,lxor,replace,no_op,cswap") + 1);
 
-    if (val & (1 << MPIDIG_ACCU_MAX_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_MAX)))
         c += snprintf(buf + c, maxlen - c, "max");
-    if (val & (1 << MPIDIG_ACCU_MIN_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_MIN)))
         c += snprintf(buf + c, maxlen - c, "%smin", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_SUM_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_SUM)))
         c += snprintf(buf + c, maxlen - c, "%ssum", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_PROD_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_PROD)))
         c += snprintf(buf + c, maxlen - c, "%sprod", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_MAXLOC_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_MAXLOC)))
         c += snprintf(buf + c, maxlen - c, "%smaxloc", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_MINLOC_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_MINLOC)))
         c += snprintf(buf + c, maxlen - c, "%sminloc", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_BAND_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_BAND)))
         c += snprintf(buf + c, maxlen - c, "%sband", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_BOR_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_BOR)))
         c += snprintf(buf + c, maxlen - c, "%sbor", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_BXOR_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_BXOR)))
         c += snprintf(buf + c, maxlen - c, "%sbxor", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_LAND_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_LAND)))
         c += snprintf(buf + c, maxlen - c, "%sland", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_LOR_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_LOR)))
         c += snprintf(buf + c, maxlen - c, "%slor", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_LXOR_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_LXOR)))
         c += snprintf(buf + c, maxlen - c, "%slxor", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_REPLACE_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_REPLACE)))
         c += snprintf(buf + c, maxlen - c, "%sreplace", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_NO_OP_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_NO_OP)))
         c += snprintf(buf + c, maxlen - c, "%sno_op", (c > 0) ? "," : "");
-    if (val & (1 << MPIDIG_ACCU_CSWAP_SHIFT))
+    if (val & (1 << MPIDIU_win_acc_op_get_index(MPI_OP_NULL)))
         c += snprintf(buf + c, maxlen - c, "%scswap", (c > 0) ? "," : "");
 
     if (c == 0)
@@ -271,7 +270,6 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
     MPIR_Win *win = (MPIR_Win *) MPIR_Handle_obj_alloc(&MPIR_Win_mem);
     MPIDIG_win_target_t *targets = NULL;
     MPIR_Comm *win_comm_ptr;
-    MPIDIG_win_info_accu_op_shift_t op_shift;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_WIN_INIT);
     MPIR_FUNC_VERBOSE_RMA_ENTER(MPID_STATE_MPIDIG_WIN_INIT);
@@ -321,9 +319,10 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
     }
 
     /* default any op */
+    int op_index;
     MPIDIG_WIN(win, info_args).which_accumulate_ops = 0;
-    for (op_shift = MPIDIG_ACCU_OP_SHIFT_FIRST; op_shift < MPIDIG_ACCU_OP_SHIFT_LAST; op_shift++)
-        MPIDIG_WIN(win, info_args).which_accumulate_ops |= (1 << op_shift);
+    for (op_index = 0; op_index < MPIDIG_ACCU_NUM_OP; op_index++)
+        MPIDIG_WIN(win, info_args).which_accumulate_ops |= (1 << op_index);
     MPIDIG_WIN(win, info_args).accumulate_noncontig_dtype = true;
     MPIDIG_WIN(win, info_args).accumulate_max_bytes = -1;
     MPIDIG_WIN(win, info_args).disable_shm_accumulate = false;


### PR DESCRIPTION
## Pull Request Description

This PR contains several small commits to add index for predefined datatypes and builtin op in MPIR. They are used to simplify the complex atomics check in CH4/RMA and CH4/OFI. This PR is a prereq for the upcoming RMA progress optimization.

Major commits include:
- Define `N_PREDEFINED` and index for predefined datatypes in MPIR (predefined dtypes include builtin and pairtypes)
- Define index for builtin ops in MPIR
- Use the above MPIR routines to simplify atomics check at ofi_init (for getting provider's atomics support) and window info handling in ch4 (for getting atomics used by user). The refactoring allows us to remove magic numbers `MPIDI_OFI_DT_SIZES` and  `MPIDI_OFI_OP_SIZES` defined in OFI.
- Define shortname for each builtin OP in MPIR and use it to simplify routines for atomics info hint "which_accumulate_ops" in CH4/RMA.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
