### PR TITLE
ch4/ofi: enable native acc/get_acc if data is contiguous 

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -319,7 +319,7 @@ int MPIDI_OFI_pack_get(void *origin_addr, int origin_count,
  * C and C++ components
  */
 /* Set max size based on OFI acc ordering limit. */
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_OFI_check_acc_order_size(MPIR_Win * win, size_t max_size)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_OFI_check_acc_order_size(MPIR_Win * win, MPI_Aint max_size)
 {
     /* Check ordering limit, a value of -1 guarantees ordering for any data size. */
     if ((MPIDIG_WIN(win, info_args).accumulate_ordering & MPIDIG_ACCU_ORDER_WAR)

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -58,8 +58,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt
                                                                  MPIR_Win * win,
                                                                  MPIDI_winattr_t winattr,
                                                                  enum fi_datatype *fi_dt,
-                                                                 enum fi_op *fi_op, size_t * count,
-                                                                 size_t * dtsize)
+                                                                 enum fi_op *fi_op,
+                                                                 MPI_Aint * count,
+                                                                 MPI_Aint * dtsize)
 {
     MPIR_Datatype *dt_ptr;
     int op_index, dt_index;
@@ -128,7 +129,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt
 
 MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_prepare_target_mr(int target_rank,
                                                           MPI_Aint target_disp,
-                                                          size_t target_extent,
+                                                          MPI_Aint target_extent,
                                                           MPI_Aint target_true_lb, MPIR_Win * win,
                                                           MPIDI_winattr_t winattr,
                                                           MPIDI_OFI_target_mr_t * target_mr)
@@ -185,7 +186,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
     uint64_t flags;
     struct fi_msg_rma msg;
     int target_contig, origin_contig;
-    size_t target_bytes, origin_bytes, target_extent;
+    MPI_Aint target_bytes, origin_bytes, target_extent;
     MPI_Aint origin_true_lb, target_true_lb;
     struct iovec iov;
     struct fi_rma_iov riov;
@@ -208,7 +209,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
 
     /* self messages */
     if (target_rank == MPIDIU_win_comm_rank(win, winattr)) {
-        size_t offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
+        MPI_Aint offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
         mpi_errno = MPIR_Localcopy(origin_addr,
                                    origin_count,
                                    origin_datatype,
@@ -363,7 +364,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
     struct fi_msg_rma msg;
     int origin_contig, target_contig;
     MPI_Aint origin_true_lb, target_true_lb;
-    size_t origin_bytes, target_bytes, target_extent;
+    MPI_Aint origin_bytes, target_bytes, target_extent;
     struct fi_rma_iov riov;
     struct iovec iov;
 
@@ -385,7 +386,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
 
     /* self messages */
     if (target_rank == MPIDIU_win_comm_rank(win, winattr)) {
-        size_t offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
+        MPI_Aint offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
         mpi_errno = MPIR_Localcopy((char *) win->base + offset,
                                    target_count,
                                    target_datatype, origin_addr, origin_count, origin_datatype);
@@ -557,7 +558,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     int mpi_errno = MPI_SUCCESS;
     enum fi_op fi_op;
     enum fi_datatype fi_dt;
-    size_t max_count, max_size, dt_size, bytes;
+    MPI_Aint max_count, max_size, dt_size, bytes;
     MPI_Aint true_lb;
     void *buffer, *rbuffer;
     struct fi_ioc originv;
@@ -668,7 +669,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
 {
     int mpi_errno = MPI_SUCCESS;
     int target_contig, origin_contig;
-    size_t target_bytes, origin_bytes, target_extent;
+    MPI_Aint target_bytes, origin_bytes, target_extent;
     MPI_Aint origin_true_lb, target_true_lb;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_ACCUMULATE);
@@ -698,7 +699,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         MPI_Datatype basic_type;
         enum fi_op fi_op;
         enum fi_datatype fi_dt;
-        size_t max_count, max_size, dt_size, basic_count;
+        MPI_Aint max_count, max_size, dt_size, basic_count;
 
         /* accept only same predefined basic datatype */
         MPIDI_OFI_GET_BASIC_TYPE(target_datatype, basic_type);
@@ -806,7 +807,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
 {
     int mpi_errno = MPI_SUCCESS;
     int target_contig, origin_contig, result_contig;
-    size_t target_bytes, target_extent, origin_bytes ATTRIBUTE((unused)),
+    MPI_Aint target_bytes, target_extent, origin_bytes ATTRIBUTE((unused)),
         result_bytes ATTRIBUTE((unused));
     MPI_Aint origin_true_lb, target_true_lb, result_true_lb;
 
@@ -839,7 +840,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         MPI_Datatype basic_type;
         enum fi_op fi_op;
         enum fi_datatype fi_dt;
-        size_t max_count, max_size, dt_size, basic_count;
+        MPI_Aint max_count, max_size, dt_size, basic_count;
 
         /* accept only same predefined basic datatype */
         MPIDI_OFI_GET_BASIC_TYPE(target_datatype, basic_type);
@@ -1045,7 +1046,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     int mpi_errno = MPI_SUCCESS;
     enum fi_op fi_op;
     enum fi_datatype fi_dt;
-    size_t max_count, max_size, dt_size, bytes;
+    MPI_Aint max_count, max_size, dt_size, bytes;
     MPI_Aint true_lb ATTRIBUTE((unused));
     void *buffer, *rbuffer;
     struct fi_ioc originv;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -405,19 +405,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
     /* contiguous messages */
     if (origin_contig && target_contig) {
         if (sigreq) {
-            if (sigreq) {
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-                if (*sigreq) {
-                    MPIR_Request_add_ref(*sigreq);
-                } else
+            if (*sigreq) {
+                MPIR_Request_add_ref(*sigreq);
+            } else
 #endif
-                {
-                    MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
-                }
-                flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
-            } else {
-                flags = FI_DELIVERY_COMPLETE;
+            {
+                MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
             }
+            flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
         } else {
             flags = 0;
         }

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -957,15 +957,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIU_win_rank_to_intra_rank(MPIR_Win * win, int r
 }
 
 /* Wait until active message acc ops are done. */
-MPL_STATIC_INLINE_PREFIX int MPIDIG_wait_am_acc(MPIR_Win * win, int target_rank, int order_needed)
+MPL_STATIC_INLINE_PREFIX int MPIDIG_wait_am_acc(MPIR_Win * win, int target_rank)
 {
     int mpi_errno = MPI_SUCCESS;
-    if (MPIDIG_WIN(win, info_args).accumulate_ordering & order_needed) {
-        MPIDIG_win_target_t *target_ptr = MPIDIG_win_target_find(win, target_rank);
-        while ((target_ptr && MPIR_cc_get(target_ptr->remote_acc_cmpl_cnts) != 0) ||
-               MPIR_cc_get(MPIDIG_WIN(win, remote_acc_cmpl_cnts)) != 0) {
-            MPIDIU_PROGRESS();
-        }
+    MPIDIG_win_target_t *target_ptr = MPIDIG_win_target_find(win, target_rank);
+    while ((target_ptr && MPIR_cc_get(target_ptr->remote_acc_cmpl_cnts) != 0) ||
+           MPIR_cc_get(MPIDIG_WIN(win, remote_acc_cmpl_cnts)) != 0) {
+        MPIDIU_PROGRESS();
     }
   fn_exit:
     return mpi_errno;


### PR DESCRIPTION
## Pull Request Description

This PR enables native acc/get_acc in OFI netmod only when the data is completely contiguous.

The PR also fixes two RMA issues:
1. Redundant code to set FI flags in OFI native get.
2. Removed ordering check when forcing completion for outstanding atomics (e.g., force completion of AM-based atomics before issuing a native atomics). We need always do it to ensure atomicity no matter what ordering hint is given.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
