### PR TITLE
CH4/RMA: optimizations to skip AM progress 

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -95,6 +95,7 @@ struct MPIR_Datatype {
     MPI_Aint extent, ub, lb, true_ub, true_lb;
     struct MPIR_Attribute *attributes;
     char name[MPI_MAX_OBJECT_NAME];
+    char predefined_short_name[MPI_MAX_OBJECT_NAME];    /* Short name for predefined types. Used in info.  */
 
 
     /* private fields */
@@ -495,6 +496,9 @@ MPL_STATIC_INLINE_PREFIX int MPIR_Datatype_predefined_get_index(MPI_Datatype dat
     }
     return dtype_index;
 }
+
+MPI_Datatype MPIR_Datatype_predefined_search_by_shortname(const char *short_name);
+const char *MPIR_Datatype_predefined_get_shortname(MPI_Datatype type);
 
 /* contents accessor functions */
 void MPIR_Type_access_contents(MPI_Datatype type, int **ints_p, MPI_Aint ** aints_p,

--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -13,6 +13,10 @@
 /* FIXME: I will fix this by refactor the current datatype code out-of configure.ac */
 #define MPIR_DATATYPE_N_BUILTIN 71
 #define MPIR_DATATYPE_PAIRTYPE 5
+
+/* FIXME: we have to use magic number in CH4 mpidpre.h and unset here because
+ * we cannot include device-dependent mpir_datatype.h in mpidpre.h. */
+#undef MPIR_DATATYPE_N_PREDEFINED
 #define MPIR_DATATYPE_N_PREDEFINED (MPIR_DATATYPE_N_BUILTIN + MPIR_DATATYPE_PAIRTYPE)
 
 #ifndef MPIR_DATATYPE_PREALLOC

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -28,89 +28,90 @@ static int datatype_attr_finalize_cb(void *dummy);
 typedef struct mpi_names_t {
     MPI_Datatype dtype;
     const char *name;
+    const char *short_name;     /* used in info */
 } mpi_names_t;
-#define type_name_entry(x_) { x_, #x_ }
+#define type_name_entry(x_, shtnm) { x_, #x_, shtnm }
 
 static mpi_names_t mpi_dtypes[] = {
-    type_name_entry(MPI_CHAR),
-    type_name_entry(MPI_UNSIGNED_CHAR),
-    type_name_entry(MPI_SIGNED_CHAR),
-    type_name_entry(MPI_BYTE),
-    type_name_entry(MPI_WCHAR),
-    type_name_entry(MPI_SHORT),
-    type_name_entry(MPI_UNSIGNED_SHORT),
-    type_name_entry(MPI_INT),
-    type_name_entry(MPI_UNSIGNED),
-    type_name_entry(MPI_LONG),
-    type_name_entry(MPI_UNSIGNED_LONG),
-    type_name_entry(MPI_FLOAT),
-    type_name_entry(MPI_DOUBLE),
-    type_name_entry(MPI_LONG_DOUBLE),
-    type_name_entry(MPI_LONG_LONG_INT),
-    type_name_entry(MPI_UNSIGNED_LONG_LONG),
-    type_name_entry(MPI_PACKED),
-    type_name_entry(MPI_LB),
-    type_name_entry(MPI_UB),
-    type_name_entry(MPI_2INT),
+    type_name_entry(MPI_CHAR, "char"),
+    type_name_entry(MPI_UNSIGNED_CHAR, "uchar"),
+    type_name_entry(MPI_SIGNED_CHAR, "char"),
+    type_name_entry(MPI_BYTE, "byte"),
+    type_name_entry(MPI_WCHAR, "wchar"),
+    type_name_entry(MPI_SHORT, "short"),
+    type_name_entry(MPI_UNSIGNED_SHORT, "ushort"),
+    type_name_entry(MPI_INT, "int"),
+    type_name_entry(MPI_UNSIGNED, "uint"),
+    type_name_entry(MPI_LONG, "long"),
+    type_name_entry(MPI_UNSIGNED_LONG, "ulong"),
+    type_name_entry(MPI_FLOAT, "float"),
+    type_name_entry(MPI_DOUBLE, "double"),
+    type_name_entry(MPI_LONG_DOUBLE, "longdouble"),
+    type_name_entry(MPI_LONG_LONG_INT, "longlongint"),
+    type_name_entry(MPI_UNSIGNED_LONG_LONG, "ulonglong"),
+    type_name_entry(MPI_PACKED, "packed"),
+    type_name_entry(MPI_LB, "lb"),
+    type_name_entry(MPI_UB, "ub"),
+    type_name_entry(MPI_2INT, "2int"),
 
     /* C99 types */
-    type_name_entry(MPI_INT8_T),
-    type_name_entry(MPI_INT16_T),
-    type_name_entry(MPI_INT32_T),
-    type_name_entry(MPI_INT64_T),
-    type_name_entry(MPI_UINT8_T),
-    type_name_entry(MPI_UINT16_T),
-    type_name_entry(MPI_UINT32_T),
-    type_name_entry(MPI_UINT64_T),
-    type_name_entry(MPI_C_BOOL),
-    type_name_entry(MPI_C_COMPLEX),
-    type_name_entry(MPI_C_DOUBLE_COMPLEX),
-    type_name_entry(MPI_C_LONG_DOUBLE_COMPLEX),
+    type_name_entry(MPI_INT8_T, "int8"),
+    type_name_entry(MPI_INT16_T, "int16"),
+    type_name_entry(MPI_INT32_T, "int32"),
+    type_name_entry(MPI_INT64_T, "int64"),
+    type_name_entry(MPI_UINT8_T, "uint8"),
+    type_name_entry(MPI_UINT16_T, "uint16"),
+    type_name_entry(MPI_UINT32_T, "uint32"),
+    type_name_entry(MPI_UINT64_T, "uint64"),
+    type_name_entry(MPI_C_BOOL, "cbool"),
+    type_name_entry(MPI_C_COMPLEX, "ccomplex"),
+    type_name_entry(MPI_C_DOUBLE_COMPLEX, "cdoublecomplex"),
+    type_name_entry(MPI_C_LONG_DOUBLE_COMPLEX, "clongdoublecomplex"),
 
     /* address/offset/count types */
-    type_name_entry(MPI_AINT),
-    type_name_entry(MPI_OFFSET),
-    type_name_entry(MPI_COUNT),
+    type_name_entry(MPI_AINT, "aint"),
+    type_name_entry(MPI_OFFSET, "offset"),
+    type_name_entry(MPI_COUNT, "count"),
 
     /* Fortran types */
-    type_name_entry(MPI_COMPLEX),
-    type_name_entry(MPI_DOUBLE_COMPLEX),
-    type_name_entry(MPI_LOGICAL),
-    type_name_entry(MPI_REAL),
-    type_name_entry(MPI_DOUBLE_PRECISION),
-    type_name_entry(MPI_INTEGER),
-    type_name_entry(MPI_2INTEGER),
-    type_name_entry(MPI_2REAL),
-    type_name_entry(MPI_2DOUBLE_PRECISION),
-    type_name_entry(MPI_CHARACTER),
+    type_name_entry(MPI_COMPLEX, "complex"),
+    type_name_entry(MPI_DOUBLE_COMPLEX, "doublecomplex"),
+    type_name_entry(MPI_LOGICAL, "logical"),
+    type_name_entry(MPI_REAL, "real"),
+    type_name_entry(MPI_DOUBLE_PRECISION, "doubleprecision"),
+    type_name_entry(MPI_INTEGER, "integer"),
+    type_name_entry(MPI_2INTEGER, "2integer"),
+    type_name_entry(MPI_2REAL, "2real"),
+    type_name_entry(MPI_2DOUBLE_PRECISION, "2doubleprecision"),
+    type_name_entry(MPI_CHARACTER, "character"),
     /* Size-specific types; these are in section 10.2.4 (Extended Fortran
      * Support) as well as optional in MPI-1
      */
-    type_name_entry(MPI_REAL4),
-    type_name_entry(MPI_REAL8),
-    type_name_entry(MPI_REAL16),
-    type_name_entry(MPI_COMPLEX8),
-    type_name_entry(MPI_COMPLEX16),
-    type_name_entry(MPI_COMPLEX32),
-    type_name_entry(MPI_INTEGER1),
-    type_name_entry(MPI_INTEGER2),
-    type_name_entry(MPI_INTEGER4),
-    type_name_entry(MPI_INTEGER8),
-    type_name_entry(MPI_INTEGER16),
+    type_name_entry(MPI_REAL4, "real4"),
+    type_name_entry(MPI_REAL8, "real8"),
+    type_name_entry(MPI_REAL16, "real16"),
+    type_name_entry(MPI_COMPLEX8, "complex8"),
+    type_name_entry(MPI_COMPLEX16, "complex16"),
+    type_name_entry(MPI_COMPLEX32, "complex32"),
+    type_name_entry(MPI_INTEGER1, "integer1"),
+    type_name_entry(MPI_INTEGER2, "integer2"),
+    type_name_entry(MPI_INTEGER4, "integer4"),
+    type_name_entry(MPI_INTEGER8, "integer8"),
+    type_name_entry(MPI_INTEGER16, "integer16"),
 
     /* C++ types */
-    type_name_entry(MPI_CXX_BOOL),
-    type_name_entry(MPI_CXX_FLOAT_COMPLEX),
-    type_name_entry(MPI_CXX_DOUBLE_COMPLEX),
-    type_name_entry(MPI_CXX_LONG_DOUBLE_COMPLEX),
+    type_name_entry(MPI_CXX_BOOL, "cxxbool"),
+    type_name_entry(MPI_CXX_FLOAT_COMPLEX, "cxxfloatcomplex"),
+    type_name_entry(MPI_CXX_DOUBLE_COMPLEX, "cxxdoublecomplex"),
+    type_name_entry(MPI_CXX_LONG_DOUBLE_COMPLEX, "cxxlongdoublecomplex"),
 };
 
 static mpi_names_t mpi_pairtypes[] = {
-    type_name_entry(MPI_FLOAT_INT),
-    type_name_entry(MPI_DOUBLE_INT),
-    type_name_entry(MPI_LONG_INT),
-    type_name_entry(MPI_SHORT_INT),
-    type_name_entry(MPI_LONG_DOUBLE_INT),
+    type_name_entry(MPI_FLOAT_INT, "floatint"),
+    type_name_entry(MPI_DOUBLE_INT, "doubleint"),
+    type_name_entry(MPI_LONG_INT, "longint"),
+    type_name_entry(MPI_SHORT_INT, "shortint"),
+    type_name_entry(MPI_LONG_DOUBLE_INT, "longdoubleint"),
 };
 
 static void predefined_index_init(void)
@@ -194,6 +195,7 @@ int MPIR_Datatype_init_predefined(void)
         dptr->true_ub = dptr->size;
         dptr->contents = NULL;  /* should never get referenced? */
         MPL_strncpy(dptr->name, mpi_dtypes[i].name, MPI_MAX_OBJECT_NAME);
+        MPL_strncpy(dptr->predefined_short_name, mpi_dtypes[i].short_name, MPI_MAX_OBJECT_NAME);
     }
 
     /* Setup pairtypes. The following assertions ensure that:
@@ -229,6 +231,7 @@ int MPIR_Datatype_init_predefined(void)
         mpi_errno = MPIR_Type_create_pairtype(mpi_pairtypes[i].dtype, (MPIR_Datatype *) dptr);
         MPIR_ERR_CHECK(mpi_errno);
         MPL_strncpy(dptr->name, mpi_pairtypes[i].name, MPI_MAX_OBJECT_NAME);
+        MPL_strncpy(dptr->predefined_short_name, mpi_pairtypes[i].short_name, MPI_MAX_OBJECT_NAME);
     }
 
     MPIR_Add_finalize(pairtypes_finalize_cb, 0, MPIR_FINALIZE_CALLBACK_PRIO - 1);
@@ -682,4 +685,25 @@ void MPIR_Datatype_get_flattened(MPI_Datatype type, void **flattened, int *flatt
 
     *flattened = dt_ptr->flattened;
     *flattened_sz = dt_ptr->flattened_sz;
+}
+
+MPI_Datatype MPIR_Datatype_predefined_search_by_shortname(const char *short_name)
+{
+    int i;
+    MPI_Datatype dtype = MPI_DATATYPE_NULL;
+    for (i = 0; i < sizeof(mpi_dtypes) / sizeof(mpi_dtypes[0]); i++) {
+        if (mpi_dtypes[i].dtype == MPI_DATATYPE_NULL)
+            continue;
+
+        if (!strcmp(mpi_dtypes[i].short_name, short_name))
+            dtype = mpi_dtypes[i].dtype;
+    }
+    return dtype;
+}
+
+const char *MPIR_Datatype_predefined_get_shortname(MPI_Datatype type)
+{
+    MPIR_Datatype *dt_ptr;
+    MPIR_Datatype_get_ptr(type, dt_ptr);
+    return dt_ptr->predefined_short_name;
 }

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -298,7 +298,18 @@ typedef enum {
     MPIDIG_ACCU_SAME_OP_NO_OP
 } MPIDIG_win_info_accumulate_ops;
 
+typedef struct MPIDIG_win_accu_op_type {
+    unsigned int used_count;    /* non-negative number. INT_MAX means unlimited
+                                 * because the user can only set int count.*/
+} MPIDIG_win_accu_op_type_t;
+
 #define MPIDIG_ACCU_NUM_OP (MPIR_OP_N_BUILTIN + 1)      /* builtin reduce op + cswap */
+
+/* FIXME: we have to use magic number for now because cannot include device-dependent mpir_datatype.h
+ * in this file. See definition of MPIR_DATATYPE_N_PREDEFINED in mpir_datatype.h. */
+#ifndef MPIR_DATATYPE_N_PREDEFINED
+#define MPIR_DATATYPE_N_PREDEFINED 76
+#endif
 
 typedef struct MPIDIG_win_info_args_t {
     int no_locks;
@@ -313,6 +324,16 @@ typedef struct MPIDIG_win_info_args_t {
                                          * with bit shift defined by op index (0<=index<MPIDIG_ACCU_NUM_OP).
                                          * any_op and none are two special values.
                                          * any_op by default. */
+
+    /* Set specific predefined datatypes and counts for each op as format below:
+     * KEY="accumulate_op_types:<op>" VALUE="<dtype1>:<used_count>,<dtype2>:<used_count>,..."
+     * For each <op, dtype>, the default used_count is INT_MAX (unlimited).
+     * NOTE: When accumulate_op_types hint is set, which_accumulate_ops hint will be
+     * ignored and set following the former; when only which_accumulate_ops is set,
+     * accumulate_op_types will be initialized with the same value of which_accumulate_ops.
+     * Internally use only accumulate_op_types because it is the superset.*/
+    MPIDIG_win_accu_op_type_t accumulate_op_types[MPIDIG_ACCU_NUM_OP][MPIR_DATATYPE_N_PREDEFINED];
+
     bool accumulate_noncontig_dtype;    /* true by default. */
     MPI_Aint accumulate_max_bytes;      /* Non-negative integer, -1 (unlimited) by default.
                                          * TODO: can be set to win_size.*/

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -353,6 +353,7 @@ typedef struct MPIDIG_win_info_args_t {
                                                          * Note that if a native RMA cannot be supported by the hardware
                                                          * (e.g., network atomics limit), we ignore the "native" hint and reset to auto.*/
     bool coll_attach;           /* false by default. Valid only for dynamic window */
+    bool no_op_cross_attached_mem;      /* false by default. Valid only for dynamic window */
 
     /* alloc_shm: MPICH specific hint (same in CH3).
      * If true, MPICH will try to use shared memory routines for the window.

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -298,6 +298,12 @@ typedef enum {
     MPIDIG_ACCU_SAME_OP_NO_OP
 } MPIDIG_win_info_accumulate_ops;
 
+typedef enum {
+    MPIDIG_RMA_ISSUE_MODE_AM,   /* always active message */
+    MPIDIG_RMA_ISSUE_MODE_NATIVE,       /* always native when possible (nm or shm) */
+    MPIDIG_RMA_ISSUE_MODE_AUTO, /* controlled by each shmmod or netmod */
+} MPIDIG_win_info_rma_issue_mode_t;
+
 typedef struct MPIDIG_win_accu_op_type {
     unsigned int used_count;    /* non-negative number. INT_MAX means unlimited
                                  * because the user can only set int count.*/
@@ -338,6 +344,14 @@ typedef struct MPIDIG_win_info_args_t {
     MPI_Aint accumulate_max_bytes;      /* Non-negative integer, -1 (unlimited) by default.
                                          * TODO: can be set to win_size.*/
     bool disable_shm_accumulate;        /* false by default. */
+    MPIDIG_win_info_rma_issue_mode_t rma_issue_mode;    /* Control the issue routine of RMA operation per window.
+                                                         * Possible value is one of "am|native|auto".
+                                                         * If am is set, we always use CH4 AM based routine for the window;
+                                                         * if native is set, we use only native path (shm or nm) when possible;
+                                                         * if auto is set, shmmod or netmod decides the optimal path.
+                                                         * auto by default.
+                                                         * Note that if a native RMA cannot be supported by the hardware
+                                                         * (e.g., network atomics limit), we ignore the "native" hint and reset to auto.*/
     bool coll_attach;           /* false by default. Valid only for dynamic window */
 
     /* alloc_shm: MPICH specific hint (same in CH3).

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -73,6 +73,7 @@ typedef int (*MPIDI_NM_rma_win_cmpl_hook_t) (MPIR_Win * win);
 typedef int (*MPIDI_NM_rma_win_local_cmpl_hook_t) (MPIR_Win * win);
 typedef int (*MPIDI_NM_rma_target_cmpl_hook_t) (int rank, MPIR_Win * win);
 typedef int (*MPIDI_NM_rma_target_local_cmpl_hook_t) (int rank, MPIR_Win * win);
+typedef bool(*MPIDI_NM_rma_am_progress_cond_check_t) (MPIR_Win * win);
 typedef void (*MPIDI_NM_am_request_init_t) (MPIR_Request * req);
 typedef void (*MPIDI_NM_am_request_finalize_t) (MPIR_Request * req);
 typedef int (*MPIDI_NM_mpi_send_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype,
@@ -401,6 +402,7 @@ typedef struct MPIDI_NM_funcs {
     MPIDI_NM_rma_win_local_cmpl_hook_t rma_win_local_cmpl_hook;
     MPIDI_NM_rma_target_cmpl_hook_t rma_target_cmpl_hook;
     MPIDI_NM_rma_target_local_cmpl_hook_t rma_target_local_cmpl_hook;
+    MPIDI_NM_rma_am_progress_cond_check_t rma_am_progress_cond_check;
     /* Request allocation routines */
     MPIDI_NM_am_request_init_t am_request_init;
     MPIDI_NM_am_request_finalize_t am_request_finalize;
@@ -589,6 +591,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank,
                                                                  MPIR_Win *
                                                                  win) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_rma_am_progress_cond_check(MPIR_Win *
+                                                                  win) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request *
                                                            req) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_rma.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_rma.h
@@ -114,6 +114,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
     return MPI_SUCCESS;
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_rma_am_progress_cond_check(MPIR_Win * win)
+{
+    return true;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr,
                                               int origin_count,
                                               MPI_Datatype origin_datatype,

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -181,6 +181,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
     return ret;
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_rma_am_progress_cond_check(MPIR_Win * win)
+{
+    bool ret;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_RMA_AM_PROGRESS_COND_CHECK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_AM_PROGRESS_COND_CHECK);
+
+    ret = MPIDI_NM_func->rma_am_progress_cond_check(win);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_RMA_AM_PROGRESS_COND_CHECK);
+    return ret;
+}
+
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_REQUEST_INIT);

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -43,6 +43,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     .rma_win_local_cmpl_hook = MPIDI_NM_rma_win_local_cmpl_hook,
     .rma_target_cmpl_hook = MPIDI_NM_rma_target_cmpl_hook,
     .rma_target_local_cmpl_hook = MPIDI_NM_rma_target_local_cmpl_hook,
+    .rma_am_progress_cond_check = MPIDI_NM_rma_am_progress_cond_check,
     /* Request initialization/cleanup routines */
     .am_request_init = MPIDI_NM_am_request_init,
     .am_request_finalize = MPIDI_NM_am_request_finalize,

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -236,6 +236,9 @@ typedef struct {
      * supply automatic progress. This can make a big performance difference when doing
      * large, non-contiguous RMA operations. */
     int progress_counter;
+
+    bool force_native_flag;     /* Whether use only native path for all RMA operations of this window.
+                                 * FALSE by default. Can be changed by user hints only at window creation.*/
 } MPIDI_OFI_win_t;
 
 typedef struct {

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -100,8 +100,8 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt
      * does not know what the same_op is on the other processes, which might be
      * unsupported (e.g., maxloc). Thus, the noop process has to always use AM, and
      * other processes have to also only use AM in order to ensure atomicity with
-     * atomic get. The user can use which_accumulate_ops hint to specify used reduce
-     * and cswap operations.
+     * atomic get. The user can use which_accumulate_ops or accumulate_op_types hint
+     * to specify used reduce and cswap operations.
      * We calculate the max count of all specified ops for each datatype at window
      * creation or info set. dtypes_max_count[dt_index] is the provider allowed
      * count for all possible ops. It is 0 if any of the op is not supported and

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -399,6 +399,7 @@ typedef struct MPIDI_OFI_win_acc_hint {
                                                                  * provided by the OFI provider (recored in MPIDI_OFI_global.win_op_table).
                                                                  * Invalid <dtype, op> defined in MPI standard are excluded.
                                                                  * This structure is prepared at window creation time. */
+    bool acc_am_required;
 } MPIDI_OFI_win_acc_hint_t;
 
 enum {

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -45,7 +45,7 @@ static void load_acc_hint(MPIR_Win * win)
             uint64_t max_count = 0;
             /* Calculate the max count of all possible atomics if this op is enabled.
              * If the op is disabled for the datatype, the max counts are set to 0 (see util.c).*/
-            if (MPIDIG_WIN(win, info_args).which_accumulate_ops & (1 << op_index)) {
+            if (MPIDIG_WIN(win, info_args).accumulate_op_types[op_index][i].used_count) {
                 MPI_Op op = MPIDIU_win_acc_get_op(op_index);
 
                 /* Invalid <datatype, op> pairs should be excluded as it is never used in a

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -383,4 +383,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank ATTRIB
   fn_fail:
     goto fn_exit;
 }
+
+
+MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_rma_am_progress_cond_check(MPIR_Win * win)
+{
+    /* FALSE if we successfully force to use native path for all RMAs */
+    return !MPIDI_OFI_WIN(win).force_native_flag;
+}
+
 #endif /* OFI_WIN_H_INCLUDED */

--- a/src/mpid/ch4/netmod/stubnm/func_table.c
+++ b/src/mpid/ch4/netmod/stubnm/func_table.c
@@ -42,6 +42,7 @@ MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     .rma_win_local_cmpl_hook = MPIDI_NM_rma_win_local_cmpl_hook,
     .rma_target_cmpl_hook = MPIDI_NM_rma_target_cmpl_hook,
     .rma_target_local_cmpl_hook = MPIDI_NM_rma_target_local_cmpl_hook,
+    .rma_am_progress_cond_check = MPIDI_NM_rma_am_progress_cond_check,
     /* Request initialization/cleanup routines */
     .am_request_init = MPIDI_NM_am_request_init,
     .am_request_finalize = MPIDI_NM_am_request_finalize,

--- a/src/mpid/ch4/netmod/stubnm/stubnm_win.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_win.h
@@ -115,4 +115,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
     return MPI_SUCCESS;
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_rma_am_progress_cond_check(MPIR_Win * win)
+{
+    return true;        /* always require AM progress for RMA */
+}
+
 #endif /* STUBNM_WIN_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -43,6 +43,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     .rma_win_local_cmpl_hook = MPIDI_NM_rma_win_local_cmpl_hook,
     .rma_target_cmpl_hook = MPIDI_NM_rma_target_cmpl_hook,
     .rma_target_local_cmpl_hook = MPIDI_NM_rma_target_local_cmpl_hook,
+    .rma_am_progress_cond_check = MPIDI_NM_rma_am_progress_cond_check,
     /* Request initialization/cleanup routines */
     .am_request_init = MPIDI_NM_am_request_init,
     .am_request_finalize = MPIDI_NM_am_request_finalize,

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -246,4 +246,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
   fn_fail:
     goto fn_exit;
 }
+
+MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_rma_am_progress_cond_check(MPIR_Win * win)
+{
+    return true;        /* always require AM progress for RMA */
+}
 #endif /* UCX_WIN_H_INCLUDED */

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -135,6 +135,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_rma_target_local_cmpl_hook(int rank,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_rma_op_cs_enter_hook(MPIR_Win *
                                                             win) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_rma_op_cs_exit_hook(MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX bool MPIDI_SHM_rma_am_progress_cond_check(MPIR_Win *
+                                                                   win) MPL_STATIC_INLINE_SUFFIX;
 
 int MPIDI_SHM_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_shared_query(MPIR_Win * win, int rank,

--- a/src/mpid/ch4/shm/posix/posix_win.h
+++ b/src/mpid/ch4/shm/posix/posix_win.h
@@ -323,4 +323,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_rma_op_cs_exit_hook(MPIR_Win * win)
     goto fn_exit;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_rma_am_progress_cond_check(MPIR_Win * win)
+{
+    bool ret = true;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_RMA_AM_PROGRESS_COND_HOOK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_RMA_AM_PROGRESS_COND_HOOK);
+
+    /* All SHM-based RMAs are completed when issuing the op, thus no AM progress is required. */
+    if (MPIDI_WIN(win, winattr) & MPIDI_WINATTR_SHM_ALLOCATED) {
+        ret = false;
+    }
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_RMA_AM_PROGRESS_COND_HOOK);
+    return ret;
+}
+
 #endif /* POSIX_WIN_H_INCLUDED */

--- a/src/mpid/ch4/shm/src/shm_am_fallback_rma.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_rma.h
@@ -111,6 +111,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_rma_target_local_cmpl_hook(int rank, MPIR
     return MPI_SUCCESS;
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIDI_SHM_rma_am_progress_cond_check(MPIR_Win * win)
+{
+    return true;        /* All RMAs are AM based, thus require AM progress. */
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_put(const void *origin_addr,
                                                int origin_count,
                                                MPI_Datatype origin_datatype,

--- a/src/mpid/ch4/shm/src/shm_hooks.h
+++ b/src/mpid/ch4/shm/src/shm_hooks.h
@@ -61,4 +61,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_rma_target_local_cmpl_hook(int rank, MPIR
     return ret;
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIDI_SHM_rma_am_progress_cond_check(MPIR_Win * win)
+{
+    bool ret;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_RMA_AM_PROGRESS_COND_HOOK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_RMA_AM_PROGRESS_COND_HOOK);
+
+    ret = MPIDI_POSIX_rma_am_progress_cond_check(win);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_RMA_AM_PROGRESS_COND_HOOK);
+    return ret;
+}
+
 #endif /* SHM_HOOKS_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -339,6 +339,11 @@ static int win_set_info(MPIR_Win * win, MPIR_Info * info, bool is_init)
                 MPIDIG_WIN(win, info_args).coll_attach = true;
             else
                 MPIDIG_WIN(win, info_args).coll_attach = false;
+        } else if (is_init && !strcmp(curr_ptr->key, "no_op_cross_attached_mem")) {
+            if (!strcmp(curr_ptr->value, "true"))
+                MPIDIG_WIN(win, info_args).no_op_cross_attached_mem = true;
+            else
+                MPIDIG_WIN(win, info_args).no_op_cross_attached_mem = false;
         } else if (is_init && !strcmp(curr_ptr->key, "rma_issue_mode")) {
             if (!strcmp(curr_ptr->value, "am") || !strcmp(curr_ptr->value, "active_message"))
                 MPIDIG_WIN(win, info_args).rma_issue_mode = MPIDIG_RMA_ISSUE_MODE_AM;
@@ -426,6 +431,7 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
     MPIDIG_WIN(win, info_args).disable_shm_accumulate = false;
     MPIDIG_WIN(win, info_args).coll_attach = false;
     MPIDIG_WIN(win, info_args).rma_issue_mode = MPIDIG_RMA_ISSUE_MODE_AUTO;
+    MPIDIG_WIN(win, info_args).no_op_cross_attached_mem = false;
 
     if ((info != NULL) && ((int *) info != (int *) MPI_INFO_NULL)) {
         mpi_errno = win_set_info(win, info, TRUE /* is_init */);
@@ -909,6 +915,12 @@ int MPIDIG_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "coll_attach", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "coll_attach", "false");
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (MPIDIG_WIN(win, info_args).no_op_cross_attached_mem)
+        mpi_errno = MPIR_Info_set_impl(*info_p_p, "no_op_cross_attached_mem", "true");
+    else
+        mpi_errno = MPIR_Info_set_impl(*info_p_p, "no_op_cross_attached_mem", "false");
     MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDIG_WIN(win, info_args).rma_issue_mode == MPIDIG_RMA_ISSUE_MODE_AM)

--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -37,6 +37,17 @@ static int accu_op_search_index_by_shortname(char *shortname)
     return op_index;
 }
 
+static const char *accu_op_cswap_shortname = "cswap";
+static const char *accu_op_get_shortname(MPI_Op op)
+{
+    /* use OP_NULL as special cswap */
+    if (op == MPI_OP_NULL) {
+        return accu_op_cswap_shortname;
+    } else {
+        return MPIR_Op_builtin_get_shortname(op);
+    }
+}
+
 static void accu_ops_info_parse_str(MPIR_Win * win, const char *val)
 {
     uint32_t ops = 0;
@@ -80,15 +91,10 @@ static void accu_ops_info_get_str(MPIR_Win * win, char *buf, size_t maxlen)
     for (op_index = 0; op_index < MPIDIG_ACCU_NUM_OP; op_index++) {
         if (MPIDIG_WIN(win, info_args).which_accumulate_ops & (1 << op_index)) {
             MPI_Op op = MPIDIU_win_acc_get_op(op_index);
+            const char *short_name = accu_op_get_shortname(op);
 
-            MPIR_Assert(c < maxlen);
-            /* use OP_NULL as special cswap */
-            if (op == MPI_OP_NULL) {
-                c += snprintf(buf + c, maxlen - c, "%scswap", (c > 0) ? "," : "");
-            } else {
-                const char *short_name = MPIR_Op_builtin_get_shortname(op);
-                c += snprintf(buf + c, maxlen - c, "%s%s", (c > 0) ? "," : "", short_name);
-            }
+            MPIR_Assert(c + strlen(short_name) + 1 < maxlen);
+            c += snprintf(buf + c, maxlen - c, "%s%s", (c > 0) ? "," : "", short_name);
         }
     }
 

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -540,6 +540,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
     /* Check window lock epoch. */
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, return mpi_errno);
 
+    bool require_am_progress = MPIDI_NM_rma_am_progress_cond_check(win);
+
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_target_cmpl_hook(rank, win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -547,7 +549,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_target_cmpl_hook(rank, win);
     MPIR_ERR_CHECK(mpi_errno);
+
+    require_am_progress |= MPIDI_SHM_rma_am_progress_cond_check(win);
 #endif
+
+    /* Skip generic progress if RMA AM progress is not required.
+     * For pt2pt and collectives, progress can be made by the corresponding
+     * pt2pt or collective calls.*/
+    if (!require_am_progress)
+        goto fn_exit;
 
     /* Ensure completion of AM operations issued to the target.
      * If target object is not created (e.g., when all operations issued
@@ -578,6 +588,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
 
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, goto fn_fail);
 
+    bool require_am_progress = MPIDI_NM_rma_am_progress_cond_check(win);
+
     /* Ensure op local completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_local_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -585,7 +597,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_win_local_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
+
+    require_am_progress |= MPIDI_SHM_rma_am_progress_cond_check(win);
 #endif
+
+    /* Skip generic progress if RMA AM progress is not required.
+     * For pt2pt and collectives, progress can be made by the corresponding
+     * pt2pt or collective calls.*/
+    if (!require_am_progress)
+        goto fn_exit;
 
     /* Ensure completion of AM operations */
 
@@ -682,6 +702,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win
     /* Check window lock epoch. */
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, return mpi_errno);
 
+    bool require_am_progress = MPIDI_NM_rma_am_progress_cond_check(win);
+
     /* Ensure op local completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_target_local_cmpl_hook(rank, win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -689,7 +711,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_target_local_cmpl_hook(rank, win);
     MPIR_ERR_CHECK(mpi_errno);
+
+    require_am_progress |= MPIDI_SHM_rma_am_progress_cond_check(win);
 #endif
+
+    /* Skip generic progress if RMA AM progress is not required.
+     * For pt2pt and collectives, progress can be made by the corresponding
+     * pt2pt or collective calls.*/
+    if (!require_am_progress)
+        goto fn_exit;
 
     /* Ensure completion of AM operations issued to the target.
      * If target object is not created (e.g., when all operations issued
@@ -735,6 +765,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_all(MPIR_Win * win)
 
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, goto fn_fail);
 
+    bool require_am_progress = MPIDI_NM_rma_am_progress_cond_check(win);
+
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -742,7 +774,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_all(MPIR_Win * win)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
+
+    require_am_progress |= MPIDI_SHM_rma_am_progress_cond_check(win);
 #endif
+
+    /* Skip generic progress if RMA AM progress is not required.
+     * For pt2pt and collectives, progress can be made by the corresponding
+     * pt2pt or collective calls.*/
+    if (!require_am_progress)
+        goto fn_exit;
 
     /* Ensure completion of AM operations */
     do {

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1831,5 +1831,7 @@ AC_OUTPUT(maint/testmerge \
           impls/mpich/mpi_t/Makefile \
           impls/mpich/comm/Makefile \
           impls/mpich/comm/testlist \
+          impls/mpich/rma/Makefile \
+          impls/mpich/rma/testlist \
           )
 

--- a/test/mpi/impls/mpich/Makefile.am
+++ b/test/mpi/impls/mpich/Makefile.am
@@ -7,7 +7,7 @@ include $(top_srcdir)/Makefile_single.mtest
 
 EXTRA_DIST = testlist.in
 
-static_subdirs = mpi_t comm
+static_subdirs = mpi_t comm rma
 # For future tests - note that the IO and RMA directories are optional,
 # and need to be handled as shown in this comment
 #SUBDIRS      = $(static_subdirs) $(iodir) $(rmadir)

--- a/test/mpi/impls/mpich/rma/Makefile.am
+++ b/test/mpi/impls/mpich/rma/Makefile.am
@@ -1,0 +1,18 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+include $(top_srcdir)/Makefile_single.mtest
+
+EXTRA_DIST = testlist.in
+
+AM_DEFAULT_SOURCE_EXT = .c
+
+## for all programs that are just built from the single corresponding source
+## file, we don't need per-target _SOURCES rules, automake will infer them
+## correctly
+noinst_PROGRAMS = win_info_hint
+
+# Copied from cxx/rma/Makefile.am
+#BINDIR=${bindir}

--- a/test/mpi/impls/mpich/rma/testlist.in
+++ b/test/mpi/impls/mpich/rma/testlist.in
@@ -1,0 +1,8 @@
+# To add a ch4 comm hints support test:
+# start with @ch4_commhints_tests_enabled@
+# use @ch3_tests@, @ch4_tests@, @ch4_ucx_tests@, or @ch4_ofi_tests@ for specific tests
+@ch4_tests@win_info_hint 1 arg=-hint=alloc_shm arg=-value=false
+@ch4_tests@win_info_hint 1 arg=-hint=which_accumulate_ops arg=-value=sum,no_op,cswap
+@ch4_tests@win_info_hint 1 arg=-hint=disable_shm_accumulate arg=-value=true
+@ch4_tests@win_info_hint 1 arg=-hint=coll_attach arg=-value=true
+@ch4_tests@win_info_hint 1 arg=-hint=accumulate_op_types:cswap arg=-value=int:1,long:1,int8:1,int16:1 arg=-hint=accumulate_op_types:sum arg=-value=float:1024,double:1024 arg=-hint=accumulate_op_types:no_op arg=-value=float:65536,double:8192

--- a/test/mpi/impls/mpich/rma/win_info_hint.c
+++ b/test/mpi/impls/mpich/rma/win_info_hint.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include <mpi.h>
+#include <string.h>
+#include "mpitest.h"
+
+#define VERBOSE 0
+#define MAX_N_HINTS 10
+static char query_key[MAX_N_HINTS][MPI_MAX_INFO_KEY], val[MAX_N_HINTS][MPI_MAX_INFO_VAL];
+static int nhints = 0, rank;
+
+static int check_win_info_get(MPI_Win win, const char *key, const char *exp_val)
+{
+    int flag = 0;
+    MPI_Info info_out = MPI_INFO_NULL;
+    char buf[MPI_MAX_INFO_VAL];
+    int errors = 0;
+
+    MPI_Win_get_info(win, &info_out);
+    MPI_Info_get(info_out, key, MPI_MAX_INFO_VAL, buf, &flag);
+    if (!flag) {
+        fprintf(stderr, "%d: Hint %s was not set\n", rank, key);
+        errors++;
+    }
+    if (strcmp(buf, exp_val)) {
+        fprintf(stderr, "%d: Hint %s, expected value: %s, received: %s\n", rank, key, exp_val, buf);
+        errors++;
+    }
+
+    if (!errors && VERBOSE)
+        fprintf(stdout, "%d: %s = %s\n", rank, key, buf);
+
+    MPI_Info_free(&info_out);
+
+    return errors;
+}
+
+static void print_usage(char **argv)
+{
+    fprintf(stdout,
+            "Usage: %s -hint=[infokey] -value=[VALUE] (-hint=[infokey] -value=[VALUE]...)\n",
+            argv[0]);
+    fflush(stdout);
+}
+
+static int prepare_hints(int argc, char **argv)
+{
+    int i;
+    for (i = 1; i < argc; i += 2) {
+        memset(query_key[nhints], 0, sizeof(query_key[nhints]));
+        memset(val[nhints], 0, sizeof(val[nhints]));
+
+        if (nhints >= MAX_N_HINTS) {
+            fprintf(stderr, "This program accepts at most %d pairs of hint and value\n",
+                    MAX_N_HINTS);
+            return 1;
+        }
+
+        if (!strncmp(argv[i], "-hint=", strlen("-hint=")))
+            strncpy(query_key[nhints], argv[i] + strlen("-hint="), MPI_MAX_INFO_KEY);
+        if (!strncmp(argv[i + 1], "-value=", strlen("-value=")) && i + 1 < argc)
+            strncpy(val[nhints], argv[i + 1] + strlen("-value="), MPI_MAX_INFO_KEY);
+
+        if (strlen(query_key[nhints]) == 0 || strlen(val[nhints]) == 0) {
+            fprintf(stderr, "Invalid parameters %s, %s\n", argv[i], argv[i + 1]);
+            return 1;
+        }
+
+        nhints++;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    MPI_Info info_in;
+    int errors = 0, i;
+    MPI_Win win;
+    void *base;
+
+
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (argc < 3 || argc % 2 == 0) {
+        fprintf(stderr, "This program requires at least a pair of hint and value, "
+                "and each hint and value have to be paired.\n");
+        print_usage(argv);
+        return MTestReturnValue(1);
+    }
+
+    /* Read each pair of info key and value. Return if invalid input is found. */
+    if (prepare_hints(argc, argv)) {
+        print_usage(argv);
+        return MTestReturnValue(1);
+    }
+
+    /* Run test */
+    MPI_Info_create(&info_in);
+    for (i = 0; i < nhints; i++) {
+        MPI_Info_set(info_in, query_key[i], val[i]);
+    }
+    MPI_Win_allocate(sizeof(int), sizeof(int), info_in, MPI_COMM_WORLD, &base, &win);
+    for (i = 0; i < nhints; i++) {
+        errors += check_win_info_get(win, query_key[i], val[i]);
+    }
+    MPI_Info_free(&info_in);
+    MPI_Win_free(&win);
+
+    MTest_Finalize(errors);
+    return MTestReturnValue(errors);
+}


### PR DESCRIPTION
## Pull Request Description

MPI generic progress is expensive. It is required to ensure progress for pt2pt, collectives, and any active message (e.g., for RMA). However, if the user program only uses RMA and all RMA are handled through native path, we can safely skip the generic progress in RMA synchronization. For instance, it significantly reduces latency for OSHMPI over MPICH RMA.

To ensure all RMA can be handled by the native path, we need several conditions ensured by both the user and the network.

From user:
1. What atomics <op, datatype> are used?
2. Is there any noncontiguous accumulate?
3. If it is dynamic window, is there any operation accessing cross two attached memory?

From network:
1. What atomics <op, datatype> are supported?
2. What is the max size limit of each atomic and for required atomics ordering?

We define a set of hints to collect the user conditions. For network part, we query at ofi_init (already in existing code). At each window creation, we check all conditions and make decision whether we can force native, and thus skip AM progress.

New window hints in this PR:
- accumulate_op_types: define all used <op, datatype> for RMA atomics in user program
- rma_issue_mode: define whether user prefers native, am, or auto path for RMA on this window. Auto by default.
- no_op_cross_attached_mem (for user condition-3)


## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
