### PR TITLE
misc: add macro INTERNAL_STATIC_INLINE

### DIFF
--- a/maint/check_internal_inline.pl
+++ b/maint/check_internal_inline.pl
@@ -1,0 +1,104 @@
+#!/usr/bin/perl
+use strict;
+
+our %opts;
+our %functions;
+
+foreach my $a (@ARGV) {
+    if ($a=~/^-(\w+)$/) {
+        $opts{$1}=1;
+    }
+    elsif ($a=~/^-(\w+)=(.*)/) {
+        $opts{$1}=$2;
+    }
+}
+my @files;
+foreach my $dir (qw(mpi mpi_t nameserv util include mpid pmi)) {
+    open In, "find src/$dir -name '*.[ch]' |" or die "Can't open find src/$dir -name '*.[ch]' |: $!\n";
+    while(<In>){
+        chomp;
+        push @files, $_;
+    }
+    close In;
+}
+
+foreach my $f (@files) {
+    open In, "$f" or die "Can't open $f: $!\n";
+    while(<In>){
+        if (/^MPL_STATIC_INLINE_PREFIX\s.*\s(\w+)\(/) {
+            if ($functions{$1}) {
+                $functions{$1}->{external_count}++;
+            }
+            else {
+                $functions{$1} = {file=>$f};
+            }
+        }
+        elsif (/^INTERNAL_STATIC_INLINE\s.*\s(\w+)\(/) {
+            $functions{$1} = {file=>$f, internal=>1};
+        }
+    }
+    close In;
+}
+foreach my $f (@files) {
+    open In, "$f" or die "Can't open $f: $!\n";
+    while(<In>){
+        if (/(\w+)\(/ && $functions{$1}) {
+            if ($f eq $functions{$1}->{file}) {
+                $functions{$1}->{internal_count}++;
+            }
+            else {
+                $functions{$1}->{external_count}++;
+            }
+        }
+    }
+    close In;
+}
+my %files_need_correct;
+foreach my $name (sort keys %functions) {
+    my $count = $functions{$name}->{external_count};
+    my $file = $functions{$name}->{file};
+    if ($functions{$name}->{internal}) {
+        if ($count>0) {
+            print "INTERNAL $name\texternally used\n";
+            $functions{$name}->{need_correct}=1;
+            $files_need_correct{$file}++;
+        }
+    }
+    else {
+        if ($count==0) {
+            my $internal_count = $functions{$name}->{internal_count};
+            if ($name=~/^MPIDI_STUBSHM_/ or $internal_count==1) {
+                next;
+            }
+            print "EXTERNAL $name\tonly used internally ($internal_count)\n";
+            $functions{$name}->{need_correct}=1;
+            $files_need_correct{$file}++;
+        }
+    }
+}
+if ($opts{correct}) {
+    foreach my $f (sort keys %files_need_correct) {
+        my @lines;
+        open In, "$f" or die "Can't open $f: $!\n";
+        while(<In>){
+            if (/^MPL_STATIC_INLINE_PREFIX\s.*\s(\w+)\(/) {
+                if ($functions{$1}->{need_correct}) {
+                    s/MPL_STATIC_INLINE_PREFIX/INTERNAL_STATIC_INLINE/;
+                }
+            }
+            elsif (/^INTERNAL_STATIC_INLINE\s.*\s(\w+)\(/) {
+                if ($functions{$1}->{need_correct}) {
+                    s/INTERNAL_STATIC_INLINE/MPL_STATIC_INLINE_PREFIX/;
+                }
+            }
+            push @lines, $_;
+        }
+        close In;
+        open Out, ">$f" or die "Can't write $f: $!\n";
+        print "  --> [$f]\n";
+        foreach my $l (@lines) {
+            print Out $l;
+        }
+        close Out;
+    }
+}

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -14,6 +14,11 @@
 #define MPIR_FINALIZE_CALLBACK_DEFAULT_PRIO 0
 #define MPIR_FINALIZE_CALLBACK_MAX_PRIO 10
 
+/* To differentiate internal static inline functions in inline header files.
+ * Note: we drop the MPIR_ prefix to make the INTERNAL nature more standout.
+ */
+#define INTERNAL_STATIC_INLINE MPL_STATIC_INLINE_PREFIX
+
 /* Define a typedef for the errflag value used by many internal
  * functions.  If an error needs to be returned, these values can be
  * used to signal such.  More details can be found further down in the

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -28,9 +28,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_prepare_recv_req(int rank, int tag,
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_PREPARE_RECV_REQ);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexpected(void *buf, MPI_Aint count,
-                                                      MPI_Datatype datatype, MPIR_Comm * comm,
-                                                      int context_offset, MPIR_Request * rreq)
+INTERNAL_STATIC_INLINE int MPIDIG_handle_unexpected(void *buf, MPI_Aint count,
+                                                    MPI_Datatype datatype, MPIR_Comm * comm,
+                                                    int context_offset, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     int dt_contig;
@@ -111,10 +111,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexpected(void *buf, MPI_Aint count,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                             int rank, int tag, MPIR_Comm * comm,
-                                             int context_offset, MPIR_Request ** request,
-                                             int alloc_req, uint64_t flags)
+INTERNAL_STATIC_INLINE int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                           int rank, int tag, MPIR_Comm * comm,
+                                           int context_offset, MPIR_Request ** request,
+                                           int alloc_req, uint64_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL, *unexp_req = NULL;

--- a/src/mpid/ch4/generic/am/mpidig_am_send.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_send.h
@@ -13,7 +13,7 @@
 #define MPIDIG_AM_SEND_FLAGS_SYNC (1)
 #define MPIDIG_AM_SEND_FLAGS_RTS (1 << 1)
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_eager_limit(int is_local)
+INTERNAL_STATIC_INLINE int MPIDIG_eager_limit(int is_local)
 {
     int thresh;
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -31,11 +31,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_eager_limit(int is_local)
     return thresh;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
-                                               MPI_Datatype datatype, int rank, int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, uint8_t flags,
-                                               MPIR_Request ** request, MPIR_Errflag_t errflag)
+INTERNAL_STATIC_INLINE int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
+                                             MPI_Datatype datatype, int rank, int tag,
+                                             MPIR_Comm * comm, int context_offset,
+                                             MPIDI_av_entry_t * addr, uint8_t flags,
+                                             MPIR_Request ** request, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = *request;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -158,11 +158,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_short_am_hdr(MPIDI_OFI_am_header_t
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
-                                                    uint64_t src,
-                                                    size_t data_sz,
-                                                    MPIR_Context_id_t context_id,
-                                                    int src_rank, MPIR_Request * rreq)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_do_rdma_read(void *dst,
+                                                  uint64_t src,
+                                                  size_t data_sz,
+                                                  MPIR_Context_id_t context_id,
+                                                  int src_rank, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t done = 0, curr_len, rem = 0;
@@ -221,9 +221,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
 
 MPL_STATIC_INLINE_PREFIX void do_long_am_recv(MPI_Aint in_data_sz, MPIR_Request * rreq,
                                               MPIDI_OFI_lmt_msg_payload_t * lmt_msg);
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_handle_long_am(MPIDI_OFI_am_header_t * msg_hdr,
-                                                         MPIDI_OFI_lmt_msg_payload_t * lmt_msg,
-                                                         void *am_hdr)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_do_handle_long_am(MPIDI_OFI_am_header_t * msg_hdr,
+                                                       MPIDI_OFI_lmt_msg_payload_t * lmt_msg,
+                                                       void *am_hdr)
 {
     int c, mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
@@ -350,9 +350,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_ack(int rank, int context_id,
 }
 
 /* internal routines */
-MPL_STATIC_INLINE_PREFIX void do_long_am_recv_contig(void *p_data, MPI_Aint data_sz,
-                                                     MPI_Aint in_data_sz, MPIR_Request * rreq,
-                                                     MPIDI_OFI_lmt_msg_payload_t * lmt_msg)
+INTERNAL_STATIC_INLINE void do_long_am_recv_contig(void *p_data, MPI_Aint data_sz,
+                                                   MPI_Aint in_data_sz, MPIR_Request * rreq,
+                                                   MPIDI_OFI_lmt_msg_payload_t * lmt_msg)
 {
     MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_type) = MPIDI_OFI_AM_LMT_IOV;
     if (in_data_sz > data_sz) {
@@ -366,9 +366,9 @@ MPL_STATIC_INLINE_PREFIX void do_long_am_recv_contig(void *p_data, MPI_Aint data
     MPIR_STATUS_SET_COUNT(rreq->status, data_sz);
 }
 
-MPL_STATIC_INLINE_PREFIX void do_long_am_recv_iov(struct iovec *iov, MPI_Aint iov_len,
-                                                  MPI_Aint in_data_sz, MPIR_Request * rreq,
-                                                  MPIDI_OFI_lmt_msg_payload_t * lmt_msg)
+INTERNAL_STATIC_INLINE void do_long_am_recv_iov(struct iovec *iov, MPI_Aint iov_len,
+                                                MPI_Aint in_data_sz, MPIR_Request * rreq,
+                                                MPIDI_OFI_lmt_msg_payload_t * lmt_msg)
 {
     MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_type) = MPIDI_OFI_AM_LMT_IOV;
     MPI_Aint rem, curr_len;
@@ -402,8 +402,8 @@ MPL_STATIC_INLINE_PREFIX void do_long_am_recv_iov(struct iovec *iov, MPI_Aint io
     MPIR_STATUS_SET_COUNT(rreq->status, done);
 }
 
-MPL_STATIC_INLINE_PREFIX void do_long_am_recv_unpack(MPI_Aint in_data_sz, MPIR_Request * rreq,
-                                                     MPIDI_OFI_lmt_msg_payload_t * lmt_msg)
+INTERNAL_STATIC_INLINE void do_long_am_recv_unpack(MPI_Aint in_data_sz, MPIR_Request * rreq,
+                                                   MPIDI_OFI_lmt_msg_payload_t * lmt_msg)
 {
     MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_type) = MPIDI_OFI_AM_LMT_UNPACK;
     MPIDIG_recv_setup(rreq);

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -181,9 +181,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_progress_do_queue(int vni_idx)
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm, int handler_id,
-                                                     const void *data, MPI_Aint data_sz,
-                                                     MPIR_Request * sreq)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm, int handler_id,
+                                                   const void *data, MPI_Aint data_sz,
+                                                   MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -258,9 +258,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm, int handler_id,
-                                                      const void *data, MPI_Aint data_sz,
-                                                      MPIR_Request * sreq)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm, int handler_id,
+                                                    const void *data, MPI_Aint data_sz,
+                                                    MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -305,11 +305,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * comm, int handler_id,
-                                                         const void *data, MPI_Aint seg_sz,
-                                                         MPI_Aint data_sz, MPIR_Request * sreq,
-                                                         MPIDI_OFI_am_send_pipeline_request_t *
-                                                         send_req)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * comm, int handler_id,
+                                                       const void *data, MPI_Aint seg_sz,
+                                                       MPI_Aint data_sz, MPIR_Request * sreq,
+                                                       MPIDI_OFI_am_send_pipeline_request_t *
+                                                       send_req)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -469,9 +469,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_eager(int rank, MPIR_Comm * c
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
-                                                          const MPIDI_OFI_am_header_t * msg_hdrp,
-                                                          const void *am_hdr, size_t am_hdr_sz)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
+                                                        const MPIDI_OFI_am_header_t * msg_hdrp,
+                                                        const void *am_hdr, size_t am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -8,14 +8,14 @@
 
 #include "ofi_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
-                                                 int tag,
-                                                 MPIR_Comm * comm,
-                                                 int context_offset,
-                                                 MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
-                                                 int *flag,
-                                                 MPI_Status * status,
-                                                 MPIR_Request ** message, uint64_t peek_flags)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_do_iprobe(int source,
+                                               int tag,
+                                               MPIR_Comm * comm,
+                                               int context_offset,
+                                               MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
+                                               int *flag,
+                                               MPI_Status * status,
+                                               MPIR_Request ** message, uint64_t peek_flags)
 {
     int mpi_errno = MPI_SUCCESS;
     fi_addr_t remote_proc;

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -21,12 +21,12 @@
       due to limitations with iovec. Needs to fall back to the unpack path.
   Other: An error occurred as indicated in the code.
 */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_t data_sz,      /* data_sz passed in here for reusing */
-                                                int rank, uint64_t match_bits, uint64_t mask_bits,
-                                                MPIR_Comm * comm, MPIR_Context_id_t context_id,
-                                                MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
-                                                MPIR_Request * rreq,
-                                                MPIR_Datatype * dt_ptr, uint64_t flags)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_t data_sz,        /* data_sz passed in here for reusing */
+                                              int rank, uint64_t match_bits, uint64_t mask_bits,
+                                              MPIR_Comm * comm, MPIR_Context_id_t context_id,
+                                              MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
+                                              MPIR_Request * rreq,
+                                              MPIR_Datatype * dt_ptr, uint64_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
     struct iovec *originv = NULL;
@@ -95,15 +95,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
-                                                MPI_Aint count,
-                                                MPI_Datatype datatype,
-                                                int rank,
-                                                int tag,
-                                                MPIR_Comm * comm,
-                                                int context_offset,
-                                                MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
-                                                MPIR_Request ** request, int mode, uint64_t flags)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_do_irecv(void *buf,
+                                              MPI_Aint count,
+                                              MPI_Datatype datatype,
+                                              int rank,
+                                              int tag,
+                                              MPIR_Comm * comm,
+                                              int context_offset,
+                                              MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
+                                              MPIR_Request ** request, int mode, uint64_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -53,14 +53,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_count_iovecs(int origin_count,
     return MPI_SUCCESS;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt, int query_type,
-                                                                 MPI_Op op,
-                                                                 MPIR_Win * win,
-                                                                 MPIDI_winattr_t winattr,
-                                                                 enum fi_datatype *fi_dt,
-                                                                 enum fi_op *fi_op,
-                                                                 MPI_Aint * count,
-                                                                 MPI_Aint * dtsize)
+INTERNAL_STATIC_INLINE void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt, int query_type,
+                                                               MPI_Op op,
+                                                               MPIR_Win * win,
+                                                               MPIDI_winattr_t winattr,
+                                                               enum fi_datatype *fi_dt,
+                                                               enum fi_op *fi_op,
+                                                               MPI_Aint * count, MPI_Aint * dtsize)
 {
     int op_index, dt_index;
 
@@ -124,12 +123,12 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_QUERY_ACC_ATOMIC_SUPPORT);
 }
 
-MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_prepare_target_mr(int target_rank,
-                                                          MPI_Aint target_disp,
-                                                          MPI_Aint target_extent,
-                                                          MPI_Aint target_true_lb, MPIR_Win * win,
-                                                          MPIDI_winattr_t winattr,
-                                                          MPIDI_OFI_target_mr_t * target_mr)
+INTERNAL_STATIC_INLINE bool MPIDI_OFI_prepare_target_mr(int target_rank,
+                                                        MPI_Aint target_disp,
+                                                        MPI_Aint target_extent,
+                                                        MPI_Aint target_true_lb, MPIR_Win * win,
+                                                        MPIDI_winattr_t winattr,
+                                                        MPIDI_OFI_target_mr_t * target_mr)
 {
     size_t offset;
 
@@ -169,15 +168,15 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_prepare_target_mr(int target_rank,
     }
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
-                                              int origin_count,
-                                              MPI_Datatype origin_datatype,
-                                              int target_rank,
-                                              MPI_Aint target_disp,
-                                              int target_count,
-                                              MPI_Datatype target_datatype,
-                                              MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                              MPIDI_winattr_t winattr, MPIR_Request ** sigreq)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_do_put(const void *origin_addr,
+                                            int origin_count,
+                                            MPI_Datatype origin_datatype,
+                                            int target_rank,
+                                            MPI_Aint target_disp,
+                                            int target_count,
+                                            MPI_Datatype target_datatype,
+                                            MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                            MPIDI_winattr_t winattr, MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
     uint64_t flags;
@@ -346,15 +345,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr,
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
-                                              int origin_count,
-                                              MPI_Datatype origin_datatype,
-                                              int target_rank,
-                                              MPI_Aint target_disp,
-                                              int target_count,
-                                              MPI_Datatype target_datatype,
-                                              MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                              MPIDI_winattr_t winattr, MPIR_Request ** sigreq)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_do_get(void *origin_addr,
+                                            int origin_count,
+                                            MPI_Datatype origin_datatype,
+                                            int target_rank,
+                                            MPI_Aint target_disp,
+                                            int target_count,
+                                            MPI_Datatype target_datatype,
+                                            MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                            MPIDI_winattr_t winattr, MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
     uint64_t flags;
@@ -652,17 +651,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
                                        target_rank, target_disp, win);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
-                                                     int origin_count,
-                                                     MPI_Datatype origin_datatype,
-                                                     int target_rank,
-                                                     MPI_Aint target_disp,
-                                                     int target_count,
-                                                     MPI_Datatype target_datatype,
-                                                     MPI_Op op, MPIR_Win * win,
-                                                     MPIDI_av_entry_t * addr,
-                                                     MPIDI_winattr_t winattr,
-                                                     MPIR_Request ** sigreq)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_do_accumulate(const void *origin_addr,
+                                                   int origin_count,
+                                                   MPI_Datatype origin_datatype,
+                                                   int target_rank,
+                                                   MPI_Aint target_disp,
+                                                   int target_count,
+                                                   MPI_Datatype target_datatype,
+                                                   MPI_Op op, MPIR_Win * win,
+                                                   MPIDI_av_entry_t * addr,
+                                                   MPIDI_winattr_t winattr, MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
     int target_contig, origin_contig;
@@ -787,20 +785,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
-                                                         int origin_count,
-                                                         MPI_Datatype origin_datatype,
-                                                         void *result_addr,
-                                                         int result_count,
-                                                         MPI_Datatype result_datatype,
-                                                         int target_rank,
-                                                         MPI_Aint target_disp,
-                                                         int target_count,
-                                                         MPI_Datatype target_datatype,
-                                                         MPI_Op op, MPIR_Win * win,
-                                                         MPIDI_av_entry_t * addr,
-                                                         MPIDI_winattr_t winattr,
-                                                         MPIR_Request ** sigreq)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
+                                                       int origin_count,
+                                                       MPI_Datatype origin_datatype,
+                                                       void *result_addr,
+                                                       int result_count,
+                                                       MPI_Datatype result_datatype,
+                                                       int target_rank,
+                                                       MPI_Aint target_disp,
+                                                       int target_count,
+                                                       MPI_Datatype target_datatype,
+                                                       MPI_Op op, MPIR_Win * win,
+                                                       MPIDI_av_entry_t * addr,
+                                                       MPIDI_winattr_t winattr,
+                                                       MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
     int target_contig, origin_contig, result_contig;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -8,14 +8,14 @@
 
 #include "ofi_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
-                                                        size_t data_sz,
-                                                        uint64_t cq_data,
-                                                        int dst_rank,
-                                                        int tag, MPIR_Comm * comm,
-                                                        int context_offset,
-                                                        MPIDI_av_entry_t * addr,
-                                                        int vni_src, int vni_dst)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_send_lightweight(const void *buf,
+                                                      size_t data_sz,
+                                                      uint64_t cq_data,
+                                                      int dst_rank,
+                                                      int tag, MPIR_Comm * comm,
+                                                      int context_offset,
+                                                      MPIDI_av_entry_t * addr,
+                                                      int vni_src, int vni_dst)
 {
     int mpi_errno = MPI_SUCCESS;
     int vni_local = vni_src;
@@ -51,11 +51,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
 
   Note: data_sz is passed in here for reusing.
 */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count, size_t data_sz,
-                                                uint64_t cq_data,
-                                                int dst_rank, uint64_t match_bits, MPIR_Comm * comm,
-                                                MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
-                                                MPIR_Request * sreq, MPIR_Datatype * dt_ptr)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count, size_t data_sz,
+                                              uint64_t cq_data,
+                                              int dst_rank, uint64_t match_bits, MPIR_Comm * comm,
+                                              MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
+                                              MPIR_Request * sreq, MPIR_Datatype * dt_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     struct iovec *originv = NULL;
@@ -116,15 +116,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint count,
-                                                   MPI_Datatype datatype,
-                                                   uint64_t cq_data, int dst_rank, int tag,
-                                                   MPIR_Comm * comm, int context_offset,
-                                                   MPIDI_av_entry_t * addr, int vni_src,
-                                                   int vni_dst, MPIR_Request ** request,
-                                                   int dt_contig, size_t data_sz,
-                                                   MPIR_Datatype * dt_ptr, MPI_Aint dt_true_lb,
-                                                   uint64_t type)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_send_normal(const void *buf, MPI_Aint count,
+                                                 MPI_Datatype datatype,
+                                                 uint64_t cq_data, int dst_rank, int tag,
+                                                 MPIR_Comm * comm, int context_offset,
+                                                 MPIDI_av_entry_t * addr, int vni_src,
+                                                 int vni_dst, MPIR_Request ** request,
+                                                 int dt_contig, size_t data_sz,
+                                                 MPIR_Datatype * dt_ptr, MPI_Aint dt_true_lb,
+                                                 uint64_t type)
 {
     int mpi_errno = MPI_SUCCESS;
     char *send_buf;
@@ -311,12 +311,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                            int dst_rank, int tag, MPIR_Comm * comm,
-                                            int context_offset, MPIDI_av_entry_t * addr,
-                                            int vni_src, int vni_dst,
-                                            MPIR_Request ** request, int noreq,
-                                            uint64_t syncflag, MPIR_Errflag_t err_flag)
+INTERNAL_STATIC_INLINE int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                          int dst_rank, int tag, MPIR_Comm * comm,
+                                          int context_offset, MPIDI_av_entry_t * addr,
+                                          int vni_src, int vni_dst,
+                                          MPIR_Request ** request, int noreq,
+                                          uint64_t syncflag, MPIR_Errflag_t err_flag)
 {
     int dt_contig, mpi_errno;
     size_t data_sz;

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -98,14 +98,14 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_mrecv_cmpl_cb(void *request, ucs_status_
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_UCX_MRECV_CMPL_CB);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_recv(void *buf,
-                                            MPI_Aint count,
-                                            MPI_Datatype datatype,
-                                            int rank,
-                                            int tag, MPIR_Comm * comm,
-                                            int context_offset,
-                                            MPIDI_av_entry_t * addr,
-                                            int vni_dst, MPIR_Request ** request)
+INTERNAL_STATIC_INLINE int MPIDI_UCX_recv(void *buf,
+                                          MPI_Aint count,
+                                          MPI_Datatype datatype,
+                                          int rank,
+                                          int tag, MPIR_Comm * comm,
+                                          int context_offset,
+                                          MPIDI_av_entry_t * addr,
+                                          int vni_dst, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t data_sz;

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -25,12 +25,12 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_rma_cmpl_cb(void *request, ucs_status_t 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_UCX_RMA_CMPL_CB);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
-                                                  size_t size,
-                                                  int target_rank,
-                                                  MPI_Aint target_disp, MPI_Aint true_lb,
-                                                  MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                  MPIR_Request ** reqptr)
+INTERNAL_STATIC_INLINE int MPIDI_UCX_contig_put(const void *origin_addr,
+                                                size_t size,
+                                                int target_rank,
+                                                MPI_Aint target_disp, MPI_Aint true_lb,
+                                                MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                                MPIR_Request ** reqptr)
 {
 
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
@@ -89,12 +89,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_noncontig_put(const void *origin_addr,
-                                                     int origin_count, MPI_Datatype origin_datatype,
-                                                     int target_rank, size_t size,
-                                                     MPI_Aint target_disp, MPI_Aint true_lb,
-                                                     MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                     MPIR_Request ** reqptr ATTRIBUTE((unused)))
+INTERNAL_STATIC_INLINE int MPIDI_UCX_noncontig_put(const void *origin_addr,
+                                                   int origin_count, MPI_Datatype origin_datatype,
+                                                   int target_rank, size_t size,
+                                                   MPI_Aint target_disp, MPI_Aint true_lb,
+                                                   MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                                   MPIR_Request ** reqptr ATTRIBUTE((unused)))
 {
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
     size_t base, offset;
@@ -129,12 +129,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_noncontig_put(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
-                                                  size_t size,
-                                                  int target_rank,
-                                                  MPI_Aint target_disp, MPI_Aint true_lb,
-                                                  MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                  MPIR_Request ** reqptr)
+INTERNAL_STATIC_INLINE int MPIDI_UCX_contig_get(void *origin_addr,
+                                                size_t size,
+                                                int target_rank,
+                                                MPI_Aint target_disp, MPI_Aint true_lb,
+                                                MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                                MPIR_Request ** reqptr)
 {
 
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
@@ -184,14 +184,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_put(const void *origin_addr,
-                                              int origin_count,
-                                              MPI_Datatype origin_datatype,
-                                              int target_rank,
-                                              MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
-                                              MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                              MPIDI_winattr_t winattr, MPIR_Request ** reqptr)
+INTERNAL_STATIC_INLINE int MPIDI_UCX_do_put(const void *origin_addr,
+                                            int origin_count,
+                                            MPI_Datatype origin_datatype,
+                                            int target_rank,
+                                            MPI_Aint target_disp,
+                                            int target_count, MPI_Datatype target_datatype,
+                                            MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                            MPIDI_winattr_t winattr, MPIR_Request ** reqptr)
 {
     int mpi_errno = MPI_SUCCESS;
     int target_contig, origin_contig;
@@ -242,14 +242,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_put(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_get(void *origin_addr,
-                                              int origin_count,
-                                              MPI_Datatype origin_datatype,
-                                              int target_rank,
-                                              MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
-                                              MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                              MPIDI_winattr_t winattr, MPIR_Request ** reqptr)
+INTERNAL_STATIC_INLINE int MPIDI_UCX_do_get(void *origin_addr,
+                                            int origin_count,
+                                            MPI_Datatype origin_datatype,
+                                            int target_rank,
+                                            MPI_Aint target_disp,
+                                            int target_count, MPI_Datatype target_datatype,
+                                            MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                            MPIDI_winattr_t winattr, MPIR_Request ** reqptr)
 {
     int mpi_errno = MPI_SUCCESS;
     int origin_contig, target_contig;

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -26,16 +26,16 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_send_cmpl_cb(void *request, ucs_status_t
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_UCX_SEND_CMPL_CB);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
-                                            MPI_Aint count,
-                                            MPI_Datatype datatype,
-                                            int rank,
-                                            int tag,
-                                            MPIR_Comm * comm,
-                                            int context_offset,
-                                            MPIDI_av_entry_t * addr,
-                                            MPIR_Request ** request,
-                                            int vni_src, int vni_dst, int have_request, int is_sync)
+INTERNAL_STATIC_INLINE int MPIDI_UCX_send(const void *buf,
+                                          MPI_Aint count,
+                                          MPI_Datatype datatype,
+                                          int rank,
+                                          int tag,
+                                          MPIR_Comm * comm,
+                                          int context_offset,
+                                          MPIDI_av_entry_t * addr,
+                                          MPIR_Request ** request,
+                                          int vni_src, int vni_dst, int have_request, int is_sync)
 {
     int dt_contig;
     size_t data_sz;

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -19,7 +19,7 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_UCX_win_need_flush(MPIR_Win * win)
     return need_flush;
 }
 
-MPL_STATIC_INLINE_PREFIX bool MPIDI_UCX_win_need_flush_local(MPIR_Win * win)
+INTERNAL_STATIC_INLINE bool MPIDI_UCX_win_need_flush_local(MPIR_Win * win)
 {
     int rank;
     bool need_flush_local = false;
@@ -29,7 +29,7 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_UCX_win_need_flush_local(MPIR_Win * win)
     return need_flush_local;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_win_unset_sync(MPIR_Win * win)
+INTERNAL_STATIC_INLINE void MPIDI_UCX_win_unset_sync(MPIR_Win * win)
 {
     int rank;
     for (rank = 0; rank < win->comm_ptr->local_size; rank++)
@@ -129,7 +129,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_flush_cmpl_cb(void *request, ucs_status_
 {
 }
 
-MPL_STATIC_INLINE_PREFIX ucs_status_t MPIDI_UCX_flush(int vni)
+INTERNAL_STATIC_INLINE ucs_status_t MPIDI_UCX_flush(int vni)
 {
     void *request = ucp_worker_flush_nb(MPIDI_UCX_global.ctx[vni].worker,
                                         0, &MPIDI_UCX_flush_cmpl_cb);

--- a/src/mpid/ch4/shm/ipc/src/ipc_recv.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_recv.h
@@ -17,10 +17,10 @@
  * corresponding handling routine. If the request is handled by an ipcmod,
  * recvd_flag is set to true. The caller should call fallback if no ipcmod
  * handles it. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_matched_recv(void *buf,
-                                                         MPI_Aint count,
-                                                         MPI_Datatype datatype,
-                                                         MPIR_Request * message, bool * recvd_flag)
+INTERNAL_STATIC_INLINE int MPIDI_IPCI_try_matched_recv(void *buf,
+                                                       MPI_Aint count,
+                                                       MPI_Datatype datatype,
+                                                       MPIR_Request * message, bool * recvd_flag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_TRY_MATCHED_RECV);

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -13,11 +13,11 @@
 #include "ipc_mem.h"
 #include "ipc_p2p.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint count,
-                                                      MPI_Datatype datatype, int rank, int tag,
-                                                      MPIR_Comm * comm, int context_offset,
-                                                      MPIDI_av_entry_t * addr,
-                                                      MPIR_Request ** request, bool * done)
+INTERNAL_STATIC_INLINE int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint count,
+                                                    MPI_Datatype datatype, int rank, int tag,
+                                                    MPIR_Comm * comm, int context_offset,
+                                                    MPIDI_av_entry_t * addr,
+                                                    MPIR_Request ** request, bool * done)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPCI_TRY_LMT_ISEND);

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -13,13 +13,13 @@
 
 /* Enqueue a request header onto the postponed message queue. This is a helper function and most
  * likely shouldn't be used outside of this file. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, size_t am_hdr_sz,
-                                                            int handler_id, const int grank,
-                                                            MPIDI_POSIX_am_header_t msg_hdr,
-                                                            MPIDI_POSIX_am_header_t * msg_hdr_p,
-                                                            struct iovec *iov_left_ptr,
-                                                            size_t iov_num_left, size_t data_sz,
-                                                            MPIR_Request * sreq)
+INTERNAL_STATIC_INLINE int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, size_t am_hdr_sz,
+                                                          int handler_id, const int grank,
+                                                          MPIDI_POSIX_am_header_t msg_hdr,
+                                                          MPIDI_POSIX_am_header_t * msg_hdr_p,
+                                                          struct iovec *iov_left_ptr,
+                                                          size_t iov_num_left, size_t data_sz,
+                                                          MPIR_Request * sreq)
 {
     MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = MPIDI_POSIX_AMREQUEST(sreq, req_hdr);
     int mpi_errno = MPI_SUCCESS;
@@ -299,10 +299,10 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_eager_buf_limit(void)
 
 /* Enqueue a request header onto the postponed message queue. This is a helper function and most
  * likely shouldn't be used outside of this file. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, size_t am_hdr_sz,
-                                                            int handler_id, const int grank,
-                                                            MPIDI_POSIX_am_header_t msg_hdr,
-                                                            size_t iov_num_left)
+INTERNAL_STATIC_INLINE int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, size_t am_hdr_sz,
+                                                          int handler_id, const int grank,
+                                                          MPIDI_POSIX_am_header_t msg_hdr,
+                                                          size_t iov_num_left)
 {
     MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = NULL;
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -9,12 +9,12 @@
 #include "ch4_impl.h"
 #include "posix_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_compute_accumulate(void *origin_addr,
-                                                            int origin_count,
-                                                            MPI_Datatype origin_datatype,
-                                                            void *target_addr,
-                                                            int target_count,
-                                                            MPI_Datatype target_datatype, MPI_Op op)
+INTERNAL_STATIC_INLINE int MPIDI_POSIX_compute_accumulate(void *origin_addr,
+                                                          int origin_count,
+                                                          MPI_Datatype origin_datatype,
+                                                          void *target_addr,
+                                                          int target_count,
+                                                          MPI_Datatype target_datatype, MPI_Op op)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Datatype basic_type = MPI_DATATYPE_NULL;
@@ -80,13 +80,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_compute_accumulate(void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
-                                                int origin_count,
-                                                MPI_Datatype origin_datatype,
-                                                int target_rank,
-                                                MPI_Aint target_disp,
-                                                int target_count, MPI_Datatype target_datatype,
-                                                MPIR_Win * win, MPIDI_winattr_t winattr)
+INTERNAL_STATIC_INLINE int MPIDI_POSIX_do_put(const void *origin_addr,
+                                              int origin_count,
+                                              MPI_Datatype origin_datatype,
+                                              int target_rank,
+                                              MPI_Aint target_disp,
+                                              int target_count, MPI_Datatype target_datatype,
+                                              MPIR_Win * win, MPIDI_winattr_t winattr)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t origin_data_sz = 0, target_data_sz = 0;
@@ -124,13 +124,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
-                                                int origin_count,
-                                                MPI_Datatype origin_datatype,
-                                                int target_rank,
-                                                MPI_Aint target_disp,
-                                                int target_count, MPI_Datatype target_datatype,
-                                                MPIR_Win * win, MPIDI_winattr_t winattr)
+INTERNAL_STATIC_INLINE int MPIDI_POSIX_do_get(void *origin_addr,
+                                              int origin_count,
+                                              MPI_Datatype origin_datatype,
+                                              int target_rank,
+                                              MPI_Aint target_disp,
+                                              int target_count, MPI_Datatype target_datatype,
+                                              MPIR_Win * win, MPIDI_winattr_t winattr)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t origin_data_sz = 0, target_data_sz = 0;
@@ -167,17 +167,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get_accumulate(const void *origin_addr,
-                                                           int origin_count,
-                                                           MPI_Datatype origin_datatype,
-                                                           void *result_addr,
-                                                           int result_count,
-                                                           MPI_Datatype result_datatype,
-                                                           int target_rank,
-                                                           MPI_Aint target_disp,
-                                                           int target_count,
-                                                           MPI_Datatype target_datatype, MPI_Op op,
-                                                           MPIR_Win * win, MPIDI_winattr_t winattr)
+INTERNAL_STATIC_INLINE int MPIDI_POSIX_do_get_accumulate(const void *origin_addr,
+                                                         int origin_count,
+                                                         MPI_Datatype origin_datatype,
+                                                         void *result_addr,
+                                                         int result_count,
+                                                         MPI_Datatype result_datatype,
+                                                         int target_rank,
+                                                         MPI_Aint target_disp,
+                                                         int target_count,
+                                                         MPI_Datatype target_datatype, MPI_Op op,
+                                                         MPIR_Win * win, MPIDI_winattr_t winattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;
@@ -232,14 +232,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get_accumulate(const void *origin_ad
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_accumulate(const void *origin_addr,
-                                                       int origin_count,
-                                                       MPI_Datatype origin_datatype,
-                                                       int target_rank,
-                                                       MPI_Aint target_disp,
-                                                       int target_count,
-                                                       MPI_Datatype target_datatype, MPI_Op op,
-                                                       MPIR_Win * win, MPIDI_winattr_t winattr)
+INTERNAL_STATIC_INLINE int MPIDI_POSIX_do_accumulate(const void *origin_addr,
+                                                     int origin_count,
+                                                     MPI_Datatype origin_datatype,
+                                                     int target_rank,
+                                                     MPI_Aint target_disp,
+                                                     int target_count,
+                                                     MPI_Datatype target_datatype, MPI_Op op,
+                                                     MPIR_Win * win, MPIDI_winattr_t winattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -73,7 +73,7 @@ MPL_STATIC_INLINE_PREFIX MPIDIG_rreq_t **MPIDIG_context_id_to_uelist(uint64_t co
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX MPIR_Context_id_t MPIDIG_win_id_to_context(uint64_t win_id)
+INTERNAL_STATIC_INLINE MPIR_Context_id_t MPIDIG_win_id_to_context(uint64_t win_id)
 {
     MPIR_Context_id_t ret;
 
@@ -397,7 +397,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
     (HANDLE_IS_BUILTIN(_datatype))
 
 /* We assume this routine is never called with rank=MPI_PROC_NULL. */
-MPL_STATIC_INLINE_PREFIX int MPIDIU_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_Group * grp)
+INTERNAL_STATIC_INLINE int MPIDIU_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_Group * grp)
 {
     int lpid;
     int size = grp->size;

--- a/src/mpid/ch4/src/ch4_probe.h
+++ b/src/mpid/ch4/src/ch4_probe.h
@@ -9,10 +9,10 @@
 #include "ch4r_proc.h"
 #include "ch4_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_unsafe(int source,
-                                                 int tag, MPIR_Comm * comm, int context_offset,
-                                                 MPIDI_av_entry_t * av, int *flag,
-                                                 MPI_Status * status)
+INTERNAL_STATIC_INLINE int MPIDI_iprobe_unsafe(int source,
+                                               int tag, MPIR_Comm * comm, int context_offset,
+                                               MPIDI_av_entry_t * av, int *flag,
+                                               MPI_Status * status)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPROBE_UNSAFE);
@@ -41,12 +41,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_unsafe(int source,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_improbe_unsafe(int source,
-                                                  int tag, MPIR_Comm * comm,
-                                                  int context_offset,
-                                                  MPIDI_av_entry_t * av,
-                                                  int *flag, MPIR_Request ** message,
-                                                  MPI_Status * status)
+INTERNAL_STATIC_INLINE int MPIDI_improbe_unsafe(int source,
+                                                int tag, MPIR_Comm * comm,
+                                                int context_offset,
+                                                MPIDI_av_entry_t * av,
+                                                int *flag, MPIR_Request ** message,
+                                                MPI_Status * status)
 {
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     return MPIDI_NM_mpi_improbe(source, tag, comm, context_offset, av, flag, message, status);
@@ -90,10 +90,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_improbe_unsafe(int source,
 #endif
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_safe(int source,
-                                               int tag, MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * av, int *flag,
-                                               MPI_Status * status)
+INTERNAL_STATIC_INLINE int MPIDI_iprobe_safe(int source,
+                                             int tag, MPIR_Comm * comm, int context_offset,
+                                             MPIDI_av_entry_t * av, int *flag, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPROBE_SAFE);
@@ -115,12 +114,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_safe(int source,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_improbe_safe(int source,
-                                                int tag, MPIR_Comm * comm,
-                                                int context_offset,
-                                                MPIDI_av_entry_t * av,
-                                                int *flag, MPIR_Request ** message,
-                                                MPI_Status * status)
+INTERNAL_STATIC_INLINE int MPIDI_improbe_safe(int source,
+                                              int tag, MPIR_Comm * comm,
+                                              int context_offset,
+                                              MPIDI_av_entry_t * av,
+                                              int *flag, MPIR_Request ** message,
+                                              MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IMPROBE_SAFE);

--- a/src/mpid/ch4/src/ch4_progress.c
+++ b/src/mpid/ch4/src/ch4_progress.c
@@ -22,7 +22,7 @@ static MPL_TLS int global_vci_poll_count = 0;
 static int global_vci_poll_count = 0;
 #endif
 
-MPL_STATIC_INLINE_PREFIX int do_global_progress(void)
+INTERNAL_STATIC_INLINE int do_global_progress(void)
 {
     if (MPIDI_global.n_vcis == 1) {
         return 1;
@@ -33,7 +33,7 @@ MPL_STATIC_INLINE_PREFIX int do_global_progress(void)
 }
 
 /* inside per-vci progress */
-MPL_STATIC_INLINE_PREFIX void check_progress_made_idx(MPID_Progress_state * state, int idx)
+INTERNAL_STATIC_INLINE void check_progress_made_idx(MPID_Progress_state * state, int idx)
 {
     if (state->progress_counts[idx] != MPIDI_global.progress_counts[state->vci[idx]]) {
         state->progress_counts[idx] = MPIDI_global.progress_counts[state->vci[idx]];
@@ -42,7 +42,7 @@ MPL_STATIC_INLINE_PREFIX void check_progress_made_idx(MPID_Progress_state * stat
 }
 
 /* inside global progress */
-MPL_STATIC_INLINE_PREFIX void check_progress_made_vci(MPID_Progress_state * state, int vci)
+INTERNAL_STATIC_INLINE void check_progress_made_vci(MPID_Progress_state * state, int vci)
 {
     for (int i = 0; i < state->vci_count; i++) {
         if (vci == state->vci[i]) {

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -9,10 +9,10 @@
 #include "ch4_impl.h"
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-MPL_STATIC_INLINE_PREFIX int anysource_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                             int rank, int tag, MPIR_Comm * comm,
-                                             int context_offset, MPIDI_av_entry_t * av,
-                                             MPIR_Request ** request)
+INTERNAL_STATIC_INLINE int anysource_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                           int rank, int tag, MPIR_Comm * comm,
+                                           int context_offset, MPIDI_av_entry_t * av,
+                                           MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     int need_unlock = 0;
@@ -160,7 +160,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_unsafe(void *buf,
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_unsafe(MPIR_Request * rreq)
+INTERNAL_STATIC_INLINE int MPIDI_cancel_recv_unsafe(MPIR_Request * rreq)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CANCEL_RECV_UNSAFE);
@@ -191,14 +191,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_unsafe(MPIR_Request * rreq)
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
-                                             MPI_Aint count,
-                                             MPI_Datatype datatype,
-                                             int rank,
-                                             int tag,
-                                             MPIR_Comm * comm,
-                                             int context_offset, MPIDI_av_entry_t * av,
-                                             MPI_Status * status, MPIR_Request ** req)
+INTERNAL_STATIC_INLINE int MPIDI_recv_safe(void *buf,
+                                           MPI_Aint count,
+                                           MPI_Datatype datatype,
+                                           int rank,
+                                           int tag,
+                                           MPIR_Comm * comm,
+                                           int context_offset, MPIDI_av_entry_t * av,
+                                           MPI_Status * status, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RECV_SAFE);
@@ -228,14 +228,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
-                                              MPI_Aint count,
-                                              MPI_Datatype datatype,
-                                              int rank,
-                                              int tag,
-                                              MPIR_Comm * comm,
-                                              int context_offset, MPIDI_av_entry_t * av,
-                                              MPIR_Request ** req)
+INTERNAL_STATIC_INLINE int MPIDI_irecv_safe(void *buf,
+                                            MPI_Aint count,
+                                            MPI_Datatype datatype,
+                                            int rank,
+                                            int tag,
+                                            MPIR_Comm * comm,
+                                            int context_offset, MPIDI_av_entry_t * av,
+                                            MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IRECV_SAFE);
@@ -264,9 +264,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
-                                               MPI_Aint count, MPI_Datatype datatype,
-                                               MPIR_Request * message)
+INTERNAL_STATIC_INLINE int MPIDI_imrecv_safe(void *buf,
+                                             MPI_Aint count, MPI_Datatype datatype,
+                                             MPIR_Request * message)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IMRECV_SAFE);
@@ -295,7 +295,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_safe(MPIR_Request * rreq)
+INTERNAL_STATIC_INLINE int MPIDI_cancel_recv_safe(MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CANCEL_RECV_SAFE);

--- a/src/mpid/ch4/src/ch4_rma.h
+++ b/src/mpid/ch4/src/ch4_rma.h
@@ -8,7 +8,7 @@
 
 #include "ch4_impl.h"
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_dbg_dump_winattr(MPIDI_winattr_t winattr)
+INTERNAL_STATIC_INLINE void MPIDI_dbg_dump_winattr(MPIDI_winattr_t winattr)
 {
 #ifndef CHECK_WINATTR
 #define CHECK_WINATTR(attr, flag) ((attr) & flag ? 1 : 0)
@@ -106,14 +106,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_unsafe(void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_unsafe(const void *origin_addr,
-                                                     int origin_count,
-                                                     MPI_Datatype origin_datatype,
-                                                     int target_rank,
-                                                     MPI_Aint target_disp,
-                                                     int target_count,
-                                                     MPI_Datatype target_datatype, MPI_Op op,
-                                                     MPIR_Win * win)
+INTERNAL_STATIC_INLINE int MPIDI_accumulate_unsafe(const void *origin_addr,
+                                                   int origin_count,
+                                                   MPI_Datatype origin_datatype,
+                                                   int target_rank,
+                                                   MPI_Aint target_disp,
+                                                   int target_count,
+                                                   MPI_Datatype target_datatype, MPI_Op op,
+                                                   MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
@@ -147,12 +147,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_unsafe(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_unsafe(const void *origin_addr,
-                                                           const void *compare_addr,
-                                                           void *result_addr,
-                                                           MPI_Datatype datatype,
-                                                           int target_rank, MPI_Aint target_disp,
-                                                           MPIR_Win * win)
+INTERNAL_STATIC_INLINE int MPIDI_compare_and_swap_unsafe(const void *origin_addr,
+                                                         const void *compare_addr,
+                                                         void *result_addr,
+                                                         MPI_Datatype datatype,
+                                                         int target_rank, MPI_Aint target_disp,
+                                                         MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
@@ -186,15 +186,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_unsafe(const void *origin_ad
 }
 
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_unsafe(const void *origin_addr,
-                                                      int origin_count,
-                                                      MPI_Datatype origin_datatype,
-                                                      int target_rank,
-                                                      MPI_Aint target_disp,
-                                                      int target_count,
-                                                      MPI_Datatype target_datatype,
-                                                      MPI_Op op, MPIR_Win * win,
-                                                      MPIR_Request ** request)
+INTERNAL_STATIC_INLINE int MPIDI_raccumulate_unsafe(const void *origin_addr,
+                                                    int origin_count,
+                                                    MPI_Datatype origin_datatype,
+                                                    int target_rank,
+                                                    MPI_Aint target_disp,
+                                                    int target_count,
+                                                    MPI_Datatype target_datatype,
+                                                    MPI_Op op, MPIR_Win * win,
+                                                    MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
@@ -228,18 +228,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_unsafe(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_unsafe(const void *origin_addr,
-                                                          int origin_count,
-                                                          MPI_Datatype origin_datatype,
-                                                          void *result_addr,
-                                                          int result_count,
-                                                          MPI_Datatype result_datatype,
-                                                          int target_rank,
-                                                          MPI_Aint target_disp,
-                                                          int target_count,
-                                                          MPI_Datatype target_datatype,
-                                                          MPI_Op op, MPIR_Win * win,
-                                                          MPIR_Request ** request)
+INTERNAL_STATIC_INLINE int MPIDI_rget_accumulate_unsafe(const void *origin_addr,
+                                                        int origin_count,
+                                                        MPI_Datatype origin_datatype,
+                                                        void *result_addr,
+                                                        int result_count,
+                                                        MPI_Datatype result_datatype,
+                                                        int target_rank,
+                                                        MPI_Aint target_disp,
+                                                        int target_count,
+                                                        MPI_Datatype target_datatype,
+                                                        MPI_Op op, MPIR_Win * win,
+                                                        MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
@@ -276,12 +276,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_unsafe(const void *origin_add
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_unsafe(const void *origin_addr,
-                                                       void *result_addr,
-                                                       MPI_Datatype datatype,
-                                                       int target_rank,
-                                                       MPI_Aint target_disp, MPI_Op op,
-                                                       MPIR_Win * win)
+INTERNAL_STATIC_INLINE int MPIDI_fetch_and_op_unsafe(const void *origin_addr,
+                                                     void *result_addr,
+                                                     MPI_Datatype datatype,
+                                                     int target_rank,
+                                                     MPI_Aint target_disp, MPI_Op op,
+                                                     MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
@@ -314,14 +314,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_unsafe(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_rget_unsafe(void *origin_addr,
-                                               int origin_count,
-                                               MPI_Datatype origin_datatype,
-                                               int target_rank,
-                                               MPI_Aint target_disp,
-                                               int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win,
-                                               MPIR_Request ** request)
+INTERNAL_STATIC_INLINE int MPIDI_rget_unsafe(void *origin_addr,
+                                             int origin_count,
+                                             MPI_Datatype origin_datatype,
+                                             int target_rank,
+                                             MPI_Aint target_disp,
+                                             int target_count,
+                                             MPI_Datatype target_datatype, MPIR_Win * win,
+                                             MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
@@ -355,14 +355,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_unsafe(void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_rput_unsafe(const void *origin_addr,
-                                               int origin_count,
-                                               MPI_Datatype origin_datatype,
-                                               int target_rank,
-                                               MPI_Aint target_disp,
-                                               int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win,
-                                               MPIR_Request ** request)
+INTERNAL_STATIC_INLINE int MPIDI_rput_unsafe(const void *origin_addr,
+                                             int origin_count,
+                                             MPI_Datatype origin_datatype,
+                                             int target_rank,
+                                             MPI_Aint target_disp,
+                                             int target_count,
+                                             MPI_Datatype target_datatype, MPIR_Win * win,
+                                             MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
@@ -396,17 +396,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rput_unsafe(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_unsafe(const void *origin_addr,
-                                                         int origin_count,
-                                                         MPI_Datatype origin_datatype,
-                                                         void *result_addr,
-                                                         int result_count,
-                                                         MPI_Datatype result_datatype,
-                                                         int target_rank,
-                                                         MPI_Aint target_disp,
-                                                         int target_count,
-                                                         MPI_Datatype target_datatype, MPI_Op op,
-                                                         MPIR_Win * win)
+INTERNAL_STATIC_INLINE int MPIDI_get_accumulate_unsafe(const void *origin_addr,
+                                                       int origin_count,
+                                                       MPI_Datatype origin_datatype,
+                                                       void *result_addr,
+                                                       int result_count,
+                                                       MPI_Datatype result_datatype,
+                                                       int target_rank,
+                                                       MPI_Aint target_disp,
+                                                       int target_count,
+                                                       MPI_Datatype target_datatype, MPI_Op op,
+                                                       MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_winattr_t winattr = MPIDI_WIN(win, winattr);
@@ -443,13 +443,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_unsafe(const void *origin_addr
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_put_safe(const void *origin_addr,
-                                            int origin_count,
-                                            MPI_Datatype origin_datatype,
-                                            int target_rank,
-                                            MPI_Aint target_disp,
-                                            int target_count, MPI_Datatype target_datatype,
-                                            MPIR_Win * win)
+INTERNAL_STATIC_INLINE int MPIDI_put_safe(const void *origin_addr,
+                                          int origin_count,
+                                          MPI_Datatype origin_datatype,
+                                          int target_rank,
+                                          MPI_Aint target_disp,
+                                          int target_count, MPI_Datatype target_datatype,
+                                          MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PUT_SAFE);
@@ -476,13 +476,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_put_safe(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_get_safe(void *origin_addr,
-                                            int origin_count,
-                                            MPI_Datatype origin_datatype,
-                                            int target_rank,
-                                            MPI_Aint target_disp,
-                                            int target_count, MPI_Datatype target_datatype,
-                                            MPIR_Win * win)
+INTERNAL_STATIC_INLINE int MPIDI_get_safe(void *origin_addr,
+                                          int origin_count,
+                                          MPI_Datatype origin_datatype,
+                                          int target_rank,
+                                          MPI_Aint target_disp,
+                                          int target_count, MPI_Datatype target_datatype,
+                                          MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_SAFE);
@@ -511,14 +511,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_safe(void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_safe(const void *origin_addr,
-                                                   int origin_count,
-                                                   MPI_Datatype origin_datatype,
-                                                   int target_rank,
-                                                   MPI_Aint target_disp,
-                                                   int target_count,
-                                                   MPI_Datatype target_datatype, MPI_Op op,
-                                                   MPIR_Win * win)
+INTERNAL_STATIC_INLINE int MPIDI_accumulate_safe(const void *origin_addr,
+                                                 int origin_count,
+                                                 MPI_Datatype origin_datatype,
+                                                 int target_rank,
+                                                 MPI_Aint target_disp,
+                                                 int target_count,
+                                                 MPI_Datatype target_datatype, MPI_Op op,
+                                                 MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACCUMULATE_SAFE);
@@ -543,12 +543,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_safe(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_safe(const void *origin_addr,
-                                                         const void *compare_addr,
-                                                         void *result_addr,
-                                                         MPI_Datatype datatype,
-                                                         int target_rank, MPI_Aint target_disp,
-                                                         MPIR_Win * win)
+INTERNAL_STATIC_INLINE int MPIDI_compare_and_swap_safe(const void *origin_addr,
+                                                       const void *compare_addr,
+                                                       void *result_addr,
+                                                       MPI_Datatype datatype,
+                                                       int target_rank, MPI_Aint target_disp,
+                                                       MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_COMPARE_AND_SWAP_SAFE);
@@ -575,15 +575,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_safe(const void *origin_addr
 }
 
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_safe(const void *origin_addr,
-                                                    int origin_count,
-                                                    MPI_Datatype origin_datatype,
-                                                    int target_rank,
-                                                    MPI_Aint target_disp,
-                                                    int target_count,
-                                                    MPI_Datatype target_datatype,
-                                                    MPI_Op op, MPIR_Win * win,
-                                                    MPIR_Request ** request)
+INTERNAL_STATIC_INLINE int MPIDI_raccumulate_safe(const void *origin_addr,
+                                                  int origin_count,
+                                                  MPI_Datatype origin_datatype,
+                                                  int target_rank,
+                                                  MPI_Aint target_disp,
+                                                  int target_count,
+                                                  MPI_Datatype target_datatype,
+                                                  MPI_Op op, MPIR_Win * win,
+                                                  MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
@@ -608,18 +608,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_safe(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_safe(const void *origin_addr,
-                                                        int origin_count,
-                                                        MPI_Datatype origin_datatype,
-                                                        void *result_addr,
-                                                        int result_count,
-                                                        MPI_Datatype result_datatype,
-                                                        int target_rank,
-                                                        MPI_Aint target_disp,
-                                                        int target_count,
-                                                        MPI_Datatype target_datatype,
-                                                        MPI_Op op, MPIR_Win * win,
-                                                        MPIR_Request ** request)
+INTERNAL_STATIC_INLINE int MPIDI_rget_accumulate_safe(const void *origin_addr,
+                                                      int origin_count,
+                                                      MPI_Datatype origin_datatype,
+                                                      void *result_addr,
+                                                      int result_count,
+                                                      MPI_Datatype result_datatype,
+                                                      int target_rank,
+                                                      MPI_Aint target_disp,
+                                                      int target_count,
+                                                      MPI_Datatype target_datatype,
+                                                      MPI_Op op, MPIR_Win * win,
+                                                      MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_ACCUMULATE_SAFE);
@@ -646,12 +646,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_safe(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_safe(const void *origin_addr,
-                                                     void *result_addr,
-                                                     MPI_Datatype datatype,
-                                                     int target_rank,
-                                                     MPI_Aint target_disp, MPI_Op op,
-                                                     MPIR_Win * win)
+INTERNAL_STATIC_INLINE int MPIDI_fetch_and_op_safe(const void *origin_addr,
+                                                   void *result_addr,
+                                                   MPI_Datatype datatype,
+                                                   int target_rank,
+                                                   MPI_Aint target_disp, MPI_Op op, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_FETCH_AND_OP_SAFE);
@@ -676,14 +675,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_safe(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_rget_safe(void *origin_addr,
-                                             int origin_count,
-                                             MPI_Datatype origin_datatype,
-                                             int target_rank,
-                                             MPI_Aint target_disp,
-                                             int target_count,
-                                             MPI_Datatype target_datatype, MPIR_Win * win,
-                                             MPIR_Request ** request)
+INTERNAL_STATIC_INLINE int MPIDI_rget_safe(void *origin_addr,
+                                           int origin_count,
+                                           MPI_Datatype origin_datatype,
+                                           int target_rank,
+                                           MPI_Aint target_disp,
+                                           int target_count,
+                                           MPI_Datatype target_datatype, MPIR_Win * win,
+                                           MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_SAFE);
@@ -709,14 +708,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_safe(void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_rput_safe(const void *origin_addr,
-                                             int origin_count,
-                                             MPI_Datatype origin_datatype,
-                                             int target_rank,
-                                             MPI_Aint target_disp,
-                                             int target_count,
-                                             MPI_Datatype target_datatype, MPIR_Win * win,
-                                             MPIR_Request ** request)
+INTERNAL_STATIC_INLINE int MPIDI_rput_safe(const void *origin_addr,
+                                           int origin_count,
+                                           MPI_Datatype origin_datatype,
+                                           int target_rank,
+                                           MPI_Aint target_disp,
+                                           int target_count,
+                                           MPI_Datatype target_datatype, MPIR_Win * win,
+                                           MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RPUT_SAFE);
@@ -742,17 +741,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rput_safe(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_safe(const void *origin_addr,
-                                                       int origin_count,
-                                                       MPI_Datatype origin_datatype,
-                                                       void *result_addr,
-                                                       int result_count,
-                                                       MPI_Datatype result_datatype,
-                                                       int target_rank,
-                                                       MPI_Aint target_disp,
-                                                       int target_count,
-                                                       MPI_Datatype target_datatype, MPI_Op op,
-                                                       MPIR_Win * win)
+INTERNAL_STATIC_INLINE int MPIDI_get_accumulate_safe(const void *origin_addr,
+                                                     int origin_count,
+                                                     MPI_Datatype origin_datatype,
+                                                     void *result_addr,
+                                                     int result_count,
+                                                     MPI_Datatype result_datatype,
+                                                     int target_rank,
+                                                     MPI_Aint target_disp,
+                                                     int target_count,
+                                                     MPI_Datatype target_datatype, MPI_Op op,
+                                                     MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACCUMULATE_SAFE);

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -231,13 +231,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_unsafe(const void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
-                                             MPI_Aint count,
-                                             MPI_Datatype datatype,
-                                             int rank,
-                                             int tag,
-                                             MPIR_Comm * comm, int context_offset,
-                                             MPIDI_av_entry_t * av, MPIR_Request ** req)
+INTERNAL_STATIC_INLINE int MPIDI_send_safe(const void *buf,
+                                           MPI_Aint count,
+                                           MPI_Datatype datatype,
+                                           int rank,
+                                           int tag,
+                                           MPIR_Comm * comm, int context_offset,
+                                           MPIDI_av_entry_t * av, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SEND_SAFE);
@@ -271,14 +271,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
-                                                  MPI_Aint count,
-                                                  MPI_Datatype datatype,
-                                                  int rank,
-                                                  int tag,
-                                                  MPIR_Comm * comm, int context_offset,
-                                                  MPIDI_av_entry_t * av, MPIR_Request ** req,
-                                                  MPIR_Errflag_t * errflag)
+INTERNAL_STATIC_INLINE int MPIDI_send_coll_safe(const void *buf,
+                                                MPI_Aint count,
+                                                MPI_Datatype datatype,
+                                                int rank,
+                                                int tag,
+                                                MPIR_Comm * comm, int context_offset,
+                                                MPIDI_av_entry_t * av, MPIR_Request ** req,
+                                                MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -307,13 +307,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
-                                              MPI_Aint count,
-                                              MPI_Datatype datatype,
-                                              int rank,
-                                              int tag,
-                                              MPIR_Comm * comm, int context_offset,
-                                              MPIDI_av_entry_t * av, MPIR_Request ** req)
+INTERNAL_STATIC_INLINE int MPIDI_isend_safe(const void *buf,
+                                            MPI_Aint count,
+                                            MPI_Datatype datatype,
+                                            int rank,
+                                            int tag,
+                                            MPIR_Comm * comm, int context_offset,
+                                            MPIDI_av_entry_t * av, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ISEND_SAFE);
@@ -342,14 +342,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
-                                                   MPI_Aint count,
-                                                   MPI_Datatype datatype,
-                                                   int rank,
-                                                   int tag,
-                                                   MPIR_Comm * comm, int context_offset,
-                                                   MPIDI_av_entry_t * av, MPIR_Request ** req,
-                                                   MPIR_Errflag_t * errflag)
+INTERNAL_STATIC_INLINE int MPIDI_isend_coll_safe(const void *buf,
+                                                 MPI_Aint count,
+                                                 MPI_Datatype datatype,
+                                                 int rank,
+                                                 int tag,
+                                                 MPIR_Comm * comm, int context_offset,
+                                                 MPIDI_av_entry_t * av, MPIR_Request ** req,
+                                                 MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -378,13 +378,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
-                                              MPI_Aint count,
-                                              MPI_Datatype datatype,
-                                              int rank,
-                                              int tag,
-                                              MPIR_Comm * comm, int context_offset,
-                                              MPIDI_av_entry_t * av, MPIR_Request ** req)
+INTERNAL_STATIC_INLINE int MPIDI_ssend_safe(const void *buf,
+                                            MPI_Aint count,
+                                            MPI_Datatype datatype,
+                                            int rank,
+                                            int tag,
+                                            MPIR_Comm * comm, int context_offset,
+                                            MPIDI_av_entry_t * av, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SSEND_SAFE);
@@ -413,13 +413,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * av, MPIR_Request ** req)
+INTERNAL_STATIC_INLINE int MPIDI_issend_safe(const void *buf,
+                                             MPI_Aint count,
+                                             MPI_Datatype datatype,
+                                             int rank,
+                                             int tag,
+                                             MPIR_Comm * comm, int context_offset,
+                                             MPIDI_av_entry_t * av, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ISSEND_SAFE);
@@ -662,14 +662,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Issend(const void *buf,
 }
 
 /* Common internal rountine for send_init family */
-MPL_STATIC_INLINE_PREFIX int MPIDI_psend_init(MPIDI_ptype ptype,
-                                              const void *buf,
-                                              MPI_Aint count,
-                                              MPI_Datatype datatype,
-                                              int rank,
-                                              int tag,
-                                              MPIR_Comm * comm, int context_offset,
-                                              MPIR_Request ** request)
+INTERNAL_STATIC_INLINE int MPIDI_psend_init(MPIDI_ptype ptype,
+                                            const void *buf,
+                                            MPI_Aint count,
+                                            MPI_Datatype datatype,
+                                            int rank,
+                                            int tag,
+                                            MPIR_Comm * comm, int context_offset,
+                                            MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;

--- a/src/mpid/ch4/src/ch4_wait.h
+++ b/src/mpid/ch4/src/ch4_wait.h
@@ -9,7 +9,7 @@
 #include "ch4_impl.h"
 
 /* a local wrapper that accounts for persistent request */
-MPL_STATIC_INLINE_PREFIX int get_vci_wrapper(MPIR_Request * req)
+INTERNAL_STATIC_INLINE int get_vci_wrapper(MPIR_Request * req)
 {
     int vci;
     if (req->kind == MPIR_REQUEST_KIND__PREQUEST_RECV ||
@@ -26,8 +26,7 @@ MPL_STATIC_INLINE_PREFIX int get_vci_wrapper(MPIR_Request * req)
     return vci;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci(MPIR_Request * req,
-                                                     MPID_Progress_state * state)
+INTERNAL_STATIC_INLINE void MPIDI_set_progress_vci(MPIR_Request * req, MPID_Progress_state * state)
 {
     state->flag = MPIDI_PROGRESS_ALL;   /* TODO: check request is_local/anysource */
     state->progress_made = 0;
@@ -41,8 +40,8 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci(MPIR_Request * req,
     state->vci[0] = vci;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci_n(int n, MPIR_Request ** reqs,
-                                                       MPID_Progress_state * state)
+INTERNAL_STATIC_INLINE void MPIDI_set_progress_vci_n(int n, MPIR_Request ** reqs,
+                                                     MPID_Progress_state * state)
 {
     state->flag = MPIDI_PROGRESS_ALL;   /* TODO: check request is_local/anysource */
     state->progress_made = 0;

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -49,7 +49,7 @@ MPL_STATIC_INLINE_PREFIX struct MPIDI_workq_elemt *MPIDI_workq_elemt_create(void
     return MPIR_Handle_obj_alloc(&MPIDI_workq_elemt_mem);
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_workq_elemt_free(struct MPIDI_workq_elemt *elemt)
+INTERNAL_STATIC_INLINE void MPIDI_workq_elemt_free(struct MPIDI_workq_elemt *elemt)
 {
     MPIR_Handle_obj_free(&MPIDI_workq_elemt_mem, elemt);
 }
@@ -270,14 +270,14 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_rma_enqueue(MPIDI_workq_op_t op,
     MPIDI_workq_enqueue(&MPIDI_global.workqueue, rma_elemt);
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_workq_release_pt2pt_elemt(MPIDI_workq_elemt_t * workq_elemt)
+INTERNAL_STATIC_INLINE void MPIDI_workq_release_pt2pt_elemt(MPIDI_workq_elemt_t * workq_elemt)
 {
     MPIR_Request *req;
     req = MPL_container_of(workq_elemt, MPIR_Request, dev.ch4.command);
     MPIR_Request_free(req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
+INTERNAL_STATIC_INLINE int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req;

--- a/src/mpid/ch4/src/ch4r_recvq.h
+++ b/src/mpid/ch4/src/ch4r_recvq.h
@@ -20,16 +20,16 @@ extern MPIR_T_pvar_timer_t PVAR_TIMER_time_matching_unexpectedq ATTRIBUTE((unuse
 
 int MPIDIG_recvq_init(void);
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_match_posted(int rank, int tag,
-                                                 MPIR_Context_id_t context_id, MPIR_Request * req)
+INTERNAL_STATIC_INLINE int MPIDIG_match_posted(int rank, int tag,
+                                               MPIR_Context_id_t context_id, MPIR_Request * req)
 {
     return (rank == MPIDIG_REQUEST(req, rank) || MPIDIG_REQUEST(req, rank) == MPI_ANY_SOURCE) &&
         (tag == MPIR_TAG_MASK_ERROR_BITS(MPIDIG_REQUEST(req, tag)) ||
          MPIDIG_REQUEST(req, tag) == MPI_ANY_TAG) && context_id == MPIDIG_REQUEST(req, context_id);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_match_unexp(int rank, int tag,
-                                                MPIR_Context_id_t context_id, MPIR_Request * req)
+INTERNAL_STATIC_INLINE int MPIDIG_match_unexp(int rank, int tag,
+                                              MPIR_Context_id_t context_id, MPIR_Request * req)
 {
     return (rank == MPIDIG_REQUEST(req, rank) || rank == MPI_ANY_SOURCE) &&
         (tag == MPIR_TAG_MASK_ERROR_BITS(MPIDIG_REQUEST(req, tag)) ||

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -20,11 +20,11 @@ extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_amhdr_set ATTRIBUTE((unused));
                             goto fn_fail, "**nomemreq");                \
     } while (0)
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_count,
-                                           MPI_Datatype origin_datatype, int target_rank,
-                                           MPI_Aint target_disp, int target_count,
-                                           MPI_Datatype target_datatype, MPIR_Win * win,
-                                           MPIR_Request ** sreq_ptr)
+INTERNAL_STATIC_INLINE int MPIDIG_do_put(const void *origin_addr, int origin_count,
+                                         MPI_Datatype origin_datatype, int target_rank,
+                                         MPI_Aint target_disp, int target_count,
+                                         MPI_Datatype target_datatype, MPIR_Win * win,
+                                         MPIR_Request ** sreq_ptr)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIR_Request *sreq = NULL;
@@ -181,11 +181,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
-                                           MPI_Datatype origin_datatype, int target_rank,
-                                           MPI_Aint target_disp, int target_count,
-                                           MPI_Datatype target_datatype, MPIR_Win * win,
-                                           MPIR_Request ** sreq_ptr)
+INTERNAL_STATIC_INLINE int MPIDIG_do_get(void *origin_addr, int origin_count,
+                                         MPI_Datatype origin_datatype, int target_rank,
+                                         MPI_Aint target_disp, int target_count,
+                                         MPI_Datatype target_datatype, MPIR_Win * win,
+                                         MPIR_Request ** sreq_ptr)
 {
     int mpi_errno = MPI_SUCCESS, c;
     size_t offset;
@@ -315,12 +315,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
 }
 
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int origin_count,
-                                                  MPI_Datatype origin_datatype, int target_rank,
-                                                  MPI_Aint target_disp, int target_count,
-                                                  MPI_Datatype target_datatype,
-                                                  MPI_Op op, MPIR_Win * win,
-                                                  MPIR_Request ** sreq_ptr)
+INTERNAL_STATIC_INLINE int MPIDIG_do_accumulate(const void *origin_addr, int origin_count,
+                                                MPI_Datatype origin_datatype, int target_rank,
+                                                MPI_Aint target_disp, int target_count,
+                                                MPI_Datatype target_datatype,
+                                                MPI_Op op, MPIR_Win * win, MPIR_Request ** sreq_ptr)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIR_Request *sreq = NULL;
@@ -481,18 +480,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
-                                                      int origin_count_,
-                                                      MPI_Datatype origin_datatype_,
-                                                      void *result_addr,
-                                                      int result_count,
-                                                      MPI_Datatype result_datatype,
-                                                      int target_rank,
-                                                      MPI_Aint target_disp,
-                                                      int target_count,
-                                                      MPI_Datatype target_datatype,
-                                                      MPI_Op op, MPIR_Win * win,
-                                                      MPIR_Request ** sreq_ptr)
+INTERNAL_STATIC_INLINE int MPIDIG_do_get_accumulate(const void *origin_addr,
+                                                    int origin_count_,
+                                                    MPI_Datatype origin_datatype_,
+                                                    void *result_addr,
+                                                    int result_count,
+                                                    MPI_Datatype result_datatype,
+                                                    int target_rank,
+                                                    MPI_Aint target_disp,
+                                                    int target_count,
+                                                    MPI_Datatype target_datatype,
+                                                    MPI_Op op, MPIR_Win * win,
+                                                    MPIR_Request ** sreq_ptr)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIR_Request *sreq = NULL;

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -94,9 +94,9 @@ int MPIDIG_mpi_win_allocate(MPI_Aint size, int disp_unit, MPIR_Info * info,
                             MPIR_Comm * comm, void *baseptr, MPIR_Win ** win_ptr);
 int MPIDIG_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_Win ** win_ptr);
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_fill_ranks_in_win_grp(MPIR_Win * win_ptr,
-                                                          MPIR_Group * group_ptr,
-                                                          int *ranks_in_win_grp)
+INTERNAL_STATIC_INLINE int MPIDIG_fill_ranks_in_win_grp(MPIR_Win * win_ptr,
+                                                        MPIR_Group * group_ptr,
+                                                        int *ranks_in_win_grp)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, *ranks_in_grp = NULL;


### PR DESCRIPTION
## Pull Request Description

We need a way to tell internal functions from exposed functions in inline headers. The visual clues that certain functions are only used inside the give source file will be very helpful. 

TODO:
* [x] convert more internal function to mark with `INTERNAL_STATIC_INLINE`
* [x] add maintenance script to check against internal function used outside the header file.

Added `maint/check_internal_inline.pl`.

`$ perl maint/check_internal_inline.pl`
will report `MPL_STATIC_INLINE_PREFIX` functions that are used only internally and `INTERNAL_STATIC_INLINE` functions that are used externally.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
