### PR TITLE
ch4/posix: refactor POSIX EAGER interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -605,7 +605,11 @@ Makefile.am-stamp
 # /test/mpi/
 /test/mpi/libtool
 /test/mpi/coll/testlist.cvar
+/test/mpi/coll/testlist.gpu
 /test/mpi/attr/testlist.dtp
+/test/mpi/attr/testlist.gpu
 /test/mpi/pt2pt/testlist.dtp
 /test/mpi/coll/testlist.dtp
 /test/mpi/rma/testlist.dtp
+/test/mpi/cxx/attr/testlist.gpu
+/test/mpi/cxx/datatype/testlist.gpu

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -71,7 +71,7 @@ static inline bool fastpath_memcpy(const void *inbuf, void *outbuf, MPI_Datatype
             (outattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
              outattr.type == MPL_GPU_POINTER_REGISTERED_HOST)) {
             MPI_Aint size = MPIR_Datatype_get_basic_size(type);
-            *actual_bytes = MPL_MIN(count * size, max_bytes);
+            *actual_bytes = MPL_MIN(count * size - offset, max_bytes);
             if (dir == MEMCPY_DIR__PACK)
                 MPIR_Memcpy(outbuf, (const char *) inbuf + offset, *actual_bytes);
             else
@@ -97,7 +97,7 @@ static inline bool fastpath_memcpy(const void *inbuf, void *outbuf, MPI_Datatype
                  inattr.type == MPL_GPU_POINTER_REGISTERED_HOST) &&
                 (outattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
                  outattr.type == MPL_GPU_POINTER_REGISTERED_HOST)) {
-                *actual_bytes = MPL_MIN(count * dtp->size, max_bytes);
+                *actual_bytes = MPL_MIN(count * dtp->size - offset, max_bytes);
                 if (dir == MEMCPY_DIR__PACK)
                     MPIR_Memcpy(outbuf, (const char *) inbuf + dtp->true_lb + offset,
                                 *actual_bytes);

--- a/src/mpid/ch4/generic/am/mpidig_am_req_cache.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_req_cache.h
@@ -16,7 +16,7 @@ static inline MPIR_Request *MPIDIG_req_cache_lookup(void *req_map, uint64_t key)
     void *ret = MPIDIU_map_lookup(req_map, key);
     if (ret != MPIDIU_MAP_NOT_FOUND) {
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        (MPL_DBG_FDEST, "req_map found: key=0x%lx, value=0x%p", key, ret));
+                        (MPL_DBG_FDEST, "req_map found: key=0x" PRIx64 ", value=0x%p", key, ret));
         return (MPIR_Request *) ret;
     }
     return NULL;
@@ -29,7 +29,7 @@ static inline void MPIDIG_req_cache_add(void *req_map, uint64_t key, MPIR_Reques
     if (likely(ret == MPIDIU_MAP_NOT_FOUND)) {
         MPIDIU_map_set_unsafe(req_map, key, (void *) rreq, MPL_MEM_OTHER);
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        (MPL_DBG_FDEST, "req_map new: key=0x%lx value=%p", key, rreq));
+                        (MPL_DBG_FDEST, "req_map new: key=0x" PRIx64 " value=%p", key, rreq));
     } else {
         MPIR_Assert(0);
     }
@@ -41,7 +41,7 @@ static inline void MPIDIG_req_cache_remove(void *req_map, uint64_t key)
     if (ret != MPIDIU_MAP_NOT_FOUND) {
         MPIDIU_map_erase(req_map, key);
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        (MPL_DBG_FDEST, "req_map remove: key=0x%lx, value=0x%p", key, ret));
+                        (MPL_DBG_FDEST, "req_map remove: key=0x" PRIx64 ", value=0x%p", key, ret));
     }
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -144,7 +144,7 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_prepare_target_mr(int target_rank,
                              (const void *) target_addr, target_extent, &target_mr_found);
 
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        (MPL_DBG_FDEST, "target_mr found %d addr 0x%lx, extent 0x%lx",
+                        (MPL_DBG_FDEST, "target_mr found %d addr 0x" PRIx64 ", extent 0x%lx",
                          target_mr_found ? 1 : 0, target_addr, target_extent));
 
         if (target_mr_found) {

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
@@ -13,9 +13,10 @@
 typedef int (*MPIDI_POSIX_eager_init_t) (int rank, int size);
 typedef int (*MPIDI_POSIX_eager_finalize_t) (void);
 
-typedef int (*MPIDI_POSIX_eager_send_t) (int grank,
-                                         MPIDI_POSIX_am_header_t ** msg_hdr,
-                                         struct iovec ** iov, size_t * iov_num);
+typedef int (*MPIDI_POSIX_eager_send_t) (int grank, MPIDI_POSIX_am_header_t * msg_hdr,
+                                         const void *am_hdr, MPI_Aint am_hdr_sz, const void *buf,
+                                         MPI_Count count, MPI_Datatype datatype, MPI_Aint offset,
+                                         MPI_Aint * bytes_sent);
 
 typedef int (*MPIDI_POSIX_eager_recv_begin_t) (MPIDI_POSIX_eager_recv_transaction_t * transaction);
 
@@ -56,10 +57,11 @@ extern char MPIDI_POSIX_eager_strings[][MPIDI_MAX_POSIX_EAGER_STRING_LEN];
 int MPIDI_POSIX_eager_init(int rank, int size);
 int MPIDI_POSIX_eager_finalize(void);
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank,
-                                                    MPIDI_POSIX_am_header_t ** msg_hdr,
-                                                    struct iovec **iov,
-                                                    size_t * iov_num) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr,
+                                                    const void *am_hdr, MPI_Aint am_hdr_sz,
+                                                    const void *buf, MPI_Count count,
+                                                    MPI_Datatype datatype, MPI_Aint offset,
+                                                    MPI_Aint * bytes_sent) MPL_STATIC_INLINE_SUFFIX;
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t *
                                                           transaction) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager_impl.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager_impl.h
@@ -9,11 +9,14 @@
 #ifndef POSIX_EAGER_INLINE
 #ifndef POSIX_EAGER_DISABLE_INLINES
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank,
-                                                    MPIDI_POSIX_am_header_t ** msg_hdr,
-                                                    struct iovec **iov, size_t * iov_num)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr,
+                                                    const void *am_hdr, MPI_Aint am_hdr_sz,
+                                                    const void *buf, MPI_Count count,
+                                                    MPI_Datatype datatype, MPI_Aint offset,
+                                                    MPI_Aint * bytes_sent)
 {
-    return MPIDI_POSIX_eager_func->send(grank, msg_hdr, iov, iov_num);
+    return MPIDI_POSIX_eager_func->send(grank, msg_hdr, am_hdr, am_hdr_sz, buf, count, datatype,
+                                        offset, bytes_sent);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t *

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -25,33 +25,33 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_eager_buf_limit(void)
  *
  * grank   - The global rank (the rank in MPI_COMM_WORLD) of the receiving process.
  * msg_hdr - The header of the message to be sent. This can be NULL if there is no header to be sent
- *           (such as if the header was sent in a previous chunk).
- * iov     - The array of iovec entries to be sent.
- * iov_num - The number of entries in the iovec array.
+ *           (such as if the header was sent in a previous chunk, am_hdr will be NULL too in this
+ *           case.
+ * am_hdr, am_hdr_sz    - am header this could be NULL if not sending the first chunk
+ * buf, count, datatype - Data buffer and signature for the send buffer. They could be NULL in the
+ *                        case of a header-only message
+ * offset               - current offset.
+ * bytes_sent           - output variable for how much data actually been sent, pass NULL if no data
+ *                        need to be send
  */
 MPL_STATIC_INLINE_PREFIX int
-MPIDI_POSIX_eager_send(int grank,
-                       MPIDI_POSIX_am_header_t ** msg_hdr, struct iovec **iov, size_t * iov_num)
+MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void *am_hdr,
+                       MPI_Aint am_hdr_sz, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                       MPI_Aint offset, MPI_Aint * bytes_sent)
 {
     MPIDI_POSIX_eager_iqueue_transport_t *transport;
     MPIDI_POSIX_eager_iqueue_cell_t *cell;
     MPIDU_genq_shmem_queue_t terminal;
-    size_t i, iov_done, capacity, available;
+    size_t capacity, available;
     char *payload;
     int ret = MPIDI_POSIX_OK;
+    MPI_Aint packed_size = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_EAGER_SEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_EAGER_SEND);
 
     /* Get the transport object that holds all of the global variables. */
     transport = MPIDI_POSIX_eager_iqueue_get_transport();
-
-    /* TODO: This function can only send one cell at a time. For a large
-     * message that require multiple cells this function has to be invoked
-     * multiple times. Can we try to send all data in this call? Moreover,
-     * we have to traverse the transport to find an empty cell, can we find
-     * all needed cells in single traversal? When putting them into the terminal,
-     * can we put all in single insertion? */
 
     /* Try to get a new cell to hold the message */
     MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell);
@@ -71,59 +71,43 @@ MPIDI_POSIX_eager_send(int grank,
 
     /* Figure out the capacity of each cell */
     capacity = MPIDI_POSIX_EAGER_IQUEUE_CELL_CAPACITY(transport);
+
     available = capacity;
 
     cell->from = MPIDI_POSIX_global.my_local_rank;
 
     /* If this is the beginning of the message, mark it as the head. Otherwise it will be the
      * tail. */
-    if (*msg_hdr) {
-        cell->am_header = **msg_hdr;
-        *msg_hdr = NULL;        /* completed header copy */
+    cell->payload_size = 0;
+    if (am_hdr) {
+        MPI_Aint resized_am_hdr_sz = MPIDI_POSIX_RESIZE_TO_MAX_ALIGN(am_hdr_sz);
+        cell->am_header = *msg_hdr;
         cell->type = MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_HDR;
+        /* send am_hdr if this is the first segment */
+        MPIR_Typerep_copy(payload, am_hdr, am_hdr_sz);
+        /* make sure the data region starts at the boundary of MAX_ALIGNMENT */
+        payload = payload + resized_am_hdr_sz;
+        cell->payload_size += resized_am_hdr_sz;
+        cell->am_header.am_hdr_sz = resized_am_hdr_sz;
+        available -= cell->am_header.am_hdr_sz;
     } else {
         cell->type = MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_DATA;
     }
 
-    /* Pack the data into the cells */
-    iov_done = 0;
-    for (i = 0; i < *iov_num; i++) {
-        /* Optimize for the case where the message will fit into the cell. */
-        if (likely(available >= (*iov)[i].iov_len)) {
-            MPIR_Typerep_copy(payload, (*iov)[i].iov_base, (*iov)[i].iov_len);
-
-            payload += (*iov)[i].iov_len;
-            available -= (*iov)[i].iov_len;
-
-            iov_done++;
-        } else {
-            /* If the message won't fit, put as much as we can and update the iovec for the next
-             * time around. */
-            MPIR_Typerep_copy(payload, (*iov)[i].iov_base, available);
-
-            (*iov)[i].iov_base = (char *) (*iov)[i].iov_base + available;
-            (*iov)[i].iov_len -= available;
-
-            available = 0;
-
-            break;
-        }
+    /* We want to skip packing of send buffer is there is no data to be sent . buf == NULL is
+     * not a correct check here because derived datatype can use absolute address for displacment
+     * which requires buffer address passed as MPI_BOTTOM which is usually NULL. count == 0 is also
+     * not reliable because the derived datatype could have zero block size which contains no
+     * data. */
+    if (bytes_sent) {
+        MPIR_Typerep_pack(buf, count, datatype, offset, payload, available, &packed_size);
+        cell->payload_size += packed_size;
     }
-
-    cell->payload_size = capacity - available;
 
     MPIDU_genq_shmem_queue_enqueue(transport->cell_pool, terminal, (void *) cell);
 
-    /* Update the user counter for number of iovecs left */
-    *iov_num -= iov_done;
-
-    /* Check to see if we finished all of the iovecs that came from the caller. If not, update
-     * the iov pointer. If so, set it to NULL. Either way, the caller will know the status of
-     * the operation from the value of iov. */
-    if (*iov_num) {
-        *iov = &((*iov)[iov_done]);
-    } else {
-        *iov = NULL;
+    if (bytes_sent) {
+        *bytes_sent = packed_size;
     }
 
   fn_exit:

--- a/src/mpid/ch4/shm/posix/eager/stub/stub_send.h
+++ b/src/mpid/ch4/shm/posix/eager/stub/stub_send.h
@@ -20,9 +20,11 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_eager_buf_limit(void)
     return 0;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank,
-                                                    MPIDI_POSIX_am_header_t ** msg_hdr,
-                                                    struct iovec **iov, size_t * iov_num)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr,
+                                                    const void *am_hdr, MPI_Aint am_hdr_sz,
+                                                    const void *buf, MPI_Count count,
+                                                    MPI_Datatype datatype, MPI_Aint offset,
+                                                    MPI_Aint * bytes_sent)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -11,19 +11,31 @@
 #include "posix_eager.h"
 #include "mpidu_genq.h"
 
+#define MPIDI_POSIX_RESIZE_TO_MAX_ALIGN(x) \
+    ((((x) / MAX_ALIGNMENT) + !!((x) % MAX_ALIGNMENT)) * MAX_ALIGNMENT)
+
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_eager_limit(void)
 {
     return MPIDI_POSIX_eager_payload_limit() - MAX_ALIGNMENT;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_send_hdr(int grank,
+                                                        MPIDI_POSIX_am_header_t * msg_hdr,
+                                                        const void *am_hdr, bool issue_deferred);
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int rank,
+                                                     MPIDI_POSIX_am_header_t * msg_hdr,
+                                                     const void *am_hdr,
+                                                     size_t am_hdr_sz,
+                                                     const void *data,
+                                                     MPI_Count count,
+                                                     MPI_Datatype datatype, MPIR_Request * sreq,
+                                                     bool issue_deferred);
+
 /* Enqueue a request header onto the postponed message queue. This is a helper function and most
  * likely shouldn't be used outside of this file. */
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, size_t am_hdr_sz,
-                                                            int handler_id, const int grank,
-                                                            MPIDI_POSIX_am_header_t msg_hdr,
+                                                            const int grank,
                                                             MPIDI_POSIX_am_header_t * msg_hdr_p,
-                                                            struct iovec *iov_left_ptr,
-                                                            size_t iov_num_left, size_t data_sz,
                                                             MPIR_Request * sreq)
 {
     MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = MPIDI_POSIX_AMREQUEST(sreq, req_hdr);
@@ -31,6 +43,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, 
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_ENQUEUE_REQUEST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_ENQUEUE_REQUEST);
+
+    MPIR_Assert(msg_hdr_p);
 
     /* Check to see if we need to create storage for the data to be sent. We did this above only if
      * we were sending a noncontiguous message, but we need it for all situations now. */
@@ -44,31 +58,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, 
         curr_sreq_hdr = MPIDI_POSIX_AMREQUEST(sreq, req_hdr);
     }
 
-    curr_sreq_hdr->handler_id = handler_id;
     curr_sreq_hdr->dst_grank = grank;
     curr_sreq_hdr->msg_hdr = NULL;
 
-    /* If this is true, the header hasn't been sent so we should copy it from stack */
-    if (msg_hdr_p) {
-        curr_sreq_hdr->msg_hdr = &curr_sreq_hdr->msg_hdr_buf;
-        curr_sreq_hdr->msg_hdr_buf = msg_hdr;
-    }
-
-    curr_sreq_hdr->iov_num = iov_num_left;
-    curr_sreq_hdr->iov_ptr = curr_sreq_hdr->iov;
-
-    if (iov_num_left == 1 && data_sz > 0) {
-        /* this is the payload */
-        curr_sreq_hdr->iov[0] = iov_left_ptr[0];
-    } else {
-        /* the first iov is am_hdr, now points to curr_sreq_hdr */
-        curr_sreq_hdr->iov[0].iov_base = curr_sreq_hdr->am_hdr;
-        curr_sreq_hdr->iov[0].iov_len = curr_sreq_hdr->am_hdr_sz;
-        /* copy the rest */
-        for (int i = 1; i < iov_num_left; i++) {
-            curr_sreq_hdr->iov[i] = iov_left_ptr[i];
-        }
-    }
+    curr_sreq_hdr->msg_hdr = &curr_sreq_hdr->msg_hdr_buf;
+    curr_sreq_hdr->msg_hdr_buf = *msg_hdr_p;
 
     curr_sreq_hdr->request = sreq;
 
@@ -92,122 +86,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
                                                   MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    int result = MPIDI_POSIX_OK;
-    int dt_contig;
-    size_t data_sz;
-    MPIR_Datatype *dt_ptr;
-    MPI_Aint dt_true_lb;
     MPIDI_POSIX_am_header_t msg_hdr;
-    uint8_t *send_buf = NULL;
-    MPIDI_POSIX_am_header_t *msg_hdr_p = &msg_hdr;
-    MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = NULL;
     const int grank = MPIDIU_rank_to_lpid(rank, comm);
-    struct iovec iov_left[MPIDI_POSIX_MAX_IOV_NUM];
-    struct iovec *iov_left_ptr;
-    size_t iov_num_left;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_ISEND);
 
-    MPIDI_POSIX_AMREQUEST(sreq, req_hdr) = NULL;
-
-    MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
-
-    send_buf = (uint8_t *) data + dt_true_lb;
-
     msg_hdr.kind = kind;
     msg_hdr.handler_id = handler_id;
     msg_hdr.am_hdr_sz = am_hdr_sz;
-    if (data_sz + am_hdr_sz <= MPIDI_POSIX_am_eager_limit()) {
-        msg_hdr.am_type = MPIDI_POSIX_AM_TYPE__SHORT;
-    } else {
-        msg_hdr.am_type = MPIDI_POSIX_AM_TYPE__PIPELINE;
-    }
 
-    /* If the data being sent is not contiguous, pack it into a contiguous buffer using the datatype
-     * engine. */
-    if (unlikely(!dt_contig && (data_sz > 0))) {
-        MPIDI_POSIX_AMREQUEST(sreq, req_hdr) = NULL;
+    mpi_errno = MPIDI_POSIX_do_am_isend(grank, &msg_hdr, am_hdr, am_hdr_sz, data, count,
+                                        datatype, sreq, false);
 
-        /* Prepare private storage with information about the pack buffer. */
-        mpi_errno = MPIDI_POSIX_am_init_req_hdr(am_hdr, am_hdr_sz,
-                                                &MPIDI_POSIX_AMREQUEST(sreq, req_hdr), sreq);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        curr_sreq_hdr = MPIDI_POSIX_AMREQUEST(sreq, req_hdr);
-
-        curr_sreq_hdr->pack_buffer = (char *) MPL_malloc(data_sz, MPL_MEM_SHM);
-
-        MPIR_ERR_CHKANDJUMP1(MPIDI_POSIX_AMREQUEST_HDR(sreq, pack_buffer) == NULL, mpi_errno,
-                             MPI_ERR_OTHER, "**nomem", "**nomem %s", "Send Pack buffer alloc");
-
-        MPI_Aint actual_pack_bytes;
-        mpi_errno = MPIR_Typerep_pack(data, count, datatype, 0,
-                                      MPIDI_POSIX_AMREQUEST_HDR(sreq, pack_buffer),
-                                      data_sz, &actual_pack_bytes);
-        MPIR_ERR_CHECK(mpi_errno);
-        MPIR_Assert(actual_pack_bytes == data_sz);
-
-        send_buf = (uint8_t *) curr_sreq_hdr->pack_buffer;
-    }
-
-    static char padding[MAX_ALIGNMENT]; /* in case we need pad to alignment */
-    iov_left[0].iov_base = (void *) am_hdr;
-    iov_left[0].iov_len = am_hdr_sz;
-    iov_num_left = 1;
-    if (data_sz > 0) {
-        if (am_hdr_sz & (MAX_ALIGNMENT - 1)) {
-            /* need padding to ensure maximum alignment (typically 16 on x86-64) */
-            iov_left[1].iov_base = (void *) padding;
-            iov_left[1].iov_len = MAX_ALIGNMENT - (am_hdr_sz & (MAX_ALIGNMENT - 1));
-            msg_hdr.am_hdr_sz += iov_left[1].iov_len;
-            iov_num_left++;
-        }
-        iov_left[iov_num_left].iov_base = (void *) send_buf;
-        iov_left[iov_num_left].iov_len = data_sz;
-        iov_num_left++;
-    }
-
-    iov_left_ptr = iov_left;
-
-    /* If we already have messages in the postponed queue, this one will probably also end up being
-     * queued so save some cycles and do it now. */
-    if (unlikely(MPIDI_POSIX_global.postponed_queue)) {
-        mpi_errno = MPIDI_POSIX_am_enqueue_request(am_hdr, am_hdr_sz, handler_id, grank, msg_hdr,
-                                                   msg_hdr_p, iov_left_ptr, iov_num_left, data_sz,
-                                                   sreq);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        goto fn_exit;
-    }
-
-    result = MPIDI_POSIX_eager_send(grank, &msg_hdr_p, &iov_left_ptr, &iov_num_left);
-
-    /* If the message was not completed, queue it to be sent later. */
-    if (unlikely((MPIDI_POSIX_NOK == result) || iov_num_left)) {
-        mpi_errno = MPIDI_POSIX_am_enqueue_request(am_hdr, am_hdr_sz, handler_id, grank, msg_hdr,
-                                                   msg_hdr_p, iov_left_ptr, iov_num_left, data_sz,
-                                                   sreq);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        goto fn_exit;
-    }
-
-    /* If we made it here, the request has been completed and we can clean up the tracking
-     * information and trigger the appropriate callbacks. */
-    if (unlikely(curr_sreq_hdr)) {
-        MPL_free(curr_sreq_hdr->pack_buffer);
-        curr_sreq_hdr->pack_buffer = NULL;
-    }
-
-    mpi_errno = MPIDIG_global.origin_cbs[handler_id] (sreq);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_AM_ISEND);
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
@@ -304,9 +197,8 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_eager_buf_limit(void)
 /* Enqueue a request header onto the postponed message queue. This is a helper function and most
  * likely shouldn't be used outside of this file. */
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, size_t am_hdr_sz,
-                                                            int handler_id, const int grank,
-                                                            MPIDI_POSIX_am_header_t msg_hdr,
-                                                            size_t iov_num_left)
+                                                            const int grank,
+                                                            MPIDI_POSIX_am_header_t * msg_hdr)
 {
     MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = NULL;
     int mpi_errno = MPI_SUCCESS;
@@ -314,22 +206,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_ENQUEUE_REQ_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_ENQUEUE_REQ_HDR);
 
+    MPIR_Assert(msg_hdr);
+
     /* Prepare private storage */
     mpi_errno = MPIDI_POSIX_am_init_req_hdr(am_hdr, am_hdr_sz, &curr_sreq_hdr, NULL);
     MPIR_ERR_CHECK(mpi_errno);
 
-    curr_sreq_hdr->handler_id = handler_id;
     curr_sreq_hdr->dst_grank = grank;
-    curr_sreq_hdr->msg_hdr = NULL;
 
     /* Header hasn't been sent so we should copy it from stack */
     curr_sreq_hdr->msg_hdr = &curr_sreq_hdr->msg_hdr_buf;
-    curr_sreq_hdr->msg_hdr_buf = msg_hdr;
-
-    curr_sreq_hdr->iov_num = iov_num_left;
-    curr_sreq_hdr->iov_ptr = curr_sreq_hdr->iov;
-    curr_sreq_hdr->iov[0].iov_base = curr_sreq_hdr->am_hdr;
-    curr_sreq_hdr->iov[0].iov_len = curr_sreq_hdr->am_hdr_sz;
+    curr_sreq_hdr->msg_hdr_buf = *msg_hdr;
 
     curr_sreq_hdr->request = NULL;
     DL_APPEND(MPIDI_POSIX_global.postponed_queue, curr_sreq_hdr);
@@ -348,46 +235,64 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank,
                                                      const void *am_hdr, size_t am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
-    int result = MPIDI_POSIX_OK;
     MPIDI_POSIX_am_header_t msg_hdr;
-    MPIDI_POSIX_am_header_t *msg_hdr_p = &msg_hdr;
-    struct iovec iov_left[1];
-    struct iovec *iov_left_ptr = iov_left;
-    size_t iov_num_left = 1;
     const int grank = MPIDIU_rank_to_lpid(rank, comm);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR);
-
-    iov_left[0].iov_base = (void *) am_hdr;
-    iov_left[0].iov_len = am_hdr_sz;
 
     msg_hdr.kind = kind;
     msg_hdr.handler_id = handler_id;
     msg_hdr.am_hdr_sz = am_hdr_sz;
     msg_hdr.am_type = MPIDI_POSIX_AM_TYPE__HDR;
 
-    if (unlikely(MPIDI_POSIX_global.postponed_queue)) {
-        mpi_errno = MPIDI_POSIX_am_enqueue_req_hdr(am_hdr, am_hdr_sz, handler_id, grank, msg_hdr,
-                                                   iov_num_left);
-        MPIR_ERR_CHECK(mpi_errno);
-    } else {
-        result = MPIDI_POSIX_eager_send(grank, &msg_hdr_p, &iov_left_ptr, &iov_num_left);
-        if (unlikely((MPIDI_POSIX_NOK == result) || iov_num_left)) {
-            mpi_errno =
-                MPIDI_POSIX_am_enqueue_req_hdr(am_hdr, am_hdr_sz, handler_id, grank, msg_hdr,
-                                               iov_num_left);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
-            else
-                goto fn_exit;
+    mpi_errno = MPIDI_POSIX_do_am_send_hdr(grank, &msg_hdr, am_hdr, false);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR);
+    return mpi_errno;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_send_hdr(int grank,
+                                                        MPIDI_POSIX_am_header_t * msg_hdr,
+                                                        const void *am_hdr, bool issue_deferred)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int rc = MPIDI_POSIX_OK;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_DO_AM_SEND_HDR);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_DO_AM_SEND_HDR);
+
+    if (!issue_deferred && MPIDI_POSIX_global.postponed_queue) {
+        goto fn_deferred;
+    }
+
+    MPIR_Assert(msg_hdr);
+
+    rc = MPIDI_POSIX_eager_send(grank, msg_hdr, am_hdr, msg_hdr->am_hdr_sz, NULL, 0,
+                                MPI_DATATYPE_NULL, 0, NULL);
+
+    if (rc == MPIDI_POSIX_NOK) {
+        if (!issue_deferred) {
+            goto fn_deferred;
+        } else {
+            goto fn_exit;
         }
     }
 
+    /* hdr is sent, dequeue if was issuing deferred op */
+    if (issue_deferred) {
+        MPIDI_POSIX_am_request_header_t *curr_req_hdr = MPIDI_POSIX_global.postponed_queue;
+        DL_DELETE(MPIDI_POSIX_global.postponed_queue, curr_req_hdr);
+        MPIDI_POSIX_am_release_req_hdr(&curr_req_hdr);
+    }
+
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_DO_AM_SEND_HDR);
     return mpi_errno;
   fn_fail:
+    goto fn_exit;
+  fn_deferred:
+    mpi_errno = MPIDI_POSIX_am_enqueue_req_hdr(am_hdr, msg_hdr->am_hdr_sz, grank, msg_hdr);
     goto fn_exit;
 }
 
@@ -411,4 +316,109 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr_reply(MPIR_Context_id_t con
     return mpi_errno;
 }
 
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int grank,
+                                                     MPIDI_POSIX_am_header_t * msg_hdr,
+                                                     const void *am_hdr,
+                                                     size_t am_hdr_sz,
+                                                     const void *data,
+                                                     MPI_Count count,
+                                                     MPI_Datatype datatype, MPIR_Request * sreq,
+                                                     bool issue_deferred)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int rc = 0;
+    MPI_Aint data_sz, send_size, offset = 0;
+    MPIDI_POSIX_am_header_t *msg_hdr_p;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_DO_AM_ISEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_DO_AM_ISEND);
+
+    /* NOTE: issue_deferred is set to true when progress use this function for deferred operations.
+     * we need to skip some code path in the scenario. Also am_hdr, am_hdr_sz and data_sz are
+     * ignored when issue_deferred is set to true. They should have been saved in the request. */
+
+    if (!issue_deferred) {
+        MPIDI_POSIX_AMREQUEST(sreq, req_hdr) = NULL;
+
+        MPIDI_Datatype_check_size(datatype, count, data_sz);
+
+        msg_hdr_p = msg_hdr;
+        if (data_sz + am_hdr_sz <= MPIDI_POSIX_am_eager_limit()) {
+            msg_hdr_p->am_type = MPIDI_POSIX_AM_TYPE__SHORT;
+        } else {
+            msg_hdr_p->am_type = MPIDI_POSIX_AM_TYPE__PIPELINE;
+        }
+
+        MPIDIG_am_send_async_init(sreq, datatype, data_sz);
+    } else {
+        /* if we are issuing as deferred operation, use the msg_hdr in sreq */
+        msg_hdr_p = MPIDI_POSIX_AMREQUEST_HDR(sreq, msg_hdr);
+    }
+
+    if (!issue_deferred && MPIDI_POSIX_global.postponed_queue) {
+        goto fn_deferred;
+    }
+
+    send_size = MPIDIG_am_send_async_get_data_sz_left(sreq);
+    offset = MPIDIG_am_send_async_get_offset(sreq);
+    if (offset) {
+        rc = MPIDI_POSIX_eager_send(grank, NULL, NULL, 0, data, count, datatype, offset,
+                                    MPIDIG_am_send_async_get_data_sz_left(sreq) ? &send_size
+                                    : NULL);
+    } else {
+        rc = MPIDI_POSIX_eager_send(grank, msg_hdr, am_hdr, am_hdr_sz, data, count, datatype,
+                                    offset, MPIDIG_am_send_async_get_data_sz_left(sreq) ? &send_size
+                                    : NULL);
+    }
+
+    if (rc == MPIDI_POSIX_NOK) {
+        if (!issue_deferred) {
+            goto fn_deferred;
+        } else {
+            goto fn_exit;
+        }
+    }
+
+    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    (MPL_DBG_FDEST,
+                     "issue seg for req handle=0x%x send_size %ld", sreq->handle, send_size));
+    MPIDIG_am_send_async_issue_seg(sreq, send_size);
+    MPIDIG_am_send_async_finish_seg(sreq);
+
+    /* if there IS MORE DATA to be sent and we ARE NOT called for issue deferred op, enqueue.
+     * if there NO MORE DATA and we ARE called for issuing deferred op, pipeline is done, dequeue
+     * skip for all other cases */
+    if (!MPIDIG_am_send_async_is_done(sreq)) {
+        if (!issue_deferred) {
+            goto fn_deferred;
+        }
+    } else {
+        /* all segments are sent, complete regularly and dequeue (if was issuing deferred op) */
+        if (issue_deferred) {
+            MPIDI_POSIX_am_request_header_t *curr_req_hdr = MPIDI_POSIX_global.postponed_queue;
+            DL_DELETE(MPIDI_POSIX_global.postponed_queue, curr_req_hdr);
+
+            MPL_free(MPIDI_POSIX_AMREQUEST_HDR(sreq, pack_buffer));
+            MPIDI_POSIX_AMREQUEST_HDR(sreq, pack_buffer) = NULL;
+        }
+        mpi_errno = MPIDIG_global.origin_cbs[msg_hdr->handler_id] (sreq);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_DO_AM_ISEND);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+  fn_deferred:
+    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    (MPL_DBG_FDEST, "deferred posix_am_isend req handle=0x%x", sreq->handle));
+
+    mpi_errno = MPIDI_POSIX_am_enqueue_request(am_hdr, am_hdr_sz, grank, msg_hdr_p, sreq);
+    MPIDI_POSIX_AMREQUEST_HDR(sreq, buf) = data;
+    MPIDI_POSIX_AMREQUEST_HDR(sreq, datatype) = datatype;
+    MPIDI_POSIX_AMREQUEST_HDR(sreq, count) = count;
+    goto fn_exit;
+}
 #endif /* POSIX_AM_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -85,17 +85,14 @@ typedef struct MPIDI_POSIX_am_request_header {
 
     uint8_t am_hdr_buf[MPIDI_POSIX_MAX_AM_HDR_SIZE];
 
-    int handler_id;
     int dst_grank;
 
-    struct iovec *iov_ptr;
-    struct iovec iov[MPIDI_POSIX_MAX_IOV_NUM];
-    size_t iov_num;
-    size_t iov_num_total;
-
-    int is_contig;
-
     size_t in_total_data_sz;
+
+    /* For postponed operation */
+    MPI_Datatype datatype;
+    const void *buf;
+    MPI_Count count;
 
     /* Structure used with POSIX postponed_queue */
     MPIR_Request *request;      /* Store address of MPIR_Request* sreq */


### PR DESCRIPTION
    Add buffer signature and am header to the send interface so it can
    handle non-contiguous send buffer.

    The data_sz_left and offset are passed explicitly so that the pipelining
    is still implemented at the POSIX level. Therefore not requiring EAGER
    module to handle long message. The eager module would only send the data
    up to its limit and return how much data is sent for POSIX to track
    progress.

    The request object is not passed by design as in the case of sending
    header only message, no request is provided.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
