### PR TITLE
mpl: inline MPL_gpu_query_pointer_attr in the fallback path

### DIFF
--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -8,9 +8,12 @@
 
 #include "mplconfig.h"
 
+#undef MPL_HAVE_GPU
 #ifdef MPL_HAVE_CUDA
+#define MPL_HAVE_GPU MPL_GPU_TYPE_CUDA
 #include "mpl_gpu_cuda.h"
 #elif defined MPL_HAVE_ZE
+#define MPL_HAVE_GPU MPL_GPU_TYPE_ZE
 #include "mpl_gpu_ze.h"
 #else
 #include "mpl_gpu_fallback.h"
@@ -33,6 +36,18 @@ typedef enum {
     MPL_GPU_TYPE_CUDA,
     MPL_GPU_TYPE_ZE,
 } MPL_gpu_type_t;
+
+#ifndef MPL_HAVE_GPU
+/* inline the query function in the fallback path to provide compiler optimization opportunity */
+static inline int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
+{
+    attr->type = MPL_GPU_POINTER_UNREGISTERED_HOST;
+    attr->device = -1;
+
+    return MPL_SUCCESS;
+}
+
+#endif /* ! MPL_HAVE_GPU */
 
 int MPL_gpu_query_support(MPL_gpu_type_t * type);
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -5,14 +5,6 @@
 
 #include "mpl.h"
 
-int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
-{
-    attr->type = MPL_GPU_POINTER_UNREGISTERED_HOST;
-    attr->device = -1;
-
-    return MPL_SUCCESS;
-}
-
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     abort();


### PR DESCRIPTION
## Pull Request Description
The check of potential gpu buffer adds a branch in critical paths.
Inline the fallback query allows compilers to optimize the branches
away.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->
[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
