### PR TITLE
ch4/ofi: replace MPIDI_OFI_progress_do_queue with fi_poll

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -28,8 +28,6 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_progress_do_queue(int vni_idx);
-
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req)
 {
     MPIDI_OFI_AMREQUEST(req, req_hdr) = NULL;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -836,35 +836,6 @@ int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_entry *wc, MPIR_Request * re
     return mpi_errno;
 }
 
-int MPIDI_OFI_get_buffered(struct fi_cq_tagged_entry *wc, ssize_t num)
-{
-    int rc = 0;
-
-    if ((MPIDI_OFI_global.cq_buffered_static_head != MPIDI_OFI_global.cq_buffered_static_tail) ||
-        (NULL != MPIDI_OFI_global.cq_buffered_dynamic_head)) {
-        /* If the static list isn't empty, do so first */
-        if (MPIDI_OFI_global.cq_buffered_static_head != MPIDI_OFI_global.cq_buffered_static_tail) {
-            wc[0] =
-                MPIDI_OFI_global.cq_buffered_static_list[MPIDI_OFI_global.
-                                                         cq_buffered_static_tail].cq_entry;
-            MPIDI_OFI_global.cq_buffered_static_tail =
-                (MPIDI_OFI_global.cq_buffered_static_tail + 1) % MPIDI_OFI_NUM_CQ_BUFFERED;
-        }
-        /* If there's anything in the dynamic list, it goes second. */
-        else if (NULL != MPIDI_OFI_global.cq_buffered_dynamic_head) {
-            MPIDI_OFI_cq_list_t *cq_list_entry = MPIDI_OFI_global.cq_buffered_dynamic_head;
-            LL_DELETE(MPIDI_OFI_global.cq_buffered_dynamic_head,
-                      MPIDI_OFI_global.cq_buffered_dynamic_tail, cq_list_entry);
-            wc[0] = cq_list_entry->cq_entry;
-            MPL_free(cq_list_entry);
-        }
-
-        rc = 1;
-    }
-
-    return rc;
-}
-
 int MPIDI_OFI_handle_cq_entries(struct fi_cq_tagged_entry *wc, ssize_t num)
 {
     int i, mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -16,7 +16,6 @@ int MPIDI_OFI_send_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq, int
 int MPIDI_OFI_rma_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * in_req);
 int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
 int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
-int MPIDI_OFI_get_buffered(struct fi_cq_tagged_entry *wc, ssize_t num);
 int MPIDI_OFI_handle_cq_entries(struct fi_cq_tagged_entry *wc, ssize_t num);
 int MPIDI_OFI_handle_cq_error(int vni_idx, ssize_t ret);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -714,9 +714,6 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
                                                   &MPIDI_OFI_global.am_hdr_buf_pool);
         MPIR_ERR_CHECK(mpi_errno);
 
-        MPIDI_OFI_global.cq_buffered_dynamic_head = MPIDI_OFI_global.cq_buffered_dynamic_tail =
-            NULL;
-        MPIDI_OFI_global.cq_buffered_static_head = MPIDI_OFI_global.cq_buffered_static_tail = 0;
         optlen = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE;
 
         MPIDI_OFI_CALL(fi_setopt(&(MPIDI_OFI_global.ctx[0].rx->fid),
@@ -846,10 +843,6 @@ int MPIDI_OFI_mpi_finalize_hook(void)
             MPL_gpu_free_host(MPIDI_OFI_global.am_bufs[i]);
 
         MPIDU_genq_private_pool_destroy_unsafe(MPIDI_OFI_global.am_hdr_buf_pool);
-
-        MPIR_Assert(MPIDI_OFI_global.cq_buffered_static_head ==
-                    MPIDI_OFI_global.cq_buffered_static_tail);
-        MPIR_Assert(NULL == MPIDI_OFI_global.cq_buffered_dynamic_head);
     }
 
     MPIDU_genq_private_pool_destroy_unsafe(MPIDI_OFI_global.pack_buf_pool);

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.c
@@ -68,9 +68,7 @@ int MPIDI_OFI_progress(int vci, int blocking)
         return MPI_SUCCESS;
     }
 
-    if (unlikely(MPIDI_OFI_get_buffered(wc, 1)))
-        mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1);
-    else if (likely(1)) {
+    {
         ret = fi_cq_read(MPIDI_OFI_global.ctx[vni].cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
 
         if (likely(ret > 0))

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -354,12 +354,6 @@ typedef struct {
     /* Pack buffers for various communication */
     MPIDU_genq_private_pool_t pack_buf_pool;
 
-    /* Completion queue buffering */
-    MPIDI_OFI_cq_buff_entry_t cq_buffered_static_list[MPIDI_OFI_NUM_CQ_BUFFERED];
-    int cq_buffered_static_head;
-    int cq_buffered_static_tail;
-    MPIDI_OFI_cq_list_t *cq_buffered_dynamic_head, *cq_buffered_dynamic_tail;
-
     /* Process management and PMI globals */
     int pname_set;
     int pname_len;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -228,6 +228,8 @@ typedef struct {
     struct fid_ep *tx;
     struct fid_ep *rx;
     struct fid_cq *cq;
+
+    struct fid_poll *pollset;
 } MPIDI_OFI_context_t;
 
 typedef union {

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -30,10 +30,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win)
 
         while (tcount > donecount) {
             MPIR_Assert(donecount <= tcount);
-            MPIDI_OFI_PROGRESS(0);
-            /* rma issued_cntr may be updated during MPIDI_OFI_PROGRESS if active messages
-             * arrive and trigger RDMA calls, so we need to update it after progress call */
-            tcount = *MPIDI_OFI_WIN(win).issued_cntr;
+            mpi_errno = MPIDI_OFI_progress_poll(0);
+            MPIR_ERR_CHECK(mpi_errno);
             donecount = fi_cntr_read(MPIDI_OFI_WIN(win).cmpl_cntr);
             itercount++;
 


### PR DESCRIPTION
## Pull Request Description

The purpose of MPIDI_OFI_progress_do_queue is to poke libfabric internal progress without processing the completion queue entries. I believe this is what `fi_poll` allows us to do. If it works, then we can eliminate the cq buffered system and save a branch in the critical progress path.

[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
