### PR TITLE
ch4: Improve RMA fallback with GPU buffers

### DIFF
--- a/src/include/mpir_gpu.h
+++ b/src/include/mpir_gpu.h
@@ -54,4 +54,16 @@ MPL_STATIC_INLINE_PREFIX int MPIR_GPU_query_pointer_attr(const void *ptr, MPL_po
     goto fn_exit;
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIR_GPU_query_pointer_is_dev(const void *ptr)
+{
+    if (MPIR_CVAR_ENABLE_GPU && ptr != NULL) {
+        MPL_pointer_attr_t attr;
+        MPL_gpu_query_pointer_attr(ptr, &attr);
+
+        return attr.type == MPL_GPU_POINTER_DEV;
+    }
+
+    return false;
+}
+
 #endif /* MPIR_GPU_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -326,7 +326,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_PUT);
     int mpi_errno = MPI_SUCCESS;
 
-    if (!MPIDI_OFI_ENABLE_RMA || !(winattr & MPIDI_WINATTR_NM_REACHABLE)) {
+    if (!MPIDI_OFI_ENABLE_RMA || !(winattr & MPIDI_WINATTR_NM_REACHABLE) ||
+        MPIR_GPU_query_pointer_is_dev(origin_addr)) {
         mpi_errno = MPIDIG_mpi_put(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win);
         goto fn_exit;
@@ -488,7 +489,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_GET);
 
-    if (!MPIDI_OFI_ENABLE_RMA || !(winattr & MPIDI_WINATTR_NM_REACHABLE)) {
+    if (!MPIDI_OFI_ENABLE_RMA || !(winattr & MPIDI_WINATTR_NM_REACHABLE) ||
+        MPIR_GPU_query_pointer_is_dev(origin_addr)) {
         mpi_errno = MPIDIG_mpi_get(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win);
         goto fn_exit;
@@ -520,7 +522,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rput(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RPUT);
     int mpi_errno = MPI_SUCCESS;
 
-    if (!MPIDI_OFI_ENABLE_RMA || !(winattr & MPIDI_WINATTR_NM_REACHABLE)) {
+    if (!MPIDI_OFI_ENABLE_RMA || !(winattr & MPIDI_WINATTR_NM_REACHABLE) ||
+        MPIR_GPU_query_pointer_is_dev(origin_addr)) {
         mpi_errno = MPIDIG_mpi_rput(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_disp, target_count, target_datatype, win, request);
         goto fn_exit;
@@ -569,7 +572,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
            !(winattr & MPIDI_WINATTR_ACCU_NO_SHM) ||
 #endif
            !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           !(winattr & MPIDI_WINATTR_NM_REACHABLE)) {
+           !(winattr & MPIDI_WINATTR_NM_REACHABLE) ||
+           MPIR_GPU_query_pointer_is_dev(origin_addr) ||
+           MPIR_GPU_query_pointer_is_dev(compare_addr) ||
+           MPIR_GPU_query_pointer_is_dev(result_addr)) {
         mpi_errno =
             MPIDIG_mpi_compare_and_swap(origin_addr, compare_addr, result_addr, datatype,
                                         target_rank, target_disp, win);
@@ -957,7 +963,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr,
            !(winattr & MPIDI_WINATTR_ACCU_NO_SHM) ||
 #endif
            !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           !(winattr & MPIDI_WINATTR_NM_REACHABLE)) {
+           !(winattr & MPIDI_WINATTR_NM_REACHABLE) || MPIR_GPU_query_pointer_is_dev(origin_addr)) {
         mpi_errno =
             MPIDIG_mpi_raccumulate(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, op, win, request);
@@ -1006,7 +1012,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget_accumulate(const void *origin_add
            !(winattr & MPIDI_WINATTR_ACCU_NO_SHM) ||
 #endif
            !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           !(winattr & MPIDI_WINATTR_NM_REACHABLE)) {
+           !(winattr & MPIDI_WINATTR_NM_REACHABLE) ||
+           MPIR_GPU_query_pointer_is_dev(origin_addr) ||
+           MPIR_GPU_query_pointer_is_dev(result_addr)) {
         mpi_errno =
             MPIDIG_mpi_rget_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
                                        result_count, result_datatype, target_rank, target_disp,
@@ -1055,7 +1063,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
            !(winattr & MPIDI_WINATTR_ACCU_NO_SHM) ||
 #endif
            !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           !(winattr & MPIDI_WINATTR_NM_REACHABLE)) {
+           !(winattr & MPIDI_WINATTR_NM_REACHABLE) ||
+           MPIR_GPU_query_pointer_is_dev(origin_addr) ||
+           MPIR_GPU_query_pointer_is_dev(result_addr)) {
         mpi_errno =
             MPIDIG_mpi_fetch_and_op(origin_addr, result_addr, datatype, target_rank, target_disp,
                                     op, win);
@@ -1142,7 +1152,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RGET);
     int mpi_errno = MPI_SUCCESS;
 
-    if (!MPIDI_OFI_ENABLE_RMA || !(winattr & MPIDI_WINATTR_NM_REACHABLE)) {
+    if (!MPIDI_OFI_ENABLE_RMA || !(winattr & MPIDI_WINATTR_NM_REACHABLE) ||
+        MPIR_GPU_query_pointer_is_dev(origin_addr)) {
         mpi_errno = MPIDIG_mpi_rget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_disp, target_count, target_datatype, win, request);
         goto fn_exit;
@@ -1188,7 +1199,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr
            !(winattr & MPIDI_WINATTR_ACCU_NO_SHM) ||
 #endif
            !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           !(winattr & MPIDI_WINATTR_NM_REACHABLE)) {
+           !(winattr & MPIDI_WINATTR_NM_REACHABLE) || MPIR_GPU_query_pointer_is_dev(origin_addr) ||
+           MPIR_GPU_query_pointer_is_dev(result_addr)) {
         mpi_errno =
             MPIDIG_mpi_get_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
                                       result_count, result_datatype, target_rank, target_disp,
@@ -1230,7 +1242,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_accumulate(const void *origin_addr,
            !(winattr & MPIDI_WINATTR_ACCU_NO_SHM) ||
 #endif
            !MPIDI_OFI_ENABLE_RMA || !MPIDI_OFI_ENABLE_ATOMICS ||
-           !(winattr & MPIDI_WINATTR_NM_REACHABLE)) {
+           !(winattr & MPIDI_WINATTR_NM_REACHABLE) || MPIR_GPU_query_pointer_is_dev(origin_addr)) {
         mpi_errno =
             MPIDIG_mpi_accumulate(origin_addr, origin_count, origin_datatype, target_rank,
                                   target_disp, target_count, target_datatype, op, win);

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -101,8 +101,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_get_source(uint64_t match_bits)
 MPL_STATIC_INLINE_PREFIX bool MPIDI_UCX_is_reachable_target(int rank, MPIR_Win * win,
                                                             MPIDI_winattr_t winattr)
 {
-    /* zero win target does not have rkey. */
-    return (winattr & MPIDI_WINATTR_NM_REACHABLE) && MPIDI_UCX_WIN_INFO(win, rank).rkey != NULL;
+    /* unmapped win target does not have rkey. */
+    return (winattr & MPIDI_WINATTR_NM_REACHABLE) || (MPIDI_UCX_WIN(win).info_table &&
+                                                      MPIDI_UCX_WIN_INFO(win, rank).rkey != NULL);
 }
 
 /* This function implements netmod vci to vni(context) mapping.

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -306,7 +306,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_PUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_PUT);
 
-    if (!MPIDI_UCX_is_reachable_target(target_rank, win, winattr)) {
+    if (!MPIDI_UCX_is_reachable_target(target_rank, win, winattr) ||
+        MPIR_GPU_query_pointer_is_dev(origin_addr)) {
         mpi_errno = MPIDIG_mpi_put(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win);
     } else {
@@ -332,7 +333,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_GET);
 
-    if (!MPIDI_UCX_is_reachable_target(target_rank, win, winattr)) {
+    if (!MPIDI_UCX_is_reachable_target(target_rank, win, winattr) ||
+        MPIR_GPU_query_pointer_is_dev(origin_addr)) {
         mpi_errno = MPIDIG_mpi_get(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win);
     } else {
@@ -365,7 +367,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rput(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RPUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RPUT);
 
-    if (!MPIDI_UCX_is_reachable_target(target_rank, win, winattr)) {
+    if (!MPIDI_UCX_is_reachable_target(target_rank, win, winattr) ||
+        MPIR_GPU_query_pointer_is_dev(origin_addr)) {
         mpi_errno = MPIDIG_mpi_rput(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_disp, target_count, target_datatype, win, request);
     } else {
@@ -475,7 +478,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RGET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RGET);
 
-    if (!MPIDI_UCX_is_reachable_target(target_rank, win, winattr)) {
+    if (!MPIDI_UCX_is_reachable_target(target_rank, win, winattr) ||
+        MPIR_GPU_query_pointer_is_dev(origin_addr)) {
         mpi_errno = MPIDIG_mpi_rget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_disp, target_count, target_datatype, win, request);
     } else {

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -260,12 +260,12 @@ int MPIDI_UCX_mpi_win_allocate_hook(MPIR_Win * win)
 
 int MPIDI_UCX_mpi_win_allocate_shared_hook(MPIR_Win * win)
 {
-    return MPI_SUCCESS;
+    return win_init(win);
 }
 
 int MPIDI_UCX_mpi_win_create_dynamic_hook(MPIR_Win * win)
 {
-    return MPI_SUCCESS;
+    return win_init(win);
 }
 
 int MPIDI_UCX_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)


### PR DESCRIPTION
## Pull Request Description

ch4 netmods do not support RMA with GPU buffers (origin|target|compare|result). Fallback to active message when we detect device buffers.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix crashes with GPU buffers in default GPU-aware builds.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
