### PR TITLE
coll: Fix in gpu fallback code and test

### DIFF
--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
@@ -367,7 +367,10 @@ int MPIR_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcount
     void *in_recvbuf = recvbuf;
     void *host_sendbuf;
     void *host_recvbuf;
-    int count = recvcounts[MPIR_Comm_rank(comm_ptr)];
+    int count = 0;
+
+    for (int i = 0; i < MPIR_Comm_size(comm_ptr); i++)
+        count += recvcounts[i];
 
     MPIR_Coll_host_buffer_alloc(sendbuf, recvbuf, count, datatype, &host_sendbuf, &host_recvbuf);
     if (host_sendbuf)

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
@@ -364,8 +364,8 @@ int MPIR_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
     void *host_sendbuf;
     void *host_recvbuf;
 
-    MPIR_Coll_host_buffer_alloc(sendbuf, recvbuf, recvcount, datatype, &host_sendbuf,
-                                &host_recvbuf);
+    MPIR_Coll_host_buffer_alloc(sendbuf, recvbuf, MPIR_Comm_size(comm_ptr) * recvcount, datatype,
+                                &host_sendbuf, &host_recvbuf);
     if (host_sendbuf)
         sendbuf = host_sendbuf;
     if (host_recvbuf)

--- a/src/mpi/coll/reduce_scatter/reduce_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter.c
@@ -247,7 +247,10 @@ int MPIR_Reduce_scatter(const void *sendbuf, void *recvbuf,
     void *in_recvbuf = recvbuf;
     void *host_sendbuf;
     void *host_recvbuf;
-    int count = recvcounts[MPIR_Comm_rank(comm_ptr)];
+    int count = 0;
+
+    for (int i = 0; i < MPIR_Comm_size(comm_ptr); i++)
+        count += recvcounts[i];
 
     MPIR_Coll_host_buffer_alloc(sendbuf, recvbuf, count, datatype, &host_sendbuf, &host_recvbuf);
     if (host_sendbuf)

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
@@ -244,8 +244,8 @@ int MPIR_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
     void *host_sendbuf;
     void *host_recvbuf;
 
-    MPIR_Coll_host_buffer_alloc(sendbuf, recvbuf, recvcount, datatype, &host_sendbuf,
-                                &host_recvbuf);
+    MPIR_Coll_host_buffer_alloc(sendbuf, recvbuf, MPIR_Comm_size(comm_ptr) * recvcount, datatype,
+                                &host_sendbuf, &host_recvbuf);
     if (host_sendbuf)
         sendbuf = host_sendbuf;
     if (host_recvbuf)

--- a/test/mpi/coll/nonblocking2.c
+++ b/test/mpi/coll/nonblocking2.c
@@ -430,9 +430,7 @@ void test_icoll_with_root(int rank, int size, int root)
     MPI_Iexscan(buf, recvbuf, COUNT, MPI_INT, MPI_SUM, MPI_COMM_WORLD, &req);
     MPI_Wait(&req, MPI_STATUS_IGNORE);
     for (i = 0; i < COUNT; ++i) {
-        if (rank == 0)
-            my_assert(recvbuf[i] == 0xdeadbeef);
-        else
+        if (rank != 0)
             my_assert(recvbuf[i] == ((rank * (rank + 1) / 2) + (i * (rank + 1)) - (rank + i)));
     }
 

--- a/test/mpi/coll/nonblocking3.c
+++ b/test/mpi/coll/nonblocking3.c
@@ -616,9 +616,7 @@ static void check_after_completion(struct laundry *l)
 
         case 18:       /* MPI_Iexscan */
             for (i = 0; i < COUNT; ++i) {
-                if (rank == 0)
-                    my_assert(recvbuf[i] == 0xdeadbeef);
-                else
+                if (rank != 0)
                     my_assert(recvbuf[i] ==
                               ((rank * (rank + 1) / 2) + (i * (rank + 1)) - (rank + i)));
             }

--- a/test/mpi/coll/op_coll.c
+++ b/test/mpi/coll/op_coll.c
@@ -268,9 +268,7 @@ void test_op_coll_with_root(int rank, int size, int root)
     MPI_Exscan(buf, recvbuf, COUNT, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
     MTestCopyContent(recvbuf, recvbuf_h, COUNT * sizeof(int), memtype);
     for (i = 0; i < COUNT; ++i) {
-        if (rank == 0)
-            my_assert(recvbuf_h[i] == 0xdeadbeef);
-        else
+        if (rank != 0)
             my_assert(recvbuf_h[i] == ((rank * (rank + 1) / 2) + (i * (rank + 1)) - (rank + i)));
     }
 
@@ -285,9 +283,7 @@ void test_op_coll_with_root(int rank, int size, int root)
     MPI_Wait(&req, MPI_STATUS_IGNORE);
     MTestCopyContent(recvbuf, recvbuf_h, COUNT * sizeof(int), memtype);
     for (i = 0; i < COUNT; ++i) {
-        if (rank == 0)
-            my_assert(recvbuf_h[i] == 0xdeadbeef);
-        else
+        if (rank != 0)
             my_assert(recvbuf_h[i] == ((rank * (rank + 1) / 2) + (i * (rank + 1)) - (rank + i)));
     }
 }

--- a/test/mpi/coll/op_coll.c
+++ b/test/mpi/coll/op_coll.c
@@ -150,7 +150,7 @@ void test_op_coll_with_root(int rank, int size, int root)
             recvbuf_h[i * COUNT + j] = 0xdeadbeef;
         }
     }
-    MTestCopyContent(buf_h, buf, COUNT * sizeof(int), memtype);
+    MTestCopyContent(buf_h, buf, size * COUNT * sizeof(int), memtype);
     MTestCopyContent(recvbuf_h, recvbuf, COUNT * sizeof(int), memtype);
     MPI_Reduce_scatter(buf, recvbuf, recvcounts, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
     MTestCopyContent(recvbuf, recvbuf_h, COUNT * sizeof(int), memtype);
@@ -172,7 +172,7 @@ void test_op_coll_with_root(int rank, int size, int root)
             recvbuf_h[i * COUNT + j] = 0xdeadbeef;
         }
     }
-    MTestCopyContent(buf_h, buf, COUNT * sizeof(int), memtype);
+    MTestCopyContent(buf_h, buf, size * COUNT * sizeof(int), memtype);
     MTestCopyContent(recvbuf_h, recvbuf, COUNT * sizeof(int), memtype);
     MPI_Ireduce_scatter(buf, recvbuf, recvcounts, MPI_INT, MPI_SUM, MPI_COMM_WORLD, &req);
     MPI_Wait(&req, MPI_STATUS_IGNORE);
@@ -194,10 +194,9 @@ void test_op_coll_with_root(int rank, int size, int root)
             recvbuf_h[i * COUNT + j] = 0xdeadbeef;
         }
     }
-    MTestCopyContent(buf_h, buf, COUNT * sizeof(int), memtype);
+    MTestCopyContent(buf_h, buf, size * COUNT * sizeof(int), memtype);
     MTestCopyContent(recvbuf_h, recvbuf, COUNT * sizeof(int), memtype);
     MPI_Reduce_scatter_block(buf, recvbuf, COUNT, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-    MPI_Wait(&req, MPI_STATUS_IGNORE);
     MTestCopyContent(recvbuf, recvbuf_h, COUNT * sizeof(int), memtype);
     for (j = 0; j < COUNT; ++j) {
         my_assert(recvbuf_h[j] == (size * rank + ((size - 1) * size) / 2));
@@ -216,7 +215,7 @@ void test_op_coll_with_root(int rank, int size, int root)
             recvbuf_h[i * COUNT + j] = 0xdeadbeef;
         }
     }
-    MTestCopyContent(buf_h, buf, COUNT * sizeof(int), memtype);
+    MTestCopyContent(buf_h, buf, size * COUNT * sizeof(int), memtype);
     MTestCopyContent(recvbuf_h, recvbuf, COUNT * sizeof(int), memtype);
     MPI_Ireduce_scatter_block(buf, recvbuf, COUNT, MPI_INT, MPI_SUM, MPI_COMM_WORLD, &req);
     MPI_Wait(&req, MPI_STATUS_IGNORE);

--- a/test/mpi/util/mtest_common.c
+++ b/test/mpi/util/mtest_common.c
@@ -379,7 +379,7 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
             zerr = zeDriverAllocHostMem(driver, &host_desc, size, mem_alignment, hostbuf);
             assert(zerr == ZE_RESULT_SUCCESS);
             if (is_calloc)
-                memset(*devicebuf, 0, size);
+                memset(*hostbuf, 0, size);
         }
         /* FIXME: currently ZE only support device 0, so we cannot change device during test.
          * Shifting device_id similar to CUDA should be added in future. */


### PR DESCRIPTION
## Pull Request Description

- Fixes the memory copy in reduce_scatter_block and reduce_scatter test.
- Fixes buffer sizes for temp memory in the fallback code for reduce_scatter_block and reduce_scatter.
- In MPI_Exscan test, the value for root can be undefined so don't need to verify that.
- Updates the correct buffer to be memset to zero. Setting device buffer leads to segfault.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
