### PR TITLE
ch4: adjust data_sz check in RMA

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -140,8 +140,10 @@ typedef struct MPIDIG_acc_req_t {
     int target_count;
     void *target_addr;
     void *flattened_dt;
-    void *data;
-    size_t data_sz;
+    void *data;                 /* for origin_data received and result_data being sent (in GET_ACC).
+                                 * Not to be confused with result_addr below which saves the
+                                 * result_addr parameter. */
+    MPI_Aint result_data_sz;    /* only used in GET_ACC */
     MPI_Op op;
     void *result_addr;
     int result_count;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -198,8 +198,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
     MPIDI_Datatype_check_contig_size_extent_lb(target_datatype, target_count, target_contig,
                                                target_bytes, target_extent, target_true_lb);
 
-    MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
-
     /* zero-byte messages */
     if (unlikely(origin_bytes == 0))
         goto null_op_exit;
@@ -361,7 +359,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
     struct fi_msg_rma msg;
     int origin_contig, target_contig;
     MPI_Aint origin_true_lb, target_true_lb;
-    MPI_Aint origin_bytes, target_bytes, target_extent;
+    MPI_Aint target_bytes, target_extent;
     struct fi_rma_iov riov;
     struct iovec iov;
 
@@ -370,15 +368,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
 
-    MPIDI_Datatype_check_contig_size_lb(origin_datatype, origin_count, origin_contig,
-                                        origin_bytes, origin_true_lb);
+    MPIDI_Datatype_check_contig_lb(origin_datatype, origin_contig, origin_true_lb);
     MPIDI_Datatype_check_contig_size_extent_lb(target_datatype, target_count, target_contig,
                                                target_bytes, target_extent, target_true_lb);
 
-    MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
-
     /* zero-byte messages */
-    if (unlikely(origin_bytes == 0))
+    if (unlikely(target_bytes == 0))
         goto null_op_exit;
 
     /* self messages */
@@ -804,8 +799,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
 {
     int mpi_errno = MPI_SUCCESS;
     int target_contig, origin_contig, result_contig;
-    MPI_Aint target_bytes, target_extent, origin_bytes ATTRIBUTE((unused)),
-        result_bytes ATTRIBUTE((unused));
+    MPI_Aint target_bytes, target_extent;
     MPI_Aint origin_true_lb, target_true_lb, result_true_lb;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_GET_ACCUMULATE);
@@ -813,10 +807,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
 
-    MPIDI_Datatype_check_contig_size_lb(origin_datatype, origin_count, origin_contig,
-                                        origin_bytes, origin_true_lb);
-    MPIDI_Datatype_check_contig_size_lb(result_datatype, result_count, result_contig,
-                                        result_bytes, result_true_lb);
+    MPIDI_Datatype_check_contig_lb(origin_datatype, origin_contig, origin_true_lb);
+    MPIDI_Datatype_check_contig_lb(result_datatype, result_contig, result_true_lb);
     MPIDI_Datatype_check_contig_size_extent_lb(target_datatype, target_count, target_contig,
                                                target_bytes, target_extent, target_true_lb);
     if (target_bytes == 0)

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -208,7 +208,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_put(const void *origin_addr,
                                                       origin_contig, target_contig,
                                                       origin_bytes, target_bytes,
                                                       origin_true_lb, target_true_lb);
-    MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
 
     if (unlikely(origin_bytes == 0))
         goto fn_exit;
@@ -266,7 +265,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_get(void *origin_addr,
                                                       origin_contig, target_contig,
                                                       origin_bytes, target_bytes,
                                                       origin_true_lb, target_true_lb);
-    MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
 
     if (unlikely(origin_bytes == 0))
         goto fn_exit;

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -323,6 +323,24 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
         }                                                       \
     } while (0)
 
+#define MPIDI_Datatype_check_contig_lb(datatype_, dt_contig_out_, dt_true_lb_) \
+    do {                                                                       \
+        if (IS_BUILTIN(datatype_)) {                                           \
+            (dt_contig_out_) = TRUE;                                           \
+            (dt_true_lb_)    = 0;                                              \
+        } else {                                                               \
+            MPIR_Datatype *dt_ptr_;                                            \
+            MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));                     \
+            if (dt_ptr_) {                                                     \
+                (dt_contig_out_) = (dt_ptr_)->is_contig;                       \
+                (dt_true_lb_)    = (dt_ptr_)->true_lb;                         \
+            } else {                                                           \
+                (dt_contig_out_) = 1;                                          \
+                (dt_true_lb_)    = 0;                                          \
+            }                                                                  \
+        }                                                                      \
+    } while (0)
+
 #define MPIDI_Datatype_check_lb(datatype_, dt_true_lb_)    \
     do {                                                   \
         if (IS_BUILTIN(datatype_)) {                       \


### PR DESCRIPTION
## Pull Request Description

The standard does not require `origin_bytes == target_bytes`. This PR removes the related check. It also adjusts the data_sz handling the AM path to correctly handle the case where `origin_bytes != target_bytes`.

Further cleanup the variable names to make the data_sz meaning clear.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
