### PR TITLE
mpl/thread: Set err = 0 for single threaded fallback macros

### DIFF
--- a/src/mpl/include/mpl_thread.h
+++ b/src/mpl/include/mpl_thread.h
@@ -38,8 +38,8 @@ typedef int MPL_thread_tls_key_t;
 typedef void (*MPL_thread_func_t) (void *data);
 #define MPL_thread_mutex_create(mutex_ptr_, err_ptr_)  { *((int*)err_ptr_) = 0;}
 #define MPL_thread_mutex_destroy(mutex_ptr_, err_ptr_) { *((int*)err_ptr_) = 0;}
-#define MPL_thread_init(err_ptr_)      do { } while (0)
-#define MPL_thread_finalize(err_ptr_)  do { } while (0)
+#define MPL_thread_init(err_ptr_)      do { *((int*)err_ptr_) = 0;} while (0)
+#define MPL_thread_finalize(err_ptr_)  do { *((int*)err_ptr_) = 0;} while (0)
 #define MPL_thread_yield()             do { } while (0)
 #else
 #error "thread package (MPL_THREAD_PACKAGE_NAME) not defined or unknown"


### PR DESCRIPTION
## Pull Request Description

These functions do nothing in the single threaded case, but they
should set the error value to 0 to avoid unintended assertion failures
due to uninitialized variables.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix crashes in single threaded configuration.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
