### PR TITLE
ch4/posix: decrease shm_limit_counter when freeing comm obj

### DIFF
--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -27,7 +27,7 @@ cvars:
     - name        : MPIR_CVAR_COLLECTIVE_FALLBACK
       category    : COLLECTIVE
       type        : enum
-      default     : error
+      default     : silent
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -257,6 +257,7 @@ int MPIDI_POSIX_coll_init(int rank, int size)
 int MPIDI_POSIX_coll_finalize(void)
 {
     int mpi_errno = MPI_SUCCESS;
+    static MPL_atomic_uint64_t MPIDI_POSIX_dummy_shm_limit_counter;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_COLL_FINALIZE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_COLL_FINALIZE);
@@ -264,6 +265,11 @@ int MPIDI_POSIX_coll_finalize(void)
     /* Destroy the shared counter which was used to track the amount of shared memory created
      * per node for intra-node collectives */
     mpi_errno = MPIDU_Init_shm_free(MPIDI_POSIX_global.shm_ptr);
+
+    /* MPIDI_POSIX_global.shm_ptr is freed but will be referenced during builtin
+     * comm free; here we set MPIDI_POSIX_shm_limit_counter as dummy counter to
+     * avoid segmentation fault */
+    MPIDI_POSIX_shm_limit_counter = &MPIDI_POSIX_dummy_shm_limit_counter;
 
     if (MPIDI_global.shm.posix.csel_root) {
         mpi_errno = MPIR_Csel_free(MPIDI_global.shm.posix.csel_root);

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather_types.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather_types.h
@@ -26,7 +26,10 @@ typedef struct MPIDI_POSIX_release_gather_comm_t {
     int num_collective_calls;
 
     MPIR_Treealgo_tree_t bcast_tree, reduce_tree;
-    int flags_shm_size;
+    /* shm mem allocated to this comm */
+    uint64_t flags_shm_size;
+    uint64_t bcast_shm_size;
+    uint64_t reduce_shm_size;
     uint64_t gather_state, release_state;
 
     void *flags_addr, *bcast_buf_addr, *reduce_buf_addr;


### PR DESCRIPTION
## Bug Description

For MPI_Reduce/Allreduce, internal reduce shm buffer will be allocated for each comm.
`MPIDI_POSIX_shm_limit_counter` is used to record the amount of shm memory allocated, which
assures the amount does not exceed the predefined threshold. 

The bug is `MPIDI_POSIX_shm_limit_counter` is increased when allocating shm memory for coll calls, 
but it is not properly decreased when freeing comm obj. When users allocate many comm objs, the total
shm memory allocated are not properly reported which causes the `no shm mem` error when MPICH detects
allocated shm memory exceeds the predefined threshold.  

This commit fixes this bug.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
