### PR TITLE
ch4: Adding am-recv and using it to handle ZCOPY transfer in PT2PT

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -96,6 +96,9 @@ typedef struct MPIDIG_rreq_t {
     MPIR_Request *match_req;
     MPIR_Request *request;
 
+    MPI_Aint zcopy_hdr_sz;
+    void *zcopy_hdr;
+
     struct MPIDIG_rreq_t *prev, *next;
 } MPIDIG_rreq_t;
 

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -34,6 +34,10 @@ typedef int (*MPIDI_NM_mpi_open_port_t) (MPIR_Info * info_ptr, char *port_name);
 typedef int (*MPIDI_NM_mpi_close_port_t) (const char *port_name);
 typedef int (*MPIDI_NM_mpi_comm_accept_t) (const char *port_name, MPIR_Info * info, int root,
                                            MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
+typedef int (*MPIDI_NM_am_prepare_send_t) (int handler_id, const void *buf, MPI_Count count,
+                                           MPI_Datatype datatype, const void *am_hdr,
+                                           MPI_Aint am_hdr_sz, void **ext_hdr,
+                                           MPI_Aint * ext_hdr_sz, MPIR_Request * sreq);
 typedef int (*MPIDI_NM_am_send_hdr_t) (int rank, MPIR_Comm * comm, int handler_id,
                                        const void *am_hdr, size_t am_hdr_sz);
 typedef int (*MPIDI_NM_am_isend_t) (int rank, MPIR_Comm * comm, int handler_id, const void *am_hdr,
@@ -391,6 +395,7 @@ typedef struct MPIDI_NM_funcs {
     MPIDI_NM_am_request_init_t am_request_init;
     MPIDI_NM_am_request_finalize_t am_request_finalize;
     /* Active Message Routines */
+    MPIDI_NM_am_prepare_send_t am_prepare_send;
     MPIDI_NM_am_send_hdr_t am_send_hdr;
     MPIDI_NM_am_isend_t am_isend;
     MPIDI_NM_am_isendv_t am_isendv;
@@ -522,6 +527,11 @@ int MPIDI_NM_mpi_open_port(MPIR_Info * info_ptr, char *port_name);
 int MPIDI_NM_mpi_close_port(const char *port_name);
 int MPIDI_NM_mpi_comm_accept(const char *port_name, MPIR_Info * info, int root, MPIR_Comm * comm,
                              MPIR_Comm ** newcomm_ptr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_prepare_send(int handler_id, const void *buf,
+                                                      MPI_Count count, MPI_Datatype datatype,
+                                                      const void *am_hdr, MPI_Aint am_hdr_sz,
+                                                      void **ext_hdr, MPI_Aint * ext_hdr_sz,
+                                                      MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
                                                   const void *am_hdr,
                                                   size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -52,6 +52,8 @@ typedef int (*MPIDI_NM_am_isend_reply_t) (MPIR_Context_id_t context_id, int src_
                                           int handler_id, const void *am_hdr, size_t am_hdr_sz,
                                           const void *data, MPI_Count count, MPI_Datatype datatype,
                                           MPIR_Request * sreq);
+typedef int (*MPIDI_NM_am_recv_t) (int src_rank, MPIR_Context_id_t context_id, const void *ext_hdr,
+                                   MPI_Aint ext_hdr_sz, MPIR_Request * rreq);
 typedef size_t(*MPIDI_NM_am_hdr_max_sz_t) (void);
 typedef size_t(*MPIDI_NM_am_eager_limit_t) (void);
 typedef size_t(*MPIDI_NM_am_eager_buf_limit_t) (void);
@@ -401,6 +403,7 @@ typedef struct MPIDI_NM_funcs {
     MPIDI_NM_am_isendv_t am_isendv;
     MPIDI_NM_am_send_hdr_reply_t am_send_hdr_reply;
     MPIDI_NM_am_isend_reply_t am_isend_reply;
+    MPIDI_NM_am_recv_t am_recv;
     MPIDI_NM_am_hdr_max_sz_t am_hdr_max_sz;
     MPIDI_NM_am_eager_limit_t am_eager_limit;
     MPIDI_NM_am_eager_buf_limit_t am_eager_buf_limit;
@@ -553,6 +556,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      size_t am_hdr_sz, const void *data,
                                                      MPI_Count count, MPI_Datatype datatype,
                                                      MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(int src_rank, MPIR_Context_id_t context_id,
+                                              const void *ext_hdr, MPI_Aint ext_hdr_sz,
+                                              MPIR_Request * rreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_limit(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_buf_limit(void) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -110,6 +110,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     return ret;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(int src_rank, MPIR_Context_id_t context_id,
+                                              const void *ext_hdr, MPI_Aint ext_hdr_sz,
+                                              MPIR_Request * rreq)
+{
+    int ret;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_RECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_RECV);
+
+    ret = MPIDI_NM_func->am_recv(src_rank, context_id, ext_hdr, ext_hdr_sz, rreq);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_RECV);
+    return ret;
+}
+
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void)
 {
     int ret;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -11,6 +11,24 @@
 #ifndef NETMOD_INLINE
 #ifndef NETMOD_DISABLE_INLINES
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_prepare_send(int handler_id, const void *buf,
+                                                      MPI_Count count, MPI_Datatype datatype,
+                                                      const void *am_hdr, MPI_Aint am_hdr_sz,
+                                                      void **ext_hdr, MPI_Aint * ext_hdr_sz,
+                                                      MPIR_Request * sreq)
+{
+    int ret;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_PREPARE_SEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_PREPARE_SEND);
+
+    ret = MPIDI_NM_func->am_prepare_send(handler_id, buf, count, datatype, am_hdr, am_hdr_sz,
+                                         ext_hdr, ext_hdr_sz, sreq);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_PREPARE_SEND);
+    return ret;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
                                                   const void *am_hdr, size_t am_hdr_sz)
 {

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -53,6 +53,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     .am_isendv = MPIDI_NM_am_isendv,
     .am_send_hdr_reply = MPIDI_NM_am_send_hdr_reply,
     .am_isend_reply = MPIDI_NM_am_isend_reply,
+    .am_recv = MPIDI_NM_am_recv,
     .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
     .am_eager_limit = MPIDI_NM_am_eager_limit,
     .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -47,6 +47,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     .am_request_init = MPIDI_NM_am_request_init,
     .am_request_finalize = MPIDI_NM_am_request_finalize,
     /* Active Message Routines */
+    .am_prepare_send = MPIDI_NM_am_prepare_send,
     .am_send_hdr = MPIDI_NM_am_send_hdr,
     .am_isend = MPIDI_NM_am_isend,
     .am_isendv = MPIDI_NM_am_isendv,

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -40,6 +40,24 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
     MPIDI_OFI_am_clear_request(req);
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_prepare_send(int handler_id, const void *buf,
+                                                      MPI_Count count, MPI_Datatype datatype,
+                                                      const void *am_hdr, MPI_Aint am_hdr_sz,
+                                                      void **ext_hdr, MPI_Aint * ext_hdr_sz,
+                                                      MPIR_Request * sreq)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_PREPARE_SEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_PREPARE_SEND);
+
+    *ext_hdr = NULL;
+    *ext_hdr_sz = 0;
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_PREPARE_SEND);
+    return mpi_errno;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                MPIR_Comm * comm,
                                                int handler_id,

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -226,4 +226,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     goto fn_exit;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(int src_rank, MPIR_Context_id_t context_id,
+                                              const void *ext_hdr, MPI_Aint ext_hdr_sz,
+                                              MPIR_Request * rreq)
+{
+    int ret = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_RECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_RECV);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_RECV);
+    return ret;
+}
+
 #endif /* OFI_AM_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.c
@@ -35,6 +35,7 @@ int MPIDI_OFI_am_rdma_read_ack_handler(int handler_id, void *am_hdr, void *data,
     src_handler_id = MPIDI_OFI_AMREQUEST_HDR(sreq, msg_hdr).handler_id;
     mpi_errno = MPIDIG_global.origin_cbs[src_handler_id] (sreq);
     MPIR_ERR_CHECK(mpi_errno);
+    MPL_free(MPIDI_OFI_AMREQUEST_HDR(sreq, ext_hdr));
     MPID_Request_complete(sreq);
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -115,6 +115,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_init_request(const void *am_hdr,
         MPIR_Memcpy(req_hdr->am_hdr, am_hdr, am_hdr_sz);
     }
 
+    MPIDI_OFI_AMREQUEST_HDR(sreq, ext_hdr) = NULL;
+
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_AM_INIT_REQUEST);
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -69,7 +69,6 @@ typedef struct {
 
     uint64_t src_offset;
     MPIR_Request *sreq_ptr;
-    uint64_t am_hdr_src;
     uint64_t rma_key;
     MPI_Aint reg_sz;
 } MPIDI_OFI_lmt_msg_payload_t;

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -120,6 +120,7 @@ typedef enum {
 
 typedef struct {
     MPIDI_OFI_lmt_msg_payload_t lmt_info;
+    void *ext_hdr;
     struct fid_mr *lmt_mr;
     MPIDI_OFI_lmt_type_t lmt_type;
     union {

--- a/src/mpid/ch4/netmod/stubnm/func_table.c
+++ b/src/mpid/ch4/netmod/stubnm/func_table.c
@@ -52,6 +52,7 @@ MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     .am_isendv = MPIDI_NM_am_isendv,
     .am_send_hdr_reply = MPIDI_NM_am_send_hdr_reply,
     .am_isend_reply = MPIDI_NM_am_isend_reply,
+    .am_recv = MPIDI_NM_am_recv,
     .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
     .am_eager_limit = MPIDI_NM_am_eager_limit,
     .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit

--- a/src/mpid/ch4/netmod/stubnm/func_table.c
+++ b/src/mpid/ch4/netmod/stubnm/func_table.c
@@ -46,6 +46,7 @@ MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     .am_request_init = MPIDI_NM_am_request_init,
     .am_request_finalize = MPIDI_NM_am_request_finalize,
     /* Active Message Routines */
+    .am_prepare_send = MPIDI_NM_am_prepare_send,
     .am_send_hdr = MPIDI_NM_am_send_hdr,
     .am_isend = MPIDI_NM_am_isend,
     .am_isendv = MPIDI_NM_am_isendv,

--- a/src/mpid/ch4/netmod/stubnm/stubnm_am.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_am.h
@@ -8,6 +8,17 @@
 
 #include "stubnm_impl.h"
 
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_prepare_send(int handler_id, const void *buf,
+                                                      MPI_Count count, MPI_Datatype datatype,
+                                                      const void *am_hdr, MPI_Aint am_hdr_sz,
+                                                      void **ext_hdr, MPI_Aint * ext_hdr_sz,
+                                                      MPIR_Request * sreq)
+{
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                MPIR_Comm * comm,
                                                int handler_id,

--- a/src/mpid/ch4/netmod/stubnm/stubnm_am.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_am.h
@@ -92,4 +92,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     return MPI_SUCCESS;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(int src_rank, MPIR_Context_id_t context_id,
+                                              const void *ext_hdr, MPI_Aint ext_hdr_sz,
+                                              MPIR_Request * rreq)
+{
+    int ret = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_RECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_RECV);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_RECV);
+    return ret;
+}
+
 #endif /* STUBNM_AM_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -53,6 +53,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     .am_isendv = MPIDI_NM_am_isendv,
     .am_send_hdr_reply = MPIDI_NM_am_send_hdr_reply,
     .am_isend_reply = MPIDI_NM_am_isend_reply,
+    .am_recv = MPIDI_NM_am_recv,
     .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
     .am_eager_limit = MPIDI_NM_am_eager_limit,
     .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -47,6 +47,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     .am_request_init = MPIDI_NM_am_request_init,
     .am_request_finalize = MPIDI_NM_am_request_finalize,
     /* Active Message Routines */
+    .am_prepare_send = MPIDI_NM_am_prepare_send,
     .am_send_hdr = MPIDI_NM_am_send_hdr,
     .am_isend = MPIDI_NM_am_isend,
     .am_isendv = MPIDI_NM_am_isendv,

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -39,6 +39,20 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_am_send_callback(void *request, ucs_stat
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_UCX_AM_SEND_CALLBACK);
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_prepare_send(int handler_id, const void *buf,
+                                                      MPI_Count count, MPI_Datatype datatype,
+                                                      const void *am_hdr, MPI_Aint am_hdr_sz,
+                                                      void **ext_hdr, MPI_Aint * ext_hdr_sz,
+                                                      MPIR_Request * sreq)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_PREPARE_SEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_PREPARE_SEND);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_PREPARE_SEND);
+    return mpi_errno;
+}
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                MPIR_Comm * comm,

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -425,4 +425,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     goto fn_exit;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(int src_rank, MPIR_Context_id_t context_id,
+                                              const void *ext_hdr, MPI_Aint ext_hdr_sz,
+                                              MPIR_Request * rreq)
+{
+    int ret = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_RECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_RECV);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_RECV);
+    return ret;
+}
+
 #endif /* UCX_AM_H_INCLUDED */

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -47,6 +47,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_
                                                       size_t am_hdr_sz, const void *data,
                                                       MPI_Count count, MPI_Datatype datatype,
                                                       MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_recv(int src_rank, MPIR_Context_id_t context_id,
+                                               const void *ext_hdr, MPI_Aint ext_hdr_sz,
+                                               MPIR_Request * rreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_eager_limit(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_eager_buf_limit(void) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -20,6 +20,12 @@ int MPIDI_SHM_mpi_open_port(MPIR_Info * info_ptr, char *port_name);
 int MPIDI_SHM_mpi_close_port(const char *port_name);
 int MPIDI_SHM_mpi_comm_accept(const char *port_name, MPIR_Info * info, int root, MPIR_Comm * comm,
                               MPIR_Comm ** newcomm_ptr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_prepare_send(int handler_id, const void *buf,
+                                                       MPI_Count count, MPI_Datatype datatype,
+                                                       const void *am_hdr, MPI_Aint am_hdr_sz,
+                                                       void **ext_hdr, MPI_Aint * ext_hdr_sz,
+                                                       MPIR_Request * sreq)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
                                                    const void *am_hdr,
                                                    size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -116,6 +116,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_
     return ret;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_recv(int src_rank, MPIR_Context_id_t context_id,
+                                               const void *ext_hdr, MPI_Aint ext_hdr_sz,
+                                               MPIR_Request * rreq)
+{
+    int ret = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_RECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_RECV);
+
+    /* TODO: handle IPC receive here */
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_RECV);
+    return ret;
+}
+
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void)
 {
     int ret;

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -10,6 +10,28 @@
 #include "../posix/shm_inline.h"
 #include "../ipc/src/shm_inline.h"
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_prepare_send(int hanadler_id, const void *buf,
+                                                       MPI_Count count, MPI_Datatype datatype,
+                                                       const void *am_hdr, MPI_Aint am_hdr_sz,
+                                                       void **ext_hdr, MPI_Aint * ext_hdr_sz,
+                                                       MPIR_Request * sreq)
+{
+    int ret = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_PREPARE_SEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_PREPARE_SEND);
+
+    /* check the buffer for GPU IPC or XPMEM IPC, create extended header for them */
+    /* TODO: add checks here */
+
+    /* if send via POSIX, no extended header needed */
+    *ext_hdr = NULL;
+    *ext_hdr_sz = 0;
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_PREPARE_SEND);
+    return ret;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
                                                    int handler_id, const void *am_hdr,
                                                    size_t am_hdr_sz)

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -70,6 +70,7 @@ typedef struct MPIDIG_hdr_t {
     uint8_t flags;
     MPIR_Request *sreq_ptr;
     size_t data_sz;
+    MPI_Aint zcopy_hdr_sz;
 } MPIDIG_hdr_t;
 
 typedef struct MPIDIG_send_cts_msg_t {

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -14,6 +14,8 @@
 #include "mpidig_am.h"
 
 int MPIDIG_do_cts(MPIR_Request * rreq);
+int MPIDIG_do_am_recv(int src_rank, MPIR_Context_id_t context_id, const void *zcopy_hdr,
+                      MPI_Aint zcopy_hdr_sz, int is_local, MPIR_Request * rreq);
 int MPIDIG_check_cmpl_order(MPIR_Request * req);
 void MPIDIG_progress_compl_list(void);
 int MPIDIG_send_origin_cb(MPIR_Request * sreq);


### PR DESCRIPTION
## Pull Request Description

This PR does three things:

1. Adding MPIDIG_do_am_recv and corresponding NM/SHM interface for CH4 to actively trigger the transport level receive operation. The main use case for these is for telling NM/SHM to start ZCOPY-based receive (RDMA read or IPC). This is currently only used in PT2PT path. CH4 are expected to call this function with the extended am header which contains the memory registration info or IPC handle from the sender.

2. Adding the NM/SHM prepare send interface. This is used for transport to decide if the given send buffer should be sent via ZCOPY. If so, it would perform the necessary steps to register the memory or create IPC handler, and them append those info after the am_hdr. The output would be this extended am header and it will be send via transport level header-only send. The function will return NULL as extended header of no ZCOPY operation will be done for the send buffer. Then CH4 will send it normally via (EAGER or RNDV).

3. Add a ZCOPY implementation based on existing RDMA read in OFI as an example of how this works.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
