### PR TITLE
xfail: Add entries for thread tests on freebsd64

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -160,6 +160,9 @@
 * * async * * sed -i "s+\(^pingping .*testsize=32.*\)+\1 xfail=issue4474+g" test/mpi/pt2pt/testlist.dtp
 # dup_leak_test suffers from mutex unfairness issue under load for ch4:ofi
 * * * ch4:ofi * sed -i "s+\(^dup_leak_test .*iter=12345.*\)+\1 xfail=issue4595+g" test/mpi/threads/comm/testlist
+# more mutex unfairness on freebsd64. note: check these after upgrading freebsd64 hardware
+* * * ch4:ofi freebsd64 sed -i "s+\(^dup_leak_test .*iter=1234.*\)+\1 xfail=issue4595+g" test/mpi/threads/comm/testlist
+* * * ch4:ofi freebsd64 sed -i "s+\(^alltoall .*\)+\1 xfail=issue4595+g" test/mpi/threads/pt2pt/testlist
 # release-gather algorithm won't work with multithread
 * * async * * sed -i "s+\(^.*_ALGORITHM=release_gather.*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist.cvar
 # freebsd failures


### PR DESCRIPTION
## Pull Request Description

These tests suffer from extreme slowdown on freebsd64. The problem is
assumed to be mutex unfairness, but we should check again when
freebsd64 hardware is upgraded with additional CPU cores.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Clean up FreeBSD Jenkins results.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
