### PR TITLE
mpi/f08: MPI_SIZEOF is deprecated in MPI-4

### DIFF
--- a/src/binding/fortran/use_mpi/manfort.txt
+++ b/src/binding/fortran/use_mpi/manfort.txt
@@ -26,7 +26,9 @@ N*/
 
    Notes:
    This routine returns the size of a basic element, in bytes, of the
-   item passed in the first argument.
+   item passed in the first argument.  This routine is deprecated.
+   Users should consider switching to Fortran 2008 storage_size() or
+   c_sizeof() instead.
 
    Implementation limitations:
    MPICH only supports scalars and one-dimensional arrays for the

--- a/test/mpi/f08/datatype/sizeof.f90
+++ b/test/mpi/f08/datatype/sizeof.f90
@@ -3,7 +3,7 @@
 !     See COPYRIGHT in top-level directory
 !
 
-! This program tests that the MPI_SIZEOF routine is implemented for the
+! This program tests that the storage_size routine is implemented for the
 ! predefined scalar Fortran types.  It confirms that the size of these
 ! types matches the size of the corresponding MPI datatypes.
 !
@@ -25,101 +25,101 @@
       call mpi_comm_rank( MPI_COMM_WORLD, rank, ierr )
 
 ! Test of scalar types
-      call mpi_sizeof( r1, size, ierr )
+      size = storage_size(r1) / 8
       call mpi_type_size( MPI_REAL, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_REAL = ", mpisize,                         &
-     &            " but MPI_SIZEOF gives ", size
+     &            " but STORAGE_SIZE gives ", size
       endif
 
-      call mpi_sizeof( d1, size, ierr )
+      size = storage_size(d1) / 8
       call mpi_type_size( MPI_DOUBLE_PRECISION, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_DOUBLE_PRECISION = ", mpisize, &
-              " but MPI_SIZEOF gives ", size
+              " but STORAGE_SIZE gives ", size
       endif
 
-      call mpi_sizeof( i1, size, ierr )
+      size = storage_size(i1) / 8
       call mpi_type_size( MPI_INTEGER, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_INTEGER = ", mpisize,                      &
-     &            " but MPI_SIZEOF gives ", size
+     &            " but STORAGE_SIZE gives ", size
       endif
 
-      call mpi_sizeof( c1, size, ierr )
+      size = storage_size(c1) / 8
       call mpi_type_size( MPI_COMPLEX, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_COMPLEX = ", mpisize,                      &
-     &            " but MPI_SIZEOF gives ", size
+     &            " but STORAGE_SIZE gives ", size
       endif
 
-      call mpi_sizeof( ch1, size, ierr )
+      size = storage_size(ch1) / 8
       call mpi_type_size( MPI_CHARACTER, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_CHARACTER = ", mpisize, &
-              " but MPI_SIZEOF gives ", size
+              " but STORAGE_SIZE gives ", size
       endif
 
-      call mpi_sizeof( l1, size, ierr )
+      size = storage_size(l1) / 8
       call mpi_type_size( MPI_LOGICAL, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_LOGICAL = ", mpisize,                        &
-     &        " but MPI_SIZEOF gives ", size
+     &        " but STORAGE_SIZE gives ", size
       endif
 !
 ! Test of vector types (1-dimensional)
-      call mpi_sizeof( r1v, size, ierr )
+      size = storage_size(r1v) / 8
       call mpi_type_size( MPI_REAL, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_REAL = ", mpisize,                         &
-     &            " but MPI_SIZEOF gives ", size
+     &            " but STORAGE_SIZE gives ", size
       endif
 
-      call mpi_sizeof( d1v, size, ierr )
+      size = storage_size(d1v) / 8
       call mpi_type_size( MPI_DOUBLE_PRECISION, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_DOUBLE_PRECISION = ", mpisize, &
-              " but MPI_SIZEOF gives ", size
+              " but STORAGE_SIZE gives ", size
       endif
 
-      call mpi_sizeof( i1v, size, ierr )
+      size = storage_size(i1v) / 8
       call mpi_type_size( MPI_INTEGER, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_INTEGER = ", mpisize,                      &
-     &            " but MPI_SIZEOF gives ", size
+     &            " but STORAGE_SIZE gives ", size
       endif
 
-      call mpi_sizeof( c1v, size, ierr )
+      size = storage_size(c1v) / 8
       call mpi_type_size( MPI_COMPLEX, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_COMPLEX = ", mpisize,                      &
-     &            " but MPI_SIZEOF gives ", size
+     &            " but STORAGE_SIZE gives ", size
       endif
 
-      call mpi_sizeof( ch1v, size, ierr )
+      size = storage_size(ch1v) / 8
       call mpi_type_size( MPI_CHARACTER, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_CHARACTER = ", mpisize, &
-              " but MPI_SIZEOF gives ", size
+              " but STORAGE_SIZE gives ", size
       endif
 
-      call mpi_sizeof( l1v, size, ierr )
+      size = storage_size(l1v) / 8
       call mpi_type_size( MPI_LOGICAL, mpisize, ierr )
       if (size .ne. mpisize) then
          errs = errs + 1
          print *, "Size of MPI_LOGICAL = ", mpisize,                        &
-     &        " but MPI_SIZEOF gives ", size
+     &        " but STORAGE_SIZE gives ", size
       endif
 
       call mtest_finalize( errs )

--- a/test/mpi/f08/misc/sizeof2.f90
+++ b/test/mpi/f08/misc/sizeof2.f90
@@ -14,43 +14,39 @@
 
           errs = 0
           call mpi_init(ierr)
-          call mpi_sizeof( errs, size1, ierr )
+          size1 = storage_size(errs) / 8
           call mpi_type_size( MPI_INTEGER, size2, ierr )
           if (size1 .ne. size2) then
              errs = errs + 1
-             print *, "integer size is ", size2, " sizeof claims ", size1
+             print *, "integer size is ", size2, " storage_size claims ", size1
           endif
 
-          call mpi_sizeof( a, size1, ierr )
+          size1 = storage_size(a) / 8
           call mpi_type_size( MPI_REAL, size2, ierr )
           if (size1 .ne. size2) then
              errs = errs + 1
-             print *, "real size is ", size2, " sizeof claims ", size1
+             print *, "real size is ", size2, " storage_size claims ", size1
           endif
 
-          call mpi_sizeof( b, size1, ierr )
+          size1 = storage_size(b) / 8
           call mpi_type_size( MPI_DOUBLE_PRECISION, size2, ierr )
           if (size1 .ne. size2) then
              errs = errs + 1
-             print *, "double precision size is ", size2, " sizeof claims ", size1
+             print *, "double precision size is ", size2, " storage_size claims ", size1
           endif
 
-          call mpi_sizeof( c, size1, ierr )
+          size1 = storage_size(c) / 8
           call mpi_type_size( MPI_COMPLEX, size2, ierr )
           if (size1 .ne. size2) then
              errs = errs + 1
-             print *, "complex size is ", size2, " sizeof claims ", size1
+             print *, "complex size is ", size2, " storage_size claims ", size1
           endif
-!
-! A previous version of this test called mpi_sizeof with a character variable.
-! However, the MPI 2.2 standard, p 494, line 41, defines MPI_SIZEOF only
-! for "numeric intrinsic type", so that test was removed.
-!
-          call mpi_sizeof( d, size1, ierr )
+
+          size1 = storage_size(d) / 8
           call mpi_type_size( MPI_REAL, size2, ierr )
           if (size1 .ne. size2) then
              errs = errs + 1
-             print *, "real array size is ", size2, " sizeof claims ", size1
+             print *, "real array size is ", size2, " storage_size claims ", size1
           endif
 
           if (errs .gt. 0) then


### PR DESCRIPTION
## Pull Request Description

This PR notes in the man page that MPI_SIZEOF is deprecated and updates the F08 tests to use storage_size instead.

Fixes https://github.com/pmodels/mpich/issues/4886

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
