### PR TITLE
xfail: Fix typo in directory name

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -73,7 +73,7 @@
 * intel * * osx sed -i "s+\(^nonblocking_inpf08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/coll/testlist
 * intel * * osx sed -i "s+\(^structf .*\)+\1 xfail=issue4374+g" test/mpi/f08/datatype/testlist
 * intel * * osx sed -i "s+\(^aintf08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/rma/testlist
-* intel * * osx sed -i "s+\(^dgraph_unwftf90 .*\)+\1 xfail=issue4374+g" test/mpi/f08/top/testlist
+* intel * * osx sed -i "s+\(^dgraph_unwftf90 .*\)+\1 xfail=issue4374+g" test/mpi/f08/topo/testlist
 ################################################################################
 # xfail large count tests on 32 bit architectures (cannot allocate such large memory)
 * * * * freebsd32 sed -i "s|\(^getfence1 [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist.dtp


### PR DESCRIPTION
## Pull Request Description

This xfail was not applied because of a typo in the file path.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

clean macOS tests

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
