### PR TITLE
f08: Support "--disable-romio" case

### DIFF
--- a/src/binding/fortran/use_mpi_f08/wrappers_c/buildiface
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/buildiface
@@ -270,6 +270,10 @@ if (-e "cdesc.h") {
 #include <ISO_Fortran_binding.h>
 #include <mpi.h>
 
+#ifndef HAVE_ROMIO
+#define MPIO_Request MPI_Request
+#endif
+
 extern MPI_Status *MPIR_C_MPI_STATUS_IGNORE;
 extern MPI_Status *MPIR_C_MPI_STATUSES_IGNORE;
 extern char **MPIR_C_MPI_ARGV_NULL;


### PR DESCRIPTION
## Pull Request Description

the f08 'buildiface' would generate prototypes that used symbols only provided in the --enable-romio case.
## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ X] Commits are self-contained and do not do two things at once
* [ X] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ X] Passes whitespace checkers
* [ X] Passes warning tests
* [ ] Passes all tests
* [X ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
