### PR TITLE
coll/ineighbor_alltoall: bug-fix for Cartesian graphs with <= 2 procs

### DIFF
--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_sched_linear.c
@@ -42,7 +42,12 @@ int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, int sendco
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    for (l = 0; l < indegree; ++l) {
+    /* receive needs to happen in the opposite order of sends.  This
+     * is to cover the case of Cartesian graphs where the same process
+     * might be both the left and right neighbor.  In this case, we
+     * need to make sure the first message (which is from the right
+     * neighbor) is received in the last buffer. */
+    for (l = indegree - 1; l >= 0; l--) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
         mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
@@ -52,7 +52,12 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int se
         MPIR_TSP_sched_isend(sb, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0, NULL);
     }
 
-    for (l = 0; l < indegree; ++l) {
+    /* receive needs to happen in the opposite order of sends.  This
+     * is to cover the case of Cartesian graphs where the same process
+     * might be both the left and right neighbor.  In this case, we
+     * need to make sure the first message (which is from the right
+     * neighbor) is received in the last buffer. */
+    for (l = indegree - 1; l >= 0; l--) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
         MPIR_TSP_sched_irecv(rb, recvcount, recvtype, srcs[l], tag, comm_ptr, sched, 0, NULL);
     }

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -157,6 +157,7 @@
 /coll/summary.xml
 /coll/testlist
 /coll/uoplong
+/coll/ring_neighbor_alltoall
 /comm/cfree
 /comm/cmfree
 /comm/cmsplit

--- a/test/mpi/coll/Makefile.am
+++ b/test/mpi/coll/Makefile.am
@@ -123,7 +123,8 @@ noinst_PROGRAMS =      \
     neighb_alltoallv   \
     neighb_alltoallw   \
     bcast              \
-    bcast_comm_world_only
+    bcast_comm_world_only \
+    ring_neighbor_alltoall
 
 allgatherv4_LDADD = $(LDADD) -lm
 

--- a/test/mpi/coll/ring_neighbor_alltoall.c
+++ b/test/mpi/coll/ring_neighbor_alltoall.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+/* This test borrows some ideas from a test provided by Rolf
+ * Rabenseifner (HLRS), but is a rewrite of the primary logic to make
+ * it more suitable for the MPICH test suite. */
+
+#include <stdio.h>
+#include <mpi.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int right, left;
+    int sum, i;
+
+    MTest_Init(&argc, &argv);
+
+    int size;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    if (size > 2) {
+        fprintf(stderr, "run this test with 1 or 2 processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    int dims[1] = { size };
+    int periods[1] = { 1 };
+    int reorder = 1;
+
+    MPI_Comm newcomm;
+    MPI_Cart_create(MPI_COMM_WORLD, 1, dims, periods, reorder, &newcomm);
+
+    int sbuf[2], rbuf[2] = { 0 };
+    sbuf[0] = -1;
+    sbuf[1] = 1;
+    MPI_Neighbor_alltoall(sbuf, 1, MPI_INT, rbuf, 1, MPI_INT, newcomm);
+
+    MPI_Comm_free(&newcomm);
+
+    int errs = 0;
+    if (rbuf[0] != 1 || rbuf[1] != -1) {
+        printf("expected rbuf to be (1,-1), but found (%d,%d)\n", rbuf[0], rbuf[1]);
+        errs++;
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/coll/testlist.in
+++ b/test/mpi/coll/testlist.in
@@ -168,3 +168,5 @@ neighb_allgatherv 4
 neighb_alltoall 4
 neighb_alltoallv 4
 neighb_alltoallw 4
+ring_neighbor_alltoall 2
+ring_neighbor_alltoall 1


### PR DESCRIPTION
## Pull Request Description

coll/ineighbor_alltoall: bug-fix for Cartesian graphs with <= 2 procs

Fixes https://github.com/pmodels/mpich/issues/4061 and https://github.com/pmodels/mpich/issues/4884.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
