### PR TITLE
ch4: adding new eager checking interface for sophisticated checking

### DIFF
--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -51,6 +51,9 @@ typedef int (*MPIDI_NM_am_isend_reply_t) (MPIR_Context_id_t context_id, int src_
 typedef size_t(*MPIDI_NM_am_hdr_max_sz_t) (void);
 typedef size_t(*MPIDI_NM_am_eager_limit_t) (void);
 typedef size_t(*MPIDI_NM_am_eager_buf_limit_t) (void);
+typedef bool(*MPIDI_NM_am_check_eager_t) (MPI_Aint am_hdr_sz, MPI_Aint data_sz, const void *data,
+                                          MPI_Count count, MPI_Datatype datatype,
+                                          MPIR_Request * sreq);
 typedef int (*MPIDI_NM_comm_get_lpid_t) (MPIR_Comm * comm_ptr, int idx, int *lpid_ptr,
                                          bool is_remote);
 typedef int (*MPIDI_NM_get_local_upids_t) (MPIR_Comm * comm, size_t ** local_upid_size,
@@ -399,6 +402,7 @@ typedef struct MPIDI_NM_funcs {
     MPIDI_NM_am_hdr_max_sz_t am_hdr_max_sz;
     MPIDI_NM_am_eager_limit_t am_eager_limit;
     MPIDI_NM_am_eager_buf_limit_t am_eager_buf_limit;
+    MPIDI_NM_am_check_eager_t am_check_eager;
 } MPIDI_NM_funcs_t;
 
 typedef struct MPIDI_NM_native_funcs {
@@ -546,6 +550,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_limit(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_buf_limit(void) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
+                                                      const void *data, MPI_Count count,
+                                                      MPI_Datatype datatype, MPIR_Request * sreq)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                     int *lpid_ptr,
                                                     bool is_remote) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -115,6 +115,13 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_buf_limit(void)
     return MPIDI_NM_func->am_eager_buf_limit();
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
+                                                      const void *data, MPI_Count count,
+                                                      MPI_Datatype datatype, MPIR_Request * sreq)
+{
+    return MPIDI_NM_func->am_check_eager(am_hdr_sz, data_sz, data, count, datatype, sreq);
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                     int *lpid_ptr, bool is_remote)
 {

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -54,7 +54,8 @@ MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     .am_isend_reply = MPIDI_NM_am_isend_reply,
     .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
     .am_eager_limit = MPIDI_NM_am_eager_limit,
-    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit
+    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit,
+    .am_check_eager = MPIDI_NM_am_check_eager
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_ofi_funcs = {

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -208,4 +208,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     goto fn_exit;
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
+                                                      const void *data, MPI_Count count,
+                                                      MPI_Datatype datatype, MPIR_Request * sreq)
+{
+    /* TODO: extending this to include pretending RDMA_READ as eager. In this case, we just tells
+     * the sender to not worry about the protocol and let netmod send the data. */
+    return (am_hdr_sz + data_sz)
+        <= (MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE - sizeof(MPIDI_OFI_am_header_t));
+}
+
 #endif /* OFI_AM_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -33,6 +33,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_progress_do_queue(int vni_idx);
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req)
 {
     MPIDI_OFI_AMREQUEST(req, req_hdr) = NULL;
+    MPIDI_OFI_AMREQUEST(req, am_type_choice) = MPIDI_AMTYPE_NONE;
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
@@ -54,25 +55,52 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND);
 
-    MPIDI_Datatype_check_size(datatype, count, data_sz);
-    /* TODO: check for RDMA read too */
-    if (data_sz + am_hdr_sz <= MPIDI_NM_am_eager_limit()) {
-        /* EAGER */
-        mpi_errno = MPIDI_OFI_do_am_isend_eager(rank, comm, handler_id, am_hdr, am_hdr_sz, data,
-                                                count, datatype, sreq,
-                                                false /* not for issue deferred */);
-    } else {
-        if (MPIDI_OFI_ENABLE_RMA && !MPIR_CVAR_CH4_OFI_AM_LONG_FORCE_PIPELINE) {
-            /* RDMA READ */
-            mpi_errno = MPIDI_OFI_do_am_isend_rdma_read(rank, comm, handler_id, am_hdr, am_hdr_sz,
-                                                        data, count, datatype, sreq,
-                                                        false /* not for issue deferred */);
-        } else {
-            /* PIPELINE */
+    switch (MPIDI_OFI_AMREQUEST(sreq, am_type_choice)) {
+        case MPIDI_AMTYPE_NONE:
+            /* if no preselected amtype, do check here */
+            MPIDI_Datatype_check_size(datatype, count, data_sz);
+            if (data_sz + am_hdr_sz <= MPIDI_NM_am_eager_limit()) {
+                /* EAGER */
+                mpi_errno = MPIDI_OFI_do_am_isend_eager(rank, comm, handler_id, am_hdr, am_hdr_sz,
+                                                        data, count, datatype, sreq, false);
+            } else {
+                if (MPIDI_OFI_ENABLE_RMA && !MPIR_CVAR_CH4_OFI_AM_LONG_FORCE_PIPELINE) {
+                    /* RDMA READ */
+                    mpi_errno = MPIDI_OFI_do_am_isend_rdma_read(rank, comm, handler_id, am_hdr,
+                                                                am_hdr_sz, data, count, datatype,
+                                                                sreq, false);
+                } else {
+                    /* PIPELINE */
+                    mpi_errno = MPIDI_OFI_do_am_isend_pipeline(rank, comm, handler_id, am_hdr,
+                                                               am_hdr_sz, data, count, datatype,
+                                                               sreq, data_sz, false);
+                }
+            }
+            break;
+        case MPIDI_AMTYPE_SHORT_HDR:
+            MPIR_Assert(0);     /* header only should go to the send hdr interface */
+            break;
+        case MPIDI_AMTYPE_SHORT:
+            mpi_errno = MPIDI_OFI_do_am_isend_eager(rank, comm, handler_id, am_hdr, am_hdr_sz, data,
+                                                    count, datatype, sreq, false);
+            /* cleanup preselected amtype to avoid problem with reused request */
+            MPIDI_OFI_AMREQUEST(sreq, am_type_choice) = MPIDI_AMTYPE_NONE;
+            break;
+        case MPIDI_AMTYPE_PIPELINE:
             mpi_errno = MPIDI_OFI_do_am_isend_pipeline(rank, comm, handler_id, am_hdr, am_hdr_sz,
-                                                       data, count, datatype, sreq, data_sz,
-                                                       false /* not for issue deferred */);
-        }
+                                                       data, count, datatype, sreq,
+                                                       MPIDI_OFI_AMREQUEST(sreq, data_sz), false);
+            /* cleanup preselected amtype to avoid problem with reused request */
+            MPIDI_OFI_AMREQUEST(sreq, am_type_choice) = MPIDI_AMTYPE_NONE;
+            break;
+        case MPIDI_AMTYPE_RDMA_READ:
+            mpi_errno = MPIDI_OFI_do_am_isend_rdma_read(rank, comm, handler_id, am_hdr, am_hdr_sz,
+                                                        data, count, datatype, sreq, false);
+            /* cleanup preselected amtype to avoid problem with reused request */
+            MPIDI_OFI_AMREQUEST(sreq, am_type_choice) = MPIDI_AMTYPE_NONE;
+            break;
+        default:
+            MPIR_Assert(0);     /* header only should go to the send hdr interface */
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISEND);
@@ -212,10 +240,25 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Ai
                                                       const void *data, MPI_Count count,
                                                       MPI_Datatype datatype, MPIR_Request * sreq)
 {
-    /* TODO: extending this to include pretending RDMA_READ as eager. In this case, we just tells
-     * the sender to not worry about the protocol and let netmod send the data. */
-    return (am_hdr_sz + data_sz)
-        <= (MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE - sizeof(MPIDI_OFI_am_header_t));
+    MPIDI_OFI_AMREQUEST(sreq, data_sz) = data_sz;
+    if ((am_hdr_sz + data_sz)
+        <= (MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE - sizeof(MPIDI_OFI_am_header_t))) {
+        MPIDI_OFI_AMREQUEST(sreq, am_type_choice) = MPIDI_AMTYPE_SHORT;
+        return true;
+    } else {
+        /* TODO: extending this to include pretending RDMA_READ as eager. In this case, we just
+         * tells the sender to not worry about the protocol and let netmod send the data. */
+        if (MPIDI_OFI_ENABLE_RMA && !MPIR_CVAR_CH4_OFI_AM_LONG_FORCE_PIPELINE) {
+            MPIDI_OFI_AMREQUEST(sreq, am_type_choice) = MPIDI_AMTYPE_RDMA_READ;
+            /* FIXME: report this is none eager and let CH4 goto RNDV path. This is just for testing
+             * and will be switched reporting true in the future to save the unnecessary RTS */
+            return false;
+        } else {
+            /* Forced PIPELINE */
+            MPIDI_OFI_AMREQUEST(sreq, am_type_choice) = MPIDI_AMTYPE_PIPELINE;
+            return false;
+        }
+    }
 }
 
 #endif /* OFI_AM_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -49,7 +49,8 @@ typedef struct {
     int conn_id;
 } MPIDI_OFI_comm_t;
 enum {
-    MPIDI_AMTYPE_SHORT_HDR = 0,
+    MPIDI_AMTYPE_NONE = 0,
+    MPIDI_AMTYPE_SHORT_HDR,
     MPIDI_AMTYPE_SHORT,
     MPIDI_AMTYPE_PIPELINE,
     MPIDI_AMTYPE_RDMA_READ
@@ -161,6 +162,8 @@ typedef struct {
     MPIDI_OFI_am_request_header_t *req_hdr;
     MPIDI_OFI_deferred_am_isend_req_t *deferred_req;    /* saving information when an AM isend is
                                                          * deferred */
+    uint8_t am_type_choice;     /* save amtype to avoid double checking */
+    MPI_Aint data_sz;           /* save data_sz to avoid double checking */
 } MPIDI_OFI_am_request_t;
 
 

--- a/src/mpid/ch4/netmod/stubnm/func_table.c
+++ b/src/mpid/ch4/netmod/stubnm/func_table.c
@@ -53,7 +53,8 @@ MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     .am_isend_reply = MPIDI_NM_am_isend_reply,
     .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
     .am_eager_limit = MPIDI_NM_am_eager_limit,
-    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit
+    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit,
+    .am_check_eager = MPIDI_NM_am_check_eager
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_stubnm_funcs = {

--- a/src/mpid/ch4/netmod/stubnm/stubnm_am.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_am.h
@@ -81,4 +81,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     return MPI_SUCCESS;
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
+                                                      const void *data, MPI_Count count,
+                                                      MPI_Datatype datatype, MPIR_Request * sreq)
+{
+    MPIR_Assert(0);
+    return false;
+}
+
 #endif /* STUBNM_AM_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -54,7 +54,8 @@ MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     .am_isend_reply = MPIDI_NM_am_isend_reply,
     .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
     .am_eager_limit = MPIDI_NM_am_eager_limit,
-    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit
+    .am_eager_buf_limit = MPIDI_NM_am_eager_buf_limit,
+    .am_check_eager = MPIDI_NM_am_check_eager
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_ucx_funcs = {

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -411,4 +411,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     goto fn_exit;
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
+                                                      const void *data, MPI_Count count,
+                                                      MPI_Datatype datatype, MPIR_Request * sreq)
+{
+    return (am_hdr_sz + data_sz) <= (MPIDI_UCX_MAX_AM_EAGER_SZ - sizeof(MPIDI_UCX_am_header_t));
+}
+
 #endif /* UCX_AM_H_INCLUDED */

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -44,6 +44,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_eager_limit(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_eager_buf_limit(void) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX bool MPIDI_SHM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
+                                                       const void *data, MPI_Count count,
+                                                       MPI_Datatype datatype, MPIR_Request * sreq)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                      int *lpid_ptr,
                                                      bool is_remote) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -138,4 +138,12 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_finalize(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_REQUEST_FINALIZE);
 }
 
+MPL_STATIC_INLINE_PREFIX bool MPIDI_SHM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
+                                                       const void *data, MPI_Count count,
+                                                       MPI_Datatype datatype, MPIR_Request * sreq)
+{
+    /* TODO: add checking for IPC transmission */
+    return (am_hdr_sz + data_sz) <= MPIDI_POSIX_am_eager_limit();
+}
+
 #endif /* SHM_AM_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

The new interface allows the netmod and shm to do a better decision.

The current eager limit checking works as NM/SHM returns an eager limit size and MPIDIG checks the (am_hdr_sz + data_sz) against it and decide whether RNDV is needed. My finding is that it would be much easier for the NM/SHM to have the ability to perform the check including am_hdr_sz, data_sz and send buffer signature (buf, count, datatype).

From the perspective of CH4, it does not need to know how exactly does the transport layer send the data. It only need to know whether the transport can handle send by itself or the transport need the CH4 sender to make sure the receiver is ready to receive before sending the data. The latter case requires CH4 to do RNDV which sends a RTS and tells the transport to send data only when CTS is received. That is, the CH4 only require to know "if I need to do something before letting transport sending the data". With that in mind, I think it is unnecessary to expose the transport's choice among EAGER, PIPELINE and RDMA_READ to sender CH4 because only PIPELINE would require CH4 to do extra work before sending (RTS-CTS).

What this PR allows is for NM/SHM to make a decision among EAGER, PIPELINE and RDMA_READ but only tells CH4 if RNDV is needed or not.

<--
One special issue regarding RDMA_READ (or any other receiver-driven ZCOPY protocol) is whether starting the receiving when a message comes in. That is a local decision to the receiver based on whether the recv request is ready. For RMA it is always ready, for PT2PT it is ready when message is matched (which requires explicit triggering from receiver CH4).  -->

This PR only provides the framework of supporting the sender side of the proposed design, it is functionality is kept the same as the current main branch---simple eager limit checking and only send RDMA_READ when CTS is received.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
