### PR TITLE
Do not propagate info during Comm_dup starting MPI-4

### DIFF
--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -862,11 +862,6 @@ int MPII_Comm_copy(MPIR_Comm * comm_ptr, int size, MPIR_Info * info, MPIR_Comm *
     }
     MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_COMM_MUTEX(comm_ptr));
 
-#if 1
-    /* FIXME: only copy over hints for MPI 3.1 and earlier */
-    memcpy((void *) (newcomm_ptr->hints), (void *) (comm_ptr->hints), sizeof(comm_ptr->hints));
-#endif
-
     if (info) {
         MPII_Comm_set_hints(newcomm_ptr, info);
     }

--- a/test/mpi/impls/mpich/comm/Makefile.am
+++ b/test/mpi/impls/mpich/comm/Makefile.am
@@ -12,7 +12,8 @@ AM_DEFAULT_SOURCE_EXT = .c
 ## for all programs that are just built from the single corresponding source
 ## file, we don't need per-target _SOURCES rules, automake will infer them
 ## correctly
-noinst_PROGRAMS = comm_info_hint
+noinst_PROGRAMS = comm_info_hint \
+	comm_dup
 
 # Copied from cxx/rma/Makefile.am
 #BINDIR=${bindir}

--- a/test/mpi/impls/mpich/comm/comm_dup.c
+++ b/test/mpi/impls/mpich/comm/comm_dup.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include <mpi.h>
+#include "mpitest.h"
+
+int main(int argc, char **argv)
+{
+    int errs = 0;
+    MPI_Comm dup, dup2;
+    MPI_Info info_in, info_out;
+    int flag;
+    char val[MPI_MAX_INFO_VAL] = { 0 };
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Info_create(&info_in);
+    MPI_Info_set(info_in, "mpi_assert_no_any_tag", "true");
+    MPI_Comm_dup_with_info(MPI_COMM_WORLD, info_in, &dup);
+
+    MPI_Comm_get_info(dup, &info_out);
+    MPI_Info_get(info_out, "mpi_assert_no_any_tag", MPI_MAX_INFO_VAL, val, &flag);
+    if (!flag) {
+        fprintf(stderr, "Hint was not set\n");
+        errs++;
+    } else if (strcmp("true", val)) {
+        fprintf(stderr, "Expected value: true, received: %s\n", val);
+        errs++;
+    }
+    MPI_Info_free(&info_out);
+
+#if MPI_VERSION >= 4
+    MPI_Comm_dup(dup, &dup2);
+    MPI_Comm_get_info(dup, &info_out);
+    MPI_Info_get(info_out, "mpi_assert_no_any_tag", MPI_MAX_INFO_VAL, val, &flag);
+    if (flag) {
+        fprintf(stderr, "Hint was set, when not expected\n");
+        errs++;
+    }
+    MPI_Comm_free(&dup2);
+    MPI_Info_free(&info_out);
+#endif
+
+    MPI_Comm_free(&dup);
+    MPI_Info_free(&info_in);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/impls/mpich/comm/comm_info_hint.c
+++ b/test/mpi/impls/mpich/comm/comm_info_hint.c
@@ -85,19 +85,7 @@ int main(int argc, char **argv)
     MPI_Info_free(&info_out1);
     /* Release comm_dup1 later, still using */
 
-    /* Test 2: comm_dup */
-    if (rank == 0)
-        MTestPrintfMsg(1, "Testing MPI_Comm_dup: source comm has user provided comm infohint");
-    MPI_Comm_dup(comm_dup1, &comm_dup2);
-    MPI_Comm_get_info(comm_dup2, &info_out2);
-    MPI_Comm_free(&comm_dup2);
-    /* Note: For MPICH, we currently expect MPI_Comm_dup to copy hints from source
-     * to dup comm. Such copying with not be done after we align behavior of MPICH
-     * with the new MPI standard (MPI 3.2 onwards). */
-    errors += ReadCommInfo(info_out2, query_key, val, buf, "MPI_Comm_dup");
-    MPI_Info_free(&info_out2);
-
-    /* Test 3: Comm_dup_with_info with comm=MPI_COMM_WORLD */
+    /* Test 2: Comm_dup_with_info with comm=MPI_COMM_WORLD */
     if (rank == 0)
         MTestPrintfMsg(1, "Testing MPI_Comm_dup_with_info with comm = MPI_COMM_WORLD");
     MPI_Comm_dup_with_info(MPI_COMM_WORLD, info_in1, &comm_dup3);
@@ -106,7 +94,7 @@ int main(int argc, char **argv)
     MPI_Info_free(&info_out3);
     /* Release comm_dup3 later, still using in a later test */
 
-    /* Test 4: Comm_dup_with_info with comm = dup of MPI_COMM_WORLD */
+    /* Test 3: Comm_dup_with_info with comm = dup of MPI_COMM_WORLD */
     if (rank == 0)
         MTestPrintfMsg(1, "Testing MPI_Comm_dup_with_info with comm = dup of MPI_COMM_WORLD");
     /* Pick a new hint that is different from the user provided hint */
@@ -120,15 +108,12 @@ int main(int argc, char **argv)
     MPI_Comm_dup_with_info(comm_dup3, info_in4, &comm_dup4);
     MPI_Comm_get_info(comm_dup4, &info_out4);
     errors += ReadCommInfo(info_out4, new_key, "true", buf, "MPI_Comm_dup_with_info-2a");
-    /* Note: Currently we expect hints to be copied from comm. When MPICH aligns with
-     * MPI 3.2+,we do not expect such copying from comm to comm_dup4 */
-    errors += ReadCommInfo(info_out4, query_key, val, buf, "MPI_Comm_dup_with_info-2b");
     MPI_Comm_free(&comm_dup3);
     MPI_Comm_free(&comm_dup4);
     MPI_Info_free(&info_in4);
     MPI_Info_free(&info_out4);
 
-    /* Test 5: MPI_Comm_split_type */
+    /* Test 4: MPI_Comm_split_type */
     MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, info_in1, &comm_split5);
     MPI_Comm_get_info(comm_split5, &info_out5);
     errors += ReadCommInfo(info_out5, query_key, val, buf, "MPI_Comm_split_type");

--- a/test/mpi/impls/mpich/comm/testlist.in
+++ b/test/mpi/impls/mpich/comm/testlist.in
@@ -6,3 +6,4 @@ comm_info_hint 1 arg=-hint=mpi_assert_no_any_tag arg=-value=true
 comm_info_hint 1 arg=-hint=mpi_assert_allow_overtaking arg=-value=true
 comm_info_hint 1 arg=-hint=mpi_assert_exact_length arg=-value=true
 @ch4_ofi_tests@comm_info_hint 1 arg=-hint=eagain arg=-value=true
+comm_dup 1


### PR DESCRIPTION
## Pull Request Description

Do not propagate info during Comm_dup starting MPI-4

Fixes https://github.com/pmodels/mpich/issues/4892

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
