### PR TITLE
MPI-4: MPI_Comm_idup_with_info

### DIFF
--- a/src/binding/fortran/use_mpi_f08/mpi_c_interface_nobuf.f90
+++ b/src/binding/fortran/use_mpi_f08/mpi_c_interface_nobuf.f90
@@ -610,6 +610,18 @@ function MPIR_Comm_idup_c(comm, newcomm, request) &
     integer(c_int) :: ierror
 end function MPIR_Comm_idup_c
 
+function MPIR_Comm_idup_with_info_c(comm, info, newcomm, request) &
+    bind(C, name="PMPIX_Comm_idup_with_info") result(ierror)
+    use, intrinsic :: iso_c_binding, only : c_int
+    use :: mpi_c_interface_types, only : c_Comm, c_Info, c_Request
+    implicit none
+    integer(c_Comm), value, intent(in) :: comm
+    integer(c_Info), value, intent(in) :: info
+    integer(c_Comm), intent(out), asynchronous :: newcomm
+    integer(c_Request), intent(out) :: request
+    integer(c_int) :: ierror
+end function MPIR_Comm_idup_with_info_c
+
 function MPIR_Comm_free_c(comm) &
     bind(C, name="PMPI_Comm_free") result(ierror)
     use, intrinsic :: iso_c_binding, only : c_int

--- a/src/binding/fortran/use_mpi_f08/mpi_f08.f90
+++ b/src/binding/fortran/use_mpi_f08/mpi_f08.f90
@@ -1451,6 +1451,18 @@ interface MPI_Comm_idup
     end subroutine MPI_Comm_idup_f08
 end interface MPI_Comm_idup
 
+interface MPIX_Comm_idup_with_info
+    subroutine MPIX_Comm_idup_with_info_f08(comm, info, newcomm, request, ierror)
+        use :: mpi_f08_types, only : MPI_Comm, MPI_Info, MPI_Request
+        implicit none
+        type(MPI_Comm), intent(in) :: comm
+        type(MPI_Info), intent(in) :: info
+        type(MPI_Comm), intent(out), asynchronous :: newcomm
+        type(MPI_Request), intent(out) :: request
+        integer, optional, intent(out) :: ierror
+    end subroutine MPIX_Comm_idup_with_info_f08
+end interface MPIX_Comm_idup_with_info
+
 interface MPI_Comm_free
     subroutine MPI_Comm_free_f08(comm, ierror)
         use :: mpi_f08_types, only : MPI_Comm

--- a/src/binding/fortran/use_mpi_f08/wrappers_f/comm_idup_with_info_f08ts.f90
+++ b/src/binding/fortran/use_mpi_f08/wrappers_f/comm_idup_with_info_f08ts.f90
@@ -1,0 +1,38 @@
+!
+! Copyright (C) by Argonne National Laboratory
+!     See COPYRIGHT in top-level directory
+!
+
+subroutine MPIX_Comm_idup_with_info_f08(comm, info, newcomm, request, ierror)
+    use, intrinsic :: iso_c_binding, only : c_int
+    use :: mpi_f08, only : MPI_Comm, MPI_Info, MPI_Request
+    use :: mpi_c_interface, only : c_Comm, c_Info, c_Request
+    use :: mpi_c_interface, only : MPIR_Comm_idup_with_info_c
+
+    implicit none
+
+    type(MPI_Comm), intent(in) :: comm
+    type(MPI_Info), intent(in) :: info
+    type(MPI_Comm), intent(out) :: newcomm
+    type(MPI_Request), intent(out) :: request
+    integer, optional, intent(out) :: ierror
+
+    integer(c_Comm) :: comm_c
+    integer(c_Info) :: info_c
+    integer(c_Comm) :: newcomm_c
+    integer(c_Request) :: request_c
+    integer(c_int) :: ierror_c
+
+    if (c_int == kind(0)) then
+        ierror_c = MPIR_Comm_idup_with_info_c(comm%MPI_VAL, info%MPI_VAL, newcomm%MPI_VAL, request%MPI_VAL)
+    else
+        comm_c = comm%MPI_VAL
+        info_c = info%MPI_VAL
+        ierror_c = MPIR_Comm_idup_with_info_c(comm_c, info_c, newcomm_c, request_c)
+        newcomm%MPI_VAL = newcomm_c
+        request%MPI_VAL = request_c
+    end if
+
+    if (present(ierror)) ierror = ierror_c
+
+end subroutine MPIX_Comm_idup_with_info_f08

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -1378,6 +1378,8 @@ int MPI_Mrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message *message,
 
 /* Nonblocking collectives */
 int MPI_Comm_idup(MPI_Comm comm, MPI_Comm *newcomm, MPI_Request *request) MPICH_API_PUBLIC;
+int MPIX_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm,
+                             MPI_Request *request) MPICH_API_PUBLIC;
 int MPI_Ibarrier(MPI_Comm comm, MPI_Request *request) MPICH_API_PUBLIC;
 int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm,
                MPI_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(1,3) MPICH_API_PUBLIC;
@@ -2031,6 +2033,8 @@ int PMPI_Mrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message *message
 
 /* Nonblocking collectives */
 int PMPI_Comm_idup(MPI_Comm comm, MPI_Comm *newcomm, MPI_Request *request) MPICH_API_PUBLIC;
+int PMPIX_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm,
+                              MPI_Request *request) MPICH_API_PUBLIC;
 int PMPI_Ibarrier(MPI_Comm comm, MPI_Request *request) MPICH_API_PUBLIC;
 int PMPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm,
                 MPI_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(1,3) MPICH_API_PUBLIC;

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -284,7 +284,8 @@ int MPIR_Comm_commit(MPIR_Comm *);
 
 int MPIR_Comm_is_parent_comm(MPIR_Comm *);
 
-int MPIR_Comm_idup_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm, MPIR_Request ** reqp);
+int MPIR_Comm_idup_impl(MPIR_Comm * comm_ptr, MPIR_Info * info, MPIR_Comm ** newcomm,
+                        MPIR_Request ** reqp);
 
 int MPIR_Comm_shrink(MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm_ptr);
 int MPIR_Comm_agree(MPIR_Comm * comm_ptr, int *flag);
@@ -379,7 +380,7 @@ int MPII_Comm_init(MPIR_Comm *);
 int MPII_Comm_is_node_consecutive(MPIR_Comm *);
 
 int MPII_Comm_copy(MPIR_Comm * comm_ptr, int size, MPIR_Info * info, MPIR_Comm ** outcomm_ptr);
-int MPII_Comm_copy_data(MPIR_Comm * comm_ptr, MPIR_Comm ** outcomm_ptr);
+int MPII_Comm_copy_data(MPIR_Comm * comm_ptr, MPIR_Info * info, MPIR_Comm ** outcomm_ptr);
 
 int MPII_Setup_intercomm_localcomm(MPIR_Comm *);
 

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -321,8 +321,6 @@ int MPIR_Comm_connect_impl(const char *port_name, MPIR_Info * info_ptr, int root
 int MPIR_Comm_create_errhandler_impl(MPI_Comm_errhandler_function * function,
                                      MPI_Errhandler * errhandler);
 int MPIR_Comm_dup_impl(MPIR_Comm * comm_ptr, MPIR_Info * info, MPIR_Comm ** newcomm_ptr);
-int MPIR_Comm_dup_with_info_impl(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr,
-                                 MPIR_Comm ** newcomm_ptr);
 int MPIR_Comm_get_info_impl(MPIR_Comm * comm_ptr, MPIR_Info ** info_ptr);
 int MPIR_Comm_set_info_impl(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr);
 int MPIR_Comm_free_impl(MPIR_Comm * comm_ptr);

--- a/src/mpi/comm/Makefile.mk
+++ b/src/mpi/comm/Makefile.mk
@@ -15,6 +15,7 @@ mpi_sources +=                       \
     src/mpi/comm/comm_set_info.c     \
     src/mpi/comm/comm_group.c        \
     src/mpi/comm/comm_idup.c         \
+    src/mpi/comm/comm_idup_with_info.c \
     src/mpi/comm/comm_rank.c         \
     src/mpi/comm/comm_size.c         \
     src/mpi/comm/comm_remote_group.c \

--- a/src/mpi/comm/comm_dup_with_info.c
+++ b/src/mpi/comm/comm_dup_with_info.c
@@ -25,22 +25,6 @@ int MPI_Comm_dup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm * newcomm)
 #undef MPI_Comm_dup_with_info
 #define MPI_Comm_dup_with_info PMPI_Comm_dup_with_info
 
-int MPIR_Comm_dup_with_info_impl(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr,
-                                 MPIR_Comm ** newcomm_p_p)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    /* FIXME: We just ignore the info argument for now and just call
-     * Comm_dup */
-    mpi_errno = MPIR_Comm_dup_impl(comm_ptr, info_ptr, newcomm_p_p);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
 #endif /* MPICH_MPI_FROM_PMPI */
 
 
@@ -119,7 +103,7 @@ int MPI_Comm_dup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm * newcomm)
 #endif /* HAVE_ERROR_CHECKING */
 
     /* ... body of routine ...  */
-    mpi_errno = MPIR_Comm_dup_with_info_impl(comm_ptr, info_ptr, &newcomm_ptr);
+    mpi_errno = MPIR_Comm_dup_impl(comm_ptr, info_ptr, &newcomm_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newcomm, newcomm_ptr->handle);

--- a/src/mpi/comm/comm_idup.c
+++ b/src/mpi/comm/comm_idup.c
@@ -26,7 +26,8 @@ int MPI_Comm_idup(MPI_Comm comm, MPI_Comm * newcomm, MPI_Request * request)
 
 /* any non-MPI functions go here, especially non-static ones */
 
-int MPIR_Comm_idup_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcommp, MPIR_Request ** reqp)
+int MPIR_Comm_idup_impl(MPIR_Comm * comm_ptr, MPIR_Info * info, MPIR_Comm ** newcommp,
+                        MPIR_Request ** reqp)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Attribute *new_attributes = 0;
@@ -42,7 +43,7 @@ int MPIR_Comm_idup_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcommp, MPIR_Reques
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    mpi_errno = MPII_Comm_copy_data(comm_ptr, newcommp);
+    mpi_errno = MPII_Comm_copy_data(comm_ptr, info, newcommp);
     MPIR_ERR_CHECK(mpi_errno);
 
     (*newcommp)->attributes = new_attributes;
@@ -127,7 +128,7 @@ int MPI_Comm_idup(MPI_Comm comm, MPI_Comm * newcomm, MPI_Request * request)
     *request = MPI_REQUEST_NULL;
     *newcomm = MPI_COMM_NULL;
 
-    mpi_errno = MPIR_Comm_idup_impl(comm_ptr, &newcomm_ptr, &dreq);
+    mpi_errno = MPIR_Comm_idup_impl(comm_ptr, NULL, &newcomm_ptr, &dreq);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* NOTE: this is a publication for most of the comm, but the context ID

--- a/src/mpi/comm/comm_idup_with_info.c
+++ b/src/mpi/comm/comm_idup_with_info.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+/* -- Begin Profiling Symbol Block for routine MPIX_Comm_idup_with_info */
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPIX_Comm_idup_with_info = PMPIX_Comm_idup_with_info
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPIX_Comm_idup_with_info  MPIX_Comm_idup_with_info
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPIX_Comm_idup_with_info as PMPIX_Comm_idup_with_info
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPIX_Comm_idup_with_info(MPI_Comm comm, MPI_Comm * newcomm, MPI_Request * request)
+    __attribute__ ((weak, alias("PMPIX_Comm_idup_with_info")));
+#endif
+/* -- End Profiling Symbol Block */
+
+/* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
+   the MPI routines */
+#ifndef MPICH_MPI_FROM_PMPI
+#undef MPIX_Comm_idup_with_info
+#define MPIX_Comm_idup_with_info PMPIX_Comm_idup_with_info
+
+#endif /* MPICH_MPI_FROM_PMPI */
+
+/*@
+MPIX_Comm_idup_with_info - nonblocking communicator duplication
+
+Input Parameters:
+. comm - communicator (handle)
+
+Output Parameters:
++ newcomm - copy of comm (handle)
+- request - communication request (handle)
+
+.N ThreadSafe
+
+.N Fortran
+
+.N Errors
+@*/
+int MPIX_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm * newcomm,
+                             MPI_Request * request)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Comm *comm_ptr = NULL;
+    MPIR_Comm *newcomm_ptr = NULL;
+    MPIR_Info *info_ptr = NULL;
+    MPIR_Request *dreq = NULL;
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_COMM_IDUP);
+
+    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_COMM_IDUP);
+
+    /* Validate parameters, especially handles needing to be converted */
+#ifdef HAVE_ERROR_CHECKING
+    {
+        MPID_BEGIN_ERROR_CHECKS;
+        {
+            MPIR_ERRTEST_COMM(comm, mpi_errno);
+            /* TODO more checks may be appropriate */
+        }
+        MPID_END_ERROR_CHECKS;
+    }
+#endif /* HAVE_ERROR_CHECKING */
+
+    /* Convert MPI object handles to object pointers */
+    MPIR_Comm_get_ptr(comm, comm_ptr);
+    MPIR_Info_get_ptr(info, info_ptr);
+
+    /* Validate parameters and objects (post conversion) */
+#ifdef HAVE_ERROR_CHECKING
+    {
+        MPID_BEGIN_ERROR_CHECKS;
+        {
+            MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
+            if (mpi_errno != MPI_SUCCESS)
+                goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
+            /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
+        }
+        MPID_END_ERROR_CHECKS;
+    }
+#endif /* HAVE_ERROR_CHECKING */
+
+    /* ... body of routine ...  */
+
+    *request = MPI_REQUEST_NULL;
+    *newcomm = MPI_COMM_NULL;
+
+    mpi_errno = MPIR_Comm_idup_impl(comm_ptr, info_ptr, &newcomm_ptr, &dreq);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* NOTE: this is a publication for most of the comm, but the context ID
+     * won't be valid yet, so we must "republish" relative to the request
+     * handle at request completion time. */
+    MPIR_OBJ_PUBLISH_HANDLE(*newcomm, newcomm_ptr->handle);
+    *request = dreq->handle;
+
+    /* ... end of body of routine ... */
+
+  fn_exit:
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_COMM_IDUP);
+    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    return mpi_errno;
+
+  fn_fail:
+    /* --BEGIN ERROR HANDLING-- */
+#ifdef HAVE_ERROR_CHECKING
+    {
+        mpi_errno =
+            MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__, MPI_ERR_OTHER,
+                                 "**mpi_comm_idup", "**mpi_comm_idup %C %p %p", comm, newcomm,
+                                 request);
+    }
+#endif
+    mpi_errno = MPIR_Err_return_comm(NULL, __func__, mpi_errno);
+    goto fn_exit;
+    /* --END ERROR HANDLING-- */
+}

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -889,7 +889,7 @@ int MPII_Comm_copy(MPIR_Comm * comm_ptr, int size, MPIR_Info * info, MPIR_Comm *
  *
  * Used by comm_idup.
  */
-int MPII_Comm_copy_data(MPIR_Comm * comm_ptr, MPIR_Comm ** outcomm_ptr)
+int MPII_Comm_copy_data(MPIR_Comm * comm_ptr, MPIR_Info * info, MPIR_Comm ** outcomm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm *newcomm_ptr = NULL;
@@ -932,6 +932,10 @@ int MPII_Comm_copy_data(MPIR_Comm * comm_ptr, MPIR_Comm ** outcomm_ptr)
         MPIR_Errhandler_add_ref(comm_ptr->errhandler);
     }
     MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_COMM_MUTEX(comm_ptr));
+
+    if (info) {
+        MPII_Comm_set_hints(newcomm_ptr, info);
+    }
 
     /* Start with no attributes on this communicator */
     newcomm_ptr->attributes = 0;

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -182,6 +182,7 @@
 /comm/ctxsplit
 /comm/dup
 /comm/dup_with_info
+/comm/idup_with_info
 /comm/dupic
 /comm/ic1
 /comm/ic2

--- a/test/mpi/comm/Makefile.am
+++ b/test/mpi/comm/Makefile.am
@@ -15,6 +15,7 @@ noinst_PROGRAMS =     \
     dup               \
     dupic             \
     dup_with_info     \
+    idup_with_info    \
     ic1               \
     ic2               \
     commname          \

--- a/test/mpi/comm/idup_with_info.c
+++ b/test/mpi/comm/idup_with_info.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include "mpitest.h"
+
+int run_tests(MPI_Comm comm)
+{
+    int rank, size, wrank, wsize, dest, a, b, errs = 0;
+    MPI_Status status;
+
+    /* Check basic properties */
+    MPI_Comm_size(MPI_COMM_WORLD, &wsize);
+    MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    if (size != wsize || rank != wrank) {
+        errs++;
+        fprintf(stderr, "Size (%d) or rank (%d) wrong\n", size, rank);
+        fflush(stderr);
+    }
+
+    MPI_Barrier(comm);
+
+    /* Can we communicate with this new communicator? */
+    dest = MPI_PROC_NULL;
+    if (rank == 0) {
+        dest = size - 1;
+        a = rank;
+        b = -1;
+        MPI_Sendrecv(&a, 1, MPI_INT, dest, 0, &b, 1, MPI_INT, dest, 0, comm, &status);
+        if (b != dest) {
+            errs++;
+            fprintf(stderr, "Received %d expected %d on %d\n", b, dest, rank);
+            fflush(stderr);
+        }
+        if (status.MPI_SOURCE != dest) {
+            errs++;
+            fprintf(stderr, "Source not set correctly in status on %d\n", rank);
+            fflush(stderr);
+        }
+    } else if (rank == size - 1) {
+        dest = 0;
+        a = rank;
+        b = -1;
+        MPI_Sendrecv(&a, 1, MPI_INT, dest, 0, &b, 1, MPI_INT, dest, 0, comm, &status);
+        if (b != dest) {
+            errs++;
+            fprintf(stderr, "Received %d expected %d on %d\n", b, dest, rank);
+            fflush(stderr);
+        }
+        if (status.MPI_SOURCE != dest) {
+            errs++;
+            fprintf(stderr, "Source not set correctly in status on %d\n", rank);
+            fflush(stderr);
+        }
+    }
+
+    MPI_Barrier(comm);
+
+    return errs;
+}
+
+int main(int argc, char **argv)
+{
+    int errs = 0;
+    MPI_Comm newcomm1, newcomm2, newcomm3, newcomm4;
+    MPI_Request reqs[2];
+    MPI_Info info;
+    int rank;
+
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    /* Dup with no info */
+    MPIX_Comm_idup_with_info(MPI_COMM_WORLD, MPI_INFO_NULL, &newcomm1, &reqs[0]);
+    MPI_Wait(&reqs[0], MPI_STATUS_IGNORE);
+    errs += run_tests(newcomm1);
+
+    MPIX_Comm_idup_with_info(MPI_COMM_WORLD, MPI_INFO_NULL, &newcomm2, &reqs[0]);
+    MPI_Wait(&reqs[0], MPI_STATUS_IGNORE);
+    errs += run_tests(newcomm2);
+
+    /* Dup with info keys in mixed order */
+    MPI_Info_create(&info);
+    MPI_Info_set(info, (char *) "host", (char *) "myhost.myorg.org");
+    MPI_Info_set(info, (char *) "file", (char *) "runfile.txt");
+    MPI_Info_set(info, (char *) "soft", (char *) "2:1000:4,3:1000:7");
+
+    if (rank % 2 == 0) {
+        MPIX_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[0]);
+        MPIX_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[1]);
+    } else {
+        MPIX_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[0]);
+        MPIX_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[1]);
+    }
+    MPI_Waitall(2, reqs, MPI_STATUSES_IGNORE);
+
+    errs += run_tests(newcomm3);
+    errs += run_tests(newcomm4);
+
+    MPI_Info_free(&info);
+    MPI_Comm_free(&newcomm4);
+    MPI_Comm_free(&newcomm3);
+
+    /* Free info keys before the communicator is fully created */
+    MPI_Info_create(&info);
+    MPI_Info_set(info, (char *) "host", (char *) "myhost.myorg.org");
+    MPI_Info_set(info, (char *) "file", (char *) "runfile.txt");
+    MPI_Info_set(info, (char *) "soft", (char *) "2:1000:4,3:1000:7");
+
+    if (rank % 2 == 0) {
+        MPIX_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[0]);
+        MPIX_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[1]);
+    } else {
+        MPIX_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[0]);
+        MPIX_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[1]);
+    }
+    MPI_Info_free(&info);
+    MPI_Waitall(2, reqs, MPI_STATUSES_IGNORE);
+
+    errs += run_tests(newcomm3);
+    errs += run_tests(newcomm4);
+
+    MPI_Comm_free(&newcomm4);
+    MPI_Comm_free(&newcomm3);
+
+    MPI_Comm_free(&newcomm2);
+    MPI_Comm_free(&newcomm1);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/comm/testlist.in
+++ b/test/mpi/comm/testlist.in
@@ -41,6 +41,9 @@ comm_idup_comm2 6
 dup_with_info 2
 dup_with_info 4
 dup_with_info 9
+idup_with_info 2
+idup_with_info 4
+idup_with_info 8
 comm_info 6
 comm_info2 1
 comm_create_group_idup 4

--- a/test/mpi/impls/mpich/comm/comm_info_hint.c
+++ b/test/mpi/impls/mpich/comm/comm_info_hint.c
@@ -120,6 +120,19 @@ int main(int argc, char **argv)
     MPI_Comm_free(&comm_split5);
     MPI_Info_free(&info_out5);
 
+    /* Test comm_idup */
+#if MPI_VERSION >= 4
+    MPI_Request request;
+    if (rank == 0)
+        MTestPrintfMsg(1, "Testing MPIX_Comm_idup_with_info with comm = MPI_COMM_WORLD");
+    MPIX_Comm_idup_with_info(MPI_COMM_WORLD, info_in1, &comm_dup3, &request);
+    MPI_Wait(&request, MPI_STATUS_IGNORE);
+    MPI_Comm_get_info(comm_dup3, &info_out3);
+    errors += ReadCommInfo(info_out3, query_key, val, buf, "MPIX_Comm_idup_with_info");
+    MPI_Info_free(&info_out3);
+    MPI_Comm_free(&comm_dup3);
+#endif
+
     /* TODO - Test: MPI_Dist_graph_create_adjacent */
 
     /* Release remaining resources */


### PR DESCRIPTION
## Pull Request Description

Initial implementation of `MPI_Comm_idup_with_info`, although the function is currently named with `MPIX_`.

Fixes https://github.com/pmodels/mpich/issues/4893

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
