### PR TITLE
Add MPI-4 Delete error class/code/string routines

### DIFF
--- a/src/binding/fortran/use_mpi_f08/mpi_c_interface_nobuf.f90
+++ b/src/binding/fortran/use_mpi_f08/mpi_c_interface_nobuf.f90
@@ -1371,6 +1371,32 @@ function MPIR_Add_error_string_c(errorcode, string) &
     integer(c_int) :: ierror
 end function MPIR_Add_error_string_c
 
+function MPIR_Delete_error_class_c(errorclass) &
+    bind(C, name="PMPIX_Delete_error_class") result(ierror)
+    use, intrinsic :: iso_c_binding, only : c_int
+    implicit none
+    integer(c_int), intent(in) :: errorclass
+    integer(c_int) :: ierror
+end function MPIR_Delete_error_class_c
+
+function MPIR_Delete_error_code_c(errorcode) &
+    bind(C, name="PMPIX_Delete_error_code") result(ierror)
+    use, intrinsic :: iso_c_binding, only : c_int
+    use :: mpi_c_interface_types, only : c_Datatype, c_Comm, c_Request
+    implicit none
+    integer(c_int), value, intent(in) :: errorcode
+    integer(c_int) :: ierror
+end function MPIR_Delete_error_code_c
+
+function MPIR_Delete_error_string_c(errorcode) &
+    bind(C, name="PMPIX_Delete_error_string") result(ierror)
+    use, intrinsic :: iso_c_binding, only : c_int
+    use :: mpi_c_interface_types, only : c_Datatype, c_Comm, c_Request
+    implicit none
+    integer(c_int), value, intent(in) :: errorcode
+    integer(c_int) :: ierror
+end function MPIR_Delete_error_string_c
+
 function MPIR_Alloc_mem_c(size, info, baseptr) &
     bind(C, name="PMPI_Alloc_mem") result(ierror)
     use, intrinsic :: iso_c_binding, only : c_ptr, c_int

--- a/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_class_f08ts.f90
+++ b/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_class_f08ts.f90
@@ -1,0 +1,27 @@
+!
+! Copyright (C) by Argonne National Laboratory
+!     See COPYRIGHT in top-level directory
+!
+
+subroutine MPIX_Delete_error_class_f08(errorclass, ierror)
+    use, intrinsic :: iso_c_binding, only : c_int
+    use :: mpi_c_interface, only : MPIR_Delete_error_class_c
+
+    implicit none
+
+    integer, intent(in) :: errorclass
+    integer, optional, intent(out) :: ierror
+
+    integer(c_int) :: errorclass_c
+    integer(c_int) :: ierror_c
+
+    if (c_int == kind(0)) then
+        ierror_c = MPIR_Delete_error_class_c(errorclass)
+    else
+        errorclass_c = errorclass
+        ierror_c = MPIR_Delete_error_class_c(errorclass_c)
+    end if
+
+    if (present(ierror)) ierror = ierror_c
+
+end subroutine MPIX_Delete_error_class_f08

--- a/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_code_f08ts.f90
+++ b/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_code_f08ts.f90
@@ -1,0 +1,28 @@
+!
+! Copyright (C) by Argonne National Laboratory
+!     See COPYRIGHT in top-level directory
+!
+
+subroutine MPIX_Delete_error_code_f08(errorcode, ierror)
+    use, intrinsic :: iso_c_binding, only : c_int
+    use :: mpi_c_interface, only : c_Datatype, c_Comm, c_Request
+    use :: mpi_c_interface, only : MPIR_Delete_error_code_c
+
+    implicit none
+
+    integer, intent(in) :: errorcode
+    integer, optional, intent(out) :: ierror
+
+    integer(c_int) :: errorcode_c
+    integer(c_int) :: ierror_c
+
+    if (c_int == kind(0)) then
+        ierror_c = MPIR_Delete_error_code_c(errorcode)
+    else
+        errorcode_c = errorcode
+        ierror_c = MPIR_Delete_error_code_c(errorcode_c)
+    end if
+
+    if (present(ierror)) ierror = ierror_c
+
+end subroutine MPIX_Delete_error_code_f08

--- a/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_string_f08ts.f90
+++ b/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_string_f08ts.f90
@@ -1,0 +1,29 @@
+!
+! Copyright (C) by Argonne National Laboratory
+!     See COPYRIGHT in top-level directory
+!
+
+subroutine MPIX_Delete_error_string_f08(errorcode, ierror)
+    use, intrinsic :: iso_c_binding, only : c_int, c_char
+    use :: mpi_c_interface, only : c_Datatype, c_Comm, c_Request
+    use :: mpi_c_interface, only : MPIR_Delete_error_string_c
+    use :: mpi_c_interface, only : MPIR_Fortran_string_f2c
+
+    implicit none
+
+    integer, intent(in) :: errorcode
+    integer, optional, intent(out) :: ierror
+
+    integer(c_int) :: errorcode_c
+    integer(c_int) :: ierror_c
+
+    if (c_int == kind(0)) then
+        ierror_c = MPIR_Delete_error_string_c(errorcode)
+    else
+        errorcode_c = errorcode
+        ierror_c = MPIR_Delete_error_string_c(errorcode_c)
+    end if
+
+    if (present(ierror)) ierror = ierror_c
+
+end subroutine MPIX_Delete_error_string_f08

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -1228,8 +1228,11 @@ int MPI_Win_sync(MPI_Win win) MPICH_API_PUBLIC;
  
 /* External Interfaces */
 int MPI_Add_error_class(int *errorclass) MPICH_API_PUBLIC;
+int MPIX_Delete_error_class(int errorclass) MPICH_API_PUBLIC;
 int MPI_Add_error_code(int errorclass, int *errorcode) MPICH_API_PUBLIC;
+int MPIX_Delete_error_code(int errorcode) MPICH_API_PUBLIC;
 int MPI_Add_error_string(int errorcode, const char *string) MPICH_API_PUBLIC;
+int MPIX_Delete_error_string(int errorcode) MPICH_API_PUBLIC;
 int MPI_Comm_call_errhandler(MPI_Comm comm, int errorcode) MPICH_API_PUBLIC;
 int MPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn,
                            MPI_Comm_delete_attr_function *comm_delete_attr_fn, int *comm_keyval,
@@ -1878,8 +1881,11 @@ int PMPI_Win_sync(MPI_Win win) MPICH_API_PUBLIC;
  
 /* External Interfaces */
 int PMPI_Add_error_class(int *errorclass) MPICH_API_PUBLIC;
+int PMPIX_Delete_error_class(int errorclass) MPICH_API_PUBLIC;
 int PMPI_Add_error_code(int errorclass, int *errorcode) MPICH_API_PUBLIC;
+int PMPIX_Delete_error_code(int errorcode) MPICH_API_PUBLIC;
 int PMPI_Add_error_string(int errorcode, const char *string) MPICH_API_PUBLIC;
+int PMPIX_Delete_error_string(int errorcode) MPICH_API_PUBLIC;
 int PMPI_Comm_call_errhandler(MPI_Comm comm, int errorcode) MPICH_API_PUBLIC;
 int PMPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn,
                             MPI_Comm_delete_attr_function *comm_delete_attr_fn, int *comm_keyval,

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -138,6 +138,7 @@ void MPIR_Err_init(void);
 void MPIR_Err_preOrPostInit(void);
 
 int MPIR_Err_set_msg(int code, const char *msg_string);
+int MPIR_Err_delete_msg(int code);
 
 /* This routine is called when there is a fatal error. Now public because file
  * error handling is defined in a separate file from comm and win, but all

--- a/src/mpi/errhan/Makefile.mk
+++ b/src/mpi/errhan/Makefile.mk
@@ -7,6 +7,9 @@ mpi_sources +=                                            \
     src/mpi/errhan/add_error_code.c         \
     src/mpi/errhan/add_error_class.c        \
     src/mpi/errhan/add_error_string.c       \
+    src/mpi/errhan/delete_error_code.c      \
+    src/mpi/errhan/delete_error_class.c     \
+    src/mpi/errhan/delete_error_string.c    \
     src/mpi/errhan/comm_call_errhandler.c   \
     src/mpi/errhan/comm_create_errhandler.c \
     src/mpi/errhan/comm_get_errhandler.c    \

--- a/src/mpi/errhan/delete_error_class.c
+++ b/src/mpi/errhan/delete_error_class.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+#include "errcodes.h"
+
+/* -- Begin Profiling Symbol Block for routine MPIX_Delete_error_class */
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPIX_Delete_error_class = PMPIX_Delete_error_class
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPIX_Delete_error_class  MPIX_Delete_error_class
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPIX_Delete_error_class as PMPIX_Delete_error_class
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPIX_Delete_error_class(int *errorclass)
+    __attribute__ ((weak, alias("PMPIX_Delete_error_class")));
+#endif
+/* -- End Profiling Symbol Block */
+
+/* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
+   the MPI routines */
+#ifndef MPICH_MPI_FROM_PMPI
+#undef MPIX_Delete_error_class
+#define MPIX_Delete_error_class PMPIX_Delete_error_class
+
+#endif
+
+/*@
+   MPIX_Delete_error_class - Delete an MPI error class to the known classes
+
+Output Parameters:
+.  errorclass - New error class
+
+.N ThreadSafe
+
+.N Fortran
+
+.N Errors
+.N MPI_SUCCESS
+.N MPI_ERR_OTHER
+@*/
+int MPIX_Delete_error_class(int errorclass)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_DELETE_ERROR_CLASS);
+
+    MPIR_ERRTEST_INITIALIZED_ORDIE();
+
+    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_DELETE_ERROR_CLASS);
+
+    /* Validate parameters, especially handles needing to be converted */
+#ifdef HAVE_ERROR_CHECKING
+    {
+        MPID_BEGIN_ERROR_CHECKS;
+        {
+            MPIR_ERRTEST_ARGNULL(errorclass, "errorclass", mpi_errno);
+        }
+        MPID_END_ERROR_CHECKS;
+    }
+#endif /* HAVE_ERROR_CHECKING */
+
+    /* ... body of routine ...  */
+
+    mpi_errno = MPIR_Err_delete_class(errorclass & ~ERROR_DYN_MASK);
+    MPIR_ERR_CHKANDJUMP(mpi_errno, mpi_errno, MPI_ERR_OTHER, "**predeferrclass");
+
+    /* ... end of body of routine ... */
+
+  fn_exit:
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_DELETE_ERROR_CLASS);
+    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    return mpi_errno;
+
+  fn_fail:
+    /* --BEGIN ERROR HANDLING-- */
+#ifdef HAVE_ERROR_CHECKING
+    {
+        mpi_errno =
+            MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__, MPI_ERR_OTHER,
+                                 "**mpi_delete_error_class", "**mpi_delete_error_class %d",
+                                 errorclass);
+    }
+#endif
+    mpi_errno = MPIR_Err_return_comm(NULL, __func__, mpi_errno);
+    goto fn_exit;
+    /* --END ERROR HANDLING-- */
+}

--- a/src/mpi/errhan/delete_error_code.c
+++ b/src/mpi/errhan/delete_error_code.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+#include "errcodes.h"
+
+/* -- Begin Profiling Symbol Block for routine MPIX_Delete_error_code */
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPIX_Delete_error_code = PMPIX_Delete_error_code
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPIX_Delete_error_code  MPIX_Delete_error_code
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPIX_Delete_error_code as PMPIX_Delete_error_code
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPIX_Delete_error_code(int errorclass, int *errorcode)
+    __attribute__ ((weak, alias("PMPIX_Delete_error_code")));
+#endif
+/* -- End Profiling Symbol Block */
+
+/* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
+   the MPI routines */
+#ifndef MPICH_MPI_FROM_PMPI
+#undef MPIX_Delete_error_code
+#define MPIX_Delete_error_code PMPIX_Delete_error_code
+
+#endif
+
+/*@
+   MPIX_Delete_error_code - Delete an MPI error code
+
+Input Parameters:
+.  errorcode - Error code to be deleted.
+
+.N ThreadSafe
+
+.N Fortran
+
+.N Errors
+.N MPI_SUCCESS
+.N MPI_ERR_OTHER
+@*/
+int MPIX_Delete_error_code(int errorcode)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_DELETE_ERROR_CODE);
+
+    MPIR_ERRTEST_INITIALIZED_ORDIE();
+
+    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_DELETE_ERROR_CODE);
+
+    /* Validate parameters, especially handles needing to be converted */
+#ifdef HAVE_ERROR_CHECKING
+    {
+        MPID_BEGIN_ERROR_CHECKS;
+        {
+            /* FIXME: verify that errorclass is a dynamic class */
+            MPIR_ERRTEST_ARGNULL(errorcode, "errorcode", mpi_errno);
+        }
+        MPID_END_ERROR_CHECKS;
+    }
+#endif /* HAVE_ERROR_CHECKING */
+
+    /* ... body of routine ...  */
+
+    mpi_errno = MPIR_Err_delete_code(errorcode);
+    MPIR_ERR_CHKANDJUMP(mpi_errno, mpi_errno, MPI_ERR_OTHER, "**predeferrcode");
+
+    /* ... end of body of routine ... */
+
+  fn_exit:
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_DELETE_ERROR_CODE);
+    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    return mpi_errno;
+
+  fn_fail:
+    /* --BEGIN ERROR HANDLING-- */
+#ifdef HAVE_ERROR_CHECKING
+    {
+        mpi_errno =
+            MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__, MPI_ERR_OTHER,
+                                 "**mpi_delete_error_code", "**mpi_delete_error_code %d",
+                                 errorcode);
+    }
+#endif
+    mpi_errno = MPIR_Err_return_comm(NULL, __func__, mpi_errno);
+    goto fn_exit;
+    /* --END ERROR HANDLING-- */
+}

--- a/src/mpi/errhan/delete_error_string.c
+++ b/src/mpi/errhan/delete_error_string.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) by Argonne National Laboratory See COPYRIGHT in
+ *     top-level directory
+ */
+
+#include "mpiimpl.h"
+#include "errcodes.h"
+
+/* -- Begin Profiling Symbol Block for routine MPIX_Delete_error_string */
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPIX_Delete_error_string = PMPIX_Delete_error_string
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPIX_Delete_error_string  MPIX_Delete_error_string
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPIX_Delete_error_string as PMPIX_Delete_error_string
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPIX_Delete_error_string(int errorcode, const char *string)
+    __attribute__ ((weak, alias("PMPIX_Delete_error_string")));
+#endif
+/* -- End Profiling Symbol Block */
+
+/* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
+   the MPI routines */
+#ifndef MPICH_MPI_FROM_PMPI
+#undef MPIX_Delete_error_string
+#define MPIX_Delete_error_string PMPIX_Delete_error_string
+
+#endif
+
+/*@
+   MPIX_Delete_error_string - Delete the error string associated with an MPI error code or
+   class
+
+Input Parameters:
++ errorcode - error code or class (integer)
+
+   Notes:
+According to the MPI-2 standard, it is erroneous to call 'MPIX_Delete_error_string'
+for an error code or class with a value less than or equal
+to 'MPI_ERR_LASTCODE'.  Thus, you cannot replace the predefined error messages
+with this routine.
+
+.N ThreadSafe
+
+.N Fortran
+
+.N Errors
+.N MPI_SUCCESS
+@*/
+int MPIX_Delete_error_string(int errorcode)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_DELETE_ERROR_STRING);
+
+    MPIR_ERRTEST_INITIALIZED_ORDIE();
+
+    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_DELETE_ERROR_STRING);
+
+    /* Validate parameters, especially handles needing to be converted */
+#ifdef HAVE_ERROR_CHECKING
+    {
+        MPID_BEGIN_ERROR_CHECKS;
+        {
+            /* verify that errorclass is a dynamic class */
+            MPIR_ERRTEST_ARGNULL(errorcode, "errcode", mpi_errno);
+        }
+        MPID_END_ERROR_CHECKS;
+    }
+#endif /* HAVE_ERROR_CHECKING */
+
+    /* ... body of routine ...  */
+
+    mpi_errno = MPIR_Err_delete_msg(errorcode);
+    if (mpi_errno != MPI_SUCCESS)
+        goto fn_fail;
+
+    /* ... end of body of routine ... */
+
+  fn_exit:
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_DELETE_ERROR_STRING);
+    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    return mpi_errno;
+
+  fn_fail:
+    /* --BEGIN ERROR HANDLING-- */
+#ifdef HAVE_ERROR_CHECKING
+    {
+        mpi_errno =
+            MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__, MPI_ERR_OTHER,
+                                 "**mpi_delete_error_string", "**mpi_delete_error_string %d",
+                                 errorcode);
+    }
+#endif
+    mpi_errno = MPIR_Err_return_comm(NULL, __func__, mpi_errno);
+    goto fn_exit;
+    /* --END ERROR HANDLING-- */
+}

--- a/src/mpi/errhan/dynerrutil.c
+++ b/src/mpi/errhan/dynerrutil.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 #include "errcodes.h"
-
+#include "uthash.h"
 #include <string.h>
 
 /*
@@ -48,8 +48,23 @@ static const char *(user_class_msgs[ERROR_MAX_NCLASS]) = {
 static const char *(user_code_msgs[ERROR_MAX_NCODE]) = {
 0};
 
-static int first_free_class = 1;        /* class 0 is reserved */
-static int first_free_code = 1; /* code 0 is reserved */
+/* a container for integer objects that can be used as a linked list
+ * or as a hashmap */
+struct intcnt {
+    int val;
+
+    struct intcnt *next;
+    struct intcnt *prev;
+
+    UT_hash_handle hh;
+};
+
+static struct {
+    int next;
+    struct intcnt *free;
+    struct intcnt *used;
+} err_class, err_code;
+
 static const char empty_error_string[1] = { 0 };
 
 /* Forward reference */
@@ -79,6 +94,13 @@ static void MPIR_Init_err_dyncodes(void)
 
     /* FIXME: Does this need a thread-safe init? */
     not_initialized = 0;
+
+    err_class.next = 1; /* class 0 is reserved */
+    err_class.free = NULL;
+    err_class.used = NULL;
+    err_code.next = 1;  /* code 0 is reserved */
+    err_code.free = NULL;
+    err_code.used = NULL;
 
     for (i = 0; i < ERROR_MAX_NCLASS; i++) {
         user_class_msgs[i] = 0;
@@ -149,8 +171,11 @@ int MPIR_Err_set_msg(int code, const char *msg_string)
 
     /* --------------------------------------------------------------------- */
     MPL_strncpy(str, msg_string, msg_len + 1);
+
     if (errcode) {
-        if (errcode < first_free_code) {
+        struct intcnt *s;
+        HASH_FIND_INT(err_code.used, &errcode, s);
+        if (s) {
             MPL_free((void *) (user_code_msgs[errcode]));
             user_code_msgs[errcode] = (const char *) str;
         } else {
@@ -158,7 +183,9 @@ int MPIR_Err_set_msg(int code, const char *msg_string)
             MPL_free(str);
         }
     } else {
-        if (errclass < first_free_class) {
+        struct intcnt *s;
+        HASH_FIND_INT(err_class.used, &errclass, s);
+        if (s) {
             MPL_free((void *) (user_class_msgs[errclass]));
             user_class_msgs[errclass] = (const char *) str;
         } else {
@@ -194,8 +221,17 @@ int MPIR_Err_add_class(void)
         MPIR_Init_err_dyncodes();
 
     /* Get new class */
-    new_class = first_free_class;
-    ++first_free_class;
+    struct intcnt *s;
+    if (err_class.free) {
+        s = err_class.free;
+        DL_DELETE(err_class.free, s);
+        HASH_ADD_INT(err_class.used, val, s, MPL_MEM_BUFFER);
+    } else {
+        s = (struct intcnt *) MPL_malloc(sizeof(struct intcnt), MPL_MEM_BUFFER);
+        s->val = err_class.next++;
+        HASH_ADD_INT(err_class.used, val, s, MPL_MEM_BUFFER);
+    }
+    new_class = s->val;
 
     /* --BEGIN ERROR HANDLING-- */
     if (new_class >= ERROR_MAX_NCLASS) {
@@ -236,8 +272,17 @@ int MPIR_Err_add_code(int class)
         MPIR_Init_err_dyncodes();
 
     /* Get the new code */
-    new_code = first_free_code;
-    ++first_free_code;
+    struct intcnt *s;
+    if (err_code.free) {
+        s = err_code.free;
+        DL_DELETE(err_code.free, s);
+        HASH_ADD_INT(err_code.used, val, s, MPL_MEM_BUFFER);
+    } else {
+        s = (struct intcnt *) MPL_malloc(sizeof(struct intcnt), MPL_MEM_BUFFER);
+        s->val = err_code.next++;
+        HASH_ADD_INT(err_code.used, val, s, MPL_MEM_BUFFER);
+    }
+    new_code = s->val;
 
     /* --BEGIN ERROR HANDLING-- */
     if (new_code >= ERROR_MAX_NCODE) {
@@ -287,13 +332,17 @@ static const char *get_dynerr_string(int code)
     }
 
     if (errcode) {
-        if (errcode < first_free_code) {
+        struct intcnt *s;
+        HASH_FIND_INT(err_code.used, &errcode, s);
+        if (s) {
             errstr = user_code_msgs[errcode];
             if (!errstr)
                 errstr = empty_error_string;
         }
     } else {
-        if (errclass < first_free_class) {
+        struct intcnt *s;
+        HASH_FIND_INT(err_class.used, &errclass, s);
+        if (s) {
             errstr = user_class_msgs[errclass];
             if (!errstr)
                 errstr = empty_error_string;
@@ -306,18 +355,33 @@ static const char *get_dynerr_string(int code)
 
 static int MPIR_Dynerrcodes_finalize(void *p ATTRIBUTE((unused)))
 {
-    int i;
-
     MPL_UNREFERENCED_ARG(p);
 
     if (not_initialized == 0) {
+        struct intcnt *s, *tmp;
 
-        for (i = 0; i < first_free_class; i++) {
-            MPL_free((char *) user_class_msgs[i]);
+        HASH_ITER(hh, err_class.used, s, tmp) {
+            MPL_free((char *) user_class_msgs[s->val]);
+            HASH_DEL(err_class.used, s);
+            MPL_free(s);
         }
 
-        for (i = 0; i < first_free_code; i++) {
-            MPL_free((char *) user_code_msgs[i]);
+        DL_FOREACH_SAFE(err_class.free, s, tmp) {
+            MPL_free((char *) user_class_msgs[s->val]);
+            DL_DELETE(err_class.free, s);
+            MPL_free(s);
+        }
+
+        HASH_ITER(hh, err_code.used, s, tmp) {
+            MPL_free((char *) user_code_msgs[s->val]);
+            HASH_DEL(err_code.used, s);
+            MPL_free(s);
+        }
+
+        DL_FOREACH_SAFE(err_code.free, s, tmp) {
+            MPL_free((char *) user_code_msgs[s->val]);
+            DL_DELETE(err_code.free, s);
+            MPL_free(s);
         }
     }
     return 0;

--- a/src/mpi/errhan/errcodes.h
+++ b/src/mpi/errhan/errcodes.h
@@ -9,7 +9,9 @@
 /* Prototypes for internal routines for the errhandling module */
 int MPIR_Err_set_msg(int, const char *);
 int MPIR_Err_add_class(void);
+int MPIR_Err_delete_class(int errclass);
 int MPIR_Err_add_code(int);
+int MPIR_Err_delete_code(int code);
 
 /*
    This file contains the definitions of the error code fields

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -39,7 +39,9 @@
 **permattr:Cannot set permanent attribute
 **keyval:Invalid keyval
 **noerrclasses:No more user-defined error classes
+**predeferrclass:Predefined error class given
 **noerrcodes:No more user-defined error codes
+**predeferrcode:Predefined error code given
 **rankdup:Duplicate ranks in rank array 
 **rankdup %d %d %d:Duplicate ranks in rank array at index %d, has value %d which is \
 also the value at index %d
@@ -1185,10 +1187,16 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **mpi_exscan %p %p %d %D %O %C:MPI_Exscan(sbuf=%p, rbuf=%p, count=%d, %D, %O, %C) failed
 **mpi_add_error_class:MPI_Add_error_class failed
 **mpi_add_error_class %p:MPI_Add_error_class(errorclass=%p) failed
+**mpi_delete_error_class:MPI_Delete_error_class failed
+**mpi_delete_error_class %d:MPI_Delete_error_class(errorclass=%d) failed
 **mpi_add_error_code:MPI_Add_error_code failed
 **mpi_add_error_code %d %p:MPI_Add_error_code(errorclass=%d, errorcode=%p) failed
+**mpi_delete_error_code:MPI_Delete_error_code failed
+**mpi_delete_error_code %d:MPI_Delete_error_code(errorcode=%d) failed
 **mpi_add_error_string:MPI_Add_error_string failed
 **mpi_add_error_string %d %s:MPI_Add_error_string(code=%d, str=\"%s\") failed
+**mpi_delete_error_string:MPI_Delete_error_string failed
+**mpi_delete_error_string %d:MPI_Delete_error_string(code=%d) failed
 **mpi_comm_call_errhandler:MPI_Comm_call_errhandler failed
 **mpi_comm_call_errhandler %C %d:MPI_Comm_call_errhandler(%C, errorcode=%d) failed
 **mpi_comm_create_keyval:MPI_Comm_create_keyval failed

--- a/test/mpi/errhan/adderr.c
+++ b/test/mpi/errhan/adderr.c
@@ -25,6 +25,27 @@ int main(int argc, char *argv[])
 
     MTest_Init(&argc, &argv);
 
+#if MPI_VERSION >= 4
+    /* add and delete a bunch of times */
+    for (int k = 0; k < 10000; k++) {
+        for (i = 0; i < NCLASSES; i++) {
+            MPI_Add_error_class(&newclass[i]);
+            for (j = 0; j < NCODES; j++) {
+                MPI_Add_error_code(newclass[i], &newcode[i][j]);
+                sprintf(string, "random incorrect string\n");
+                MPI_Add_error_string(newcode[i][j], string);
+            }
+        }
+        for (i = 0; i < NCLASSES; i++) {
+            for (j = 0; j < NCODES; j++) {
+                MPIX_Delete_error_string(newcode[i][j]);
+                MPIX_Delete_error_code(newcode[i][j]);
+            }
+            MPIX_Delete_error_class(newclass[i]);
+        }
+    }
+#endif
+
     /* Initialize the new codes */
     for (i = 0; i < NCLASSES; i++) {
         MPI_Add_error_class(&newclass[i]);


### PR DESCRIPTION
## Pull Request Description

Add MPI-4 Delete error class/code/string routines.

Fixes https://github.com/pmodels/mpich/issues/4885

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
