### PR TITLE
f08: warning squash

### DIFF
--- a/src/binding/fortran/use_mpi_f08/wrappers_c/buildiface
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/buildiface
@@ -308,9 +308,11 @@ char **MPIR_C_MPI_ARGV_NULL = MPI_ARGV_NULL;
 char ***MPIR_C_MPI_ARGVS_NULL = MPI_ARGVS_NULL;
 int *MPIR_C_MPI_ERRCODES_IGNORE = MPI_ERRCODES_IGNORE;
 
+/* Fortran 2008 specifies a maximum rank of 15 */
+#define MAX_RANK  (15)
+
 int cdesc_create_datatype(CFI_cdesc_t *cdesc, int oldcount, MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
-    const int MAX_RANK = 15; /* Fortran 2008 specifies a maximum rank of 15 */
     MPI_Datatype types[MAX_RANK + 1]; /* Use a fixed size array to avoid malloc. + 1 for oldtype */
     int mpi_errno = MPI_SUCCESS;
     int accum_elems = 1;


### PR DESCRIPTION
## Pull Request Description

gfortran seems to treat a const int as an unbounded array, while it
treats a macro as bounded.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
