### PR TITLE
cleanup comments on deprecated/removed functions 

### DIFF
--- a/maint/docnotes
+++ b/maint/docnotes
@@ -150,13 +150,11 @@ N*/
 N*/
 
 -----------------------------------------------------------------------------
-MPI-2 deprecated some routines (see 2.6.1)
+Deprecated routines (see 2.6.1)
 /*N Deprecated
  Deprecated Function:
- The MPI-2 standard deprecated a number of routines because MPI-2 provides
- better versions.  This routine is one of those that was deprecated.  The
- routine may continue to be used, but new code should use the replacement
- routine.
+ The current MPI standard defines this routine as deprecated. The routine may
+ continue to be used, but new code should use the replacement routine.
 N*/
 -----------------------------------------------------------------------------
 /*N Errhandler

--- a/maint/docnotes
+++ b/maint/docnotes
@@ -156,6 +156,12 @@ Deprecated routines (see 2.6.1)
  The current MPI standard defines this routine as deprecated. The routine may
  continue to be used, but new code should use the replacement routine.
 N*/
+Removed routines (see 2.6.1)
+/*N Removed
+ Removed Function:
+ The current MPI standard defines this routine as removed. The user should use
+ the replacement routine.
+N*/
 -----------------------------------------------------------------------------
 /*N Errhandler
     Error handlers:

--- a/src/mpi/datatype/address.c
+++ b/src/mpi/datatype/address.c
@@ -44,7 +44,7 @@ Output Parameters:
 
 .N SignalSafe
 
-.N Deprecated
+.N Removed
 The replacement for this routine is 'MPI_Get_address'.
 
 .N Fortran

--- a/src/mpi/datatype/type_extent.c
+++ b/src/mpi/datatype/type_extent.c
@@ -37,7 +37,7 @@ Output Parameters:
 
 .N SignalSafe
 
-.N Deprecated
+.N Removed
 The replacement for this routine is 'MPI_Type_get_extent'.
 
 .N Fortran

--- a/src/mpi/datatype/type_hindexed.c
+++ b/src/mpi/datatype/type_hindexed.c
@@ -39,7 +39,7 @@ Input Parameters:
 Output Parameters:
 . newtype - new datatype (handle)
 
-.N Deprecated
+.N Removed
 This routine is replaced by 'MPI_Type_create_hindexed'.
 
 .N ThreadSafe

--- a/src/mpi/datatype/type_hvector.c
+++ b/src/mpi/datatype/type_hvector.c
@@ -38,7 +38,11 @@ Input Parameters:
 Output Parameters:
 . newtype - new datatype (handle)
 
-   Notes:
+.N Removed
+
+This routine is replaced by 'MPI_Type_create_hvector'.
+
+.N ThreadSafe
 
 .N Fortran
 

--- a/src/mpi/datatype/type_lb.c
+++ b/src/mpi/datatype/type_lb.c
@@ -35,7 +35,7 @@ Output Parameters:
 . displacement - displacement of lower bound from origin,
                              in bytes (address integer)
 
-.N Deprecated
+.N Removed
 The replacement for this routine is 'MPI_Type_Get_extent'.
 
 .N SignalSafe

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -43,7 +43,7 @@ of handles to datatype objects)
 Output Parameters:
 . newtype - new datatype (handle)
 
-.N Deprecated
+.N Removed
 The replacement for this routine is 'MPI_Type_create_struct'
 
 Notes:

--- a/src/mpi/datatype/type_ub.c
+++ b/src/mpi/datatype/type_ub.c
@@ -37,7 +37,7 @@ Output Parameters:
 . displacement - displacement of upper bound from origin,
                              in bytes (address integer)
 
-.N Deprecated
+.N Removed
 The replacement for this routine is 'MPI_Type_get_extent'
 
 .N SignalSafe

--- a/src/mpi/errhan/errhandler_create.c
+++ b/src/mpi/errhan/errhandler_create.c
@@ -45,7 +45,7 @@ freed.
 
 .N ThreadSafe
 
-.N Deprecated
+.N Removed
 The replacement routine for this function is 'MPI_Comm_create_errhandler'.
 
 .N Fortran

--- a/src/mpi/errhan/errhandler_get.c
+++ b/src/mpi/errhan/errhandler_get.c
@@ -36,6 +36,9 @@ Output Parameters:
 . errhandler - MPI error handler currently associated with communicator
 (handle)
 
+.N Removed
+The replacement routine for this function is 'MPI_Comm_get_errhandler'.
+
 .N ThreadSafe
 
 .N Fortran

--- a/src/mpi/errhan/errhandler_set.c
+++ b/src/mpi/errhan/errhandler_set.c
@@ -35,7 +35,7 @@ Input Parameters:
 
 .N ThreadSafe
 
-.N Deprecated
+.N Removed
 The replacement for this routine is 'MPI_Comm_set_errhandler'.
 
 .N Fortran


### PR DESCRIPTION
## Pull Request Description

MPI-4 will additionally deprecated functions (#4888) although the current `.N Deprecated` macro mentions only MPI-2. This patch introduces new keywords to prepare for MPI-4.

~This PR introduces new keywords `DeprecatedMPI2` and `DeprecatedMPI2RemovedMPI3` to make sure that these functions were deprecated by MPI-2 and some of them were already removed by MPI-3.~ [EDIT] This PR introduces rewrites an explanation of `Deprecated` and introduces a new keyword `Removed` to make sure that these functions were deprecated by the latest MPI and some of them were already removed.

`MPI_Type_hvector()` and `MPI_Errhandler_get()` missed `Removed`, so this PR also fixed it.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
