### PR TITLE
MPI-4: MPI_Dims_create() accepts ndims = 0

### DIFF
--- a/src/mpi/topo/dims_create.c
+++ b/src/mpi/topo/dims_create.c
@@ -71,7 +71,11 @@ int MPI_Dims_create(int nnodes, int ndims, int dims[])
         {
             MPIR_ERRTEST_ARGNEG(nnodes, "nnodes", mpi_errno);
             MPIR_ERRTEST_ARGNEG(ndims, "ndims", mpi_errno);
-            MPIR_ERRTEST_ARGNULL(dims, "dims", mpi_errno);
+            if (!(nnodes == 1 && ndims == 0)) {
+                /* nnodes == 1 && ndims == 0 is allowed.
+                 * When ndims is 0, dims can be NULL. */
+                MPIR_ERRTEST_ARGNULL(dims, "dims", mpi_errno);
+            }
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1459,6 +1459,7 @@
 /topo/cartsuball
 /topo/cartzero
 /topo/dgraph_unwgt
+/topo/dims0
 /topo/dims1
 /topo/dims2
 /topo/dims3

--- a/test/mpi/topo/Makefile.am
+++ b/test/mpi/topo/Makefile.am
@@ -16,6 +16,7 @@ noinst_PROGRAMS = \
     cartshift1    \
     cartsuball    \
     cartcreates   \
+    dims0         \
     dims1         \
     dims2         \
     dims3         \

--- a/test/mpi/topo/dims0.c
+++ b/test/mpi/topo/dims0.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include "mpitest.h"
+
+/*
+ * Test a corner case. See https://github.com/mpi-forum/mpi-issues/issues/72
+ */
+int main(int argc, char *argv[])
+{
+    int mpi_error, errs = 0;
+    MTest_Init(&argc, &argv);
+
+    /* 0 dimensional test */
+    mpi_error = MPI_Dims_create(1, 0, NULL);
+    if (mpi_error != MPI_SUCCESS) {
+        errs++;
+        printf("Dims_create should succeed if nnodes = 1 and ndims = 0\n");
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/topo/testlist
+++ b/test/mpi/topo/testlist
@@ -3,6 +3,7 @@ cartzero 4
 cartshift1 4
 cartsuball 4
 cartcreates 4
+dims0 1
 dims1 4
 dims2 1
 dims3 1


### PR DESCRIPTION
## Pull Request Description

`MPI_Dims_create()` should accept `ndims = 0` if `nnodes = 1`.

This patch resolves #4922. 
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
