### PR TITLE
MPI-4: deprecate MPI_T_ERR_INVALID_ITEM

### DIFF
--- a/doc/mansrc/mpiconsts.txt
+++ b/doc/mansrc/mpiconsts.txt
@@ -528,7 +528,6 @@ Error codes for MPI_T:
 . MPI_T_ERR_NOT_INITIALIZED   - Interface not initialized
 . MPI_T_ERR_CANNOT_INIT       - Interface not in the state to be initialized
 . MPI_T_ERR_INVALID_INDEX     - The index is invalid or has been deleted
-. MPI_T_ERR_INVALID_ITEM      - Item index queried is out of range
 . MPI_T_ERR_INVALID_HANDLE    - The handle is invalid
 . MPI_T_ERR_OUT_OF_HANDLES    - No more handles available
 . MPI_T_ERR_OUT_OF_SESSIONS   - No more sessions available

--- a/maint/docnotes
+++ b/maint/docnotes
@@ -484,10 +484,6 @@ N*/
 . MPI_T_ERR_INVALID_INDEX - Index is invalid or has been deleted.
 N*/
 
-/*N MPI_T_ERR_INVALID_ITEM
-. MPI_T_ERR_INVALID_ITEM - Item index queried is out of range.
-N*/
-
 /*N MPI_T_ERR_INVALID_NAME
 . MPI_T_ERR_INVALID_NAME - The variable or category name is invalid
 N*/

--- a/src/env/mpivars.c
+++ b/src/env/mpivars.c
@@ -536,9 +536,6 @@ const char *mpit_errclasscheck(int err)
         case MPI_T_ERR_INVALID_INDEX:
             p = "MPI_T index invalid";
             break;
-        case MPI_T_ERR_INVALID_ITEM:
-            p = "MPI_T item index out of range";
-            break;
         case MPI_T_ERR_INVALID_HANDLE:
             p = "MPI_T handle invalid";
             break;

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -856,7 +856,9 @@ typedef int (MPIX_Grequest_wait_function)(int, void **, double, MPI_Status *);
                                            be initialized */
 #define MPI_T_ERR_INVALID_INDEX     62  /* The index is invalid or
                                            has been deleted  */
-#define MPI_T_ERR_INVALID_ITEM      63  /* Item index queried is out of range */
+#define MPI_T_ERR_INVALID_ITEM      MPI_T_ERR_INVALID_INDEX
+                                        /* Deprecated.  If a queried item index is out of range,
+                                         * MPI-4 will return MPI_T_ERR_INVALID_INDEX instead. */
 #define MPI_T_ERR_INVALID_HANDLE    64  /* The handle is invalid */
 #define MPI_T_ERR_OUT_OF_HANDLES    65  /* No more handles available */
 #define MPI_T_ERR_OUT_OF_SESSIONS   66  /* No more sessions available */

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -697,7 +697,7 @@ cvars:
     do {                                                                \
         if ((index_) < 0 || ((unsigned) index_) >= utarray_len((enum_)->items)) \
         {                                                               \
-            MPIR_ERR_SETANDSTMT(err_, MPI_T_ERR_INVALID_ITEM, goto fn_fail, "**itemindex"); \
+            MPIR_ERR_SETANDSTMT(err_, MPI_T_ERR_INVALID_INDEX, goto fn_fail, "**itemindex"); \
         }                                                               \
     } while (0)
 

--- a/src/mpi_t/enum_get_item.c
+++ b/src/mpi_t/enum_get_item.c
@@ -45,7 +45,7 @@ Output Parameters:
 .N MPI_SUCCESS
 .N MPI_T_ERR_NOT_INITIALIZED
 .N MPI_T_ERR_INVALID_HANDLE
-.N MPI_T_ERR_INVALID_ITEM
+.N MPI_T_ERR_INVALID_INDEX
 @*/
 int MPI_T_enum_get_item(MPI_T_enum enumtype, int indx, int *value, char *name, int *name_len)
 {

--- a/test/mpi/mpi_t/mpit_vars.c
+++ b/test/mpi/mpi_t/mpit_vars.c
@@ -470,9 +470,6 @@ char *mpit_errclassToStr(int err)
         case MPI_T_ERR_INVALID_INDEX:
             p = "ERR_INVALID_INDEX";
             break;
-        case MPI_T_ERR_INVALID_ITEM:
-            p = "ERR_INVALID_ITEM";
-            break;
         case MPI_T_ERR_INVALID_HANDLE:
             p = "ERR_INVALID_HANDLE";
             break;

--- a/test/mpi/threads/mpi_t/mpit_threading.c
+++ b/test/mpi/threads/mpi_t/mpit_threading.c
@@ -494,9 +494,6 @@ char *mpit_errclassToStr(int err)
         case MPI_T_ERR_INVALID_INDEX:
             p = "ERR_INVALID_INDEX";
             break;
-        case MPI_T_ERR_INVALID_ITEM:
-            p = "ERR_INVALID_ITEM";
-            break;
         case MPI_T_ERR_INVALID_HANDLE:
             p = "ERR_INVALID_HANDLE";
             break;


### PR DESCRIPTION

## Pull Request Description

MPI-4 deprecated `MPI_T_ERR_INVALID_ITEM` by replacing it with `MPI_T_ERR_INVALID_INDEX`.  `MPI_T_ERR_INVALID_ITEM` is currently used only by `MPI_T_enum_get_item()` in MPICH.

`MPI_T_ERR_INVALID_ITEM` becomes an alias of `MPI_T_ERR_INVALID_INDEX` for backward compatibility.

This PR resolves #4918.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Strictly speaking, this breaks the ABI compatibility since the value of the `MPI_T_ERR_INVALID_ITEM` constant gets changed.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
