### PR TITLE
test: add jenkins/set_xfail.py

### DIFF
--- a/test/mpi/maint/jenkins/set_xfail.py
+++ b/test/mpi/maint/jenkins/set_xfail.py
@@ -1,0 +1,137 @@
+import re
+import sys
+import os
+
+class G:
+    opts = {'jobname': '-', 'compiler': '-', 'jenkins_configure': '-', 'label': '-', 'netmod': '-'}
+    states = []
+    xfails = {}
+
+class RE:
+    m = None
+    def match(pat, str, flags=0):
+        RE.m = re.match(pat, str, flags)
+        return RE.m
+    def search(pat, str, flags=0):
+        RE.m = re.search(pat, str, flags)
+        return RE.m
+
+def main():
+    parse_args()
+    load_xfail_conf()
+    apply_xfails()
+
+# ---- subroutines --------------------------------------------
+def parse_args():
+    opt_names = {'j': "jobname", 'c': "compiler", 'o': "jenkins_configure", 'q': "label", 'm': "netmod", 'f': "XFAIL_CONF"}
+    last_opt = ''
+    for a in sys.argv[1:]:
+        if last_opt:
+            G.opts[last_opt] = a
+            last_opt = ""
+        elif RE.match(r'-(\w)$', a):
+            if RE.m.group(1) in opt_names:
+                last_opt = opt_names[RE.m.group(1)]
+            else:
+                last_opt = RE.m.group(1)
+        elif RE.match(r'--(\w+)=(.*)', a):
+            G.opts[RE.m.group(1)] = RE.m.group(2)
+        elif os.path.exists(a):
+            G.opts['XFAIL_CONF'] = a
+        else:
+            raise Exception("Unrecognized option [%s]\n" % a)
+
+    if 'dir' in G.opts:
+        os.chdir(G.opts['dir'])
+
+    G.states = (G.opts['jobname'], G.opts['compiler'], G.opts['jenkins_configure'], G.opts['netmod'], G.opts['label'])
+
+    if 'XFAIL_CONF' not in G.opts:
+        raise Exception("%s: missing -f XFAIL_CONF\n" % 0)
+
+    str_states = ' | '.join(G.states)
+    print("set_xfail states: %s" % str_states)
+
+def load_xfail_conf():
+    with open(G.opts['XFAIL_CONF'], "r") as In:
+        for line in In:
+            if RE.match(r'^\s*#', line):
+                pass
+            elif RE.match(r'^\s*$', line):
+                pass
+            elif RE.match(r'\s*(.*?)\s*sed\s+-i\s*"([^"]+)"\s+(test.mpi.*)', line):
+                # -- old "sed" pattern
+                cond, pat, testlist = RE.m.group(1, 2, 3)
+                if match_states(cond, G.states):
+                    cond = re.sub(r'\s\s+', ' ', cond)
+                    if testlist not in G.xfails:
+                        G.xfails[testlist] = []
+                    if RE.search(r's[\+\|]\\\((.*)\\\)[\+\|]\\1\s+xfail=(.*)[\+\|]g', pat):
+                        G.xfails[testlist].append({'cond': cond, 'pat': RE.m.group(1), 'reason': RE.m.group(2)})
+                    else:
+                        raise Exception("Unrecognized xfail.conf rule: [%s]\n" % pat)
+                else:
+                    # print(" Unmatched state [%s] - [%s] - %s" % (cond, pat, testlist))
+                    pass
+            elif RE.match(r'\s*(.*?)\s*\/(.*)\/\s*xfail=(\w*)\s*(\S+)\s*$', line):
+                # -- new direct pattern
+                cond, pat, reason, testlist = RE.m.group(1, 2, 3, 4)
+                if match_states(cond, G.states):
+                    cond = re.sub(r'\s\s+', ' ', cond)
+                    if testlist not in G.xfails:
+                        G.xfails[testlist] = []
+                    G.xfails[testlist].append({'cond': cond, 'pat': pat, 'reason': reason})
+                else:
+                    # print(" Unmatched state [%s] - [%s] - %s" % (cond, pat, testlist))
+                    pass
+            else:
+                print("Not parsed: [%s]" % line.rstrip())
+
+def apply_xfails():
+    for f in sorted (G.xfails.keys()):
+        if not os.path.exists(f):
+            print("! testlist: %s does not exist\n" % f)
+            continue
+        rules = G.xfails[f]
+        lines = []
+        n_applied = 0
+        print("testlist: %s ..." % f)
+        with open(f, "r") as In:
+            for line in In:
+                for r in rules:
+                    if not RE.search(r'xfail=', line):
+                        if RE.search(r['pat'], line):
+                            print("    %s:\t%s\t-> xfail=%s" % (r['cond'], r['pat'], r['reason']))
+                            if "dryrun" not in G.opts:
+                                line = line.rstrip() + " xfail=%s\n" % (r['reason'])
+                            n_applied+=1
+                            break
+                lines.append(line)
+
+        if n_applied:
+            with open(f, "w") as Out:
+                for l in lines:
+                    print(l, end='', file=Out)
+        else:
+            print("    %s not changed. Is there a mistake? Rules list:" % f, file=sys.stderr)
+            for r in rules:
+                print("        %s \t:%s" % (r['pat'], r['reason']), file=sys.stderr)
+
+def match_states(cond, states):
+    tlist = cond.split()
+    for i in range(5):
+        if not match(tlist[i], G.states[i]):
+            return 0
+    return 1
+
+def match(pat, var):
+    if pat == '*':
+        return 1
+    elif RE.match(pat, var):
+        return 1
+    else:
+        return 0
+
+# ---------------------------------------------------------
+if __name__ == "__main__":
+    main()

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -31,82 +31,82 @@
 ################################################################################
 
 # xfail ch4 bugs
-* * * ch4:ofi * sed -i "s+\(^idup_comm_gen .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
-* * * ch4:ofi * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
-* * * ch4:ucx * sed -i "s+\(^idup_comm_gen .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
-* * * ch4:ucx * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
+* * * ch4:ofi *         /^idup_comm_gen/ xfail=ticket3794        test/mpi/threads/comm/testlist
+* * * ch4:ofi *         /^idup_nb/       xfail=ticket3794        test/mpi/threads/comm/testlist
+* * * ch4:ucx *         /^idup_comm_gen/ xfail=ticket3794        test/mpi/threads/comm/testlist
+* * * ch4:ucx *         /^idup_nb/       xfail=ticket3794        test/mpi/threads/comm/testlist
 ################################################################################
 # misc special build
-* * nofast * * sed -i "s+\(^large_acc_flush_local .*\)+\1 xfail=issue4663+g" test/mpi/rma/testlist
+* * nofast * *          /^large_acc_flush_local/ xfail=issue4663 test/mpi/rma/testlist
 #ch3:ofi
-* * * ch3:ofi * sed -i  "s+\(^manyget .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
-* * * ch3:ofi * sed -i  "s+\(^manyrma2 .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
-* * * ch3:ofi * sed -i  "s+\(^manyrma2_shm .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
+* * * ch3:ofi *         /^manyget/               xfail=ticket0   test/mpi/rma/testlist
+* * * ch3:ofi *         /^manyrma2/              xfail=ticket0   test/mpi/rma/testlist
+* * * ch3:ofi *         /^manyrma2_shm/          xfail=ticket0   test/mpi/rma/testlist
 ################################################################################
-* * * * osx sed -i "s+\(^throwtest .*\)+\1 xfail=ticket0+g" test/mpi/errors/cxx/errhan/testlist
-* * * * osx sed -i "s+\(^commerrx .*\)+\1 xfail=ticket0+g" test/mpi/errors/cxx/errhan/testlist
-* * * * osx sed -i "s+\(^fileerrretx .*\)+\1 xfail=ticket0+g" test/mpi/errors/cxx/io/testlist
-* * * * osx sed -i "s+\(^throwtestfilex .*\)+\1 xfail=ticket0+g" test/mpi/errors/cxx/io/testlist
-* gnu debug ch3:tcp osx sed -i "s+\(^namepubx .*\)+\1 xfail=issue3506+g" test/mpi/cxx/spawn/testlist
-* intel * * osx sed -i "s+\(^statusesf08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/pt2pt/testlist
-* intel * * osx sed -i "s+\(^vw_inplacef08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/coll/testlist
-* intel * * osx sed -i "s+\(^red_scat_blockf08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/coll/testlist
-* intel * * osx sed -i "s+\(^nonblocking_inpf08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/coll/testlist
-* intel * * osx sed -i "s+\(^structf .*\)+\1 xfail=issue4374+g" test/mpi/f08/datatype/testlist
-* intel * * osx sed -i "s+\(^aintf08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/rma/testlist
-* * * * osx sed -i "s+\(^dgraph_unwgtf90 .*\)+\1 xfail=issue4374+g" test/mpi/f08/topo/testlist
+* * * * osx             /^throwtest/            xfail=ticket0   test/mpi/errors/cxx/errhan/testlist
+* * * * osx             /^commerrx/             xfail=ticket0   test/mpi/errors/cxx/errhan/testlist
+* * * * osx             /^fileerrretx/          xfail=ticket0   test/mpi/errors/cxx/io/testlist
+* * * * osx             /^throwtestfilex/       xfail=ticket0   test/mpi/errors/cxx/io/testlist
+* gnu debug ch3:tcp osx /^namepubx/             xfail=issue3506 test/mpi/cxx/spawn/testlist
+* intel * * osx         /^statusesf08/          xfail=issue4374 test/mpi/f08/pt2pt/testlist
+* intel * * osx         /^vw_inplacef08/        xfail=issue4374 test/mpi/f08/coll/testlist
+* intel * * osx         /^red_scat_blockf08/    xfail=issue4374 test/mpi/f08/coll/testlist
+* intel * * osx         /^nonblocking_inpf08/   xfail=issue4374 test/mpi/f08/coll/testlist
+* intel * * osx         /^structf/              xfail=issue4374 test/mpi/f08/datatype/testlist
+* intel * * osx         /^aintf08/              xfail=issue4374 test/mpi/f08/rma/testlist
+* intel * * osx         /^dgraph_unwgtf90/      xfail=issue4374 test/mpi/f08/topo/testlist
 ################################################################################
 # xfail large count tests on 32 bit architectures (cannot allocate such large memory)
-* * * * freebsd32 sed -i "s|\(^getfence1 [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist.dtp
-* * * * freebsd32 sed -i "s|\(^putfence1 [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist.dtp
-* * * * ubuntu32 sed -i "s|\(^getfence1 [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist.dtp
-* * * * ubuntu32 sed -i "s|\(^putfence1 [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist.dtp
+* * * * freebsd32       /^getfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   test/mpi/rma/testlist.dtp
+* * * * freebsd32       /^putfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   test/mpi/rma/testlist.dtp
+* * * * ubuntu32        /^getfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   test/mpi/rma/testlist.dtp
+* * * * ubuntu32        /^putfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   test/mpi/rma/testlist.dtp
 # intercomm abort test are expected to fail since MPI_Finalize will try to perform Allreduce on all process (includeing the aborted ones)
-* * * * * sed -i "s+\(^intercomm_abort .*\)+\1 xfail=ticket0+g" test/mpi/errors/comm/testlist
+* * * * *               /^intercomm_abort/       xfail=ticket0   test/mpi/errors/comm/testlist
 # asan glitches with ucx for large buffer (when greater than ~1GB)
-* * asan ch4:ucx * sed -i "s+\(^.*\(262144\|65530\|16000000\).*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist.dtp
-* * asan ch4:ucx * sed -i "s+\(^.*\(262144\|65530\|16000000\).*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist.dtp
-* * asan ch4:ucx * sed -i "s+\(^.*\(262144\|65530\|16000000\).*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist.dtp
+* * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   test/mpi/coll/testlist.dtp
+* * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   test/mpi/pt2pt/testlist.dtp
+* * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   test/mpi/rma/testlist.dtp
 # Bug - Github Issue https://github.com/pmodels/mpich/issues/3618
-* * * ch4:ucx * sed -i "s+\(^darray_pack .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
+* * * ch4:ucx *         /^darray_pack/   xfail=ticket0   test/mpi/datatype/testlist
 # Collectivess other than bcast don't currently detect mismatched datatype lengths
-* * * * * sed -i "s+\(^reducelength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^ireducelength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^allreducelength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^iallreducelength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^reduceop .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^ireduceop .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^gatherlength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^igatherlength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^allgatherlength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^iallgatherlength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^alltoalllength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^ialltoalllength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^scatterlength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
-* * * * * sed -i "s+\(^iscatterlength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
+* * * * *               /^reducelength/         xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^ireducelength/        xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^allreducelength/      xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^iallreducelength/     xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^reduceop/             xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^ireduceop/            xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^gatherlength/         xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^igatherlength/        xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^allgatherlength/      xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^iallgatherlength/     xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^alltoalllength/       xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^ialltoalllength/      xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^scatterlength/        xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^iscatterlength/       xfail=ticket3655        test/mpi/errors/coll/testlist
 # some of the bcastlength test that is still failing
-* * *       ch3:ofi * sed -i "s+\(^ibcastlength .*\)+\1 xfail=issue3775+g" test/mpi/errors/coll/testlist
-* * *       ch3:ofi * sed -i "s+\(^bcastlength .*\)+\1 xfail=issue4373+g" test/mpi/errors/coll/testlist
+* * * ch3:ofi *         /^ibcastlength/         xfail=issue3775         test/mpi/errors/coll/testlist
+* * * ch3:ofi *         /^bcastlength/          xfail=issue4373         test/mpi/errors/coll/testlist
 # hwloc is unable to detect topology info on FreeBSD in strict mode with GCC
-* gnu strict * freebsd64 sed -i "s+\(^cmsplit_type .*\)+\1 xfail=ticket3972+g" test/mpi/comm/testlist
-* gnu strict * freebsd32 sed -i "s+\(^cmsplit_type .*\)+\1 xfail=ticket3972+g" test/mpi/comm/testlist
+* gnu strict * freebsd64        /^cmsplit_type/         xfail=ticket3972        test/mpi/comm/testlist
+* gnu strict * freebsd32        /^cmsplit_type/         xfail=ticket3972        test/mpi/comm/testlist
 # multi-threading tests failing for ch3 freebsd64
-* * *       ch3:tcp freebsd64 sed -i "s+\(^mt_iprobe_isendrecv .*\)+\1 xfail=issue4258+g" test/mpi/threads/pt2pt/testlist
-* * *       ch3:tcp freebsd64 sed -i "s+\(^mt_improbe_isendrecv .*\)+\1 xfail=issue4258+g" test/mpi/threads/pt2pt/testlist
+* * * ch3:tcp *         /^mt_iprobe_isendrecv/          xfail=issue4258         test/mpi/threads/pt2pt/testlist
+* * * ch3:tcp *         /^mt_improbe_isendrecv/         xfail=issue4258         test/mpi/threads/pt2pt/testlist
 # pingping tests with large testsize currently fails async tests due to netmod handling of large message queue
-* * async * * sed -i "s+\(^pingping .*testsize=32.*\)+\1 xfail=issue4474+g" test/mpi/pt2pt/testlist.dtp
+* * async * *           /^pingpingtestsize=32.*/         xfail=issue4474        test/mpi/pt2pt/testlist.dtp
 # dup_leak_test suffers from mutex unfairness issue under load for ch4:ofi
-* * * ch4:ofi * sed -i "s+\(^dup_leak_test .*iter=12345.*\)+\1 xfail=issue4595+g" test/mpi/threads/comm/testlist
+* * * ch4:ofi *         /^dup_leak_testiter=12345.*/     xfail=issue4595        test/mpi/threads/comm/testlist
 # more mutex unfairness on freebsd64. note: check these after upgrading freebsd64 hardware
-* * * ch4:ofi freebsd64 sed -i "s+\(^dup_leak_test .*iter=1234.*\)+\1 xfail=issue4595+g" test/mpi/threads/comm/testlist
-* * * ch4:ofi freebsd64 sed -i "s+\(^alltoall .*\)+\1 xfail=issue4595+g" test/mpi/threads/pt2pt/testlist
+* * * ch4:ofi freebsd64 /^dup_leak_testiter=1234.*/      xfail=issue4595        test/mpi/threads/comm/testlist
+* * * ch4:ofi freebsd64 /^alltoall/                      xfail=issue4595        test/mpi/threads/pt2pt/testlist
 # release-gather algorithm won't work with multithread
-* * async * * sed -i "s+\(^.*_ALGORITHM=release_gather.*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist.cvar
+* * async * *           /^.*_ALGORITHM=release_gather.*/ xfail=ticket0          test/mpi/coll/testlist.cvar
 # freebsd failures
-* * debug ch3:tcp freebsd64 sed -i "s+\(^comm_create_group_threads .*\)+\1 xfail=issue4372+g" test/mpi/threads/comm/testlist
+* * debug ch3:tcp freebsd64     /^comm_create_group_threads/     xfail=issue4372        test/mpi/threads/comm/testlist
 
 # Job-sepecific xfails
 # Our Arm servers are too slow for some tests
-mpich-main-arm.* * * * * sed -i "s+\(^sendflood .*\)+\1 xfail=ticket0+g"        test/mpi/pt2pt/testlist
-mpich-main-arm.* * * * * sed -i "s+\(^nonblocking3 .*\)+\1 xfail=ticket0+g"     test/mpi/coll/testlist
-mpich-main-arm.* * * * * sed -i "s+\(^alltoall .*\)+\1 xfail=ticket0+g"         test/mpi/threads/pt2pt/testlist
+mpich-main-arm.* * * * * /^sendflood /          xfail=ticket0       test/mpi/pt2pt/testlist
+mpich-main-arm.* * * * * /^nonblocking3 /       xfail=ticket0       test/mpi/coll/testlist
+mpich-main-arm.* * * * * /^alltoall /           xfail=ticket0       test/mpi/threads/pt2pt/testlist


### PR DESCRIPTION
## Pull Request Description
It is odd to have xfail.conf and set_xfail script maintained in
different repository. This patch adds the script that applies
xfail.conf.

The current script works with the current xfail.conf format, which uses
sed. However, the script actually parses the regex pattern and
applies them directly without depending on sed. Once stablized, we can
further simplify the xfail.conf format.

For example, the current syntax is like this:
```
* * * ch4:ofi * sed -i "s+\(^idup_comm_gen .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
```
It can be simplified as
```
* * * ch4:ofi * /^idup_comm_gen/   xfail=ticket3794   test/mpi/threads/comm/testlist
```

Run the script after `configure` with:
```
python test/mpi/main/jenkins/set_xfail.py -j $JOB_NAME -c $compiler -o $jenkins_configure -q $label -m $netmod -f $SRC/test/mpi/maint/jenkins/xfail.conf
```


<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->
[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
