### PR TITLE
autogen: add libtool patch for NVIDIA HPC compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -613,3 +613,7 @@ Makefile.am-stamp
 /test/mpi/rma/testlist.dtp
 /test/mpi/cxx/attr/testlist.gpu
 /test/mpi/cxx/datatype/testlist.gpu
+
+# /src/binding/c/
+/src/binding/c/Makefile.mk
+/src/binding/c/pt2pt


### PR DESCRIPTION
## Pull Request Description

NVIDIA HPC compilers add nvc, nvc++, nvfortran in addition to the PGI
compiler binary names. This patch fixes libtool for them.

This should fixes the previous attempt which broke the PGI build.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
