### PR TITLE
romio: bcast truncate errno so that all ranks return same error value

### DIFF
--- a/src/mpi/romio/adio/common/ad_resize.c
+++ b/src/mpi/romio/adio/common/ad_resize.c
@@ -20,14 +20,19 @@ void ADIOI_GEN_Resize(ADIO_File fd, ADIO_Offset size, int *error_code)
     if (rank == fd->hints->ranklist[0]) {
         ADIOI_Assert(size == (off_t) size);
         err = ftruncate(fd->fd_sys, (off_t) size);
+        if (err == -1) {
+            /* detected an error, capture value of errno */
+            err = errno;
+        }
     }
 
-    /* bcast return value */
+    /* bcast success/errno value */
     MPI_Bcast(&err, 1, MPI_INT, fd->hints->ranklist[0], fd->comm);
 
     /* --BEGIN ERROR HANDLING-- */
-    if (err == -1) {
-        *error_code = ADIOI_Err_create_code(myname, fd->filename, errno);
+    if (err != 0) {
+        /* when err is not 0, it contains the errno value from ftruncate */
+        *error_code = ADIOI_Err_create_code(myname, fd->filename, err);
         return;
     }
     /* --END ERROR HANDLING-- */


### PR DESCRIPTION
## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

In the call to ``ADIOI_GEN_Resize``, if ``ftruncate()`` returns with an error, it sets ``errno`` to indicate why.  While all ranks detect an error, only rank 0 had the errno, and so only this rank was returning the proper return code from ``ADIOI_GEN_Resize``.  Other ranks were incorrectly returning ``MPI_SUCCESS``.

See: https://github.com/LLNL/UnifyFS/issues/577#issuecomment-733363946

This fix has not been tested.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
