### PR TITLE
romio/daos: update configure to remove unneeded library

### DIFF
--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -780,18 +780,6 @@ if test -n "$FILE_SYSTEM" ; then
    done
 fi
 
-AC_ARG_WITH([cart],
-    [AS_HELP_STRING([--with-cart],
-            [Build DAOS ROMIO driver[default=no]])],,
-    [with_cart=no])
-
-AS_IF([test "x$with_cart" != xno], [
-    CART="yes"
-    PAC_SET_HEADER_LIB_PATH(cart)
-    AC_CHECK_HEADERS(gurt/hash.h,, [unset CART])
-    AC_CHECK_LIB([gurt], [d_hash_table_create],, [unset CART])
-])
-
 AC_ARG_WITH([daos],
     [AS_HELP_STRING([--with-daos],
 	    [Build DAOS ROMIO driver[default=no]])],,
@@ -801,20 +789,19 @@ AS_IF([test "x$with_daos" != xno], [
     DAOS="yes"
     PAC_SET_HEADER_LIB_PATH(daos)
     AC_CHECK_HEADERS(daos_types.h,, [unset DAOS])
+    AC_CHECK_HEADERS(gurt/hash.h,, [unset DAOS])
+    AC_CHECK_LIB([gurt], [d_hash_table_create],, [unset DAOS])
     AC_CHECK_LIB([uuid], [uuid_generate],, [unset DAOS])
-    AC_CHECK_LIB([daos_common], [daos_sgl_init],, [unset DAOS])
     AC_CHECK_LIB([daos], [daos_init],, [unset DAOS])
     AC_CHECK_LIB([dfs], [dfs_mount],, [unset DAOS])
     AC_CHECK_LIB([duns], [duns_resolve_path],, [unset DAOS])
 ])
 
-AS_IF([test "x$CART" != xyes], [unset DAOS])
-
 if test -n "$file_system_daos" ; then
     if test "x$DAOS" == xyes ; then
 	AC_DEFINE(ROMIO_DAOS,1,[Define for ROMIO with DAOS])
     else
-	AC_MSG_ERROR([DAOS support requested but not found (--with-daos, --with-cart)])
+	AC_MSG_ERROR([DAOS support requested but not found (--with-daos)])
     fi
 fi
 


### PR DESCRIPTION
- libdaos_common is not needed anymore
- with-cart option is not needed since cart has been integrated into
  DAOS. in older version of DAOS, cart was installed in production in
  the same location anyway so this change will be backwards compatible.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
