### PR TITLE
datatype/romio: fixing Type_create_darray plus romio flatten

### DIFF
--- a/src/mpi/datatype/datatype_impl.c
+++ b/src/mpi/datatype/datatype_impl.c
@@ -678,6 +678,13 @@ static int MPIR_Type_block(const int *array_of_gsizes,
     if (mysize == 0)
         *st_offset = 0;
 
+    MPI_Datatype type_tmp;
+    MPI_Aint ex;
+    MPIR_Datatype_get_extent_macro(type_old, ex);
+    mpi_errno = MPIR_Type_create_resized(*type_new, 0, array_of_gsizes[dim] * ex, &type_tmp);
+    MPIR_Type_free_impl(type_new);
+    *type_new = type_tmp;
+
     return MPI_SUCCESS;
 }
 
@@ -817,6 +824,12 @@ static int MPIR_Type_cyclic(const int *array_of_gsizes,
 
     if (local_size == 0)
         *st_offset = 0;
+
+    MPI_Aint ex;
+    MPIR_Datatype_get_extent_macro(type_old, ex);
+    mpi_errno = MPIR_Type_create_resized(*type_new, 0, array_of_gsizes[dim] * ex, &type_tmp);
+    MPIR_Type_free_impl(type_new);
+    *type_new = type_tmp;
 
     return MPI_SUCCESS;
 }

--- a/src/mpi/romio/adio/common/ad_darray.c
+++ b/src/mpi/romio/adio/common/ad_darray.c
@@ -195,6 +195,13 @@ static int MPIOI_Type_block(int *array_of_gsizes, int dim, int ndims, int nprocs
     if (mysize == 0)
         *st_offset = 0;
 
+    MPI_Aint ex;
+    MPI_Type_extent(type_old, &ex);
+    MPI_Datatype type_tmp;
+    MPI_Type_create_resized(*type_new, 0, array_of_gsizes[dim] * ex, &type_tmp);
+    MPI_Type_free(type_new);
+    *type_new = type_tmp;
+
     return MPI_SUCCESS;
 }
 
@@ -289,6 +296,12 @@ static int MPIOI_Type_cyclic(int *array_of_gsizes, int dim, int ndims, int nproc
 
     if (local_size == 0)
         *st_offset = 0;
+
+    MPI_Aint ex;
+    MPI_Type_extent(type_old, &ex);
+    MPI_Type_create_resized(*type_new, 0, array_of_gsizes[dim] * ex, &type_tmp);
+    MPI_Type_free(type_new);
+    *type_new = type_tmp;
 
     return MPI_SUCCESS;
 }

--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -28,6 +28,33 @@ static ADIOI_Flatlist_node *flatlist_node_new(MPI_Datatype datatype, MPI_Count c
     return flat;
 }
 
+/*
+ * I don't really expect this to ever trigger, but without the below safety
+ * valve, the design relies on the Count function coming out >= whatever
+ * the Flatten function comes up with.  There are enough differences between
+ * the two that it's hard to be positive this will always be true.  So every
+ * time something's added to flat's arrays, let's make sure they're big enough
+ * and re-alloc if not.
+ */
+static void flatlist_node_grow(ADIOI_Flatlist_node * flat, int idx)
+{
+    if (idx >= flat->count) {
+        ADIO_Offset *new_blocklens;
+        ADIO_Offset *new_indices;
+        int new_count = (flat->count * 1.25 + 4);
+        new_blocklens = (ADIO_Offset *) ADIOI_Calloc(new_count * 2, sizeof(ADIO_Offset));
+        new_indices = new_blocklens + new_count;
+        if (flat->count) {
+            memcpy(new_blocklens, flat->blocklens, flat->count * sizeof(ADIO_Offset));
+            memcpy(new_indices, flat->indices, flat->count * sizeof(ADIO_Offset));
+            ADIOI_Free(flat->blocklens);
+        }
+        flat->blocklens = new_blocklens;
+        flat->indices = new_indices;
+        flat->count = new_count;
+    }
+}
+
 void ADIOI_Optimize_flattened(ADIOI_Flatlist_node * flat_type);
 /* flatten datatype and add it to Flatlist */
 ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype datatype)
@@ -82,6 +109,16 @@ ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype datatype)
 #ifdef FLATTEN_DEBUG
         DBG_FPRINTF(stderr, "ADIOI_Flatten_datatype:: ADIOI_Flatten\n");
 #endif
+
+/*
+ * Setting flat->count to curr_index, since curr_index is the most fundamentally
+ * correct updated value that represents what's in the indices/blocklens arrays.
+ * It would be nice if the counter function and the flatten function were in sync,
+ * but the numerous cases that decrement flat->count in the flatten function show
+ * that syncing them is a hack, and as long as the counter doesn't under-count
+ * it's good enough.
+ */
+        flat->count = curr_index;
 
         ADIOI_Optimize_flattened(flat);
 /* debug */
@@ -228,6 +265,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
             if (prev_index == *curr_index) {
 /* simplest case, made up of basic or contiguous types */
                 j = *curr_index;
+                flatlist_node_grow(flat, j);
                 flat->indices[j] = st_offset;
                 MPI_Type_size_x(types[0], &old_size);
                 flat->blocklens[j] = top_count * old_size;
@@ -246,6 +284,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                 MPI_Type_extent(types[0], &old_extent);
                 for (m = 1; m < top_count; m++) {
                     for (i = 0; i < num; i++) {
+                        flatlist_node_grow(flat, j);
                         flat->indices[j] =
                             flat->indices[j - num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
                         flat->blocklens[j] = flat->blocklens[j - num];
@@ -279,10 +318,12 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                  * avoid >2G integer arithmetic problems */
                 ADIO_Offset blocklength = ints[1], stride = ints[2];
                 j = *curr_index;
+                flatlist_node_grow(flat, j);
                 flat->indices[j] = st_offset;
                 MPI_Type_size_x(types[0], &old_size);
                 flat->blocklens[j] = blocklength * old_size;
                 for (i = j + 1; i < j + top_count; i++) {
+                    flatlist_node_grow(flat, i);
                     flat->indices[i] = flat->indices[i - 1] + stride * old_size;
                     flat->blocklens[i] = flat->blocklens[j];
                 }
@@ -301,6 +342,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                 MPI_Type_extent(types[0], &old_extent);
                 for (m = 1; m < blocklength; m++) {
                     for (i = 0; i < num; i++) {
+                        flatlist_node_grow(flat, j);
                         flat->indices[j] =
                             flat->indices[j - num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
                         flat->blocklens[j] = flat->blocklens[j - num];
@@ -313,6 +355,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                 num = *curr_index - prev_index;
                 for (i = 1; i < top_count; i++) {
                     for (m = 0; m < num; m++) {
+                        flatlist_node_grow(flat, j);
                         flat->indices[j] =
                             flat->indices[j - num] + stride * ADIOI_AINT_CAST_TO_OFFSET old_extent;
                         flat->blocklens[j] = flat->blocklens[j - num];
@@ -342,10 +385,12 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                  * avoid >2G integer arithmetic problems */
                 ADIO_Offset blocklength = ints[1];
                 j = *curr_index;
+                flatlist_node_grow(flat, j);
                 flat->indices[j] = st_offset;
                 MPI_Type_size_x(types[0], &old_size);
                 flat->blocklens[j] = blocklength * old_size;
                 for (i = j + 1; i < j + top_count; i++) {
+                    flatlist_node_grow(flat, i);
                     flat->indices[i] = flat->indices[i - 1] + adds[0];
                     flat->blocklens[i] = flat->blocklens[j];
                 }
@@ -364,6 +409,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                 MPI_Type_extent(types[0], &old_extent);
                 for (m = 1; m < blocklength; m++) {
                     for (i = 0; i < num; i++) {
+                        flatlist_node_grow(flat, j);
                         flat->indices[j] =
                             flat->indices[j - num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
                         flat->blocklens[j] = flat->blocklens[j - num];
@@ -376,6 +422,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                 num = *curr_index - prev_index;
                 for (i = 1; i < top_count; i++) {
                     for (m = 0; m < num; m++) {
+                        flatlist_node_grow(flat, j);
                         flat->indices[j] = flat->indices[j - num] + adds[0];
                         flat->blocklens[j] = flat->blocklens[j - num];
                         j++;
@@ -412,16 +459,15 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                      * avoid >2G integer arithmetic problems */
                     ADIO_Offset blocklength = ints[1 + i - j], stride = ints[top_count + 1 + i - j];
                     if (blocklength > 0) {
+                        flatlist_node_grow(flat, nonzeroth);
                         flat->indices[nonzeroth] =
                             st_offset + stride * ADIOI_AINT_CAST_TO_OFFSET old_extent;
                         flat->blocklens[nonzeroth] =
                             blocklength * ADIOI_AINT_CAST_TO_OFFSET old_extent;
                         nonzeroth++;
-                    } else {
-                        flat->count--;  /* don't count/consider any zero-length blocklens */
                     }
                 }
-                *curr_index = i;
+                *curr_index = nonzeroth;
             } else {
 /* indexed type made up of noncontiguous derived types */
 
@@ -434,14 +480,13 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                 for (m = 1; m < ints[1]; m++) {
                     for (i = 0, nonzeroth = j; i < num; i++) {
                         if (flat->blocklens[j - num] > 0) {
+                            flatlist_node_grow(flat, nonzeroth);
                             flat->indices[nonzeroth] =
                                 flat->indices[nonzeroth - num] +
                                 ADIOI_AINT_CAST_TO_OFFSET old_extent;
                             flat->blocklens[nonzeroth] = flat->blocklens[nonzeroth - num];
                             j++;
                             nonzeroth++;
-                        } else {
-                            flat->count--;
                         }
                     }
                 }
@@ -456,28 +501,26 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                          * avoid >2G integer arithmetic problems */
                         ADIO_Offset stride = ints[top_count + 1 + i] - ints[top_count + i];
                         if (flat->blocklens[j - num] > 0) {
+                            flatlist_node_grow(flat, nonzeroth);
                             flat->indices[nonzeroth] =
                                 flat->indices[j - num] +
                                 stride * ADIOI_AINT_CAST_TO_OFFSET old_extent;
                             flat->blocklens[nonzeroth] = flat->blocklens[j - num];
                             j++;
                             nonzeroth++;
-                        } else {
-                            flat->count--;
                         }
                     }
                     *curr_index = j;
                     for (m = 1; m < ints[1 + i]; m++) {
                         for (k = 0, nonzeroth = j; k < basic_num; k++) {
                             if (flat->blocklens[j - basic_num] > 0) {
+                                flatlist_node_grow(flat, nonzeroth);
                                 flat->indices[nonzeroth] =
                                     flat->indices[j - basic_num] +
                                     ADIOI_AINT_CAST_TO_OFFSET old_extent;
                                 flat->blocklens[nonzeroth] = flat->blocklens[j - basic_num];
                                 j++;
                                 nonzeroth++;
-                            } else {
-                                flat->count--;
                             }
                         }
                     }
@@ -523,9 +566,11 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                      * avoid >2G integer arithmetic problems */
                     ADIO_Offset blocklength = ints[1];
                     if (is_hindexed_block) {
+                        flatlist_node_grow(flat, i);
                         flat->indices[i] = st_offset + adds[i - j];
                     } else {
                         ADIO_Offset stride = ints[1 + 1 + i - j];
+                        flatlist_node_grow(flat, i);
                         flat->indices[i] = st_offset +
                             stride * ADIOI_AINT_CAST_TO_OFFSET old_extent;
                     }
@@ -547,6 +592,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                              * extent of a type */
                             MPI_Type_extent(types[0], &old_extent);
                         }
+                        flatlist_node_grow(flat, j);
                         flat->indices[j] = flat->indices[j - num] +
                             ADIOI_AINT_CAST_TO_OFFSET old_extent;
                         flat->blocklens[j] = flat->blocklens[j - num];
@@ -560,11 +606,13 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                 for (i = 1; i < top_count; i++) {
                     for (m = 0; m < num; m++) {
                         if (is_hindexed_block) {
+                            flatlist_node_grow(flat, j);
                             flat->indices[j] = flat->indices[j - num] + adds[i] - adds[i - 1];
                         } else {
                             /* By using ADIO_Offset we preserve +/- sign and
                              * avoid >2G integer arithmetic problems */
                             ADIO_Offset stride = ints[2 + i] - ints[1 + i];
+                            flatlist_node_grow(flat, j);
                             flat->indices[j] = flat->indices[j - num] +
                                 stride * ADIOI_AINT_CAST_TO_OFFSET old_extent;
                         }
@@ -599,14 +647,13 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                         /* By using ADIO_Offset we preserve +/- sign and
                          * avoid >2G integer arithmetic problems */
                         ADIO_Offset blocklength = ints[1 + i - j];
+                        flatlist_node_grow(flat, nonzeroth);
                         flat->indices[nonzeroth] = st_offset + adds[i - j];
                         flat->blocklens[nonzeroth] = blocklength * old_size;
                         nonzeroth++;
-                    } else {
-                        flat->count--;
                     }
                 }
-                *curr_index = i;
+                *curr_index = nonzeroth;
             } else {
 /* indexed type made up of noncontiguous derived types */
 
@@ -620,13 +667,12 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                 for (m = 1; m < ints[1]; m++) {
                     for (i = 0, nonzeroth = j; i < num; i++) {
                         if (flat->blocklens[j - num] > 0) {
+                            flatlist_node_grow(flat, nonzeroth);
                             flat->indices[nonzeroth] =
                                 flat->indices[j - num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
                             flat->blocklens[nonzeroth] = flat->blocklens[j - num];
                             j++;
                             nonzeroth++;
-                        } else {
-                            flat->count--;
                         }
                     }
                 }
@@ -638,19 +684,19 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                     prev_index = *curr_index;
                     for (m = 0, nonzeroth = j; m < basic_num; m++) {
                         if (flat->blocklens[j - num] > 0) {
+                            flatlist_node_grow(flat, nonzeroth);
                             flat->indices[nonzeroth] =
                                 flat->indices[j - num] + adds[i] - adds[i - 1];
                             flat->blocklens[nonzeroth] = flat->blocklens[j - num];
                             j++;
                             nonzeroth++;
-                        } else {
-                            flat->count--;
                         }
                     }
                     *curr_index = j;
                     for (m = 1; m < ints[1 + i]; m++) {
                         for (k = 0, nonzeroth = j; k < basic_num; k++) {
                             if (flat->blocklens[j - basic_num] > 0) {
+                                flatlist_node_grow(flat, nonzeroth);
                                 flat->indices[nonzeroth] =
                                     flat->indices[j - basic_num] +
                                     ADIOI_AINT_CAST_TO_OFFSET old_extent;
@@ -686,6 +732,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                     if (ints[1 + n] > 0 || types[n] == MPI_LB || types[n] == MPI_UB) {
                         ADIO_Offset blocklength = ints[1 + n];
                         j = *curr_index;
+                        flatlist_node_grow(flat, j);
                         flat->indices[j] = st_offset + adds[n];
                         MPI_Type_size_x(types[n], &old_size);
                         flat->blocklens[j] = blocklength * old_size;
@@ -700,9 +747,6 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                                     n, adds[n], j, flat->indices[j], j, flat->blocklens[j]);
 #endif
                         (*curr_index)++;
-                    } else {
-                        flat->count--;  /* don't count/consider any zero-length
-                                         * blocklens */
                     }
                 } else {
 /* current type made up of noncontiguous derived types */
@@ -714,6 +758,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                     MPI_Type_extent(types[n], &old_extent);
                     for (m = 1; m < ints[1 + n]; m++) {
                         for (i = 0; i < num; i++) {
+                            flatlist_node_grow(flat, j);
                             flat->indices[j] =
                                 flat->indices[j - num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
                             flat->blocklens[j] = flat->blocklens[j - num];
@@ -746,6 +791,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
              * bound based on the inner type, but the lower bound based on the
              * upper type.  check both lb and ub to prevent mixing updates */
             if (flat->lb_idx == -1 && flat->ub_idx == -1) {
+                flatlist_node_grow(flat, j);
                 flat->indices[j] = st_offset + adds[0];
                 /* this zero-length blocklens[] element, unlike elsewhere in the
                  * flattening code, is correct and is used to indicate a lower bound
@@ -765,7 +811,6 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
             } else {
                 /* skipped over this chunk because something else higher-up in the
                  * type construction set this for us already */
-                flat->count--;
                 st_offset -= adds[0];
             }
 
@@ -779,6 +824,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
             } else {
                 /* current type is basic or contiguous */
                 j = *curr_index;
+                flatlist_node_grow(flat, j);
                 flat->indices[j] = st_offset;
                 MPI_Type_size_x(types[0], &old_size);
                 flat->blocklens[j] = old_size;
@@ -797,6 +843,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
             /* see note above about mixing updates for why we check lb and ub */
             if ((flat->lb_idx == -1 && flat->ub_idx == -1) || lb_updated) {
                 j = *curr_index;
+                flatlist_node_grow(flat, j);
                 flat->indices[j] = st_offset + adds[0] + adds[1];
                 /* again, zero-element ok: an upper-bound marker explicitly set by the
                  * constructor of this resized type */
@@ -805,7 +852,6 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
             } else {
                 /* skipped over this chunk because something else higher-up in the
                  * type construction set this for us already */
-                flat->count--;
                 (*curr_index)--;
             }
 


### PR DESCRIPTION
Two fixes here:
1. darray needs a resize in the block()/cyclic() subtype creation
2. romio flatten has flat->count consistency problems

When Type_create_darray() uses the block()/cyclic() function to
construct a subtype for whatever dimension it's processing, it
needs to resize the resulting type before it goes into the type
construction as the input for processing the next dimension.

(The same problem is in the main path's type creation, and in romio's
mirroring of it).

Gist for a testcase:
https://gist.github.com/markalle/940de93d64fd779e304ee124855b8e6a

The darray_bug_romio.c testcase creates a darray using
* 4 ranks in a 2x2 grid
* looking at the type made for rank 0
* inner dimension: 4 ints distributed block over 2 ranks with 2 items each
* outer dimension: 6 of the above distributed cyclic over 2 ranks with 2 items each

The type created by processing the first dimension should look like this
[ x x . . ]

And then distributing 6 of the above for the outer dimension would be
[ x x . . ]
[ x x . . ]
[ . . . . ]
[ . . . . ]
[ x x . . ]
[ x x . . ]

But if we remove this PR's resize at the bottom of MPIOI_Type_block()
for example, the first dimension is just
[ x x ]

And then distributing those for the second dimension becomes

[ x x x x ]
[ . . . . ]
[ . . . . ]
[ . . . . ]
[ x x x x ]
[ . . . . ]

Going to the MPI standard to justify why the first layout is right,
it's where the definiton of the cyclic() function has a ub_marker
of gsize*ex, eg 4 ints for that first type.

I did notice datatype_impl.c has a resize already in its cyclic() function,
but I wasn't sure if that was trying to handle this case or not, and that
resize isn't mirrored in the romio code.  Either way it's not handling the
case right as "ex" in the standard isn't the orig_extent, it's the extent
of oldtype that came from the previous dimension.  Eg in the outer dimension
above gsize=6 and ex=16 when setting the size for the final type.

--------
Second change, orthogonal to the above, for romio Flatten:

ADIOI_Count_contiguous_blocks and ADIOI_Flatten are very similar functions,
but they diverge a lot around the edges and in degenerate cases.  In Spectrum
MPI I spent some time making them consistent with each other but
found that to be a losing battle.

So the approach I used here is to not have Count() be as definitive,
and rather let Flatten() have the last word on what the final flat->count
really is.  Eg Flatten's *curr_index is the real count.

The changes I made are

1. Fix a couple places in Flatten where *curr_index was updated out
of sync with what was actually being added to flat->indices[] and
flat->blocklens[].  That's one of the important book-keeping rules
Flatten should follow.  There were a couple places (when counts[] arrays
have 0s) where that wasn't the case (see the "nonzeroth" var in this
commit).

2. The main change I made was to reset flat->count based on
Flatten's curr_index.  This is because the divergence between the
two functions is too great to reliably fix.

3. A third change is just a safety valve, using a
flatlist_node_grow() function just in case the
Count function returns a smaller value than Flatten ends up
trying to write into the array, and related to this I
got rid of the various --(flat->count) lines, since that var now
represents the allocated size of the array, until right after
the Flatten function when it's reset to represent the data written
to the array like it used to be.

I don't think we even need ADIOI_Count_contiguous_blocks() anymore,
but I didn't remove it.

Signed-off-by: Mark Allen <markalle@us.ibm.com>

***************************************************************
I'm not sure if IBM has a signed contributors license yet, but I figure
we can do that in the background while this PR is being reviewed.