### PR TITLE
config: default ch4 netmod selection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5502,4 +5502,27 @@ AC_OUTPUT(Makefile \
           doc/userguide/Makefile \
           test/commands/cmdtests)
 
+if test ${device_name} = "ch4" ; then
+cat <<EOF
+***
+*** device: ch4
+*** netmods: ${ch4_netmods}
+*** shm: ${ch4_shm}
+***
+EOF
+elif test ${DEVICE} = "ch3:nemesis" ; then
+cat <<EOF
+***
+*** device configuration: ch3:nemesis
+*** nemesis networks: ${nemesis_networks}
+***
+EOF
+else
+cat <<EOF
+***
+*** device configuration: ${DEVICE}
+***
+EOF
+fi
+
 echo 'Configuration completed.'

--- a/configure.ac
+++ b/configure.ac
@@ -480,33 +480,7 @@ dnl "default" is a special device that allows MPICH to choose one
 dnl based on the environment.
 AC_ARG_WITH(device,
 	AC_HELP_STRING([--with-device=name], [Specify the communication device for MPICH]),,
-	with_device=default)
-
-if test $with_device = "default" -o $with_device = "ch4" ; then
-  dnl default linux builds must choose a netmod.
-  AC_MSG_ERROR([no ch4 netmod selected
-
-  The default ch4 device requires users to choose a netmod. Supported
-  options are ofi (libfabric) and ucx:
-
-    --with-device=ch4:ofi or --with-device=ch4:ucx
-
-  Configure will attempt to discover external libfabric or ucx
-  libraries to link with. Users may also specify an installation by
-  adding
-
-    --with-libfabric=<path/to/install> or --with-ucx=<path/to/install>
-
-  to the configuration. If no installation is specified or found, an
-  embedded library will be built and used.
-
-  The previous MPICH default device (ch3) is also available and
-  supported with option:
-
-    --with-device=ch3
-  ])
-fi
-
+	with_device=ch4)
 
 AC_ARG_WITH(pmi,
 	AC_HELP_STRING([--with-pmi=name], [Specify the pmi interface for MPICH]),,

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -46,28 +46,34 @@ MPID_MAX_ERROR_STRING=512
 
 # $device_args - contains the netmods
 if test -z "${device_args}" ; then
-  dnl default linux builds must choose a netmod.
-  AC_MSG_ERROR([no ch4 netmod selected
+  dnl attempt to choose a netmod from the installed libraries
+  if test $have_ucx = "yes" -a $have_libfabric = "no" ; then
+      ch4_netmods=ucx
+  elif test $have_ucx = "no" -a $have_libfabric = "yes" ; then
+      ch4_netmods=ofi
+  else
+      dnl prompt the user to choose
+      AC_MSG_ERROR([no ch4 netmod selected
 
-  The default ch4 device requires users to choose a netmod. Supported
-  options are ofi (libfabric) and ucx:
+  The default ch4 device could not detect a preferred network
+  library. Supported options are ofi (libfabric) and ucx:
 
     --with-device=ch4:ofi or --with-device=ch4:ucx
 
-  Configure will attempt to discover external libfabric or ucx
-  libraries to link with. Users may also specify an installation by
-  adding
+  Configure will use an embedded copy of libfabric or ucx if one is
+  not found in the user environment. An installation can be specified
+  by adding
 
     --with-libfabric=<path/to/install> or --with-ucx=<path/to/install>
 
-  to the configuration. If no installation is specified or found, an
-  embedded library will be built and used.
+  to the configuration.
 
   The previous MPICH default device (ch3) is also available and
   supported with option:
 
     --with-device=ch3
   ])
+  fi
 else
     changequote(<<,>>)
     netmod_args=`echo ${device_args} | sed -e 's/^[^:]*//' -e 's/^://' -e 's/,/ /g'`

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -46,8 +46,28 @@ MPID_MAX_ERROR_STRING=512
 
 # $device_args - contains the netmods
 if test -z "${device_args}" ; then
-    AC_MSG_ERROR([Netmod configuration not specified. To build ch4, you must select a netmod:
-    --with-device=ch4:ofi or --with-device=ch4:ucx])
+  dnl default linux builds must choose a netmod.
+  AC_MSG_ERROR([no ch4 netmod selected
+
+  The default ch4 device requires users to choose a netmod. Supported
+  options are ofi (libfabric) and ucx:
+
+    --with-device=ch4:ofi or --with-device=ch4:ucx
+
+  Configure will attempt to discover external libfabric or ucx
+  libraries to link with. Users may also specify an installation by
+  adding
+
+    --with-libfabric=<path/to/install> or --with-ucx=<path/to/install>
+
+  to the configuration. If no installation is specified or found, an
+  embedded library will be built and used.
+
+  The previous MPICH default device (ch3) is also available and
+  supported with option:
+
+    --with-device=ch3
+  ])
 else
     changequote(<<,>>)
     netmod_args=`echo ${device_args} | sed -e 's/^[^:]*//' -e 's/^://' -e 's/,/ /g'`

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -46,14 +46,16 @@ MPID_MAX_ERROR_STRING=512
 
 # $device_args - contains the netmods
 if test -z "${device_args}" ; then
-  dnl attempt to choose a netmod from the installed libraries
-  if test $have_ucx = "yes" -a $have_libfabric = "no" ; then
-      ch4_netmods=ucx
-  elif test $have_ucx = "no" -a $have_libfabric = "yes" ; then
-      ch4_netmods=ofi
-  else
-      dnl prompt the user to choose
-      AC_MSG_ERROR([no ch4 netmod selected
+  AS_CASE([$host_os],
+  [linux*],[
+    dnl attempt to choose a netmod from the installed libraries
+    if test $have_ucx = "yes" -a $have_libfabric = "no" ; then
+        ch4_netmods=ucx
+    elif test $have_ucx = "no" -a $have_libfabric = "yes" ; then
+        ch4_netmods=ofi
+    else
+        dnl prompt the user to choose
+        AC_MSG_ERROR([no ch4 netmod selected
 
   The default ch4 device could not detect a preferred network
   library. Supported options are ofi (libfabric) and ucx:
@@ -72,8 +74,12 @@ if test -z "${device_args}" ; then
   supported with option:
 
     --with-device=ch3
-  ])
-  fi
+    ])
+    fi],
+    [
+      dnl non-linux use libfabric
+      ch4_netmods=ofi
+    ])
 else
     changequote(<<,>>)
     netmod_args=`echo ${device_args} | sed -e 's/^[^:]*//' -e 's/^://' -e 's/,/ /g'`


### PR DESCRIPTION
## Pull Request Description

Add rudimentary logic for default ch4 netmod selection based on host OS and library information.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Users will not be prompted to select a netmod if configure can make an informed guess.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
