### PR TITLE
test: do not free MPI_COMM_WORLD in group error tests

### DIFF
--- a/test/mpi/errors/group/group_difference_nullarg.c
+++ b/test/mpi/errors/group/group_difference_nullarg.c
@@ -38,7 +38,6 @@ int main(int argc, char **argv)
     MPI_Group_free(&basegroup);
     MPI_Group_free(&g1);
     MPI_Group_free(&g2);
-    MPI_Comm_free(&comm);
     MPI_Comm_free(&newcomm);
     MPI_Comm_free(&dupcomm);
     MTest_Finalize(errs);

--- a/test/mpi/errors/group/group_intersection_nullarg.c
+++ b/test/mpi/errors/group/group_intersection_nullarg.c
@@ -33,7 +33,6 @@ int main(int argc, char **argv)
     if (errclass != MPI_ERR_ARG)
         ++errs;
 
-    MPI_Comm_free(&comm);
     MPI_Comm_free(&newcomm);
     MPI_Group_free(&basegroup);
     MPI_Group_free(&g1);

--- a/test/mpi/errors/group/group_range_excl_nullarg.c
+++ b/test/mpi/errors/group/group_range_excl_nullarg.c
@@ -36,7 +36,6 @@ int main(int argc, char **argv)
     if (errclass != MPI_ERR_ARG)
         ++errs;
 
-    MPI_Comm_free(&comm);
     MPI_Comm_free(&newcomm);
     MPI_Group_free(&basegroup);
     MPI_Group_free(&g1);

--- a/test/mpi/errors/group/group_range_incl_nullarg.c
+++ b/test/mpi/errors/group/group_range_incl_nullarg.c
@@ -36,7 +36,6 @@ int main(int argc, char **argv)
     if (errclass != MPI_ERR_ARG)
         ++errs;
 
-    MPI_Comm_free(&comm);
     MPI_Comm_free(&newcomm);
     MPI_Group_free(&basegroup);
     MPI_Group_free(&g1);

--- a/test/mpi/errors/group/group_rank_nullarg.c
+++ b/test/mpi/errors/group/group_rank_nullarg.c
@@ -27,7 +27,6 @@ int main(int argc, char **argv)
     if (errclass != MPI_ERR_ARG)
         ++errs;
 
-    MPI_Comm_free(&comm);
     MPI_Group_free(&basegroup);
     MTest_Finalize(errs);
     return 0;

--- a/test/mpi/errors/group/group_size_nullarg.c
+++ b/test/mpi/errors/group/group_size_nullarg.c
@@ -29,7 +29,6 @@ int main(int argc, char **argv)
     if (errclass != MPI_ERR_ARG)
         ++errs;
 
-    MPI_Comm_free(&comm);
     MPI_Group_free(&basegroup);
     MTest_Finalize(errs);
     return 0;

--- a/test/mpi/errors/group/group_translate_ranks_nullarg.c
+++ b/test/mpi/errors/group/group_translate_ranks_nullarg.c
@@ -38,7 +38,6 @@ int main(int argc, char **argv)
     if (errclass != MPI_ERR_ARG)
         ++errs;
 
-    MPI_Comm_free(&comm);
     MPI_Comm_free(&newcomm);
     MPI_Group_free(&basegroup);
     MPI_Group_free(&g1);

--- a/test/mpi/errors/group/group_union_nullarg.c
+++ b/test/mpi/errors/group/group_union_nullarg.c
@@ -34,7 +34,6 @@ int main(int argc, char **argv)
     if (errclass != MPI_ERR_ARG)
         ++errs;
 
-    MPI_Comm_free(&comm);
     MPI_Comm_free(&newcomm);
     MPI_Comm_free(&dupcomm);
     MPI_Group_free(&basegroup);


### PR DESCRIPTION
## Pull Request Description

I believe freeing built-in comm is erroneous or at least undefined.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
