### PR TITLE
mpi: rename mpi 4.0 functions from MPIX to MPI prefix

### DIFF
--- a/src/binding/fortran/use_mpi_f08/mpi_c_interface_nobuf.f90
+++ b/src/binding/fortran/use_mpi_f08/mpi_c_interface_nobuf.f90
@@ -1384,7 +1384,7 @@ function MPIR_Add_error_string_c(errorcode, string) &
 end function MPIR_Add_error_string_c
 
 function MPIR_Delete_error_class_c(errorclass) &
-    bind(C, name="PMPIX_Delete_error_class") result(ierror)
+    bind(C, name="PMPI_Delete_error_class") result(ierror)
     use, intrinsic :: iso_c_binding, only : c_int
     implicit none
     integer(c_int), intent(in) :: errorclass
@@ -1392,7 +1392,7 @@ function MPIR_Delete_error_class_c(errorclass) &
 end function MPIR_Delete_error_class_c
 
 function MPIR_Delete_error_code_c(errorcode) &
-    bind(C, name="PMPIX_Delete_error_code") result(ierror)
+    bind(C, name="PMPI_Delete_error_code") result(ierror)
     use, intrinsic :: iso_c_binding, only : c_int
     use :: mpi_c_interface_types, only : c_Datatype, c_Comm, c_Request
     implicit none
@@ -1401,7 +1401,7 @@ function MPIR_Delete_error_code_c(errorcode) &
 end function MPIR_Delete_error_code_c
 
 function MPIR_Delete_error_string_c(errorcode) &
-    bind(C, name="PMPIX_Delete_error_string") result(ierror)
+    bind(C, name="PMPI_Delete_error_string") result(ierror)
     use, intrinsic :: iso_c_binding, only : c_int
     use :: mpi_c_interface_types, only : c_Datatype, c_Comm, c_Request
     implicit none

--- a/src/binding/fortran/use_mpi_f08/mpi_c_interface_nobuf.f90
+++ b/src/binding/fortran/use_mpi_f08/mpi_c_interface_nobuf.f90
@@ -611,7 +611,7 @@ function MPIR_Comm_idup_c(comm, newcomm, request) &
 end function MPIR_Comm_idup_c
 
 function MPIR_Comm_idup_with_info_c(comm, info, newcomm, request) &
-    bind(C, name="PMPIX_Comm_idup_with_info") result(ierror)
+    bind(C, name="PMPI_Comm_idup_with_info") result(ierror)
     use, intrinsic :: iso_c_binding, only : c_int
     use :: mpi_c_interface_types, only : c_Comm, c_Info, c_Request
     implicit none

--- a/src/binding/fortran/use_mpi_f08/mpi_f08.f90
+++ b/src/binding/fortran/use_mpi_f08/mpi_f08.f90
@@ -1451,8 +1451,8 @@ interface MPI_Comm_idup
     end subroutine MPI_Comm_idup_f08
 end interface MPI_Comm_idup
 
-interface MPIX_Comm_idup_with_info
-    subroutine MPIX_Comm_idup_with_info_f08(comm, info, newcomm, request, ierror)
+interface MPI_Comm_idup_with_info
+    subroutine MPI_Comm_idup_with_info_f08(comm, info, newcomm, request, ierror)
         use :: mpi_f08_types, only : MPI_Comm, MPI_Info, MPI_Request
         implicit none
         type(MPI_Comm), intent(in) :: comm
@@ -1460,8 +1460,8 @@ interface MPIX_Comm_idup_with_info
         type(MPI_Comm), intent(out), asynchronous :: newcomm
         type(MPI_Request), intent(out) :: request
         integer, optional, intent(out) :: ierror
-    end subroutine MPIX_Comm_idup_with_info_f08
-end interface MPIX_Comm_idup_with_info
+    end subroutine MPI_Comm_idup_with_info_f08
+end interface MPI_Comm_idup_with_info
 
 interface MPI_Comm_free
     subroutine MPI_Comm_free_f08(comm, ierror)

--- a/src/binding/fortran/use_mpi_f08/wrappers_f/comm_idup_with_info_f08ts.f90
+++ b/src/binding/fortran/use_mpi_f08/wrappers_f/comm_idup_with_info_f08ts.f90
@@ -3,7 +3,7 @@
 !     See COPYRIGHT in top-level directory
 !
 
-subroutine MPIX_Comm_idup_with_info_f08(comm, info, newcomm, request, ierror)
+subroutine MPI_Comm_idup_with_info_f08(comm, info, newcomm, request, ierror)
     use, intrinsic :: iso_c_binding, only : c_int
     use :: mpi_f08, only : MPI_Comm, MPI_Info, MPI_Request
     use :: mpi_c_interface, only : c_Comm, c_Info, c_Request
@@ -35,4 +35,4 @@ subroutine MPIX_Comm_idup_with_info_f08(comm, info, newcomm, request, ierror)
 
     if (present(ierror)) ierror = ierror_c
 
-end subroutine MPIX_Comm_idup_with_info_f08
+end subroutine MPI_Comm_idup_with_info_f08

--- a/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_class_f08ts.f90
+++ b/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_class_f08ts.f90
@@ -3,7 +3,7 @@
 !     See COPYRIGHT in top-level directory
 !
 
-subroutine MPIX_Delete_error_class_f08(errorclass, ierror)
+subroutine MPI_Delete_error_class_f08(errorclass, ierror)
     use, intrinsic :: iso_c_binding, only : c_int
     use :: mpi_c_interface, only : MPIR_Delete_error_class_c
 
@@ -24,4 +24,4 @@ subroutine MPIX_Delete_error_class_f08(errorclass, ierror)
 
     if (present(ierror)) ierror = ierror_c
 
-end subroutine MPIX_Delete_error_class_f08
+end subroutine MPI_Delete_error_class_f08

--- a/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_code_f08ts.f90
+++ b/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_code_f08ts.f90
@@ -3,7 +3,7 @@
 !     See COPYRIGHT in top-level directory
 !
 
-subroutine MPIX_Delete_error_code_f08(errorcode, ierror)
+subroutine MPI_Delete_error_code_f08(errorcode, ierror)
     use, intrinsic :: iso_c_binding, only : c_int
     use :: mpi_c_interface, only : c_Datatype, c_Comm, c_Request
     use :: mpi_c_interface, only : MPIR_Delete_error_code_c
@@ -25,4 +25,4 @@ subroutine MPIX_Delete_error_code_f08(errorcode, ierror)
 
     if (present(ierror)) ierror = ierror_c
 
-end subroutine MPIX_Delete_error_code_f08
+end subroutine MPI_Delete_error_code_f08

--- a/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_string_f08ts.f90
+++ b/src/binding/fortran/use_mpi_f08/wrappers_f/delete_error_string_f08ts.f90
@@ -3,7 +3,7 @@
 !     See COPYRIGHT in top-level directory
 !
 
-subroutine MPIX_Delete_error_string_f08(errorcode, ierror)
+subroutine MPI_Delete_error_string_f08(errorcode, ierror)
     use, intrinsic :: iso_c_binding, only : c_int, c_char
     use :: mpi_c_interface, only : c_Datatype, c_Comm, c_Request
     use :: mpi_c_interface, only : MPIR_Delete_error_string_c
@@ -26,4 +26,4 @@ subroutine MPIX_Delete_error_string_f08(errorcode, ierror)
 
     if (present(ierror)) ierror = ierror_c
 
-end subroutine MPIX_Delete_error_string_f08
+end subroutine MPI_Delete_error_string_f08

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -1230,11 +1230,11 @@ int MPI_Win_sync(MPI_Win win) MPICH_API_PUBLIC;
  
 /* External Interfaces */
 int MPI_Add_error_class(int *errorclass) MPICH_API_PUBLIC;
-int MPIX_Delete_error_class(int errorclass) MPICH_API_PUBLIC;
+int MPI_Delete_error_class(int errorclass) MPICH_API_PUBLIC;
 int MPI_Add_error_code(int errorclass, int *errorcode) MPICH_API_PUBLIC;
-int MPIX_Delete_error_code(int errorcode) MPICH_API_PUBLIC;
+int MPI_Delete_error_code(int errorcode) MPICH_API_PUBLIC;
 int MPI_Add_error_string(int errorcode, const char *string) MPICH_API_PUBLIC;
-int MPIX_Delete_error_string(int errorcode) MPICH_API_PUBLIC;
+int MPI_Delete_error_string(int errorcode) MPICH_API_PUBLIC;
 int MPI_Comm_call_errhandler(MPI_Comm comm, int errorcode) MPICH_API_PUBLIC;
 int MPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn,
                            MPI_Comm_delete_attr_function *comm_delete_attr_fn, int *comm_keyval,
@@ -1885,11 +1885,11 @@ int PMPI_Win_sync(MPI_Win win) MPICH_API_PUBLIC;
  
 /* External Interfaces */
 int PMPI_Add_error_class(int *errorclass) MPICH_API_PUBLIC;
-int PMPIX_Delete_error_class(int errorclass) MPICH_API_PUBLIC;
+int PMPI_Delete_error_class(int errorclass) MPICH_API_PUBLIC;
 int PMPI_Add_error_code(int errorclass, int *errorcode) MPICH_API_PUBLIC;
-int PMPIX_Delete_error_code(int errorcode) MPICH_API_PUBLIC;
+int PMPI_Delete_error_code(int errorcode) MPICH_API_PUBLIC;
 int PMPI_Add_error_string(int errorcode, const char *string) MPICH_API_PUBLIC;
-int PMPIX_Delete_error_string(int errorcode) MPICH_API_PUBLIC;
+int PMPI_Delete_error_string(int errorcode) MPICH_API_PUBLIC;
 int PMPI_Comm_call_errhandler(MPI_Comm comm, int errorcode) MPICH_API_PUBLIC;
 int PMPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn,
                             MPI_Comm_delete_attr_function *comm_delete_attr_fn, int *comm_keyval,

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -1380,8 +1380,8 @@ int MPI_Mrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message *message,
 
 /* Nonblocking collectives */
 int MPI_Comm_idup(MPI_Comm comm, MPI_Comm *newcomm, MPI_Request *request) MPICH_API_PUBLIC;
-int MPIX_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm,
-                             MPI_Request *request) MPICH_API_PUBLIC;
+int MPI_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm,
+                            MPI_Request *request) MPICH_API_PUBLIC;
 int MPI_Ibarrier(MPI_Comm comm, MPI_Request *request) MPICH_API_PUBLIC;
 int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm,
                MPI_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(1,3) MPICH_API_PUBLIC;
@@ -2035,8 +2035,8 @@ int PMPI_Mrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message *message
 
 /* Nonblocking collectives */
 int PMPI_Comm_idup(MPI_Comm comm, MPI_Comm *newcomm, MPI_Request *request) MPICH_API_PUBLIC;
-int PMPIX_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm,
-                              MPI_Request *request) MPICH_API_PUBLIC;
+int PMPI_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm,
+                             MPI_Request *request) MPICH_API_PUBLIC;
 int PMPI_Ibarrier(MPI_Comm comm, MPI_Request *request) MPICH_API_PUBLIC;
 int PMPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm,
                 MPI_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(1,3) MPICH_API_PUBLIC;

--- a/src/mpi/comm/comm_idup_with_info.c
+++ b/src/mpi/comm/comm_idup_with_info.c
@@ -5,30 +5,29 @@
 
 #include "mpiimpl.h"
 
-/* -- Begin Profiling Symbol Block for routine MPIX_Comm_idup_with_info */
+/* -- Begin Profiling Symbol Block for routine MPI_Comm_idup_with_info */
 #if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPIX_Comm_idup_with_info = PMPIX_Comm_idup_with_info
+#pragma weak MPI_Comm_idup_with_info = PMPI_Comm_idup_with_info
 #elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPIX_Comm_idup_with_info  MPIX_Comm_idup_with_info
+#pragma _HP_SECONDARY_DEF PMPI_Comm_idup_with_info  MPI_Comm_idup_with_info
 #elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPIX_Comm_idup_with_info as PMPIX_Comm_idup_with_info
+#pragma _CRI duplicate MPI_Comm_idup_with_info as PMPI_Comm_idup_with_info
 #elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPIX_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm * newcomm,
-                             MPI_Request * request)
-    __attribute__ ((weak, alias("PMPIX_Comm_idup_with_info")));
+int MPI_Comm_idup_with_info(MPI_Comm comm, MPI_Comm * newcomm, MPI_Request * request)
+    __attribute__ ((weak, alias("PMPI_Comm_idup_with_info")));
 #endif
 /* -- End Profiling Symbol Block */
 
 /* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
    the MPI routines */
 #ifndef MPICH_MPI_FROM_PMPI
-#undef MPIX_Comm_idup_with_info
-#define MPIX_Comm_idup_with_info PMPIX_Comm_idup_with_info
+#undef MPI_Comm_idup_with_info
+#define MPI_Comm_idup_with_info PMPI_Comm_idup_with_info
 
 #endif /* MPICH_MPI_FROM_PMPI */
 
 /*@
-MPIX_Comm_idup_with_info - nonblocking communicator duplication
+MPI_Comm_idup_with_info - nonblocking communicator duplication
 
 Input Parameters:
 . comm - communicator (handle)
@@ -43,8 +42,7 @@ Output Parameters:
 
 .N Errors
 @*/
-int MPIX_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm * newcomm,
-                             MPI_Request * request)
+int MPI_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm * newcomm, MPI_Request * request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm *comm_ptr = NULL;
@@ -114,7 +112,8 @@ int MPIX_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm * newcomm,
     {
         mpi_errno =
             MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__, MPI_ERR_OTHER,
-                                 "**mpi_comm_idup", "**mpi_comm_idup %C %p %p", comm, newcomm,
+                                 "**mpi_comm_idup_with_info",
+                                 "**mpi_comm_idup_with_info %C %I %p %p", comm, info, newcomm,
                                  request);
     }
 #endif

--- a/src/mpi/errhan/delete_error_class.c
+++ b/src/mpi/errhan/delete_error_class.c
@@ -6,29 +6,29 @@
 #include "mpiimpl.h"
 #include "errcodes.h"
 
-/* -- Begin Profiling Symbol Block for routine MPIX_Delete_error_class */
+/* -- Begin Profiling Symbol Block for routine MPI_Delete_error_class */
 #if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPIX_Delete_error_class = PMPIX_Delete_error_class
+#pragma weak MPI_Delete_error_class = PMPI_Delete_error_class
 #elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPIX_Delete_error_class  MPIX_Delete_error_class
+#pragma _HP_SECONDARY_DEF PMPI_Delete_error_class  MPI_Delete_error_class
 #elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPIX_Delete_error_class as PMPIX_Delete_error_class
+#pragma _CRI duplicate MPI_Delete_error_class as PMPI_Delete_error_class
 #elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPIX_Delete_error_class(int errorclass)
-    __attribute__ ((weak, alias("PMPIX_Delete_error_class")));
+int MPI_Delete_error_class(int errorclass)
+    __attribute__ ((weak, alias("PMPI_Delete_error_class")));
 #endif
 /* -- End Profiling Symbol Block */
 
 /* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
    the MPI routines */
 #ifndef MPICH_MPI_FROM_PMPI
-#undef MPIX_Delete_error_class
-#define MPIX_Delete_error_class PMPIX_Delete_error_class
+#undef MPI_Delete_error_class
+#define MPI_Delete_error_class PMPI_Delete_error_class
 
 #endif
 
 /*@
-   MPIX_Delete_error_class - Delete an MPI error class to the known classes
+   MPI_Delete_error_class - Delete an MPI error class to the known classes
 
 Output Parameters:
 .  errorclass - New error class
@@ -41,7 +41,7 @@ Output Parameters:
 .N MPI_SUCCESS
 .N MPI_ERR_OTHER
 @*/
-int MPIX_Delete_error_class(int errorclass)
+int MPI_Delete_error_class(int errorclass)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_DELETE_ERROR_CLASS);

--- a/src/mpi/errhan/delete_error_code.c
+++ b/src/mpi/errhan/delete_error_code.c
@@ -6,29 +6,29 @@
 #include "mpiimpl.h"
 #include "errcodes.h"
 
-/* -- Begin Profiling Symbol Block for routine MPIX_Delete_error_code */
+/* -- Begin Profiling Symbol Block for routine MPI_Delete_error_code */
 #if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPIX_Delete_error_code = PMPIX_Delete_error_code
+#pragma weak MPI_Delete_error_code = PMPI_Delete_error_code
 #elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPIX_Delete_error_code  MPIX_Delete_error_code
+#pragma _HP_SECONDARY_DEF PMPI_Delete_error_code  MPI_Delete_error_code
 #elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPIX_Delete_error_code as PMPIX_Delete_error_code
+#pragma _CRI duplicate MPI_Delete_error_code as PMPI_Delete_error_code
 #elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPIX_Delete_error_code(int errorcode)
-    __attribute__ ((weak, alias("PMPIX_Delete_error_code")));
+int MPI_Delete_error_code(int errorcode)
+    __attribute__ ((weak, alias("PMPI_Delete_error_code")));
 #endif
 /* -- End Profiling Symbol Block */
 
 /* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
    the MPI routines */
 #ifndef MPICH_MPI_FROM_PMPI
-#undef MPIX_Delete_error_code
-#define MPIX_Delete_error_code PMPIX_Delete_error_code
+#undef MPI_Delete_error_code
+#define MPI_Delete_error_code PMPI_Delete_error_code
 
 #endif
 
 /*@
-   MPIX_Delete_error_code - Delete an MPI error code
+   MPI_Delete_error_code - Delete an MPI error code
 
 Input Parameters:
 .  errorcode - Error code to be deleted.
@@ -41,7 +41,7 @@ Input Parameters:
 .N MPI_SUCCESS
 .N MPI_ERR_OTHER
 @*/
-int MPIX_Delete_error_code(int errorcode)
+int MPI_Delete_error_code(int errorcode)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_DELETE_ERROR_CODE);

--- a/src/mpi/errhan/delete_error_string.c
+++ b/src/mpi/errhan/delete_error_string.c
@@ -6,36 +6,36 @@
 #include "mpiimpl.h"
 #include "errcodes.h"
 
-/* -- Begin Profiling Symbol Block for routine MPIX_Delete_error_string */
+/* -- Begin Profiling Symbol Block for routine MPI_Delete_error_string */
 #if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPIX_Delete_error_string = PMPIX_Delete_error_string
+#pragma weak MPI_Delete_error_string = PMPI_Delete_error_string
 #elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPIX_Delete_error_string  MPIX_Delete_error_string
+#pragma _HP_SECONDARY_DEF PMPI_Delete_error_string  MPI_Delete_error_string
 #elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPIX_Delete_error_string as PMPIX_Delete_error_string
+#pragma _CRI duplicate MPI_Delete_error_string as PMPI_Delete_error_string
 #elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPIX_Delete_error_string(int errorcode)
-    __attribute__ ((weak, alias("PMPIX_Delete_error_string")));
+int MPI_Delete_error_string(int errorcode)
+    __attribute__ ((weak, alias("PMPI_Delete_error_string")));
 #endif
 /* -- End Profiling Symbol Block */
 
 /* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
    the MPI routines */
 #ifndef MPICH_MPI_FROM_PMPI
-#undef MPIX_Delete_error_string
-#define MPIX_Delete_error_string PMPIX_Delete_error_string
+#undef MPI_Delete_error_string
+#define MPI_Delete_error_string PMPI_Delete_error_string
 
 #endif
 
 /*@
-   MPIX_Delete_error_string - Delete the error string associated with an MPI error code or
+   MPI_Delete_error_string - Delete the error string associated with an MPI error code or
    class
 
 Input Parameters:
 + errorcode - error code or class (integer)
 
    Notes:
-According to the MPI-2 standard, it is erroneous to call 'MPIX_Delete_error_string'
+According to the MPI-2 standard, it is erroneous to call 'MPI_Delete_error_string'
 for an error code or class with a value less than or equal
 to 'MPI_ERR_LASTCODE'.  Thus, you cannot replace the predefined error messages
 with this routine.
@@ -47,7 +47,7 @@ with this routine.
 .N Errors
 .N MPI_SUCCESS
 @*/
-int MPIX_Delete_error_string(int errorcode)
+int MPI_Delete_error_string(int errorcode)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_DELETE_ERROR_STRING);

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -1420,6 +1420,8 @@ is too big (> MPIU_SHMW_GHND_SZ)
 ## MPI-3 nonblocking comm dup
 **mpi_comm_idup: MPI_Comm_idup failed
 **mpi_comm_idup %C %p %p: MPI_Comm_idup(comm=%C, newcomm=%p, request=%p)
+**mpi_comm_idup_with_info: MPI_Comm_idup failed
+**mpi_comm_idup_with_info %C %I %p %p: MPI_Comm_idup(comm=%C, info=%I, newcomm=%p, request=%p)
 
 ## MPI-3 nonblocking collectives
 **mpi_ibarrier: MPI_Ibarrier failed

--- a/test/mpi/comm/idup_with_info.c
+++ b/test/mpi/comm/idup_with_info.c
@@ -77,11 +77,11 @@ int main(int argc, char **argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     /* Dup with no info */
-    MPIX_Comm_idup_with_info(MPI_COMM_WORLD, MPI_INFO_NULL, &newcomm1, &reqs[0]);
+    MPI_Comm_idup_with_info(MPI_COMM_WORLD, MPI_INFO_NULL, &newcomm1, &reqs[0]);
     MPI_Wait(&reqs[0], MPI_STATUS_IGNORE);
     errs += run_tests(newcomm1);
 
-    MPIX_Comm_idup_with_info(MPI_COMM_WORLD, MPI_INFO_NULL, &newcomm2, &reqs[0]);
+    MPI_Comm_idup_with_info(MPI_COMM_WORLD, MPI_INFO_NULL, &newcomm2, &reqs[0]);
     MPI_Wait(&reqs[0], MPI_STATUS_IGNORE);
     errs += run_tests(newcomm2);
 
@@ -92,11 +92,11 @@ int main(int argc, char **argv)
     MPI_Info_set(info, (char *) "soft", (char *) "2:1000:4,3:1000:7");
 
     if (rank % 2 == 0) {
-        MPIX_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[0]);
-        MPIX_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[1]);
+        MPI_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[0]);
+        MPI_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[1]);
     } else {
-        MPIX_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[0]);
-        MPIX_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[1]);
+        MPI_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[0]);
+        MPI_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[1]);
     }
     MPI_Waitall(2, reqs, MPI_STATUSES_IGNORE);
 
@@ -114,11 +114,11 @@ int main(int argc, char **argv)
     MPI_Info_set(info, (char *) "soft", (char *) "2:1000:4,3:1000:7");
 
     if (rank % 2 == 0) {
-        MPIX_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[0]);
-        MPIX_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[1]);
+        MPI_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[0]);
+        MPI_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[1]);
     } else {
-        MPIX_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[0]);
-        MPIX_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[1]);
+        MPI_Comm_idup_with_info(newcomm2, info, &newcomm4, &reqs[0]);
+        MPI_Comm_idup_with_info(newcomm1, info, &newcomm3, &reqs[1]);
     }
     MPI_Info_free(&info);
     MPI_Waitall(2, reqs, MPI_STATUSES_IGNORE);

--- a/test/mpi/errhan/adderr.c
+++ b/test/mpi/errhan/adderr.c
@@ -38,10 +38,10 @@ int main(int argc, char *argv[])
         }
         for (i = 0; i < NCLASSES; i++) {
             for (j = 0; j < NCODES; j++) {
-                MPIX_Delete_error_string(newcode[i][j]);
-                MPIX_Delete_error_code(newcode[i][j]);
+                MPI_Delete_error_string(newcode[i][j]);
+                MPI_Delete_error_code(newcode[i][j]);
             }
-            MPIX_Delete_error_class(newclass[i]);
+            MPI_Delete_error_class(newclass[i]);
         }
     }
 #endif

--- a/test/mpi/impls/mpich/comm/comm_info_hint.c
+++ b/test/mpi/impls/mpich/comm/comm_info_hint.c
@@ -124,11 +124,11 @@ int main(int argc, char **argv)
 #if MPI_VERSION >= 4
     MPI_Request request;
     if (rank == 0)
-        MTestPrintfMsg(1, "Testing MPIX_Comm_idup_with_info with comm = MPI_COMM_WORLD");
-    MPIX_Comm_idup_with_info(MPI_COMM_WORLD, info_in1, &comm_dup3, &request);
+        MTestPrintfMsg(1, "Testing MPI_Comm_idup_with_info with comm = MPI_COMM_WORLD");
+    MPI_Comm_idup_with_info(MPI_COMM_WORLD, info_in1, &comm_dup3, &request);
     MPI_Wait(&request, MPI_STATUS_IGNORE);
     MPI_Comm_get_info(comm_dup3, &info_out3);
-    errors += ReadCommInfo(info_out3, query_key, val, buf, "MPIX_Comm_idup_with_info");
+    errors += ReadCommInfo(info_out3, query_key, val, buf, "MPI_Comm_idup_with_info");
     MPI_Info_free(&info_out3);
     MPI_Comm_free(&comm_dup3);
 #endif


### PR DESCRIPTION
## Pull Request Description

The main branch is targeting for the mpich 4.0 release, and it assumes MPI 4.0 support. Thus we don't need MPIX_ prefix for the new functions.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
