### PR TITLE
make ADIOI_GEN_WriteStrided not step on itself

### DIFF
--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_write.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_write.c
@@ -438,8 +438,20 @@ void ADIOI_NFS_WriteStrided(ADIO_File fd, const void *buf, int count,
              * datatypes, instead of a count of bytes (which might overflow)
              * Other WriteContig calls in this path are operating on data
              * sieving buffer */
+            int tsize;
+            MPI_Type_size(datatype, &tsize);
+            size_t from = offset;
+            size_t sz = tsize * count;
+            int comm_size;
+            MPI_Comm_size(fd->comm, &comm_size);
+            if (fd->view_has_noncontig && comm_size > 1) {
+                ADIOI_WRITE_LOCK(fd, from, SEEK_SET, sz);
+            }
             ADIO_WriteContig(fd, buf, count, datatype, ADIO_EXPLICIT_OFFSET,
                              offset, status, error_code);
+            if (fd->view_has_noncontig && comm_size > 1) {
+                ADIOI_UNLOCK(fd, from, SEEK_SET, sz);
+            }
 
             if (file_ptr_type == ADIO_INDIVIDUAL) {
                 /* update MPI-IO file pointer to point to the first byte

--- a/src/mpi/romio/adio/common/ad_open.c
+++ b/src/mpi/romio/adio/common/ad_open.c
@@ -62,6 +62,13 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
     fd->filetype = filetype;    /* MPI_BYTE by default */
     fd->etype_size = 1; /* default etype is MPI_BYTE */
 
+    /* All romio calls to ADIO_Open appear to use MPI_BYTE, so I don't
+     * really want to check the contiguousness of filetype and allreduce
+     * it here to fill in the below if it's not necessary. The main place
+     * the below gets checked and set via allreduce is in the set_view call.
+     */
+    fd->view_has_noncontig = 0;
+
     fd->file_realm_st_offs = NULL;
     fd->file_realm_types = NULL;
 

--- a/src/mpi/romio/adio/common/ad_set_view.c
+++ b/src/mpi/romio/adio/common/ad_set_view.c
@@ -120,5 +120,11 @@ void ADIO_Set_view(ADIO_File fd, ADIO_Offset disp, MPI_Datatype etype,
             }
         }
     }
+
+    int filetype_is_contig_globally;
+    MPI_Allreduce(&filetype_is_contig, &filetype_is_contig_globally,
+                  1, MPI_INT, MPI_LAND, fd->comm);
+    fd->view_has_noncontig = !filetype_is_contig_globally;
+
     *error_code = MPI_SUCCESS;
 }

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -205,6 +205,7 @@ typedef struct ADIOI_FileD {
     ADIO_Offset disp;           /* reqd. for MPI-IO */
     MPI_Datatype etype;         /* reqd. for MPI-IO */
     MPI_Datatype filetype;      /* reqd. for MPI-IO */
+    int view_has_noncontig;     /* are any ranks set_view() noncontig */
     MPI_Count etype_size;       /* in bytes */
     ADIOI_Hints *hints;         /* structure containing fs-indep. info values */
     MPI_Info info;


### PR DESCRIPTION
The ADIOI_GEN_WriteStrided funcion uses data sieving on non-contiguous
types. That is, if it wants to write data at locations
```    [W...X...Y...Z...]```
it reads the whole buffer
```    [dddddddddddddddd]```
changes the locations it wants to write to
```    [WdddXdddYdddZddd]```
then writes the whole thing back.  It uses locks to make this safe, but
the problem is this only protects against other parts of the product that
are using locks.  And without this PR a peer who is simultaneously making
a simple non-contiguous write wouldn't have locked.

In the fully general case I'm not positive this commit makes WriteStrided
safe as I'm not confident that all WriteContig calls are protected by locks.
But in practice I couldn't come up with a testcase that failed after putting
in this fix.  It turned out that a wide variety of calls end up back at
the location where I added the lock, so a lot of code is made safe by this
checkin.

A testcase to demonstrate the original problem is here:
    https://gist.github.com/markalle/d7da240c19e57f095c5d1b13240dae24
```
% mpicc -o x romio_write_timing.c
% mpirun -np 4 ./x
```
Note: you need to use a filesystem that uses ADIOI_GEN_WriteStrided to
hit the bug.  I was using GPFS.

This commit adds detection at File_set_view() time to see if any of
the ranks are using a non-contiguous view, and uses that to key off of
later in GEN_WriteStrided() to make a rank lock in that case even if
its personal view is contiguous.

Part of this commit is in ad_io_coll.c where a temporary view is created.
I don't have a testcase that goes through that path.  I wasn't sure just
from reading the code whether all calls into ADIOI_IOFiletype() were
collectives, so I didn't want to do an Allreduce there.  So instead I
went a level up and attached an attribute to a temporary datatype that
was created by its caller.  That may have been unnecessary, but that's
how I made sure I was only every running my Allreduce from a location that
I was sure was indeed collective.

Signed-off-by: Mark Allen <markalle@us.ibm.com>
