### PR TITLE
misc: making some internal api types more consistent

### DIFF
--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -1076,7 +1076,7 @@ int MPIDI_CH3U_Win_gather_info(void *, MPI_Aint, int, MPIR_Info *, MPIR_Comm *,
 
 
 #ifdef MPIDI_CH3I_HAS_ALLOC_MEM
-void* MPIDI_CH3I_Alloc_mem(size_t size, MPIR_Info *info_ptr);
+void* MPIDI_CH3I_Alloc_mem(MPI_Aint size, MPIR_Info *info_ptr);
 /* fallback to MPL_malloc if channel does not have its own RMA memory allocator */
 #else
 #define MPIDI_CH3I_Alloc_mem(size, info_ptr)    MPL_malloc(size, MPL_MEM_USER)

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -725,7 +725,7 @@ void MPID_Request_free_hook(MPIR_Request *);
 void MPID_Request_destroy_hook(MPIR_Request *);
 int MPID_Request_complete(MPIR_Request *);
 
-void *MPID_Alloc_mem( size_t size, MPIR_Info *info );
+void *MPID_Alloc_mem(MPI_Aint size, MPIR_Info *info );
 int MPID_Free_mem( void *ptr );
 
 /* Prototypes and definitions for the node ID code.  This is used to support

--- a/src/mpid/ch3/src/mpid_rma.c
+++ b/src/mpid/ch3/src/mpid_rma.c
@@ -130,7 +130,7 @@ int MPID_Win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm_ptr, MPIR_Win ** 
 
 
 /* The memory allocation functions */
-void *MPID_Alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPID_Alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     void *ap = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ALLOC_MEM);

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -151,9 +151,9 @@ Native API:
       NM*: rreq
      SHM*: rreq
   mpi_alloc_mem : void *
-      NM : size-3, info_ptr
-     SHM : size-3, info_ptr
-     MPIDIG: size-3, info_ptr
+      NM : size-2, info_ptr
+     SHM : size-2, info_ptr
+     MPIDIG: size-2, info_ptr
   mpi_free_mem : int
       NM : ptr
      SHM : ptr
@@ -551,7 +551,6 @@ PARAM:
     sendtypes-2: const MPI_Datatype *
     size: int
     size-2: MPI_Aint
-    size-3: size_t
     size-4: MPI_Aint *
     source: int
     src_rank: int

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -52,18 +52,18 @@ Non Native API:
   am_recv: int
       NM*: rreq
      SHM*: rreq
-  am_hdr_max_sz : size_t
+  am_hdr_max_sz : MPI_Aint
       NM*: void
      SHM*: void
-  am_eager_limit : size_t
+  am_eager_limit : MPI_Aint
       NM*: void
      SHM*: void
-  am_eager_buf_limit : size_t
+  am_eager_buf_limit : MPI_Aint
       NM*: void
      SHM*: void
   am_check_eager: bool
-      NM*: am_hdr_sz-2, data_sz, data, count, datatype, sreq
-     SHM*: am_hdr_sz-2, data_sz, data, count, datatype, sreq
+      NM*: am_hdr_sz, data_sz, data, count, datatype, sreq
+     SHM*: am_hdr_sz, data_sz, data, count, datatype, sreq
   comm_get_lpid : int
       NM*: comm_ptr, idx, lpid_ptr, is_remote
      SHM*: comm_ptr, idx, lpid_ptr, is_remote
@@ -460,8 +460,7 @@ Native API:
 PARAM:
     addr: MPIDI_av_entry_t *
     am_hdr: const void *
-    am_hdr_sz: size_t
-    am_hdr_sz-2: MPI_Aint
+    am_hdr_sz: MPI_Aint
     am_hdrs: struct iovec *
     appnum: int
     assert: int

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -26,8 +26,8 @@ Non Native API:
       NM : comm_ptr
      SHM : comm_ptr
   mpi_open_port : int
-      NM : info_ptr, port_name-2
-     SHM : info_ptr, port_name-2
+      NM : info, port_name-2
+     SHM : info, port_name-2
   mpi_close_port : int
       NM : port_name
      SHM : port_name
@@ -151,9 +151,9 @@ Native API:
       NM*: rreq
      SHM*: rreq
   mpi_alloc_mem : void *
-      NM : size-2, info_ptr
-     SHM : size-2, info_ptr
-     MPIDIG: size-2, info_ptr
+      NM : size-2, info
+     SHM : size-2, info
+     MPIDIG: size-2, info
   mpi_free_mem : int
       NM : ptr
      SHM : ptr
@@ -235,9 +235,9 @@ Native API:
      SHM : win, base, size-2
      MPIDIG: win, base, size-2
   mpi_win_allocate_shared : int
-      NM : size-2, disp_unit-2, info_ptr, comm_ptr, base_ptr, win_ptr
-     SHM : size-2, disp_unit-2, info_ptr, comm_ptr, base_ptr, win_ptr
-     MPIDIG: size-2, disp_unit-2, info_ptr, comm_ptr, base_ptr, win_ptr
+      NM : size-2, disp_unit-2, info, comm_ptr, base_ptr, win_ptr
+     SHM : size-2, disp_unit-2, info, comm_ptr, base_ptr, win_ptr
+     MPIDIG: size-2, disp_unit-2, info, comm_ptr, base_ptr, win_ptr
   mpi_rput : int
       NM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, addr, winattr, request
      SHM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, winattr, request
@@ -495,7 +495,6 @@ PARAM:
     idx: int
     info: MPIR_Info *
     info_p_p: MPIR_Info **
-    info_ptr: MPIR_Info *
     init_comm: MPIR_Comm *
     iov_len: size_t
     is_remote: bool

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -73,9 +73,6 @@ Non Native API:
   upids_to_lupids : int
       NM : size, remote_upid_size, remote_upids, remote_lupids
      SHM : size, remote_upid_size, remote_upids, remote_lupids
-  create_intercomm_from_lpids : int
-      NM : newcomm_ptr-2, size, lpids
-     SHM : newcomm_ptr-2, size, lpids
   mpi_comm_commit_pre_hook : int
       NM : comm
      SHM : comm
@@ -507,7 +504,6 @@ PARAM:
     message: MPIR_Request *
     message_p: MPIR_Request **
     newcomm_ptr: MPIR_Comm **
-    newcomm_ptr-2: MPIR_Comm *
     op: MPI_Op
     op_p: MPIR_Op *
     origin_addr: const void *

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -127,23 +127,23 @@ Non Native API:
 
 Native API:
   mpi_isend : int
-      NM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, request
-     SHM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, request
-     MPIDIG: buf, count-2, datatype, rank, tag, comm, context_offset, addr, request
+      NM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
+     SHM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
+     MPIDIG: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
   isend_coll : int
-      NM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, request, errflag
-     SHM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, request, errflag
-     MPIDIG: buf, count-2, datatype, rank, tag, comm, context_offset, addr, request, errflag
+      NM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
+     SHM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
+     MPIDIG: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
   mpi_issend : int
-      NM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, request
-     SHM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, request
-     MPIDIG: buf, count-2, datatype, rank, tag, comm, context_offset, addr, request
+      NM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
+     SHM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
+     MPIDIG: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
   mpi_cancel_send : int
       NM*: sreq
      SHM*: sreq
   mpi_irecv : int
-      NM*: buf-2, count-2, datatype, rank, tag, comm, context_offset, addr, request, partner
-     SHM*: buf-2, count-2, datatype, rank, tag, comm, context_offset, request
+      NM*: buf-2, count-2, datatype, rank, tag, comm, context_offset, addr, req_p, partner
+     SHM*: buf-2, count-2, datatype, rank, tag, comm, context_offset, req_p
   mpi_imrecv : int
       NM*: buf-2, count-2, datatype, message
      SHM*: buf-2, count-2, datatype, message
@@ -159,9 +159,9 @@ Native API:
      SHM : ptr
      MPIDIG: ptr
   mpi_improbe : int
-      NM*: source, tag, comm, context_offset, addr, flag, message-2, status
-     SHM*: source, tag, comm, context_offset, flag, message-2, status
-     MPIDIG: source, tag, comm, context_offset, flag, message-2, status
+      NM*: source, tag, comm, context_offset, addr, flag, message_p, status
+     SHM*: source, tag, comm, context_offset, flag, message_p, status
+     MPIDIG: source, tag, comm, context_offset, flag, message_p, status
   mpi_iprobe : int
       NM*: source, tag, comm, context_offset, addr, flag, status
      SHM*: source, tag, comm, context_offset, flag, status
@@ -171,9 +171,9 @@ Native API:
      SHM : win, info
      MPIDIG: win, info
   mpi_win_shared_query : int
-      NM*: win, rank, size-4, disp_unit, baseptr
-     SHM*: win, rank, size-4, disp_unit, baseptr
-     MPIDIG: win, rank, size-4, disp_unit, baseptr
+      NM*: win, rank, size_p, disp_unit_p, baseptr
+     SHM*: win, rank, size_p, disp_unit_p, baseptr
+     MPIDIG: win, rank, size_p, disp_unit_p, baseptr
   mpi_put : int
       NM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, addr, winattr
      SHM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, winattr
@@ -207,25 +207,25 @@ Native API:
      SHM*: rank, win
      MPIDIG: rank, win
   mpi_win_get_info : int
-      NM : win, info_p_p
-     SHM : win, info_p_p
-     MPIDIG: win, info_p_p
+      NM : win, info_p
+     SHM : win, info_p
+     MPIDIG: win, info_p
   mpi_get : int
       NM*: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, addr, winattr
      SHM*: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, winattr
      MPIDIG: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win
   mpi_win_free : int
-      NM : win_ptr
-     SHM : win_ptr
-     MPIDIG: win_ptr
+      NM : win_p
+     SHM : win_p
+     MPIDIG: win_p
   mpi_win_fence : int
       NM*: assert, win
      SHM*: assert, win
      MPIDIG: assert, win
   mpi_win_create : int
-      NM : base, length, disp_unit-2, info, comm_ptr, win_ptr
-     SHM : base, length, disp_unit-2, info, comm_ptr, win_ptr
-     MPIDIG: base, length, disp_unit-2, info, comm_ptr, win_ptr
+      NM : base, length, disp_unit, info, comm_ptr, win_p
+     SHM : base, length, disp_unit, info, comm_ptr, win_p
+     MPIDIG: base, length, disp_unit, info, comm_ptr, win_p
   mpi_accumulate : int
       NM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, addr, winattr
      SHM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, winattr
@@ -235,13 +235,13 @@ Native API:
      SHM : win, base, size-2
      MPIDIG: win, base, size-2
   mpi_win_allocate_shared : int
-      NM : size-2, disp_unit-2, info, comm_ptr, base_ptr, win_ptr
-     SHM : size-2, disp_unit-2, info, comm_ptr, base_ptr, win_ptr
-     MPIDIG: size-2, disp_unit-2, info, comm_ptr, base_ptr, win_ptr
+      NM : size-2, disp_unit, info, comm_ptr, baseptr_p, win_p
+     SHM : size-2, disp_unit, info, comm_ptr, baseptr_p, win_p
+     MPIDIG: size-2, disp_unit, info, comm_ptr, base_ptr, win_p
   mpi_rput : int
-      NM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, addr, winattr, request
-     SHM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, winattr, request
-     MPIDIG: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, request
+      NM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, addr, winattr, req_p
+     SHM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, winattr, req_p
+     MPIDIG: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, req_p
   mpi_win_flush_local : int
       NM*: rank, win, addr
      SHM*: rank, win
@@ -255,21 +255,21 @@ Native API:
      SHM*: origin_addr, compare_addr, result_addr, datatype, target_rank, target_disp, win, winattr
      MPIDIG: origin_addr, compare_addr, result_addr, datatype, target_rank, target_disp, win
   mpi_raccumulate : int
-      NM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, addr, winattr, request
-     SHM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, winattr, request
-     MPIDIG: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, request
+      NM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, addr, winattr, req_p
+     SHM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, winattr, req_p
+     MPIDIG: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, req_p
   mpi_rget_accumulate : int
-      NM*: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, addr, winattr, request
-     SHM*: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, winattr, request
-     MPIDIG: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, request
+      NM*: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, addr, winattr, req_p
+     SHM*: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, winattr, req_p
+     MPIDIG: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, req_p
   mpi_fetch_and_op : int
       NM*: origin_addr, result_addr, datatype, target_rank, target_disp, op, win, addr, winattr
      SHM*: origin_addr, result_addr, datatype, target_rank, target_disp, op, win, winattr
      MPIDIG: origin_addr, result_addr, datatype, target_rank, target_disp, op, win
   mpi_win_allocate : int
-      NM : size-2, disp_unit-2, info, comm, baseptr, win-2
-     SHM : size-2, disp_unit-2, info, comm, baseptr, win-2
-     MPIDIG : size-2, disp_unit-2, info, comm, baseptr, win-2
+      NM : size-2, disp_unit, info, comm, baseptr, win_p
+     SHM : size-2, disp_unit, info, comm, baseptr, win_p
+     MPIDIG : size-2, disp_unit, info, comm, baseptr, win_p
   mpi_win_flush : int
       NM*: rank, win, addr
      SHM*: rank, win
@@ -281,13 +281,13 @@ Native API:
       NM*: win
      SHM*: win
   mpi_win_create_dynamic : int
-      NM : info, comm, win-2
-     SHM : info, comm, win-2
-     MPIDIG : info, comm, win-2
+      NM : info, comm, win_p
+     SHM : info, comm, win_p
+     MPIDIG : info, comm, win_p
   mpi_rget : int
-      NM*: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, addr, winattr, request
-     SHM*: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, winattr, request
-     MPIDIG: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, request
+      NM*: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, addr, winattr, req_p
+     SHM*: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, winattr, req_p
+     MPIDIG: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, req_p
   mpi_win_sync : int
       NM*: win
      SHM*: win
@@ -375,71 +375,71 @@ Native API:
       NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm
      SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm
   mpi_ineighbor_allgather : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req-2
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req-2
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
   mpi_ineighbor_allgatherv : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req-2
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req-2
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req_p
   mpi_ineighbor_alltoall : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req-2
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req-2
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
   mpi_ineighbor_alltoallv : int
-      NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req-2
-     SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req-2
+      NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req_p
+     SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req_p
   mpi_ineighbor_alltoallw : int
-      NM*: sendbuf, sendcounts, sdispls-2, sendtypes, recvbuf, recvcounts, rdispls-2, recvtypes, comm, req-2
-     SHM*: sendbuf, sendcounts, sdispls-2, sendtypes, recvbuf, recvcounts, rdispls-2, recvtypes, comm, req-2
+      NM*: sendbuf, sendcounts, sdispls-2, sendtypes, recvbuf, recvcounts, rdispls-2, recvtypes, comm, req_p
+     SHM*: sendbuf, sendcounts, sdispls-2, sendtypes, recvbuf, recvcounts, rdispls-2, recvtypes, comm, req_p
   mpi_ibarrier : int
-      NM*: comm, req-2
-     SHM*: comm, req-2
+      NM*: comm, req_p
+     SHM*: comm, req_p
   mpi_ibcast : int
-      NM*: buffer, count-3, datatype, root, comm, req-2
-     SHM*: buffer, count-3, datatype, root, comm, req-2
+      NM*: buffer, count-3, datatype, root, comm, req_p
+     SHM*: buffer, count-3, datatype, root, comm, req_p
   mpi_iallgather : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req-2
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req-2
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
   mpi_iallgatherv : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req-2
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req-2
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req_p
   mpi_iallreduce : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, req-2
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, req-2
+      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
+     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
   mpi_ialltoall : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req-2
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req-2
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
   mpi_ialltoallv : int
-      NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req-2
-     SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req-2
+      NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req_p
+     SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req_p
   mpi_ialltoallw : int
-      NM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, req-2
-     SHM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, req-2
+      NM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, req_p
+     SHM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, req_p
   mpi_iexscan : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, req-2
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, req-2
+      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
+     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
   mpi_igather : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req-2
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req-2
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
   mpi_igatherv : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, req-2
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, req-2
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, req_p
   mpi_ireduce_scatter_block : int
-      NM*: sendbuf, recvbuf, recvcount, datatype, op, comm, req-2
-     SHM*: sendbuf, recvbuf, recvcount, datatype, op, comm, req-2
+      NM*: sendbuf, recvbuf, recvcount, datatype, op, comm, req_p
+     SHM*: sendbuf, recvbuf, recvcount, datatype, op, comm, req_p
   mpi_ireduce_scatter : int
-      NM*: sendbuf, recvbuf, recvcounts, datatype, op, comm, req-2
-     SHM*: sendbuf, recvbuf, recvcounts, datatype, op, comm, req-2
+      NM*: sendbuf, recvbuf, recvcounts, datatype, op, comm, req_p
+     SHM*: sendbuf, recvbuf, recvcounts, datatype, op, comm, req_p
   mpi_ireduce : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, root, comm_ptr, req-2
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, root, comm_ptr, req-2
+      NM*: sendbuf, recvbuf, count-3, datatype, op, root, comm_ptr, req_p
+     SHM*: sendbuf, recvbuf, count-3, datatype, op, root, comm_ptr, req_p
   mpi_iscan : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, req-2
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, req-2
+      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
+     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
   mpi_iscatter : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req-2
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req-2
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
   mpi_iscatterv : int
-      NM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, req-2
-     SHM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, req-2
+      NM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, req_p
+     SHM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, req_p
   mpi_type_commit_hook : int
       NM : datatype_p
      SHM : type
@@ -448,10 +448,10 @@ Native API:
      SHM : type
   mpi_op_commit_hook : int
       NM : op_p
-     SHM : op-2
+     SHM : op_p
   mpi_op_free_hook : int
       NM : op_p
-     SHM : op-2
+     SHM : op_p
   rma_op_cs_enter_hook : int
      SHM*: win
   rma_op_cs_exit_hook : int
@@ -467,8 +467,8 @@ PARAM:
     av: MPIDI_av_entry_t *
     base: void *
     base-2: const void *
-    base_ptr: void **
     baseptr: void *
+    baseptr_p: void **
     blocking: int
     buf: const void *
     buf-2: void *
@@ -485,8 +485,8 @@ PARAM:
     data_sz: MPI_Aint
     datatype: MPI_Datatype
     datatype_p: MPIR_Datatype *
-    disp_unit: int *
-    disp_unit-2: int
+    disp_unit: int
+    disp_unit_p: int *
     displs: const int *
     errflag: MPIR_Errflag_t *
     flag: int *
@@ -494,7 +494,7 @@ PARAM:
     handler_id: int
     idx: int
     info: MPIR_Info *
-    info_p_p: MPIR_Info **
+    info_p: MPIR_Info **
     init_comm: MPIR_Comm *
     iov_len: size_t
     is_remote: bool
@@ -505,11 +505,10 @@ PARAM:
     lpid_ptr: int *
     lpids: const int[]
     message: MPIR_Request *
-    message-2: MPIR_Request **
+    message_p: MPIR_Request **
     newcomm_ptr: MPIR_Comm **
     newcomm_ptr-2: MPIR_Comm *
     op: MPI_Op
-    op-2: MPIR_Op *
     op_p: MPIR_Op *
     origin_addr: const void *
     origin_addr-2: void *
@@ -531,8 +530,7 @@ PARAM:
     remote_upid_size: size_t *
     remote_upids: char *
     req: MPIR_Request *
-    req-2: MPIR_Request **
-    request: MPIR_Request **
+    req_p: MPIR_Request **
     result_addr: void *
     result_count: int
     result_datatype: MPI_Datatype
@@ -546,8 +544,8 @@ PARAM:
     sendtype: MPI_Datatype
     sendtypes: const MPI_Datatype[]
     size: int
+    size_p: MPI_Aint *
     size-2: MPI_Aint
-    size-4: MPI_Aint *
     source: int
     src_rank: int
     sreq: MPIR_Request *
@@ -564,6 +562,5 @@ PARAM:
     vci: int
     void: 
     win: MPIR_Win *
-    win-2: MPIR_Win **
-    win_ptr: MPIR_Win **
+    win_p: MPIR_Win **
     winattr: MPIDI_winattr_t

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -124,26 +124,26 @@ Non Native API:
 
 Native API:
   mpi_isend : int
-      NM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
-     SHM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
-     MPIDIG: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
+      NM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
+     SHM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
+     MPIDIG: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
   isend_coll : int
-      NM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
-     SHM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
-     MPIDIG: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
+      NM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
+     SHM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
+     MPIDIG: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
   mpi_issend : int
-      NM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
-     SHM*: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
-     MPIDIG: buf, count-2, datatype, rank, tag, comm, context_offset, addr, req_p
+      NM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
+     SHM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
+     MPIDIG: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
   mpi_cancel_send : int
       NM*: sreq
      SHM*: sreq
   mpi_irecv : int
-      NM*: buf-2, count-2, datatype, rank, tag, comm, context_offset, addr, req_p, partner
-     SHM*: buf-2, count-2, datatype, rank, tag, comm, context_offset, req_p
+      NM*: buf-2, count, datatype, rank, tag, comm, context_offset, addr, req_p, partner
+     SHM*: buf-2, count, datatype, rank, tag, comm, context_offset, req_p
   mpi_imrecv : int
-      NM*: buf-2, count-2, datatype, message
-     SHM*: buf-2, count-2, datatype, message
+      NM*: buf-2, count, datatype, message
+     SHM*: buf-2, count, datatype, message
   mpi_cancel_recv : int
       NM*: rreq
      SHM*: rreq
@@ -475,8 +475,7 @@ PARAM:
     compare_addr: const void *
     context_id: MPIR_Context_id_t
     context_offset: int
-    count: MPI_Count
-    count-2: MPI_Aint
+    count: MPI_Aint
     count-3: int
     data: const void *
     data_sz: MPI_Aint

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -369,8 +369,8 @@ Native API:
       NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm
      SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm
   mpi_neighbor_alltoallw : int
-      NM*: sendbuf, sendcounts, sdispls-2, sendtypes-2, recvbuf, recvcounts, rdispls-2, recvtypes-2, comm
-     SHM*: sendbuf, sendcounts, sdispls-2, sendtypes-2, recvbuf, recvcounts, rdispls-2, recvtypes-2, comm
+      NM*: sendbuf, sendcounts, sdispls-2, sendtypes, recvbuf, recvcounts, rdispls-2, recvtypes, comm
+     SHM*: sendbuf, sendcounts, sdispls-2, sendtypes, recvbuf, recvcounts, rdispls-2, recvtypes, comm
   mpi_neighbor_alltoall : int
       NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm
      SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm
@@ -387,8 +387,8 @@ Native API:
       NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req-2
      SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req-2
   mpi_ineighbor_alltoallw : int
-      NM*: sendbuf, sendcounts, sdispls-2, sendtypes-2, recvbuf, recvcounts, rdispls-2, recvtypes-2, comm, req-2
-     SHM*: sendbuf, sendcounts, sdispls-2, sendtypes-2, recvbuf, recvcounts, rdispls-2, recvtypes-2, comm, req-2
+      NM*: sendbuf, sendcounts, sdispls-2, sendtypes, recvbuf, recvcounts, rdispls-2, recvtypes, comm, req-2
+     SHM*: sendbuf, sendcounts, sdispls-2, sendtypes, recvbuf, recvcounts, rdispls-2, recvtypes, comm, req-2
   mpi_ibarrier : int
       NM*: comm, req-2
      SHM*: comm, req-2
@@ -529,7 +529,6 @@ PARAM:
     recvcounts: const int *
     recvtype: MPI_Datatype
     recvtypes: const MPI_Datatype[]
-    recvtypes-2: const MPI_Datatype *
     remote_lupids: int **
     remote_upid_size: size_t *
     remote_upids: char *
@@ -548,7 +547,6 @@ PARAM:
     sendcounts: const int *
     sendtype: MPI_Datatype
     sendtypes: const MPI_Datatype[]
-    sendtypes-2: const MPI_Datatype *
     size: int
     size-2: MPI_Aint
     size-4: MPI_Aint *

--- a/src/mpid/ch4/generic/am/mpidig_am_send.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_send.h
@@ -13,7 +13,7 @@
 #define MPIDIG_AM_SEND_FLAGS_RTS (1 << 1)
 
 MPL_STATIC_INLINE_PREFIX bool MPIDIG_check_eager(int is_local, MPI_Aint am_hdr_sz, MPI_Aint data_sz,
-                                                 const void *buf, MPI_Count count,
+                                                 const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPIR_Request * sreq)
 {
 #ifdef MPIDI_CH4_DIRECT_NETMOD

--- a/src/mpid/ch4/generic/am/mpidig_am_send.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_send.h
@@ -69,16 +69,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
 #endif
 
     int is_local = MPIDI_av_is_local(addr);
-    if (MPIDIG_check_eager(is_local, sizeof(am_hdr), data_sz, buf, count, datatype, sreq)) {
+    MPI_Aint am_hdr_sz = (MPI_Aint) sizeof(am_hdr);
+    if (MPIDIG_check_eager(is_local, am_hdr_sz, data_sz, buf, count, datatype, sreq)) {
         /* EAGER send */
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (is_local) {
-            mpi_errno = MPIDI_SHM_am_isend(rank, comm, MPIDIG_SEND, &am_hdr, sizeof(am_hdr), buf,
+            mpi_errno = MPIDI_SHM_am_isend(rank, comm, MPIDIG_SEND, &am_hdr, am_hdr_sz, buf,
                                            count, datatype, sreq);
         } else
 #endif
         {
-            mpi_errno = MPIDI_NM_am_isend(rank, comm, MPIDIG_SEND, &am_hdr, sizeof(am_hdr), buf,
+            mpi_errno = MPIDI_NM_am_isend(rank, comm, MPIDIG_SEND, &am_hdr, am_hdr_sz, buf,
                                           count, datatype, sreq);
         }
     } else {
@@ -94,11 +95,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (is_local) {
-            mpi_errno = MPIDI_SHM_am_send_hdr(rank, comm, MPIDIG_SEND, &am_hdr, sizeof(am_hdr));
+            mpi_errno = MPIDI_SHM_am_send_hdr(rank, comm, MPIDIG_SEND, &am_hdr, am_hdr_sz);
         } else
 #endif
         {
-            mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDIG_SEND, &am_hdr, sizeof(am_hdr));
+            mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDIG_SEND, &am_hdr, am_hdr_sz);
         }
     }
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -149,7 +149,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get_accumulate(const void *, int, MPI_Datatype
                                                  MPI_Datatype, int, MPI_Aint, int, MPI_Datatype,
                                                  MPI_Op, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_lock_all(int, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
-void *MPID_Alloc_mem(size_t, MPIR_Info *);
+void *MPID_Alloc_mem(MPI_Aint, MPIR_Info *);
 int MPID_Free_mem(void *);
 int MPID_Get_node_id(MPIR_Comm *, int rank, int *);
 int MPID_Get_max_node_id(MPIR_Comm *, int *);

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -79,7 +79,7 @@ typedef enum {
 typedef struct MPIDIG_sreq_t {
     /* persistent send fields */
     const void *src_buf;
-    MPI_Count count;
+    MPI_Aint count;
     MPI_Datatype datatype;
     int rank;
     MPIR_Context_id_t context_id;

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -45,7 +45,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                MPIR_Comm * comm,
                                                int handler_id,
                                                const void *am_hdr,
-                                               size_t am_hdr_sz,
+                                               MPI_Aint am_hdr_sz,
                                                const void *data,
                                                MPI_Count count, MPI_Datatype datatype,
                                                MPIR_Request * sreq)
@@ -117,7 +117,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
                                                 MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS, is_allocated;
-    size_t am_hdr_sz = 0, i;
+    int i;
+    MPI_Aint am_hdr_sz = 0;
     char *am_hdr_buf;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_ISENDV);
@@ -160,7 +161,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      int src_rank,
                                                      int handler_id,
                                                      const void *am_hdr,
-                                                     size_t am_hdr_sz,
+                                                     MPI_Aint am_hdr_sz,
                                                      const void *data,
                                                      MPI_Count count,
                                                      MPI_Datatype datatype, MPIR_Request * sreq)
@@ -176,21 +177,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_NM_am_hdr_max_sz(void)
 {
     /* Maximum size that fits in short send */
-    size_t max_shortsend = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE -
+    MPI_Aint max_shortsend = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE -
         (sizeof(MPIDI_OFI_am_header_t) + sizeof(MPIDI_OFI_lmt_msg_payload_t));
     /* Maximum payload size representable by MPIDI_OFI_am_header_t::am_hdr_sz field */
     return MPL_MIN(max_shortsend, MPIDI_OFI_MAX_AM_HDR_SIZE);
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_limit(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_NM_am_eager_limit(void)
 {
     return MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE - sizeof(MPIDI_OFI_am_header_t);
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_buf_limit(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_NM_am_eager_buf_limit(void)
 {
     return MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE;
 }
@@ -198,7 +199,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_buf_limit(void)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
                                                   MPIR_Comm * comm,
                                                   int handler_id, const void *am_hdr,
-                                                  size_t am_hdr_sz)
+                                                  MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
@@ -217,7 +218,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
                                                         int src_rank,
                                                         int handler_id, const void *am_hdr,
-                                                        size_t am_hdr_sz)
+                                                        MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -47,7 +47,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                const void *am_hdr,
                                                MPI_Aint am_hdr_sz,
                                                const void *data,
-                                               MPI_Count count, MPI_Datatype datatype,
+                                               MPI_Aint count, MPI_Datatype datatype,
                                                MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -113,7 +113,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
                                                 struct iovec *am_hdr,
                                                 size_t iov_len,
                                                 const void *data,
-                                                MPI_Count count, MPI_Datatype datatype,
+                                                MPI_Aint count, MPI_Datatype datatype,
                                                 MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS, is_allocated;
@@ -163,7 +163,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      const void *am_hdr,
                                                      MPI_Aint am_hdr_sz,
                                                      const void *data,
-                                                     MPI_Count count,
+                                                     MPI_Aint count,
                                                      MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -238,7 +238,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
 }
 
 MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
-                                                      const void *data, MPI_Count count,
+                                                      const void *data, MPI_Aint count,
                                                       MPI_Datatype datatype, MPIR_Request * sreq)
 {
     MPIDI_OFI_AMREQUEST(sreq, data_sz) = data_sz;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -281,7 +281,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_rdma_read_ack(int rank, int context
 
     ack_msg.sreq_ptr = sreq_ptr;
     mpi_errno = MPIDI_NM_am_send_hdr_reply(context_id, rank, MPIDI_OFI_AM_RDMA_READ_ACK, &ack_msg,
-                                           sizeof(ack_msg));
+                                           (MPI_Aint) sizeof(ack_msg));
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -911,7 +911,7 @@ int MPIDI_OFI_get_vci_attr(int vci)
     return MPIDI_VCI_TX | MPIDI_VCI_RX;
 }
 
-void *MPIDI_OFI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_OFI_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     return MPIDIG_mpi_alloc_mem(size, info_ptr);
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -898,11 +898,6 @@ int MPIDI_OFI_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_
     goto fn_exit;
 }
 
-int MPIDI_OFI_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[])
-{
-    return 0;
-}
-
 int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -44,7 +44,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                MPIR_Comm * comm,
                                                int handler_id,
                                                const void *am_hdr,
-                                               size_t am_hdr_sz,
+                                               MPI_Aint am_hdr_sz,
                                                const void *data,
                                                MPI_Count count, MPI_Datatype datatype,
                                                MPIR_Request * sreq)
@@ -188,7 +188,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      int src_rank,
                                                      int handler_id,
                                                      const void *am_hdr,
-                                                     size_t am_hdr_sz,
+                                                     MPI_Aint am_hdr_sz,
                                                      const void *data, MPI_Count count,
                                                      MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -293,25 +293,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void)
-{
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_HDR_MAX_SZ);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_HDR_MAX_SZ);
-
-    ret = (MPIDI_UCX_MAX_AM_EAGER_SZ - sizeof(MPIDI_UCX_am_header_t));
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_HDR_MAX_SZ);
-    return ret;
-}
-
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_limit(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_NM_am_hdr_max_sz(void)
 {
     return (MPIDI_UCX_MAX_AM_EAGER_SZ - sizeof(MPIDI_UCX_am_header_t));
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_buf_limit(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_NM_am_eager_limit(void)
+{
+    return (MPIDI_UCX_MAX_AM_EAGER_SZ - sizeof(MPIDI_UCX_am_header_t));
+}
+
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_NM_am_eager_buf_limit(void)
 {
     return MPIDI_UCX_MAX_AM_EAGER_SZ;
 }
@@ -319,7 +311,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_buf_limit(void)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
                                                   MPIR_Comm * comm,
                                                   int handler_id, const void *am_hdr,
-                                                  size_t am_hdr_sz)
+                                                  MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request;
@@ -366,7 +358,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
                                                         int src_rank,
                                                         int handler_id, const void *am_hdr,
-                                                        size_t am_hdr_sz)
+                                                        MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request;

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -46,7 +46,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                const void *am_hdr,
                                                MPI_Aint am_hdr_sz,
                                                const void *data,
-                                               MPI_Count count, MPI_Datatype datatype,
+                                               MPI_Aint count, MPI_Datatype datatype,
                                                MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -113,7 +113,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
                                                 struct iovec *am_hdr,
                                                 size_t iov_len,
                                                 const void *data,
-                                                MPI_Count count, MPI_Datatype datatype,
+                                                MPI_Aint count, MPI_Datatype datatype,
                                                 MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -189,7 +189,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      int handler_id,
                                                      const void *am_hdr,
                                                      MPI_Aint am_hdr_sz,
-                                                     const void *data, MPI_Count count,
+                                                     const void *data, MPI_Aint count,
                                                      MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -404,7 +404,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
 }
 
 MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
-                                                      const void *data, MPI_Count count,
+                                                      const void *data, MPI_Aint count,
                                                       MPI_Datatype datatype, MPIR_Request * sreq)
 {
     return (am_hdr_sz + data_sz) <= (MPIDI_UCX_MAX_AM_EAGER_SZ - sizeof(MPIDI_UCX_am_header_t));

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -417,11 +417,6 @@ int MPIDI_UCX_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_
     return MPI_SUCCESS;
 }
 
-int MPIDI_UCX_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[])
-{
-    return MPI_SUCCESS;
-}
-
 int MPIDI_UCX_mpi_free_mem(void *ptr)
 {
     return MPIDIG_mpi_free_mem(ptr);

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -427,7 +427,7 @@ int MPIDI_UCX_mpi_free_mem(void *ptr)
     return MPIDIG_mpi_free_mem(ptr);
 }
 
-void *MPIDI_UCX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_UCX_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     return MPIDIG_mpi_alloc_mem(size, info_ptr);
 }

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
@@ -15,7 +15,7 @@ typedef int (*MPIDI_POSIX_eager_finalize_t) (void);
 
 typedef int (*MPIDI_POSIX_eager_send_t) (int grank, MPIDI_POSIX_am_header_t * msg_hdr,
                                          const void *am_hdr, MPI_Aint am_hdr_sz, const void *buf,
-                                         MPI_Count count, MPI_Datatype datatype, MPI_Aint offset,
+                                         MPI_Aint count, MPI_Datatype datatype, MPI_Aint offset,
                                          MPI_Aint * bytes_sent);
 
 typedef int (*MPIDI_POSIX_eager_recv_begin_t) (MPIDI_POSIX_eager_recv_transaction_t * transaction);
@@ -59,7 +59,7 @@ int MPIDI_POSIX_eager_finalize(void);
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr,
                                                     const void *am_hdr, MPI_Aint am_hdr_sz,
-                                                    const void *buf, MPI_Count count,
+                                                    const void *buf, MPI_Aint count,
                                                     MPI_Datatype datatype, MPI_Aint offset,
                                                     MPI_Aint * bytes_sent) MPL_STATIC_INLINE_SUFFIX;
 

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager_impl.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager_impl.h
@@ -11,7 +11,7 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr,
                                                     const void *am_hdr, MPI_Aint am_hdr_sz,
-                                                    const void *buf, MPI_Count count,
+                                                    const void *buf, MPI_Aint count,
                                                     MPI_Datatype datatype, MPI_Aint offset,
                                                     MPI_Aint * bytes_sent)
 {

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -36,7 +36,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_eager_buf_limit(void)
  */
 MPL_STATIC_INLINE_PREFIX int
 MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void *am_hdr,
-                       MPI_Aint am_hdr_sz, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                       MPI_Aint am_hdr_sz, const void *buf, MPI_Aint count, MPI_Datatype datatype,
                        MPI_Aint offset, MPI_Aint * bytes_sent)
 {
     MPIDI_POSIX_eager_iqueue_transport_t *transport;

--- a/src/mpid/ch4/shm/posix/eager/stub/stub_send.h
+++ b/src/mpid/ch4/shm/posix/eager/stub/stub_send.h
@@ -22,7 +22,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_eager_buf_limit(void)
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr,
                                                     const void *am_hdr, MPI_Aint am_hdr_sz,
-                                                    const void *buf, MPI_Count count,
+                                                    const void *buf, MPI_Aint count,
                                                     MPI_Datatype datatype, MPI_Aint offset,
                                                     MPI_Aint * bytes_sent)
 {

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -27,7 +27,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int rank,
                                                      const void *am_hdr,
                                                      MPI_Aint am_hdr_sz,
                                                      const void *data,
-                                                     MPI_Count count,
+                                                     MPI_Aint count,
                                                      MPI_Datatype datatype, MPIR_Request * sreq,
                                                      bool issue_deferred);
 
@@ -82,7 +82,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
                                                   const void *am_hdr,
                                                   MPI_Aint am_hdr_sz,
                                                   const void *data,
-                                                  MPI_Count count,
+                                                  MPI_Aint count,
                                                   MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -110,7 +110,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
                                                    struct iovec *am_hdr,
                                                    size_t iov_len,
                                                    const void *data,
-                                                   MPI_Count count,
+                                                   MPI_Aint count,
                                                    MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -163,7 +163,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(MPIR_Context_id_t contex
                                                         const void *am_hdr,
                                                         MPI_Aint am_hdr_sz,
                                                         const void *data,
-                                                        MPI_Count count,
+                                                        MPI_Aint count,
                                                         MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -322,7 +322,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int grank,
                                                      const void *am_hdr,
                                                      MPI_Aint am_hdr_sz,
                                                      const void *data,
-                                                     MPI_Count count,
+                                                     MPI_Aint count,
                                                      MPI_Datatype datatype, MPIR_Request * sreq,
                                                      bool issue_deferred)
 {

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -14,7 +14,7 @@
 #define MPIDI_POSIX_RESIZE_TO_MAX_ALIGN(x) \
     ((((x) / MAX_ALIGNMENT) + !!((x) % MAX_ALIGNMENT)) * MAX_ALIGNMENT)
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_eager_limit(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_POSIX_am_eager_limit(void)
 {
     return MPIDI_POSIX_eager_payload_limit() - MAX_ALIGNMENT;
 }
@@ -25,7 +25,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_send_hdr(int grank,
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int rank,
                                                      MPIDI_POSIX_am_header_t * msg_hdr,
                                                      const void *am_hdr,
-                                                     size_t am_hdr_sz,
+                                                     MPI_Aint am_hdr_sz,
                                                      const void *data,
                                                      MPI_Count count,
                                                      MPI_Datatype datatype, MPIR_Request * sreq,
@@ -33,7 +33,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int rank,
 
 /* Enqueue a request header onto the postponed message queue. This is a helper function and most
  * likely shouldn't be used outside of this file. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, size_t am_hdr_sz,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, MPI_Aint am_hdr_sz,
                                                             const int grank,
                                                             MPIDI_POSIX_am_header_t * msg_hdr_p,
                                                             MPIR_Request * sreq)
@@ -80,7 +80,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
                                                   MPIDI_POSIX_am_header_kind_t kind,
                                                   int handler_id,
                                                   const void *am_hdr,
-                                                  size_t am_hdr_sz,
+                                                  MPI_Aint am_hdr_sz,
                                                   const void *data,
                                                   MPI_Count count,
                                                   MPI_Datatype datatype, MPIR_Request * sreq)
@@ -115,7 +115,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
 {
     int mpi_errno = MPI_SUCCESS;
     int is_allocated;
-    size_t am_hdr_sz = 0;
+    MPI_Aint am_hdr_sz = 0;
     int i;
     uint8_t *am_hdr_buf = NULL;
 
@@ -161,7 +161,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(MPIR_Context_id_t contex
                                                         MPIDI_POSIX_am_header_kind_t kind,
                                                         int handler_id,
                                                         const void *am_hdr,
-                                                        size_t am_hdr_sz,
+                                                        MPI_Aint am_hdr_sz,
                                                         const void *data,
                                                         MPI_Count count,
                                                         MPI_Datatype datatype, MPIR_Request * sreq)
@@ -179,24 +179,24 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(MPIR_Context_id_t contex
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_hdr_max_sz(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_POSIX_am_hdr_max_sz(void)
 {
     /* Maximum size that fits in short send */
 
-    size_t max_shortsend = MPIDI_POSIX_eager_payload_limit();
+    MPI_Aint max_shortsend = MPIDI_POSIX_eager_payload_limit();
 
     /* Maximum payload size representable by MPIDI_POSIX_am_header_t::am_hdr_sz field */
     return MPL_MIN(max_shortsend, MPIDI_POSIX_MAX_AM_HDR_SIZE);
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_eager_buf_limit(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_POSIX_am_eager_buf_limit(void)
 {
     return MPIDI_POSIX_eager_buf_limit();
 }
 
 /* Enqueue a request header onto the postponed message queue. This is a helper function and most
  * likely shouldn't be used outside of this file. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, size_t am_hdr_sz,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, MPI_Aint am_hdr_sz,
                                                             const int grank,
                                                             MPIDI_POSIX_am_header_t * msg_hdr)
 {
@@ -232,7 +232,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank,
                                                      MPIR_Comm * comm,
                                                      MPIDI_POSIX_am_header_kind_t kind,
                                                      int handler_id,
-                                                     const void *am_hdr, size_t am_hdr_sz)
+                                                     const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_am_header_t msg_hdr;
@@ -300,7 +300,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr_reply(MPIR_Context_id_t con
                                                            int src_rank,
                                                            MPIDI_POSIX_am_header_kind_t kind,
                                                            int handler_id, const void *am_hdr,
-                                                           size_t am_hdr_sz)
+                                                           MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -320,7 +320,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr_reply(MPIR_Context_id_t con
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int grank,
                                                      MPIDI_POSIX_am_header_t * msg_hdr,
                                                      const void *am_hdr,
-                                                     size_t am_hdr_sz,
+                                                     MPI_Aint am_hdr_sz,
                                                      const void *data,
                                                      MPI_Count count,
                                                      MPI_Datatype datatype, MPIR_Request * sreq,

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -286,7 +286,7 @@ int MPIDI_POSIX_get_vci_attr(int vci)
     return MPIDI_VCI_TX | MPIDI_VCI_RX;
 }
 
-void *MPIDI_POSIX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_POSIX_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     return MPIDIG_mpi_alloc_mem(size, info_ptr);
 }

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -308,9 +308,3 @@ int MPIDI_POSIX_upids_to_lupids(int size, size_t * remote_upid_size, char *remot
     MPIR_Assert(0);
     return MPI_SUCCESS;
 }
-
-int MPIDI_POSIX_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[])
-{
-    MPIR_Assert(0);
-    return MPI_SUCCESS;
-}

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -92,7 +92,7 @@ typedef struct MPIDI_POSIX_am_request_header {
     /* For postponed operation */
     MPI_Datatype datatype;
     const void *buf;
-    MPI_Count count;
+    MPI_Aint count;
 
     /* Structure used with POSIX postponed_queue */
     MPIR_Request *request;      /* Store address of MPIR_Request* sreq */

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -12,7 +12,7 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
                                                    int handler_id, const void *am_hdr,
-                                                   size_t am_hdr_sz)
+                                                   MPI_Aint am_hdr_sz)
 {
     int ret;
 
@@ -27,7 +27,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
-                                                const void *am_hdr, size_t am_hdr_sz,
+                                                const void *am_hdr, MPI_Aint am_hdr_sz,
                                                 const void *data, MPI_Count count,
                                                 MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -62,7 +62,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id,
                                                          int src_rank, int handler_id,
-                                                         const void *am_hdr, size_t am_hdr_sz)
+                                                         const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     int ret;
 
@@ -78,7 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t conte
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id,
                                                       int src_rank, int handler_id,
-                                                      const void *am_hdr, size_t am_hdr_sz,
+                                                      const void *am_hdr, MPI_Aint am_hdr_sz,
                                                       const void *data, MPI_Count count,
                                                       MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -107,25 +107,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_recv(MPIR_Request * rreq)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_SHM_am_hdr_max_sz(void)
 {
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_HDR_MAX_SZ);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_HDR_MAX_SZ);
-
-    ret = MPIDI_POSIX_am_hdr_max_sz();
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_HDR_MAX_SZ);
-    return ret;
+    return MPIDI_POSIX_am_hdr_max_sz();
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_eager_limit(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_SHM_am_eager_limit(void)
 {
     return MPIDI_POSIX_am_eager_limit();
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_eager_buf_limit(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_SHM_am_eager_buf_limit(void)
 {
     return MPIDI_POSIX_am_eager_buf_limit();
 }

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -28,7 +28,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                 const void *am_hdr, MPI_Aint am_hdr_sz,
-                                                const void *data, MPI_Count count,
+                                                const void *data, MPI_Aint count,
                                                 MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
@@ -45,7 +45,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                  struct iovec *am_hdrs, size_t iov_len,
-                                                 const void *data, MPI_Count count,
+                                                 const void *data, MPI_Aint count,
                                                  MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
@@ -79,7 +79,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t conte
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id,
                                                       int src_rank, int handler_id,
                                                       const void *am_hdr, MPI_Aint am_hdr_sz,
-                                                      const void *data, MPI_Count count,
+                                                      const void *data, MPI_Aint count,
                                                       MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
@@ -144,7 +144,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_finalize(MPIR_Request * req)
 }
 
 MPL_STATIC_INLINE_PREFIX bool MPIDI_SHM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
-                                                       const void *data, MPI_Count count,
+                                                       const void *data, MPI_Aint count,
                                                        MPI_Datatype datatype, MPIR_Request * sreq)
 {
     /* TODO: add checking for IPC transmission */

--- a/src/mpid/ch4/shm/src/shm_mem.c
+++ b/src/mpid/ch4/shm/src/shm_mem.c
@@ -7,7 +7,7 @@
 #include "shm_noinline.h"
 #include "../posix/posix_noinline.h"
 
-void *MPIDI_SHM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_SHM_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     void *ret;
 

--- a/src/mpid/ch4/shm/src/shm_misc.c
+++ b/src/mpid/ch4/shm/src/shm_misc.c
@@ -33,16 +33,3 @@ int MPIDI_SHM_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_UPIDS_TO_LUPIDS);
     return ret;
 }
-
-int MPIDI_SHM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[])
-{
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_CREATE_INTERCOMM_FROM_LPIDS);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_CREATE_INTERCOMM_FROM_LPIDS);
-
-    ret = MPIDI_POSIX_create_intercomm_from_lpids(newcomm_ptr, size, lpids);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_CREATE_INTERCOMM_FROM_LPIDS);
-    return ret;
-}

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -867,7 +867,7 @@ typedef struct {
 
 static alloc_mem_container_s *alloc_mem_container_list = NULL;
 
-void *MPID_Alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPID_Alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ALLOC_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_ALLOC_MEM);

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -25,7 +25,7 @@ int MPIDIG_do_cts(MPIR_Request * rreq)
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
                                            MPIDIG_REQUEST(rreq, rank), MPIDIG_SEND_CTS, &am_hdr,
-                                           sizeof(am_hdr));
+                                           (MPI_Aint) sizeof(am_hdr));
 #else
     if (MPIDI_REQUEST(rreq, is_local)) {
         mpi_errno = MPIDI_SHM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
@@ -34,7 +34,7 @@ int MPIDIG_do_cts(MPIR_Request * rreq)
     } else {
         mpi_errno = MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
                                                MPIDIG_REQUEST(rreq, rank),
-                                               MPIDIG_SEND_CTS, &am_hdr, sizeof(am_hdr));
+                                               MPIDIG_SEND_CTS, &am_hdr, (MPI_Aint) sizeof(am_hdr));
     }
 #endif
     MPIR_ERR_CHECK(mpi_errno);
@@ -549,7 +549,7 @@ int MPIDIG_send_cts_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_
         mpi_errno =
             MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(sreq, req->sreq).context_id,
                                      MPIDIG_REQUEST(sreq, rank), MPIDIG_SEND_DATA,
-                                     &send_hdr, sizeof(send_hdr),
+                                     &send_hdr, (MPI_Aint) sizeof(send_hdr),
                                      MPIDIG_REQUEST(sreq, req->sreq).src_buf,
                                      MPIDIG_REQUEST(sreq, req->sreq).count,
                                      MPIDIG_REQUEST(sreq, req->sreq).datatype, sreq);
@@ -559,7 +559,7 @@ int MPIDIG_send_cts_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_
         mpi_errno =
             MPIDI_NM_am_isend_reply(MPIDIG_REQUEST(sreq, req->sreq).context_id,
                                     MPIDIG_REQUEST(sreq, rank), MPIDIG_SEND_DATA,
-                                    &send_hdr, sizeof(send_hdr),
+                                    &send_hdr, (MPI_Aint) sizeof(send_hdr),
                                     MPIDIG_REQUEST(sreq, req->sreq).src_buf,
                                     MPIDIG_REQUEST(sreq, req->sreq).count,
                                     MPIDIG_REQUEST(sreq, req->sreq).datatype, sreq);

--- a/src/mpid/ch4/src/ch4r_init.c
+++ b/src/mpid/ch4/src/ch4r_init.c
@@ -88,7 +88,7 @@ int MPIDIG_destroy_comm(MPIR_Comm * comm)
     return mpi_errno;
 }
 
-void *MPIDIG_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDIG_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_ALLOC_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_ALLOC_MEM);

--- a/src/mpid/ch4/src/ch4r_init.h
+++ b/src/mpid/ch4/src/ch4r_init.h
@@ -8,7 +8,7 @@
 
 int MPIDIG_init_comm(MPIR_Comm * comm);
 int MPIDIG_destroy_comm(MPIR_Comm * comm);
-void *MPIDIG_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+void *MPIDIG_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr);
 int MPIDIG_mpi_free_mem(void *ptr);
 
 #endif /* CH4R_INIT_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_recv.h
+++ b/src/mpid/ch4/src/ch4r_recv.h
@@ -21,14 +21,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_reply_ssend(MPIR_Request * rreq)
         mpi_errno =
             MPIDI_SHM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK, &ack_msg,
-                                        sizeof(ack_msg));
+                                        (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
         mpi_errno =
             MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK, &ack_msg,
-                                       sizeof(ack_msg));
+                                       (MPI_Aint) sizeof(ack_msg));
     }
 
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -234,7 +234,7 @@ static int ack_put(MPIR_Request * rreq)
             MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
                                         (MPIDIG_REQUEST(rreq, req->preq.win_ptr)),
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_ACK,
-                                        &ack_msg, sizeof(ack_msg));
+                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
@@ -242,7 +242,7 @@ static int ack_put(MPIR_Request * rreq)
             MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
                                        (MPIDIG_REQUEST(rreq, req->preq.win_ptr)),
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_ACK,
-                                       &ack_msg, sizeof(ack_msg));
+                                       &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -275,7 +275,7 @@ static int ack_cswap(MPIR_Request * rreq)
             MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context
                                      (MPIDIG_REQUEST(rreq, req->creq.win_ptr)),
                                      MPIDIG_REQUEST(rreq, rank), MPIDIG_CSWAP_ACK, &ack_msg,
-                                     sizeof(ack_msg), result_addr, 1,
+                                     (MPI_Aint) sizeof(ack_msg), result_addr, 1,
                                      MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
     else
 #endif
@@ -284,7 +284,7 @@ static int ack_cswap(MPIR_Request * rreq)
             MPIDI_NM_am_isend_reply(MPIDIG_win_to_context
                                     (MPIDIG_REQUEST(rreq, req->creq.win_ptr)),
                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_CSWAP_ACK, &ack_msg,
-                                    sizeof(ack_msg), result_addr, 1,
+                                    (MPI_Aint) sizeof(ack_msg), result_addr, 1,
                                     MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
     }
 
@@ -311,7 +311,7 @@ static int ack_acc(MPIR_Request * rreq)
             MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
                                         (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_ACK,
-                                        &ack_msg, sizeof(ack_msg));
+                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
@@ -319,7 +319,7 @@ static int ack_acc(MPIR_Request * rreq)
             MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
                                        (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_ACK,
-                                       &ack_msg, sizeof(ack_msg));
+                                       &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -347,7 +347,7 @@ static int ack_get_acc(MPIR_Request * rreq)
             MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context
                                      (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
                                      MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_ACK,
-                                     &ack_msg, sizeof(ack_msg),
+                                     &ack_msg, (MPI_Aint) sizeof(ack_msg),
                                      MPIDIG_REQUEST(rreq, req->areq.data),
                                      MPIDIG_REQUEST(rreq, req->areq.result_data_sz), MPI_BYTE,
                                      rreq);
@@ -358,7 +358,7 @@ static int ack_get_acc(MPIR_Request * rreq)
             MPIDI_NM_am_isend_reply(MPIDIG_win_to_context
                                     (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_ACK,
-                                    &ack_msg, sizeof(ack_msg),
+                                    &ack_msg, (MPI_Aint) sizeof(ack_msg),
                                     MPIDIG_REQUEST(rreq, req->areq.data),
                                     MPIDIG_REQUEST(rreq, req->areq.result_data_sz), MPI_BYTE, rreq);
     }
@@ -407,12 +407,14 @@ static int win_lock_advance(MPIR_Win * win)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (MPIDI_rank_is_local(lock->rank, win->comm_ptr))
             mpi_errno = MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context(win),
-                                                    lock->rank, handler_id, &msg, sizeof(msg));
+                                                    lock->rank, handler_id,
+                                                    &msg, (MPI_Aint) sizeof(msg));
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context(win),
-                                                   lock->rank, handler_id, &msg, sizeof(msg));
+                                                   lock->rank, handler_id,
+                                                   &msg, (MPI_Aint) sizeof(msg));
         }
 
         MPIR_ERR_CHECK(mpi_errno);
@@ -498,13 +500,14 @@ static void win_unlock_proc(const MPIDIG_win_cntrl_msg_t * info, int is_local, M
     if (is_local)
         mpi_errno = MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context(win),
                                                 info->origin_rank,
-                                                MPIDIG_WIN_UNLOCK_ACK, &msg, sizeof(msg));
+                                                MPIDIG_WIN_UNLOCK_ACK,
+                                                &msg, (MPI_Aint) sizeof(msg));
     else
 #endif
     {
         mpi_errno = MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context(win),
                                                info->origin_rank,
-                                               MPIDIG_WIN_UNLOCK_ACK, &msg, sizeof(msg));
+                                               MPIDIG_WIN_UNLOCK_ACK, &msg, (MPI_Aint) sizeof(msg));
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -750,7 +753,8 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (MPIDI_REQUEST(rreq, is_local))
             mpi_errno = MPIDI_SHM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
-                                                 MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
+                                                 MPIDIG_GET_ACK,
+                                                 &get_ack, (MPI_Aint) sizeof(get_ack),
                                                  (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
                                                  MPIDIG_REQUEST(rreq, req->greq.count),
                                                  MPIDIG_REQUEST(rreq, req->greq.datatype), rreq);
@@ -758,7 +762,8 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
 #endif
         {
             mpi_errno = MPIDI_NM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
-                                                MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
+                                                MPIDIG_GET_ACK,
+                                                &get_ack, (MPI_Aint) sizeof(get_ack),
                                                 (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
                                                 MPIDIG_REQUEST(rreq, req->greq.count),
                                                 MPIDIG_REQUEST(rreq, req->greq.datatype), rreq);
@@ -785,7 +790,7 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno = MPIDI_SHM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
-                                             MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
+                                             MPIDIG_GET_ACK, &get_ack, (MPI_Aint) sizeof(get_ack),
                                              MPIDIG_REQUEST(rreq, req->greq.addr),
                                              MPIDIG_REQUEST(rreq, req->greq.count), dt->handle,
                                              rreq);
@@ -793,7 +798,7 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
 #endif
     {
         mpi_errno = MPIDI_NM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
-                                            MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
+                                            MPIDIG_GET_ACK, &get_ack, (MPI_Aint) sizeof(get_ack),
                                             MPIDIG_REQUEST(rreq, req->greq.addr),
                                             MPIDIG_REQUEST(rreq, req->greq.count), dt->handle,
                                             rreq);
@@ -850,7 +855,7 @@ static int put_dt_target_cmpl_cb(MPIR_Request * rreq)
             MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
                                         (MPIDIG_REQUEST(rreq, req->preq.win_ptr)),
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_DT_ACK,
-                                        &ack_msg, sizeof(ack_msg));
+                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
@@ -858,7 +863,7 @@ static int put_dt_target_cmpl_cb(MPIR_Request * rreq)
             MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
                                        (MPIDIG_REQUEST(rreq, req->preq.win_ptr)),
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_DT_ACK,
-                                       &ack_msg, sizeof(ack_msg));
+                                       &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -887,7 +892,7 @@ static int acc_dt_target_cmpl_cb(MPIR_Request * rreq)
             MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
                                         (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_DT_ACK,
-                                        &ack_msg, sizeof(ack_msg));
+                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
@@ -895,7 +900,7 @@ static int acc_dt_target_cmpl_cb(MPIR_Request * rreq)
             MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
                                        (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_DT_ACK,
-                                       &ack_msg, sizeof(ack_msg));
+                                       &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -924,7 +929,7 @@ static int get_acc_dt_target_cmpl_cb(MPIR_Request * rreq)
             MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
                                         (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_DT_ACK,
-                                        &ack_msg, sizeof(ack_msg));
+                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
@@ -932,7 +937,7 @@ static int get_acc_dt_target_cmpl_cb(MPIR_Request * rreq)
             MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
                                        (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_DT_ACK,
-                                       &ack_msg, sizeof(ack_msg));
+                                       &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -1450,7 +1455,8 @@ int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
     if (is_local)
         mpi_errno = MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context(win),
                                              MPIDIG_REQUEST(origin_req, rank),
-                                             MPIDIG_PUT_DAT_REQ, &dat_msg, sizeof(dat_msg),
+                                             MPIDIG_PUT_DAT_REQ,
+                                             &dat_msg, (MPI_Aint) sizeof(dat_msg),
                                              MPIDIG_REQUEST(origin_req, req->preq.origin_addr),
                                              MPIDIG_REQUEST(origin_req, req->preq.origin_count),
                                              MPIDIG_REQUEST(origin_req, req->preq.origin_datatype),
@@ -1460,7 +1466,8 @@ int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
     {
         mpi_errno = MPIDI_NM_am_isend_reply(MPIDIG_win_to_context(win),
                                             MPIDIG_REQUEST(origin_req, rank),
-                                            MPIDIG_PUT_DAT_REQ, &dat_msg, sizeof(dat_msg),
+                                            MPIDIG_PUT_DAT_REQ,
+                                            &dat_msg, (MPI_Aint) sizeof(dat_msg),
                                             MPIDIG_REQUEST(origin_req, req->preq.origin_addr),
                                             MPIDIG_REQUEST(origin_req, req->preq.origin_count),
                                             MPIDIG_REQUEST(origin_req, req->preq.origin_datatype),
@@ -1507,7 +1514,7 @@ int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
         mpi_errno = MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context(win),
                                              MPIDIG_REQUEST(origin_req, rank),
                                              MPIDIG_ACC_DAT_REQ,
-                                             &dat_msg, sizeof(dat_msg),
+                                             &dat_msg, (MPI_Aint) sizeof(dat_msg),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_count),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
@@ -1518,7 +1525,7 @@ int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
         mpi_errno = MPIDI_NM_am_isend_reply(MPIDIG_win_to_context(win),
                                             MPIDIG_REQUEST(origin_req, rank),
                                             MPIDIG_ACC_DAT_REQ,
-                                            &dat_msg, sizeof(dat_msg),
+                                            &dat_msg, (MPI_Aint) sizeof(dat_msg),
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_count),
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
@@ -1566,7 +1573,7 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data
         mpi_errno = MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context(win),
                                              MPIDIG_REQUEST(origin_req, rank),
                                              MPIDIG_GET_ACC_DAT_REQ,
-                                             &dat_msg, sizeof(dat_msg),
+                                             &dat_msg, (MPI_Aint) sizeof(dat_msg),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_count),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
@@ -1577,7 +1584,7 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data
         mpi_errno = MPIDI_NM_am_isend_reply(MPIDIG_win_to_context(win),
                                             MPIDIG_REQUEST(origin_req, rank),
                                             MPIDIG_GET_ACC_DAT_REQ,
-                                            &dat_msg, sizeof(dat_msg),
+                                            &dat_msg, (MPI_Aint) sizeof(dat_msg),
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_count),
                                             MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -204,12 +204,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_complete(MPIR_Win * win)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (MPIDI_rank_is_local(peer, win->comm_ptr))
             mpi_errno = MPIDI_SHM_am_send_hdr(peer, win->comm_ptr,
-                                              MPIDIG_WIN_COMPLETE, &msg, sizeof(msg));
+                                              MPIDIG_WIN_COMPLETE, &msg, (MPI_Aint) sizeof(msg));
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_send_hdr(peer, win->comm_ptr,
-                                             MPIDIG_WIN_COMPLETE, &msg, sizeof(msg));
+                                             MPIDIG_WIN_COMPLETE, &msg, (MPI_Aint) sizeof(msg));
         }
 
         if (mpi_errno != MPI_SUCCESS)
@@ -269,12 +269,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_post(MPIR_Group * group, int assert,
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (MPIDI_rank_is_local(peer, win->comm_ptr))
             mpi_errno = MPIDI_SHM_am_send_hdr(peer, win->comm_ptr,
-                                              MPIDIG_WIN_POST, &msg, sizeof(msg));
+                                              MPIDIG_WIN_POST, &msg, (MPI_Aint) sizeof(msg));
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_send_hdr(peer, win->comm_ptr,
-                                             MPIDIG_WIN_POST, &msg, sizeof(msg));
+                                             MPIDIG_WIN_POST, &msg, (MPI_Aint) sizeof(msg));
         }
 
         if (mpi_errno != MPI_SUCCESS)
@@ -377,11 +377,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock(int lock_type, int rank, int as
     locked = slock->locked + 1;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_rank_is_local(rank, win->comm_ptr))
-        mpi_errno = MPIDI_SHM_am_send_hdr(rank, win->comm_ptr, MPIDIG_WIN_LOCK, &msg, sizeof(msg));
+        mpi_errno = MPIDI_SHM_am_send_hdr(rank, win->comm_ptr,
+                                          MPIDIG_WIN_LOCK, &msg, (MPI_Aint) sizeof(msg));
     else
 #endif
     {
-        mpi_errno = MPIDI_NM_am_send_hdr(rank, win->comm_ptr, MPIDIG_WIN_LOCK, &msg, sizeof(msg));
+        mpi_errno = MPIDI_NM_am_send_hdr(rank, win->comm_ptr,
+                                         MPIDIG_WIN_LOCK, &msg, (MPI_Aint) sizeof(msg));
     }
 
     if (mpi_errno != MPI_SUCCESS)
@@ -448,11 +450,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_rank_is_local(rank, win->comm_ptr))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr(rank, win->comm_ptr, MPIDIG_WIN_UNLOCK, &msg, sizeof(msg));
+            MPIDI_SHM_am_send_hdr(rank, win->comm_ptr,
+                                  MPIDIG_WIN_UNLOCK, &msg, (MPI_Aint) sizeof(msg));
     else
 #endif
     {
-        mpi_errno = MPIDI_NM_am_send_hdr(rank, win->comm_ptr, MPIDIG_WIN_UNLOCK, &msg, sizeof(msg));
+        mpi_errno = MPIDI_NM_am_send_hdr(rank, win->comm_ptr,
+                                         MPIDIG_WIN_UNLOCK, &msg, (MPI_Aint) sizeof(msg));
     }
 
     if (mpi_errno != MPI_SUCCESS)
@@ -687,12 +691,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (MPIDI_rank_is_local(i, win->comm_ptr))
             mpi_errno = MPIDI_SHM_am_send_hdr(i, win->comm_ptr,
-                                              MPIDIG_WIN_UNLOCKALL, &msg, sizeof(msg));
+                                              MPIDIG_WIN_UNLOCKALL, &msg, (MPI_Aint) sizeof(msg));
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_send_hdr(i, win->comm_ptr,
-                                             MPIDIG_WIN_UNLOCKALL, &msg, sizeof(msg));
+                                             MPIDIG_WIN_UNLOCKALL, &msg, (MPI_Aint) sizeof(msg));
         }
 
         if (mpi_errno != MPI_SUCCESS)
@@ -830,12 +834,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock_all(int assert, MPIR_Win * win)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (MPIDI_rank_is_local(i, win->comm_ptr))
             mpi_errno = MPIDI_SHM_am_send_hdr(i, win->comm_ptr,
-                                              MPIDIG_WIN_LOCKALL, &msg, sizeof(msg));
+                                              MPIDIG_WIN_LOCKALL, &msg, (MPI_Aint) sizeof(msg));
         else
 #endif
         {
             mpi_errno = MPIDI_NM_am_send_hdr(i, win->comm_ptr,
-                                             MPIDIG_WIN_LOCKALL, &msg, sizeof(msg));
+                                             MPIDIG_WIN_LOCKALL, &msg, (MPI_Aint) sizeof(msg));
         }
 
         if (mpi_errno != MPI_SUCCESS)


### PR DESCRIPTION
## Pull Request Description

Our internal ch4 in some place uses inconsistent types for the same parameters, in some place parameters with same name refers to different semantics. The inconsistency can be confusing and in some place places unnecessary hidden hazard.

This PR fixes most of these inconsistencies. 

[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
