### PR TITLE
init: split MPID_Init into MPID_Init_local and MPID_Init_world

### DIFF
--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -531,6 +531,10 @@ typedef struct {
 
 int MPID_Init(int required, int *provided);
 
+int MPID_Init_local(int requested, int *provided);
+
+int MPID_Init_world(void);
+
 int MPID_InitCompleted( void );
 
 int MPID_Finalize(void);

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -64,18 +64,32 @@ static int finalize_failed_procs_group(void *param)
 
 int MPID_Init(int requested, int *provided)
 {
-    int pmi_errno;
     int mpi_errno = MPI_SUCCESS;
-    int has_parent;
-    MPIDI_PG_t * pg=NULL;
-    int pg_rank=-1;
-    int pg_size;
-    MPIR_Comm * comm;
-    int p;
-    int val;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT);
-
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT);
+
+    mpi_errno = MPID_Init_local(requested, provided);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPID_Init_world();
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT);
+    return mpi_errno;
+
+    /* --BEGIN ERROR HANDLING-- */
+  fn_fail:
+    goto fn_exit;
+    /* --END ERROR HANDLING-- */
+}
+
+int MPID_Init_local(int requested, int *provided)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_LOCAL);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT_LOCAL);
+    int pmi_errno;
 
     if (MPICH_THREAD_LEVEL >= requested)
         *provided = requested;
@@ -95,6 +109,7 @@ int MPID_Init(int requested, int *provided)
 #ifdef USE_PMI2_API
     MPIDI_failed_procs_string = MPL_malloc(sizeof(char) * PMI2_MAX_VALLEN, MPL_MEM_STRINGS);
 #else
+    int val;
     pmi_errno = PMI_KVS_Get_value_length_max(&val);
     if (pmi_errno != PMI_SUCCESS)
     {
@@ -114,13 +129,13 @@ int MPID_Init(int requested, int *provided)
     /*
      * Perform channel-independent PMI initialization
      */
+    MPIDI_PG_t * pg=NULL;
+    int has_parent, pg_rank;
     mpi_errno = init_pg(&has_parent, &pg_rank, &pg);
     if (mpi_errno) {
 	MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER, "**ch3|ch3_init");
     }
     
-    /* FIXME: Why are pg_size and pg_rank handled differently? */
-    pg_size = MPIDI_PG_Get_size(pg);
     MPIDI_Process.my_pg = pg;  /* brad : this is rework for shared memories 
 				* because they need this set earlier
                                 * for getting the business card
@@ -153,12 +168,29 @@ int MPID_Init(int requested, int *provided)
     MPIDI_CH3_DBG_REFCOUNT = MPL_dbg_class_alloc("REFCOUNT", "refcount");
 #endif /* MPL_USE_DBG_LOGGING */
 
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT_LOCAL);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPID_Init_world(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Comm *comm;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_WORLD);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT_WORLD);
     /*
      * Let the channel perform any necessary initialization
      * The channel init should assume that PMI_Init has been called and that
      * the basic information about the job has been extracted from PMI (e.g.,
      * the size and rank of this process, and the process group id)
      */
+    MPIDI_PG_t *pg = MPIDI_Process.my_pg;
+    int has_parent = MPIR_Process.has_parent;
+    int pg_rank = MPIR_Process.rank;
+    int pg_size = MPIR_Process.size;
     mpi_errno = MPIDI_CH3_Init(has_parent, pg, pg_rank);
     if (mpi_errno != MPI_SUCCESS) {
 	MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER, "**ch3|ch3_init");
@@ -189,7 +221,7 @@ int MPID_Init(int requested, int *provided)
 
     /* Initialize the connection table on COMM_WORLD from the process group's
        connection table */
-    for (p = 0; p < pg_size; p++)
+    for (int p = 0; p < pg_size; p++)
     {
 	MPIDI_VCR_Dup(&pg->vct[p], &comm->dev.vcrt->vcr_table[p]);
     }
@@ -244,25 +276,13 @@ int MPID_Init(int requested, int *provided)
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT_WORLD);
     return mpi_errno;
 
     /* --BEGIN ERROR HANDLING-- */
   fn_fail:
     goto fn_exit;
     /* --END ERROR HANDLING-- */
-}
-
-int MPID_Init_local(int requested, int *provided)
-{
-    int mpi_errno = MPI_SUCCESS;
-    return mpi_errno;
-}
-
-int MPID_Init_world(void)
-{
-    int mpi_errno = MPI_SUCCESS;
-    return mpi_errno;
 }
 
 static int init_spawn(void)

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -253,6 +253,18 @@ int MPID_Init(int requested, int *provided)
     /* --END ERROR HANDLING-- */
 }
 
+int MPID_Init_local(int requested, int *provided)
+{
+    int mpi_errno = MPI_SUCCESS;
+    return mpi_errno;
+}
+
+int MPID_Init_world(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    return mpi_errno;
+}
+
 static int init_spawn(void)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -13,6 +13,8 @@
  */
 
 int MPID_Init(int, int *);
+int MPID_Init_local(int requested, int *provided);
+int MPID_Init_world(void);
 int MPID_InitCompleted(void);
 MPL_STATIC_INLINE_PREFIX int MPID_Cancel_recv(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Cancel_send(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -633,6 +633,18 @@ int MPID_Init(int requested, int *provided)
     goto fn_exit;
 }
 
+int MPID_Init_local(int requested, int *provided)
+{
+    int mpi_errno = MPI_SUCCESS;
+    return mpi_errno;
+}
+
+int MPID_Init_world(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    return mpi_errno;
+}
+
 int MPID_InitCompleted(void)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -466,12 +466,30 @@ static int generic_init(void)
 
 int MPID_Init(int requested, int *provided)
 {
-    int mpi_errno = MPI_SUCCESS, rank, size, appnum;
-    MPIR_Comm *init_comm = NULL;
-    char strerrbuf[MPIR_STRERROR_BUF_SIZE];
-
+    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT);
+
+    mpi_errno = MPID_Init_local(requested, provided);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPID_Init_world();
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPID_Init_local(int requested, int *provided)
+{
+    int mpi_errno = MPI_SUCCESS;
+    char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_LOCAL);
+
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT_LOCAL);
 
     switch (requested) {
         case MPI_THREAD_SINGLE:
@@ -507,10 +525,6 @@ int MPID_Init(int requested, int *provided)
 
     mpi_errno = MPIR_pmi_init();
     MPIR_ERR_CHECK(mpi_errno);
-
-    rank = MPIR_Process.rank;
-    size = MPIR_Process.size;
-    appnum = MPIR_Process.appnum;
 
     int err;
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_MUTEX, &err);
@@ -551,16 +565,6 @@ int MPID_Init(int requested, int *provided)
     mpi_errno = generic_init();
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* setup receive queue statistics */
-    mpi_errno = MPIDIG_recvq_init();
-    MPIR_ERR_CHECK(mpi_errno);
-
-    mpi_errno = create_init_comm(&init_comm);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    mpi_errno = MPIDU_Init_shm_init();
-    MPIR_ERR_CHECK(mpi_errno);
-
     /* Initialize multiple VCIs */
     /* TODO: add checks to ensure MPIDI_vci_t is padded or aligned to MPL_CACHELINE_SIZE */
     MPIDI_global.n_vcis = 1;
@@ -582,7 +586,35 @@ int MPID_Init(int requested, int *provided)
         /* TODO: workq */
     }
 
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT_LOCAL);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPID_Init_world(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Comm *init_comm = NULL;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_WORLD);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT_WORLD);
+
+    /* setup receive queue statistics */
+    mpi_errno = MPIDIG_recvq_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = create_init_comm(&init_comm);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIDU_Init_shm_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
     {
+        int rank = MPIR_Process.rank;
+        int size = MPIR_Process.size;
+        int appnum = MPIR_Process.appnum;
+
         int shm_tag_bits = MPIR_TAG_BITS_DEFAULT, nm_tag_bits = MPIR_TAG_BITS_DEFAULT;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         mpi_errno = MPIDI_SHM_mpi_init_hook(rank, size, &shm_tag_bits);
@@ -617,7 +649,7 @@ int MPID_Init(int requested, int *provided)
     MPIDI_global.MPIR_Comm_fns_store.split_type = MPIDI_Comm_split_type;
     MPIR_Comm_fns = &MPIDI_global.MPIR_Comm_fns_store;
 
-    MPIR_Process.attrs.appnum = appnum;
+    MPIR_Process.attrs.appnum = MPIR_Process.appnum;
     MPIR_Process.attrs.io = MPI_ANY_SOURCE;
 
     destroy_init_comm(&init_comm);
@@ -627,22 +659,10 @@ int MPID_Init(int requested, int *provided)
     MPIDI_global.is_initialized = 0;
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT_WORLD);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
-}
-
-int MPID_Init_local(int requested, int *provided)
-{
-    int mpi_errno = MPI_SUCCESS;
-    return mpi_errno;
-}
-
-int MPID_Init_world(void)
-{
-    int mpi_errno = MPI_SUCCESS;
-    return mpi_errno;
 }
 
 int MPID_InitCompleted(void)


### PR DESCRIPTION
## Pull Request Description

To prepare for MPI session from the coming MPI 4.0 standard, we need separate the current initialization process into local initialization that is entirely local and the rest of the initialization that require communication (or the establishment of it).

This PR splits MPID_Init into MPID_Init_local and MPID_Init_world for that separation.

Refference https://github.com/pmodels/mpich/issues/4878, https://github.com/pmodels/mpich/pull/4949

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
