### PR TITLE
pm/hydra: Fix nodelist parsing when prefix contains 0-9 (e.g. cl2n001)

### DIFF
--- a/src/pm/hydra/maint/slurm_nodelist_parse.c
+++ b/src/pm/hydra/maint/slurm_nodelist_parse.c
@@ -75,18 +75,20 @@ void list_to_nodes(char *str, struct list **node_list)
 
     /* compile group-0 regex for old format: "[h00-h12,h14] | h00-h12 | h14" */
     regcomp(&gmatch_old[0],
-            "(,|^)(\\[[-,a-z0-9]+\\]|[a-z]+[0-9]+-[a-z]+[0-9]+|[a-z]+[0-9]+)(,|$)",
+            "(,|^)(\\[[-,a-z0-9]+\\]|[a-z0-9]*[a-z][0-9]+-[a-z0-9]*[a-z][0-9]+|[a-z0-9]*[a-z][0-9]+)(,|$)",
             REG_EXTENDED | REG_ICASE);
 
     /* compile group-1 regex for old format: "h00-h12 | h14" */
     regcomp(&gmatch_old[1],
-            "([[,]|^)([a-z]+[0-9]+-[a-z]+[0-9]+|[a-z]+[0-9]+)([],]|$)", REG_EXTENDED | REG_ICASE);
+            "([[,]|^)([a-z0-9]*[a-z][0-9]+-[a-z0-9]*[a-z][0-9]+|[a-z0-9]*[a-z][0-9]+)([],]|$)",
+            REG_EXTENDED | REG_ICASE);
 
     /* compile range regex for old format: "h00-h12" */
-    regcomp(&rmatch_old, "([a-z]+)([0-9]+)-([a-z]+)([0-9]+)", REG_EXTENDED | REG_ICASE);
+    regcomp(&rmatch_old, "([a-z0-9]*[a-z])([0-9]+)-([a-z0-9]*[a-z])([0-9]+)",
+            REG_EXTENDED | REG_ICASE);
 
     /* compile element regex for old format: "h14" */
-    regcomp(&ematch_old, "([a-z]+[0-9]+)", REG_EXTENDED | REG_ICASE);
+    regcomp(&ematch_old, "([a-z0-9]*[a-z][0-9]+)", REG_EXTENDED | REG_ICASE);
 
     /* compile group-0 regex for new format: "h00-[00-12,14] | h00[00-12,14] | h00-14 | h0014" */
     regcomp(&gmatch_new[0], "(,|^)([a-z0-9][\\.a-z0-9-]+)(\\[[-,0-9]+\\])?(,|$)",

--- a/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
+++ b/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
@@ -94,18 +94,20 @@ static HYD_status list_to_nodes(char *str)
 
     /* compile group-0 regex for old format: "[h00-h12,h14] | h00-h12 | h14" */
     regcomp(&gmatch_old[0],
-            "(,|^)(\\[[-,a-z0-9]+\\]|[a-z]+[0-9]+-[a-z]+[0-9]+|[a-z]+[0-9]+)(,|$)",
+            "(,|^)(\\[[-,a-z0-9]+\\]|[a-z0-9]*[a-z][0-9]+-[a-z0-9]*[a-z][0-9]+|[a-z0-9]*[a-z][0-9]+)(,|$)",
             REG_EXTENDED | REG_ICASE);
 
     /* compile group-1 regex for old format: "h00-h12 | h14" */
     regcomp(&gmatch_old[1],
-            "([[,]|^)([a-z]+[0-9]+-[a-z]+[0-9]+|[a-z]+[0-9]+)([],]|$)", REG_EXTENDED | REG_ICASE);
+            "([[,]|^)([a-z0-9]*[a-z][0-9]+-[a-z0-9]*[a-z][0-9]+|[a-z0-9]*[a-z][0-9]+)([],]|$)",
+            REG_EXTENDED | REG_ICASE);
 
     /* compile range regex for old format: "h00-h12" */
-    regcomp(&rmatch_old, "([a-z]+)([0-9]+)-([a-z]+)([0-9]+)", REG_EXTENDED | REG_ICASE);
+    regcomp(&rmatch_old, "([a-z0-9]*[a-z])([0-9]+)-([a-z0-9]*[a-z])([0-9]+)",
+            REG_EXTENDED | REG_ICASE);
 
     /* compile element regex for old format: "h14" */
-    regcomp(&ematch_old, "([a-z]+[0-9]+)", REG_EXTENDED | REG_ICASE);
+    regcomp(&ematch_old, "([a-z0-9]*[a-z][0-9]+)", REG_EXTENDED | REG_ICASE);
 
     /* compile group-0 regex for new format: "h00-[00-12,14] | h00[00-12,14] | h00-14 | h0014" */
     regcomp(&gmatch_new[0], "(,|^)([a-z0-9][\\.a-z0-9-]+)(\\[[-,0-9]+\\])?(,|$)",


### PR DESCRIPTION
## Pull Request Description

With mpich >=3.3 I have `Error: node list format not recognized. Try using '-hosts=<hostnames>'.` errors on my cluster.
The problem is that my cluster nodes are named cl2n001, cl2n002, ... = with a (fixed) number inside the name prefix.
This patch fixes the problem by modifying the regex to properly parse this sort of node names.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
