### PR TITLE
MPI-4: allow info functions to be called without MPI initialization

### DIFF
--- a/src/include/mpir_handlemem.h
+++ b/src/include/mpir_handlemem.h
@@ -233,6 +233,9 @@ Input Parameters:
   +*/
 static inline void *MPIR_Handle_obj_alloc(MPIR_Object_alloc_t * objmem)
 {
+    /* MPI_Info must call MPIR_Info_handle_obj_alloc(). */
+    MPIR_Assert(objmem->kind != MPIR_INFO);
+
     void *ret;
     MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_HANDLE_MUTEX);
     MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_HANDLE_MUTEX);
@@ -354,6 +357,9 @@ Input Parameters:
   +*/
 static inline void MPIR_Handle_obj_free(MPIR_Object_alloc_t * objmem, void *object)
 {
+    /* MPI_Info must call MPIR_Info_handle_obj_free(). */
+    MPIR_Assert(objmem->kind != MPIR_INFO);
+
     MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_HANDLE_MUTEX);
     MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_HANDLE_MUTEX);
     MPIR_Handle_obj_free_unsafe(objmem, object, /* not info */ FALSE);
@@ -418,6 +424,8 @@ static inline void MPIR_Handle_obj_free_unsafe(MPIR_Object_alloc_t * objmem, voi
             MPIR_Handle_free(objmem);
         }
     }
+    /* Currently is_info must be enabled for MPI_Info. */
+    MPIR_Assert(is_info || objmem->kind != MPIR_INFO);
 }
 
 /*

--- a/src/include/mpir_handlemem.h
+++ b/src/include/mpir_handlemem.h
@@ -107,6 +107,8 @@ static inline void *MPIR_Handle_direct_init(MPIR_Object_alloc_t * objmem)
 
         HANDLE_VG_LABEL(hptr, objmem->size, objmem->kind, 1);
     }
+    objmem->num_allocated += objmem->direct_size;
+    objmem->num_avail += objmem->direct_size;
 
     if (hptr)
         hptr->next = 0;
@@ -169,6 +171,8 @@ static inline void *MPIR_Handle_indirect_init(MPIR_Object_alloc_t * objmem,
     /* printf("loc of update is %x\n", &(objmem->indirect)[objmem->indirect_size]);  */
     objmem->indirect[objmem->indirect_size] = block_ptr;
     objmem->indirect_size = objmem->indirect_size + 1;
+    objmem->num_allocated += indirect_num_indices;
+    objmem->num_avail += indirect_num_indices;
     return block_ptr;
 }
 
@@ -309,6 +313,7 @@ static inline void *MPIR_Handle_obj_alloc_unsafe(MPIR_Object_alloc_t * objmem,
                                                    ptr, ptr->handle));
     }
 
+    objmem->num_avail--;
     return ptr;
 }
 
@@ -378,6 +383,7 @@ static inline void MPIR_Handle_obj_free_unsafe(MPIR_Object_alloc_t * objmem, voi
 
     obj->next = objmem->avail;
     objmem->avail = obj;
+    objmem->num_avail++;
 }
 
 /*

--- a/src/include/mpir_handlemem.h
+++ b/src/include/mpir_handlemem.h
@@ -53,6 +53,10 @@ int MPIR_check_handles_on_finalize(void *objmem_ptr);
 
    None of these routines is thread-safe.  Any routine that uses them
    must ensure that only one thread at a time may call them.
+
+   As of MPI-4, MPI_Info handles can be created and freed before MPI_Init() and
+   after MPI_Finalize(), so some internal functions below may be called before
+   MPI_Init() and after MPI_Finalize().
 */
 
 /* This routine is called by finalize when MPI exits */

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -432,9 +432,11 @@ typedef struct MPIR_Object_alloc_t {
                                  */
 } MPIR_Object_alloc_t;
 static inline void *MPIR_Handle_obj_alloc(MPIR_Object_alloc_t *);
+void *MPIR_Info_handle_obj_alloc(MPIR_Object_alloc_t *);
 static inline void *MPIR_Handle_obj_alloc_unsafe(MPIR_Object_alloc_t *,
                                                  int max_blocks, int max_indices);
 static inline void MPIR_Handle_obj_free(MPIR_Object_alloc_t *, void *);
+void MPIR_Info_handle_obj_free(MPIR_Object_alloc_t *, void *);
 static inline void MPIR_Handle_obj_free_unsafe(MPIR_Object_alloc_t *, void *, bool is_info);
 static inline void *MPIR_Handle_get_ptr_indirect(int, MPIR_Object_alloc_t *);
 

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -435,7 +435,7 @@ static inline void *MPIR_Handle_obj_alloc(MPIR_Object_alloc_t *);
 static inline void *MPIR_Handle_obj_alloc_unsafe(MPIR_Object_alloc_t *,
                                                  int max_blocks, int max_indices);
 static inline void MPIR_Handle_obj_free(MPIR_Object_alloc_t *, void *);
-static inline void MPIR_Handle_obj_free_unsafe(MPIR_Object_alloc_t *, void *);
+static inline void MPIR_Handle_obj_free_unsafe(MPIR_Object_alloc_t *, void *, bool is_info);
 static inline void *MPIR_Handle_get_ptr_indirect(int, MPIR_Object_alloc_t *);
 
 

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -416,6 +416,9 @@ typedef struct MPIR_Object_alloc_t {
     int initialized;            /* */
     void **indirect;            /* Pointer to indirect object blocks */
     int indirect_size;          /* Number of allocated indirect blocks */
+    int num_allocated;          /* Total capacity of this allocator including both
+                                 * direct and indirect */
+    int num_avail;              /* Number of available objects including both direct and indirect */
     MPII_Object_kind kind;      /* Kind of object this is for */
     int size;                   /* Size of an individual object */
     void *direct;               /* Pointer to direct block, used

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -474,10 +474,10 @@ static inline void MPIR_Request_free_with_safety(MPIR_Request * req, int need_sa
 
         if (need_safety) {
             MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_HANDLE_MUTEX);
-            MPIR_Handle_obj_free_unsafe(&MPIR_Request_mem[pool], req);
+            MPIR_Handle_obj_free_unsafe(&MPIR_Request_mem[pool], req, /* not info */ FALSE);
             MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_HANDLE_MUTEX);
         } else {
-            MPIR_Handle_obj_free_unsafe(&MPIR_Request_mem[pool], req);
+            MPIR_Handle_obj_free_unsafe(&MPIR_Request_mem[pool], req, /* not info */ FALSE);
         }
     }
     if (need_safety) {

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -18,7 +18,7 @@
 /* Preallocated keyval objects */
 MPII_Keyval MPII_Keyval_direct[MPID_KEYVAL_PREALLOC];
 
-MPIR_Object_alloc_t MPII_Keyval_mem = { 0, 0, 0, 0, MPIR_KEYVAL,
+MPIR_Object_alloc_t MPII_Keyval_mem = { 0, 0, 0, 0, 0, 0, MPIR_KEYVAL,
     sizeof(MPII_Keyval),
     MPII_Keyval_direct,
     MPID_KEYVAL_PREALLOC,
@@ -32,7 +32,7 @@ MPIR_Object_alloc_t MPII_Keyval_mem = { 0, 0, 0, 0, MPIR_KEYVAL,
 /* Preallocated keyval objects */
 MPIR_Attribute MPID_Attr_direct[MPIR_ATTR_PREALLOC];
 
-MPIR_Object_alloc_t MPID_Attr_mem = { 0, 0, 0, 0, MPIR_ATTR,
+MPIR_Object_alloc_t MPID_Attr_mem = { 0, 0, 0, 0, 0, 0, MPIR_ATTR,
     sizeof(MPIR_Attribute),
     MPID_Attr_direct,
     MPIR_ATTR_PREALLOC,

--- a/src/mpi/coll/op/op_create.c
+++ b/src/mpi/coll/op/op_create.c
@@ -32,7 +32,7 @@ int MPI_Op_create(MPI_User_function * user_fn, int commute, MPI_Op * op)
 MPIR_Op MPIR_Op_builtin[MPIR_OP_N_BUILTIN];
 MPIR_Op MPIR_Op_direct[MPIR_OP_PREALLOC];
 
-MPIR_Object_alloc_t MPIR_Op_mem = { 0, 0, 0, 0, MPIR_OP,
+MPIR_Object_alloc_t MPIR_Op_mem = { 0, 0, 0, 0, 0, 0, MPIR_OP,
     sizeof(MPIR_Op),
     MPIR_Op_direct,
     MPIR_OP_PREALLOC,

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -26,6 +26,8 @@ MPIR_Object_alloc_t MPIR_Comm_mem = {
     0,
     0,
     0,
+    0,
+    0,
     MPIR_COMM,
     sizeof(MPIR_Comm),
     MPIR_Comm_direct,

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -14,7 +14,7 @@
 MPIR_Datatype MPIR_Datatype_builtin[MPIR_DATATYPE_N_BUILTIN];
 MPIR_Datatype MPIR_Datatype_direct[MPIR_DATATYPE_PREALLOC];
 
-MPIR_Object_alloc_t MPIR_Datatype_mem = { 0, 0, 0, 0, MPIR_DATATYPE,
+MPIR_Object_alloc_t MPIR_Datatype_mem = { 0, 0, 0, 0, 0, 0, MPIR_DATATYPE,
     sizeof(MPIR_Datatype), MPIR_Datatype_direct,
     MPIR_DATATYPE_PREALLOC,
     NULL

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -139,7 +139,7 @@ static int checkForUserErrcode(int);
 MPIR_Errhandler MPIR_Errhandler_builtin[MPIR_ERRHANDLER_N_BUILTIN];
 MPIR_Errhandler MPIR_Errhandler_direct[MPIR_ERRHANDLER_PREALLOC];
 
-MPIR_Object_alloc_t MPIR_Errhandler_mem = { 0, 0, 0, 0, MPIR_ERRHANDLER,
+MPIR_Object_alloc_t MPIR_Errhandler_mem = { 0, 0, 0, 0, 0, 0, MPIR_ERRHANDLER,
     sizeof(MPIR_Errhandler),
     MPIR_Errhandler_direct,
     MPIR_ERRHANDLER_PREALLOC,

--- a/src/mpi/group/grouputil.c
+++ b/src/mpi/group/grouputil.c
@@ -14,7 +14,7 @@
 MPIR_Group MPIR_Group_builtin[MPIR_GROUP_N_BUILTIN];
 MPIR_Group MPIR_Group_direct[MPID_GROUP_PREALLOC];
 
-MPIR_Object_alloc_t MPIR_Group_mem = { 0, 0, 0, 0, MPIR_GROUP,
+MPIR_Object_alloc_t MPIR_Group_mem = { 0, 0, 0, 0, 0, 0, MPIR_GROUP,
     sizeof(MPIR_Group), MPIR_Group_direct,
     MPID_GROUP_PREALLOC,
     NULL

--- a/src/mpi/info/info_impl.c
+++ b/src/mpi/info/info_impl.c
@@ -5,6 +5,7 @@
 
 #include "mpiimpl.h"
 
+/* All the MPIR_Info routines may be called before initialization or after finalization of MPI. */
 int MPIR_Info_delete_impl(MPIR_Info * info_ptr, const char *key)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -18,7 +19,7 @@ int MPIR_Info_delete_impl(MPIR_Info * info_ptr, const char *key)
             MPL_free(curr_ptr->key);
             MPL_free(curr_ptr->value);
             prev_ptr->next = curr_ptr->next;
-            MPIR_Handle_obj_free(&MPIR_Info_mem, curr_ptr);
+            MPIR_Info_handle_obj_free(&MPIR_Info_mem, curr_ptr);
             break;
         }
         prev_ptr = curr_ptr;

--- a/src/mpi/info/info_impl.c
+++ b/src/mpi/info/info_impl.c
@@ -16,8 +16,10 @@ int MPIR_Info_delete_impl(MPIR_Info * info_ptr, const char *key)
 
     while (curr_ptr) {
         if (!strncmp(curr_ptr->key, key, MPI_MAX_INFO_KEY)) {
-            MPL_free(curr_ptr->key);
-            MPL_free(curr_ptr->value);
+            /* MPI_Info objects are allocated by MPL_direct_malloc(), so they need to be
+             * freed by MPL_direct_free(), not MPL_free(). */
+            MPL_direct_free(curr_ptr->key);
+            MPL_direct_free(curr_ptr->value);
             prev_ptr->next = curr_ptr->next;
             MPIR_Info_handle_obj_free(&MPIR_Info_mem, curr_ptr);
             break;
@@ -61,8 +63,12 @@ int MPIR_Info_dup_impl(MPIR_Info * info_ptr, MPIR_Info ** new_info_ptr)
         MPIR_ERR_CHECK(mpi_errno);
 
         curr_new = curr_new->next;
-        curr_new->key = MPL_strdup(curr_old->key);
-        curr_new->value = MPL_strdup(curr_old->value);
+        /* MPI_Info objects may not be allocated by MPL_strdup() since MPL_strdup() may not be
+         * called before MPI_Init() and the allocated memory must have been freed before
+         * MPI_Finalize() while MPI-4 allows calling MPI_Info routines before MPI_Init() and
+         * after MPI_Finalize(). */
+        curr_new->key = MPL_direct_strdup(curr_old->key);
+        curr_new->value = MPL_direct_strdup(curr_old->value);
 
         curr_old = curr_old->next;
     }
@@ -183,8 +189,13 @@ int MPIR_Info_set_impl(MPIR_Info * info_ptr, const char *key, const char *value)
     while (curr_ptr) {
         if (!strncmp(curr_ptr->key, key, MPI_MAX_INFO_KEY)) {
             /* Key already present; replace value */
-            MPL_free(curr_ptr->value);
-            curr_ptr->value = MPL_strdup(value);
+
+            /* MPI_Info objects may not be allocated by MPL_strdup() since MPL_strdup() may not be
+             * called before MPI_Init() and the allocated memory must have been freed before
+             * MPI_Finalize() while MPI-4 allows calling MPI_Info routines before MPI_Init() and
+             * after MPI_Finalize().  For the same reason, we need to use free, not MPL_free(). */
+            MPL_direct_free(curr_ptr->value);
+            curr_ptr->value = MPL_direct_strdup(value);
             break;
         }
         prev_ptr = curr_ptr;
@@ -198,8 +209,10 @@ int MPIR_Info_set_impl(MPIR_Info * info_ptr, const char *key, const char *value)
 
         /*printf("Inserting new elm %x at %x\n", curr_ptr->id, prev_ptr->id); */
         prev_ptr->next = curr_ptr;
-        curr_ptr->key = MPL_strdup(key);
-        curr_ptr->value = MPL_strdup(value);
+        /* MPI_Info objects must be allocated by MPL_direct_strdup(), not MPL_strdup() because
+         * this function may be called before MPI_Init() and after MPI_Finalize(). */
+        curr_ptr->key = MPL_direct_strdup(key);
+        curr_ptr->value = MPL_direct_strdup(value);
     }
 
   fn_exit:

--- a/src/mpi/info/infoutil.c
+++ b/src/mpi/info/infoutil.c
@@ -17,7 +17,7 @@
 MPIR_Info MPIR_Info_builtin[MPIR_INFO_N_BUILTIN];
 MPIR_Info MPIR_Info_direct[MPIR_INFO_PREALLOC];
 
-MPIR_Object_alloc_t MPIR_Info_mem = { 0, 0, 0, 0, MPIR_INFO,
+MPIR_Object_alloc_t MPIR_Info_mem = { 0, 0, 0, 0, 0, 0, MPIR_INFO,
     sizeof(MPIR_Info), MPIR_Info_direct,
     MPIR_INFO_PREALLOC,
     NULL

--- a/src/mpi/info/infoutil.c
+++ b/src/mpi/info/infoutil.c
@@ -37,8 +37,10 @@ int MPIR_Info_free_impl(MPIR_Info * info_ptr)
     /* printf("Returning info %x\n", info_ptr->id); */
     /* First, free the string storage */
     while (curr_ptr) {
-        MPL_free(curr_ptr->key);
-        MPL_free(curr_ptr->value);
+        /* MPI_Info objects are allocated by normal MPL_direct_xxx() functions, so
+         * they need to be freed by MPL_direct_free(), not MPL_free(). */
+        MPL_direct_free(curr_ptr->key);
+        MPL_direct_free(curr_ptr->value);
         last_ptr = curr_ptr;
         curr_ptr = curr_ptr->next;
         MPIR_Info_handle_obj_free(&MPIR_Info_mem, last_ptr);

--- a/src/mpi/info/infoutil.c
+++ b/src/mpi/info/infoutil.c
@@ -32,7 +32,7 @@ int MPIR_Info_free_impl(MPIR_Info * info_ptr)
     curr_ptr = info_ptr->next;
     last_ptr = NULL;
 
-    MPIR_Handle_obj_free(&MPIR_Info_mem, info_ptr);
+    MPIR_Info_handle_obj_free(&MPIR_Info_mem, info_ptr);
 
     /* printf("Returning info %x\n", info_ptr->id); */
     /* First, free the string storage */
@@ -41,7 +41,7 @@ int MPIR_Info_free_impl(MPIR_Info * info_ptr)
         MPL_free(curr_ptr->value);
         last_ptr = curr_ptr;
         curr_ptr = curr_ptr->next;
-        MPIR_Handle_obj_free(&MPIR_Info_mem, last_ptr);
+        MPIR_Info_handle_obj_free(&MPIR_Info_mem, last_ptr);
     }
     return MPI_SUCCESS;
 }
@@ -52,7 +52,7 @@ int MPIR_Info_free_impl(MPIR_Info * info_ptr)
 int MPIR_Info_alloc(MPIR_Info ** info_p_p)
 {
     int mpi_errno = MPI_SUCCESS;
-    *info_p_p = (MPIR_Info *) MPIR_Handle_obj_alloc(&MPIR_Info_mem);
+    *info_p_p = (MPIR_Info *) MPIR_Info_handle_obj_alloc(&MPIR_Info_mem);
     MPIR_ERR_CHKANDJUMP1(!*info_p_p, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s", "MPI_Info");
 
     MPIR_Object_set_ref(*info_p_p, 0);

--- a/src/mpi/request/mpir_greq.c
+++ b/src/mpi/request/mpir_greq.c
@@ -12,7 +12,7 @@
 
 MPIR_Grequest_class MPIR_Grequest_class_direct[MPIR_GREQ_CLASS_PREALLOC];
 
-MPIR_Object_alloc_t MPIR_Grequest_class_mem = { 0, 0, 0, 0, MPIR_GREQ_CLASS,
+MPIR_Object_alloc_t MPIR_Grequest_class_mem = { 0, 0, 0, 0, 0, 0, MPIR_GREQ_CLASS,
     sizeof(MPIR_Grequest_class),
     MPIR_Grequest_class_direct,
     MPIR_GREQ_CLASS_PREALLOC,

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -31,9 +31,9 @@ void MPII_init_request(void)
 #endif
 
     /* *INDENT-OFF* */
-    MPIR_Request_mem[0] = (MPIR_Object_alloc_t) { 0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), MPIR_Request_direct, MPIR_REQUEST_PREALLOC, lock_ptr };
+    MPIR_Request_mem[0] = (MPIR_Object_alloc_t) { 0, 0, 0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), MPIR_Request_direct, MPIR_REQUEST_PREALLOC, lock_ptr };
     for (int i = 1; i < MPIR_REQUEST_NUM_POOLS; i++) {
-        MPIR_Request_mem[i] = (MPIR_Object_alloc_t) { 0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), NULL, 0, lock_ptr };
+        MPIR_Request_mem[i] = (MPIR_Object_alloc_t) { 0, 0, 0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), NULL, 0, lock_ptr };
     }
     /* *INDENT-ON* */
 

--- a/src/mpi/rma/winutil.c
+++ b/src/mpi/rma/winutil.c
@@ -14,7 +14,7 @@
 /* Preallocated window objects */
 MPIR_Win MPIR_Win_direct[MPIR_WIN_PREALLOC];
 
-MPIR_Object_alloc_t MPIR_Win_mem = { 0, 0, 0, 0, MPIR_WIN,
+MPIR_Object_alloc_t MPIR_Win_mem = { 0, 0, 0, 0, 0, 0, MPIR_WIN,
     sizeof(MPIR_Win), MPIR_Win_direct,
     MPIR_WIN_PREALLOC,
     NULL

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -256,6 +256,14 @@ typedef struct {
 #define MPL_mmap(a,b,c,d,e,f,g) MPL_trmmap((a),(b),(c),(d),(e),(f),(g),__LINE__,__FILE__)
 #define MPL_munmap(a,b,c) MPL_trmunmap((a),(b),(c),__LINE__,__FILE__)
 
+/* Directly call malloc/calloc/realloc, so those memory segments are not
+ * checked in MPI_Finalize() */
+void *MPL_direct_malloc(size_t size);
+void *MPL_direct_calloc(size_t nmemb, size_t size);
+void *MPL_direct_realloc(void *ptr, size_t size);
+char *MPL_direct_strdup(const char *s);
+void MPL_direct_free(void *ptr);
+
 #ifdef MPL_DEFINE_ALIGNED_ALLOC
 #define MPL_aligned_alloc(a,b,c) MPL_traligned_alloc((a),(b),(c),__LINE__,__FILE__)
 #endif /* #ifdef MPL_DEFINE_ALIGNED_ALLOC */
@@ -296,6 +304,12 @@ static inline void *MPL_realloc(void *ptr, size_t size, MPL_memory_class memclas
 #define MPL_free(a)      free((void *)(a))
 #define MPL_mmap(a,b,c,d,e,f,g) mmap((void *)(a),(size_t)(b),(int)(c),(int)(d),(int)(e),(off_t)(f))
 #define MPL_munmap(a,b,c)  munmap((void *)(a),(size_t)(b))
+
+#define MPL_direct_malloc   malloc
+#define MPL_direct_calloc   calloc
+#define MPL_direct_realloc  realloc
+#define MPL_direct_strdup   strdup
+#define MPL_direct_free     free
 
 #ifdef MPL_DEFINE_ALIGNED_ALLOC
 MPL_STATIC_INLINE_PREFIX void *MPL_aligned_alloc(size_t alignment, size_t size,

--- a/src/mpl/include/mpl_valgrind.h
+++ b/src/mpl/include/mpl_valgrind.h
@@ -135,6 +135,7 @@
 #define MPL_VG_CHECK_MEM_IS_ADDRESSABLE(addr_,len_) VALGRIND_CHECK_WRITABLE((addr_),(len_))
 #endif
 #define MPL_VG_CREATE_BLOCK(addr_,len_,desc_)       do { (void) VALGRIND_CREATE_BLOCK((addr_),(len_),(desc_)); } while (0)
+#define MPL_VG_DISCARD(addr_)                       do { (void) VALGRIND_DISCARD(addr_); } while (0)
 #define MPL_VG_RUNNING_ON_VALGRIND()                RUNNING_ON_VALGRIND
 #define MPL_VG_PRINTF_BACKTRACE                     VALGRIND_PRINTF_BACKTRACE
 /* Valgrind has a bug
@@ -160,6 +161,7 @@
 #define MPL_VG_CHECK_MEM_IS_DEFINED(addr_,len_)     do {} while (0)
 #define MPL_VG_CHECK_MEM_IS_ADDRESSABLE(addr_,len_) do {} while (0)
 #define MPL_VG_CREATE_BLOCK(addr_,len_,desc_)       do {} while (0)
+#define MPL_VG_DISCARD(addr_)                       do {} while (0)
 #define MPL_VG_RUNNING_ON_VALGRIND()                (0) /*always false */
 #define MPL_VG_MEM_INIT(addr_,len_)                 do {} while (0)
 #if defined(MPL_HAVE_MACRO_VA_ARGS)

--- a/src/mpl/src/mem/mpl_trmem.c
+++ b/src/mpl/src/mem/mpl_trmem.c
@@ -19,6 +19,7 @@
 /* Undefine these in case they were set to 'error' */
 #undef malloc
 #undef calloc
+#undef realloc
 #undef free
 #undef strdup
 #undef mmap
@@ -992,3 +993,31 @@ char *MPL_strdup_no_spaces(const char *str)
 
     return newstr;
 }
+
+#ifdef MPL_USE_MEMORY_TRACING
+/* Direct functions. */
+void *MPL_direct_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+void *MPL_direct_calloc(size_t nmemb, size_t size)
+{
+    return calloc(nmemb, size);
+}
+
+void *MPL_direct_realloc(void *ptr, size_t size)
+{
+    return realloc(ptr, size);
+}
+
+char *MPL_direct_strdup(const char *s)
+{
+    return strdup(s);
+}
+
+void MPL_direct_free(void *ptr)
+{
+    free(ptr);
+}
+#endif

--- a/src/util/mpir_handlemem.c
+++ b/src/util/mpir_handlemem.c
@@ -169,3 +169,40 @@ const char *MPIR_Handle_get_kind_str(int kind)
     }
 #undef mpiu_name_case_
 }
+
+static MPL_initlock_t info_handle_obj_lock = MPL_INITLOCK_INITIALIZER;
+/*+
+  MPIR_Info_handle_obj_alloc - Create an INFO object using the handle allocator
+                               even before MPI_Init() or after MPI_Finalize().
+
+  This routine has an independent "static" lock that is different from
+  MPIR_THREAD_POBJ_HANDLE_MUTEX and MPIR_THREAD_VCI_HANDLE_MUTEX.  Since this
+  routine does not share the lock with MPIR_Handle_obj_alloc() and MPIR_Handle_obj_free(),
+  this routine may not update any global data that can be updated by MPIR_Handle_obj_alloc()
+  and MPIR_Handle_obj_free().
+  +*/
+void *MPIR_Info_handle_obj_alloc(MPIR_Object_alloc_t * objmem)
+{
+    void *ret;
+    MPL_initlock_lock(&info_handle_obj_lock);
+    ret = MPIR_Handle_obj_alloc_unsafe(objmem, HANDLE_NUM_BLOCKS, HANDLE_NUM_INDICES);
+    MPL_initlock_unlock(&info_handle_obj_lock);
+    return ret;
+}
+
+/*+
+  MPIR_Info_handle_obj_free - Free an INFO object allocated by MPIR_Info_handle_obj_alloc()
+                              even before MPI_Init() or after MPI_Finalize().
+
+  This routine has an independent "static" lock that is different from
+  MPIR_THREAD_POBJ_HANDLE_MUTEX and MPIR_THREAD_VCI_HANDLE_MUTEX.  Since this
+  routine does not share the lock with MPIR_Handle_obj_alloc() and MPIR_Handle_obj_free(),
+  this routine may not update any global data that can be updated by MPIR_Handle_obj_alloc()
+  and MPIR_Handle_obj_free().
+  +*/
+void MPIR_Info_handle_obj_free(MPIR_Object_alloc_t * objmem, void *object)
+{
+    MPL_initlock_lock(&info_handle_obj_lock);
+    MPIR_Handle_obj_free_unsafe(objmem, object, /* info object */ TRUE);
+    MPL_initlock_unlock(&info_handle_obj_lock);
+}

--- a/src/util/mpir_handlemem.c
+++ b/src/util/mpir_handlemem.c
@@ -183,6 +183,9 @@ static MPL_initlock_t info_handle_obj_lock = MPL_INITLOCK_INITIALIZER;
   +*/
 void *MPIR_Info_handle_obj_alloc(MPIR_Object_alloc_t * objmem)
 {
+    /* Non-MPI_Info objects must call MPIR_Handle_obj_alloc(). */
+    MPIR_Assert(objmem->kind == MPIR_INFO);
+
     void *ret;
     MPL_initlock_lock(&info_handle_obj_lock);
     ret = MPIR_Handle_obj_alloc_unsafe(objmem, HANDLE_NUM_BLOCKS, HANDLE_NUM_INDICES);
@@ -202,6 +205,8 @@ void *MPIR_Info_handle_obj_alloc(MPIR_Object_alloc_t * objmem)
   +*/
 void MPIR_Info_handle_obj_free(MPIR_Object_alloc_t * objmem, void *object)
 {
+    MPIR_Assert(objmem->kind == MPIR_INFO);
+
     MPL_initlock_lock(&info_handle_obj_lock);
     MPIR_Handle_obj_free_unsafe(objmem, object, /* info object */ TRUE);
     MPL_initlock_unlock(&info_handle_obj_lock);

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1061,6 +1061,7 @@
 /info/infoorder
 /info/infotest
 /info/infovallen
+/info/info_no_init
 /init/attrself
 /init/exitst1
 /init/exitst2

--- a/test/mpi/info/Makefile.am
+++ b/test/mpi/info/Makefile.am
@@ -20,4 +20,5 @@ noinst_PROGRAMS = \
     infotest      \
     infoget       \
     infogetstring \
-    infoenv
+    infoenv       \
+    info_no_init

--- a/test/mpi/info/info_no_init.c
+++ b/test/mpi/info/info_no_init.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "mpitestconf.h"
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#include "mpitest.h"
+
+#define NUM_INFOS 128
+
+int modify_info(MPI_Info * infos, const char *get_key, const char *get_value,
+                const char *set_key, const char *set_value);
+
+int main(int argc, char *argv[])
+{
+    MPI_Info infos[NUM_INFOS];
+    int i, nerrs = 0;
+
+    /* MPI_Info functions can be called before MPI_Init(). */
+    for (i = 0; i < NUM_INFOS; i++)
+        MPI_Info_create(&infos[i]);
+
+    /* Modify some. */
+    nerrs += modify_info(infos, NULL, NULL, "key1", "value1");
+    nerrs += modify_info(infos, "key1", "value1", "key2", "value2");
+
+    MPI_Init(&argc, &argv);
+
+    /* Modify some. */
+    nerrs += modify_info(infos, "key2", "value2", "key3", "value3");
+
+    MPI_Finalize();
+
+    /* MPI_Info functions can be called after MPI_Finalize(). */
+
+    /* Modify some. */
+    nerrs += modify_info(infos, "key3", "value3", "key4", "value4");
+    nerrs += modify_info(infos, "key4", "value4", NULL, NULL);
+    for (i = 0; i < NUM_INFOS; i++)
+        MPI_Info_free(&infos[i]);
+
+    /* Let's check if we can create all info objects now.  This checks if the
+     * MPICH implementation internally cleans up the MPI_Info handle pool
+     * properly when all handles are freed and that pool is still
+     * reinitialized. */
+    for (i = 0; i < NUM_INFOS; i++)
+        MPI_Info_create(&infos[i]);
+    for (i = 0; i < NUM_INFOS; i++)
+        MPI_Info_free(&infos[i]);
+
+    if (nerrs) {
+        printf(" Found %d errors\n", nerrs);
+    } else {
+        printf(" No Errors\n");
+    }
+    fflush(stdout);
+
+    return nerrs ? 1 : 0;;
+}
+
+
+int modify_info(MPI_Info * infos, const char *get_key, const char *get_value,
+                const char *set_key, const char *set_value)
+{
+    int i, nerrs = 0;
+    static int num_modified = 0;
+
+    /* Duplicate some info objects to check if MPI_Info_dup() works.  Always
+     * 50% will be duplicated and replaced. */
+    for (i = 0; i < NUM_INFOS; i += (1 << (num_modified + 1))) {
+        int j;
+        for (j = i; j < i + (1 << num_modified); j++) {
+            if (j >= NUM_INFOS)
+                continue;
+            MPI_Info newinfo;
+            MPI_Info_dup(infos[i], &newinfo);
+            /* infos[i] is not needed. */
+            MPI_Info_free(&infos[i]);
+            /* newinfo becomes a new infos[i]. */
+            infos[i] = newinfo;
+        }
+    }
+    num_modified += 1;
+    if ((1 << num_modified) >= NUM_INFOS) {
+        num_modified = 0;
+    }
+
+    /* Get values. */
+    if (get_key && get_value) {
+        for (i = 0; i < NUM_INFOS; i++) {
+            int valuelen = MPI_MAX_INFO_VAL, flag;
+            char value[MPI_MAX_INFO_VAL];
+            MPI_Info_get_string(infos[i], get_key, &valuelen, value, &flag);
+            if (!flag) {
+                /* infos[i] should have get_key:get_value pair */
+                nerrs++;
+            } else if (strcmp(value, get_value) != 0) {
+                /* infos[i] should have get_key:get_value pair */
+                nerrs++;
+            }
+        }
+    }
+
+    /* Create new info objects to check if MPI_Info_create() works. Always 50%
+     * will be newly created and replaced. */
+    for (i = 0; i < NUM_INFOS; i += (1 << (num_modified + 1))) {
+        int j;
+        for (j = i; j < i + (1 << num_modified); j++) {
+            if (j >= NUM_INFOS)
+                continue;
+            MPI_Info_free(&infos[i]);
+            MPI_Info_create(&infos[i]);
+        }
+    }
+    num_modified += 1;
+    if ((1 << num_modified) >= NUM_INFOS) {
+        num_modified = 0;
+    }
+
+    /* Set values. */
+    if (set_key && set_value) {
+        for (i = 0; i < NUM_INFOS; i++) {
+            MPI_Info_set(infos[i], set_key, set_value);
+        }
+    }
+
+    return nerrs;
+}

--- a/test/mpi/info/testlist
+++ b/test/mpi/info/testlist
@@ -1,3 +1,4 @@
+
 infodup 1
 infodel 1
 infovallen 1
@@ -8,3 +9,4 @@ infotest 1
 infoget 1
 infogetstring 1
 infoenv 1
+info_no_init 1


### PR DESCRIPTION
## Pull Request Description

This is prerequisite for #4915 (implementation `MPI_Info_create_env()`).

This PR allows `MPI_Info` routines to be called before MPI initialization or after MPI finalization. Specifically, this PR changes `MPI_Info` handle management so that it can be created/destroyed regardless of the MPI initialization/finalization phase.

The tests for `MPI_Info_create_env()` will cover if `MPI_Info` routines can be called before `MPI_Init()`/`MPI_Init_thread()` and after `MPI_Finalize()`.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

Note that this patch may not make `MPI_Info_xxx()` routines perfectly safe especially when it returns an error (e.g., how to handle `MPIR_Err_return_comm()` if this `MPI_Info_xxx()` function returns an error while MPI is being *initialized* or *finalized*), but it's an extreme corner case that no one really cares. Anyway this kind of error handling is out of the MPI specification. As far as I check, `MPI_Info_xxx()` routines should work without MPI initialization in a successful case. 

## Expected Impact

This patch would slightly slow down `MPI_Info` allocation by changing its lock from a mutex to a spinlock, but it should not matter much. `MPI_Info` will be excluded from the refcount system because, in MPI-4, it is not necessary to free all `MPI_Info` handles before `MPI_Finalize()`.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
