### PR TITLE
ch4/ofi: fix data pointer assignment bug in am_recv_event

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -646,14 +646,14 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 
             break;
         case MPIDI_AMTYPE_PIPELINE:
-            p_data = (char *) wc->buf + sizeof(*am_hdr) + am_hdr->am_hdr_sz;
+            p_data = (char *) orig_buf + sizeof(*am_hdr) + am_hdr->am_hdr_sz;
             mpi_errno = MPIDI_OFI_handle_pipeline(am_hdr, am_hdr + 1, p_data);
             MPIR_ERR_CHECK(mpi_errno);
             break;
 
         case MPIDI_AMTYPE_RDMA_READ:
             /* buffer always copied together (there is no payload, just LMT header) */
-            p_data = (char *) am_hdr + sizeof(*am_hdr) + am_hdr->am_hdr_sz;
+            p_data = (char *) orig_buf + sizeof(*am_hdr) + am_hdr->am_hdr_sz;
             mpi_errno = MPIDI_OFI_handle_rdma_read(am_hdr, am_hdr + 1,
                                                    (MPIDI_OFI_lmt_msg_payload_t *) p_data);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -627,7 +627,7 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     }
 
     /* Received an expected message */
-  repeat:
+  fn_repeat:
     fi_src_addr = am_hdr->fi_src_addr;
     next_seqno = am_hdr->seqno + 1;
 
@@ -694,7 +694,7 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
          * in MPIDI_OFI_am_enqueue_unordered_msg */
         has_alignment_copy = 1;
 #endif
-        goto repeat;
+        goto fn_repeat;
     }
 
     /* Record the next expected sequence number from fi_src_addr */


### PR DESCRIPTION
## Pull Request Description
This patch fixes incorrect data addr assignment in `am_recv_event` function 
under `MPIDI_AMTYPE_RDMA_READ` path. 
when we get data from ofi module, the actual data addr should be
p_data = (char *) buf + sizeof(*ofi_hdr) + ofi_hdr->am_hdr_sz
ofi_hdr is the ofi header and ofi_hdr->am_hdr_sz is the am header size.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
