### PR TITLE
ch4: shortcut self comm communications

### DIFF
--- a/src/binding/c/coll_api.txt
+++ b/src/binding/c/coll_api.txt
@@ -197,6 +197,16 @@ MPI_Neighbor_alltoallw:
 MPI_Reduce:
     .desc: Reduces values on all processes to a single value
     .docnotes: collops
+{ -- early_return --
+    if (comm_ptr->remote_size == 1 && comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
+        mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
+        if (mpi_errno) {
+            goto fn_fail;
+        } else {
+            goto fn_exit;
+        }
+    }
+}
 
 MPI_Reduce_local:
     .desc: Applies a reduction operator to local arguments.

--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -182,6 +182,15 @@ MPI_Improbe:
 
 MPI_Imrecv:
     .desc: Nonblocking receive of message matched by MPI_Mprobe or MPI_Improbe.
+{ -- early_return --
+    if (message_ptr == NULL || message_ptr->handle == MPIR_REQUEST_NULL_RECV) {
+        MPIR_Request *rreq;
+        rreq = MPIR_Request_create_null_recv();
+        *request = rreq->handle;
+        *message = MPI_MESSAGE_NULL;
+        goto fn_exit;
+    }
+}
 {
     MPIR_Request *rreq = NULL;
 
@@ -300,6 +309,14 @@ MPI_Mprobe:
 
 MPI_Mrecv:
     .desc: Blocking receive of message matched by MPI_Mprobe or MPI_Improbe.
+{ -- early_return --
+    if (message_ptr == NULL || message_ptr->handle == MPIR_REQUEST_NULL_RECV) {
+        /* treat as though MPI_MESSAGE_NO_PROC was passed */
+        MPIR_Status_set_procnull(status);
+        *message = MPI_MESSAGE_NULL;
+        goto fn_exit;
+    }
+}
 {
     MPIR_Request *rreq = NULL;
     mpi_errno = MPID_Mrecv(buf, count, datatype, message_ptr, status, &rreq);

--- a/src/mpid/ch3/src/mpid_imrecv.c
+++ b/src/mpid/ch3/src/mpid_imrecv.c
@@ -13,14 +13,6 @@ int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
     MPIR_Comm *comm;
     MPIDI_VC_t *vc = NULL;
 
-    /* message==NULL is equivalent to MPI_MESSAGE_NO_PROC being passed at the
-     * upper level */
-    if (message == NULL)
-    {
-        *rreqp = MPIR_Request_create_null_recv();
-        goto fn_exit;
-    }
-
     MPIR_Assert(message != NULL);
     MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
 

--- a/src/mpid/ch3/src/mpid_mrecv.c
+++ b/src/mpid/ch3/src/mpid_mrecv.c
@@ -11,12 +11,6 @@ int MPID_Mrecv(void *buf, int count, MPI_Datatype datatype,
     int mpi_errno = MPI_SUCCESS;
     *rreq = NULL;
 
-    if (message == NULL) {
-        /* treat as though MPI_MESSAGE_NO_PROC was passed */
-        MPIR_Status_set_procnull(status);
-        goto fn_exit;
-    }
-
     /* There is no optimized MPID_Mrecv at this time because there is no real
      * optimization potential in that case.  MPID_Recv exists to prevent
      * creating a request unnecessarily for messages that are already present

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -260,6 +260,17 @@ typedef struct MPIDI_part_request {
     MPI_Datatype datatype;
 } MPIDI_part_request_t;
 
+/* message queue within "self"-comms, i.e. MPI_COMM_SELF and all communicators with size of 1. */
+
+typedef struct {
+    void *buf;
+    MPI_Aint count;
+    MPI_Datatype datatype;
+    int tag;
+    int context_id;
+    MPIR_Request *match_req;    /* for mrecv */
+} MPIDI_self_request_t;
+
 typedef struct MPIDI_Devreq_t {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     int is_local;
@@ -278,6 +289,8 @@ typedef struct MPIDI_Devreq_t {
 
         /* Used by partitioned communication */
         MPIDI_part_request_t part_req;
+
+        MPIDI_self_request_t self;
 
         /* Used by the netmod direct apis */
         union {
@@ -300,6 +313,7 @@ typedef struct MPIDI_Devreq_t {
 #define MPIDI_PREQUEST(req,field)       (((req)->dev.ch4.preq).field)
 #define MPIDI_PART_REQUEST(req,field)   (((req)->dev.ch4.part_req).field)
 #define MPIDIG_PART_REQUEST(req, field)   (((req)->dev.ch4.part_req).am.field)
+#define MPIDI_SELF_REQUEST(req, field)  (((req)->dev.ch4.self).field)
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
 /* `(r)->dev.ch4.am.req` might not be allocated right after SHM_mpi_recv when

--- a/src/mpid/ch4/src/Makefile.mk
+++ b/src/mpid/ch4/src/Makefile.mk
@@ -38,6 +38,7 @@ mpi_core_sources += src/mpid/ch4/src/ch4_globals.c        \
                     src/mpid/ch4/src/ch4_spawn.c          \
                     src/mpid/ch4/src/ch4_win.c            \
                     src/mpid/ch4/src/ch4_part.c           \
+                    src/mpid/ch4/src/ch4_self.c           \
                     src/mpid/ch4/src/ch4i_comm.c          \
                     src/mpid/ch4/src/ch4r_init.c          \
                     src/mpid/ch4/src/ch4r_proc.c          \

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -10,6 +10,7 @@
 #include "mpidig_am.h"
 #include "mpidu_shm.h"
 #include "ch4r_proc.h"
+#include "ch4_self.h"
 
 int MPIDIG_get_context_index(uint64_t context_id);
 uint64_t MPIDIG_generate_win_id(MPIR_Comm * comm_ptr);

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -272,15 +272,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_MRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_MRECV);
 
-    *rreq = NULL;
-
-    if (message == NULL || message->handle == MPIR_REQUEST_NULL_RECV) {
-        /* treat as though MPI_MESSAGE_NO_PROC was passed */
-        MPIR_Status_set_procnull(status);
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
-
     MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
     message->kind = MPIR_REQUEST_KIND__RECV;
     *rreq = message;
@@ -302,11 +293,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf, MPI_Aint count, MPI_Datatype
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_IMRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_IMRECV);
-
-    if (message == NULL) {
-        *rreqp = MPIR_Request_create_null_recv();
-        goto fn_exit;
-    }
 
     MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
     message->kind = MPIR_REQUEST_KIND__RECV;

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -64,22 +64,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_unsafe(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CANCEL_RECV_UNSAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CANCEL_RECV_UNSAFE);
 
-#ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_cancel_recv(rreq);
-#else
-    if (MPIDI_REQUEST(rreq, is_local)) {
-        MPIR_Request *partner_rreq = MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq);
-        if (unlikely(partner_rreq)) {
-            /* Canceling MPI_ANY_SOURCE receive -- first cancel NM recv, then SHM */
-            mpi_errno = MPIDI_NM_mpi_cancel_recv(partner_rreq);
-            MPIR_ERR_CHECK(mpi_errno);
-            MPIDI_CH4_REQUEST_FREE(partner_rreq);
-        }
-        mpi_errno = MPIDI_SHM_mpi_cancel_recv(rreq);
+    if (rreq->comm && MPIDI_is_self_comm(rreq->comm)) {
+        mpi_errno = MPIDI_Self_cancel(rreq);
     } else {
+#ifdef MPIDI_CH4_DIRECT_NETMOD
         mpi_errno = MPIDI_NM_mpi_cancel_recv(rreq);
-    }
+#else
+        if (MPIDI_REQUEST(rreq, is_local)) {
+            MPIR_Request *partner_rreq = MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq);
+            if (unlikely(partner_rreq)) {
+                /* Canceling MPI_ANY_SOURCE receive -- first cancel NM recv, then SHM */
+                mpi_errno = MPIDI_NM_mpi_cancel_recv(partner_rreq);
+                MPIR_ERR_CHECK(mpi_errno);
+                MPIDI_CH4_REQUEST_FREE(partner_rreq);
+            }
+            mpi_errno = MPIDI_SHM_mpi_cancel_recv(rreq);
+        } else {
+            mpi_errno = MPIDI_NM_mpi_cancel_recv(rreq);
+        }
 #endif
+    }
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -274,9 +278,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
 
     MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
     message->kind = MPIR_REQUEST_KIND__RECV;
-    *rreq = message;
 
-    mpi_errno = MPIDI_imrecv(buf, count, datatype, message);
+    if (message->comm && MPIDI_is_self_comm(message->comm)) {
+        mpi_errno = MPIDI_Self_imrecv(buf, count, datatype, message, rreq);
+    } else {
+        *rreq = message;
+        mpi_errno = MPIDI_imrecv(buf, count, datatype, message);
+    }
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -296,9 +304,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf, MPI_Aint count, MPI_Datatype
 
     MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
     message->kind = MPIR_REQUEST_KIND__RECV;
-    *rreqp = message;
 
-    mpi_errno = MPIDI_imrecv(buf, count, datatype, message);
+    if (message->comm && MPIDI_is_self_comm(message->comm)) {
+        mpi_errno = MPIDI_Self_imrecv(buf, count, datatype, message, rreqp);
+    } else {
+        *rreqp = message;
+        mpi_errno = MPIDI_imrecv(buf, count, datatype, message);
+    }
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_IMRECV);
@@ -319,8 +331,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irecv(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_IRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_IRECV);
 
-    MPIDI_av_entry_t *av = (rank == MPI_ANY_SOURCE ? NULL : MPIDIU_comm_rank_to_av(comm, rank));
-    mpi_errno = MPIDI_irecv(buf, count, datatype, rank, tag, comm, context_offset, av, request);
+    if (MPIDI_is_self_comm(comm)) {
+        mpi_errno =
+            MPIDI_Self_irecv(buf, count, datatype, rank, tag, comm, context_offset, request);
+    } else {
+        MPIDI_av_entry_t *av = (rank == MPI_ANY_SOURCE ? NULL : MPIDIU_comm_rank_to_av(comm, rank));
+        mpi_errno = MPIDI_irecv(buf, count, datatype, rank, tag, comm, context_offset, av, request);
+    }
 
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:

--- a/src/mpid/ch4/src/ch4_self.c
+++ b/src/mpid/ch4/src/ch4_self.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "utlist.h"
+
+/* This utitility handles messages within "self"-comms, i.e. MPI_COMM_SELF and all
+ * communicators with size of 1.
+ *
+ * Note: we don't really need the rank argument since self-comm rank has to be 0. Nevertheless
+ * we would like to maintain a similar interface as other send/recv. It may come handy in case
+ * we ever want to extend the functionality to all self messages.
+ */
+
+static MPID_Thread_mutex_t MPIDIU_THREAD_SELF_MUTEX;
+static MPIDI_Devreq_t *self_send_queue;
+static MPIDI_Devreq_t *self_recv_queue;
+
+/* We'll enqueue MPIDI_Devreq_t. Assuming MPIR_Request *req and MPIDI_Devreq_t *p, then
+ *     p = &(req->dev)
+ *     req = MPL_container_of(p, MPIR_Request, dev)
+ *
+ *  MPIDI_self_request_t can be accessed via
+ *     req->dev.ch4.self, or
+ *     p->ch4.self
+ */
+
+#define ENQUEUE_SELF(req_, buf_, count_, datatype_, tag_, context_id_, queue) \
+    do { \
+        req_->dev.ch4.self.buf = (char *) buf_; \
+        req_->dev.ch4.self.count = count_; \
+        req_->dev.ch4.self.datatype = datatype_; \
+        req_->dev.ch4.self.tag = tag_; \
+        req_->dev.ch4.self.context_id = context_id_; \
+        DL_APPEND(queue, &(req_->dev)); \
+    } while (0)
+
+#define ENQUEUE_SELF_SEND(req, buf, count, datatype, tag, context_id) \
+    ENQUEUE_SELF(req, buf, count, datatype, tag, context_id, self_send_queue)
+
+#define ENQUEUE_SELF_RECV(req, buf, count, datatype, tag, context_id) \
+    ENQUEUE_SELF(req, buf, count, datatype, tag, context_id, self_recv_queue)
+
+#define MATCH_TAG(tag1, tag2) (tag1 == tag2 || tag1 == MPI_ANY_TAG || tag2 == MPI_ANY_TAG)
+#define DEQUEUE_SELF(req_, tag_, context_id_, queue) \
+    do { \
+        MPIDI_Devreq_t *curr, *tmp; \
+        DL_FOREACH_SAFE(queue, curr, tmp) { \
+            if (curr->ch4.self.context_id == context_id_ && MATCH_TAG(curr->ch4.self.tag, tag_)) { \
+                req_ = MPL_container_of(curr, MPIR_Request, dev); \
+                DL_DELETE(queue, curr); \
+                break; \
+            } \
+        } \
+    } while (0)
+
+#define DEQUEUE_SELF_SEND(req, tag, context_id) DEQUEUE_SELF(req, tag, context_id, self_send_queue)
+#define DEQUEUE_SELF_RECV(req, tag, context_id) DEQUEUE_SELF(req, tag, context_id, self_recv_queue)
+
+#define FIND_SELF_SEND(req_, tag_, context_id_) \
+    do { \
+        MPIDI_Devreq_t *curr, *tmp; \
+        DL_FOREACH_SAFE(self_send_queue, curr, tmp) { \
+            if (curr->ch4.self.context_id == context_id_ && MATCH_TAG(curr->ch4.self.tag, tag_)) { \
+                req_ = MPL_container_of(curr, MPIR_Request, dev); \
+                break; \
+            } \
+        } \
+    } while (0)
+
+int MPIDI_Self_init(void)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SELF_INIT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SELF_INIT);
+
+    int err;
+    MPID_Thread_mutex_create(&MPIDIU_THREAD_SELF_MUTEX, &err);
+    MPIR_Assert(err == 0);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SELF_INIT);
+    return MPI_SUCCESS;
+}
+
+int MPIDI_Self_finalize(void)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SELF_FINALIZE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SELF_FINALIZE);
+
+    int err;
+    MPID_Thread_mutex_destroy(&MPIDIU_THREAD_SELF_MUTEX, &err);
+    MPIR_Assert(err == 0);
+
+    MPIR_Assert(self_send_queue == NULL);
+    MPIR_Assert(self_recv_queue == NULL);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SELF_FINALIZE);
+    return MPI_SUCCESS;
+}
+
+#define SELF_COPY(sendbuf, sendcnt, sendtype, recvbuf, recvcnt, recvtype, status, tag) \
+    do { \
+        MPI_Aint sdata_sz, rdata_sz; \
+        MPIR_Datatype_get_size_macro(sendtype, sdata_sz); \
+        MPIR_Datatype_get_size_macro(recvtype, rdata_sz); \
+        sdata_sz *= sendcnt; \
+        rdata_sz *= recvcnt; \
+        MPIR_Localcopy(sendbuf, sendcnt, sendtype, recvbuf, recvcnt, recvtype); \
+        status.MPI_SOURCE = 0; \
+        status.MPI_TAG = tag; \
+        if (sdata_sz > rdata_sz) { \
+            MPIR_STATUS_SET_COUNT(status, rdata_sz); \
+            status.MPI_ERROR =  MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, \
+                                                     __func__, __LINE__, MPI_ERR_TRUNCATE, \
+                                                     "**truncate", "**truncate %d %d %d %d", \
+                                                     status.MPI_SOURCE, status.MPI_TAG, \
+                                                     (int) rdata_sz, (int) sdata_sz); \
+        } else { \
+            MPIR_STATUS_SET_COUNT(status, sdata_sz); \
+            status.MPI_ERROR = MPI_SUCCESS; \
+        } \
+    } while (0)
+
+int MPIDI_Self_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
+                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
+{
+    MPIR_Request *sreq = NULL;
+    MPIR_Request *rreq = NULL;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SELF_ISEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SELF_ISEND);
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SELF_MUTEX);
+
+    DEQUEUE_SELF_RECV(rreq, tag, comm->context_id);
+    if (rreq) {
+        SELF_COPY(buf, count, datatype, rreq->dev.ch4.self.buf,
+                  rreq->dev.ch4.self.count, rreq->dev.ch4.self.datatype, rreq->status, tag);
+        MPIR_cc_set(&rreq->cc, 0);
+        /* comm will be released by MPIR_Request_free(rreq) */
+        MPIR_Datatype_release_if_not_builtin(rreq->dev.ch4.self.datatype);
+        sreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
+    } else {
+        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+        ENQUEUE_SELF_SEND(sreq, buf, count, datatype, tag, comm->context_id);
+        sreq->comm = comm;
+        MPIR_Comm_add_ref(comm);
+        MPIR_Datatype_add_ref_if_not_builtin(datatype);
+    }
+
+    *request = sreq;
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_SELF_MUTEX);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SELF_ISEND);
+    return MPI_SUCCESS;
+}
+
+int MPIDI_Self_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
+                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
+{
+    MPIR_Request *sreq = NULL;
+    MPIR_Request *rreq = NULL;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SELF_IRECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SELF_IRECV);
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SELF_MUTEX);
+
+    rreq = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+
+    DEQUEUE_SELF_SEND(sreq, tag, comm->context_id);
+    if (sreq) {
+        SELF_COPY(sreq->dev.ch4.self.buf,
+                  sreq->dev.ch4.self.count,
+                  sreq->dev.ch4.self.datatype,
+                  buf, count, datatype, rreq->status, sreq->dev.ch4.self.tag);
+        MPIR_cc_set(&sreq->cc, 0);
+        /* comm will be released by MPIR_Request_free(sreq) */
+        MPIR_Datatype_release_if_not_builtin(sreq->dev.ch4.self.datatype);
+        MPIR_cc_set(&rreq->cc, 0);
+    } else {
+        ENQUEUE_SELF_RECV(rreq, buf, count, datatype, tag, comm->context_id);
+        rreq->comm = comm;
+        MPIR_Comm_add_ref(comm);
+        MPIR_Datatype_add_ref_if_not_builtin(datatype);
+    }
+
+    *request = rreq;
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_SELF_MUTEX);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SELF_IRECV);
+    return MPI_SUCCESS;
+}
+
+int MPIDI_Self_iprobe(int rank, int tag, MPIR_Comm * comm, int context_offset,
+                      int *flag, MPI_Status * status)
+{
+    MPIR_Request *sreq = NULL;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SELF_IPROBE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SELF_IPROBE);
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SELF_MUTEX);
+
+    FIND_SELF_SEND(sreq, tag, comm->context_id);
+    if (sreq) {
+        if (status != MPI_STATUS_IGNORE) {
+            MPI_Aint sdata_sz;
+            MPIR_Datatype_get_size_macro(sreq->dev.ch4.self.datatype, sdata_sz);
+            sdata_sz *= sreq->dev.ch4.self.count;
+            MPIR_STATUS_SET_COUNT(*status, sdata_sz);
+            status->MPI_SOURCE = 0;
+            status->MPI_TAG = sreq->dev.ch4.self.tag;
+            status->MPI_ERROR = MPI_SUCCESS;
+        }
+        *flag = TRUE;
+    } else {
+        *flag = FALSE;
+    }
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_SELF_MUTEX);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SELF_IPROBE);
+    return MPI_SUCCESS;
+}
+
+int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int context_offset,
+                       int *flag, MPIR_Request ** message, MPI_Status * status)
+{
+    MPIR_Request *sreq = NULL;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SELF_IMPROBE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SELF_IMPROBE);
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SELF_MUTEX);
+
+    DEQUEUE_SELF_SEND(sreq, tag, comm->context_id);
+    if (sreq) {
+        if (status != MPI_STATUS_IGNORE) {
+            MPI_Aint sdata_sz;
+            MPIR_Datatype_get_size_macro(sreq->dev.ch4.self.datatype, sdata_sz);
+            sdata_sz *= sreq->dev.ch4.self.count;
+            MPIR_STATUS_SET_COUNT(*status, sdata_sz);
+            status->MPI_SOURCE = 0;
+            status->MPI_TAG = sreq->dev.ch4.self.tag;
+            status->MPI_ERROR = MPI_SUCCESS;
+        }
+        *flag = TRUE;
+
+        *message = MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE);
+        (*message)->dev.ch4.self.match_req = sreq;
+        (*message)->comm = sreq->comm;  /* set so we can check it in MPI_{M,Im}recv */
+    } else {
+        *flag = FALSE;
+    }
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_SELF_MUTEX);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SELF_IMPROBE);
+    return MPI_SUCCESS;
+}
+
+int MPIDI_Self_imrecv(char *buf, MPI_Aint count, MPI_Datatype datatype,
+                      MPIR_Request * message, MPIR_Request ** request)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SELF_IMRECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SELF_IMRECV);
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SELF_MUTEX);
+
+    message->comm = NULL;       /* was set in MPIDI_Self_improbe */
+
+    MPIR_Request *sreq = message->dev.ch4.self.match_req;
+    MPIR_Request *rreq = message;
+    rreq->kind = MPIR_REQUEST_KIND__RECV;
+    SELF_COPY(sreq->dev.ch4.self.buf,
+              sreq->dev.ch4.self.count,
+              sreq->dev.ch4.self.datatype,
+              buf, count, datatype, rreq->status, sreq->dev.ch4.self.tag);
+    MPIR_cc_set(&sreq->cc, 0);
+    /* comm will be released by MPIR_Request_free(sreq) */
+    MPIR_Datatype_release_if_not_builtin(sreq->dev.ch4.self.datatype);
+    MPIR_cc_set(&rreq->cc, 0);
+
+    *request = rreq;
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_SELF_MUTEX);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SELF_IMRECV);
+    return MPI_SUCCESS;
+}
+
+#define DELETE_SELF(req_, found, queue) \
+    do { \
+        MPIDI_Devreq_t *curr, *tmp; \
+        DL_FOREACH_SAFE(queue, curr, tmp) { \
+            if (MPL_container_of(curr, MPIR_Request, dev) == req_) { \
+                found = 1; \
+                DL_DELETE(queue, curr); \
+                break; \
+            } \
+        } \
+    } while (0)
+
+int MPIDI_Self_cancel(MPIR_Request * request)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SELF_CANCEL);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SELF_CANCEL);
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SELF_MUTEX);
+
+    if (!MPIR_Request_is_complete(request) && !MPIR_STATUS_GET_CANCEL_BIT(request->status)) {
+        int found = 0;
+        if (request->kind == MPIR_REQUEST_KIND__SEND) {
+            DELETE_SELF(request, found, self_send_queue);
+        } else {
+            DELETE_SELF(request, found, self_recv_queue);
+        }
+        if (found) {
+            /* comm will be released at MPIR_Request_free */
+            MPIR_Datatype_release_if_not_builtin(request->dev.ch4.self.datatype);
+        } else {
+            goto fn_exit;
+        }
+        MPIR_STATUS_SET_CANCEL_BIT(request->status, TRUE);
+        MPIR_STATUS_SET_COUNT(request->status, 0);
+        MPIR_cc_set(&request->cc, 0);
+    }
+
+  fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_SELF_MUTEX);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SELF_CANCEL);
+    return MPI_SUCCESS;
+}

--- a/src/mpid/ch4/src/ch4_self.h
+++ b/src/mpid/ch4/src/ch4_self.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPIDI_SELF_H_INCLUDED
+#define MPIDI_SELF_H_INCLUDED
+
+#define MPIDI_is_self_comm(comm) \
+    (comm->remote_size == 1 && comm->comm_kind == MPIR_COMM_KIND__INTRACOMM)
+
+int MPIDI_Self_init(void);
+int MPIDI_Self_finalize(void);
+int MPIDI_Self_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
+                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request);
+int MPIDI_Self_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
+                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request);
+int MPIDI_Self_iprobe(int rank, int tag, MPIR_Comm * comm, int context_offset,
+                      int *flag, MPI_Status * status);
+int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int context_offset,
+                       int *flag, MPIR_Request ** message, MPI_Status * status);
+int MPIDI_Self_imrecv(char *buf, MPI_Aint count, MPI_Datatype datatype,
+                      MPIR_Request * message, MPIR_Request ** request);
+int MPIDI_Self_cancel(MPIR_Request * request);
+
+#endif /* MPIDI_SELF_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_startall.h
+++ b/src/mpid/ch4/src/ch4_startall.h
@@ -16,38 +16,68 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_prequest_start(MPIR_Request * preq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PREQUEST_START);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PREQUEST_START);
 
+    MPIR_Comm *comm = preq->comm;
     switch (MPIDI_PREQUEST(preq, p_type)) {
 
         case MPIDI_PTYPE_RECV:
-            mpi_errno = MPID_Irecv(MPIDI_PREQUEST(preq, buffer), MPIDI_PREQUEST(preq, count),
-                                   MPIDI_PREQUEST(preq, datatype), MPIDI_PREQUEST(preq, rank),
-                                   MPIDI_PREQUEST(preq, tag), preq->comm,
-                                   MPIDI_prequest_get_context_offset(preq),
-                                   &preq->u.persist.real_request);
+            if (comm->remote_size == 1 && comm->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
+                mpi_errno = MPIDI_Self_irecv(MPIDI_PREQUEST(preq, buffer),
+                                             MPIDI_PREQUEST(preq, count),
+                                             MPIDI_PREQUEST(preq, datatype),
+                                             MPIDI_PREQUEST(preq, rank),
+                                             MPIDI_PREQUEST(preq, tag), comm,
+                                             MPIDI_prequest_get_context_offset(preq),
+                                             &preq->u.persist.real_request);
+            } else {
+                mpi_errno = MPID_Irecv(MPIDI_PREQUEST(preq, buffer), MPIDI_PREQUEST(preq, count),
+                                       MPIDI_PREQUEST(preq, datatype), MPIDI_PREQUEST(preq, rank),
+                                       MPIDI_PREQUEST(preq, tag), comm,
+                                       MPIDI_prequest_get_context_offset(preq),
+                                       &preq->u.persist.real_request);
+            }
             break;
 
         case MPIDI_PTYPE_SEND:
-            mpi_errno = MPID_Isend(MPIDI_PREQUEST(preq, buffer), MPIDI_PREQUEST(preq, count),
-                                   MPIDI_PREQUEST(preq, datatype), MPIDI_PREQUEST(preq, rank),
-                                   MPIDI_PREQUEST(preq, tag), preq->comm,
-                                   MPIDI_prequest_get_context_offset(preq),
-                                   &preq->u.persist.real_request);
+            if (comm->remote_size == 1 && comm->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
+                mpi_errno = MPIDI_Self_isend(MPIDI_PREQUEST(preq, buffer),
+                                             MPIDI_PREQUEST(preq, count),
+                                             MPIDI_PREQUEST(preq, datatype),
+                                             MPIDI_PREQUEST(preq, rank),
+                                             MPIDI_PREQUEST(preq, tag), comm,
+                                             MPIDI_prequest_get_context_offset(preq),
+                                             &preq->u.persist.real_request);
+            } else {
+                mpi_errno = MPID_Isend(MPIDI_PREQUEST(preq, buffer), MPIDI_PREQUEST(preq, count),
+                                       MPIDI_PREQUEST(preq, datatype), MPIDI_PREQUEST(preq, rank),
+                                       MPIDI_PREQUEST(preq, tag), comm,
+                                       MPIDI_prequest_get_context_offset(preq),
+                                       &preq->u.persist.real_request);
+            }
             break;
 
         case MPIDI_PTYPE_SSEND:
-            mpi_errno = MPID_Issend(MPIDI_PREQUEST(preq, buffer), MPIDI_PREQUEST(preq, count),
-                                    MPIDI_PREQUEST(preq, datatype), MPIDI_PREQUEST(preq, rank),
-                                    MPIDI_PREQUEST(preq, tag), preq->comm,
-                                    MPIDI_prequest_get_context_offset(preq),
-                                    &preq->u.persist.real_request);
+            if (comm->remote_size == 1 && comm->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
+                mpi_errno = MPIDI_Self_isend(MPIDI_PREQUEST(preq, buffer),
+                                             MPIDI_PREQUEST(preq, count),
+                                             MPIDI_PREQUEST(preq, datatype),
+                                             MPIDI_PREQUEST(preq, rank),
+                                             MPIDI_PREQUEST(preq, tag), comm,
+                                             MPIDI_prequest_get_context_offset(preq),
+                                             &preq->u.persist.real_request);
+            } else {
+                mpi_errno = MPID_Issend(MPIDI_PREQUEST(preq, buffer), MPIDI_PREQUEST(preq, count),
+                                        MPIDI_PREQUEST(preq, datatype), MPIDI_PREQUEST(preq, rank),
+                                        MPIDI_PREQUEST(preq, tag), comm,
+                                        MPIDI_prequest_get_context_offset(preq),
+                                        &preq->u.persist.real_request);
+            }
             break;
 
         case MPIDI_PTYPE_BSEND:
             mpi_errno =
                 MPIR_Bsend_isend(MPIDI_PREQUEST(preq, buffer), MPIDI_PREQUEST(preq, count),
                                  MPIDI_PREQUEST(preq, datatype), MPIDI_PREQUEST(preq, rank),
-                                 MPIDI_PREQUEST(preq, tag), preq->comm,
-                                 &preq->u.persist.real_request);
+                                 MPIDI_PREQUEST(preq, tag), comm, &preq->u.persist.real_request);
             if (mpi_errno == MPI_SUCCESS) {
                 preq->status.MPI_ERROR = MPI_SUCCESS;
                 preq->cc_ptr = &preq->cc;


### PR DESCRIPTION
## Pull Request Description

MPI Session creates the scenario that a process may only create self comm -- communicators that are essentially dup of MPI_COMM_SELF. Because world initialization may never run in this case, we can's assume it is safe to let the device handle the self-comm communications.

This PR implements a solution that simply shortcut the self path and handle it in a device-independent way. This solution releases some burdens of device refactoring, so probably it is good to have for easier maintenance.

Currently, this is only implemented in `ch4`. With `ch3` we have to enforce the global initialization in `MPI_Session_init`.
[skip warnings]

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
