### PR TITLE
warnings: in generated MPI_Comm_spawn_multiple

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -667,6 +667,9 @@ def dump_function_normal(func, state_name, mapping):
             dump_handle_ptr_var(func, p)
     if '_comm_from_request' in func:
         G.out.append("MPIR_Comm *comm_ptr = NULL;")
+    if 'code-declare' in func:
+        for l in func['code-declare']:
+            G.out.append(l)
 
     G.out.append("MPIR_FUNC_TERSE_STATE_DECL(%s);" % state_name)
 

--- a/src/binding/c/spawn_api.txt
+++ b/src/binding/c/spawn_api.txt
@@ -56,8 +56,10 @@ MPI_Comm_spawn_multiple:
     .extra: errtest_comm_intra
     .skip: validate-STRING_ARRAY, validate-STRING_2DARRAY, validate-COMM_SIZE, validate-INFO, validate-ERROR_CODE
     .error: MPI_ERR_INFO
-{ -- handle_ptr -- array_of_info
+{ -- declare --
     MPIR_Info **array_of_info_ptrs = NULL;
+}
+{ -- handle_ptr -- array_of_info
     if (comm_ptr->rank == root) {
         array_of_info_ptrs = MPL_malloc(count * sizeof(MPIR_Info *), MPL_MEM_OTHER);
         for (int i = 0; i < count; i++) {


### PR DESCRIPTION
## Pull Request Description

Often we can simply declare the local variable within the local code
block, but sometime we may need to declare the variable at function
scope especially when the variable is referenced within the fn_exit label.

The warning was introduced in PR #4967
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
