### PR TITLE
coll: Fix GPU-aware nonblocking op collectives

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -363,6 +363,9 @@ static inline MPIR_Request *MPIR_Request_create_from_pool(MPIR_Request_kind_t ki
                 break;
             case MPIR_REQUEST_KIND__COLL:
                 req->u.nbc.errflag = MPIR_ERR_NONE;
+                req->u.nbc.coll.host_sendbuf = NULL;
+                req->u.nbc.coll.host_recvbuf = NULL;
+                req->u.nbc.coll.datatype = MPI_DATATYPE_NULL;
                 break;
             default:
                 break;

--- a/src/mpi/coll/iallreduce/iallreduce.c
+++ b/src/mpi/coll/iallreduce/iallreduce.c
@@ -479,13 +479,8 @@ int MPIR_Iallreduce(const void *sendbuf, void *recvbuf, int count,
         mpi_errno = MPIR_Iallreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, request);
     }
 
-    /* Copy out data from host recv buffer to GPU buffer */
-    if (host_recvbuf) {
-        recvbuf = in_recvbuf;
-        MPIR_Localcopy(host_recvbuf, count, datatype, recvbuf, count, datatype);
-    }
-
-    MPIR_Coll_host_buffer_free(host_sendbuf, host_recvbuf);
+    MPII_COLL_HOST_BUFFER_SWAP_BACK(host_sendbuf, host_recvbuf, in_recvbuf, count, datatype,
+                                    request);
 
     return mpi_errno;
 }

--- a/src/mpi/coll/iexscan/iexscan.c
+++ b/src/mpi/coll/iexscan/iexscan.c
@@ -155,13 +155,8 @@ int MPIR_Iexscan(const void *sendbuf, void *recvbuf, int count,
         mpi_errno = MPIR_Iexscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, request);
     }
 
-    /* Copy out data from host recv buffer to GPU buffer */
-    if (host_recvbuf) {
-        recvbuf = in_recvbuf;
-        MPIR_Localcopy(host_recvbuf, count, datatype, recvbuf, count, datatype);
-    }
-
-    MPIR_Coll_host_buffer_free(host_sendbuf, host_recvbuf);
+    MPII_COLL_HOST_BUFFER_SWAP_BACK(host_sendbuf, host_recvbuf, in_recvbuf, count, datatype,
+                                    request);
 
     return mpi_errno;
 }

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -105,4 +105,27 @@ void MPIR_Coll_host_buffer_alloc(const void *sendbuf, const void *recvbuf, MPI_A
                                  MPI_Datatype datatype, void **host_sendbuf, void **host_recvbuf);
 void MPIR_Coll_host_buffer_free(void *host_sendbuf, void *host_recvbuf);
 
+#define MPII_COLL_HOST_BUFFER_SWAP_BACK(host_sendbuf_, host_recvbuf_, in_recvbuf_, count_, datatype_, request_) \
+    do {                                                                                      \
+        if (host_recvbuf_ == NULL) {                                                          \
+            /* no copy at completion necessary, just return */                                \
+            return mpi_errno;                                                                 \
+        }                                                                                     \
+                                                                                              \
+        if (*request_ == NULL || MPIR_Request_is_complete(*request_)) {                       \
+            /* operation is complete, copy the data and return */                             \
+            MPIR_Localcopy(host_recvbuf_, count_, datatype_, in_recvbuf_, count_, datatype_); \
+            MPIR_Coll_host_buffer_free(host_sendbuf_, host_recvbuf_);                         \
+            return mpi_errno;                                                                 \
+        }                                                                                     \
+                                                                                              \
+        /* data will be copied later during request completion */                             \
+        (*request_)->u.nbc.coll.host_sendbuf = host_sendbuf_;                                 \
+        (*request_)->u.nbc.coll.host_recvbuf = host_recvbuf_;                                 \
+        (*request_)->u.nbc.coll.user_recvbuf = in_recvbuf_;                                   \
+        (*request_)->u.nbc.coll.count = count_;                                               \
+        (*request_)->u.nbc.coll.datatype = datatype_;                                         \
+        MPIR_Datatype_add_ref_if_not_builtin(datatype_);                                      \
+    } while (0)
+
 #endif /* COLL_IMPL_H_INCLUDED */

--- a/src/mpi/coll/include/coll_types.h
+++ b/src/mpi/coll/include/coll_types.h
@@ -52,6 +52,17 @@ enum {
 typedef struct MPII_Coll_req_t {
     void *sched;                /* pointer to the schedule */
 
+    /*
+     * Fields used by GPU-aware fallback path for op collectives. GPU buffers
+     * are swapped for host buffers for collective execution. If the user
+     * recv buffer is on the GPU, data is copied to it at completion.
+     */
+    void *host_sendbuf;         /* temporary host buffer */
+    void *host_recvbuf;         /* temporary recv buffer */
+    void *user_recvbuf;         /* pointer to user recv buffer */
+    MPI_Aint count;             /* recv count */
+    MPI_Datatype datatype;      /* recv datatype */
+
     struct MPII_Coll_req_t *next;       /* linked-list next pointer */
     struct MPII_Coll_req_t *prev;       /* linked-list prev pointer */
 } MPII_Coll_req_t;

--- a/src/mpi/coll/ireduce/ireduce.c
+++ b/src/mpi/coll/ireduce/ireduce.c
@@ -397,13 +397,8 @@ int MPIR_Ireduce(const void *sendbuf, void *recvbuf, int count,
                                       request);
     }
 
-    /* Copy out data from host recv buffer to GPU buffer */
-    if (host_recvbuf) {
-        recvbuf = in_recvbuf;
-        MPIR_Localcopy(host_recvbuf, count, datatype, recvbuf, count, datatype);
-    }
-
-    MPIR_Coll_host_buffer_free(host_sendbuf, host_recvbuf);
+    MPII_COLL_HOST_BUFFER_SWAP_BACK(host_sendbuf, host_recvbuf, in_recvbuf, count, datatype,
+                                    request);
 
     return mpi_errno;
 }

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
@@ -368,13 +368,8 @@ int MPIR_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcount
                                               request);
     }
 
-    /* Copy out data from host recv buffer to GPU buffer */
-    if (host_recvbuf) {
-        recvbuf = in_recvbuf;
-        MPIR_Localcopy(host_recvbuf, count, datatype, recvbuf, count, datatype);
-    }
-
-    MPIR_Coll_host_buffer_free(host_sendbuf, host_recvbuf);
+    MPII_COLL_HOST_BUFFER_SWAP_BACK(host_sendbuf, host_recvbuf, in_recvbuf, count, datatype,
+                                    request);
 
     return mpi_errno;
 }

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
@@ -361,13 +361,8 @@ int MPIR_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                     comm_ptr, request);
     }
 
-    /* Copy out data from host recv buffer to GPU buffer */
-    if (host_recvbuf) {
-        recvbuf = in_recvbuf;
-        MPIR_Localcopy(host_recvbuf, recvcount, datatype, recvbuf, recvcount, datatype);
-    }
-
-    MPIR_Coll_host_buffer_free(host_sendbuf, host_recvbuf);
+    MPII_COLL_HOST_BUFFER_SWAP_BACK(host_sendbuf, host_recvbuf, in_recvbuf, recvcount, datatype,
+                                    request);
 
     return mpi_errno;
 }

--- a/src/mpi/coll/iscan/iscan.c
+++ b/src/mpi/coll/iscan/iscan.c
@@ -184,13 +184,8 @@ int MPIR_Iscan(const void *sendbuf, void *recvbuf, int count,
         mpi_errno = MPIR_Iscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, request);
     }
 
-    /* Copy out data from host recv buffer to GPU buffer */
-    if (host_recvbuf) {
-        recvbuf = in_recvbuf;
-        MPIR_Localcopy(host_recvbuf, count, datatype, recvbuf, count, datatype);
-    }
-
-    MPIR_Coll_host_buffer_free(host_sendbuf, host_recvbuf);
+    MPII_COLL_HOST_BUFFER_SWAP_BACK(host_sendbuf, host_recvbuf, in_recvbuf, count, datatype,
+                                    request);
 
     return mpi_errno;
 }


### PR DESCRIPTION
## Pull Request Description

Delay copy and free of temporary buffers until the collective operation is complete.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix GPU-awareness in nonblocking ops collectives.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
