### PR TITLE
mpl/gavl: Remove anonymous union and struct

### DIFF
--- a/src/mpl/include/mpl_gavl.h
+++ b/src/mpl/include/mpl_gavl.h
@@ -48,9 +48,9 @@ typedef struct MPLI_gavl_tree_node {
             struct MPLI_gavl_tree_node *parent;
             struct MPLI_gavl_tree_node *left;
             struct MPLI_gavl_tree_node *right;
-        };
+        } s;
         struct MPLI_gavl_tree_node *next;
-    };
+    } u;
     uintptr_t height;
     uintptr_t addr;
     uintptr_t len;
@@ -147,9 +147,9 @@ MPL_STATIC_INLINE_PREFIX int MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, con
             *val = (void *) cur_node->val;
             break;
         } else if (cmp_ret == MPLI_GAVL_SEARCH_LEFT) {
-            cur_node = cur_node->left;
+            cur_node = cur_node->u.s.left;
         } else {
-            cur_node = cur_node->right;
+            cur_node = cur_node->u.s.right;
         }
     }
 

--- a/src/mpl/src/gavl/mpl_gavl.c
+++ b/src/mpl/src/gavl/mpl_gavl.c
@@ -52,27 +52,27 @@ static void gavl_tree_delete_removed_nodes(MPLI_gavl_tree_s * tree_ptr, uintptr_
 
 static void gavl_update_node_info(MPLI_gavl_tree_node_s * node_iptr)
 {
-    int lheight = node_iptr->left == NULL ? 0 : node_iptr->left->height;
-    int rheight = node_iptr->right == NULL ? 0 : node_iptr->right->height;
+    int lheight = node_iptr->u.s.left == NULL ? 0 : node_iptr->u.s.left->height;
+    int rheight = node_iptr->u.s.right == NULL ? 0 : node_iptr->u.s.right->height;
     node_iptr->height = (lheight < rheight ? rheight : lheight) + 1;
     return;
 }
 
 static void gavl_right_rotation(MPLI_gavl_tree_node_s * parent_ptr, MPLI_gavl_tree_node_s * lchild)
 {
-    parent_ptr->left = lchild->right;
-    lchild->right = parent_ptr;
-    lchild->parent = parent_ptr->parent;
-    if (lchild->parent != NULL) {
-        if (lchild->parent->left == parent_ptr)
-            lchild->parent->left = lchild;
+    parent_ptr->u.s.left = lchild->u.s.right;
+    lchild->u.s.right = parent_ptr;
+    lchild->u.s.parent = parent_ptr->u.s.parent;
+    if (lchild->u.s.parent != NULL) {
+        if (lchild->u.s.parent->u.s.left == parent_ptr)
+            lchild->u.s.parent->u.s.left = lchild;
         else
-            lchild->parent->right = lchild;
+            lchild->u.s.parent->u.s.right = lchild;
     }
 
-    parent_ptr->parent = lchild;
-    if (parent_ptr->left != NULL)
-        parent_ptr->left->parent = parent_ptr;
+    parent_ptr->u.s.parent = lchild;
+    if (parent_ptr->u.s.left != NULL)
+        parent_ptr->u.s.left->u.s.parent = parent_ptr;
 
     gavl_update_node_info(parent_ptr);
     gavl_update_node_info(lchild);
@@ -81,19 +81,19 @@ static void gavl_right_rotation(MPLI_gavl_tree_node_s * parent_ptr, MPLI_gavl_tr
 
 static void gavl_left_rotation(MPLI_gavl_tree_node_s * parent_ptr, MPLI_gavl_tree_node_s * rchild)
 {
-    parent_ptr->right = rchild->left;
-    rchild->left = parent_ptr;
-    rchild->parent = parent_ptr->parent;
-    if (rchild->parent != NULL) {
-        if (rchild->parent->left == parent_ptr)
-            rchild->parent->left = rchild;
+    parent_ptr->u.s.right = rchild->u.s.left;
+    rchild->u.s.left = parent_ptr;
+    rchild->u.s.parent = parent_ptr->u.s.parent;
+    if (rchild->u.s.parent != NULL) {
+        if (rchild->u.s.parent->u.s.left == parent_ptr)
+            rchild->u.s.parent->u.s.left = rchild;
         else
-            rchild->parent->right = rchild;
+            rchild->u.s.parent->u.s.right = rchild;
     }
 
-    parent_ptr->parent = rchild;
-    if (parent_ptr->right != NULL)
-        parent_ptr->right->parent = parent_ptr;
+    parent_ptr->u.s.parent = rchild;
+    if (parent_ptr->u.s.right != NULL)
+        parent_ptr->u.s.right->u.s.parent = parent_ptr;
 
     gavl_update_node_info(parent_ptr);
     gavl_update_node_info(rchild);
@@ -103,7 +103,7 @@ static void gavl_left_rotation(MPLI_gavl_tree_node_s * parent_ptr, MPLI_gavl_tre
 static void gavl_left_right_rotation(MPLI_gavl_tree_node_s * parent_ptr,
                                      MPLI_gavl_tree_node_s * lchild)
 {
-    MPLI_gavl_tree_node_s *rlchild = lchild->right;
+    MPLI_gavl_tree_node_s *rlchild = lchild->u.s.right;
     gavl_left_rotation(lchild, rlchild);
     gavl_right_rotation(parent_ptr, rlchild);
     return;
@@ -112,7 +112,7 @@ static void gavl_left_right_rotation(MPLI_gavl_tree_node_s * parent_ptr,
 static void gavl_right_left_rotation(MPLI_gavl_tree_node_s * parent_ptr,
                                      MPLI_gavl_tree_node_s * rchild)
 {
-    MPLI_gavl_tree_node_s *lrchild = rchild->left;
+    MPLI_gavl_tree_node_s *lrchild = rchild->u.s.left;
     gavl_right_rotation(rchild, lrchild);
     gavl_left_rotation(parent_ptr, lrchild);
     return;
@@ -156,17 +156,17 @@ static MPLI_gavl_tree_node_s *gavl_tree_search_internal(MPLI_gavl_tree_s * tree_
     do {
         GAVL_TREE_NODE_CMP(cur_node, addr, len, mode, cmp_ret);
         if (cmp_ret == MPLI_GAVL_SEARCH_LEFT) {
-            if (cur_node->left != NULL) {
+            if (cur_node->u.s.left != NULL) {
                 TREE_STACK_PUSH(tree_ptr, cur_node);
-                cur_node = cur_node->left;
+                cur_node = cur_node->u.s.left;
                 continue;
             } else {
                 break;
             }
         } else if (cmp_ret == MPLI_GAVL_SEARCH_RIGHT) {
-            if (cur_node->right != NULL) {
+            if (cur_node->u.s.right != NULL) {
                 TREE_STACK_PUSH(tree_ptr, cur_node);
-                cur_node = cur_node->right;
+                cur_node = cur_node->u.s.right;
                 continue;
             } else {
                 break;
@@ -193,12 +193,12 @@ static void gavl_tree_rebalance(MPLI_gavl_tree_s * tree_ptr)
         do {
             gavl_update_node_info(cur_node);
 
-            int lheight = cur_node->left == NULL ? 0 : cur_node->left->height;
-            int rheight = cur_node->right == NULL ? 0 : cur_node->right->height;
+            int lheight = cur_node->u.s.left == NULL ? 0 : cur_node->u.s.left->height;
+            int rheight = cur_node->u.s.right == NULL ? 0 : cur_node->u.s.right->height;
             if (lheight - rheight > 1) {
                 /* find imbalance: left child is 2 level higher than right child */
-                MPLI_gavl_tree_node_s *lnode = cur_node->left;
-                int llheight = lnode->left == NULL ? 0 : lnode->left->height;
+                MPLI_gavl_tree_node_s *lnode = cur_node->u.s.left;
+                int llheight = lnode->u.s.left == NULL ? 0 : lnode->u.s.left->height;
                 /* if left child's (lnode's) left child causes this imbalance, we need to perform right
                  * rotation to reduce the height of lnode's left child;
                  * right rotation sets left child (lnode) as central node, moves lnode to parent (cur_node)
@@ -214,8 +214,8 @@ static void gavl_tree_rebalance(MPLI_gavl_tree_s * tree_ptr)
                     gavl_left_right_rotation(cur_node, lnode);
             } else if (rheight - lheight > 1) {
                 /* find imbalance: right child is 2 level higher than left child */
-                MPLI_gavl_tree_node_s *rnode = cur_node->right;
-                int rlheight = rnode->left == NULL ? 0 : rnode->left->height;
+                MPLI_gavl_tree_node_s *rnode = cur_node->u.s.right;
+                int rlheight = rnode->u.s.left == NULL ? 0 : rnode->u.s.left->height;
                 /* the purpose of gavl_right_left_rotation and gavl_left_rotation is similar to
                  * gavl_right_rotation and gavl_left_right_rotation mention above; the difference
                  * is just doing rotation for right child here*/
@@ -235,8 +235,8 @@ static void gavl_tree_rebalance(MPLI_gavl_tree_s * tree_ptr)
         } while (1);
 
         /* after rebalance, we need to update root because it might be changed after rebalance */
-        while (tree_ptr->root && tree_ptr->root->parent != NULL)
-            tree_ptr->root = tree_ptr->root->parent;
+        while (tree_ptr->root && tree_ptr->root->u.s.parent != NULL)
+            tree_ptr->root = tree_ptr->root->u.s.parent;
     }
 
     return;
@@ -293,10 +293,10 @@ int MPL_gavl_tree_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t 
 
         /* insert new node into pnode */
         if (cmp_ret == MPLI_GAVL_SEARCH_LEFT)
-            pnode->left = node_ptr;
+            pnode->u.s.left = node_ptr;
         else
-            pnode->right = node_ptr;
-        node_ptr->parent = pnode;
+            pnode->u.s.right = node_ptr;
+        node_ptr->u.s.parent = pnode;
 
         /* after insertion, the tree could be imbalanced, so rebalance is required here */
         gavl_tree_rebalance(tree_ptr);
@@ -321,18 +321,18 @@ int MPL_gavl_tree_destory(MPL_gavl_tree_t gavl_tree)
     MPLI_gavl_tree_node_s *cur_node = tree_ptr->root;
     MPLI_gavl_tree_node_s *dnode = NULL;
     while (cur_node) {
-        if (cur_node->left) {
-            cur_node = cur_node->left;
-        } else if (cur_node->right) {
-            cur_node = cur_node->right;
+        if (cur_node->u.s.left) {
+            cur_node = cur_node->u.s.left;
+        } else if (cur_node->u.s.right) {
+            cur_node = cur_node->u.s.right;
         } else {
             dnode = cur_node;
-            cur_node = cur_node->parent;
+            cur_node = cur_node->u.s.parent;
             if (cur_node) {
-                if (cur_node->left == dnode)
-                    cur_node->left = NULL;
+                if (cur_node->u.s.left == dnode)
+                    cur_node->u.s.left = NULL;
                 else
-                    cur_node->right = NULL;
+                    cur_node->u.s.right = NULL;
             }
             if (tree_ptr->gavl_free_fn)
                 tree_ptr->gavl_free_fn((void *) dnode->val);
@@ -348,27 +348,27 @@ static void gavl_tree_remove_node_internal(MPLI_gavl_tree_s * tree_ptr,
 {
     MPLI_gavl_tree_node_s *inorder_node;
 
-    if (dnode->right == NULL) {
+    if (dnode->u.s.right == NULL) {
         /* no right child, next inorder node is parent */
-        if (dnode->parent == NULL) {
+        if (dnode->u.s.parent == NULL) {
             /* delete root node; if it has left child, set left child as root node;
              * if not, set tree root as NULL */
-            if (dnode->left) {
-                tree_ptr->root = dnode->left;
-                tree_ptr->root->parent = NULL;
+            if (dnode->u.s.left) {
+                tree_ptr->root = dnode->u.s.left;
+                tree_ptr->root->u.s.parent = NULL;
             } else {
                 tree_ptr->root = NULL;
             }
         } else {
             /* assign deleted node's left child to its parent */
-            inorder_node = dnode->parent;
-            if (inorder_node->left == dnode)
-                inorder_node->left = dnode->left;
+            inorder_node = dnode->u.s.parent;
+            if (inorder_node->u.s.left == dnode)
+                inorder_node->u.s.left = dnode->u.s.left;
             else
-                inorder_node->right = dnode->left;
+                inorder_node->u.s.right = dnode->u.s.left;
 
-            if (dnode->left)
-                dnode->left->parent = inorder_node;
+            if (dnode->u.s.left)
+                dnode->u.s.left->u.s.parent = inorder_node;
 
             TREE_STACK_PUSH(tree_ptr, inorder_node);
         }
@@ -378,22 +378,22 @@ static void gavl_tree_remove_node_internal(MPLI_gavl_tree_s * tree_ptr,
 
         /* find the next inorder node and move its buffer objects to dnode;
          * the original buffer object in dnode is freed */
-        inorder_node = dnode->right;
+        inorder_node = dnode->u.s.right;
         TREE_STACK_PUSH(tree_ptr, dnode);
 
         /* search left most node of right child of dnode for next inorder node */
-        while (inorder_node->left) {
+        while (inorder_node->u.s.left) {
             TREE_STACK_PUSH(tree_ptr, inorder_node);
-            inorder_node = inorder_node->left;
+            inorder_node = inorder_node->u.s.left;
         }
 
         /* remove inorder_node from the tree. */
-        if (inorder_node->parent != dnode) {
-            if (inorder_node->right)
-                inorder_node->right->parent = inorder_node->parent;
-            inorder_node->parent->left = inorder_node->right;
+        if (inorder_node->u.s.parent != dnode) {
+            if (inorder_node->u.s.right)
+                inorder_node->u.s.right->u.s.parent = inorder_node->u.s.parent;
+            inorder_node->u.s.parent->u.s.left = inorder_node->u.s.right;
         } else {
-            dnode->right = NULL;
+            dnode->u.s.right = NULL;
         }
 
         /* exchange inorder_node with dnode and then add dnode into remove_list */
@@ -410,7 +410,7 @@ static void gavl_tree_remove_node_internal(MPLI_gavl_tree_s * tree_ptr,
     }
 
     /* add removed node into remove list */
-    dnode->next = tree_ptr->remove_list;
+    dnode->u.next = tree_ptr->remove_list;
     tree_ptr->remove_list = dnode;
 
     /* update stack for the consequent rebalance which will start from the top of
@@ -518,18 +518,18 @@ static void gavl_tree_delete_removed_nodes(MPLI_gavl_tree_s * tree_ptr, uintptr_
         GAVL_TREE_NODE_CMP(cur, addr, len, mode, cmp_ret);
         if (cmp_ret == MPLI_GAVL_BUFFER_MATCH) {
             if (prev)
-                prev->next = cur->next;
+                prev->u.next = cur->u.next;
             else
-                tree_ptr->remove_list = cur->next;
+                tree_ptr->remove_list = cur->u.next;
 
             dnode = cur;
-            cur = cur->next;
+            cur = cur->u.next;
             if (tree_ptr->gavl_free_fn)
                 tree_ptr->gavl_free_fn((void *) dnode->val);
             MPL_free(dnode);
         } else {
             prev = cur;
-            cur = cur->next;
+            cur = cur->u.next;
         }
     }
 }


### PR DESCRIPTION
## Pull Request Description

Using this C11 feature impacts some of our downstream users. Add
simple one character names to work with compilers that do not support
this feature.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix MPL for compilers which do not support anonymous struct/union.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
