### PR TITLE
gpu: consistently use MPIR_GPU_query_pointer_attr

### DIFF
--- a/src/include/mpir_gpu.h
+++ b/src/include/mpir_gpu.h
@@ -33,6 +33,14 @@ cvars:
 
 extern int MPIR_CVAR_ENABLE_GPU;
 
+#undef ENABLE_GPU
+
+#ifdef MPL_HAVE_GPU
+#define ENABLE_GPU MPIR_CVAR_ENABLE_GPU
+#else
+#define ENABLE_GPU FALSE
+#endif
+
 MPL_STATIC_INLINE_PREFIX int MPIR_GPU_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     int mpi_errno = MPI_SUCCESS, mpl_err = MPL_SUCCESS;
@@ -40,7 +48,7 @@ MPL_STATIC_INLINE_PREFIX int MPIR_GPU_query_pointer_attr(const void *ptr, MPL_po
     /* Skip query if GPU support is disabled by CVAR. Because we assume
      * no GPU buffer is used. If the user disables GPU at configure time
      * (e.g., --without-cuda), then MPL fallback will handle the query. */
-    if (MPIR_CVAR_ENABLE_GPU) {
+    if (ENABLE_GPU) {
         mpl_err = MPL_gpu_query_pointer_attr(ptr, attr);
         MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_query_ptr");
     } else {
@@ -56,7 +64,7 @@ MPL_STATIC_INLINE_PREFIX int MPIR_GPU_query_pointer_attr(const void *ptr, MPL_po
 
 MPL_STATIC_INLINE_PREFIX bool MPIR_GPU_query_pointer_is_dev(const void *ptr)
 {
-    if (MPIR_CVAR_ENABLE_GPU && ptr != NULL) {
+    if (ENABLE_GPU && ptr != NULL) {
         MPL_pointer_attr_t attr;
         MPL_gpu_query_pointer_attr(ptr, &attr);
 

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -218,7 +218,7 @@ void MPIR_Coll_host_buffer_alloc(const void *sendbuf, const void *recvbuf, MPI_A
     MPI_Aint extent = 0;
 
     if (sendbuf != MPI_IN_PLACE) {
-        MPL_gpu_query_pointer_attr(sendbuf, &attr);
+        MPIR_GPU_query_pointer_attr(sendbuf, &attr);
         if (attr.type == MPL_GPU_POINTER_DEV) {
             MPI_Aint true_extent;
             MPI_Aint true_lb;
@@ -233,7 +233,7 @@ void MPIR_Coll_host_buffer_alloc(const void *sendbuf, const void *recvbuf, MPI_A
         }
     }
 
-    MPL_gpu_query_pointer_attr(recvbuf, &attr);
+    MPIR_GPU_query_pointer_attr(recvbuf, &attr);
     if (attr.type == MPL_GPU_POINTER_DEV) {
         if (!extent) {
             MPI_Aint true_extent;

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -20,8 +20,8 @@ int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
     }
 
     MPL_pointer_attr_t inattr, outattr;
-    MPL_gpu_query_pointer_attr(inbuf, &inattr);
-    MPL_gpu_query_pointer_attr(outbuf, &outattr);
+    MPIR_GPU_query_pointer_attr(inbuf, &inattr);
+    MPIR_GPU_query_pointer_attr(outbuf, &outattr);
 
     if ((inattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
          inattr.type == MPL_GPU_POINTER_REGISTERED_HOST) &&
@@ -63,8 +63,8 @@ static inline bool fastpath_memcpy(const void *inbuf, void *outbuf, MPI_Datatype
      * true_lb) into the MPIR_Datatype structure */
     if (HANDLE_IS_BUILTIN(type)) {
         MPL_pointer_attr_t inattr, outattr;
-        MPL_gpu_query_pointer_attr(inbuf, &inattr);
-        MPL_gpu_query_pointer_attr(outbuf, &outattr);
+        MPIR_GPU_query_pointer_attr(inbuf, &inattr);
+        MPIR_GPU_query_pointer_attr(outbuf, &outattr);
 
         if ((inattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
              inattr.type == MPL_GPU_POINTER_REGISTERED_HOST) &&
@@ -86,11 +86,11 @@ static inline bool fastpath_memcpy(const void *inbuf, void *outbuf, MPI_Datatype
             MPL_pointer_attr_t inattr, outattr;
 
             if (dir == MEMCPY_DIR__PACK) {
-                MPL_gpu_query_pointer_attr((const char *) inbuf + dtp->true_lb + offset, &inattr);
-                MPL_gpu_query_pointer_attr(outbuf, &outattr);
+                MPIR_GPU_query_pointer_attr((const char *) inbuf + dtp->true_lb + offset, &inattr);
+                MPIR_GPU_query_pointer_attr(outbuf, &outattr);
             } else {
-                MPL_gpu_query_pointer_attr(inbuf, &inattr);
-                MPL_gpu_query_pointer_attr((char *) outbuf + dtp->true_lb + offset, &outattr);
+                MPIR_GPU_query_pointer_attr(inbuf, &inattr);
+                MPIR_GPU_query_pointer_attr((char *) outbuf + dtp->true_lb + offset, &outattr);
             }
 
             if ((inattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -66,8 +66,8 @@ int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtyp
         intptr_t sfirst;
         intptr_t rfirst;
 
-        MPL_gpu_query_pointer_attr(sendbuf, &send_attr);
-        MPL_gpu_query_pointer_attr(recvbuf, &recv_attr);
+        MPIR_GPU_query_pointer_attr(sendbuf, &send_attr);
+        MPIR_GPU_query_pointer_attr(recvbuf, &recv_attr);
 
         if (send_attr.type == MPL_GPU_POINTER_DEV && recv_attr.type == MPL_GPU_POINTER_DEV) {
             MPL_gpu_malloc((void **) &buf, COPY_BUFFER_SZ, recv_attr.device);

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -1043,7 +1043,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_compute_acc_op(void *source_buf, int source_
     void *in_targetbuf = target_buf;
     void *host_targetbuf = NULL;
     MPL_pointer_attr_t attr;
-    MPL_gpu_query_pointer_attr(target_buf, &attr);
+    MPIR_GPU_query_pointer_attr(target_buf, &attr);
     /* FIXME: use typerep/yaksa GPU-aware accumulate when available */
     if (attr.type == MPL_GPU_POINTER_DEV) {
         MPI_Aint extent, true_extent;


### PR DESCRIPTION
## Pull Request Description

Consistently use `MPIR_GPU_query_pointer_attr` so `MPIR_CVAR_ENABLE_GPU` is always checked.

Bypass the branch if `MPL_HAVE_GPU` if not defined.

[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
