### PR TITLE
mpir: refactoring MPIR request test|wait{all,any,some}

### DIFF
--- a/src/binding/c/request_api.txt
+++ b/src/binding/c/request_api.txt
@@ -189,11 +189,6 @@ MPI_Testany:
     'array_of_requests', such an action is considered erroneous and may cause the
     program to unexecpectedly terminate or produce incorrect results.
 */
-{ -- error_check --
-    if (count > 0) {
-        MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
-    }
-}
 {
     int n_inactive = 0;
     int last_disabled_anysource = -1;

--- a/src/binding/c/request_api.txt
+++ b/src/binding/c/request_api.txt
@@ -406,13 +406,6 @@ MPI_Waitany:
     *indx = MPI_UNDEFINED;
 
     for (int i = 0; i < count; i++) {
-#ifdef HAVE_ERROR_CHECKING
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
-        }
-        MPID_END_ERROR_CHECKS;
-#endif /* HAVE_ERROR_CHECKING */
         if (array_of_requests[i] != MPI_REQUEST_NULL) {
             if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptrs[i]))) {
                 last_disabled_anysource = i;

--- a/src/binding/c/request_api.txt
+++ b/src/binding/c/request_api.txt
@@ -190,78 +190,10 @@ MPI_Testany:
     program to unexecpectedly terminate or produce incorrect results.
 */
 {
-    int n_inactive = 0;
-    int last_disabled_anysource = -1;
-    int first_nonnull = count;
-
-    *flag = FALSE;
-    *indx = MPI_UNDEFINED;
-
-    for (int i = 0; i < count; i++) {
-        if (array_of_requests[i] != MPI_REQUEST_NULL) {
-            if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptrs[i]))) {
-                last_disabled_anysource = i;
-            }
-
-            if (MPIR_Request_is_complete(request_ptrs[i])) {
-                if (MPIR_Request_is_active(request_ptrs[i])) {
-                    *indx = i;
-                    *flag = TRUE;
-                    break;
-                } else {
-                    request_ptrs[i] = NULL;
-                }
-            } else {
-                if (first_nonnull == count)
-                    first_nonnull = i;
-            }
-        } else {
-            request_ptrs[i] = NULL;
-            n_inactive += 1;
-        }
-    }
-
-    if (n_inactive == count) {
-        *flag = TRUE;
-        *indx = MPI_UNDEFINED;
-        if (status != NULL)     /* could be null if count=0 */
-            MPIR_Status_set_empty(status);
-        goto fn_exit;
-    }
-
-    if (*indx == MPI_UNDEFINED) {
-        mpi_errno =
-            MPID_Testany(count - first_nonnull, &request_ptrs[first_nonnull], indx, flag, status);
-        /* --BEGIN ERROR HANDLING-- */
-        if (mpi_errno != MPI_SUCCESS) {
-            goto fn_fail;
-        }
-        /* --END ERROR HANDLING-- */
-
-        if (*indx != MPI_UNDEFINED) {
-            *indx += first_nonnull;
-        }
-    }
-
-    if (*indx != MPI_UNDEFINED) {
-        mpi_errno = MPIR_Request_completion_processing(request_ptrs[*indx], status);
-        if (!MPIR_Request_is_persistent(request_ptrs[*indx])) {
-            MPIR_Request_free(request_ptrs[*indx]);
-            array_of_requests[*indx] = MPI_REQUEST_NULL;
-        }
-        MPIR_ERR_CHECK(mpi_errno);
-        goto fn_exit;
-    }
-
-    /* If none of the requests completed, mark the last anysource request as
-     * pending failure. */
-    if (unlikely(last_disabled_anysource != -1)) {
-        MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
-        if (status != MPI_STATUS_IGNORE)
-            status->MPI_ERROR = mpi_errno;
-        *flag = TRUE;
+    /* Pass down request ptr to avoid redundant handle to ptr translation. */
+    mpi_errno = MPIR_Testany(count, array_of_requests, request_ptrs, indx, flag, status);
+    if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
-    }
 }
 
 MPI_Testsome:
@@ -282,71 +214,11 @@ MPI_Testsome:
     }
 }
 {
-    int n_inactive;
-    int proc_failure = FALSE;
-
-    *outcount = 0;
-    n_inactive = 0;
-    for (int i = 0; i < incount; i++) {
-        if (array_of_requests[i] != MPI_REQUEST_NULL) {
-            if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptrs[i]))) {
-                proc_failure = TRUE;
-                int rc = MPI_SUCCESS;
-                MPIR_ERR_SET(rc, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
-                if (array_of_statuses != MPI_STATUSES_IGNORE)
-                    array_of_statuses[i].MPI_ERROR = rc;
-            }
-        } else {
-            request_ptrs[i] = NULL;
-            n_inactive += 1;
-        }
-    }
-
-    if (n_inactive == incount) {
-        *outcount = MPI_UNDEFINED;
-        goto fn_exit;
-    }
-
-    mpi_errno = MPID_Testsome(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
-    /* --BEGIN ERROR HANDLING-- */
+    /* Pass down request ptr to avoid redundant handle to ptr translation. */
+    mpi_errno = MPIR_Testsome(incount, array_of_requests, request_ptrs, outcount,
+                              array_of_indices, array_of_statuses);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
-    /* --END ERROR HANDLING-- */
-
-    if (proc_failure)
-        mpi_errno = MPI_ERR_IN_STATUS;
-
-    if (*outcount == MPI_UNDEFINED)
-        goto fn_exit;
-
-    for (int i = 0; i < *outcount; i++) {
-        int idx = array_of_indices[i];
-        MPI_Status *status_ptr = (array_of_statuses == MPI_STATUSES_IGNORE) ?
-            MPI_STATUS_IGNORE : &array_of_statuses[i];
-        int rc = MPIR_Request_completion_processing(request_ptrs[idx], status_ptr);
-        if (!MPIR_Request_is_persistent(request_ptrs[idx])) {
-            MPIR_Request_free(request_ptrs[idx]);
-            array_of_requests[idx] = MPI_REQUEST_NULL;
-        }
-        if (rc == MPI_SUCCESS) {
-            request_ptrs[idx] = NULL;
-        } else {
-            mpi_errno = MPI_ERR_IN_STATUS;
-            if (status_ptr != MPI_STATUS_IGNORE) {
-                status_ptr->MPI_ERROR = rc;
-            }
-        }
-    }
-
-    if (mpi_errno == MPI_ERR_IN_STATUS) {
-        if (array_of_statuses != MPI_STATUSES_IGNORE) {
-            for (int i = 0; i < *outcount; i++) {
-                if (request_ptrs[array_of_indices[i]] == NULL) {
-                    array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
-                }
-            }
-        }
-    }
 }
 
 MPI_Wait:
@@ -400,61 +272,10 @@ MPI_Waitany:
     program to unexecpectedly terminate or produce incorrect results.
 */
 {
-    int last_disabled_anysource = -1;
-    int first_nonnull = count;
-
-    *indx = MPI_UNDEFINED;
-
-    for (int i = 0; i < count; i++) {
-        if (array_of_requests[i] != MPI_REQUEST_NULL) {
-            if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptrs[i]))) {
-                last_disabled_anysource = i;
-            }
-
-            /* Since waitany is likely to return as soon as a
-             * completed request is found, the first loop here is
-             * taking the longest. We can check for any completed
-             * request here, and we can poll from the first entry
-             * which is not null. */
-            if (MPIR_Request_is_complete(request_ptrs[i])) {
-                if (MPIR_Request_is_active(request_ptrs[i])) {
-                    *indx = i;
-                    break;
-                } else {
-                    request_ptrs[i] = NULL;
-                }
-            } else {
-                if (first_nonnull == count)
-                    first_nonnull = i;
-            }
-        } else {
-            request_ptrs[i] = NULL;
-        }
-    }
-
-    if (*indx == MPI_UNDEFINED) {
-        if (unlikely(last_disabled_anysource != -1)) {
-            int flag;
-            mpi_errno = MPI_Testany(count, array_of_requests, indx, &flag, status);
-            goto fn_exit;
-        }
-
-        mpi_errno = MPID_Waitany(count - first_nonnull, &request_ptrs[first_nonnull], indx, status);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        if (*indx != MPI_UNDEFINED) {
-            *indx += first_nonnull;
-        } else {
-            goto fn_exit;
-        }
-    }
-
-    mpi_errno = MPIR_Request_completion_processing(request_ptrs[*indx], status);
-    if (!MPIR_Request_is_persistent(request_ptrs[*indx])) {
-        MPIR_Request_free(request_ptrs[*indx]);
-        array_of_requests[*indx] = MPI_REQUEST_NULL;
-    }
-    MPIR_ERR_CHECK(mpi_errno);
+    /* Pass down request ptr to avoid redundant handle to ptr translation. */
+    mpi_errno = MPIR_Waitany(count, array_of_requests, request_ptrs, indx, status);
+    if (mpi_errno)
+        goto fn_fail;
 }
 
 MPI_Waitsome:
@@ -490,69 +311,9 @@ MPI_Waitsome:
     }
 }
 {
-    int n_inactive;
-    int disabled_anysource = FALSE;
-
-    *outcount = 0;
-    n_inactive = 0;
-    for (int i = 0; i < incount; i++) {
-        if (array_of_requests[i] != MPI_REQUEST_NULL) {
-            /* If one of the requests is an anysource on a communicator that's
-             * disabled such communication, convert this operation to a testall
-             * instead to prevent getting stuck in the progress engine. */
-            if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptrs[i]))) {
-                disabled_anysource = TRUE;
-            }
-        } else {
-            n_inactive += 1;
-            request_ptrs[i] = NULL;
-        }
-    }
-
-    if (n_inactive == incount) {
-        *outcount = MPI_UNDEFINED;
-        goto fn_exit;
-    }
-
-    if (unlikely(disabled_anysource)) {
-        mpi_errno =
-            MPI_Testsome(incount, array_of_requests, outcount, array_of_indices, array_of_statuses);
-        goto fn_exit;
-    }
-
-    mpi_errno = MPID_Waitsome(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
-    if (mpi_errno != MPI_SUCCESS) {
+    /* Pass down request ptr to avoid redundant handle to ptr translation. */
+    mpi_errno = MPIR_Waitsome(incount, array_of_requests, request_ptrs, outcount,
+                              array_of_indices, array_of_statuses);
+    if (mpi_errno)
         goto fn_fail;
-    }
-
-    if (*outcount == MPI_UNDEFINED)
-        goto fn_exit;
-
-    for (int i = 0; i < *outcount; i++) {
-        int idx = array_of_indices[i];
-        MPI_Status *status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
-        int rc = MPIR_Request_completion_processing(request_ptrs[idx], status_ptr);
-        if (!MPIR_Request_is_persistent(request_ptrs[idx])) {
-            MPIR_Request_free(request_ptrs[idx]);
-            array_of_requests[idx] = MPI_REQUEST_NULL;
-        }
-        if (rc == MPI_SUCCESS) {
-            request_ptrs[idx] = NULL;
-        } else {
-            mpi_errno = MPI_ERR_IN_STATUS;
-            if (status_ptr != MPI_STATUS_IGNORE) {
-                status_ptr->MPI_ERROR = rc;
-            }
-        }
-    }
-
-    if (mpi_errno == MPI_ERR_IN_STATUS) {
-        if (array_of_statuses != MPI_STATUSES_IGNORE) {
-            for (int i = 0; i < *outcount; i++) {
-                if (request_ptrs[array_of_indices[i]] == NULL) {
-                    array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
-                }
-            }
-        }
-    }
 }

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -642,7 +642,15 @@ int MPIR_Waitsome_impl(int incount, MPIR_Request * request_ptrs[],
 int MPIR_Test(MPI_Request * request, int *flag, MPI_Status * status);
 int MPIR_Testall(int count, MPI_Request array_of_requests[], int *flag,
                  MPI_Status array_of_statuses[]);
+int MPIR_Testany(int count, MPI_Request array_of_requests[], MPIR_Request * request_ptrs[],
+                 int *indx, int *flag, MPI_Status * status);
+int MPIR_Testsome(int incount, MPI_Request array_of_requests[], MPIR_Request * request_ptrs[],
+                  int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]);
 int MPIR_Wait(MPI_Request * request, MPI_Status * status);
 int MPIR_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of_statuses[]);
+int MPIR_Waitany(int count, MPI_Request array_of_requests[], MPIR_Request * request_ptrs[],
+                 int *indx, MPI_Status * status);
+int MPIR_Waitsome(int incount, MPI_Request array_of_requests[], MPIR_Request * request_ptrs[],
+                  int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]);
 
 #endif /* MPIR_REQUEST_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

Current `MPIR_Test|Wait` family define only `test,wait,testall,waitall`. The wait logic for `any|some` is still written in MPI layer (`src/binding/c/request_api.txt`). This is inconsistent and inconvenient when we change the wait logic. This PR defines MPIR API for any|some.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
