### PR TITLE
make ADIOI_GEN_WriteStrided not step on itself

### DIFF
--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrstr.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrstr.c
@@ -13,7 +13,7 @@
                 ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,  \
                                  ADIO_EXPLICIT_OFFSET, writebuf_off,    \
                                  &status1, error_code);                 \
-                if (!(fd->atomicity))                                   \
+                if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
                     ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
                 if (*error_code != MPI_SUCCESS) {                       \
                     *error_code = MPIO_Err_create_code(*error_code,     \
@@ -30,7 +30,7 @@
             writebuf_len = (unsigned) MPL_MIN(end_offset - writebuf_off + 1, \
                                               (writebuf_off / stripe_size + 1) * \
                                               stripe_size - writebuf_off); \
-            if (!(fd->atomicity))                                       \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
                 ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET,                       \
@@ -53,7 +53,7 @@
         while (write_sz != req_len) {                                   \
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,      \
                              ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
-            if (!(fd->atomicity))                                       \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
                 ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (*error_code != MPI_SUCCESS) {                           \
                 *error_code = MPIO_Err_create_code(*error_code,         \
@@ -70,7 +70,7 @@
             writebuf_len = (unsigned) MPL_MIN(end_offset - writebuf_off + 1, \
                                               (writebuf_off / stripe_size + 1) * \
                                               stripe_size - writebuf_off); \
-            if (!(fd->atomicity))                                       \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
                 ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET,                       \
@@ -213,8 +213,9 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
         writebuf_off = 0;
         writebuf_len = 0;
 
-        /* if atomicity is true, lock the region to be accessed */
-        if (fd->atomicity)
+        /* if atomicity is true or data sieving is not disable, lock the region
+         * to be accessed */
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_WRITE_LOCK(fd, start_off, SEEK_SET, bufsize);
 
         for (j = 0; j < count; j++) {
@@ -231,7 +232,7 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
         ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,
                          ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code);
 
-        if (fd->atomicity)
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_UNLOCK(fd, start_off, SEEK_SET, bufsize);
         if (*error_code != MPI_SUCCESS) {
             ADIOI_Free(writebuf);
@@ -311,8 +312,12 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
             userbuf_off = 0;
             ADIOI_BUFFERED_WRITE_WITHOUT_READ;
             /* write the buffer out finally */
+            if (fd->hints->ds_write != ADIOI_HINT_DISABLE)
+                ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,
                              ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code);
+            if (fd->hints->ds_write != ADIOI_HINT_DISABLE)
+                ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
 
             if (file_ptr_type == ADIO_INDIVIDUAL) {
                 /* update MPI-IO file pointer to point to the first byte
@@ -362,8 +367,9 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
             fwr_size = MPL_MIN(flat_file->blocklens[j], bufsize - i_offset);
         }
 
-/* if atomicity is true, lock the region to be accessed */
-        if (fd->atomicity)
+        /* if atomicity is true or data sieving is not disable, lock the region
+         * to be accessed */
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_WRITE_LOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         writebuf_off = 0;
@@ -481,12 +487,12 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
         if (writebuf_len) {
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,
                              ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code);
-            if (!(fd->atomicity))
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE)
                 ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
             if (*error_code != MPI_SUCCESS)
                 return;
         }
-        if (fd->atomicity)
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_UNLOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         ADIOI_Free(writebuf);

--- a/src/mpi/romio/adio/common/ad_write_str.c
+++ b/src/mpi/romio/adio/common/ad_write_str.c
@@ -12,7 +12,8 @@
             if (writebuf_len) {                                         \
                 ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,  \
                                  ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
-                if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+                if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
+                    ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
                 if (*error_code != MPI_SUCCESS) {                       \
                     *error_code = MPIO_Err_create_code(*error_code,     \
                                                        MPIR_ERR_RECOVERABLE, myname, \
@@ -23,7 +24,8 @@
             }                                                           \
             writebuf_off = req_off;                                     \
             writebuf_len = (unsigned) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
+                ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
             if (*error_code != MPI_SUCCESS) {                           \
@@ -40,7 +42,8 @@
         while (write_sz != req_len) {                                   \
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,      \
                              ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
+                ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (*error_code != MPI_SUCCESS) {                           \
                 *error_code = MPIO_Err_create_code(*error_code,         \
                                                    MPIR_ERR_RECOVERABLE, myname, \
@@ -52,7 +55,8 @@
             userbuf_off += write_sz;                                    \
             writebuf_off += writebuf_len;                               \
             writebuf_len = (unsigned) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
+                ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
             if (*error_code != MPI_SUCCESS) {                           \
@@ -184,8 +188,9 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
         writebuf = (char *) ADIOI_Malloc(max_bufsize);
         writebuf_len = (unsigned) (MPL_MIN(max_bufsize, end_offset - writebuf_off + 1));
 
-/* if atomicity is true, lock the region to be accessed */
-        if (fd->atomicity)
+        /* if atomicity is true or data sieving is not disable, lock the region
+         * to be accessed */
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_WRITE_LOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         for (j = 0; j < count; j++) {
@@ -204,7 +209,7 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
                              writebuf_off, &status1, error_code);
         }
 
-        if (fd->atomicity)
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_UNLOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         if (*error_code != MPI_SUCCESS)
@@ -280,8 +285,10 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
              * datatypes, instead of a count of bytes (which might overflow)
              * Other WriteContig calls in this path are operating on data
              * sieving buffer */
+            ADIOI_WRITE_LOCK(fd, offset, SEEK_SET, bufsize);
             ADIO_WriteContig(fd, buf, count, datatype, ADIO_EXPLICIT_OFFSET,
                              offset, status, error_code);
+            ADIOI_UNLOCK(fd, offset, SEEK_SET, bufsize);
 
             if (file_ptr_type == ADIO_INDIVIDUAL) {
                 /* update MPI-IO file pointer to point to the first byte
@@ -330,8 +337,9 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
             fwr_size = MPL_MIN(flat_file->blocklens[j], bufsize - i_offset);
         }
 
-/* if atomicity is true, lock the region to be accessed */
-        if (fd->atomicity)
+        /* if atomicity is true or data sieving is not disable, lock the region
+         * to be accessed */
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_WRITE_LOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         writebuf_off = 0;
@@ -451,12 +459,12 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
         if (writebuf_len) {
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE, ADIO_EXPLICIT_OFFSET,
                              writebuf_off, &status1, error_code);
-            if (!(fd->atomicity))
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE)
                 ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
             if (*error_code != MPI_SUCCESS)
                 goto fn_exit;
         }
-        if (fd->atomicity)
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_UNLOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         if (file_ptr_type == ADIO_INDIVIDUAL)


### PR DESCRIPTION
make ADIOI_GEN_WriteStrided not step on itself

The ADIOI_GEN_WriteStrided funcion uses data sieving on non-contiguous
types. That is, if it wants to write data at locations
    [W...X...Y...Z...]
it reads the whole buffer
    [dddddddddddddddd]
changes the locations it wants to write to
    [WdddXdddYdddZddd]
then writes the whole thing back. It uses locks to make this safe, but
the problem is this only protects against other parts of the product that
are using locks. And without this PR a peer who is simultaneously making
a simple non-contiguous write wouldn't have locked.

A testcase to demonstrate the original problem is here:
https://gist.github.com/markalle/d7da240c19e57f095c5d1b13240dae24

% mpicc -o x romio_write_timing.c
% mpirun -np 4 ./x

Note: you need to use a filesystem that uses ADIOI_GEN_WriteStrided to
hit the bug. I was using GPFS.

This commit is pulled from wkliao after discussing where to put the
new lock.  It adds locks to contiguous writes in independent write
functions when data sieving write is not disabled

(Updated PR description to include info about how to hit the bug
from the initial PR 4956, where we had my version of the fix that got
replaced with wkliao's fix seen here)