### PR TITLE
romio/daos: fix a double free issue when path has "." in it.

### DIFF
--- a/src/mpi/romio/adio/ad_daos/ad_daos_open.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_open.c
@@ -29,22 +29,20 @@ static int parse_filename(const char *path, char **_obj_name, char **_cont_name)
     fname = basename(f1);
     cont_name = dirname(f2);
 
-    if (cont_name[0] == '.') {
+    if (cont_name[0] != '/') {
         char *ptr;
-        char cwd[PATH_MAX];
+        char buf[PATH_MAX];
 
-        ptr = getcwd(cwd, PATH_MAX);
+        ptr = realpath(cont_name, buf);
         if (ptr == NULL) {
             rc = errno;
             goto out;
         }
 
-        if (strcmp(cont_name, ".") == 0) {
-            cont_name = ADIOI_Strdup(cwd);
-            if (cont_name == NULL) {
-                rc = ENOMEM;
-                goto out;
-            }
+        cont_name = ADIOI_Strdup(ptr);
+        if (cont_name == NULL) {
+            rc = ENOMEM;
+            goto out;
         }
         *_cont_name = cont_name;
     } else {


### PR DESCRIPTION
## Pull Request Description
romio/daos: fix a double free issue when path has "." in it.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
