### PR TITLE
mpl/spinlock: implement MPL_spinlock_t

### DIFF
--- a/src/mpl/include/mpl.h
+++ b/src/mpl/include/mpl.h
@@ -18,6 +18,7 @@
 #include "mpl_env.h"
 #include "mpl_sock.h"
 #include "mpl_sockaddr.h"
+#include "mpl_spinlock.h"
 #include "mpl_msg.h"
 #include "mpl_iov.h"
 #include "mpl_bt.h"

--- a/src/mpl/include/mpl_spinlock.h
+++ b/src/mpl/include/mpl_spinlock.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPL_SPINLOCK_H_INCLUDED
+#define MPL_SPINLOCK_H_INCLUDED
+
+#include <assert.h>
+#include "mplconfig.h"
+#include "mpl_atomic.h"
+
+#ifndef MPL_USE_NO_ATOMIC_PRIMITIVES
+
+/* Let's use atomic-based spinlock. */
+typedef struct MPL_spinlock_t {
+    MPL_atomic_int_t val;
+} MPL_spinlock_t;
+
+#define MPL_SPINLOCK_INITIALIZER { MPL_ATOMIC_INT_T_INITIALIZER(0) }
+
+static void MPL_spinlock_lock(MPL_spinlock_t * lock)
+{
+    while (MPL_atomic_cas_int(&lock->val, 0, 1));
+}
+
+static int MPL_spinlock_trylock(MPL_spinlock_t * lock)
+{
+    /* Return 0 if the lock is successfully taken.  Otherwise, return non-zero.
+     * This trylock is strong since MPL_atomic_cas_int is atomically strong. */
+    return MPL_atomic_cas_int(&lock->val, 0, 1);
+}
+
+static void MPL_spinlock_unlock(MPL_spinlock_t * lock)
+{
+    assert(MPL_atomic_relaxed_load_int(&lock->val) == 1);
+    MPL_atomic_release_store_int(&lock->val, 0);
+}
+
+#elif defined(MPL_HAVE_PTHREAD_H)
+
+/* If pthread can be used, let's use pthread_mutex. Note that we cannot use
+ * pthread's spinlock because it does not have a static initializer. */
+#include <pthread.h>
+
+#define MPL_spinlock_t pthread_mutex_t
+
+#define MPL_SPINLOCK_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+
+static void MPL_spinlock_lock(MPL_spinlock_t * lock)
+{
+    int ret = pthread_mutex_lock(lock);
+    assert(ret == 0);
+}
+
+static int MPL_spinlock_trylock(MPL_spinlock_t * lock)
+{
+    int ret = pthread_mutex_trylock(lock);
+    return ret == 0 ? 0 : 1;
+}
+
+static void MPL_spinlock_unlock(MPL_spinlock_t * lock)
+{
+    int ret = pthread_mutex_unlock(lock);
+    assert(ret == 0);
+}
+
+#else /* MPL_HAVE_PTHREAD_H */
+
+#error "Neither atomic primitives nor POSIX thread is supported."
+
+#endif /* !MPL_HAVE_PTHREAD_H */
+
+#endif /* MPL_SPINLOCK_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

`MPL_spinlock_t` is a spinlock implementation that can be initialized statically and used before `MPI_Init()` and after `MPI_Finalize()`. This is useful for #4978, the session implementation, and maybe the error code utilities

~This patch does not affect the current implementation since no code includes this header.~ As far as I checked, both atomic and mutex versions work.

## Expected Impact

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
