### PR TITLE
mpl/initlock: implement MPL_initlock_t

### DIFF
--- a/src/mpl/include/mpl.h
+++ b/src/mpl/include/mpl.h
@@ -30,5 +30,6 @@
 #include "mpl_proc_mutex.h"
 #include "mpl_gpu.h"
 #include "mpl_gavl.h"
+#include "mpl_initlock.h"
 
 #endif /* MPL_H_INCLUDED */

--- a/src/mpl/include/mpl_initlock.h
+++ b/src/mpl/include/mpl_initlock.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPL_INITLOCK_H_INCLUDED
+#define MPL_INITLOCK_H_INCLUDED
+
+#include <assert.h>
+#include "mplconfig.h"
+#include "mpl_atomic.h"
+
+/* Note: this "initlock" does not internally yield, so a thread should not wait
+ * for something while taking this lock.  This affects the behavior of
+ * non-preemptive threads such as Argobots. */
+
+#if defined(MPL_HAVE_PTHREAD_H)
+
+/* If pthread can be used, let's use pthread_mutex. */
+#include <pthread.h>
+
+#define MPL_initlock_t pthread_mutex_t
+
+#define MPL_INITLOCK_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+
+static inline void MPL_initlock_lock(MPL_initlock_t * lock)
+{
+    int ret = pthread_mutex_lock(lock);
+    assert(ret == 0);
+}
+
+static inline int MPL_initlock_trylock(MPL_initlock_t * lock)
+{
+    int ret = pthread_mutex_trylock(lock);
+    return ret == 0 ? 0 : 1;
+}
+
+static inline void MPL_initlock_unlock(MPL_initlock_t * lock)
+{
+    int ret = pthread_mutex_unlock(lock);
+    assert(ret == 0);
+}
+
+#elif !defined(MPL_USE_NO_ATOMIC_PRIMITIVES)
+
+/* Let's use atomic-based initlock as a fall-back implementation. */
+typedef struct MPL_initlock_t {
+    MPL_atomic_int_t val;
+} MPL_initlock_t;
+
+#define MPL_INITLOCK_INITIALIZER { MPL_ATOMIC_INT_T_INITIALIZER(0) }
+
+static inline void MPL_initlock_lock(MPL_initlock_t * lock)
+{
+    while (MPL_atomic_cas_int(&lock->val, 0, 1));
+}
+
+static inline int MPL_initlock_trylock(MPL_initlock_t * lock)
+{
+    /* Return 0 if the lock is successfully taken.  Otherwise, return non-zero.
+     * This trylock is strong since MPL_atomic_cas_int is atomically strong. */
+    return MPL_atomic_cas_int(&lock->val, 0, 1);
+}
+
+static inline void MPL_initlock_unlock(MPL_initlock_t * lock)
+{
+    assert(MPL_atomic_relaxed_load_int(&lock->val) == 1);
+    MPL_atomic_release_store_int(&lock->val, 0);
+}
+
+#else
+
+#error "Neither POSIX thread nor atomic primitives is supported."
+
+#endif
+
+#endif /* MPL_INITLOCK_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

The same functionality as #4998 but a different name. `MPL_initlock_t` is a lock implementation that can be initialized statically and used before `MPI_Init()` and after `MPI_Finalize()`. This is useful for #4978, the session implementation, and maybe the error code utilities

As far as I checked on my local laptop, both atomic and mutex versions work.

## Expected Impact

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
