### PR TITLE
Fix inconsistent mr key bug

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.c
@@ -23,7 +23,7 @@ int MPIDI_OFI_am_rdma_read_ack_handler(int handler_id, void *am_hdr, void *data,
 
     if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
         uint64_t mr_key = fi_mr_key(MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr));
-        MPIDI_OFI_mr_key_free(mr_key);
+        MPIDI_OFI_mr_key_free(MPIDI_OFI_LOCAL_MR_KEY, mr_key);
     }
     MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr)->fid), mr_unreg);
     MPL_atomic_fetch_sub_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs, 1);

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -213,7 +213,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
 
     lmt_info->sreq_ptr = sreq;
     if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
-        lmt_info->rma_key = MPIDI_OFI_mr_key_alloc();
+        lmt_info->rma_key =
+            MPIDI_OFI_mr_key_alloc(MPIDI_OFI_LOCAL_MR_KEY, MPIDI_OFI_INVALID_MR_KEY);
     } else {
         lmt_info->rma_key = 0;
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -353,7 +353,7 @@ static int send_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
         /* Clean up the memory region */
         if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
             uint64_t key = fi_mr_key(huge_send_mr);
-            MPIDI_OFI_mr_key_free(key);
+            MPIDI_OFI_mr_key_free(MPIDI_OFI_LOCAL_MR_KEY, key);
         }
         MPIDI_OFI_CALL(fi_close(&huge_send_mr->fid), mr_unreg);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -219,6 +219,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr()
 }
 
 /* Externs:  see util.c for definition */
+#define MPIDI_OFI_LOCAL_MR_KEY 0
+#define MPIDI_OFI_COLL_MR_KEY 1
+#define MPIDI_OFI_INVALID_MR_KEY 0xFFFFFFFFFFFFFFFFULL
 int MPIDI_OFI_handle_cq_error_util(int ep_idx, ssize_t ret);
 int MPIDI_OFI_retry_progress(void);
 int MPIDI_OFI_control_handler(int handler_id, void *am_hdr, void *data, MPI_Aint data_sz,
@@ -229,8 +232,8 @@ int MPIDI_OFI_am_rdma_read_ack_handler(int handler_id, void *am_hdr, void *data,
 int MPIDI_OFI_control_dispatch(void *buf);
 void MPIDI_OFI_index_datatypes(void);
 int MPIDI_OFI_mr_key_allocator_init(void);
-uint64_t MPIDI_OFI_mr_key_alloc(void);
-void MPIDI_OFI_mr_key_free(uint64_t index);
+uint64_t MPIDI_OFI_mr_key_alloc(int key_type, uint64_t requested_key);
+void MPIDI_OFI_mr_key_free(int key_type, uint64_t index);
 void MPIDI_OFI_mr_key_allocator_destroy(void);
 
 /* RMA */

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -255,7 +255,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
 
         if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
             /* Set up a memory region for the lmt data transfer */
-            ctrl.rma_key = MPIDI_OFI_mr_key_alloc();
+            ctrl.rma_key = MPIDI_OFI_mr_key_alloc(MPIDI_OFI_LOCAL_MR_KEY, MPIDI_OFI_INVALID_MR_KEY);
             rma_key = ctrl.rma_key;
         }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -511,7 +511,8 @@ static int win_init(MPIR_Win * win)
 
     memset(&MPIDI_OFI_WIN(win), 0, sizeof(MPIDI_OFI_win_t));
 
-    MPIDI_OFI_WIN(win).win_id = MPIDI_OFI_mr_key_alloc();
+    MPIDI_OFI_WIN(win).win_id =
+        MPIDI_OFI_mr_key_alloc(MPIDI_OFI_LOCAL_MR_KEY, MPIDI_OFI_INVALID_MR_KEY);
 
     MPIDIU_map_set(MPIDI_OFI_global.win_map, MPIDI_OFI_WIN(win).win_id, win, MPL_MEM_RMA);
 
@@ -552,7 +553,7 @@ static void dwin_close_mr(void *obj)
         int ret;
         if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
             uint64_t requested_key = fi_mr_key(mr);
-            MPIDI_OFI_mr_key_free(requested_key);
+            MPIDI_OFI_mr_key_free(MPIDI_OFI_LOCAL_MR_KEY, requested_key);
         }
         MPIDI_OFI_CALL_RETURN(fi_close(&mr->fid), ret);
         MPIR_Assert(ret >= 0);
@@ -845,7 +846,7 @@ int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
 
     uint64_t requested_key = 0ULL;
     if (!MPIDI_OFI_ENABLE_MR_PROV_KEY)
-        requested_key = MPIDI_OFI_mr_key_alloc();
+        requested_key = MPIDI_OFI_mr_key_alloc(MPIDI_OFI_LOCAL_MR_KEY, MPIDI_OFI_INVALID_MR_KEY);
 
     int rc = 0, allrc = 0;
     struct fid_mr *mr = NULL;


### PR DESCRIPTION
## Pull Request Description  
Processes in a window have inconsistent mr key which causes segmentation fault due to unable to find window buffer during rma operations. 

We have two solutions for this issue.
The first one is to keep mr key data structure (winfo) for each process and look up the corresponding mr key of target whenever a rma operation happens. This would correct the bug but winfo is not a scalable data structure that may consume a lot of memory when the number of processes is large and providers allow user-defined mr key (e.g. psm2).

The second one is to collectively pick a common mr key in win init stage for all processes and keep it until the end of window life cycle. This solution can avoid winfo structure and guarantee the consistent mr key throughout rma operations. 

The third one is applying second solution as base, but using context_id as the part of mr key for each window and mark a specific bit to indicate its collective key attribute. This method avoids duplicate common mr key allocation during win init stage and allows other types of key to be allocated as well such as in pt2pt and am-based accumulate.

We pick the third one as our solution.

The bug can be triggered in the following example:  
When the MPIDI_OFI_ENABLE_MR_PROV_KEY is by default set to FALSE in psm2 network, in win_allgather, if all disp_units are same, we will free winfo and think all processes in this window have the same mr_key which will be used by ofi to reference the win buffer.
If we have 0, 1, 2, 3 processes.
P0 and P1 create a window W1 and get the mr_key 0.
then P0, 1, 2, 3 create another window W2, but this time, P0, P1 will get mr_key 1; P2, P3 will get mr_key 0.
when they use W2 for RMA operations, P0 cannot find its win buffer due to incorrect mr_key

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
