### PR TITLE
typerep/yaksa: always pass info hint for yaksa pack/unpack

### DIFF
--- a/src/include/mpir_gpu.h
+++ b/src/include/mpir_gpu.h
@@ -74,4 +74,40 @@ MPL_STATIC_INLINE_PREFIX bool MPIR_GPU_query_pointer_is_dev(const void *ptr)
     return false;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIR_gpu_register_host(const void *ptr, size_t size)
+{
+    if (ENABLE_GPU) {
+        return MPL_gpu_register_host(ptr, size);
+    }
+    return MPI_SUCCESS;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIR_gpu_unregister_host(const void *ptr)
+{
+    if (ENABLE_GPU) {
+        return MPL_gpu_unregister_host(ptr);
+    }
+    return MPI_SUCCESS;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIR_gpu_malloc_host(void **ptr, size_t size)
+{
+    if (ENABLE_GPU) {
+        return MPL_gpu_malloc_host(ptr, size);
+    } else {
+        *ptr = MPL_malloc(size, MPL_MEM_BUFFER);
+        return MPI_SUCCESS;
+    }
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIR_gpu_free_host(void *ptr)
+{
+    if (ENABLE_GPU) {
+        return MPL_gpu_free_host(ptr);
+    } else {
+        MPL_free(ptr);
+        return MPI_SUCCESS;
+    }
+}
+
 #endif /* MPIR_GPU_H_INCLUDED */

--- a/src/mpi/datatype/typerep/src/typerep_internal.h
+++ b/src/mpi/datatype/typerep/src/typerep_internal.h
@@ -19,6 +19,48 @@ extern yaksa_info_t MPII_yaksa_info_nogpu;
 
 yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type);
 
+static inline yaksa_info_t MPII_yaksa_get_info(MPL_pointer_attr_t * inattr,
+                                               MPL_pointer_attr_t * outattr)
+{
+    if (inattr->type != MPL_GPU_POINTER_DEV && outattr->type != MPL_GPU_POINTER_DEV) {
+        return MPII_yaksa_info_nogpu;
+    }
+
+    yaksa_info_t info;
+    yaksa_info_create(&info);
+#ifdef MPL_HAVE_GPU
+#if MPL_HAVE_GPU == MPL_GPU_TYPE_CUDA
+    int rc;
+    yaksa_info_keyval_append(info, "yaksa_gpu_driver", "cuda", 5);
+    rc = yaksa_info_keyval_append(info, "yaksa_cuda_inbuf_ptr_attr", &inattr->device_attr,
+                                  sizeof(MPL_gpu_device_attr));
+    MPIR_Assert(rc == 0);
+    rc = yaksa_info_keyval_append(info, "yaksa_cuda_outbuf_ptr_attr", &outattr->device_attr,
+                                  sizeof(MPL_gpu_device_attr));
+    MPIR_Assert(rc == 0);
+#elif MPL_HAVE_GPU == MPL_GPU_TYPE_ZE
+    int rc;
+    yaksa_info_keyval_append(info, "yaksa_gpu_driver", "ze", 3);
+    rc = yaksa_info_keyval_append(info, "yaksa_ze_inbuf_ptr_attr", &inattr->device_attr,
+                                  sizeof(MPL_gpu_device_attr));
+    MPIR_Assert(rc == 0);
+    rc = yaksa_info_keyval_append(info, "yaksa_ze_outbuf_ptr_attr", &outattr->device_attr,
+                                  sizeof(MPL_gpu_device_attr));
+    MPIR_Assert(rc == 0);
+#endif
+#endif
+    return info;
+}
+
+static inline int MPII_yaksa_free_info(yaksa_info_t info)
+{
+    int rc = 0;
+    if (info != MPII_yaksa_info_nogpu) {
+        rc = yaksa_info_free(info);
+    }
+    return rc;
+}
+
 #else
 
 int MPII_Typerep_convert_subarray(int ndims, MPI_Aint * array_of_sizes,

--- a/src/mpi/datatype/typerep/src/typerep_internal.h
+++ b/src/mpi/datatype/typerep/src/typerep_internal.h
@@ -14,6 +14,9 @@
 #if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
 
 #include "yaksa.h"
+
+extern yaksa_info_t MPII_yaksa_info_nogpu;
+
 yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type);
 
 #else

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
@@ -369,7 +369,15 @@ void MPIR_Typerep_init(void)
      */
     MPIR_Assert(sizeof(MPI_Aint) == sizeof(intptr_t));
 
-    yaksa_init(NULL);
+    yaksa_info_create(&MPII_yaksa_info_nogpu);
+    yaksa_info_keyval_append(MPII_yaksa_info_nogpu, "yaksa_gpu_driver", "nogpu", 6);
+
+    if (MPIR_CVAR_ENABLE_GPU) {
+        yaksa_init(NULL);
+    } else {
+        /* prevent yaksa to query gpu devices, which can be very expensive */
+        yaksa_init(MPII_yaksa_info_nogpu);
+    }
 
     MPIR_Datatype_get_size_macro(MPI_REAL16, size);
     yaksa_type_create_contig(size, YAKSA_TYPE__BYTE, NULL, &TYPEREP_YAKSA_TYPE__REAL16);
@@ -379,9 +387,6 @@ void MPIR_Typerep_init(void)
 
     MPIR_Datatype_get_size_macro(MPI_INTEGER16, size);
     yaksa_type_create_contig(size, YAKSA_TYPE__BYTE, NULL, &TYPEREP_YAKSA_TYPE__INTEGER16);
-
-    yaksa_info_create(&MPII_yaksa_info_nogpu);
-    yaksa_info_keyval_append(MPII_yaksa_info_nogpu, "yaksa_gpu_driver", "nogpu", 6);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_INIT);
 }

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
@@ -11,6 +11,8 @@ static yaksa_type_t TYPEREP_YAKSA_TYPE__REAL16;
 static yaksa_type_t TYPEREP_YAKSA_TYPE__COMPLEX32;
 static yaksa_type_t TYPEREP_YAKSA_TYPE__INTEGER16;
 
+yaksa_info_t MPII_yaksa_info_nogpu;
+
 yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPII_TYPEREP_GET_YAKSA_TYPE);
@@ -378,6 +380,9 @@ void MPIR_Typerep_init(void)
     MPIR_Datatype_get_size_macro(MPI_INTEGER16, size);
     yaksa_type_create_contig(size, YAKSA_TYPE__BYTE, NULL, &TYPEREP_YAKSA_TYPE__INTEGER16);
 
+    yaksa_info_create(&MPII_yaksa_info_nogpu);
+    yaksa_info_keyval_append(MPII_yaksa_info_nogpu, "yaksa_gpu_driver", "nogpu", 6);
+
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_INIT);
 }
 
@@ -389,6 +394,8 @@ void MPIR_Typerep_finalize(void)
     yaksa_type_free(TYPEREP_YAKSA_TYPE__REAL16);
     yaksa_type_free(TYPEREP_YAKSA_TYPE__COMPLEX32);
     yaksa_type_free(TYPEREP_YAKSA_TYPE__INTEGER16);
+
+    yaksa_info_free(MPII_yaksa_info_nogpu);
 
     yaksa_finalize();
 

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -31,12 +31,17 @@ int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
     } else {
         yaksa_request_t request;
         uintptr_t actual_pack_bytes;
+
+        yaksa_info_t info = MPII_yaksa_get_info(&inattr, &outattr);
         rc = yaksa_ipack(inbuf, num_bytes, YAKSA_TYPE__BYTE, 0, outbuf, num_bytes,
-                         &actual_pack_bytes, NULL, YAKSA_OP__REPLACE, &request);
+                         &actual_pack_bytes, info, YAKSA_OP__REPLACE, &request);
         MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
         MPIR_Assert(actual_pack_bytes == num_bytes);
 
         rc = yaksa_request_wait(request);
+        MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+        rc = MPII_yaksa_free_info(info);
         MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
     }
 
@@ -128,21 +133,48 @@ int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype
 
     MPIR_Assert(datatype != MPI_DATATYPE_NULL);
 
-    /* fast-path for contig CPU buffers */
-    bool fast = fastpath_memcpy(inbuf, outbuf, datatype, incount, inoffset, max_pack_bytes,
-                                actual_pack_bytes, MEMCPY_DIR__PACK);
-    if (fast)
+    int is_contig = 0;
+    const void *inbuf_ptr;      /* adjusted by true_lb */
+    MPI_Aint total_size = 0;
+    if (HANDLE_IS_BUILTIN(datatype)) {
+        is_contig = 1;
+        inbuf_ptr = inbuf;
+        total_size = incount * MPIR_Datatype_get_basic_size(datatype);
+    } else {
+        MPIR_Datatype *dtp;
+        MPIR_Datatype_get_ptr(datatype, dtp);
+        is_contig = dtp->is_contig;
+        inbuf_ptr = (const char *) inbuf + dtp->true_lb;
+        total_size = incount * dtp->size;
+    }
+
+    MPL_pointer_attr_t inattr, outattr;
+    MPIR_GPU_query_pointer_attr(inbuf_ptr, &inattr);
+    MPIR_GPU_query_pointer_attr(outbuf, &outattr);
+
+    if (is_contig &&
+        (inattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
+         inattr.type == MPL_GPU_POINTER_REGISTERED_HOST) &&
+        (outattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
+         outattr.type == MPL_GPU_POINTER_REGISTERED_HOST)) {
+        *actual_pack_bytes = MPL_MIN(total_size - inoffset, max_pack_bytes);
+        MPIR_Memcpy(outbuf, (const char *) inbuf_ptr + inoffset, *actual_pack_bytes);
         goto fn_exit;
+    }
 
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(datatype);
+    yaksa_info_t info = MPII_yaksa_get_info(&inattr, &outattr);
 
     yaksa_request_t request;
     uintptr_t real_pack_bytes;
     rc = yaksa_ipack(inbuf, incount, type, inoffset, outbuf, max_pack_bytes, &real_pack_bytes,
-                     NULL, YAKSA_OP__REPLACE, &request);
+                     info, YAKSA_OP__REPLACE, &request);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
     rc = yaksa_request_wait(request);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    rc = MPII_yaksa_free_info(info);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
     *actual_pack_bytes = (MPI_Aint) real_pack_bytes;
@@ -170,27 +202,50 @@ int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_Ai
 
     MPIR_Assert(datatype != MPI_DATATYPE_NULL);
 
-    /* fast-path for contig CPU buffers */
-    bool fast = fastpath_memcpy(inbuf, outbuf, datatype, outcount, outoffset, insize,
-                                actual_unpack_bytes, MEMCPY_DIR__UNPACK);
-    if (fast)
+    int is_contig = 0;
+    const void *outbuf_ptr;     /* adjusted by true_lb */
+    MPI_Aint total_size = 0;
+    if (HANDLE_IS_BUILTIN(datatype)) {
+        is_contig = 1;
+        outbuf_ptr = outbuf;
+        total_size = outcount * MPIR_Datatype_get_basic_size(datatype);
+    } else {
+        MPIR_Datatype *dtp;
+        MPIR_Datatype_get_ptr(datatype, dtp);
+        is_contig = dtp->is_contig;
+        outbuf_ptr = (char *) outbuf + dtp->true_lb;
+        total_size = outcount * dtp->size;
+    }
+
+    MPL_pointer_attr_t inattr, outattr;
+    MPIR_GPU_query_pointer_attr(inbuf, &inattr);
+    MPIR_GPU_query_pointer_attr(outbuf_ptr, &outattr);
+
+    if (is_contig &&
+        (inattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
+         inattr.type == MPL_GPU_POINTER_REGISTERED_HOST) &&
+        (outattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
+         outattr.type == MPL_GPU_POINTER_REGISTERED_HOST)) {
+        *actual_unpack_bytes = MPL_MIN(total_size - outoffset, insize);
+        MPIR_Memcpy((char *) outbuf_ptr + outoffset, inbuf, *actual_unpack_bytes);
         goto fn_exit;
+    }
 
     yaksa_type_t type = MPII_Typerep_get_yaksa_type(datatype);
+    yaksa_info_t info = MPII_yaksa_get_info(&inattr, &outattr);
 
-    uintptr_t size;
-    rc = yaksa_type_get_size(type, &size);
-    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
-
-    uintptr_t real_insize = MPL_MIN(insize, size * outcount);
+    uintptr_t real_insize = MPL_MIN(total_size - outoffset, insize);
 
     yaksa_request_t request;
     uintptr_t real_unpack_bytes;
     rc = yaksa_iunpack(inbuf, real_insize, outbuf, outcount, type, outoffset, &real_unpack_bytes,
-                       NULL, YAKSA_OP__REPLACE, &request);
+                       info, YAKSA_OP__REPLACE, &request);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
     rc = yaksa_request_wait(request);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+
+    rc = MPII_yaksa_free_info(info);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
     *actual_unpack_bytes = (MPI_Aint) real_unpack_bytes;

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -57,65 +57,6 @@ typedef enum {
     MEMCPY_DIR__UNPACK,
 } memcpy_dir_e;
 
-static inline bool fastpath_memcpy(const void *inbuf, void *outbuf, MPI_Datatype type,
-                                   MPI_Aint count, MPI_Aint offset, MPI_Aint max_bytes,
-                                   MPI_Aint * actual_bytes, memcpy_dir_e dir)
-{
-    bool ret = false;
-
-    /* special case builtin types, over other contiguous types, to
-     * avoid the three pointer dereferences (for is_contig, size and
-     * true_lb) into the MPIR_Datatype structure */
-    if (HANDLE_IS_BUILTIN(type)) {
-        MPL_pointer_attr_t inattr, outattr;
-        MPIR_GPU_query_pointer_attr(inbuf, &inattr);
-        MPIR_GPU_query_pointer_attr(outbuf, &outattr);
-
-        if ((inattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
-             inattr.type == MPL_GPU_POINTER_REGISTERED_HOST) &&
-            (outattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
-             outattr.type == MPL_GPU_POINTER_REGISTERED_HOST)) {
-            MPI_Aint size = MPIR_Datatype_get_basic_size(type);
-            *actual_bytes = MPL_MIN(count * size - offset, max_bytes);
-            if (dir == MEMCPY_DIR__PACK)
-                MPIR_Memcpy(outbuf, (const char *) inbuf + offset, *actual_bytes);
-            else
-                MPIR_Memcpy((char *) outbuf + offset, inbuf, *actual_bytes);
-            ret = true;
-        }
-    } else {
-        MPIR_Datatype *dtp;
-        MPIR_Datatype_get_ptr(type, dtp);
-
-        if (dtp->is_contig) {
-            MPL_pointer_attr_t inattr, outattr;
-
-            if (dir == MEMCPY_DIR__PACK) {
-                MPIR_GPU_query_pointer_attr((const char *) inbuf + dtp->true_lb + offset, &inattr);
-                MPIR_GPU_query_pointer_attr(outbuf, &outattr);
-            } else {
-                MPIR_GPU_query_pointer_attr(inbuf, &inattr);
-                MPIR_GPU_query_pointer_attr((char *) outbuf + dtp->true_lb + offset, &outattr);
-            }
-
-            if ((inattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
-                 inattr.type == MPL_GPU_POINTER_REGISTERED_HOST) &&
-                (outattr.type == MPL_GPU_POINTER_UNREGISTERED_HOST ||
-                 outattr.type == MPL_GPU_POINTER_REGISTERED_HOST)) {
-                *actual_bytes = MPL_MIN(count * dtp->size - offset, max_bytes);
-                if (dir == MEMCPY_DIR__PACK)
-                    MPIR_Memcpy(outbuf, (const char *) inbuf + dtp->true_lb + offset,
-                                *actual_bytes);
-                else
-                    MPIR_Memcpy((char *) outbuf + dtp->true_lb + offset, inbuf, *actual_bytes);
-                ret = true;
-            }
-        }
-    }
-
-    return ret;
-}
-
 int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                       MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
                       MPI_Aint * actual_pack_bytes)

--- a/src/mpid/ch4/generic/am/mpidig_am_init.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_init.c
@@ -65,7 +65,7 @@ static void *host_alloc_buffer_registered(uintptr_t size)
 {
     void *ptr = MPL_malloc(size, MPL_MEM_BUFFER);
     MPIR_Assert(ptr);
-    MPL_gpu_register_host(ptr, size);
+    MPIR_gpu_register_host(ptr, size);
     return ptr;
 }
 
@@ -76,7 +76,7 @@ static void host_free(void *ptr)
 
 static void host_free_buffer_registered(void *ptr)
 {
-    MPL_gpu_unregister_host(ptr);
+    MPIR_gpu_unregister_host(ptr);
     MPL_free(ptr);
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.c
@@ -28,7 +28,7 @@ int MPIDI_OFI_am_rdma_read_ack_handler(int handler_id, void *am_hdr, void *data,
     MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr)->fid), mr_unreg);
     MPL_atomic_fetch_sub_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs, 1);
 
-    MPL_gpu_free_host(MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer));
+    MPIR_gpu_free_host(MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer));
 
     /* retrieve the handler_id of the original send request for origin cb. Note the handler_id
      * parameter is MPIDI_OFI_AM_RDMA_READ_ACK and should never be called with origin_cbs */

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -381,7 +381,7 @@ MPL_STATIC_INLINE_PREFIX int do_long_am_recv_unpack(MPI_Aint in_data_sz, MPIR_Re
     p->context_id = lmt_msg->context_id;
     p->src_offset = lmt_msg->src_offset;
 
-    mpi_errno = MPL_gpu_malloc_host(&p->unpack_buffer, pack_size);
+    mpi_errno = MPIR_gpu_malloc_host(&p->unpack_buffer, pack_size);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPI_Aint remain = MPIDIG_REQUEST(rreq, req->recv_async).in_data_sz;
@@ -417,7 +417,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_lmt_unpack_event(MPIR_Request * rreq)
         return FALSE;
     } else {
         /* all done. */
-        MPL_gpu_free_host(p->unpack_buffer);
+        MPIR_gpu_free_host(p->unpack_buffer);
         return TRUE;
     }
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -736,7 +736,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_rdma_read(int rank, MPIR_Comm
         /* FIXME: currently always allocate pack buffer for any size. This should be removed in next
          * step when we work on ZCOPY protocol support. Basically, if the src buf and datatype needs
          * packing, we should not be doing RDMA read. */
-        MPL_gpu_malloc_host((void **) &send_buf, data_sz);
+        MPIR_gpu_malloc_host((void **) &send_buf, data_sz);
         mpi_errno = MPIR_Typerep_pack(buf, count, datatype, 0, send_buf, data_sz, &last);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(data_sz == last);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -247,7 +247,7 @@ static int send_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
         MPIDI_OFI_CALL(fi_close(&huge_send_mr->fid), mr_unreg);
 
         if (MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer)) {
-            MPL_gpu_free_host(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer));
+            MPIR_gpu_free_host(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer));
         }
 
         MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(sreq, datatype));

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(struct fi_cq_tagged_entry *wc 
     if (c == 0) {
         if ((event_id == MPIDI_OFI_EVENT_SEND_PACK) &&
             (MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer))) {
-            MPL_gpu_free_host(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer));
+            MPIR_gpu_free_host(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer));
         } else if (MPIDI_OFI_ENABLE_PT2PT_NOPACK && (event_id == MPIDI_OFI_EVENT_SEND_NOPACK))
             MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.nopack));
 
@@ -78,7 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
                             MPIDI_OFI_REQUEST(rreq, noncontig.pack.count),
                             MPIDI_OFI_REQUEST(rreq, noncontig.pack.datatype), 0,
                             &actual_unpack_bytes);
-        MPL_gpu_free_host(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer));
+        MPIR_gpu_free_host(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer));
         if (actual_unpack_bytes != (MPI_Aint) count) {
             rreq->status.MPI_ERROR =
                 MPIR_Err_create_code(MPI_SUCCESS,

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -397,7 +397,7 @@ static void *host_alloc_registered(uintptr_t size)
 {
     void *ptr = MPL_malloc(size, MPL_MEM_BUFFER);
     MPIR_Assert(ptr);
-    MPL_gpu_register_host(ptr, size);
+    MPIR_gpu_register_host(ptr, size);
     return ptr;
 }
 
@@ -408,7 +408,7 @@ static void host_free(void *ptr)
 
 static void host_free_registered(void *ptr)
 {
-    MPL_gpu_unregister_host(ptr);
+    MPIR_gpu_unregister_host(ptr);
     MPL_free(ptr);
 }
 
@@ -597,7 +597,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
         MPIDI_OFI_global.am_unordered_msgs = NULL;
 
         for (int i = 0; i < MPIDI_OFI_NUM_AM_BUFFERS; i++) {
-            MPL_gpu_malloc_host(&(MPIDI_OFI_global.am_bufs[i]), MPIDI_OFI_AM_BUFF_SZ);
+            MPIR_gpu_malloc_host(&(MPIDI_OFI_global.am_bufs[i]), MPIDI_OFI_AM_BUFF_SZ);
             MPIDI_OFI_global.am_reqs[i].event_id = MPIDI_OFI_EVENT_AM_RECV;
             MPIDI_OFI_global.am_reqs[i].index = i;
             MPIR_Assert(MPIDI_OFI_global.am_bufs[i]);
@@ -768,7 +768,7 @@ int MPIDI_OFI_mpi_finalize_hook(void)
         MPIDIU_map_destroy(MPIDI_OFI_global.am_recv_seq_tracker);
 
         for (i = 0; i < MPIDI_OFI_NUM_AM_BUFFERS; i++)
-            MPL_gpu_free_host(MPIDI_OFI_global.am_bufs[i]);
+            MPIR_gpu_free_host(MPIDI_OFI_global.am_bufs[i]);
 
         MPIDU_genq_private_pool_destroy_unsafe(MPIDI_OFI_global.am_hdr_buf_pool);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -186,8 +186,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
          * However, once the new buffer pool infrastructure is setup, we would simply be
          * allocating a buffer from the pool, so whether it's a regular malloc buffer or a GPU
          * registered buffer should be equivalent with respect to performance. */
-        MPL_gpu_malloc_host((void **) &MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer),
-                            data_sz);
+        MPIR_gpu_malloc_host((void **) &MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer),
+                             data_sz);
         MPIR_ERR_CHKANDJUMP1(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer) == NULL, mpi_errno,
                              MPI_ERR_OTHER, "**nomem", "**nomem %s", "Recv Pack Buffer alloc");
         recv_buf = MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -211,8 +211,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
          * However, once the new buffer pool infrastructure is setup, we would simply be
          * allocating a buffer from the pool, so whether it's a regular malloc buffer or a GPU
          * registered buffer should be equivalent with respect to performance. */
-        MPL_gpu_malloc_host((void **) &MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer),
-                            data_sz);
+        MPIR_gpu_malloc_host((void **) &MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer),
+                             data_sz);
         MPIR_ERR_CHKANDJUMP1(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer) == NULL, mpi_errno,
                              MPI_ERR_OTHER, "**nomem", "**nomem %s", "Send Pack buffer alloc");
 
@@ -340,7 +340,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
             if (!MPIDI_OFI_ENABLE_HMEM) {
                 /* Force pack for GPU buffer. */
                 void *host_buf = NULL;
-                MPL_gpu_malloc_host(&host_buf, data_sz);
+                MPIR_gpu_malloc_host(&host_buf, data_sz);
                 MPIR_Typerep_pack(buf, count, datatype, 0, host_buf, data_sz, &actual_pack_bytes);
                 MPIR_Assert(actual_pack_bytes == data_sz);
                 send_buf = host_buf;
@@ -351,7 +351,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         if (actual_pack_bytes > 0) {
             /* Free stage host buf (assigned to send_buf already) after
              * lightweight_send. */
-            MPL_gpu_free_host(send_buf);
+            MPIR_gpu_free_host(send_buf);
         }
         if (!noreq) {
             *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -17,7 +17,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_am_isend_callback(void *request, ucs_sta
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_UCX_AM_ISEND_CALLBACK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_AM_ISEND_CALLBACK);
 
-    MPL_gpu_free_host(req->dev.ch4.am.netmod_am.ucx.pack_buffer);
+    MPIR_gpu_free_host(req->dev.ch4.am.netmod_am.ucx.pack_buffer);
     req->dev.ch4.am.netmod_am.ucx.pack_buffer = NULL;
     MPIDIG_global.origin_cbs[handler_id] (req);
     ucp_request->req = NULL;
@@ -69,7 +69,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
     ucx_hdr.handler_id = handler_id;
     ucx_hdr.data_sz = data_sz;
 
-    MPL_gpu_malloc_host((void **) &send_buf, data_sz + am_hdr_sz + sizeof(ucx_hdr));
+    MPIR_gpu_malloc_host((void **) &send_buf, data_sz + am_hdr_sz + sizeof(ucx_hdr));
     MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
     MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
 
@@ -88,7 +88,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
 
     /* send is done. free all resources and complete the request */
     if (ucp_request == NULL) {
-        MPL_gpu_free_host(send_buf);
+        MPIR_gpu_free_host(send_buf);
         MPIDIG_global.origin_cbs[handler_id] (sreq);
         goto fn_exit;
     }
@@ -138,7 +138,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
     }
 
     /* copy headers to send buffer */
-    MPL_gpu_malloc_host((void **) &send_buf, data_sz + am_hdr_sz + sizeof(ucx_hdr));
+    MPIR_gpu_malloc_host((void **) &send_buf, data_sz + am_hdr_sz + sizeof(ucx_hdr));
     ucx_hdr.handler_id = handler_id;
     ucx_hdr.data_sz = data_sz;
     MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
@@ -251,7 +251,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
          * However, once the new buffer pool infrastructure is setup, we would simply be
          * allocating a buffer from the pool, so whether it's a regular malloc buffer or a GPU
          * registered buffer should be equivalent with respect to performance. */
-        MPL_gpu_malloc_host((void **) &send_buf, data_sz + am_hdr_sz + sizeof(ucx_hdr));
+        MPIR_gpu_malloc_host((void **) &send_buf, data_sz + am_hdr_sz + sizeof(ucx_hdr));
 
         MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
         MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
@@ -275,7 +275,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
 
     /* send is done. free all resources and complete the request */
     if (ucp_request == NULL) {
-        MPL_gpu_free_host(send_buf);
+        MPIR_gpu_free_host(send_buf);
         MPIDIG_global.origin_cbs[handler_id] (sreq);
         goto fn_exit;
     }

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -34,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
                 break;
 
             /* message is available. allocate a buffer and start receiving it */
-            MPL_gpu_malloc_host(&MPIDI_UCX_am_buf, info.length);
+            MPIR_gpu_malloc_host(&MPIDI_UCX_am_buf, info.length);
             ucp_request =
                 (MPIDI_UCX_ucp_request_t *) ucp_tag_msg_recv_nb(MPIDI_UCX_global.ctx[0].worker,
                                                                 MPIDI_UCX_am_buf, info.length,
@@ -49,7 +49,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
 
             /* free resources for handled message */
             ucp_request_release(ucp_request);
-            MPL_gpu_free_host(MPIDI_UCX_am_buf);
+            MPIR_gpu_free_host(MPIDI_UCX_am_buf);
         }
     }
 

--- a/src/mpid/ch4/netmod/ucx/ucx_request.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_request.h
@@ -15,7 +15,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req)
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
 {
-    MPL_gpu_free_host((req)->dev.ch4.am.netmod_am.ucx.pack_buffer);
+    MPIR_gpu_free_host((req)->dev.ch4.am.netmod_am.ucx.pack_buffer);
     /* MPIR_Request_free(req); */
 }
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_init.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_init.c
@@ -32,8 +32,10 @@ int MPIDI_IPC_mpi_init_hook(int rank, int size, int *tag_bits)
     mpi_errno = MPIDI_XPMEM_mpi_init_hook(rank, size, tag_bits);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIDI_GPU_mpi_init_hook(rank, size, tag_bits);
-    MPIR_ERR_CHECK(mpi_errno);
+    if (MPIR_CVAR_ENABLE_GPU) {
+        mpi_errno = MPIDI_GPU_mpi_init_hook(rank, size, tag_bits);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPC_MPI_INIT_HOOK);

--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.c
@@ -80,7 +80,7 @@ int MPIDU_genq_shmem_pool_create_unsafe(uintptr_t cell_size, uintptr_t cells_per
     rc = MPIDU_Init_shm_alloc(slab_size, &pool_obj->slab);
     MPIR_ERR_CHECK(rc);
 
-    rc = MPL_gpu_register_host(pool_obj->slab, slab_size);
+    rc = MPIR_gpu_register_host(pool_obj->slab, slab_size);
     MPIR_ERR_CHECK(rc);
 
     pool_obj->cell_header_base = (MPIDU_genqi_shmem_cell_header_s *) pool_obj->slab;

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -29,6 +29,7 @@ typedef enum {
 typedef struct {
     MPL_pointer_type_t type;
     MPL_gpu_device_handle_t device;
+    MPL_gpu_device_attr device_attr;
 } MPL_pointer_attr_t;
 
 typedef enum {

--- a/src/mpl/include/mpl_gpu_cuda.h
+++ b/src/mpl/include/mpl_gpu_cuda.h
@@ -11,6 +11,7 @@
 
 typedef cudaIpcMemHandle_t MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
+typedef struct cudaPointerAttributes MPL_gpu_device_attr;
 #define MPL_GPU_DEVICE_INVALID -1
 
 #endif /* ifndef MPL_GPU_CUDA_H_INCLUDED */

--- a/src/mpl/include/mpl_gpu_fallback.h
+++ b/src/mpl/include/mpl_gpu_fallback.h
@@ -8,6 +8,7 @@
 
 typedef int MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
+typedef int MPL_gpu_device_attr;        /* dummy type */
 #define MPL_GPU_DEVICE_INVALID -1
 
 #endif /* ifndef MPL_GPU_CUDA_H_INCLUDED */

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -10,6 +10,7 @@
 
 typedef ze_ipc_mem_handle_t MPL_gpu_ipc_mem_handle_t;
 typedef ze_device_handle_t MPL_gpu_device_handle_t;
+typedef ze_memory_allocation_properties_t MPL_gpu_device_attr;
 #define MPL_GPU_DEVICE_INVALID NULL
 
 #endif /* ifndef MPL_GPU_ZE_H_INCLUDED */

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -25,25 +25,24 @@ static int gpu_mem_hook_init();
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     cudaError_t ret;
-    struct cudaPointerAttributes ptr_attr;
-    ret = cudaPointerGetAttributes(&ptr_attr, ptr);
+    ret = cudaPointerGetAttributes(&attr->device_attr, ptr);
     if (ret == cudaSuccess) {
-        switch (ptr_attr.type) {
+        switch (attr->device_attr.type) {
             case cudaMemoryTypeUnregistered:
                 attr->type = MPL_GPU_POINTER_UNREGISTERED_HOST;
-                attr->device = ptr_attr.device;
+                attr->device = attr->device_attr.device;
                 break;
             case cudaMemoryTypeHost:
                 attr->type = MPL_GPU_POINTER_REGISTERED_HOST;
-                attr->device = ptr_attr.device;
+                attr->device = attr->device_attr.device;
                 break;
             case cudaMemoryTypeDevice:
                 attr->type = MPL_GPU_POINTER_DEV;
-                attr->device = ptr_attr.device;
+                attr->device = attr->device_attr.device;
                 break;
             case cudaMemoryTypeManaged:
                 attr->type = MPL_GPU_POINTER_MANAGED;
-                attr->device = ptr_attr.device;
+                attr->device = attr->device_attr.device;
                 break;
         }
     } else if (ret == cudaErrorInvalidValue) {

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -166,13 +166,12 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     ze_result_t ret;
-    ze_memory_allocation_properties_t ptr_attr;
     ze_device_handle_t device;
-    memset(&ptr_attr, 0, sizeof(ze_memory_allocation_properties_t));
-    ret = zeMemGetAllocProperties(global_ze_context, ptr, &ptr_attr, &device);
+    memset(&attr->device_attr, 0, sizeof(ze_memory_allocation_properties_t));
+    ret = zeMemGetAllocProperties(global_ze_context, ptr, &attr->device_attr, &device);
     ZE_ERR_CHECK(ret);
     attr->device = device;
-    switch (ptr_attr.type) {
+    switch (attr->device_attr.type) {
         case ZE_MEMORY_TYPE_UNKNOWN:
             attr->type = MPL_GPU_POINTER_UNREGISTERED_HOST;
             break;


### PR DESCRIPTION
## Pull Request Description

GPU pointer attribute query can be expensive. Since we have already done that in MPICH, we should avoid do it again in yaksa, thus need to pass in the info hint.

This PR depends on a new yaksa feature: https://github.com/pmodels/yaksa/pull/169 and pass in the "nogpu" hint when no device memory is involved in either `inbuf` or `outbuf`. It will create a new yaksa hint when GPU memory is involved.

Fixes #5002

Creating yaksa info hint incurs overhead -- `malloc`, `memcpy`, `strcmp` -- so additional optimization may be needed. This is left as TODO.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->
[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
