### PR TITLE
mpl: fix NULL pointer bug in cudaFree/cuMemFree trap function

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -284,9 +284,12 @@ int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
 static void gpu_free_hooks_cb(void *dptr)
 {
     gpu_free_hook_s *current = free_hook_chain;
-    while (current) {
-        current->free_hook(dptr);
-        current = current->next;
+    if (dptr != NULL) {
+        /* we call gpu hook only when dptr != NULL */
+        while (current) {
+            current->free_hook(dptr);
+            current = current->next;
+        }
     }
     return;
 }


### PR DESCRIPTION
## Pull Request Description
MPL uses cuMemFree/cudaFree to trap cuda free calls from users, but
current code does not consider NULL pointer. This patch fixes this bug.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
