### PR TITLE
MPI-4: deprecate MPI_Info_get and MPI_Info_get_valuelen

### DIFF
--- a/src/binding/c/info_api.txt
+++ b/src/binding/c/info_api.txt
@@ -30,6 +30,10 @@ MPI_Info_free:
 MPI_Info_get:
     .desc: Retrieves the value associated with a key
     .skip: initcheck
+/*
+.N Deprecated
+   'MPI_Info_get_string' should be used instead of this routine.
+*/
 
 MPI_Info_get_nkeys:
     .desc: Returns the number of currently defined keys in info
@@ -42,6 +46,10 @@ MPI_Info_get_nthkey:
 MPI_Info_get_valuelen:
     .desc: Retrieves the length of the value associated with a key
     .skip: initcheck
+/*
+.N Deprecated
+   'MPI_Info_get_string' should be used instead of this routine.
+*/
 
 MPI_Info_set:
     .desc: Adds a (key,value) pair to info


### PR DESCRIPTION
## Pull Request Description

This PR closes #4888. `MPI_Info_get_string()` should be used instead of `MPI_Info_get()` and `MPI_Info_get_valuelen()`, so
`MPI_Info_get()` and `MPI_Info_get_valuelen()` are marked as deprecated.

This patch only adds `.N deprecated` comments, so it does not change the behavior of MPICH.

Note that this PR does not use `.replace` since `MPI_Info_get_string()` does not "replace" those functions.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
