### PR TITLE
ch4/ofi: free allocated mr key during win detach

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -550,6 +550,10 @@ static void dwin_close_mr(void *obj)
     struct fid_mr *mr = (struct fid_mr *) obj;
     if (mr) {
         int ret;
+        if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
+            uint64_t requested_key = fi_mr_key(mr);
+            MPIDI_OFI_mr_key_free(requested_key);
+        }
         MPIDI_OFI_CALL_RETURN(fi_close(&mr->fid), ret);
         MPIR_Assert(ret >= 0);
     }


### PR DESCRIPTION
## Pull Request Description
Current win detach does not free the previously allocated mr key in win attach. 
This patch fixes this issue.


<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
