### PR TITLE
config: only enable gpu with explicit options

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -982,17 +982,19 @@ AC_SUBST(libmpl_so_versionflags)
 #######################################################################
 have_gpu="no"
 # Check CUDA availability
-PAC_SET_HEADER_LIB_PATH([cuda])
-PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cudart=yes],[have_cudart=no])
-PAC_CHECK_HEADER_LIB([cuda.h],[cuda],[cuMemGetAddressRange],[have_cuda=yes],[have_cuda=no])
-if test "X${have_cudart}" = "Xyes" -a \
-    "X${have_cuda}" = "Xyes" ; then
-    AC_DEFINE([HAVE_CUDA],[1],[Define if CUDA is available])
-    have_gpu="yes"
+if test -n "$with_cuda" -a "$with_cuda" != "no" ; then
+    PAC_SET_HEADER_LIB_PATH([cuda])
+    PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cudart=yes],[have_cudart=no])
+    PAC_CHECK_HEADER_LIB([cuda.h],[cuda],[cuMemGetAddressRange],[have_cuda=yes],[have_cuda=no])
+    if test "X${have_cudart}" = "Xyes" -a \
+        "X${have_cuda}" = "Xyes" ; then
+        AC_DEFINE([HAVE_CUDA],[1],[Define if CUDA is available])
+        have_gpu="yes"
+    fi
 fi
 AM_CONDITIONAL([MPL_HAVE_CUDA],[test "X${have_cudart}" = "Xyes" -a "X${have_cuda}" = "Xyes"])
 
-if test "$have_gpu" = "no" ; then
+if test "$have_gpu" = "no" -a -n "$with_ze" -a "$with_ze" != "no"; then
     # Check Level Zero availability when no other GPU library is available
     PAC_SET_HEADER_LIB_PATH([ze])
     PAC_CHECK_HEADER_LIB([level_zero/ze_api.h],[ze_loader],[zeInit],[have_ze=yes],[have_ze=no])

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -730,22 +730,24 @@ PAC_PUSH_FLAG([LDFLAGS])
 PAC_PUSH_FLAG([LIBS])
 
 # Check CUDA availability
-PAC_SET_HEADER_LIB_PATH([cuda])
-PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cuda=yes],[have_cuda=no])
 cuda_CPPFLAGS=""
 cuda_LDFLAGS=""
 cuda_LIBS=""
-if test "X${have_cuda}" = "Xyes" ; then
-    AC_DEFINE([HAVE_CUDA],[1],[Define if CUDA is available])
-    have_gpu="yes"
-    if test -n "${with_cuda}" ; then
-        cuda_CPPFLAGS="-I${with_cuda}/include"
-        if test -d ${with_cuda}/lib64 ; then
-            cuda_LDFLAGS="-L${with_cuda}/lib64 -L${with_cuda}/lib"
-        else
-            cuda_LDFLAGS="-L${with_cuda}/lib"
+if test -n "$with_cuda" -a "$with_cuda" != "no" ; then
+    PAC_SET_HEADER_LIB_PATH([cuda])
+    PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cuda=yes],[have_cuda=no])
+    if test "X${have_cuda}" = "Xyes" ; then
+        AC_DEFINE([HAVE_CUDA],[1],[Define if CUDA is available])
+        have_gpu="yes"
+        if test -n "${with_cuda}" ; then
+            cuda_CPPFLAGS="-I${with_cuda}/include"
+            if test -d ${with_cuda}/lib64 ; then
+                cuda_LDFLAGS="-L${with_cuda}/lib64 -L${with_cuda}/lib"
+            else
+                cuda_LDFLAGS="-L${with_cuda}/lib"
+            fi
+            cuda_LIBS="-lcudart"
         fi
-        cuda_LIBS="-lcudart"
     fi
 fi
 AM_CONDITIONAL([HAVE_CUDA],[test "X${have_cuda}" = "Xyes"])
@@ -753,7 +755,7 @@ AC_SUBST([cuda_CPPFLAGS])
 AC_SUBST([cuda_LDFLAGS])
 AC_SUBST([cuda_LIBS])
 
-if test "$have_gpu" = "no" ; then
+if test "$have_gpu" = "no" -a -n "$with_ze" -a "$with_ze" != "no" ; then
     # Check Level Zero availability when no other GPU library is available
     PAC_SET_HEADER_LIB_PATH([ze])
     PAC_CHECK_HEADER_LIB([level_zero/ze_api.h],[ze_loader],[zeInit],[have_ze=yes],[have_ze=no])


### PR DESCRIPTION
## Pull Request Description

Here is the argument for only enable GPU with explicit `--with-cuda[=path]` or `--with-ze[=path]`:

* When the user need GPU support, the code will crash if mpich is not GPU enabled, so the user will read `./configure --help` to find the options
* When a user doesn't need GPU support, it is too easy to accidentally configured with GPU since e.g. Cuda quite often finds its way into the system path nowadays. Accidentally having GPU enabled has a great possibility to degrade a CPU-only application unless the user is aware of how to disable it during runtime (ref. #5000)
* When user *really* want to disable GPU support, currently it appears there is no easy way 😞 

TODO: patch yaksa similarly.

[My story: my office workstation currently has a broken Cuda since I don't want to risk rebooting it remotely. The Cuda is in the system path but won't compile due to a halfway upgrade. I am struggling every time checking out a build. ]

[skip warnings]
## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
