### PR TITLE
init: implementing mpi session

### DIFF
--- a/src/binding/c/init_api.txt
+++ b/src/binding/c/init_api.txt
@@ -151,3 +151,34 @@ MPI_Query_thread:
 {
     *provided = MPIR_ThreadInfo.thread_provided;
 }
+
+MPI_Session_init:
+    .desc: Initialize an MPI session
+    .skip: initcheck
+
+MPI_Session_finalize:
+    .desc: Finalize an MPI Session
+    .skip: ThreadSafe, global_cs
+
+MPI_Session_get_num_psets:
+    .desc: Get number of available processes sets
+
+MPI_Session_get_nth_pset:
+    .desc: Get the nth processes set
+{ -- error_check -- pset_name
+    if (*pset_len) {
+        MPIR_ERRTEST_ARGNULL(pset_name, "pset_name", mpi_errno);
+    }
+}
+
+MPI_Session_get_info:
+    .desc: Get the info hints associated to the session
+
+MPI_Session_get_pset_info:
+    .desc: Get the info associated with the processes set
+
+MPI_Group_from_session_pset:
+    .desc: Get group from a session processes set
+
+MPI_Comm_create_from_group:
+    .desc: Create communicator from a group

--- a/src/binding/fortran/use_mpi/buildiface
+++ b/src/binding/fortran/use_mpi/buildiface
@@ -110,6 +110,8 @@ my $line_limit = 80; # Max line length
          'MPI_Op*' => 'INTEGER', # Never an array of ops
          'MPI_Message' => 'INTEGER',
          'MPI_Message*' => 'INTEGER', # Never an array of messages
+         'MPI_Session' => 'INTEGER',
+         'MPI_Session*' => 'INTEGER', # Never an array of sessions
          'MPI_Status*' => 'INTEGER %name%(MPI_STATUS_SIZE)',
          'MPI_Status[]' => 'INTEGER %name%(MPI_STATUS_SIZE,*)',
          'MPI_Aint' => 'INTEGER(KIND=MPI_ADDRESS_KIND)',

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -1131,6 +1131,14 @@ int MPI_Init(int *argc, char ***argv) MPICH_API_PUBLIC;
 int MPI_Finalize(void) MPICH_API_PUBLIC;
 int MPI_Initialized(int *flag) MPICH_API_PUBLIC;
 int MPI_Abort(MPI_Comm comm, int errorcode) MPICH_API_PUBLIC;
+int MPI_Session_init(MPI_Info info, MPI_Errhandler errhandler, MPI_Session *session) MPICH_API_PUBLIC;
+int MPI_Session_finalize(MPI_Session *session) MPICH_API_PUBLIC;
+int MPI_Session_get_num_psets(MPI_Session session, MPI_Info info, int *pset_names) MPICH_API_PUBLIC;
+int MPI_Session_get_nth_pset(MPI_Session session, MPI_Info info, int n, int *pset_len, char *pset_name) MPICH_API_PUBLIC;
+int MPI_Session_get_info(MPI_Session session, MPI_Info *info_used) MPICH_API_PUBLIC;
+int MPI_Session_get_pset_info(MPI_Session session, const char *pset_name, MPI_Info *info) MPICH_API_PUBLIC;
+int MPI_Group_from_session_pset(MPI_Session session, const char *pset_name, MPI_Group *group) MPICH_API_PUBLIC;
+int MPI_Comm_create_from_group(MPI_Group group, const char *stringtag, MPI_Info info, MPI_Errhandler errhandler, MPI_Comm *newcomm) MPICH_API_PUBLIC;
 
 /* Note that we may need to define a @PCONTROL_LIST@ depending on whether
    stdargs are supported */
@@ -1798,6 +1806,14 @@ int PMPI_Init(int *argc, char ***argv) MPICH_API_PUBLIC;
 int PMPI_Finalize(void) MPICH_API_PUBLIC;
 int PMPI_Initialized(int *flag) MPICH_API_PUBLIC;
 int PMPI_Abort(MPI_Comm comm, int errorcode) MPICH_API_PUBLIC;
+int PMPI_Session_init(MPI_Info info, MPI_Errhandler errhandler, MPI_Session *session) MPICH_API_PUBLIC;
+int PMPI_Session_finalize(MPI_Session *session) MPICH_API_PUBLIC;
+int PMPI_Session_get_num_psets(MPI_Session session, MPI_Info info, int *pset_names) MPICH_API_PUBLIC;
+int PMPI_Session_get_nth_pset(MPI_Session session, MPI_Info info, int n, int *pset_len, char *pset_name) MPICH_API_PUBLIC;
+int PMPI_Session_get_info(MPI_Session session, MPI_Info *info_used) MPICH_API_PUBLIC;
+int PMPI_Session_get_pset_info(MPI_Session session, const char *pset_name, MPI_Info *info) MPICH_API_PUBLIC;
+int PMPI_Group_from_session_pset(MPI_Session session, const char *pset_name, MPI_Group *group) MPICH_API_PUBLIC;
+int PMPI_Comm_create_from_group(MPI_Group group, const char *stringtag, MPI_Info info, MPI_Errhandler errhandler, MPI_Comm *newcomm) MPICH_API_PUBLIC;
 
 /* Note that we may need to define a @PCONTROL_LIST@ depending on whether
    stdargs are supported */

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -17,11 +17,11 @@ typedef struct PreDefined_attrs {
     int wtime_is_global;        /* Wtime is global over processes in COMM_WORLD */
 } PreDefined_attrs;
 
-typedef struct MPIR_Session {
+struct MPIR_Session {
     MPIR_OBJECT_HEADER;
     int thread_level;
     void *dummy;                /* hack to insure pointer alignment (for MPIR_Handle_common access) */
-} MPIR_Session;
+};
 
 extern MPIR_Session MPIR_Session_direct[];
 extern MPIR_Object_alloc_t MPIR_Session_mem;

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -95,11 +95,6 @@ int MPIR_Init_impl(int *argc, char ***argv)
 int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
                      MPIR_Session ** p_session_ptr)
 {
-    return MPI_SUCCESS;
-}
-
-int MPIR_Init_thread_impl(int *argc, char ***argv, int user_required, int *provided)
-{
     int mpi_errno = MPI_SUCCESS;
     int required = user_required;
     int err;
@@ -247,14 +242,14 @@ int MPIR_Init_thread_impl(int *argc, char ***argv, int user_required, int *provi
     goto fn_exit;
 }
 
+int MPIR_Init_thread_impl(int *argc, char ***argv, int user_required, int *provided)
+{
+    return MPII_Init_thread(argc, argv, user_required, provided, NULL);
+}
+
 /* ------------ Finalize ------------------- */
 
 int MPII_Finalize(MPIR_Session * session_ptr)
-{
-    return MPI_SUCCESS;
-}
-
-int MPIR_Finalize_impl(void)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank = MPIR_Process.comm_world->rank;
@@ -323,4 +318,9 @@ int MPIR_Finalize_impl(void)
     return mpi_errno;
   fn_fail:
     goto fn_exit;
+}
+
+int MPIR_Finalize_impl(void)
+{
+    return MPII_Finalize(NULL);
 }

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -63,6 +63,12 @@ static MPL_initlock_t init_lock = MPL_INITLOCK_INITIALIZER;
 /* Note: we are not using atomic variable since it is always accessed under init_lock */
 static int init_counter;
 
+/* TODO: currently the world model is not distinguished with session model, neither between
+ * sessions, in that there is no session pointer attached to communicators, datatypes, etc.
+ * To properly reflect the session semantics, we may need to always assoicate a session
+ * pointer to all MPI objects (other than info) and add runtime validation checks everywhere.
+ */
+
 /* ------------ Init ------------------- */
 
 int MPIR_Init_impl(int *argc, char ***argv)
@@ -87,7 +93,7 @@ int MPIR_Init_impl(int *argc, char ***argv)
     }
 
     int provided;
-    mpi_errno = MPIR_Init_thread_impl(argc, argv, threadLevel, &provided);
+    mpi_errno = MPII_Init_thread(argc, argv, threadLevel, &provided, NULL);
 
     return mpi_errno;
 }
@@ -97,9 +103,16 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
 {
     int mpi_errno = MPI_SUCCESS;
     int required = user_required;
+    bool is_world_model = (p_session_ptr == NULL);
     int err;
 
     MPL_initlock_lock(&init_lock);
+
+    if (!is_world_model) {
+        *p_session_ptr = (MPIR_Session *) MPIR_Handle_obj_alloc(&MPIR_Session_mem);
+        MPIR_ERR_CHKHANDLEMEM(*p_session_ptr);
+    }
+
     init_counter++;
     if (init_counter > 1) {
         *provided = MPIR_ThreadInfo.thread_provided;
@@ -234,7 +247,9 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
         *provided = MPIR_ThreadInfo.thread_provided;
 
   fn_exit:
-    MPII_world_set_initilized();
+    if (is_world_model) {
+        MPII_world_set_initilized();
+    }
     MPL_initlock_unlock(&init_lock);
     return mpi_errno;
 
@@ -253,8 +268,15 @@ int MPII_Finalize(MPIR_Session * session_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank = MPIR_Process.comm_world->rank;
+    bool is_world_model = (session_ptr == NULL);
 
     MPL_initlock_lock(&init_lock);
+
+    if (!is_world_model) {
+        /* handle any clean up on session */
+        MPIR_Handle_obj_free(&MPIR_Session_mem, session_ptr);
+    }
+
     init_counter--;
     if (init_counter > 0) {
         goto fn_exit;
@@ -313,7 +335,9 @@ int MPII_Finalize(MPIR_Session * session_ptr)
     MPL_atomic_store_int(&MPIR_Process.mpich_state, MPICH_MPI_STATE__UNINITIALIZED);
 
   fn_exit:
-    MPII_world_set_finalized();
+    if (is_world_model) {
+        MPII_world_set_finalized();
+    }
     MPL_initlock_unlock(&init_lock);
     return mpi_errno;
   fn_fail:

--- a/test/mpi/init/Makefile.am
+++ b/test/mpi/init/Makefile.am
@@ -16,7 +16,13 @@ noinst_PROGRAMS = \
     exitst2       \
     exitst3       \
     initstat      \
+    session       \
+    session_mult_init \
+    session_psets \
     version       \
     library_version \
     timeout       \
     finalized
+
+session_mult_init_SOURCES = session.c
+session_mult_init_CPPFLAGS = -DMULT_INIT $(AM_CPPFLAGS)

--- a/test/mpi/init/session.c
+++ b/test/mpi/init/session.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include <assert.h>
+#include "mpitest.h"
+
+/* This is example 10.8 from MPI Standard 4.0
+ * Simple example illustrating creation of an MPI communicator using the Session
+ * Model. The pre-defined "mpi://WORLD" process set can be used to first create
+ * a local MPI group and then subsequently to create an MPI communicator from
+ * this group.
+ */
+
+int errs = 0;
+
+int library_foo_test(void);
+void library_foo_init(void);
+void library_foo_finalize(void);
+
+int main(int argc, char *argv[])
+{
+#ifdef MULT_INIT
+    int rank, size, provided;
+    int num_repeat = 1;
+
+    if (argc > 1) {
+        num_repeat = atoi(argv[1]);
+        /* basic sanity check */
+        assert(num_repeat > 0 && num_repeat < 100);
+    }
+
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    for (int i = 0; i < num_repeat; i++) {
+        library_foo_test();
+    }
+    MPI_Finalize();
+#else
+    int rank = library_foo_test();
+#endif
+    if (rank == 0 && errs == 0) {
+        printf("No Errors\n");
+    }
+    return MTestReturnValue(errs);
+}
+
+static MPI_Session lib_shandle = MPI_SESSION_NULL;
+static MPI_Comm lib_comm = MPI_COMM_NULL;
+
+int library_foo_test(void)
+{
+    int rank, size;
+
+    library_foo_init();
+
+    MPI_Comm_size(lib_comm, &size);
+    MPI_Comm_rank(lib_comm, &rank);
+
+    int sum;
+    MPI_Reduce(&rank, &sum, 1, MPI_INT, MPI_SUM, 0, lib_comm);
+    if (rank == 0) {
+        if (sum != (size - 1) * size / 2) {
+            printf("MPI_Reduce: expect %d, got %d\n", (size - 1) * size / 2, sum);
+            errs++;
+        }
+    }
+
+    library_foo_finalize();
+
+    return rank;
+}
+
+void library_foo_init(void)
+{
+    int rc, flag;
+    int ret = 0;
+    const char pset_name[] = "mpi://WORLD";
+    const char mt_key[] = "mpi_thread_support_level";
+    const char mt_value[] = "MPI_THREAD_MULTIPLE";
+    char out_value[100];        /* large enough */
+
+    MPI_Group wgroup = MPI_GROUP_NULL;
+    MPI_Info sinfo = MPI_INFO_NULL;
+    MPI_Info tinfo = MPI_INFO_NULL;
+    MPI_Info_create(&sinfo);
+    MPI_Info_set(sinfo, mt_key, mt_value);
+    rc = MPI_Session_init(sinfo, MPI_ERRORS_RETURN, &lib_shandle);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        goto fn_exit;
+    }
+
+    /* check we got thread support level foo library needs */
+    rc = MPI_Session_get_info(lib_shandle, &tinfo);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        goto fn_exit;
+    }
+
+    MPI_Info_get(tinfo, mt_key, sizeof(out_value), out_value, &flag);
+    if (!flag) {
+        printf("Could not find key %s\n", mt_key);
+        errs++;
+        goto fn_exit;
+    }
+    if (strcmp(out_value, mt_value)) {
+        printf("Did not get thread multiple support, got %s\n", out_value);
+        errs++;
+        goto fn_exit;
+    }
+
+    /* create a group from the WORLD process set */
+    rc = MPI_Group_from_session_pset(lib_shandle, pset_name, &wgroup);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        goto fn_exit;
+    }
+
+    /* get a communicator */
+    rc = MPI_Comm_create_from_group(wgroup, "org.mpi-forum.mpi-v4_0.example-ex10_8",
+                                    MPI_INFO_NULL, MPI_ERRORS_RETURN, &lib_comm);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        goto fn_exit;
+    }
+
+    /* free group, library doesn’t need it. */
+  fn_exit:
+    MPI_Group_free(&wgroup);
+    if (sinfo != MPI_INFO_NULL) {
+        MPI_Info_free(&sinfo);
+    }
+    if (tinfo != MPI_INFO_NULL) {
+        MPI_Info_free(&tinfo);
+    }
+    if (ret != MPI_SUCCESS) {
+        MPI_Session_finalize(&lib_shandle);
+    }
+}
+
+void library_foo_finalize(void)
+{
+    int rc;
+
+    rc = MPI_Comm_free(&lib_comm);
+    if (rc != MPI_SUCCESS) {
+        printf("MPI_Comm_free returned %d\n", rc);
+        errs++;
+        return;
+    }
+
+    rc = MPI_Session_finalize(&lib_shandle);
+    if (rc != MPI_SUCCESS) {
+        printf("MPI_Session_finalize returned %d\n", rc);
+        errs++;
+        return;
+    }
+}

--- a/test/mpi/init/session_psets.c
+++ b/test/mpi/init/session_psets.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include <assert.h>
+#include "mpitest.h"
+
+/* This is adapted example 10.9 from MPI Standard 4.0
+ * This example illustrates the use of Process Set query functions to select a
+ * Process Set to use for MPI Group creation. First, the default error handler
+ * can be specified when instatiating a Session instance. Second, thre must be
+ * at least two process sets associated with a Session. Third, the example
+ * illustrates use of session info object and the one required key: "mpi_size".
+ */
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    int n_psets, psetlen, rc, ret;
+    int valuelen;
+    int flag = 0;
+    char *info_val = NULL;
+    char *pset_name = NULL;
+    char **all_pset_names;
+    MPI_Session shandle = MPI_SESSION_NULL;
+    MPI_Info sinfo = MPI_INFO_NULL;
+    MPI_Group pgroup = MPI_GROUP_NULL;
+
+    rc = MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &shandle);
+    if (rc != MPI_SUCCESS) {
+        printf("Could not initialize session, bailing out\n");
+        errs++;
+        return MTestReturnValue(errs);
+    }
+
+    MPI_Session_get_num_psets(shandle, MPI_INFO_NULL, &n_psets);
+    all_pset_names = malloc(n_psets * sizeof(char *));
+    assert(all_pset_names);
+
+    for (int i = 0; i < n_psets; i++) {
+        psetlen = 0;
+        MPI_Session_get_nth_pset(shandle, MPI_INFO_NULL, i, &psetlen, NULL);
+        if (psetlen <= 0) {
+            printf("MPI_Session_get_nth_pset: returns psetlen = %d\n", psetlen);
+            errs++;
+        }
+
+        pset_name = (char *) malloc(sizeof(char) * psetlen);
+        MPI_Session_get_nth_pset(shandle, MPI_INFO_NULL, i, &psetlen, pset_name);
+        if (strlen(pset_name) + 1 != psetlen) {
+            printf("MPI_Session_get_nth_pset: strlen(\"%s\") + 1 != %d\n", pset_name, psetlen);
+            errs++;
+        }
+
+        all_pset_names[i] = strdup(pset_name);
+
+        free(pset_name);
+        pset_name = NULL;
+    }
+
+    bool got_world = false;
+    bool got_self = false;
+    for (int i = 0; i < n_psets; i++) {
+        /* get instance of an info object for this Session */
+        MPI_Session_get_pset_info(shandle, all_pset_names[i], &sinfo);
+        MPI_Info_get_valuelen(sinfo, "mpi_size", &valuelen, &flag);
+        if (valuelen <= 0) {
+            printf("MPI_Session_get_pset_info: valuelen of mpi_size is %d\n", valuelen);
+            errs++;
+        }
+        info_val = (char *) malloc(valuelen + 1);
+        MPI_Info_get(sinfo, "mpi_size", valuelen, info_val, &flag);
+        if (atol(info_val) <= 0) {
+            printf("\"mpi_size\" of %s proc set is %s\n", all_pset_names[i], info_val);
+        }
+        if (strcmp("mpi://WORLD", all_pset_names[i]) == 0) {
+            got_world = true;
+        }
+        if (strcmp("mpi://SELF", all_pset_names[i]) == 0) {
+            got_self = true;
+            if (atol(info_val) != 1) {
+                printf("\"mpi_size\" of SELF proc set is %s\n", info_val);
+            }
+        }
+        free(info_val);
+
+        /* create a group from the process set */
+        rc = MPI_Group_from_session_pset(shandle, all_pset_names[i], &pgroup);
+        if (rc != MPI_SUCCESS) {
+            printf("Could not create group from pset %s\n", all_pset_names[i]);
+            errs++;
+        }
+
+        free(all_pset_names[i]);
+        MPI_Group_free(&pgroup);
+        MPI_Info_free(&sinfo);
+    }
+    free(all_pset_names);
+    MPI_Session_finalize(&shandle);
+
+    if (!got_self) {
+        printf("proc set mpi://SELF not found\n");
+        errs++;
+    }
+    if (!got_world) {
+        printf("proc set mpi://WORLD not found\n");
+        errs++;
+    }
+
+    if (errs == 0) {
+        printf("No Errors\n");
+    } else {
+        printf("%d Errors\n", errs);
+    }
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/init/testlist
+++ b/test/mpi/init/testlist
@@ -6,3 +6,7 @@ version 1
 finalized 1
 attrself 1
 library_version 1
+session 4
+session_mult_init 4
+session_mult_init 4 arg=5
+session_psets 1

--- a/test/mpi/threads/init/Makefile.am
+++ b/test/mpi/threads/init/Makefile.am
@@ -7,4 +7,6 @@ include $(top_srcdir)/Makefile_threads.mtest
 
 EXTRA_DIST = testlist
 
-noinst_PROGRAMS = initth
+noinst_PROGRAMS = \
+    initth \
+    mult_session

--- a/test/mpi/threads/init/mult_session.c
+++ b/test/mpi/threads/init/mult_session.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include "mpitest.h"
+
+/* adapted from init/session.c */
+
+#define NTHREADS 4
+
+int thread_errs[NTHREADS];
+
+MTEST_THREAD_RETURN_TYPE library_foo_test(void *p);
+
+int main(int argc, char *argv[])
+{
+    int provided;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+
+    for (int i = 1; i < NTHREADS; i++) {
+        MTest_Start_thread(library_foo_test, (void *) (long) i);
+    }
+
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    thread_errs[0] += MTestTestIntracomm(MPI_COMM_WORLD);
+
+    MTest_Join_threads();
+    MPI_Finalize();
+
+    int errs = 0;
+    for (int i = 0; i < NTHREADS; i++) {
+        errs += thread_errs[i];
+    }
+
+    if (rank == 0 && errs == 0) {
+        printf("No Errors\n");
+    }
+    return MTestReturnValue(errs);
+}
+
+static bool library_foo_init(int thread_idx, MPI_Session * p_session, MPI_Comm * p_comm);
+static void library_foo_finalize(int thread_idx, MPI_Session * p_session, MPI_Comm * p_comm);
+
+MTEST_THREAD_RETURN_TYPE library_foo_test(void *p)
+{
+    int rank, size;
+    int thread_idx = (int) (long) p;
+
+    MPI_Session lib_shandle = MPI_SESSION_NULL;
+    MPI_Comm lib_comm = MPI_COMM_NULL;
+    if (library_foo_init(thread_idx, &lib_shandle, &lib_comm)) {
+        MPI_Comm_size(lib_comm, &size);
+        MPI_Comm_rank(lib_comm, &rank);
+
+        thread_errs[thread_idx] += MTestTestIntracomm(lib_comm);
+
+        library_foo_finalize(thread_idx, &lib_shandle, &lib_comm);
+    }
+
+    return MTEST_THREAD_RETVAL_IGN;
+}
+
+static bool library_foo_init(int thread_idx, MPI_Session * p_session, MPI_Comm * p_comm)
+{
+    int rc, flag;
+    int ret = MPI_SUCCESS;
+    const char *pset_name;
+    char out_value[100];        /* large enough */
+
+    /* Let's test both WORLD and SELF. e.g. with 4 threads, thread 2 will run on SELF */
+    if (thread_idx % 2) {
+        pset_name = "mpi://WORLD";
+    } else {
+        pset_name = "mpi://SELF";
+    }
+
+    MPI_Group wgroup = MPI_GROUP_NULL;
+    rc = MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, p_session);
+    if (rc != MPI_SUCCESS) {
+        thread_errs[thread_idx]++;
+        printf("MPI_Session_init failed in thread %d\n", thread_idx);
+        goto fn_exit;
+    }
+
+    /* check we got thread support level foo library needs */
+    MPI_Info tinfo = MPI_INFO_NULL;
+    const char mt_key[] = "mpi_thread_support_level";
+    const char mt_value[] = "MPI_THREAD_MULTIPLE";
+    rc = MPI_Session_get_info(*p_session, &tinfo);
+    if (rc != MPI_SUCCESS) {
+        thread_errs[thread_idx]++;
+        goto fn_exit;
+    }
+
+    MPI_Info_get(tinfo, mt_key, sizeof(out_value), out_value, &flag);
+    if (flag != 1) {
+        thread_errs[thread_idx]++;
+        printf("Could not find key %s\n", mt_key);
+        goto fn_exit;
+    }
+    if (strcmp(out_value, mt_value)) {
+        thread_errs[thread_idx]++;
+        printf("Did not get thread multiple support, got %s\n", out_value);
+        goto fn_exit;
+    }
+
+    /* create a group from the WORLD process set */
+    rc = MPI_Group_from_session_pset(*p_session, pset_name, &wgroup);
+    if (rc != MPI_SUCCESS) {
+        thread_errs[thread_idx]++;
+        printf("MPI_Group_from_session_pset failed in thread %d\n", thread_idx);
+        goto fn_exit;
+    }
+
+    /* get a communicator */
+    char string_tag[20];
+    sprintf(string_tag, "thread %d", thread_idx);
+    rc = MPI_Comm_create_from_group(wgroup, string_tag, MPI_INFO_NULL, MPI_ERRORS_RETURN, p_comm);
+    if (rc != MPI_SUCCESS) {
+        thread_errs[thread_idx]++;
+        printf("MPI_Comm_create_from_group failed in thread %d\n", thread_idx);
+        goto fn_exit;
+    }
+
+    /* free group, library doesn’t need it. */
+  fn_exit:
+    MPI_Group_free(&wgroup);
+    if (tinfo != MPI_INFO_NULL) {
+        MPI_Info_free(&tinfo);
+    }
+    if (ret != MPI_SUCCESS) {
+        MPI_Session_finalize(p_session);
+    }
+    return (ret == MPI_SUCCESS);
+}
+
+static void library_foo_finalize(int thread_idx, MPI_Session * p_session, MPI_Comm * p_comm)
+{
+    int rc;
+
+    rc = MPI_Comm_free(p_comm);
+    if (rc != MPI_SUCCESS) {
+        thread_errs[thread_idx]++;
+        printf("MPI_Comm_free returned %d\n", rc);
+        return;
+    }
+
+    rc = MPI_Session_finalize(p_session);
+    if (rc != MPI_SUCCESS) {
+        thread_errs[thread_idx]++;
+        printf("MPI_Session_finalize returned %d\n", rc);
+        return;
+    }
+}

--- a/test/mpi/threads/init/testlist
+++ b/test/mpi/threads/init/testlist
@@ -1,2 +1,3 @@
 initth 1
 initth 2
+mult_session 4


### PR DESCRIPTION
## Pull Request Description

This PR implements the MPI 4.0 MPI Session in a device backward compatible way. The internal initialization process is not changed and happens during MPI_Session_init. Thus, it requires all processes to call MPI_Session_init collectively. We will make MPI_Session_init a local initialization only in our next iteration. Meanwhile, note that this PR will not break existing applications that do not use sessions. And it will work correctly for applications that all processes will call MPI_Session_init at an early stage -- which we believe all practical applications will do anyway.

This PR replaces #4949.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
