### PR TITLE
Fix test for clang 6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2864,7 +2864,7 @@ fi
 if test "$MPID_NO_FLOAT16" != "yes" ; then
     AC_CACHE_CHECK([whether _Float16 is supported],
     pac_cv_have_float16,[
-    AC_TRY_COMPILE(,[_Float16 a;],
+    AC_TRY_COMPILE(,[_Float16 a=1;_Float16 b=1;_Float16 c=a+b;],
     pac_cv_have_float16=yes,pac_cv_have_float16=no)])
     if test "$pac_cv_have_float16" = "yes" ; then
         AC_DEFINE(HAVE_FLOAT16,1,[Define if _Float16 is supported])


### PR DESCRIPTION
## Pull Request Description

clang 6.0.0 does not complain about `_Float16` on unsupported targets, only when do arithmetic it will fail to link:

```
$ cat test1.c 
int main ()
{
  _Float16 a;
  return 0;
}
$ clang test1.c 
   ... it works ...
$ cat test2.c 
int main ()
{
  _Float16 a;
  _Float16 b;
  _Float16 c = a + b;
  return 0;
}
# clang test2.c 
/tmp/test2-6ead14.o: In function `main':
test2.c:(.text+0x19): undefined reference to `__gnu_h2f_ieee'
test2.c:(.text+0x27): undefined reference to `__gnu_h2f_ieee'
test2.c:(.text+0x38): undefined reference to `__gnu_f2h_ieee'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Fixes #5029 

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
