### PR TITLE
config: Fix test for _Float16

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2864,7 +2864,10 @@ fi
 if test "$MPID_NO_FLOAT16" != "yes" ; then
     AC_CACHE_CHECK([whether _Float16 is supported],
     pac_cv_have_float16,[
-    AC_TRY_COMPILE(,[_Float16 a;],
+    # The compiler might optimize out _Float16 usage and give a false
+    # positive for this test (observed with clang 6 on Linux with -O2).
+    # We use volatile as a way to disable optimizations.
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([],[volatile _Float16 a=1; return (int)a;])],
     pac_cv_have_float16=yes,pac_cv_have_float16=no)])
     if test "$pac_cv_have_float16" = "yes" ; then
         AC_DEFINE(HAVE_FLOAT16,1,[Define if _Float16 is supported])


### PR DESCRIPTION
## Pull Request Description

Fixes a build issue with clang 6, which accepts the type but fails
when used in arithmetic. Fixes pmodels/mpich#5029

Reported-by: Harmen Stoppels <harmenstoppels@gmail.com>

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix build issue for clang 6 compiler.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
