### PR TITLE
binding/f08: support separated buf,count,dtype params

### DIFF
--- a/src/binding/fortran/use_mpi_f08/wrappers_c/buildiface
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/buildiface
@@ -609,12 +609,29 @@ EOT
             if ($i) { print CFILE ", "; }
             if ($arglist[$i] =~ /CFI_cdesc_t\*/) {
                 my $j = 0;
+
+                # print buf
                 while ($vec[$j] != $i) { $j++; }
+                print CFILE "buf$vec[$j]";
+                $i++;
+
+                # replace with count if defined
                 if ($vec[$j + 1] >= 0) {
-                    print CFILE "buf$i, count$i, dtype$i";
-                    $i += 3;
-                } else {
-                    print CFILE "buf$i";
+                    while ($vec[$j + 1] != $i) {
+                      print CFILE ", x$i";
+                      $i++;
+                    }
+                    print CFILE ", count$vec[$j]";
+                    $i++;
+                }
+
+                # replace with dtype if defined
+                if ($vec[$j + 2] >= 0) {
+                    while ($vec[$j + 2] != $i) {
+                      print CFILE ", x$i";
+                      $i++;
+                    }
+                    print CFILE ", dtype$vec[$j]";
                     $i++;
                 }
             } else {


### PR DESCRIPTION
Current script assumes buf,count,dtype are always set continuously, thus replace them together. However, the assumption will not be held for functions such as psend_init|precv_init. This commit fixes it. Now we replace each of the params individually based on the index.

Before the fix, it works only when `buf, count, dtype` are continuous parameters (e.g., `x0, x1, x2`). If they are separated, e.g., `x0 <buf>, x1 <something else>, x2 <count>, x3 <dtype>`, the f08 wrapper will not be generated correctly.


## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
