### PR TITLE
QMPI Implementation with Autogenerated Bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -539,6 +539,9 @@ Makefile.am-stamp
 
 # /src/mpi/spawn/
 
+# /src/mpi_t/
+/src/mpi_t/qmpi_register.h
+
 # /src/mpid/ch3/channels/nemesis/nemesis/src/
 /src/mpid/ch3/channels/nemesis/src/mpid_nem_net_array.c
 

--- a/configure.ac
+++ b/configure.ac
@@ -558,7 +558,7 @@ AC_ARG_ENABLE(weak-symbols,
 AC_ARG_ENABLE(qmpi,
 	AC_HELP_STRING([--enable-qmpi],
 			[Enable QMPI support (default)]),,
-		enable_qmpi=yes)
+		enable_qmpi=no)
 
 if test "$enable_qmpi" = "yes" ; then
     AC_DEFINE(ENABLE_QMPI,1,[Define if QMPI enabled])

--- a/configure.ac
+++ b/configure.ac
@@ -555,6 +555,19 @@ AC_ARG_ENABLE(weak-symbols,
 			[Use weak symbols to implement PMPI routines (default)]),,
 		enable_weak_symbols=yes)
 
+AC_ARG_ENABLE(qmpi,
+	AC_HELP_STRING([--enable-qmpi],
+			[Enable QMPI support (default)]),,
+		enable_qmpi=yes)
+
+if test "$enable_qmpi" = "yes" ; then
+    AC_DEFINE(ENABLE_QMPI,1,[Define if QMPI enabled])
+    ENABLE_QMPI=1
+else
+    ENABLE_QMPI=0
+fi
+AC_SUBST(ENABLE_QMPI)
+
 AC_ARG_ENABLE([two-level-namespace],
               [AS_HELP_STRING([--enable-two-level-namespace],
                               [(Darwin only) Build shared libraries and programs

--- a/maint/gen_binding_c.py
+++ b/maint/gen_binding_c.py
@@ -51,6 +51,7 @@ def main():
     dump_Makefile_mk("%s/Makefile.mk" % c_dir)
     dump_mpir_impl_h("src/include/mpir_impl.h")
     dump_errnames_txt("%s/errnames.txt" % c_dir)
+    dump_qmpi_register_h("src/mpi_t/qmpi_register.h")
     dump_mpi_proto_h("src/include/mpi_proto.h")
     dump_mtest_mpix_h("test/mpi/include/mtest_mpix.h")
 

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -934,6 +934,12 @@ typedef int (MPI_Datarep_extent_function)(MPI_Datatype datatype, MPI_Aint *,
                       void *);
 #define MPI_CONVERSION_FN_NULL ((MPI_Datarep_conversion_function *)0)
 
+typedef struct {
+    void **storage_stack;
+} QMPI_Context;
+
+#define QMPI_MAX_TOOL_NAME_LENGTH 256
+
 /* 
    For systems that may need to add additional definitions to support
    different declaration styles and options (e.g., different calling 
@@ -949,6 +955,16 @@ typedef int (MPI_Datarep_extent_function)(MPI_Datatype datatype, MPI_Aint *,
 /* We require that the C compiler support prototypes */
 #include <mpi_proto.h>
 #endif /* MPICH_SUPPRESS_PROTOTYPES */
+
+int QMPI_Register_tool_name(const char *tool_name,
+                            void (*init_function_ptr) (int tool_id)) MPICH_API_PUBLIC;
+int QMPI_Register_tool_storage(int tool_id, void *tool_storage) MPICH_API_PUBLIC;
+int QMPI_Register_function(int calling_tool_id, enum QMPI_Functions_enum function_enum,
+                           void (*function_ptr) (void)) MPICH_API_PUBLIC;
+int QMPI_Get_function(int calling_tool_id, enum QMPI_Functions_enum function_enum,
+                      void (**function_ptr) (void), int *next_tool_id) MPICH_API_PUBLIC;
+int QMPI_Get_tool_storage(QMPI_Context context, int tool_id, void **storage) MPICH_API_PUBLIC;
+int QMPI_Get_calling_address(QMPI_Context context, void **address) MPICH_API_PUBLIC;
 
 /* GPU extensions */
 #define MPIX_GPU_SUPPORT_CUDA  (0)

--- a/src/include/mpir_ext.h.in
+++ b/src/include/mpir_ext.h.in
@@ -85,4 +85,18 @@ int MPIR_Ext_datatype_iscommitted(MPI_Datatype datatype);
 /* make comm split based on access to a common file system easier */
 int MPIR_Get_node_id(MPI_Comm comm, int rank, int *id);
 
+#ifdef ENABLE_QMPI
+extern void (**MPIR_QMPI_pointers) (void);
+extern void **MPIR_QMPI_storage;
+extern void (**MPIR_QMPI_tool_init_callbacks) (int);
+extern int MPIR_QMPI_num_tools;
+extern char **MPIR_QMPI_tool_names;
+extern void (**MPIR_QMPI_first_fn_ptrs) (void);
+extern int *MPIR_QMPI_first_tool_ids;
+int MPII_qmpi_stash_first_tools(void);
+int MPII_qmpi_pre_init(void);
+int MPII_qmpi_init(void);
+void MPII_qmpi_teardown(void);
+#endif /* ENABLE_QMPI */
+
 #endif

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -305,6 +305,10 @@ int MPII_Finalize(MPIR_Session * session_ptr)
     mpi_errno = MPID_Finalize();
     MPIR_ERR_CHECK(mpi_errno);
 
+#ifdef ENABLE_QMPI
+    MPII_qmpi_teardown();
+#endif
+
     mpi_errno = MPII_Coll_finalize();
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpi_t/Makefile.mk
+++ b/src/mpi_t/Makefile.mk
@@ -3,10 +3,13 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
+AM_CPPFLAGS += -I$(top_srcdir)/src/mpi_t
+
 mpi_core_sources += \
         src/mpi_t/mpit_finalize.c       \
         src/mpi_t/mpit_initthread.c     \
         src/mpi_t/mpit_impl.c \
         src/mpi_t/pvar_impl.c \
         src/mpi_t/mpit.c \
-        src/mpi_t/events_impl.c
+        src/mpi_t/events_impl.c \
+        src/mpi_t/qmpi_register.c

--- a/src/mpi_t/errnames.txt
+++ b/src/mpi_t/errnames.txt
@@ -74,3 +74,5 @@
 **mpi_t_pvar_get_index %p %d %p: mpi_t_pvar_get_index(name=%p, var_class=%d, pvar_index=%p)
 **mpi_t_category_get_index: mpi_t_category_get_index failed
 **mpi_t_category_get_index %p %p: mpi_t_category_get_index(name=%p, cat_index=%p)
+**qmpi_invalid_name: tool name is invalid
+**qmpi_invalid_name %s: tool name is invalid (name=%s)

--- a/src/mpi_t/qmpi_register.c
+++ b/src/mpi_t/qmpi_register.c
@@ -1,0 +1,436 @@
+
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+#ifdef ENABLE_QMPI
+
+#include "qmpi_register.h"
+#include <execinfo.h>
+#define BACKTRACE_SIZE 5
+
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+categories:
+    - name        : TOOLS
+      description : cvars that control tools connected to MPICH
+
+cvars:
+    - name        : MPIR_CVAR_QMPI_TOOL_LIST
+      alias       : QMPI_TOOL_LIST
+      category    : TOOLS
+      type        : string
+      default     : NULL
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        Set the number and order of QMPI tools to be loaded by the MPI library when it is
+        initialized.
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
+typedef void (*generic_mpi_func) (void);
+
+void (**MPIR_QMPI_pointers) (void);
+void **MPIR_QMPI_storage;
+void (**MPIR_QMPI_tool_init_callbacks) (int);
+int MPIR_QMPI_num_tools = 0;
+char **MPIR_QMPI_tool_names;
+void (**MPIR_QMPI_first_fn_ptrs) (void);
+int *MPIR_QMPI_first_tool_ids;
+
+/* Cache the first function and tool ID in the chain of QMPI tools to optimize the lookup in all of
+ * the internal MPI_* functions. */
+int MPII_qmpi_stash_first_tools(void)
+{
+    if (MPIR_QMPI_num_tools == 0) {
+        return MPI_SUCCESS;
+    }
+
+    for (int i = 0; i < MPI_LAST_FUNC_T; i++) {
+        MPIR_QMPI_first_fn_ptrs[i] = NULL;
+
+        for (int j = 1; j <= MPIR_QMPI_num_tools; j++) {
+            if (MPIR_QMPI_pointers[j * MPI_LAST_FUNC_T + i] != NULL) {
+                MPIR_QMPI_first_fn_ptrs[i] = MPIR_QMPI_pointers[j * MPI_LAST_FUNC_T + i];
+                MPIR_QMPI_first_tool_ids[i] = j;
+                break;
+            }
+        }
+
+        if (MPIR_QMPI_first_fn_ptrs[i] == NULL) {
+            MPIR_QMPI_first_fn_ptrs[i] = MPIR_QMPI_pointers[i];
+            MPIR_QMPI_first_tool_ids[i] = 0;
+        }
+    }
+    return MPI_SUCCESS;
+}
+
+int MPII_qmpi_init(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    static bool qmpi_initialized = false;
+
+    if (!qmpi_initialized) {
+        qmpi_initialized = true;
+
+        /* Call this function in case it is needed */
+        mpi_errno = MPII_qmpi_pre_init();
+        MPIR_ERR_CHECK(mpi_errno);
+
+        /* Initialize the tools that have been registered */
+        for (int i = 1; i < MPIR_QMPI_num_tools + 1; i++) {
+            MPIR_QMPI_tool_init_callbacks[i] (i);
+        }
+
+        mpi_errno = MPII_qmpi_stash_first_tools();
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPII_qmpi_pre_init(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    size_t len = 0;
+
+    static bool qmpi_pre_initialized = false;
+
+    if (!qmpi_pre_initialized) {
+        qmpi_pre_initialized = true;
+
+        mpi_errno = MPIR_T_env_init();
+        MPIR_ERR_CHECK(mpi_errno);
+
+        /* Parse environment variable to get the number and list of tools */
+        if (MPIR_CVAR_QMPI_TOOL_LIST == NULL) {
+            MPIR_QMPI_num_tools = 0;
+            goto fn_exit;
+        } else {
+            MPIR_QMPI_num_tools = 1;
+            len = strlen(MPIR_CVAR_QMPI_TOOL_LIST);
+        }
+
+        for (int i = 0; i < len; i++) {
+            if (MPIR_CVAR_QMPI_TOOL_LIST[i] == ':') {
+                MPIR_QMPI_num_tools++;
+            }
+        }
+        MPIR_QMPI_tool_names = MPL_calloc(MPIR_QMPI_num_tools + 1, sizeof(char *), MPL_MEM_OTHER);
+        if (!MPIR_QMPI_tool_names) {
+            MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                 MPI_ERR_OTHER, "**nomem", "**nomem %s", "MPIR_QMPI_num_tools");
+            goto fn_exit;
+        }
+        for (int i = 0; i < MPIR_QMPI_num_tools + 1; i++) {
+            MPIR_QMPI_tool_names[i] =
+                MPL_calloc(QMPI_MAX_TOOL_NAME_LENGTH, sizeof(char), MPL_MEM_OTHER);
+            if (!MPIR_QMPI_tool_names[i]) {
+                MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                     MPI_ERR_OTHER, "**nomem", "**nomem %s", "MPIR_QMPI_num_tools");
+                goto fn_exit;
+            }
+        }
+
+        char *save_ptr, *val;
+        char *tmp_str = MPL_strdup(MPIR_CVAR_QMPI_TOOL_LIST);
+        val = strtok_r(tmp_str, ":", &save_ptr);
+        int tool_num = 1;       /* Counter for the ID of each tool. MPI itself is "tool 0". */
+        while (val != NULL) {
+            strncpy(MPIR_QMPI_tool_names[tool_num], val, QMPI_MAX_TOOL_NAME_LENGTH);
+            /* Make sure the string is null terminated */
+            MPIR_QMPI_tool_names[tool_num][QMPI_MAX_TOOL_NAME_LENGTH - 1] = '\0';
+            tool_num++;
+            val = strtok_r(NULL, ":", &save_ptr);
+        }
+        MPL_free(tmp_str);
+        MPIR_QMPI_num_tools = tool_num - 1;
+
+        /* Get the number of MPI functions that we have to track. */
+        int num_funcs = MPI_LAST_FUNC_T;
+
+        /* For each of the allocations below, we actually allocate one extra entry, but it
+         * simplifies things to have a single numbering system that can just use the tool IDs as the
+         * index into the arrays. */
+
+        /* Allocate space for as many tools as we say we support */
+        MPIR_QMPI_pointers = MPL_calloc(1, sizeof(generic_mpi_func *) * num_funcs * tool_num,
+                                        MPL_MEM_OTHER);
+        if (!MPIR_QMPI_pointers) {
+            MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                 MPI_ERR_OTHER, "**nomem", "**nomem %s", "MPIR_QMPI_pointers");
+            goto fn_exit;
+        }
+
+        /* Allocate space to stash the first callback function in the chain */
+        MPIR_QMPI_first_fn_ptrs = MPL_calloc(1, sizeof(generic_mpi_func *) * num_funcs,
+                                             MPL_MEM_OTHER);
+        if (!MPIR_QMPI_first_fn_ptrs) {
+            MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                 MPI_ERR_OTHER, "**nomem", "**nomem %s", "MPIR_QMPI_pointers");
+            goto fn_exit;
+        }
+
+        /* Allocate space to stash the first tool ID in the chain */
+        MPIR_QMPI_first_tool_ids = MPL_calloc(1, sizeof(int) * num_funcs, MPL_MEM_OTHER);
+        if (!MPIR_QMPI_first_tool_ids) {
+            MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                 MPI_ERR_OTHER, "**nomem", "**nomem %s", "MPIR_QMPI_pointers");
+            goto fn_exit;
+        }
+
+        MPIR_QMPI_storage = MPL_calloc(1, sizeof(void *) * tool_num, MPL_MEM_OTHER);
+        if (!MPIR_QMPI_storage) {
+            MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                 MPI_ERR_OTHER, "**nomem", "**nomem %s", "MPIR_QMPI_storage");
+            goto fn_exit;
+        }
+
+        MPIR_QMPI_tool_init_callbacks = MPL_calloc(1, sizeof(generic_mpi_func *) * num_funcs *
+                                                   tool_num, MPL_MEM_OTHER);
+        if (!MPIR_QMPI_tool_init_callbacks) {
+            MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                 MPI_ERR_OTHER, "**nomem", "**nomem %s", "MPIR_QMPI_pointers");
+            goto fn_exit;
+        }
+
+        /* Call generated function to register the internal function pointers. */
+        MPII_qmpi_register_internal_functions();
+
+        MPIR_QMPI_storage[0] = NULL;
+
+        mpi_errno = MPII_qmpi_stash_first_tools();
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+void MPII_qmpi_teardown(void)
+{
+    int counter = 0;
+
+    MPL_free(MPIR_QMPI_pointers);
+    MPL_free(MPIR_QMPI_storage);
+    if (MPIR_CVAR_QMPI_TOOL_LIST != NULL) {
+        /* We allocate one extra tool name so we don't have to shift to avoid the MPICH functions */
+        MPL_free(MPIR_QMPI_tool_names[counter++]);
+        MPL_free(MPIR_QMPI_tool_names[counter++]);
+        size_t len = strlen(MPIR_CVAR_QMPI_TOOL_LIST);
+        for (int i = 0; i <= len; i++) {
+            if (MPIR_CVAR_QMPI_TOOL_LIST[i] == ':') {
+                MPL_free(MPIR_QMPI_tool_names[counter++]);
+            }
+        }
+    }
+    MPL_free(MPIR_QMPI_first_fn_ptrs);
+    MPL_free(MPIR_QMPI_first_tool_ids);
+    MPL_free(MPIR_QMPI_tool_names);
+    MPL_free(MPIR_QMPI_tool_init_callbacks);
+}
+
+/*@
+   QMPI_Register - Register a QMPI tool.
+
+Output Parameters:
+. funcs - A struct of functions that includes every function for every attached QMPI tool, in
+addition to the MPI library itself.
+
+   Notes:
+
+.N Fortran
+
+.N Errors
+.N MPI_SUCCESS
+@*/
+int QMPI_Register_tool_name(const char *tool_name, void (*init_function_ptr) (int tool_id))
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_QMPIX_REGISTER);
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_QMPIX_REGISTER);
+
+    /* If the QMPI globals have not yet been set up, do so now. This does not need to be protected
+     * by a mutex because it will be called before the application has even reached its main
+     * function. */
+    MPII_qmpi_pre_init();
+
+    if (MPIR_QMPI_num_tools) {
+        /* Copy the tool information into internal arrays */
+        bool found = false;
+        for (int i = 1; i <= MPIR_QMPI_num_tools; i++) {
+            if (strcmp(MPIR_QMPI_tool_names[i], tool_name) == 0 &&
+                MPIR_QMPI_tool_init_callbacks[i] == NULL) {
+                MPIR_QMPI_tool_init_callbacks[i] = init_function_ptr;
+                found = true;
+            }
+        }
+        if (!found) {
+            MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                 MPI_ERR_OTHER, "**qmpi_invalid_name", "**qmpi_invalid_name %s",
+                                 tool_name);
+            goto fn_exit;
+        }
+    }
+
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_QMPIX_REGISTER);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int QMPI_Register_tool_storage(int tool_id, void *tool_storage)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    /* Store the tool's context information */
+    MPIR_QMPI_storage[tool_id] = tool_storage;
+
+    return mpi_errno;
+}
+
+int QMPI_Register_function(int tool_id, enum QMPI_Functions_enum function_enum,
+                           void (*function_ptr) (void))
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    if (function_enum < 0 && function_enum >= MPI_LAST_FUNC_T) {
+        MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                             MPI_ERR_ARG, "**arg", "**arg %s", "invalid enum value");
+        goto fn_exit;
+    }
+
+    MPIR_QMPI_pointers[tool_id * MPI_LAST_FUNC_T + function_enum] = function_ptr;
+
+  fn_exit:
+    return mpi_errno;
+}
+
+int QMPI_Get_function(int calling_tool_id, enum QMPI_Functions_enum function_enum,
+                      void (**function_ptr) (void), int *next_tool_id)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    for (int i = calling_tool_id + 1; i <= MPIR_QMPI_num_tools; i++) {
+        if (MPIR_QMPI_pointers[i * MPI_LAST_FUNC_T + function_enum] != NULL) {
+            *function_ptr = MPIR_QMPI_pointers[i * MPI_LAST_FUNC_T + function_enum];
+            *next_tool_id = i;
+            return mpi_errno;
+        }
+    }
+
+    *function_ptr = MPIR_QMPI_pointers[function_enum];
+    *next_tool_id = 0;
+
+    return mpi_errno;
+}
+
+int QMPI_Get_tool_storage(QMPI_Context context, int tool_id, void **storage)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    *storage = MPIR_QMPI_storage[tool_id];
+
+    return mpi_errno;
+}
+
+int QMPI_Get_calling_address(QMPI_Context context, void **address)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    void *array[BACKTRACE_SIZE];
+    char **traces;
+    int size, i;
+    int trace_entry = 1;        /* pick entry at 1 by default */
+    char *target = NULL;
+
+    /* Capture the calling function address */
+    size = backtrace(array, BACKTRACE_SIZE);
+    traces = backtrace_symbols(array, size);
+    if (traces != NULL) {
+        for (i = 0; i < size; i++) {
+            /* Skip PMPI_* calls */
+            char search[] = "PMPI_";
+            char *found = strstr(traces[i], search);
+            if (found != NULL) {
+                trace_entry += i;
+                break;
+            }
+        }
+        /* Extract the address from the backtrace */
+        if (size > trace_entry) {
+            const char *start_pattern = "[";
+            const char *end_pattern = "]";
+
+            char *start, *end;
+            start = strstr(traces[trace_entry], start_pattern);
+            if (NULL != start) {
+                start += strlen(start_pattern);
+                end = strstr(start, end_pattern);
+                if (NULL != end) {
+                    target = (char *) MPL_malloc(end - start + 1, MPL_MEM_OTHER);
+                    memcpy(target, start, end - start);
+                    target[end - start] = '\0';
+                }
+            }
+        }
+    }
+    MPL_free(traces);
+    /* Store the calling address */
+    *address = MPL_calloc(0, strlen(target) + 1, MPL_MEM_OTHER);
+    memcpy(*address, target, strlen(target) + 1);
+    MPL_free(target);
+
+    return mpi_errno;
+}
+
+#else
+
+int QMPI_Register_tool_name(const char *tool_name, void (*init_function_ptr) (int tool_id))
+{
+    return MPI_ERR_UNSUPPORTED_OPERATION;
+}
+
+int QMPI_Register_tool_storage(int tool_id, void *tool_storage)
+{
+    return MPI_ERR_UNSUPPORTED_OPERATION;
+}
+
+int QMPI_Register_function(int tool_id, enum QMPI_Functions_enum function_enum,
+                           void (*function_ptr) (void))
+{
+    return MPI_ERR_UNSUPPORTED_OPERATION;
+}
+
+int QMPI_Get_function(int calling_tool_id, enum QMPI_Functions_enum function_enum,
+                      void (**function_ptr) (void), int *next_tool_id)
+{
+    return MPI_ERR_UNSUPPORTED_OPERATION;
+}
+
+int QMPI_Get_tool_storage(QMPI_Context context, int tool_id, void **storage)
+{
+    return MPI_ERR_UNSUPPORTED_OPERATION;
+}
+
+int QMPI_Get_calling_address(QMPI_Context context, void **address)
+{
+    return MPI_ERR_UNSUPPORTED_OPERATION;
+}
+
+#endif /* ENABLE_QMPI */

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1112,6 +1112,7 @@
 /mpi_t/getindex
 /mpi_t/mpi_t_str
 /mpi_t/mpit_vars
+/mpi_t/qmpi_test
 /perf/allredtrace
 /perf/commcreatep
 /perf/dtpack

--- a/test/mpi/mpi_t/Makefile.am
+++ b/test/mpi/mpi_t/Makefile.am
@@ -14,4 +14,5 @@ noinst_PROGRAMS =     \
     mpi_t_str   \
     mpit_vars   \
     cvarwrite   \
-    getindex
+    getindex    \
+    qmpi_test

--- a/test/mpi/mpi_t/qmpi_test.c
+++ b/test/mpi/mpi_t/qmpi_test.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+/* This test checks that using QMPI works properly with two tools attached. This should cover
+ * testing for any number of attached tools. */
+
+#include "mpi.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "mpitest.h"
+#include "mpitestconf.h"
+
+static int test_val = 0;
+static int qmpi_on = 0;
+
+void test_init_function_pointer(int tool_id);
+int Test_Init_Thread(QMPI_Context context, int tool_id, int *argc, char ***argv, int required,
+                     int *provided);
+int Test_Finalize(QMPI_Context context, int tool_id);
+int Test_Recv(QMPI_Context context, int tool_id, void *buf, int count,
+              MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status * status);
+int Test_Send(QMPI_Context context, int tool_id, const void *buf, int count,
+              MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+
+struct tool_struct {
+    int my_tool_id;
+};
+struct tool_struct my_tool_struct[2];
+QMPI_Recv_t *next_recv_fn[2];
+int next_recv_id[2];
+QMPI_Send_t *next_send_fn[2];
+int next_send_id[2];
+QMPI_Finalize_t *next_finalize_fn[2];
+int next_finalize_id[2];
+
+__attribute__ ((constructor))
+void static_register_my_tool()
+{
+    if (MPI_SUCCESS == QMPI_Register_tool_name("test_tool", &test_init_function_pointer)) {
+        qmpi_on = 1;
+    }
+}
+
+void test_init_function_pointer(int tool_id)
+{
+    my_tool_struct[tool_id - 1].my_tool_id = tool_id;
+
+    QMPI_Register_tool_storage(tool_id, &my_tool_struct[tool_id - 1]);
+    QMPI_Register_function(tool_id, MPI_INIT_THREAD_T, (void (*)(void)) &Test_Init_Thread);
+    QMPI_Register_function(tool_id, MPI_FINALIZE_T, (void (*)(void)) &Test_Finalize);
+    QMPI_Register_function(tool_id, MPI_SEND_T, (void (*)(void)) &Test_Send);
+    QMPI_Register_function(tool_id, MPI_RECV_T, (void (*)(void)) &Test_Recv);
+}
+
+int Test_Init_Thread(QMPI_Context context, int tool_id, int *argc, char ***argv, int required,
+                     int *provided)
+{
+    QMPI_Init_thread_t *next_init_thread_fn;
+    int next_tool_id, ret;
+    struct tool_struct *storage;
+
+    QMPI_Get_tool_storage(context, tool_id, (void *) &storage);
+
+    QMPI_Get_function(tool_id, MPI_INIT_THREAD_T, (void (**)(void)) &next_init_thread_fn,
+                      &next_tool_id);
+    QMPI_Get_function(tool_id, MPI_FINALIZE_T, (void (**)(void)) &next_finalize_fn[tool_id - 1],
+                      &next_finalize_id[tool_id - 1]);
+    QMPI_Get_function(tool_id, MPI_RECV_T, (void (**)(void)) &next_recv_fn[tool_id - 1],
+                      &next_recv_id[tool_id - 1]);
+    QMPI_Get_function(tool_id, MPI_SEND_T, (void (**)(void)) &next_send_fn[tool_id - 1],
+                      &next_send_id[tool_id - 1]);
+
+    ret = (*next_init_thread_fn) (context, next_tool_id, argc, argv, required, provided);
+
+    return ret;
+}
+
+int Test_Finalize(QMPI_Context context, int tool_id)
+{
+    int ret;
+    struct tool_struct *storage;
+
+    QMPI_Get_tool_storage(context, tool_id, (void *) &storage);
+
+    ret = (*next_finalize_fn[tool_id - 1]) (context, next_finalize_id[tool_id - 1]);
+
+    return ret;
+}
+
+int Test_Recv(QMPI_Context context, int tool_id, void *buf, int count,
+              MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status * status)
+{
+    int ret;
+    struct tool_struct *storage;
+
+    QMPI_Get_tool_storage(context, tool_id, (void *) &storage);
+
+    test_val++;
+
+    ret = (*next_recv_fn[tool_id - 1]) (context, next_recv_id[tool_id - 1], buf, count, datatype,
+                                        source, tag, comm, status);
+
+    return ret;
+}
+
+int Test_Send(QMPI_Context context, int tool_id, const void *buf, int count,
+              MPI_Datatype datatype, int dest, int tag, MPI_Comm comm)
+{
+    int ret;
+    struct tool_struct *storage;
+
+    QMPI_Get_tool_storage(context, tool_id, (void *) &storage);
+
+    test_val++;
+
+    ret = (*next_send_fn[tool_id - 1]) (context, next_send_id[tool_id - 1], buf, count, datatype,
+                                        dest, tag, comm);
+
+    return ret;
+}
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    int rank, size, send_buf = 1337, recv_buf;
+    int expected_output = 4;
+
+    if (!qmpi_on)
+        expected_output = 0;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (rank == 0) {
+        MPI_Send(&send_buf, 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+        MPI_Recv(&recv_buf, 1, MPI_INT, 1, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+    } else {
+        MPI_Recv(&recv_buf, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        MPI_Send(&send_buf, 1, MPI_INT, 0, 0, MPI_COMM_WORLD);
+    }
+
+    if (recv_buf != 1337) {
+        fprintf(stderr, "Received incorrect data: %d != 1337\n", recv_buf);
+        errs++;
+    }
+
+    if (test_val != expected_output) {
+        fprintf(stderr, "QMPI tool did not increment value: %d != 2\n", test_val);
+        errs++;
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/mpi_t/testlist
+++ b/test/mpi/mpi_t/testlist
@@ -2,3 +2,4 @@ mpi_t_str 1
 mpit_vars 1
 cvarwrite 1
 getindex 1
+qmpi_test 2 env=MPIR_CVAR_QMPI_TOOL_LIST=test_tool:test_tool


### PR DESCRIPTION
## Pull Request Description

This PR replaces #4715 is a more up to date way to implement the QMPI bindings that uses the new autogenerated C bindings from the many previous PRs that added that feature.

This branch is based on https://github.com/pmodels/mpich/pull/5022 and includes that PR's commits so it should be merged after that branch is merged. Only the last few commits are actually part of this work:

```
* qmpi: Add QMPI Support
* ch4: Include return value for bool in netmod_impl
* git: Ignore autogened files
```

### Current API

#### Initialization / Finalization

The tool should use a system specific option to initialize the library when it's loaded. GCC and other compiler use the `__attribute__((constructor)` trick to accomplish this. The same can be used during finalization.

#### Registration

During the initialization call, the tool should call:

```c
int QMPI_Register_tool(void * tool_context, int * tool_id);
```

This function allows the tool to provide a context object (`tool_context`) which lets the tool store some information specific to its incarnation of itself (in case there are multiple copies of a tool). MPI will return the `tool_id` to indicate where in the stack this tool has been registered. Tools will be called in reverse order (i.e., the largest number will be called first and will move backward until MPICH is called). MPICH will always be tool 0.

Then the tool can register each function that it wishes to override with this call:

```c
int QMPI_Register_function(int calling_tool_id, enum QMPI_Functions_enum function_enum, void (* function_ptr)(void))
```

This function takes `calling_tool_id` as the ID of the tool that is registering functions and `function_enum` as a way of specifying which MPI function is being registered. The enum values are defined in `mpi.h and here:

```c
enum QMPI_Functions_enum {
    MPI_ABORT_T,
    MPI_ACCUMULATE_T,
    ... snip ...
    MPI_WTIME_T,
    MPI_LAST_FUNC
};
```

`function_ptr` should be a pointer to the tool's interception function pointer. This function pointer will be the same signature as the MPI function, with an addition `void *` argument in the last position to allow tools to get their context objects back at call time. These functions are all `typedef`ed in `mpi.h` in the form of `QMPI_<function_name>_t` (e.g. `QMPI_Send_t`).

#### Interception

When the tool's interception function is called, it can get any tool-specific information from the context object. It is recommended that the tool stores its ID in that object for easy retrieval later. When the tool is done, it should call this function to determine the next tool in the QMPI stack (which the tool is responsible for calling):

```c
int QMPI_Get_function(int calling_tool_id, enum QMPI_Functions_enum function_enum, void (** function_ptr)(void), void **next_tool_context);
```

This function also uses `calling_tool_id` and `function_enum` to determine the current tool's ID and the enum value for the function being queried. It also provides a function pointer in a similar format to the registration function. Finally, the function returns the context object of the next tool in the call stack which should be used when calling the returned function.

An example of what a tool that implements this API would look like is here: https://gist.github.com/wesbland/065de74b3582913c3945099af5cf5130

## Expected Impact

Some basic benchmarks with OSU MBW and Latency show about 3% or less performance loss with one tool attached.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
