### PR TITLE
topo: internally call MPIR_Comm_get_attr

### DIFF
--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -33,8 +33,8 @@ MPIR_Topology *MPIR_Topology_get(MPIR_Comm * comm_ptr)
         return 0;
     }
 
-    mpi_errno = MPII_Comm_get_attr(comm_ptr->handle, MPIR_Topology_keyval,
-                                   &topo_ptr, &flag, MPIR_ATTR_PTR);
+    mpi_errno = MPIR_Comm_get_attr_impl(comm_ptr, MPIR_Topology_keyval,
+                                        &topo_ptr, &flag, MPIR_ATTR_PTR);
     if (mpi_errno)
         return NULL;
 


### PR DESCRIPTION
## Pull Request Description

... instead of calling MPII_Comm_get_attr. We takes global lock in
MPII_Comm_get_attr and it will cause recursive locking if called
internally. Call `MPIR_Comm_get_attr_impl` instead.


Fixes #5036 
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->
[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
