### PR TITLE
ch4: fix missing return in autogened netmod_impl.c|.h

### DIFF
--- a/maint/gen_ch4_api.py
+++ b/maint/gen_ch4_api.py
@@ -185,7 +185,7 @@ def dump_netmod_impl_h(h_file):
 
             print("{", file=Out)
             use_ret = ''
-            if re.search(r'int|size_t', a['ret']):
+            if not re.match(r'void\s*$', a['ret']):
                 use_ret = 1
                 print("    %s ret;" % a['ret'], file=Out)
                 print("", file=Out)
@@ -246,7 +246,7 @@ def dump_netmod_impl_c(c_file):
 
             print("{", file=Out)
             use_ret = ''
-            if re.search(r'int|size_t', a['ret']):
+            if not re.match(r'void\s*$', a['ret']):
                 use_ret = 1
                 print("    %s ret;" % a['ret'], file=Out)
                 print("", file=Out)


### PR DESCRIPTION
Return with bool type or void* type is missing. It caused compiling
warning with noinline build.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
