### PR TITLE
fortran: fix MPI_STATUS type in use_mpi

### DIFF
--- a/src/binding/fortran/use_mpi/buildiface
+++ b/src/binding/fortran/use_mpi/buildiface
@@ -696,9 +696,9 @@ $PRIVATEVAR = "";
 print MPIFD <<EOT;
         TYPE$BINDACCESS :: MPI_Status
            $BINDDEF
-           INTEGER$PUBLICVAR :: MPI_SOURCE, MPI_TAG, MPI_ERROR
            INTEGER$PRIVATEVAR :: count_lo
            INTEGER$PRIVATEVAR :: count_hi_and_cancelled
+           INTEGER$PUBLICVAR :: MPI_SOURCE, MPI_TAG, MPI_ERROR
         END TYPE MPI_Status
 EOT
 


### PR DESCRIPTION
## Pull Request Description

The status fields doesn't match what defined in mpi.h.in. It is not
triggered in the wild because the interface in use_mpi still uses
INTEGER(MPI_STATUS_SIZE) array, thus the status type is rarely used in
use mpi.



<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
