### PR TITLE
coll: internally use MPI_Aint for count parameters

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -885,8 +885,12 @@ def push_impl_decl(func, impl_name=None):
         impl_name = re.sub(r'^MPIX?_', 'MPIR_', func['name']) + "_impl"
     if func['impl_param_list']:
         params = ', '.join(func['impl_param_list'])
-        if func['dir'] == 'coll' and not RE.match(r'MPI_(I|Neighbor)', func['name']):
-            params = params + ", MPIR_Errflag_t *errflag"
+        if func['dir'] == 'coll':
+            # All collective impl function use MPI_Aint counts
+            params = re.sub(r' int (count|sendcount|recvcount),', r' MPI_Aint \1,', params)
+            # block collective use an extra errflag
+            if not RE.match(r'MPI_(I|Neighbor)', func['name']):
+                params = params + ", MPIR_Errflag_t *errflag"
     else:
         params="void"
 

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -885,10 +885,16 @@ def push_impl_decl(func, impl_name=None):
         impl_name = re.sub(r'^MPIX?_', 'MPIR_', func['name']) + "_impl"
     if func['impl_param_list']:
         params = ', '.join(func['impl_param_list'])
-        if func['dir'] == 'coll' and not RE.match(r'MPI_I', func['name']):
+        if func['dir'] == 'coll' and not RE.match(r'MPI_(I|Neighbor)', func['name']):
             params = params + ", MPIR_Errflag_t *errflag"
     else:
         params="void"
+
+    if func['dir'] == 'coll':
+        # collective also dump MPIR_Xxx(...)
+        mpir_name = re.sub(r'^MPIX?_', 'MPIR_', func['name'])
+        G.impl_declares.append("int %s(%s);" % (mpir_name, params))
+    # dump MPIR_Xxx_impl(...)
     G.impl_declares.append("int %s(%s);" % (impl_name, params))
 
 def dump_CHECKENUM(var, errname, t, type="ENUM"):

--- a/src/binding/c/coll_api.txt
+++ b/src/binding/c/coll_api.txt
@@ -169,55 +169,27 @@ MPI_Iscatterv:
     .desc: Scatters a buffer in parts to all processes in a communicator in a nonblocking way
 
 MPI_Neighbor_allgather:
-    .desc: In this function, each process i gathers data items from each process j if an edge (j,i) exists in the topology graph, and each process i sends the same data items to all processes j where an edge (i,j) exists. The send buffer is sent to each neighboring process and the l-th block in the receive buffer is received from the l-th neighbor.
-{
-    mpi_errno = MPIR_Neighbor_allgather(sendbuf, sendcount, sendtype, recvbuf,
-                                        recvcount, recvtype, comm_ptr);
-    if (mpi_errno) {
-        goto fn_fail;
-    }
-}
+    .desc: Gathers data from all neighboring processes and distribute the combined data to all neighboring processes
+/*
+    Notes:
+    In this function, each process i gathers data items from each process j if an edge (j,i) exists in the topology graph, and each process i sends the same data items to all processes j where an edge (i,j) exists. The send buffer is sent to each neighboring process and the l-th block in the receive buffer is received from the l-th neighbor.
+*/
 
 MPI_Neighbor_allgatherv:
     .desc: The vector variant of MPI_Neighbor_allgather.
-{
-    mpi_errno = MPIR_Neighbor_allgatherv(sendbuf, sendcount, sendtype, recvbuf,
-                                         recvcounts, displs, recvtype, comm_ptr);
-    if (mpi_errno) {
-        goto fn_fail;
-    }
-}
 
 MPI_Neighbor_alltoall:
-    .desc: In this function, each process i receives data items from each process j if an edge (j,i) exists in the topology graph or Cartesian topology.  Similarly, each process i sends data items to all processes j where an edge (i,j) exists. This call is more general than MPI_NEIGHBOR_ALLGATHER in that different data items can be sent to each neighbor. The k-th block in send buffer is sent to the k-th neighboring process and the l-th block in the receive buffer is received from the l-th neighbor.
-{
-    mpi_errno = MPIR_Neighbor_alltoall(sendbuf, sendcount, sendtype, recvbuf,
-                                       recvcount, recvtype, comm_ptr);
-    if (mpi_errno) {
-        goto fn_fail;
-    }
-}
+    .desc: Sends and Receivs data from all neighboring processes
+/*
+    Notes:
+    In this function, each process i receives data items from each process j if an edge (j,i) exists in the topology graph or Cartesian topology.  Similarly, each process i sends data items to all processes j where an edge (i,j) exists. This call is more general than MPI_NEIGHBOR_ALLGATHER in that different data items can be sent to each neighbor. The k-th block in send buffer is sent to the k-th neighboring process and the l-th block in the receive buffer is received from the l-th neighbor.
+*/
 
 MPI_Neighbor_alltoallv:
     .desc: The vector variant of MPI_Neighbor_alltoall allows sending/receiving different numbers of elements to and from each neighbor.
-{
-    mpi_errno = MPIR_Neighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype,
-                                        recvbuf, recvcounts, rdispls, recvtype, comm_ptr);
-    if (mpi_errno) {
-        goto fn_fail;
-    }
-}
 
 MPI_Neighbor_alltoallw:
     .desc: Like MPI_Neighbor_alltoallv but it allows one to send and receive with different types to and from each neighbor.
-{
-    mpi_errno = MPIR_Neighbor_alltoallw_impl(sendbuf, sendcounts, sdispls,
-                                             sendtypes, recvbuf, recvcounts,
-                                             rdispls, recvtypes, comm_ptr);
-    if (mpi_errno) {
-        goto fn_fail;
-    }
-}
 
 MPI_Reduce:
     .desc: Reduces values on all processes to a single value

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -41,13 +41,6 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[],
 
 
 /******************************** Allgather ********************************/
-int MPIR_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                   int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                   MPIR_Errflag_t * errflag);
-int MPIR_Allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                        int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                        MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Allgather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
@@ -76,13 +69,6 @@ int MPIR_Allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype s
 
 
 /******************************** Allgatherv ********************************/
-int MPIR_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                    const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                         const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                         MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Allgatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                  void *recvbuf, const int *recvcounts, const int *displs,
@@ -117,11 +103,6 @@ int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype 
 
 
 /******************************** Allreduce ********************************/
-int MPIR_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                        MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Allreduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
@@ -146,13 +127,6 @@ int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI
 
 
 /******************************** Alltoall ********************************/
-int MPIR_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                  int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                  MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                       int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                       MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Alltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
@@ -183,14 +157,6 @@ int MPIR_Alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype se
 
 
 /******************************** Alltoallv ********************************/
-int MPIR_Alltoallv(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                   MPI_Datatype sendtype, void *recvbuf, const int *recvcounts, const int *rdispls,
-                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                        MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                        const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                        MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Alltoallv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                 MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
@@ -221,15 +187,6 @@ int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const int *sendcounts, const 
 
 
 /******************************** Alltoallw ********************************/
-int MPIR_Alltoallw(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                   const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
-                   const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                   MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                        const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
-                        const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                        MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Alltoallw_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                 const MPI_Datatype * sendtypes, void *recvbuf,
@@ -263,9 +220,6 @@ int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const int *sendcounts, const 
 
 
 /******************************** Barrier ********************************/
-int MPIR_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_impl(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Barrier_allcomm_auto(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
@@ -279,11 +233,6 @@ int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Bcast ********************************/
-int MPIR_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
-               MPIR_Errflag_t * errflag);
-int MPIR_Bcast_impl(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Bcast_allcomm_auto(void *buffer, int count, MPI_Datatype datatype, int root,
                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
@@ -310,11 +259,6 @@ int MPIR_Bcast_allcomm_nb(void *buffer, int count, MPI_Datatype datatype, int ro
 
 
 /******************************** Exscan ********************************/
-int MPIR_Exscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Exscan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Exscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
@@ -328,13 +272,6 @@ int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Da
 
 
 /******************************** Gather ********************************/
-int MPIR_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                MPIR_Errflag_t * errflag);
-int MPIR_Gather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                     int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                     MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Gather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                              void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
@@ -359,13 +296,6 @@ int MPIR_Gather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype send
 
 
 /******************************** Gatherv ********************************/
-int MPIR_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                 const int *recvcounts, const int *displs, MPI_Datatype recvtype, int root,
-                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Gatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                      const int *recvcounts, const int *displs, MPI_Datatype recvtype, int root,
-                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Gatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                               void *recvbuf, const int *recvcounts, const int *displs,
@@ -387,12 +317,6 @@ int MPIR_Gatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sen
 
 /******************************** Iallgather ********************************/
 /* request-based functions */
-int MPIR_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                    int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                    MPIR_Request ** request);
-int MPIR_Iallgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                         int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                         MPIR_Request ** request);
 int MPIR_Iallgather_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                          MPIR_Comm * comm_ptr, int k, MPIR_Request ** request);
@@ -444,12 +368,6 @@ int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, i
 
 /******************************** Iallgatherv ********************************/
 /* request-based functions */
-int MPIR_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                     const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                     MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                          const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                          MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Iallgatherv_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                           void *recvbuf, const int recvcounts[], const int displs[],
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int k,
@@ -508,10 +426,6 @@ int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, 
 
 /******************************** Iallreduce ********************************/
 /* request-based functions */
-int MPIR_Iallreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                    MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Iallreduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count,
                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                  MPIR_Request ** request);
@@ -574,12 +488,6 @@ int MPIR_Iallreduce_inter_sched_remote_reduce_local_bcast(const void *sendbuf, v
 
 /******************************** Ialltoall ********************************/
 /* request-based functions */
-int MPIR_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                   int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                   MPIR_Request ** request);
-int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                        int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                        MPIR_Request ** request);
 int MPIR_Ialltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                 MPIR_Comm * comm_ptr, MPIR_Request ** request);
@@ -631,13 +539,6 @@ int MPIR_Ialltoall_inter_sched_pairwise_exchange(const void *sendbuf, int sendco
 
 /******************************** Ialltoallv ********************************/
 /* request-based functions */
-int MPIR_Ialltoallv(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                    MPI_Datatype sendtype, void *recvbuf, const int *recvcounts, const int *rdispls,
-                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ialltoallv_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                         MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                         const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                         MPIR_Request ** request);
 int MPIR_Ialltoallv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                  MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
                                  const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -695,14 +596,6 @@ int MPIR_Ialltoallv_inter_sched_pairwise_exchange(const void *sendbuf, const int
 
 /******************************** Ialltoallw ********************************/
 /* request-based functions */
-int MPIR_Ialltoallw(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                    const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
-                    const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                    MPIR_Request ** request);
-int MPIR_Ialltoallw_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                         const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
-                         const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                         MPIR_Request ** request);
 int MPIR_Ialltoallw_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                  const MPI_Datatype * sendtypes, void *recvbuf,
                                  const int *recvcounts, const int *rdispls,
@@ -758,8 +651,6 @@ int MPIR_Ialltoallw_inter_sched_pairwise_exchange(const void *sendbuf, const int
 
 /******************************** Ibarrier ********************************/
 /* request-based functions */
-int MPIR_Ibarrier(MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Ibarrier_allcomm_auto(MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
@@ -777,10 +668,6 @@ int MPIR_Ibarrier_inter_sched_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /******************************** Ibcast ********************************/
 /* request-based functions */
-int MPIR_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
-                MPIR_Request ** request);
-int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
-                     MPIR_Request ** request);
 int MPIR_Ibcast_allcomm_auto(void *buffer, int count, MPI_Datatype datatype, int root,
                              MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Ibcast_intra_gentran_tree(void *buffer, int count, MPI_Datatype datatype, int root,
@@ -821,10 +708,6 @@ int MPIR_Ibcast_inter_sched_flat(void *buffer, int count, MPI_Datatype datatype,
 
 /******************************** Iexscan ********************************/
 /* request-based functions */
-int MPIR_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                 MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                      MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Iexscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
@@ -839,12 +722,6 @@ int MPIR_Iexscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvb
 
 /******************************** Igather ********************************/
 /* request-based functions */
-int MPIR_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                 int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                 MPIR_Request ** request);
-int MPIR_Igather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                      int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                      MPIR_Request ** request);
 int MPIR_Igather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                               void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
                               MPIR_Comm * comm_ptr, MPIR_Request ** request);
@@ -879,12 +756,6 @@ int MPIR_Igather_inter_sched_short(const void *sendbuf, int sendcount, MPI_Datat
 
 /******************************** Igatherv ********************************/
 /* request-based functions */
-int MPIR_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                  const int *recvcounts, const int *displs, MPI_Datatype recvtype, int root,
-                  MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                       const int *recvcounts, const int *displs, MPI_Datatype recvtype, int root,
-                       MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Igatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const int *recvcounts, const int *displs,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
@@ -920,12 +791,6 @@ int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, int sendcount, MPI_D
 
 /******************************** Ineighbor_allgather ********************************/
 /* request-based functions */
-int MPIR_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                             MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                  MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Ineighbor_allgather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                           void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                           MPIR_Comm * comm_ptr, MPIR_Request ** request);
@@ -960,13 +825,6 @@ int MPIR_Ineighbor_allgather_allcomm_sched_linear(const void *sendbuf, int sendc
 
 /******************************** Ineighbor_allgatherv ********************************/
 /* request-based functions */
-int MPIR_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, const int recvcounts[], const int displs[],
-                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, const int recvcounts[], const int displs[],
-                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                   MPIR_Request ** request);
 int MPIR_Ineighbor_allgatherv_allcomm_auto(const void *sendbuf, int sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
                                            const int recvcounts[], const int displs[],
@@ -1008,12 +866,6 @@ int MPIR_Ineighbor_allgatherv_allcomm_sched_linear(const void *sendbuf, int send
 
 /******************************** Ineighbor_alltoall ********************************/
 /* request-based functions */
-int MPIR_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                            MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                 MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Ineighbor_alltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                          MPIR_Comm * comm_ptr, MPIR_Request ** request);
@@ -1048,14 +900,6 @@ int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, int sendco
 
 /******************************** Ineighbor_alltoallv ********************************/
 /* request-based functions */
-int MPIR_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                             MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                             const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                             MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                                  MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                  const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                  MPIR_Request ** request);
 int MPIR_Ineighbor_alltoallv_allcomm_auto(const void *sendbuf, const int sendcounts[],
                                           const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                           const int recvcounts[], const int rdispls[],
@@ -1098,15 +942,6 @@ int MPIR_Ineighbor_alltoallv_allcomm_sched_linear(const void *sendbuf, const int
 
 /******************************** Ineighbor_alltoallw ********************************/
 /* request-based functions */
-int MPIR_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[],
-                             const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
-                             const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                             MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
-                                  const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                  void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[],
-                                  const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                  MPIR_Request ** request);
 int MPIR_Ineighbor_alltoallw_allcomm_auto(const void *sendbuf, const int sendcounts[],
                                           const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                           void *recvbuf, const int recvcounts[],
@@ -1154,10 +989,6 @@ int MPIR_Ineighbor_alltoallw_allcomm_sched_linear(const void *sendbuf, const int
 
 /******************************** Ireduce ********************************/
 /* request-based functions */
-int MPIR_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                 int root, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                      MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Ireduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
                               MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Ireduce_intra_gentran_tree(const void *sendbuf, void *recvbuf, int count,
@@ -1198,12 +1029,6 @@ int MPIR_Ireduce_inter_sched_local_reduce_remote_send(const void *sendbuf, void 
 
 /******************************** Ireduce_scatter ********************************/
 /* request-based functions */
-int MPIR_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                         MPIR_Request ** request);
-int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                              MPIR_Request ** request);
 int MPIR_Ireduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf, const int *recvcounts,
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                       MPIR_Request ** request);
@@ -1251,12 +1076,6 @@ int MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(const void *se
 
 /******************************** Ireduce_scatter_block ********************************/
 /* request-based functions */
-int MPIR_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
-                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Request ** request);
-int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf, int recvcount,
-                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Request ** request);
 int MPIR_Ireduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, int recvcount,
                                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                             MPIR_Request ** request);
@@ -1305,10 +1124,6 @@ int MPIR_Ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv(const vo
 
 /******************************** Iscan ********************************/
 /* request-based functions */
-int MPIR_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-               MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                    MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Iscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
                             MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
@@ -1328,12 +1143,6 @@ int MPIR_Iscan_intra_gentran_recursive_doubling(const void *sendbuf, void *recvb
 
 /******************************** Iscatter ********************************/
 /* request-based functions */
-int MPIR_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                  int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                  MPIR_Request ** request);
-int MPIR_Iscatter_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                       int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                       MPIR_Request ** request);
 int MPIR_Iscatter_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
                                MPIR_Comm * comm_ptr, MPIR_Request ** request);
@@ -1370,12 +1179,6 @@ int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, int
 
 /******************************** Iscatterv ********************************/
 /* request-based functions */
-int MPIR_Iscatterv(const void *sendbuf, const int *sendcounts, const int *displs,
-                   MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                   int root, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iscatterv_impl(const void *sendbuf, const int *sendcounts, const int *displs,
-                        MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                        int root, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Iscatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *displs,
                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
@@ -1411,13 +1214,6 @@ int MPIR_Iscatterv_allcomm_sched_linear(const void *sendbuf, const int *sendcoun
 
 
 /******************************** Neighbor_allgather ********************************/
-int MPIR_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                            MPIR_Comm * comm_ptr);
-int MPIR_Neighbor_allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                 MPIR_Comm * comm_ptr);
-
 /* intracomm-only functions */
 int MPIR_Neighbor_allgather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
@@ -1432,13 +1228,6 @@ int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_D
 
 
 /******************************** Neighbor_allgatherv ********************************/
-int MPIR_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, const int recvcounts[], const int displs[],
-                             MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-int MPIR_Neighbor_allgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, const int recvcounts[], const int displs[],
-                                  MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-
 /* intracomm-only functions */
 int MPIR_Neighbor_allgatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                           void *recvbuf, const int recvcounts[], const int displs[],
@@ -1453,12 +1242,6 @@ int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_
 
 
 /******************************** Neighbor_alltoall ********************************/
-int MPIR_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                           int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-int MPIR_Neighbor_alltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                MPIR_Comm * comm_ptr);
-
 /* intracomm-only functions */
 int MPIR_Neighbor_alltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
@@ -1473,13 +1256,6 @@ int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Da
 
 
 /******************************** Neighbor_alltoallv ********************************/
-int MPIR_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                            MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                            const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-int MPIR_Neighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                                 MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                 const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-
 /* intracomm-only functions */
 int MPIR_Neighbor_alltoallv_allcomm_auto(const void *sendbuf, const int sendcounts[],
                                          const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
@@ -1496,15 +1272,6 @@ int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const int sendcounts
 
 
 /******************************** Neighbor_alltoallw ********************************/
-int MPIR_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[],
-                            const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
-                            const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                            MPIR_Comm * comm_ptr);
-int MPIR_Neighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
-                                 const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                 void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[],
-                                 const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr);
-
 /* intracomm-only functions */
 int MPIR_Neighbor_alltoallw_allcomm_auto(const void *sendbuf, const int sendcounts[],
                                          const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
@@ -1523,11 +1290,6 @@ int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const int sendcounts
 
 
 /******************************** Reduce ********************************/
-int MPIR_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                     MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Reduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
                              MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
@@ -1555,13 +1317,6 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype
 
 
 /******************************** Reduce_scatter ********************************/
-int MPIR_Reduce_scatter(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                        MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_impl(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                             MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Reduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf, const int *recvcounts,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
@@ -1596,13 +1351,6 @@ int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const int
 
 
 /******************************** Reduce_scatter_block ********************************/
-int MPIR_Reduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
-                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_impl(const void *sendbuf, void *recvbuf, int recvcount,
-                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Reduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, int recvcount,
                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
@@ -1636,11 +1384,6 @@ int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, int
 
 
 /******************************** Scan ********************************/
-int MPIR_Scan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Scan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Scan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
@@ -1656,13 +1399,6 @@ int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Data
 
 
 /******************************** Scatter ********************************/
-int MPIR_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                 int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                 MPIR_Errflag_t * errflag);
-int MPIR_Scatter_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                      int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                      MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Scatter_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                               void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
@@ -1687,13 +1423,6 @@ int MPIR_Scatter_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sen
 
 
 /******************************** Scatterv ********************************/
-int MPIR_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
-                  MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                  int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Scatterv_impl(const void *sendbuf, const int *sendcounts, const int *displs,
-                       MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                       int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
 /* intracomm-only functions */
 int MPIR_Scatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *displs,
                                MPI_Datatype sendtype, void *recvbuf, int recvcount,

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -42,61 +42,61 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[],
 
 /******************************** Allgather ********************************/
 /* intracomm-only functions */
-int MPIR_Allgather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Allgather_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Allgather_intra_brucks(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf, int sendcount,
-                                            MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                            MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                            MPIR_Errflag_t * errflag);
-int MPIR_Allgather_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf, MPI_Aint sendcount,
+                                            MPI_Datatype sendtype, void *recvbuf,
+                                            MPI_Aint recvcount, MPI_Datatype recvtype,
+                                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Allgather_intra_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
-int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, int sendcount,
+int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Allgatherv ********************************/
 /* intracomm-only functions */
-int MPIR_Allgatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                  void *recvbuf, const int *recvcounts, const int *displs,
                                  MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                  MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Allgatherv_intra_brucks(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                  void *recvbuf, const int *recvcounts, const int *displs,
                                  MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                  MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf, int sendcount,
+int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
                                              const int *recvcounts, const int *displs,
                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                              MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Allgatherv_intra_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const int *recvcounts, const int *displs,
                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
-int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, int sendcount,
+int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int *recvcounts, const int *displs,
                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                     MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const int *recvcounts, const int *displs,
                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                MPIR_Errflag_t * errflag);
@@ -104,55 +104,58 @@ int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype 
 
 /******************************** Allreduce ********************************/
 /* intracomm-only functions */
-int MPIR_Allreduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Allreduce_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                 MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                             MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
+int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                             MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                             MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
-int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                              MPIR_Errflag_t * errflag);
 
 
 /******************************** Alltoall ********************************/
 /* intracomm-only functions */
-int MPIR_Alltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Alltoall_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Alltoall_intra_brucks(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_pairwise(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Alltoall_intra_pairwise(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf, int sendcount,
+int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_scattered(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Alltoall_intra_scattered(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
-int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                          MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, MPI_Aint sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                          MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                             void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
@@ -234,70 +237,72 @@ int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /******************************** Bcast ********************************/
 /* intracomm-only functions */
-int MPIR_Bcast_allcomm_auto(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Bcast_allcomm_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_binomial(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Bcast_intra_binomial(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer, int count,
+int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer, MPI_Aint count,
                                                           MPI_Datatype datatype, int root,
                                                           MPIR_Comm * comm_ptr,
                                                           MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer, int count, MPI_Datatype datatype,
+int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                             int root, MPIR_Comm * comm_ptr,
                                             MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_smp(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                          MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
-int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer, int count, MPI_Datatype datatype,
+int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                              int root, MPIR_Comm * comm_ptr,
                                              MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Bcast_allcomm_nb(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Bcast_allcomm_nb(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Exscan ********************************/
 /* intracomm-only functions */
-int MPIR_Exscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                             MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Exscan_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                             MPIR_Errflag_t * errflag);
+int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                          MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                           MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                           MPIR_Errflag_t * errflag);
 
 
 /******************************** Gather ********************************/
 /* intracomm-only functions */
-int MPIR_Gather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Gather_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                             void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
-int MPIR_Gather_inter_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                             void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, int sendcount,
-                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                               MPI_Datatype recvtype, int root,
+int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sendcount,
+                                               MPI_Datatype sendtype, void *recvbuf,
+                                               MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Gather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                           int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t * errflag);
+int MPIR_Gather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                           void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Gatherv ********************************/
 /* intracomm-only functions */
-int MPIR_Gatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Gatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                               void *recvbuf, const int *recvcounts, const int *displs,
                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                               MPIR_Errflag_t * errflag);
@@ -305,11 +310,11 @@ int MPIR_Gatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype s
 /* intercomm-only functions */
 
 /* anycomm functions */
-int MPIR_Gatherv_allcomm_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Gatherv_allcomm_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, const int *recvcounts, const int *displs,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                 MPIR_Errflag_t * errflag);
-int MPIR_Gatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Gatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                             void *recvbuf, const int *recvcounts, const int *displs,
                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                             MPIR_Errflag_t * errflag);
@@ -317,107 +322,114 @@ int MPIR_Gatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sen
 
 /******************************** Iallgather ********************************/
 /* request-based functions */
-int MPIR_Iallgather_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                         MPIR_Comm * comm_ptr, int k, MPIR_Request ** request);
-int MPIR_Iallgather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iallgather_intra_gentran_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int k,
+                                         MPIR_Request ** request);
+int MPIR_Iallgather_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                  MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Iallgather_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iallgather_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Iallgather_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iallgather_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgather_intra_sched_recursive_doubling(const void *sendbuf, int sendcount,
+int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Iallgather_intra_sched_recursive_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgather_intra_sched_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iallgather_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgather_intra_gentran_recexch_doubling(const void *sendbuf, int sendcount,
+int MPIR_Iallgather_intra_gentran_recexch_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, int k,
                                                    MPIR_Request ** request);
-int MPIR_Iallgather_intra_gentran_recexch_halving(const void *sendbuf, int sendcount,
+int MPIR_Iallgather_intra_gentran_recexch_halving(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
                                                   MPIR_Comm * comm_ptr, int k,
                                                   MPIR_Request ** request);
-int MPIR_Iallgather_intra_gentran_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Request ** request);
+int MPIR_Iallgather_intra_gentran_ring(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                       MPIR_Request ** request);
 /* sched-based intercomm-only functions */
-int MPIR_Iallgather_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iallgather_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, int sendcount,
+int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
-                                                          int recvcount, MPI_Datatype recvtype,
+                                                          MPI_Aint recvcount, MPI_Datatype recvtype,
                                                           MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Iallgatherv ********************************/
 /* request-based functions */
-int MPIR_Iallgatherv_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, const int recvcounts[], const int displs[],
+int MPIR_Iallgatherv_intra_gentran_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          const int recvcounts[], const int displs[],
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int k,
                                           MPIR_Request ** request);
-int MPIR_Iallgatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Iallgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, const int *recvcounts, const int *displs,
                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                   MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Iallgatherv_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Iallgatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, const int *recvcounts, const int *displs,
                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Iallgatherv_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, const int *recvcounts, const int *displs,
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, const int recvcounts[], const int displs[],
+int MPIR_Iallgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
+                                      const int *displs, MPI_Datatype recvtype,
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        const int recvcounts[], const int displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                         MPIR_Sched_t s);
-int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, int sendcount,
+int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int recvcounts[], const int displs[],
                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                     MPIR_Sched_t s);
-int MPIR_Iallgatherv_intra_sched_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgatherv_intra_gentran_recexch_doubling(const void *sendbuf, int sendcount,
+int MPIR_Iallgatherv_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
+                                      const int displs[], MPI_Datatype recvtype,
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Iallgatherv_intra_gentran_recexch_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int *recvcounts, const int *displs,
                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                     int k, MPIR_Request ** request);
-int MPIR_Iallgatherv_intra_gentran_recexch_halving(const void *sendbuf, int sendcount,
+int MPIR_Iallgatherv_intra_gentran_recexch_halving(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int *recvcounts, const int *displs,
                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                    int k, MPIR_Request ** request);
-int MPIR_Iallgatherv_intra_gentran_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, const int *recvcounts, const int *displs,
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Request ** request);
+int MPIR_Iallgatherv_intra_gentran_ring(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
+                                        const int *displs, MPI_Datatype recvtype,
+                                        MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based intercomm-only functions */
-int MPIR_Iallgatherv_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, const int *recvcounts, const int *displs,
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, int sendcount,
+int MPIR_Iallgatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
+                                      const int *displs, MPI_Datatype recvtype,
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            const int *recvcounts, const int *displs,
                                                            MPI_Datatype recvtype,
@@ -426,114 +438,117 @@ int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, 
 
 /******************************** Iallreduce ********************************/
 /* request-based functions */
-int MPIR_Iallreduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                  MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Iallreduce_sched_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Iallreduce_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                               MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Iallreduce_intra_sched_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                      MPIR_Sched_t s);
-int MPIR_Iallreduce_intra_sched_naive(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_intra_sched_naive(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                       MPIR_Sched_t s);
-int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op,
+int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf,
+                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Iallreduce_intra_sched_reduce_scatter_allgather(const void *sendbuf, void *recvbuf,
-                                                         int count, MPI_Datatype datatype,
+                                                         MPI_Aint count, MPI_Datatype datatype,
                                                          MPI_Op op, MPIR_Comm * comm_ptr,
                                                          MPIR_Sched_t s);
 int MPIR_Iallreduce_intra_gentran_recexch_single_buffer(const void *sendbuf, void *recvbuf,
-                                                        int count, MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm_ptr, int k,
+                                                        MPI_Aint count, MPI_Datatype datatype,
+                                                        MPI_Op op, MPIR_Comm * comm_ptr, int k,
                                                         MPIR_Request ** request);
 int MPIR_Iallreduce_intra_gentran_recexch_multiple_buffer(const void *sendbuf, void *recvbuf,
-                                                          int count, MPI_Datatype datatype,
+                                                          MPI_Aint count, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr, int k,
                                                           MPIR_Request ** request);
-int MPIR_Iallreduce_intra_gentran_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_intra_gentran_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                        int tree_type, int k, int maxbytes, int buffer_per_child,
                                        MPIR_Request ** request);
-int MPIR_Iallreduce_intra_gentran_ring(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_intra_gentran_ring(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                        MPIR_Request ** request);
 int MPIR_Iallreduce_intra_gentran_recexch_reduce_scatter_recexch_allgatherv(const void *sendbuf,
                                                                             void *recvbuf,
-                                                                            int count,
+                                                                            MPI_Aint count,
                                                                             MPI_Datatype datatype,
                                                                             MPI_Op op,
                                                                             MPIR_Comm * comm_ptr,
                                                                             int k,
                                                                             MPIR_Request **
                                                                             request);
-int MPIR_Iallreduce_intra_sched_smp(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                     MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Iallreduce_inter_sched_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_inter_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                      MPIR_Sched_t s);
 int MPIR_Iallreduce_inter_sched_remote_reduce_local_bcast(const void *sendbuf, void *recvbuf,
-                                                          int count, MPI_Datatype datatype,
+                                                          MPI_Aint count, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
                                                           MPIR_Sched_t s);
 
 
 /******************************** Ialltoall ********************************/
 /* request-based functions */
-int MPIR_Ialltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Ialltoall_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                 MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ialltoall_intra_gentran_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ialltoall_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, int k, int buffer_per_phase,
-                                        MPIR_Request ** request);
-int MPIR_Ialltoall_intra_gentran_scattered(const void *sendbuf, int sendcount,
-                                           MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_Ialltoall_intra_gentran_ring(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Request ** request);
+int MPIR_Ialltoall_intra_gentran_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int k,
+                                        int buffer_per_phase, MPIR_Request ** request);
+int MPIR_Ialltoall_intra_gentran_scattered(const void *sendbuf, MPI_Aint sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                            MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                            int batch_size, int bblock, MPIR_Request ** request);
 
 
 /* sched-based functions */
-int MPIR_Ialltoall_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Ialltoall_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ialltoall_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Ialltoall_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoall_intra_sched_inplace(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoall_intra_sched_pairwise(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoall_intra_sched_permuted_sendrecv(const void *sendbuf, int sendcount,
+int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ialltoall_intra_sched_inplace(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ialltoall_intra_sched_pairwise(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                        MPIR_Sched_t s);
+int MPIR_Ialltoall_intra_sched_permuted_sendrecv(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype,
+                                                 MPI_Aint recvcount, MPI_Datatype recvtype,
                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ialltoall_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Ialltoall_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoall_inter_sched_pairwise_exchange(const void *sendbuf, int sendcount,
+int MPIR_Ialltoall_inter_sched_pairwise_exchange(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype,
+                                                 MPI_Aint recvcount, MPI_Datatype recvtype,
                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
@@ -668,196 +683,203 @@ int MPIR_Ibarrier_inter_sched_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /******************************** Ibcast ********************************/
 /* request-based functions */
-int MPIR_Ibcast_allcomm_auto(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_allcomm_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                              MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ibcast_intra_gentran_tree(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_intra_gentran_tree(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                    MPIR_Comm * comm_ptr, int tree_type, int k, int maxbytes,
                                    MPIR_Request ** request);
-int MPIR_Ibcast_intra_gentran_scatterv_recexch_allgatherv(void *buffer, int count,
+int MPIR_Ibcast_intra_gentran_scatterv_recexch_allgatherv(void *buffer, MPI_Aint count,
                                                           MPI_Datatype datatype, int root,
                                                           MPIR_Comm * comm_ptr, int scatterv_k,
                                                           int allgatherv_k,
                                                           MPIR_Request ** request);
-int MPIR_Ibcast_intra_gentran_ring(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_intra_gentran_ring(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                    MPIR_Comm * comm_ptr, int maxbytes, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ibcast_sched_auto(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                            MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ibcast_intra_sched_auto(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_intra_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibcast_intra_sched_binomial(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, int count,
+int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, MPI_Aint count,
                                                                  MPI_Datatype datatype, int root,
                                                                  MPIR_Comm * comm_ptr,
                                                                  MPIR_Sched_t s);
-int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, int count, MPI_Datatype datatype,
-                                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibcast_intra_sched_smp(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
+                                                   MPI_Datatype datatype, int root,
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ibcast_intra_sched_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ibcast_inter_sched_auto(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_inter_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibcast_inter_sched_flat(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_inter_sched_flat(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Iexscan ********************************/
 /* request-based functions */
-int MPIR_Iexscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request);
+int MPIR_Iexscan_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                              MPIR_Request ** request);
 
 /* sched-based intracomm-only functions */
-int MPIR_Iexscan_intra_sched_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iexscan_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                   MPIR_Sched_t s);
-int MPIR_Iexscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iexscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Igather ********************************/
 /* request-based functions */
-int MPIR_Igather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Igather_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                               MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Igather_intra_gentran_tree(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                    MPIR_Comm * comm_ptr, int k, MPIR_Request ** request);
+int MPIR_Igather_intra_gentran_tree(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                    int root, MPIR_Comm * comm_ptr, int k, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Igather_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Igather_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                            void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                             MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Igather_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Igather_intra_sched_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Igather_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                  int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                      MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Igather_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Igather_inter_sched_long(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Igather_inter_sched_short(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Igather_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                  int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Igather_inter_sched_long(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                  int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Igather_inter_sched_short(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Igatherv ********************************/
 /* request-based functions */
-int MPIR_Igatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Igatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const int *recvcounts, const int *displs,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                MPIR_Request ** request);
-int MPIR_Igatherv_allcomm_gentran_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, const int *recvcounts, const int *displs,
+int MPIR_Igatherv_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         const int *recvcounts, const int *displs,
                                          MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                          MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Igatherv_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Igatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                              void *recvbuf, const int *recvcounts, const int *displs,
                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Igatherv_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Igatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int *recvcounts, const int *displs,
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                    MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Igatherv_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Igatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int *recvcounts, const int *displs,
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                    MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, const int *recvcounts, const int *displs,
-                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                       MPIR_Sched_t s);
+int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
+                                       const int *displs, MPI_Datatype recvtype, int root,
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Ineighbor_allgather ********************************/
 /* request-based functions */
-int MPIR_Ineighbor_allgather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                          MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_allgather_allcomm_gentran_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgather_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                          MPIR_Request ** request);
+int MPIR_Ineighbor_allgather_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ineighbor_allgather_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgather_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                        MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ineighbor_allgather_intra_sched_auto(const void *sendbuf, int sendcount,
-                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
+int MPIR_Ineighbor_allgather_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                              MPI_Datatype sendtype, void *recvbuf,
+                                              MPI_Aint recvcount, MPI_Datatype recvtype,
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ineighbor_allgather_inter_sched_auto(const void *sendbuf, int sendcount,
-                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
+int MPIR_Ineighbor_allgather_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                              MPI_Datatype sendtype, void *recvbuf,
+                                              MPI_Aint recvcount, MPI_Datatype recvtype,
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Ineighbor_allgather_allcomm_sched_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgather_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Ineighbor_allgatherv ********************************/
 /* request-based functions */
-int MPIR_Ineighbor_allgatherv_allcomm_auto(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
                                            const int recvcounts[], const int displs[],
                                            MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                            MPIR_Request ** request);
-int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const int recvcounts[], const int displs[],
                                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                      MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ineighbor_allgatherv_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, const int recvcounts[], const int displs[],
+int MPIR_Ineighbor_allgatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         const int recvcounts[], const int displs[],
                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                          MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ineighbor_allgatherv_intra_sched_auto(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ineighbor_allgatherv_inter_sched_auto(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Ineighbor_allgatherv_allcomm_sched_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int recvcounts[], const int displs[],
                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -866,35 +888,36 @@ int MPIR_Ineighbor_allgatherv_allcomm_sched_linear(const void *sendbuf, int send
 
 /******************************** Ineighbor_alltoall ********************************/
 /* request-based functions */
-int MPIR_Ineighbor_alltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                         MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoall_allcomm_gentran_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_alltoall_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                         MPIR_Request ** request);
+int MPIR_Ineighbor_alltoall_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ineighbor_alltoall_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoall_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ineighbor_alltoall_intra_sched_auto(const void *sendbuf, int sendcount,
-                                             MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                             MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                             MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoall_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                             MPI_Datatype sendtype, void *recvbuf,
+                                             MPI_Aint recvcount, MPI_Datatype recvtype,
+                                             MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ineighbor_alltoall_inter_sched_auto(const void *sendbuf, int sendcount,
-                                             MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                             MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                             MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoall_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                             MPI_Datatype sendtype, void *recvbuf,
+                                             MPI_Aint recvcount, MPI_Datatype recvtype,
+                                             MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype,
+                                                 MPI_Aint recvcount, MPI_Datatype recvtype,
                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
@@ -989,42 +1012,45 @@ int MPIR_Ineighbor_alltoallw_allcomm_sched_linear(const void *sendbuf, const int
 
 /******************************** Ireduce ********************************/
 /* request-based functions */
-int MPIR_Ireduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                              MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ireduce_intra_gentran_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                              MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
+                              MPIR_Request ** request);
+int MPIR_Ireduce_intra_gentran_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                     MPI_Datatype datatype, MPI_Op op, int root,
                                     MPIR_Comm * comm_ptr, int tree_type, int k, int maxbytes,
                                     int buffer_per_child, MPIR_Request ** request);
-int MPIR_Ireduce_intra_gentran_ring(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_intra_gentran_ring(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                     MPI_Datatype datatype, MPI_Op op, int root,
                                     MPIR_Comm * comm_ptr, int maxbytes, int buffer_per_child,
                                     MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ireduce_sched_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ireduce_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                            MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
+                            MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ireduce_intra_sched_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                   MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
                                   MPIR_Sched_t s);
-int MPIR_Ireduce_intra_sched_binomial(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_intra_sched_binomial(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                       MPI_Datatype datatype, MPI_Op op, int root,
                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ireduce_intra_sched_smp(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *recvbuf,
+                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
+                                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ireduce_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                  MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
                                  MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ireduce_inter_sched_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_inter_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                   MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
                                   MPIR_Sched_t s);
-int MPIR_Ireduce_inter_sched_local_reduce_remote_send(const void *sendbuf, void *recvbuf, int count,
-                                                      MPI_Datatype datatype, MPI_Op op, int root,
-                                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ireduce_inter_sched_local_reduce_remote_send(const void *sendbuf, void *recvbuf,
+                                                      MPI_Aint count, MPI_Datatype datatype,
+                                                      MPI_Op op, int root, MPIR_Comm * comm_ptr,
+                                                      MPIR_Sched_t s);
 
 
 /******************************** Ireduce_scatter ********************************/
@@ -1076,46 +1102,47 @@ int MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(const void *se
 
 /******************************** Ireduce_scatter_block ********************************/
 /* request-based functions */
-int MPIR_Ireduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, int recvcount,
+int MPIR_Ireduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                             MPIR_Request ** request);
 int MPIR_Ireduce_scatter_block_intra_gentran_recexch(const void *sendbuf, void *recvbuf,
-                                                     int recvcount, MPI_Datatype datatype,
+                                                     MPI_Aint recvcount, MPI_Datatype datatype,
                                                      MPI_Op op, MPIR_Comm * comm_ptr, int k,
                                                      MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ireduce_scatter_block_sched_auto(const void *sendbuf, void *recvbuf, int recvcount,
+int MPIR_Ireduce_scatter_block_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                           MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ireduce_scatter_block_intra_sched_auto(const void *sendbuf, void *recvbuf, int recvcount,
-                                                MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_block_intra_sched_auto(const void *sendbuf, void *recvbuf,
+                                                MPI_Aint recvcount, MPI_Datatype datatype,
+                                                MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_block_intra_sched_noncommutative(const void *sendbuf, void *recvbuf,
-                                                          int recvcount, MPI_Datatype datatype,
+                                                          MPI_Aint recvcount, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
                                                           MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_block_intra_sched_pairwise(const void *sendbuf, void *recvbuf,
-                                                    int recvcount, MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                    MPI_Aint recvcount, MPI_Datatype datatype,
+                                                    MPI_Op op, MPIR_Comm * comm_ptr,
+                                                    MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_block_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf,
-                                                              int recvcount, MPI_Datatype datatype,
-                                                              MPI_Op op, MPIR_Comm * comm_ptr,
-                                                              MPIR_Sched_t s);
+                                                              MPI_Aint recvcount,
+                                                              MPI_Datatype datatype, MPI_Op op,
+                                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_block_intra_sched_recursive_halving(const void *sendbuf, void *recvbuf,
-                                                             int recvcount, MPI_Datatype datatype,
-                                                             MPI_Op op, MPIR_Comm * comm_ptr,
-                                                             MPIR_Sched_t s);
+                                                             MPI_Aint recvcount,
+                                                             MPI_Datatype datatype, MPI_Op op,
+                                                             MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ireduce_scatter_block_inter_sched_auto(const void *sendbuf, void *recvbuf, int recvcount,
-                                                MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_block_inter_sched_auto(const void *sendbuf, void *recvbuf,
+                                                MPI_Aint recvcount, MPI_Datatype datatype,
+                                                MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv(const void *sendbuf,
                                                                         void *recvbuf,
-                                                                        int recvcount,
+                                                                        MPI_Aint recvcount,
                                                                         MPI_Datatype datatype,
                                                                         MPI_Op op,
                                                                         MPIR_Comm * comm_ptr,
@@ -1124,55 +1151,59 @@ int MPIR_Ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv(const vo
 
 /******************************** Iscan ********************************/
 /* request-based functions */
-int MPIR_Iscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request);
+int MPIR_Iscan_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                            MPIR_Request ** request);
 
 /* sched-based intracomm-only functions */
-int MPIR_Iscan_intra_sched_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iscan_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                 MPIR_Sched_t s);
-int MPIR_Iscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                               MPI_Datatype datatype, MPI_Op op,
                                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscan_intra_sched_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscan_intra_gentran_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iscan_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                               MPIR_Sched_t s);
+int MPIR_Iscan_intra_gentran_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 
 /******************************** Iscatter ********************************/
 /* request-based functions */
-int MPIR_Iscatter_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Iscatter_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iscatter_intra_gentran_tree(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                     MPIR_Comm * comm_ptr, int k, MPIR_Request ** request);
+int MPIR_Iscatter_intra_gentran_tree(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                     int root, MPIR_Comm * comm_ptr, int k,
+                                     MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Iscatter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Iscatter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                             void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Iscatter_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Iscatter_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                                       MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Iscatter_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscatter_inter_sched_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, int sendcount,
+int MPIR_Iscatter_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Iscatter_inter_sched_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                     int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
-                                                        int recvcount, MPI_Datatype recvtype,
+                                                        MPI_Aint recvcount, MPI_Datatype recvtype,
                                                         int root, MPIR_Comm * comm_ptr,
                                                         MPIR_Sched_t s);
 
@@ -1180,79 +1211,81 @@ int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, int
 /******************************** Iscatterv ********************************/
 /* request-based functions */
 int MPIR_Iscatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                 MPIR_Request ** request);
 int MPIR_Iscatterv_allcomm_gentran_linear(const void *sendbuf, const int *sendcounts,
                                           const int *displs, MPI_Datatype sendtype, void *recvbuf,
-                                          int recvcount, MPI_Datatype recvtype, int root,
+                                          MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                           MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
 int MPIR_Iscatterv_sched_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                              MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                               MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iscatterv_intra_sched_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                                    MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                    MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                     MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Iscatterv_inter_sched_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                                    MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                    MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                     MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Iscatterv_allcomm_sched_linear(const void *sendbuf, const int *sendcounts,
                                         const int *displs, MPI_Datatype sendtype, void *recvbuf,
-                                        int recvcount, MPI_Datatype recvtype, int root,
+                                        MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                         MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Neighbor_allgather ********************************/
 /* intracomm-only functions */
-int MPIR_Neighbor_allgather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                         MPIR_Comm * comm_ptr);
+int MPIR_Neighbor_allgather_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 /* intercomm-only functions */
 
 /* anycomm functions */
-int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr);
+int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 
 /******************************** Neighbor_allgatherv ********************************/
 /* intracomm-only functions */
-int MPIR_Neighbor_allgatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, const int recvcounts[], const int displs[],
+int MPIR_Neighbor_allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          const int recvcounts[], const int displs[],
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 /* intercomm-only functions */
 
 /* anycomm functions */
-int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, const int recvcounts[], const int displs[],
+int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        const int recvcounts[], const int displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 
 /******************************** Neighbor_alltoall ********************************/
 /* intracomm-only functions */
-int MPIR_Neighbor_alltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr);
+int MPIR_Neighbor_alltoall_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 /* intercomm-only functions */
 
 /* anycomm functions */
-int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr);
+int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 
 /******************************** Neighbor_alltoallv ********************************/
@@ -1291,28 +1324,31 @@ int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const int sendcounts
 
 /******************************** Reduce ********************************/
 /* intracomm-only functions */
-int MPIR_Reduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                             MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_intra_binomial(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Reduce_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                             MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
+                             MPIR_Errflag_t * errflag);
+int MPIR_Reduce_intra_binomial(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                               MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
+                               MPIR_Errflag_t * errflag);
+int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                             MPI_Datatype datatype, MPI_Op op, int root,
                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
                           MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
-int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op, int root,
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                           MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                           MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
+                           MPIR_Errflag_t * errflag);
 
 
 /******************************** Reduce_local ********************************/
-int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype datatype,
+int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
                       MPI_Op op);
 
 
@@ -1352,80 +1388,83 @@ int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const int
 
 /******************************** Reduce_scatter_block ********************************/
 /* intracomm-only functions */
-int MPIR_Reduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, int recvcount,
+int MPIR_Reduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                            MPIR_Errflag_t * errflag);
 int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf, void *recvbuf,
-                                                   int recvcount, MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf, void *recvbuf, int recvcount,
+                                                   MPI_Aint recvcount, MPI_Datatype datatype,
+                                                   MPI_Op op, MPIR_Comm * comm_ptr,
+                                                   MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                              MPIR_Errflag_t * errflag);
 int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
-                                                       int recvcount, MPI_Datatype datatype,
+                                                       MPI_Aint recvcount, MPI_Datatype datatype,
                                                        MPI_Op op, MPIR_Comm * comm_ptr,
                                                        MPIR_Errflag_t * errflag);
 int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf, void *recvbuf,
-                                                      int recvcount, MPI_Datatype datatype,
+                                                      MPI_Aint recvcount, MPI_Datatype datatype,
                                                       MPI_Op op, MPIR_Comm * comm_ptr,
                                                       MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
 int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *sendbuf, void *recvbuf,
-                                                                int recvcount,
+                                                                MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
                                                                 MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, int recvcount,
+int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                          MPIR_Errflag_t * errflag);
 
 
 /******************************** Scan ********************************/
 /* intracomm-only functions */
-int MPIR_Scan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                           MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Scan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Scan_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                           MPIR_Errflag_t * errflag);
+int MPIR_Scan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                        MPIR_Errflag_t * errflag);
-int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Scatter ********************************/
 /* intracomm-only functions */
-int MPIR_Scatter_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Scatter_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Scatter_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
-int MPIR_Scatter_inter_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, int sendcount,
+int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+                                                 MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                 int root, MPIR_Comm * comm_ptr,
+                                                 MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Scatter_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Scatter_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                            void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Scatterv ********************************/
 /* intracomm-only functions */
 int MPIR_Scatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                               MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                MPIR_Errflag_t * errflag);
 
@@ -1433,11 +1472,11 @@ int MPIR_Scatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const
 
 /* anycomm functions */
 int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const int *sendcounts, const int *displs,
-                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                 MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                  MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                  MPIR_Errflag_t * errflag);
 int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const int *sendcounts, const int *displs,
-                             MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                             MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                              MPIR_Errflag_t * errflag);
 

--- a/src/include/mpir_csel.h
+++ b/src/include/mpir_csel.h
@@ -64,15 +64,15 @@ typedef struct {
     union {
         struct {
             const void *sendbuf;
-            int sendcount;
+            MPI_Aint sendcount;
             MPI_Datatype sendtype;
             void *recvbuf;
-            int recvcount;
+            MPI_Aint recvcount;
             MPI_Datatype recvtype;
         } allgather, iallgather, neighbor_allgather, ineighbor_allgather;
         struct {
             const void *sendbuf;
-            int sendcount;
+            MPI_Aint sendcount;
             MPI_Datatype sendtype;
             void *recvbuf;
             const int *recvcounts;
@@ -82,15 +82,15 @@ typedef struct {
         struct {
             const void *sendbuf;
             void *recvbuf;
-            int count;
+            MPI_Aint count;
             MPI_Datatype datatype;
             MPI_Op op;
         } allreduce, iallreduce;
         struct {
             const void *sendbuf;
-            int sendcount;
+            MPI_Aint sendcount;
             MPI_Datatype sendtype;
-            int recvcount;
+            MPI_Aint recvcount;
             void *recvbuf;
             MPI_Datatype recvtype;
         } alltoall, ialltoall, neighbor_alltoall, ineighbor_alltoall;
@@ -129,29 +129,29 @@ typedef struct {
         } barrier, ibarrier;
         struct {
             void *buffer;
-            int count;
+            MPI_Aint count;
             MPI_Datatype datatype;
             int root;
         } bcast, ibcast;
         struct {
             const void *sendbuf;
             void *recvbuf;
-            int count;
+            MPI_Aint count;
             MPI_Datatype datatype;
             MPI_Op op;
         } exscan, iexscan;
         struct {
             const void *sendbuf;
-            int sendcount;
+            MPI_Aint sendcount;
             MPI_Datatype sendtype;
-            int recvcount;
+            MPI_Aint recvcount;
             void *recvbuf;
             MPI_Datatype recvtype;
             int root;
         } gather, igather, scatter, iscatter;
         struct {
             const void *sendbuf;
-            int sendcount;
+            MPI_Aint sendcount;
             MPI_Datatype sendtype;
             void *recvbuf;
             const int *recvcounts;
@@ -162,7 +162,7 @@ typedef struct {
         struct {
             const void *sendbuf;
             void *recvbuf;
-            int count;
+            MPI_Aint count;
             MPI_Datatype datatype;
             MPI_Op op;
             int root;
@@ -177,14 +177,14 @@ typedef struct {
         struct {
             const void *sendbuf;
             void *recvbuf;
-            int recvcount;
+            MPI_Aint recvcount;
             MPI_Datatype datatype;
             MPI_Op op;
         } reduce_scatter_block, ireduce_scatter_block;
         struct {
             const void *sendbuf;
             void *recvbuf;
-            int count;
+            MPI_Aint count;
             MPI_Datatype datatype;
             MPI_Op op;
         } scan, iscan;
@@ -193,7 +193,7 @@ typedef struct {
             const int *sendcounts;
             const int *displs;
             MPI_Datatype sendtype;
-            int recvcount;
+            MPI_Aint recvcount;
             void *recvbuf;
             MPI_Datatype recvtype;
             int root;

--- a/src/mpi/coll/allgather/allgather.c
+++ b/src/mpi/coll/allgather/allgather.c
@@ -80,10 +80,10 @@ cvars:
 */
 
 int MPIR_Allgather_allcomm_auto(const void *sendbuf,
-                                int sendcount,
+                                MPI_Aint sendcount,
                                 MPI_Datatype sendtype,
                                 void *recvbuf,
-                                int recvcount,
+                                MPI_Aint recvcount,
                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                 MPIR_Errflag_t * errflag)
 {
@@ -143,8 +143,8 @@ int MPIR_Allgather_allcomm_auto(const void *sendbuf,
     return mpi_errno;
 }
 
-int MPIR_Allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Allgather_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                        void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                         MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -211,8 +211,8 @@ int MPIR_Allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
     goto fn_exit;
 }
 
-int MPIR_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Allgather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/allgather/allgather_allcomm_nb.c
+++ b/src/mpi/coll/allgather/allgather_allcomm_nb.c
@@ -5,8 +5,8 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
@@ -12,9 +12,9 @@
  * broadcast.
  */
 
-int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, int sendcount,
+int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS, root;

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -15,10 +15,10 @@
  * where n is total size of data gathered on each process.
  */
 int MPIR_Allgather_intra_brucks(const void *sendbuf,
-                                int sendcount,
+                                MPI_Aint sendcount,
                                 MPI_Datatype sendtype,
                                 void *recvbuf,
-                                int recvcount,
+                                MPI_Aint recvcount,
                                 MPI_Datatype recvtype,
                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
@@ -18,10 +18,10 @@
  * PVM/MPI 2003).
  */
 int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
-                                            int sendcount,
+                                            MPI_Aint sendcount,
                                             MPI_Datatype sendtype,
                                             void *recvbuf,
-                                            int recvcount,
+                                            MPI_Aint recvcount,
                                             MPI_Datatype recvtype,
                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/allgather/allgather_intra_ring.c
+++ b/src/mpi/coll/allgather/allgather_intra_ring.c
@@ -21,10 +21,10 @@
  * Myrinet and IBM SP).
  */
 int MPIR_Allgather_intra_ring(const void *sendbuf,
-                              int sendcount,
+                              MPI_Aint sendcount,
                               MPI_Datatype sendtype,
                               void *recvbuf,
-                              int recvcount,
+                              MPI_Aint recvcount,
                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int comm_size, rank;

--- a/src/mpi/coll/allgatherv/allgatherv.c
+++ b/src/mpi/coll/allgatherv/allgatherv.c
@@ -67,7 +67,7 @@ cvars:
 */
 
 int MPIR_Allgatherv_allcomm_auto(const void *sendbuf,
-                                 int sendcount,
+                                 MPI_Aint sendcount,
                                  MPI_Datatype sendtype,
                                  void *recvbuf,
                                  const int *recvcounts,
@@ -136,7 +136,7 @@ int MPIR_Allgatherv_allcomm_auto(const void *sendbuf,
     goto fn_exit;
 }
 
-int MPIR_Allgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Allgatherv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                          void *recvbuf, const int *recvcounts, const int *displs,
                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -205,7 +205,7 @@ int MPIR_Allgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendty
     goto fn_exit;
 }
 
-int MPIR_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Allgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                     void *recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const int *recvcounts, const int *displs,
                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                MPIR_Errflag_t * errflag)

--- a/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
+++ b/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
@@ -15,7 +15,7 @@
  * intracommunicator broadcast.
  */
 
-int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, int sendcount,
+int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int *recvcounts, const int
                                                     *displs, MPI_Datatype recvtype,

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -17,7 +17,7 @@
  */
 
 int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
-                                 int sendcount,
+                                 MPI_Aint sendcount,
                                  MPI_Datatype sendtype,
                                  void *recvbuf,
                                  const int *recvcounts,

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -19,7 +19,7 @@
  */
 
 int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
-                                             int sendcount,
+                                             MPI_Aint sendcount,
                                              MPI_Datatype sendtype,
                                              void *recvbuf,
                                              const int *recvcounts,

--- a/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
@@ -23,7 +23,7 @@
  */
 
 int MPIR_Allgatherv_intra_ring(const void *sendbuf,
-                               int sendcount,
+                               MPI_Aint sendcount,
                                MPI_Datatype sendtype,
                                void *recvbuf,
                                const int *recvcounts,

--- a/src/mpi/coll/allreduce/allreduce.c
+++ b/src/mpi/coll/allreduce/allreduce.c
@@ -100,7 +100,7 @@ MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[] = {
 };
 
 
-int MPIR_Allreduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Allreduce_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                 MPIR_Errflag_t * errflag)
 {
@@ -159,7 +159,7 @@ int MPIR_Allreduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count,
     goto fn_exit;
 }
 
-int MPIR_Allreduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+int MPIR_Allreduce_impl(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -222,7 +222,7 @@ int MPIR_Allreduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datat
     goto fn_exit;
 }
 
-int MPIR_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+int MPIR_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
+++ b/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
@@ -5,8 +5,9 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                              MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;

--- a/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
+++ b/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
@@ -13,8 +13,8 @@
  * group.
  */
 
-int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbuf, int
-                                               count, MPI_Datatype datatype, MPI_Op op,
+int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                                               MPI_Datatype datatype, MPI_Op op,
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno;

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -19,7 +19,7 @@
 
 int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
                                             void *recvbuf,
-                                            int count,
+                                            MPI_Aint count,
                                             MPI_Datatype datatype,
                                             MPI_Op op,
                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -40,7 +40,7 @@
 
 int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
                                                   void *recvbuf,
-                                                  int count,
+                                                  MPI_Aint count,
                                                   MPI_Datatype datatype,
                                                   MPI_Op op,
                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)

--- a/src/mpi/coll/allreduce/allreduce_intra_smp.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_smp.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                              MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -15,7 +15,7 @@
         MPIR_Assert((cr_) != MPI_UNDEFINED);                                                                  \
     } while (0)
 
-int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, int count,
+int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                MPIR_Group * group_ptr, int tag, MPIR_Errflag_t * errflag)
 {
@@ -337,7 +337,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, int count,
     goto fn_exit;
 }
 
-int MPII_Allreduce_group(void *sendbuf, void *recvbuf, int count,
+int MPII_Allreduce_group(void *sendbuf, void *recvbuf, MPI_Aint count,
                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                          MPIR_Group * group_ptr, int tag, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/allreduce_group/allreduce_group.h
+++ b/src/mpi/coll/allreduce_group/allreduce_group.h
@@ -8,10 +8,10 @@
 #ifndef ALLREDUCE_GROUP_H_INCLUDED
 #define ALLREDUCE_GROUP_H_INCLUDED
 
-int MPII_Allreduce_group(void *sendbuf, void *recvbuf, int count,
+int MPII_Allreduce_group(void *sendbuf, void *recvbuf, MPI_Aint count,
                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                          MPIR_Group * group_ptr, int tag, MPIR_Errflag_t * errflag);
-int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, int count,
+int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                MPIR_Group * group_ptr, int tag, MPIR_Errflag_t * errflag);
 

--- a/src/mpi/coll/alltoall/alltoall.c
+++ b/src/mpi/coll/alltoall/alltoall.c
@@ -98,10 +98,10 @@ cvars:
 */
 
 int MPIR_Alltoall_allcomm_auto(const void *sendbuf,
-                               int sendcount,
+                               MPI_Aint sendcount,
                                MPI_Datatype sendtype,
                                void *recvbuf,
-                               int recvcount,
+                               MPI_Aint recvcount,
                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                MPIR_Errflag_t * errflag)
 {
@@ -172,8 +172,8 @@ int MPIR_Alltoall_allcomm_auto(const void *sendbuf,
     goto fn_exit;
 }
 
-int MPIR_Alltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Alltoall_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                       void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                        MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -245,8 +245,8 @@ int MPIR_Alltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
     goto fn_exit;
 }
 
-int MPIR_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Alltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
+++ b/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
@@ -5,8 +5,8 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                             void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
@@ -16,8 +16,8 @@
  * max_size if dst < remote_size.
  */
 
-int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, int sendcount,
-                                          MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, MPI_Aint sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                           MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -19,10 +19,10 @@
  * other processes.
  */
 int MPIR_Alltoall_intra_brucks(const void *sendbuf,
-                               int sendcount,
+                               MPI_Aint sendcount,
                                MPI_Datatype sendtype,
                                void *recvbuf,
-                               int recvcount,
+                               MPI_Aint recvcount,
                                MPI_Datatype recvtype,
                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
@@ -23,10 +23,10 @@
  * other processes.
  */
 int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
-                                 int sendcount,
+                                 MPI_Aint sendcount,
                                  MPI_Datatype sendtype,
                                  void *recvbuf,
-                                 int recvcount,
+                                 MPI_Aint recvcount,
                                  MPI_Datatype recvtype,
                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
@@ -20,10 +20,10 @@
  * MADRE is probably the best solution for the MPI_IN_PLACE scenario.
  */
 int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf,
-                                                  int sendcount,
+                                                  MPI_Aint sendcount,
                                                   MPI_Datatype sendtype,
                                                   void *recvbuf,
-                                                  int recvcount,
+                                                  MPI_Aint recvcount,
                                                   MPI_Datatype recvtype,
                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/alltoall/alltoall_intra_scattered.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_scattered.c
@@ -28,10 +28,10 @@
  */
 
 int MPIR_Alltoall_intra_scattered(const void *sendbuf,
-                                  int sendcount,
+                                  MPI_Aint sendcount,
                                   MPI_Datatype sendtype,
                                   void *recvbuf,
-                                  int recvcount,
+                                  MPI_Aint recvcount,
                                   MPI_Datatype recvtype,
                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/bcast/bcast.c
+++ b/src/mpi/coll/bcast/bcast.c
@@ -128,7 +128,7 @@ cvars:
 */
 
 
-int MPIR_Bcast_allcomm_auto(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Bcast_allcomm_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -184,8 +184,8 @@ int MPIR_Bcast_allcomm_auto(void *buffer, int count, MPI_Datatype datatype, int 
     return mpi_errno;
 }
 
-int MPIR_Bcast_impl(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * errflag)
+int MPIR_Bcast_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
+                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -247,7 +247,7 @@ int MPIR_Bcast_impl(void *buffer, int count, MPI_Datatype datatype, int root, MP
     goto fn_exit;
 }
 
-int MPIR_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
+int MPIR_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
                MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/bcast/bcast.h
+++ b/src/mpi/coll/bcast/bcast.h
@@ -8,8 +8,8 @@
 
 #include "mpiimpl.h"
 
-int MPII_Scatter_for_bcast(void *buffer, int count, MPI_Datatype datatype,
-                           int root, MPIR_Comm * comm_ptr, int nbytes, void *tmp_buf,
+int MPII_Scatter_for_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
+                           int root, MPIR_Comm * comm_ptr, MPI_Aint nbytes, void *tmp_buf,
                            int is_contig, MPIR_Errflag_t * errflag);
 
 #endif /* BCAST_H_INCLUDED */

--- a/src/mpi/coll/bcast/bcast_allcomm_nb.c
+++ b/src/mpi/coll/bcast/bcast_allcomm_nb.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Bcast_allcomm_nb(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Bcast_allcomm_nb(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
+++ b/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
@@ -12,7 +12,7 @@
  */
 
 int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
-                                             int count,
+                                             MPI_Aint count,
                                              MPI_Datatype datatype,
                                              int root,
                                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -11,7 +11,7 @@
  * Cost = lgp.alpha + n.lgp.beta
  */
 int MPIR_Bcast_intra_binomial(void *buffer,
-                              int count,
+                              MPI_Aint count,
                               MPI_Datatype datatype,
                               int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -26,7 +26,7 @@
  * Total Cost = 2.lgp.alpha + 2.n.((p-1)/p).beta
 */
 int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
-                                                          int count,
+                                                          MPI_Aint count,
                                                           MPI_Datatype datatype,
                                                           int root,
                                                           MPIR_Comm * comm_ptr,

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -22,7 +22,7 @@
  * Total Cost = (lgp+p-1).alpha + 2.n.((p-1)/p).beta
  */
 int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
-                                            int count,
+                                            MPI_Aint count,
                                             MPI_Datatype datatype,
                                             int root,
                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)

--- a/src/mpi/coll/bcast/bcast_intra_smp.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp.c
@@ -10,7 +10,7 @@
  * the cutoff points for these algorithms.  If I've done this right, you should
  * be able to make changes along these lines almost exclusively in this function
  * and some new functions. [goodell@ 2008/01/07] */
-int MPIR_Bcast_intra_smp(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                          MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -17,11 +17,11 @@
    At the moment this function always scatters a buffer of nbytes starting at
    tmp_buf address. */
 int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
-                           int count ATTRIBUTE((unused)),
+                           MPI_Aint count ATTRIBUTE((unused)),
                            MPI_Datatype datatype ATTRIBUTE((unused)),
                            int root,
                            MPIR_Comm * comm_ptr,
-                           int nbytes, void *tmp_buf, int is_contig, MPIR_Errflag_t * errflag)
+                           MPI_Aint nbytes, void *tmp_buf, int is_contig, MPIR_Errflag_t * errflag)
 {
     MPI_Status status;
     int rank, comm_size, src, dst;

--- a/src/mpi/coll/exscan/exscan.c
+++ b/src/mpi/coll/exscan/exscan.c
@@ -41,8 +41,9 @@ cvars:
 */
 
 
-int MPIR_Exscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                             MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Exscan_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                             MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -79,7 +80,7 @@ int MPIR_Exscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_
     return mpi_errno;
 }
 
-int MPIR_Exscan_impl(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Exscan_impl(const void *sendbuf, void *recvbuf, MPI_Aint count,
                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                      MPIR_Errflag_t * errflag)
 {
@@ -112,7 +113,7 @@ int MPIR_Exscan_impl(const void *sendbuf, void *recvbuf, int count,
     goto fn_exit;
 }
 
-int MPIR_Exscan(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/exscan/exscan_allcomm_nb.c
+++ b/src/mpi/coll/exscan/exscan_allcomm_nb.c
@@ -5,8 +5,9 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                           MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                           MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -46,7 +46,7 @@
 */
 int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
                                          void *recvbuf,
-                                         int count,
+                                         MPI_Aint count,
                                          MPI_Datatype datatype,
                                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/gather/gather.c
+++ b/src/mpi/coll/gather/gather.c
@@ -66,8 +66,8 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-int MPIR_Gather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Gather_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                             void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -121,8 +121,8 @@ int MPIR_Gather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype se
     return mpi_errno;
 }
 
-int MPIR_Gather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Gather_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                      int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -183,8 +183,8 @@ int MPIR_Gather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     goto fn_exit;
 }
 
-int MPIR_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Gather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                 int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/gather/gather_allcomm_nb.c
+++ b/src/mpi/coll/gather/gather_allcomm_nb.c
@@ -5,9 +5,9 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Gather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                           int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t * errflag)
+int MPIR_Gather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                           void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;

--- a/src/mpi/coll/gather/gather_inter_linear.c
+++ b/src/mpi/coll/gather/gather_inter_linear.c
@@ -13,8 +13,8 @@
  * Cost: p.alpha + n.beta
  */
 
-int MPIR_Gather_inter_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                             void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int remote_size, mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -13,9 +13,9 @@
  * Cost: (lgp+1).alpha + n.((p-1)/p).beta + n.beta
  */
 
-int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, int sendcount,
-                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                               MPI_Datatype recvtype, int root,
+int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sendcount,
+                                               MPI_Datatype sendtype, void *recvbuf,
+                                               MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -37,8 +37,8 @@ cvars:
  * Cost = lgp.alpha + n.((p-1)/p).beta where n is the total size of the data
  * gathered at the root.
  */
-int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int comm_size, rank;

--- a/src/mpi/coll/gatherv/gatherv.c
+++ b/src/mpi/coll/gatherv/gatherv.c
@@ -53,7 +53,7 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-int MPIR_Gatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Gatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                               void *recvbuf, const int *recvcounts, const int *displs,
                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                               MPIR_Errflag_t * errflag)
@@ -97,7 +97,7 @@ int MPIR_Gatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype s
     return mpi_errno;
 }
 
-int MPIR_Gatherv_impl(const void *sendbuf, int sendcount,
+int MPIR_Gatherv_impl(const void *sendbuf, MPI_Aint sendcount,
                       MPI_Datatype sendtype, void *recvbuf,
                       const int *recvcounts, const int *displs,
                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
@@ -157,7 +157,7 @@ int MPIR_Gatherv_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Gatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                  void *recvbuf, const int *recvcounts, const int *displs,
                  MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -36,7 +36,7 @@ cvars:
  * Cost = (p-1).alpha + n.((p-1)/p).beta
 */
 int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
-                                int sendcount,
+                                MPI_Aint sendcount,
                                 MPI_Datatype sendtype,
                                 void *recvbuf,
                                 const int *recvcounts,

--- a/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Gatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Gatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                             void *recvbuf, const int *recvcounts, const int *displs,
                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                             MPIR_Errflag_t * errflag)

--- a/src/mpi/coll/iallgather/iallgather.c
+++ b/src/mpi/coll/iallgather/iallgather.c
@@ -124,8 +124,8 @@ cvars:
    End Algorithm: MPI_Allgather
 */
 
-int MPIR_Iallgather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iallgather_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                  MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -219,8 +219,8 @@ int MPIR_Iallgather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatyp
     goto fn_exit;
 }
 
-int MPIR_Iallgather_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iallgather_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -256,8 +256,8 @@ int MPIR_Iallgather_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Dat
     goto fn_exit;
 }
 
-int MPIR_Iallgather_inter_sched_auto(const void *sendbuf, int sendcount,
-                                     MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_Iallgather_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                     MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -269,9 +269,9 @@ int MPIR_Iallgather_inter_sched_auto(const void *sendbuf, int sendcount,
     return mpi_errno;
 }
 
-int MPIR_Iallgather_sched_auto(const void *sendbuf, int sendcount,
+int MPIR_Iallgather_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                MPI_Datatype sendtype, void *recvbuf,
-                               int recvcount, MPI_Datatype recvtype,
+                               MPI_Aint recvcount, MPI_Datatype recvtype,
                                MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -287,8 +287,8 @@ int MPIR_Iallgather_sched_auto(const void *sendbuf, int sendcount,
     return mpi_errno;
 }
 
-int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
-                         MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_Iallgather_impl(const void *sendbuf, MPI_Aint sendcount,
+                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -397,8 +397,8 @@ int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iallgather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                     MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallgather/iallgather_inter_sched_local_gather_remote_bcast.c
+++ b/src/mpi/coll/iallgather/iallgather_inter_sched_local_gather_remote_bcast.c
@@ -11,9 +11,9 @@
  * intracommunicator, and then does an intercommunicator broadcast.
  */
 
-int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, int sendcount,
+int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
-                                                          int recvcount, MPI_Datatype recvtype,
+                                                          MPI_Aint recvcount, MPI_Datatype recvtype,
                                                           MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallgather/iallgather_intra_gentran_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_gentran_brucks.c
@@ -10,9 +10,10 @@
 #include "iallgather_tsp_brucks_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iallgather_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                         MPIR_Comm * comm_ptr, int k, MPIR_Request ** request)
+int MPIR_Iallgather_intra_gentran_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int k,
+                                         MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/iallgather/iallgather_intra_gentran_recexch_doubling.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_gentran_recexch_doubling.c
@@ -10,9 +10,9 @@
 #include "iallgather_tsp_recexch_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iallgather_intra_gentran_recexch_doubling(const void *sendbuf, int sendcount,
+int MPIR_Iallgather_intra_gentran_recexch_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm, int k, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallgather/iallgather_intra_gentran_recexch_halving.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_gentran_recexch_halving.c
@@ -10,9 +10,9 @@
 #include "iallgather_tsp_recexch_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iallgather_intra_gentran_recexch_halving(const void *sendbuf, int sendcount,
+int MPIR_Iallgather_intra_gentran_recexch_halving(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
                                                   MPIR_Comm * comm, int k, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallgather/iallgather_intra_gentran_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_gentran_ring.c
@@ -10,9 +10,9 @@
 #include "iallgather_tsp_ring_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iallgather_intra_gentran_ring(const void *sendbuf, int sendcount,
+int MPIR_Iallgather_intra_gentran_ring(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype sendtype, void *recvbuf,
-                                       int recvcount,
+                                       MPI_Aint recvcount,
                                        MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_brucks.c
@@ -14,9 +14,9 @@
  * Cost = lgp.alpha + n.((p-1)/p).beta
  * where n is total size of data gathered on each process.
  */
-int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int pof2, curr_cnt, rem, src, dst;

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_recursive_doubling.c
@@ -41,9 +41,9 @@ static int dtp_release_ref(MPIR_Comm * comm, int tag, void *state)
  * property of recursive doubling (see Benson et al paper in Euro
  * PVM/MPI 2003).
  */
-int MPIR_Iallgather_intra_sched_recursive_doubling(const void *sendbuf, int sendcount,
+int MPIR_Iallgather_intra_sched_recursive_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_ring.c
@@ -20,9 +20,9 @@
  * performs twice as fast as recursive doubling for long messages (on
  * Myrinet and IBM SP).
  */
-int MPIR_Iallgather_intra_sched_ring(const void *sendbuf, int sendcount, MPI_Datatype
-                                     sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Iallgather_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype
+                                     sendtype, void *recvbuf, MPI_Aint recvcount,
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size;

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
@@ -11,9 +11,9 @@
 #include "tsp_namespace_def.h"
 
 int
-MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
+MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype sendtype, void *recvbuf,
-                                       int recvcount, MPI_Datatype recvtype,
+                                       MPI_Aint recvcount, MPI_Datatype recvtype,
                                        MPIR_Comm * comm, MPIR_TSP_sched_t * sched, int k)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -173,8 +173,8 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
 
 
 /* Non-blocking brucks based Allgather */
-int MPIR_TSP_Iallgather_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_TSP_Iallgather_intra_brucks(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                      MPIR_Comm * comm_ptr, MPIR_Request ** req, int k)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos_prototypes.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos_prototypes.h
@@ -14,10 +14,10 @@
 #undef MPIR_TSP_Iallgather_sched_intra_brucks
 #define MPIR_TSP_Iallgather_sched_intra_brucks           MPIR_TSP_NAMESPACE(Iallgather_sched_intra_brucks)
 
-int MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
-                                           MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                            MPI_Datatype recvtype, MPIR_Comm * comm,
                                            MPIR_TSP_sched_t * s, int k);
-int MPIR_TSP_Iallgather_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_TSP_Iallgather_intra_brucks(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                      MPIR_Comm * comm_ptr, MPIR_Request ** request, int k);

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
@@ -13,7 +13,8 @@
 int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int nranks, int k, int p_of_k,
                                                           int log_pofk, int T, void *recvbuf,
                                                           MPI_Datatype recvtype, size_t recv_extent,
-                                                          int recvcount, int tag, MPIR_Comm * comm,
+                                                          MPI_Aint recvcount, int tag,
+                                                          MPIR_Comm * comm,
                                                           MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -55,7 +56,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int nranks, 
 int MPIR_TSP_Iallgather_sched_intra_recexch_step1(int step1_sendto, int *step1_recvfrom,
                                                   int step1_nrecvs, int is_inplace, int rank,
                                                   int tag, const void *sendbuf, void *recvbuf,
-                                                  size_t recv_extent, int recvcount,
+                                                  size_t recv_extent, MPI_Aint recvcount,
                                                   MPI_Datatype recvtype, int n_invtcs, int *invtx,
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
 {
@@ -93,7 +94,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int step2_np
                                                   int **step2_nbrs, int rank, int nranks, int k,
                                                   int p_of_k, int log_pofk, int T, int *nrecvs_,
                                                   int **recv_id_, int tag, void *recvbuf,
-                                                  size_t recv_extent, int recvcount,
+                                                  size_t recv_extent, MPI_Aint recvcount,
                                                   MPI_Datatype recvtype, int is_dist_halving,
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
 {
@@ -163,8 +164,8 @@ int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int step2_np
 
 int MPIR_TSP_Iallgather_sched_intra_recexch_step3(int step1_sendto, int *step1_recvfrom,
                                                   int step1_nrecvs, int step2_nphases,
-                                                  void *recvbuf, int recvcount, int nranks, int k,
-                                                  int nrecvs, int *recv_id, int tag,
+                                                  void *recvbuf, MPI_Aint recvcount, int nranks,
+                                                  int k, int nrecvs, int *recv_id, int tag,
                                                   MPI_Datatype recvtype, MPIR_Comm * comm,
                                                   MPIR_TSP_sched_t * sched)
 {
@@ -198,10 +199,11 @@ int MPIR_TSP_Iallgather_sched_intra_recexch_step3(int step1_sendto, int *step1_r
  * paper, Sack et al, "Faster topology-aware collective algorithms through
  * non-minimal communication", 2012.
  * */
-int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, int sendcount,
-                                            MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                            int is_dist_halving, int k, MPIR_TSP_sched_t * sched)
+int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
+                                            MPI_Datatype sendtype, void *recvbuf,
+                                            MPI_Aint recvcount, MPI_Datatype recvtype,
+                                            MPIR_Comm * comm, int is_dist_halving, int k,
+                                            MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_inplace, i;
@@ -302,10 +304,10 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, int sendcount,
 
 
 /* Non-blocking recexch based Allgather */
-int MPIR_TSP_Iallgather_intra_recexch(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm, MPIR_Request ** req, int allgather_type,
-                                      int k)
+int MPIR_TSP_Iallgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                      MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req,
+                                      int allgather_type, int k)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos_prototypes.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos_prototypes.h
@@ -25,14 +25,14 @@
 int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int nranks, int k, int p_of_k,
                                                           int log_pofk, int T, void *recvbuf,
                                                           MPI_Datatype recvtype, size_t recv_extent,
-                                                          int recvcount, int tag,
+                                                          MPI_Aint recvcount, int tag,
                                                           MPIR_Comm * comm,
                                                           MPIR_TSP_sched_t * sched);
 
 int MPIR_TSP_Iallgather_sched_intra_recexch_step1(int step1_sendto, int *step1_recvfrom,
                                                   int step1_nrecvs, int is_inplace, int rank,
                                                   int tag, const void *sendbuf, void *recvbuf,
-                                                  size_t recv_extent, int recvcount,
+                                                  size_t recv_extent, MPI_Aint recvcount,
                                                   MPI_Datatype recvtype, int n_invtcs, int *invtx,
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t * sched);
 
@@ -40,23 +40,24 @@ int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int step2_np
                                                   int **step2_nbrs, int rank, int nranks, int k,
                                                   int p_of_k, int log_pofk, int T, int *nrecvs_,
                                                   int **recv_id_, int tag, void *recvbuf,
-                                                  size_t recv_extent, int recvcount,
+                                                  size_t recv_extent, MPI_Aint recvcount,
                                                   MPI_Datatype recvtype, int is_dist_halving,
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t * sched);
 
 int MPIR_TSP_Iallgather_sched_intra_recexch_step3(int step1_sendto, int *step1_recvfrom,
                                                   int step1_nrecvs, int step2_nphases,
-                                                  void *recvbuf, int recvcount, int nranks, int k,
-                                                  int nrecvs, int *recv_id, int tag,
+                                                  void *recvbuf, MPI_Aint recvcount, int nranks,
+                                                  int k, int nrecvs, int *recv_id, int tag,
                                                   MPI_Datatype recvtype, MPIR_Comm * comm,
                                                   MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, int sendcount,
-                                            MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                            int is_dist_halving, int k, MPIR_TSP_sched_t * sched);
+int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
+                                            MPI_Datatype sendtype, void *recvbuf,
+                                            MPI_Aint recvcount, MPI_Datatype recvtype,
+                                            MPIR_Comm * comm, int is_dist_halving, int k,
+                                            MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Iallgather_intra_recexch(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm, MPIR_Request ** req, int allgather_type,
-                                      int k);
+int MPIR_TSP_Iallgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                      MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req,
+                                      int allgather_type, int k);

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
@@ -10,9 +10,9 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a ring based allgather */
-int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount,
+int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                          MPI_Datatype sendtype, void *recvbuf,
-                                         int recvcount, MPI_Datatype recvtype,
+                                         MPI_Aint recvcount, MPI_Datatype recvtype,
                                          MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -148,8 +148,8 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount,
 }
 
 /* Non-blocking ring based Allgather */
-int MPIR_TSP_Iallgather_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_TSP_Iallgather_intra_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                    MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring_algos_prototypes.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring_algos_prototypes.h
@@ -14,11 +14,11 @@
 #undef MPIR_TSP_Iallgather_sched_intra_ring
 #define MPIR_TSP_Iallgather_sched_intra_ring                MPIR_TSP_NAMESPACE(Iallgather_sched_intra_ring)
 
-int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount,
-                                         MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                          MPI_Datatype recvtype, MPIR_Comm * comm,
                                          MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Iallgather_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_TSP_Iallgather_intra_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                    MPIR_Comm * comm, MPIR_Request ** req);

--- a/src/mpi/coll/iallgatherv/iallgatherv.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv.c
@@ -117,7 +117,7 @@ cvars:
    End Algorithm: MPI_Allgatherv
 */
 
-int MPIR_Iallgatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Iallgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, const int *recvcounts, const int *displs,
                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                   MPIR_Request ** request)
@@ -217,9 +217,10 @@ int MPIR_Iallgatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Dataty
     goto fn_exit;
 }
 
-int MPIR_Iallgatherv_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Iallgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
+                                      const int displs[], MPI_Datatype recvtype,
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, comm_size, total_count, recvtype_size;
@@ -265,9 +266,10 @@ int MPIR_Iallgatherv_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Da
     goto fn_exit;
 }
 
-int MPIR_Iallgatherv_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Iallgatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
+                                      const int displs[], MPI_Datatype recvtype,
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -279,7 +281,7 @@ int MPIR_Iallgatherv_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Da
     return mpi_errno;
 }
 
-int MPIR_Iallgatherv_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Iallgatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, const int recvcounts[], const int displs[],
                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
@@ -298,7 +300,7 @@ int MPIR_Iallgatherv_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype
     return mpi_errno;
 }
 
-int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Iallgatherv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                           void *recvbuf, const int recvcounts[], const int displs[],
                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
@@ -430,7 +432,7 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
     goto fn_exit;
 }
 
-int MPIR_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Iallgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                      void *recvbuf, const int recvcounts[], const int displs[],
                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {

--- a/src/mpi/coll/iallgatherv/iallgatherv_inter_sched_remote_gather_local_bcast.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_inter_sched_remote_gather_local_bcast.c
@@ -16,7 +16,7 @@
  * intracommunicator broadcast.
  */
 
-int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, int sendcount,
+int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            const int recvcounts[],
                                                            const int displs[],

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_brucks.c
@@ -10,8 +10,9 @@
 #include "iallgatherv_tsp_brucks_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iallgatherv_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, const int recvcounts[], const int displs[],
+int MPIR_Iallgatherv_intra_gentran_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          const int recvcounts[], const int displs[],
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int k,
                                           MPIR_Request ** request)
 {

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_recexch_doubling.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_recexch_doubling.c
@@ -10,7 +10,7 @@
 #include "iallgatherv_tsp_recexch_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iallgatherv_intra_gentran_recexch_doubling(const void *sendbuf, int sendcount,
+int MPIR_Iallgatherv_intra_gentran_recexch_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int *recvcounts, const int *displs,
                                                     MPI_Datatype recvtype, MPIR_Comm * comm, int k,

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_recexch_halving.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_recexch_halving.c
@@ -10,7 +10,7 @@
 #include "iallgatherv_tsp_recexch_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iallgatherv_intra_gentran_recexch_halving(const void *sendbuf, int sendcount,
+int MPIR_Iallgatherv_intra_gentran_recexch_halving(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int *recvcounts, const int *displs,
                                                    MPI_Datatype recvtype, MPIR_Comm * comm, int k,

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_ring.c
@@ -10,7 +10,7 @@
 #include "iallgatherv_tsp_ring_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iallgatherv_intra_gentran_ring(const void *sendbuf, int sendcount,
+int MPIR_Iallgatherv_intra_gentran_ring(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype sendtype, void *recvbuf,
                                         const int *recvcounts, const int *displs,
                                         MPI_Datatype recvtype, MPIR_Comm * comm,

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
@@ -5,8 +5,9 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, const int recvcounts[], const int displs[],
+int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        const int recvcounts[], const int displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, int sendcount,
+int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int recvcounts[], const int displs[],
                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_ring.c
@@ -5,9 +5,10 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Iallgatherv_intra_sched_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Iallgatherv_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
+                                      const int displs[], MPI_Datatype recvtype,
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, total_count;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
@@ -30,8 +30,9 @@
  */
 
 int
-MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, const int recvcounts[], const int displs[],
+MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        const int recvcounts[], const int displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm,
                                         MPIR_TSP_sched_t * sched, int k)
 {
@@ -315,10 +316,10 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
 }
 
 /* Non-blocking brucks based Allgatherv */
-int MPIR_TSP_Iallgatherv_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                      MPIR_Request ** req, int k)
+int MPIR_TSP_Iallgatherv_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
+                                      const int displs[], MPI_Datatype recvtype,
+                                      MPIR_Comm * comm_ptr, MPIR_Request ** req, int k)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_IALLGATHERV_INTRA_BRUCKS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TSP_IALLGATHERV_INTRA_BRUCKS);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos_prototypes.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos_prototypes.h
@@ -14,12 +14,12 @@
 #undef MPIR_TSP_Iallgatherv_sched_intra_brucks
 #define MPIR_TSP_Iallgatherv_sched_intra_brucks           MPIR_TSP_NAMESPACE(Iallgatherv_sched_intra_brucks)
 
-int MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount,
+int MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                             MPI_Datatype sendtype, void *recvbuf,
                                             const int recvcounts[], const int displs[],
                                             MPI_Datatype recvtype, MPIR_Comm * comm,
                                             MPIR_TSP_sched_t * s, int k);
-int MPIR_TSP_Iallgatherv_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                      MPIR_Request ** request, int k);
+int MPIR_TSP_Iallgatherv_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
+                                      const int displs[], MPI_Datatype recvtype,
+                                      MPIR_Comm * comm_ptr, MPIR_Request ** request, int k);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
@@ -214,7 +214,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step3(int step1_sendto, int *step1_
 }
 
 /* Routine to schedule a recursive exchange based allgather */
-int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, int sendcount,
+int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
                                              const int *recvcounts, const int *displs,
                                              MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -326,10 +326,10 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, int sendcount,
 
 
 /* Non-blocking recexch based Allgather */
-int MPIR_TSP_Iallgatherv_intra_recexch(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, const int *recvcounts, const int *displs,
-                                       MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req,
-                                       int algo_type, int k)
+int MPIR_TSP_Iallgatherv_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
+                                       const int *displs, MPI_Datatype recvtype, MPIR_Comm * comm,
+                                       MPIR_Request ** req, int algo_type, int k)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos_prototypes.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos_prototypes.h
@@ -54,13 +54,13 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step3(int step1_sendto, int *step1_
                                                    MPI_Datatype recvtype, MPIR_Comm * comm,
                                                    MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, int sendcount,
+int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
                                              const int *recvcounts, const int *displs,
                                              MPI_Datatype recvtype, MPIR_Comm * comm,
                                              int is_dist_halving, int k, MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Iallgatherv_intra_recexch(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, const int *recvcounts, const int *displs,
-                                       MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req,
-                                       int allgatherv_type, int k);
+int MPIR_TSP_Iallgatherv_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
+                                       const int *displs, MPI_Datatype recvtype, MPIR_Comm * comm,
+                                       MPIR_Request ** req, int allgatherv_type, int k);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
@@ -11,7 +11,7 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a recursive exchange based allgatherv */
-int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount,
+int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf,
                                           const int *recvcounts, const int *displs,
                                           MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -147,7 +147,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount,
 
 
 /* Non-blocking ring based Allgatherv */
-int MPIR_TSP_Iallgatherv_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_TSP_Iallgatherv_intra_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                     void *recvbuf, const int *recvcounts, const int *displs,
                                     MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req)
 {

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos_prototypes.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos_prototypes.h
@@ -14,12 +14,12 @@
 #undef MPIR_TSP_Iallgatherv_sched_intra_ring
 #define MPIR_TSP_Iallgatherv_sched_intra_ring                MPIR_TSP_NAMESPACE(Iallgatherv_sched_intra_ring)
 
-int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount,
+int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf,
                                           const int *recvcounts, const int *displs,
                                           MPI_Datatype recvtype, MPIR_Comm * comm,
                                           MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Iallgatherv_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_TSP_Iallgatherv_intra_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                     void *recvbuf, const int *recvcounts, const int *displs,
                                     MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req);

--- a/src/mpi/coll/iallreduce/iallreduce.c
+++ b/src/mpi/coll/iallreduce/iallreduce.c
@@ -121,7 +121,7 @@ cvars:
 */
 
 
-int MPIR_Iallreduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                  MPIR_Request ** request)
 {
@@ -234,7 +234,7 @@ int MPIR_Iallreduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count,
     goto fn_exit;
 }
 
-int MPIR_Iallreduce_intra_sched_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                      MPIR_Sched_t s)
 {
@@ -287,7 +287,7 @@ int MPIR_Iallreduce_intra_sched_auto(const void *sendbuf, void *recvbuf, int cou
     goto fn_exit;
 }
 
-int MPIR_Iallreduce_inter_sched_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_inter_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                      MPIR_Sched_t s)
 {
@@ -300,8 +300,9 @@ int MPIR_Iallreduce_inter_sched_auto(const void *sendbuf, void *recvbuf, int cou
 }
 
 
-int MPIR_Iallreduce_sched_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Iallreduce_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                               MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -316,7 +317,7 @@ int MPIR_Iallreduce_sched_auto(const void *sendbuf, void *recvbuf, int count, MP
     return mpi_errno;
 }
 
-int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, MPI_Aint count,
                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                          MPIR_Request ** request)
 {
@@ -457,7 +458,7 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
     goto fn_exit;
 }
 
-int MPIR_Iallreduce(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallreduce/iallreduce_inter_sched_remote_reduce_local_bcast.c
+++ b/src/mpi/coll/iallreduce/iallreduce_inter_sched_remote_reduce_local_bcast.c
@@ -17,7 +17,7 @@
  */
 
 int MPIR_Iallreduce_inter_sched_remote_reduce_local_bcast(const void *sendbuf, void *recvbuf,
-                                                          int count, MPI_Datatype datatype,
+                                                          MPI_Aint count, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
                                                           MPIR_Sched_t s)
 {

--- a/src/mpi/coll/iallreduce/iallreduce_intra_gentran_recexch_multiple_buffer.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_gentran_recexch_multiple_buffer.c
@@ -11,7 +11,7 @@
 #include "tsp_undef.h"
 
 int MPIR_Iallreduce_intra_gentran_recexch_multiple_buffer(const void *sendbuf, void *recvbuf,
-                                                          int count, MPI_Datatype datatype,
+                                                          MPI_Aint count, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm, int k,
                                                           MPIR_Request ** req)
 {

--- a/src/mpi/coll/iallreduce/iallreduce_intra_gentran_recexch_reduce_scatter_recexch_allgatherv.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_gentran_recexch_reduce_scatter_recexch_allgatherv.c
@@ -12,7 +12,7 @@
 
 int MPIR_Iallreduce_intra_gentran_recexch_reduce_scatter_recexch_allgatherv(const void *sendbuf,
                                                                             void *recvbuf,
-                                                                            int count,
+                                                                            MPI_Aint count,
                                                                             MPI_Datatype datatype,
                                                                             MPI_Op op,
                                                                             MPIR_Comm * comm, int k,

--- a/src/mpi/coll/iallreduce/iallreduce_intra_gentran_recexch_single_buffer.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_gentran_recexch_single_buffer.c
@@ -11,8 +11,8 @@
 #include "tsp_undef.h"
 
 int MPIR_Iallreduce_intra_gentran_recexch_single_buffer(const void *sendbuf, void *recvbuf,
-                                                        int count, MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm, int k,
+                                                        MPI_Aint count, MPI_Datatype datatype,
+                                                        MPI_Op op, MPIR_Comm * comm, int k,
                                                         MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallreduce/iallreduce_intra_gentran_ring.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_gentran_ring.c
@@ -10,7 +10,7 @@
 #include "iallreduce_tsp_ring_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iallreduce_intra_gentran_ring(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_intra_gentran_ring(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                        MPI_Datatype datatype, MPI_Op op,
                                        MPIR_Comm * comm, MPIR_Request ** req)
 {

--- a/src/mpi/coll/iallreduce/iallreduce_intra_gentran_tree.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_gentran_tree.c
@@ -10,7 +10,7 @@
 #include "iallreduce_tsp_tree_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iallreduce_intra_gentran_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_intra_gentran_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                        int tree_type, int k, int chunk_size, int buffer_per_child,
                                        MPIR_Request ** request)

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_naive.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_naive.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 /* implements the naive intracomm allreduce, that is, reduce followed by bcast */
-int MPIR_Iallreduce_intra_sched_naive(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_intra_sched_naive(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                       MPIR_Sched_t s)
 {

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_recursive_doubling.c
@@ -5,8 +5,8 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op,
+int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf,
+                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_reduce_scatter_allgather.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_reduce_scatter_allgather.c
@@ -7,7 +7,7 @@
 
 /* also known as "Rabenseifner's algorithm" */
 int MPIR_Iallreduce_intra_sched_reduce_scatter_allgather(const void *sendbuf, void *recvbuf,
-                                                         int count, MPI_Datatype datatype,
+                                                         MPI_Aint count, MPI_Datatype datatype,
                                                          MPI_Op op, MPIR_Comm * comm_ptr,
                                                          MPIR_Sched_t s)
 {

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_smp.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_smp.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 
-int MPIR_Iallreduce_intra_sched_smp(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iallreduce_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                     MPIR_Sched_t s)
 {

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
@@ -13,7 +13,7 @@
 #include "iallreduce_tsp_recursive_exchange_common_prototypes.h"
 
 /* Routine to schedule a recursive exchange based allreduce */
-int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                             MPI_Datatype datatype, MPI_Op op,
                                             MPIR_Comm * comm, int per_nbr_buffer, int k,
                                             MPIR_TSP_sched_t * sched)
@@ -310,7 +310,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
 
 
 /* Non-blocking recexch based ALLREDUCE */
-int MPIR_TSP_Iallreduce_intra_recexch(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_intra_recexch(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                       MPIR_Request ** req, int recexch_type, int k)
 {

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos_prototypes.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos_prototypes.h
@@ -14,12 +14,12 @@
 #undef MPIR_TSP_Iallreduce_sched_intra_recexch
 #define MPIR_TSP_Iallreduce_sched_intra_recexch                MPIR_TSP_NAMESPACE(Iallreduce_sched_intra_recexch)
 
-int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                             MPI_Datatype datatype, MPI_Op op,
                                             MPIR_Comm * comm, int recexch_type, int k,
                                             MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Iallreduce_intra_recexch(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_intra_recexch(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                       MPI_Datatype datatype, MPI_Op op,
                                       MPIR_Comm * comm, MPIR_Request ** req, int recexch_type,
                                       int k);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv_algos.h
@@ -16,7 +16,7 @@
 /* Routine to schedule a recursive exchange based allreduce */
 int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(const void *sendbuf,
                                                                               void *recvbuf,
-                                                                              int count,
+                                                                              MPI_Aint count,
                                                                               MPI_Datatype datatype,
                                                                               MPI_Op op,
                                                                               MPIR_Comm * comm,
@@ -182,7 +182,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
 
 /* Non-blocking recexch_reduce_scatter_recexch_allgatherv based ALLREDUCE */
 int MPIR_TSP_Iallreduce_intra_recexch_reduce_scatter_recexch_allgatherv(const void *sendbuf,
-                                                                        void *recvbuf, int count,
+                                                                        void *recvbuf,
+                                                                        MPI_Aint count,
                                                                         MPI_Datatype datatype,
                                                                         MPI_Op op, MPIR_Comm * comm,
                                                                         MPIR_Request ** req, int k)

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv_algos_prototypes.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv_algos_prototypes.h
@@ -16,7 +16,7 @@
 
 int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(const void *sendbuf,
                                                                               void *recvbuf,
-                                                                              int count,
+                                                                              MPI_Aint count,
                                                                               MPI_Datatype datatype,
                                                                               MPI_Op op,
                                                                               MPIR_Comm * comm,
@@ -25,7 +25,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
                                                                               sched);
 
 int MPIR_TSP_Iallreduce_intra_recexch_reduce_scatter_recexch_allgatherv(const void *sendbuf,
-                                                                        void *recvbuf, int count,
+                                                                        void *recvbuf,
+                                                                        MPI_Aint count,
                                                                         MPI_Datatype datatype,
                                                                         MPI_Op op, MPIR_Comm * comm,
                                                                         MPIR_Request ** req, int k);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.h
@@ -42,7 +42,7 @@ Input Parameters:
 
 int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                                                   void *recvbuf,
-                                                  int count,
+                                                  MPI_Aint count,
                                                   MPI_Datatype datatype,
                                                   MPI_Op op, int is_commutative, int tag,
                                                   int extent, int dtcopy_id, int *recv_id,

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common_prototypes.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common_prototypes.h
@@ -14,7 +14,7 @@
 
 int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                                                   void *recvbuf,
-                                                  int count,
+                                                  MPI_Aint count,
                                                   MPI_Datatype datatype,
                                                   MPI_Op op, int is_commutative, int tag,
                                                   int extent, int dtcopy_id, int *recv_id,

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_ring_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_ring_algos.h
@@ -15,7 +15,7 @@
  * The implementation is based on Baidu's ring algorithm
  * for Machine Learning/Deep Learning. The algorithm is
  * explained here: http://andrew.gibiansky.com/ */
-int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                          MPI_Datatype datatype, MPI_Op op,
                                          MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
 {
@@ -122,7 +122,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, int
 }
 
 /* Non-blocking ring based Allreduce */
-int MPIR_TSP_Iallreduce_intra_ring(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_intra_ring(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                    MPIR_Request ** req)
 {

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_ring_algos_prototypes.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_ring_algos_prototypes.h
@@ -14,10 +14,10 @@
 #undef MPIR_TSP_Iallreduce_sched_intra_ring
 #define MPIR_TSP_Iallreduce_sched_intra_ring                MPIR_TSP_NAMESPACE(Iallreduce_sched_intra_ring)
 
-int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                          MPI_Datatype datatype, MPI_Op op,
                                          MPIR_Comm * comm, MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Iallreduce_intra_ring(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_intra_ring(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                    MPI_Datatype datatype, MPI_Op op,
                                    MPIR_Comm * comm, MPIR_Request ** req);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
@@ -12,7 +12,7 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a pipelined tree based allreduce */
-int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                          MPI_Datatype datatype, MPI_Op op,
                                          MPIR_Comm * comm, int tree_type, int k, int chunk_size,
                                          int buffer_per_child, MPIR_TSP_sched_t * sched)
@@ -223,7 +223,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
 
 
 /* Non-blocking tree based allreduce */
-int MPIR_TSP_Iallreduce_intra_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_intra_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                    MPIR_Request ** req, int tree_type, int k, int chunk_size,
                                    int buffer_per_child)

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos_prototypes.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos_prototypes.h
@@ -14,11 +14,11 @@
 #undef MPIR_TSP_Iallreduce_sched_intra_tree
 #define MPIR_TSP_Iallreduce_sched_intra_tree                MPIR_TSP_NAMESPACE(Iallreduce_sched_intra_tree)
 
-int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                          MPI_Datatype datatype, MPI_Op op,
                                          MPIR_Comm * comm, int tree_type, int k, int segsize,
                                          int buffer_per_child, MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Iallreduce_intra_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iallreduce_intra_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                    MPIR_Request ** req, int tree_type, int k, int segsize,
                                    int buffer_per_child);

--- a/src/mpi/coll/ialltoall/ialltoall.c
+++ b/src/mpi/coll/ialltoall/ialltoall.c
@@ -105,8 +105,8 @@ cvars:
    End Algorithm: MPI_Alltoall
 */
 
-int MPIR_Ialltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Ialltoall_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                 MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -197,8 +197,8 @@ int MPIR_Ialltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype
     goto fn_exit;
 }
 
-int MPIR_Ialltoall_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Ialltoall_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -235,9 +235,9 @@ int MPIR_Ialltoall_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Data
 }
 
 
-int MPIR_Ialltoall_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype
-                                    sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ialltoall_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype
+                                    sendtype, void *recvbuf, MPI_Aint recvcount,
+                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -248,8 +248,8 @@ int MPIR_Ialltoall_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Data
     return mpi_errno;
 }
 
-int MPIR_Ialltoall_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Ialltoall_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                               MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -265,8 +265,8 @@ int MPIR_Ialltoall_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype s
     return mpi_errno;
 }
 
-int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
-                        MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_Ialltoall_impl(const void *sendbuf, MPI_Aint sendcount,
+                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -371,8 +371,8 @@ int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Ialltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                    MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ialltoall/ialltoall_inter_sched_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoall/ialltoall_inter_sched_pairwise_exchange.c
@@ -16,9 +16,9 @@
  * max_size if dst < remote_size.
  */
 
-int MPIR_Ialltoall_inter_sched_pairwise_exchange(const void *sendbuf, int sendcount,
+int MPIR_Ialltoall_inter_sched_pairwise_exchange(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype,
+                                                 MPI_Aint recvcount, MPI_Datatype recvtype,
                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ialltoall/ialltoall_intra_gentran_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_gentran_brucks.c
@@ -10,10 +10,10 @@
 #include "ialltoall_tsp_brucks_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ialltoall_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, int k, int buffer_per_phase,
-                                        MPIR_Request ** request)
+int MPIR_Ialltoall_intra_gentran_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int k,
+                                        int buffer_per_phase, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/ialltoall/ialltoall_intra_gentran_ring.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_gentran_ring.c
@@ -10,9 +10,9 @@
 #include "ialltoall_tsp_ring_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ialltoall_intra_gentran_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm, MPIR_Request ** req)
+int MPIR_Ialltoall_intra_gentran_ring(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                      MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/ialltoall/ialltoall_intra_gentran_scattered.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_gentran_scattered.c
@@ -10,9 +10,9 @@
 #include "ialltoall_tsp_scattered_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ialltoall_intra_gentran_scattered(const void *sendbuf, int sendcount,
+int MPIR_Ialltoall_intra_gentran_scattered(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
-                                           int recvcount,
+                                           MPI_Aint recvcount,
                                            MPI_Datatype recvtype, MPIR_Comm * comm, int batch_size,
                                            int bblock, MPIR_Request ** req)
 {

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
@@ -18,9 +18,9 @@
  * where n is the total amount of data a process needs to send to all
  * other processes.
  */
-int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_inplace.c
@@ -17,9 +17,9 @@
  * Note that this is not an especially efficient algorithm in terms of time.
  * Something like MADRE is probably the best solution for the MPI_IN_PLACE
  * scenario. */
-int MPIR_Ialltoall_intra_sched_inplace(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ialltoall_intra_sched_inplace(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     void *tmp_buf = NULL;

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_pairwise.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_pairwise.c
@@ -22,9 +22,9 @@
  * where n is the total amount of data a process needs to send to all
  * other processes.
  */
-int MPIR_Ialltoall_intra_sched_pairwise(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ialltoall_intra_sched_pairwise(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_permuted_sendrecv.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_permuted_sendrecv.c
@@ -13,9 +13,9 @@
  *
  * We use this as our medium-sized-message algorithm.
  */
-int MPIR_Ialltoall_intra_sched_permuted_sendrecv(const void *sendbuf, int sendcount,
+int MPIR_Ialltoall_intra_sched_permuted_sendrecv(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype,
+                                                 MPI_Aint recvcount, MPI_Datatype recvtype,
                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
@@ -114,10 +114,10 @@ brucks_sched_pup(int pack, void *rbuf, void *pupbuf, MPI_Datatype rtype, int cou
 }
 
 int
-MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm, MPIR_TSP_sched_t * sched, int k,
-                                      int buffer_per_phase)
+MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                      MPI_Datatype recvtype, MPIR_Comm * comm,
+                                      MPIR_TSP_sched_t * sched, int k, int buffer_per_phase)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, j;
@@ -378,8 +378,8 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
 }
 
 /* Non-blocking brucks based Alltoall */
-int MPIR_TSP_Ialltoall_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_TSP_Ialltoall_intra_brucks(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                     MPIR_Comm * comm_ptr, MPIR_Request ** req, int k,
                                     int buffer_per_phase)
 {

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos_prototypes.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos_prototypes.h
@@ -14,11 +14,11 @@
 #undef MPIR_TSP_Ialltoall_sched_intra_brucks
 #define MPIR_TSP_Ialltoall_sched_intra_brucks           MPIR_TSP_NAMESPACE(Ialltoall_sched_intra_brucks)
 
-int MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                          MPIR_Comm * comm, MPIR_TSP_sched_t * s, int k,
-                                          int buffer_per_phase);
-int MPIR_TSP_Ialltoall_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                          MPI_Datatype recvtype, MPIR_Comm * comm,
+                                          MPIR_TSP_sched_t * s, int k, int buffer_per_phase);
+int MPIR_TSP_Ialltoall_intra_brucks(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                     MPIR_Comm * comm_ptr, MPIR_Request ** request, int k,
                                     int buffer_per_phase);

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
@@ -37,9 +37,10 @@ copy (buf1)<--recv (buf1)            send (buf2)   /
 */
 
 /* Routine to schedule a ring based allgather */
-int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
+int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                        MPI_Datatype recvtype, MPIR_Comm * comm,
+                                        MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, src, dst, copy_dst;
@@ -180,8 +181,8 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, int sendcount, MPI_
 }
 
 /* Non-blocking ring based Alltoall */
-int MPIR_TSP_Ialltoall_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_TSP_Ialltoall_intra_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                   MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos_prototypes.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos_prototypes.h
@@ -14,10 +14,11 @@
 #undef MPIR_TSP_Ialltoall_sched_intra_ring
 #define MPIR_TSP_Ialltoall_sched_intra_ring           MPIR_TSP_NAMESPACE(Ialltoall_sched_intra_ring)
 
-int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm, MPIR_TSP_sched_t * sched);
+int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                        MPI_Datatype recvtype, MPIR_Comm * comm,
+                                        MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Ialltoall_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_TSP_Ialltoall_intra_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                   MPIR_Comm * comm, MPIR_Request ** req);

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_scattered_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_scattered_algos.h
@@ -38,9 +38,9 @@ cvars:
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a scattered based alltoall */
-int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
-                                             int recvcount, MPI_Datatype recvtype,
+                                             MPI_Aint recvcount, MPI_Datatype recvtype,
                                              MPIR_Comm * comm, int batch_size, int bblock,
                                              MPIR_TSP_sched_t * sched)
 {
@@ -154,9 +154,9 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, int sendcount,
 }
 
 /* Scattered sliding window based Alltoall */
-int MPIR_TSP_Ialltoall_intra_scattered(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ialltoall_intra_scattered(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype sendtype, void *recvbuf,
-                                       int recvcount, MPI_Datatype recvtype,
+                                       MPI_Aint recvcount, MPI_Datatype recvtype,
                                        MPIR_Comm * comm, int batch_size, int bblock,
                                        MPIR_Request ** req)
 {

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_scattered_algos_prototypes.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_scattered_algos_prototypes.h
@@ -14,14 +14,14 @@
 #undef MPIR_TSP_Ialltoall_sched_intra_scattered
 #define MPIR_TSP_Ialltoall_sched_intra_scattered           MPIR_TSP_NAMESPACE(Ialltoall_sched_intra_scattered)
 
-int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
-                                             int recvcount, MPI_Datatype recvtype,
+                                             MPI_Aint recvcount, MPI_Datatype recvtype,
                                              MPIR_Comm * comm, int batch_size, int bblock,
                                              MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Ialltoall_intra_scattered(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ialltoall_intra_scattered(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype sendtype, void *recvbuf,
-                                       int recvcount, MPI_Datatype recvtype,
+                                       MPI_Aint recvcount, MPI_Datatype recvtype,
                                        MPIR_Comm * comm, int batch_size, int bblock,
                                        MPIR_Request ** req);

--- a/src/mpi/coll/ibcast/ibcast.c
+++ b/src/mpi/coll/ibcast/ibcast.c
@@ -131,7 +131,7 @@ cvars:
  * hierarchy.  It will choose between several different algorithms
  * based on the given parameters. */
 
-int MPIR_Ibcast_allcomm_auto(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_allcomm_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                              MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -222,7 +222,7 @@ int MPIR_Ibcast_allcomm_auto(void *buffer, int count, MPI_Datatype datatype, int
     goto fn_exit;
 }
 
-int MPIR_Ibcast_intra_sched_auto(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_intra_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -272,7 +272,7 @@ int MPIR_Ibcast_intra_sched_auto(void *buffer, int count, MPI_Datatype datatype,
 /* Provides a "flat" broadcast for intercommunicators that doesn't
  * know anything about hierarchy.  It will choose between several
  * different algorithms based on the given parameters. */
-int MPIR_Ibcast_inter_sched_auto(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_inter_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -282,7 +282,7 @@ int MPIR_Ibcast_inter_sched_auto(void *buffer, int count, MPI_Datatype datatype,
     return mpi_errno;
 }
 
-int MPIR_Ibcast_sched_auto(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                            MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -296,7 +296,7 @@ int MPIR_Ibcast_sched_auto(void *buffer, int count, MPI_Datatype datatype, int r
     return mpi_errno;
 }
 
-int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                      MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -396,7 +396,7 @@ int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
     goto fn_exit;
 }
 
-int MPIR_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
+int MPIR_Ibcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
                 MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ibcast/ibcast_inter_sched_flat.c
+++ b/src/mpi/coll/ibcast/ibcast_inter_sched_flat.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 #include "ibcast.h"
 
-int MPIR_Ibcast_inter_sched_flat(void *buffer, int count, MPI_Datatype datatype,
+int MPIR_Ibcast_inter_sched_flat(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                  int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ibcast/ibcast_intra_gentran_ring.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_gentran_ring.c
@@ -11,7 +11,7 @@
 #include "ibcast_tsp_tree_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ibcast_intra_gentran_ring(void *buffer, int count,
+int MPIR_Ibcast_intra_gentran_ring(void *buffer, MPI_Aint count,
                                    MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
                                    int chunk_size, MPIR_Request ** request)
 {

--- a/src/mpi/coll/ibcast/ibcast_intra_gentran_scatter_recexch_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_gentran_scatter_recexch_allgather.c
@@ -11,7 +11,7 @@
 #include "ibcast_tsp_scatter_recexch_allgather_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ibcast_intra_gentran_scatter_recexch_allgather(void *buffer, int count,
+int MPIR_Ibcast_intra_gentran_scatter_recexch_allgather(void *buffer, MPI_Aint count,
                                                         MPI_Datatype datatype, int root,
                                                         MPIR_Comm * comm_ptr,
                                                         MPIR_Request ** request)

--- a/src/mpi/coll/ibcast/ibcast_intra_gentran_scatterv_recexch_allgatherv.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_gentran_scatterv_recexch_allgatherv.c
@@ -11,7 +11,7 @@
 #include "ibcast_tsp_scatterv_allgatherv_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ibcast_intra_gentran_scatterv_recexch_allgatherv(void *buffer, int count,
+int MPIR_Ibcast_intra_gentran_scatterv_recexch_allgatherv(void *buffer, MPI_Aint count,
                                                           MPI_Datatype datatype, int root,
                                                           MPIR_Comm * comm_ptr, int scatterv_k,
                                                           int allgatherv_k, MPIR_Request ** request)

--- a/src/mpi/coll/ibcast/ibcast_intra_gentran_tree.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_gentran_tree.c
@@ -11,7 +11,7 @@
 #include "ibcast_tsp_tree_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ibcast_intra_gentran_tree(void *buffer, int count,
+int MPIR_Ibcast_intra_gentran_tree(void *buffer, MPI_Aint count,
                                    MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
                                    int tree_type, int k, int chunk_size, MPIR_Request ** request)
 {

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
@@ -12,7 +12,7 @@
  * binomial broadcast.  It does _not_ start the schedule.  This permits callers
  * to build up a larger hierarchical broadcast from multiple invocations of this
  * function. */
-int MPIR_Ibcast_intra_sched_binomial(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
@@ -46,7 +46,7 @@
  * bytes and knows how to deal with a "ragged edge" vector length and we
  * implement the recursive doubling algorithm here.
  */
-int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, int count,
+int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, MPI_Aint count,
                                                                  MPI_Datatype datatype, int root,
                                                                  MPIR_Comm * comm_ptr,
                                                                  MPIR_Sched_t s)

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
@@ -24,8 +24,9 @@
  *
  * Total Cost = (lgp+p-1).alpha + 2.n.((p-1)/p).beta
  */
-int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, int count, MPI_Datatype datatype,
-                                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
+                                                   MPI_Datatype datatype, int root,
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank;

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_smp.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_smp.c
@@ -25,7 +25,7 @@ static int sched_test_length(MPIR_Comm * comm, int tag, void *state)
 /* This routine purely handles the hierarchical version of bcast, and does not
  * currently make any decision about which particular algorithm to use for any
  * subcommunicator. */
-int MPIR_Ibcast_intra_sched_smp(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_Ibcast_intra_sched_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv_algos.h
@@ -12,7 +12,7 @@
 #include "../iallgatherv/iallgatherv_tsp_recexch_algos_prototypes.h"
 
 /* Routine to schedule a scatter followed by recursive exchange based broadcast */
-int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, int count,
+int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count,
                                                     MPI_Datatype datatype, int root,
                                                     MPIR_Comm * comm, int scatterv_k,
                                                     int allgatherv_k, MPIR_TSP_sched_t * sched)
@@ -194,7 +194,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, int count,
 
 
 /* Non-blocking scatter followed by recursive exchange allgather  based broadcast */
-int MPIR_TSP_Ibcast_intra_scatterv_allgatherv(void *buffer, int count, MPI_Datatype datatype,
+int MPIR_TSP_Ibcast_intra_scatterv_allgatherv(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                               int root, MPIR_Comm * comm, int scatterv_k,
                                               int allgatherv_k, MPIR_Request ** req)
 {

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv_algos_prototypes.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv_algos_prototypes.h
@@ -14,10 +14,10 @@
 #undef MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv
 #define MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv       MPIR_TSP_NAMESPACE(Ibcast_sched_intra_scatterv_allgatherv)
 
-int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, int count,
+int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count,
                                                     MPI_Datatype datatype, int root,
                                                     MPIR_Comm * comm, int scatterv_k,
                                                     int allgatherv_k, MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Ibcast_intra_scatterv_allgatherv(void *buffer, int count, MPI_Datatype datatype,
+int MPIR_TSP_Ibcast_intra_scatterv_allgatherv(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                               int root, MPIR_Comm * comm, int scatterv_k,
                                               int allgatherv_k, MPIR_Request ** req);

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
@@ -12,7 +12,7 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a pipelined tree based broadcast */
-int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                      MPIR_Comm * comm, int tree_type, int k, int chunk_size,
                                      MPIR_TSP_sched_t * sched)
 {
@@ -96,7 +96,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, int count, MPI_Datatype datat
 
 
 /* Non-blocking tree based broadcast */
-int MPIR_TSP_Ibcast_intra_tree(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_TSP_Ibcast_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                MPIR_Comm * comm, MPIR_Request ** req, int tree_type, int k,
                                int chunk_size)
 {

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree_algos_prototypes.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree_algos_prototypes.h
@@ -14,9 +14,9 @@
 #undef MPIR_TSP_Ibcast_sched_intra_tree
 #define MPIR_TSP_Ibcast_sched_intra_tree                MPIR_TSP_NAMESPACE(Ibcast_sched_intra_tree)
 
-int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                      MPIR_Comm * comm, int tree_type, int k, int segsize,
                                      MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Ibcast_intra_tree(void *buffer, int count, MPI_Datatype datatype, int root,
+int MPIR_TSP_Ibcast_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                MPIR_Comm * comm, MPIR_Request ** req, int tree_type, int k,
                                int segsize);

--- a/src/mpi/coll/iexscan/iexscan.c
+++ b/src/mpi/coll/iexscan/iexscan.c
@@ -41,8 +41,9 @@ cvars:
 */
 
 
-int MPIR_Iexscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request)
+int MPIR_Iexscan_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                              MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -81,7 +82,7 @@ int MPIR_Iexscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI
     goto fn_exit;
 }
 
-int MPIR_Iexscan_intra_sched_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iexscan_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                   MPIR_Sched_t s)
 {
@@ -99,7 +100,7 @@ int MPIR_Iexscan_intra_sched_auto(const void *sendbuf, void *recvbuf, int count,
     goto fn_exit;
 }
 
-int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, MPI_Aint count,
                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                       MPIR_Request ** request)
 {
@@ -133,7 +134,7 @@ int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, int count,
     goto fn_exit;
 }
 
-int MPIR_Iexscan(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iexscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iexscan/iexscan_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iexscan/iexscan_intra_sched_recursive_doubling.c
@@ -48,7 +48,7 @@
 
    End Algorithm: MPI_Exscan
 */
-int MPIR_Iexscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iexscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {

--- a/src/mpi/coll/igather/igather.c
+++ b/src/mpi/coll/igather/igather.c
@@ -65,8 +65,8 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-int MPIR_Igather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Igather_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                               MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -130,9 +130,9 @@ int MPIR_Igather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype s
     goto fn_exit;
 }
 
-int MPIR_Igather_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Igather_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                  int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -147,9 +147,9 @@ int MPIR_Igather_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Dataty
     goto fn_exit;
 }
 
-int MPIR_Igather_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Igather_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                  int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint local_size, remote_size;
@@ -186,8 +186,8 @@ int MPIR_Igather_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Dataty
     return mpi_errno;
 }
 
-int MPIR_Igather_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Igather_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                            void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                             int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -203,8 +203,8 @@ int MPIR_Igather_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sen
     return mpi_errno;
 }
 
-int MPIR_Igather_impl(const void *sendbuf, int sendcount,
-                      MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_Igather_impl(const void *sendbuf, MPI_Aint sendcount,
+                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                       MPIR_Request ** request)
 {
@@ -282,8 +282,8 @@ int MPIR_Igather_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                 void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Igather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                  MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/igather/igather_inter_sched_long.c
+++ b/src/mpi/coll/igather/igather_inter_sched_long.c
@@ -12,9 +12,9 @@
  *
  * Cost: p.alpha + n.beta
  */
-int MPIR_Igather_inter_sched_long(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Igather_inter_sched_long(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                  int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint remote_size;

--- a/src/mpi/coll/igather/igather_inter_sched_short.c
+++ b/src/mpi/coll/igather/igather_inter_sched_short.c
@@ -13,9 +13,9 @@
  *
  * Cost: (lgp+1).alpha + n.((p-1)/p).beta + n.beta
  */
-int MPIR_Igather_inter_sched_short(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Igather_inter_sched_short(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank;

--- a/src/mpi/coll/igather/igather_intra_gentran_tree.c
+++ b/src/mpi/coll/igather/igather_intra_gentran_tree.c
@@ -10,8 +10,8 @@
 #include "igather_tsp_tree_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Igather_intra_gentran_tree(const void *sendbuf, int sendcount,
-                                    MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_Igather_intra_gentran_tree(const void *sendbuf, MPI_Aint sendcount,
+                                    MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, int k,
                                     MPIR_Request ** request)
 {

--- a/src/mpi/coll/igather/igather_intra_sched_binomial.c
+++ b/src/mpi/coll/igather/igather_intra_sched_binomial.c
@@ -25,9 +25,10 @@
 
    End Algorithm: MPI_Gather
 */
-int MPIR_Igather_intra_sched_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                      MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank;

--- a/src/mpi/coll/igather/igather_tsp_tree_algos.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos.h
@@ -12,8 +12,8 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a tree based gather */
-int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
-                                      MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                       int k, MPIR_TSP_sched_t * sched)
 {
@@ -190,8 +190,8 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
 
 
 /* Non-blocking tree based gather */
-int MPIR_TSP_Igather_intra_tree(const void *sendbuf, int sendcount,
-                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_TSP_Igather_intra_tree(const void *sendbuf, MPI_Aint sendcount,
+                                MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                 MPIR_Request ** req, int k)
 {

--- a/src/mpi/coll/igather/igather_tsp_tree_algos_prototypes.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos_prototypes.h
@@ -14,11 +14,11 @@
 #undef MPIR_TSP_Igather_sched_intra_tree
 #define MPIR_TSP_Igather_sched_intra_tree                MPIR_TSP_NAMESPACE(Igather_sched_intra_tree)
 
-int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
-                                      MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                       int k, MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Igather_intra_tree(const void *sendbuf, int sendcount,
-                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_TSP_Igather_intra_tree(const void *sendbuf, MPI_Aint sendcount,
+                                MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                 MPIR_Request ** request, int k);

--- a/src/mpi/coll/igatherv/igatherv.c
+++ b/src/mpi/coll/igatherv/igatherv.c
@@ -54,7 +54,7 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-int MPIR_Igatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Igatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const int *recvcounts, const int *displs,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                MPIR_Request ** request)
@@ -111,7 +111,7 @@ int MPIR_Igatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype 
     goto fn_exit;
 }
 
-int MPIR_Igatherv_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Igatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int recvcounts[], const int displs[],
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                    MPIR_Sched_t s)
@@ -130,7 +130,7 @@ int MPIR_Igatherv_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datat
     goto fn_exit;
 }
 
-int MPIR_Igatherv_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Igatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int recvcounts[], const int displs[],
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                    MPIR_Sched_t s)
@@ -149,7 +149,7 @@ int MPIR_Igatherv_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datat
     goto fn_exit;
 }
 
-int MPIR_Igatherv_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_Igatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                              void *recvbuf, const int recvcounts[], const int displs[],
                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
@@ -166,9 +166,10 @@ int MPIR_Igatherv_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype se
     return mpi_errno;
 }
 
-int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                       const int recvcounts[], const int displs[], MPI_Datatype recvtype,
-                       int root, MPIR_Comm * comm_ptr, MPIR_Request ** request)
+int MPIR_Igatherv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                       void *recvbuf, const int recvcounts[], const int displs[],
+                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                       MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -241,7 +242,7 @@ int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
     goto fn_exit;
 }
 
-int MPIR_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
+int MPIR_Igatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype, void *recvbuf,
                   const int recvcounts[], const int displs[], MPI_Datatype recvtype,
                   int root, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {

--- a/src/mpi/coll/igatherv/igatherv_allcomm_gentran_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_gentran_linear.c
@@ -10,8 +10,9 @@
 #include "igatherv_tsp_linear_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Igatherv_allcomm_gentran_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, const int recvcounts[], const int displs[],
+int MPIR_Igatherv_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         const int recvcounts[], const int displs[],
                                          MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                          MPIR_Request ** request)
 {

--- a/src/mpi/coll/igatherv/igatherv_allcomm_sched_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_sched_linear.c
@@ -11,10 +11,10 @@
  * Root receives from all processes, everyone else sends to root.
  */
 
-int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, const int recvcounts[], const int displs[],
-                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                       MPIR_Sched_t s)
+int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
+                                       const int displs[], MPI_Datatype recvtype, int root,
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;

--- a/src/mpi/coll/igatherv/igatherv_tsp_linear_algos.h
+++ b/src/mpi/coll/igatherv/igatherv_tsp_linear_algos.h
@@ -21,7 +21,7 @@
 
    Cost = (p-1).alpha + n.((p-1)/p).beta
 */
-int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount,
+int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
                                            const int recvcounts[], const int displs[],
                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
@@ -93,7 +93,7 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount,
 }
 
 /* Non-blocking linear algorithm for gatherv */
-int MPIR_TSP_Igatherv_allcomm_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_TSP_Igatherv_allcomm_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, const int recvcounts[], const int displs[],
                                      MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                      MPIR_Request ** req)

--- a/src/mpi/coll/igatherv/igatherv_tsp_linear_algos_prototypes.h
+++ b/src/mpi/coll/igatherv/igatherv_tsp_linear_algos_prototypes.h
@@ -14,12 +14,12 @@
 #undef MPIR_TSP_Igatherv_sched_allcomm_linear
 #define MPIR_TSP_Igatherv_sched_allcomm_linear       MPIR_TSP_NAMESPACE(Igatherv_sched_allcomm_linear)
 
-int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount,
+int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
                                            const int recvcounts[], const int displs[],
                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                            MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Igatherv_allcomm_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPIR_TSP_Igatherv_allcomm_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, const int recvcounts[], const int displs[],
                                      MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                      MPIR_Request ** request);

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
@@ -55,9 +55,10 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-int MPIR_Ineighbor_allgather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                          MPIR_Comm * comm_ptr, MPIR_Request ** request)
+int MPIR_Ineighbor_allgather_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                          MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -109,10 +110,10 @@ int MPIR_Ineighbor_allgather_allcomm_auto(const void *sendbuf, int sendcount, MP
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_allgather_intra_sched_auto(const void *sendbuf, int sendcount,
-                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s)
+int MPIR_Ineighbor_allgather_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                              MPI_Datatype sendtype, void *recvbuf,
+                                              MPI_Aint recvcount, MPI_Datatype recvtype,
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -128,10 +129,10 @@ int MPIR_Ineighbor_allgather_intra_sched_auto(const void *sendbuf, int sendcount
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_allgather_inter_sched_auto(const void *sendbuf, int sendcount,
-                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s)
+int MPIR_Ineighbor_allgather_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                              MPI_Datatype sendtype, void *recvbuf,
+                                              MPI_Aint recvcount, MPI_Datatype recvtype,
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -147,9 +148,9 @@ int MPIR_Ineighbor_allgather_inter_sched_auto(const void *sendbuf, int sendcount
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_allgather_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ineighbor_allgather_sched_auto(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -166,9 +167,9 @@ int MPIR_Ineighbor_allgather_sched_auto(const void *sendbuf, int sendcount, MPI_
     return mpi_errno;
 }
 
-int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgather_impl(const void *sendbuf, MPI_Aint sendcount,
                                   MPI_Datatype sendtype, void *recvbuf,
-                                  int recvcount, MPI_Datatype recvtype,
+                                  MPI_Aint recvcount, MPI_Datatype recvtype,
                                   MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -245,9 +246,9 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_allgather(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgather(const void *sendbuf, MPI_Aint sendcount,
                              MPI_Datatype sendtype, void *recvbuf,
-                             int recvcount, MPI_Datatype recvtype,
+                             MPI_Aint recvcount, MPI_Datatype recvtype,
                              MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_gentran_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_gentran_linear.c
@@ -10,9 +10,9 @@
 #include "ineighbor_allgather_tsp_linear_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ineighbor_allgather_allcomm_gentran_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgather_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_sched_linear.c
@@ -12,9 +12,9 @@
  * neighbor.
  */
 
-int MPIR_Ineighbor_allgather_allcomm_sched_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgather_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
@@ -12,9 +12,9 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a pipelined tree based broadcast */
-int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      int recvcount, MPI_Datatype recvtype,
+                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
                                                       MPIR_Comm * comm_ptr,
                                                       MPIR_TSP_sched_t * sched)
 {
@@ -65,10 +65,10 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int s
 
 
 /* Non-blocking linear algo based neighbor_allgather */
-int MPIR_TSP_Ineighbor_allgather_allcomm_linear(const void *sendbuf, int sendcount,
-                                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                MPIR_Request ** req)
+int MPIR_TSP_Ineighbor_allgather_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
+                                                MPI_Datatype sendtype, void *recvbuf,
+                                                MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos_prototypes.h
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos_prototypes.h
@@ -14,12 +14,12 @@
 #undef MPIR_TSP_Ineighor_allgather_sched_allcomm_linear
 #define MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear  MPIR_TSP_NAMESPACE(Ineighbor_allgather_sched_allcomm_linear)
 
-int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      int recvcount, MPI_Datatype recvtype,
+                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
                                                       MPIR_Comm * comm_ptr,
                                                       MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Ineighbor_allgather_allcomm_linear(const void *sendbuf, int sendcount,
-                                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                MPIR_Request ** req);
+int MPIR_TSP_Ineighbor_allgather_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
+                                                MPI_Datatype sendtype, void *recvbuf,
+                                                MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                MPIR_Comm * comm_ptr, MPIR_Request ** req);

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
@@ -56,7 +56,7 @@ cvars:
 */
 
 
-int MPIR_Ineighbor_allgatherv_allcomm_auto(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
                                            const int recvcounts[], const int displs[],
                                            MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -113,7 +113,7 @@ int MPIR_Ineighbor_allgatherv_allcomm_auto(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_allgatherv_intra_sched_auto(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -133,7 +133,7 @@ int MPIR_Ineighbor_allgatherv_intra_sched_auto(const void *sendbuf, int sendcoun
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_allgatherv_inter_sched_auto(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -153,7 +153,7 @@ int MPIR_Ineighbor_allgatherv_inter_sched_auto(const void *sendbuf, int sendcoun
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_allgatherv_sched_auto(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                          MPI_Datatype sendtype, void *recvbuf,
                                          const int recvcounts[], const int displs[],
                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -174,7 +174,7 @@ int MPIR_Ineighbor_allgatherv_sched_auto(const void *sendbuf, int sendcount,
     return mpi_errno;
 }
 
-int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, MPI_Aint sendcount,
                                    MPI_Datatype sendtype, void *recvbuf,
                                    const int recvcounts[], const int displs[],
                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -260,7 +260,7 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_allgatherv(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                               MPI_Datatype sendtype, void *recvbuf,
                               const int recvcounts[], const int displs[],
                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request)

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_gentran_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_gentran_linear.c
@@ -10,7 +10,7 @@
 #include "ineighbor_allgatherv_tsp_linear_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const int recvcounts[], const int displs[],
                                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_sched_linear.c
@@ -12,7 +12,7 @@
  * neighbor.
  */
 
-int MPIR_Ineighbor_allgatherv_allcomm_sched_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_allgatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int recvcounts[], const int displs[],
                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
@@ -12,7 +12,7 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule linear algorithm fir neighbor_allgatherv */
-int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
                                                        const int recvcounts[], const int displs[],
                                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -64,7 +64,7 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int 
 
 
 /* Non-blocking linear algo based neighbor_allgatherv */
-int MPIR_TSP_Ineighbor_allgatherv_allcomm_linear(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ineighbor_allgatherv_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  const int recvcounts[], const int displs[],
                                                  MPI_Datatype recvtype, MPIR_Comm * comm_ptr,

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos_prototypes.h
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos_prototypes.h
@@ -14,12 +14,12 @@
 #undef MPIR_TSP_Ineighor_allgatherv_sched_allcomm_linear
 #define MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear  MPIR_TSP_NAMESPACE(Ineighbor_allgatherv_sched_allcomm_linear)
 
-int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
                                                        const int recvcounts[], const int displs[],
                                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                        MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Ineighbor_allgatherv_allcomm_linear(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ineighbor_allgatherv_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  const int recvcounts[], const int displs[],
                                                  MPI_Datatype recvtype, MPIR_Comm * comm_ptr,

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
@@ -57,9 +57,10 @@ cvars:
 */
 
 
-int MPIR_Ineighbor_alltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                         MPIR_Comm * comm_ptr, MPIR_Request ** request)
+int MPIR_Ineighbor_alltoall_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                         MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -111,9 +112,9 @@ int MPIR_Ineighbor_alltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoall_intra_sched_auto(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_alltoall_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
-                                             int recvcount, MPI_Datatype recvtype,
+                                             MPI_Aint recvcount, MPI_Datatype recvtype,
                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -130,9 +131,9 @@ int MPIR_Ineighbor_alltoall_intra_sched_auto(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoall_inter_sched_auto(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_alltoall_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
-                                             int recvcount, MPI_Datatype recvtype,
+                                             MPI_Aint recvcount, MPI_Datatype recvtype,
                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -149,9 +150,9 @@ int MPIR_Ineighbor_alltoall_inter_sched_auto(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoall_sched_auto(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_alltoall_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype sendtype, void *recvbuf,
-                                       int recvcount, MPI_Datatype recvtype,
+                                       MPI_Aint recvcount, MPI_Datatype recvtype,
                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -169,9 +170,9 @@ int MPIR_Ineighbor_alltoall_sched_auto(const void *sendbuf, int sendcount,
     return mpi_errno;
 }
 
-int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, MPI_Aint sendcount,
                                  MPI_Datatype sendtype, void *recvbuf,
-                                 int recvcount, MPI_Datatype recvtype,
+                                 MPI_Aint recvcount, MPI_Datatype recvtype,
                                  MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -248,9 +249,9 @@ int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoall(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_alltoall(const void *sendbuf, MPI_Aint sendcount,
                             MPI_Datatype sendtype, void *recvbuf,
-                            int recvcount, MPI_Datatype recvtype,
+                            MPI_Aint recvcount, MPI_Datatype recvtype,
                             MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_gentran_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_gentran_linear.c
@@ -10,9 +10,9 @@
 #include "ineighbor_alltoall_tsp_linear_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ineighbor_alltoall_allcomm_gentran_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_alltoall_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_sched_linear.c
@@ -12,9 +12,9 @@
  * neighbor.
  */
 
-int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, int sendcount,
+int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype,
+                                                 MPI_Aint recvcount, MPI_Datatype recvtype,
                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
@@ -12,9 +12,9 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule linear algorithm fir neighbor_alltoall */
-int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm_ptr, MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -72,9 +72,9 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int se
 
 
 /* Non-blocking linear algo based neighbor_allgatherv */
-int MPIR_TSP_Ineighbor_alltoall_allcomm_linear(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ineighbor_alltoall_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
-                                               int recvcount, MPI_Datatype recvtype,
+                                               MPI_Aint recvcount, MPI_Datatype recvtype,
                                                MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos_prototypes.h
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos_prototypes.h
@@ -14,12 +14,12 @@
 #undef MPIR_TSP_Ineighor_alltoall_sched_allcomm_linear
 #define MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear  MPIR_TSP_NAMESPACE(Ineighbor_alltoall_sched_allcomm_linear)
 
-int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendcount,
+int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm_ptr,
                                                      MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Ineighbor_alltoall_allcomm_linear(const void *sendbuf, int sendcount,
-                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                               MPIR_Request ** req);
+int MPIR_TSP_Ineighbor_alltoall_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
+                                               MPI_Datatype sendtype, void *recvbuf,
+                                               MPI_Aint recvcount, MPI_Datatype recvtype,
+                                               MPIR_Comm * comm_ptr, MPIR_Request ** req);

--- a/src/mpi/coll/ireduce/ireduce.c
+++ b/src/mpi/coll/ireduce/ireduce.c
@@ -118,8 +118,9 @@ cvars:
 */
 
 
-int MPIR_Ireduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                              MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Request ** request)
+int MPIR_Ireduce_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                              MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
+                              MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -199,7 +200,7 @@ int MPIR_Ireduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI
     goto fn_exit;
 }
 
-int MPIR_Ireduce_intra_sched_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                   MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
                                   MPIR_Sched_t s)
 {
@@ -244,7 +245,7 @@ int MPIR_Ireduce_intra_sched_auto(const void *sendbuf, void *recvbuf, int count,
 }
 
 int MPIR_Ireduce_inter_sched_auto(const void *sendbuf, void *recvbuf,
-                                  int count, MPI_Datatype datatype, MPI_Op op, int root,
+                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op, int root,
                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -255,8 +256,9 @@ int MPIR_Ireduce_inter_sched_auto(const void *sendbuf, void *recvbuf,
     return mpi_errno;
 }
 
-int MPIR_Ireduce_sched_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ireduce_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                            MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
+                            MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -271,7 +273,7 @@ int MPIR_Ireduce_sched_auto(const void *sendbuf, void *recvbuf, int count, MPI_D
     return mpi_errno;
 }
 
-int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, MPI_Aint count,
                       MPI_Datatype datatype, MPI_Op op, int root,
                       MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
@@ -373,7 +375,7 @@ int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count,
     goto fn_exit;
 }
 
-int MPIR_Ireduce(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                  MPI_Datatype datatype, MPI_Op op, int root,
                  MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {

--- a/src/mpi/coll/ireduce/ireduce_inter_sched_local_reduce_remote_send.c
+++ b/src/mpi/coll/ireduce/ireduce_inter_sched_local_reduce_remote_send.c
@@ -11,9 +11,10 @@
  * 0 then sends data to root.
  */
 
-int MPIR_Ireduce_inter_sched_local_reduce_remote_send(const void *sendbuf, void *recvbuf, int count,
-                                                      MPI_Datatype datatype, MPI_Op op, int root,
-                                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ireduce_inter_sched_local_reduce_remote_send(const void *sendbuf, void *recvbuf,
+                                                      MPI_Aint count, MPI_Datatype datatype,
+                                                      MPI_Op op, int root, MPIR_Comm * comm_ptr,
+                                                      MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank;

--- a/src/mpi/coll/ireduce/ireduce_intra_gentran_ring.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_gentran_ring.c
@@ -10,7 +10,7 @@
 #include "ireduce_tsp_tree_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ireduce_intra_gentran_ring(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_intra_gentran_ring(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                     MPI_Datatype datatype, MPI_Op op, int root,
                                     MPIR_Comm * comm_ptr, int chunk_size, int buffer_per_child,
                                     MPIR_Request ** request)

--- a/src/mpi/coll/ireduce/ireduce_intra_gentran_tree.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_gentran_tree.c
@@ -10,7 +10,7 @@
 #include "ireduce_tsp_tree_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ireduce_intra_gentran_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_intra_gentran_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                     MPI_Datatype datatype, MPI_Op op, int root,
                                     MPIR_Comm * comm_ptr, int tree_type, int k, int chunk_size,
                                     int buffer_per_child, MPIR_Request ** request)

--- a/src/mpi/coll/ireduce/ireduce_intra_sched_binomial.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_sched_binomial.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Ireduce_intra_sched_binomial(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_intra_sched_binomial(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                       MPI_Datatype datatype, MPI_Op op, int root,
                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {

--- a/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
@@ -32,9 +32,9 @@
    Cost = (2.floor(lgp)+1).alpha + (2.((p-1)/p) + 1).n.beta +
            n.(1+(p-1)/p).gamma
 */
-int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *recvbuf,
+                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
+                                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, j, comm_size, rank, pof2, is_commutative ATTRIBUTE((unused));

--- a/src/mpi/coll/ireduce/ireduce_intra_sched_smp.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_sched_smp.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Ireduce_intra_sched_smp(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Ireduce_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                  MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
                                  MPIR_Sched_t s)
 {

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
@@ -12,7 +12,7 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a pipelined tree based reduce */
-int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                       MPI_Datatype datatype, MPI_Op op, int root,
                                       MPIR_Comm * comm, int tree_type, int k, int chunk_size,
                                       int buffer_per_child, MPIR_TSP_sched_t * sched)
@@ -263,7 +263,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int co
 
 
 /* Non-blocking tree based reduce */
-int MPIR_TSP_Ireduce_intra_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Ireduce_intra_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                 MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm,
                                 MPIR_Request ** req, int tree_type, int k, int chunk_size,
                                 int buffer_per_child)

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree_algos_prototypes.h
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree_algos_prototypes.h
@@ -14,11 +14,11 @@
 #undef MPIR_TSP_Ireduce_sched_intra_tree
 #define MPIR_TSP_Ireduce_sched_intra_tree                MPIR_TSP_NAMESPACE(Ireduce_sched_intra_tree)
 
-int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                       MPI_Datatype datatype, MPI_Op op, int root,
                                       MPIR_Comm * comm, int tree_type, int k, int segsize,
                                       int buffer_per_child, MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Ireduce_intra_tree(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Ireduce_intra_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                 MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm,
                                 MPIR_Request ** req, int tree_type, int k, int segsize,
                                 int buffer_per_child);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
@@ -68,7 +68,7 @@ cvars:
 */
 
 
-int MPIR_Ireduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, int recvcount,
+int MPIR_Ireduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                             MPIR_Request ** request)
 {
@@ -143,9 +143,9 @@ int MPIR_Ireduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, 
     goto fn_exit;
 }
 
-int MPIR_Ireduce_scatter_block_intra_sched_auto(const void *sendbuf, void *recvbuf, int recvcount,
-                                                MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ireduce_scatter_block_intra_sched_auto(const void *sendbuf, void *recvbuf,
+                                                MPI_Aint recvcount, MPI_Datatype datatype,
+                                                MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative;
@@ -198,9 +198,9 @@ int MPIR_Ireduce_scatter_block_intra_sched_auto(const void *sendbuf, void *recvb
 }
 
 
-int MPIR_Ireduce_scatter_block_inter_sched_auto(const void *sendbuf, void *recvbuf, int recvcount,
-                                                MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ireduce_scatter_block_inter_sched_auto(const void *sendbuf, void *recvbuf,
+                                                MPI_Aint recvcount, MPI_Datatype datatype,
+                                                MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -212,7 +212,7 @@ int MPIR_Ireduce_scatter_block_inter_sched_auto(const void *sendbuf, void *recvb
     return mpi_errno;
 }
 
-int MPIR_Ireduce_scatter_block_sched_auto(const void *sendbuf, void *recvbuf, int recvcount,
+int MPIR_Ireduce_scatter_block_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                           MPIR_Sched_t s)
 {
@@ -232,7 +232,7 @@ int MPIR_Ireduce_scatter_block_sched_auto(const void *sendbuf, void *recvbuf, in
 }
 
 int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
-                                    int recvcount, MPI_Datatype datatype,
+                                    MPI_Aint recvcount, MPI_Datatype datatype,
                                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -335,7 +335,7 @@ int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
 }
 
 int MPIR_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
-                               int recvcount, MPI_Datatype datatype,
+                               MPI_Aint recvcount, MPI_Datatype datatype,
                                MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv.c
@@ -14,7 +14,7 @@
 
 int MPIR_Ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv(const void *sendbuf,
                                                                         void *recvbuf,
-                                                                        int recvcount,
+                                                                        MPI_Aint recvcount,
                                                                         MPI_Datatype datatype,
                                                                         MPI_Op op,
                                                                         MPIR_Comm * comm_ptr,

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_gentran_recexch.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_gentran_recexch.c
@@ -11,7 +11,7 @@
 #include "tsp_undef.h"
 
 int MPIR_Ireduce_scatter_block_intra_gentran_recexch(const void *sendbuf, void *recvbuf,
-                                                     int recvcount, MPI_Datatype datatype,
+                                                     MPI_Aint recvcount, MPI_Datatype datatype,
                                                      MPI_Op op, MPIR_Comm * comm, int k,
                                                      MPIR_Request ** req)
 {

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_noncommutative.c
@@ -10,7 +10,7 @@
  * from EuroPVM/MPI 2005.  This function currently only implements support for
  * the power-of-2 case. */
 int MPIR_Ireduce_scatter_block_intra_sched_noncommutative(const void *sendbuf, void *recvbuf,
-                                                          int recvcount, MPI_Datatype datatype,
+                                                          MPI_Aint recvcount, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
                                                           MPIR_Sched_t s)
 {

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_pairwise.c
@@ -8,8 +8,8 @@
 /* A pairwise exchange algorithm for MPI_Ireduce_scatter_block.  Requires a
  * commutative op and is intended for use with large messages. */
 int MPIR_Ireduce_scatter_block_intra_sched_pairwise(const void *sendbuf, void *recvbuf,
-                                                    int recvcount, MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                    MPI_Aint recvcount, MPI_Datatype datatype,
+                                                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_doubling.c
@@ -8,9 +8,9 @@
 /* A recursive doubling algorithm for MPI_Ireduce_scatter_block, suitable for
  * noncommutative and (non-pof2 or block irregular). */
 int MPIR_Ireduce_scatter_block_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf,
-                                                              int recvcount, MPI_Datatype datatype,
-                                                              MPI_Op op, MPIR_Comm * comm_ptr,
-                                                              MPIR_Sched_t s)
+                                                              MPI_Aint recvcount,
+                                                              MPI_Datatype datatype, MPI_Op op,
+                                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_halving.c
@@ -8,9 +8,9 @@
 /* A recursive halving MPI_Ireduce_scatter_block algorithm.  Requires that op is
  * commutative.  Typically yields better performance for shorter messages. */
 int MPIR_Ireduce_scatter_block_intra_sched_recursive_halving(const void *sendbuf, void *recvbuf,
-                                                             int recvcount, MPI_Datatype datatype,
-                                                             MPI_Op op, MPIR_Comm * comm_ptr,
-                                                             MPIR_Sched_t s)
+                                                             MPI_Aint recvcount,
+                                                             MPI_Datatype datatype, MPI_Op op,
+                                                             MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
@@ -13,7 +13,7 @@
 
 /* Routine to schedule a recursive exchange based reduce_scatter with distance halving in each phase */
 int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void *recvbuf,
-                                                       int recvcount, MPI_Datatype datatype,
+                                                       MPI_Aint recvcount, MPI_Datatype datatype,
                                                        MPI_Op op, MPIR_Comm * comm, int k,
                                                        MPIR_TSP_sched_t * sched)
 {
@@ -200,9 +200,10 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
 
 
 /* Non-blocking recexch based REDUCE_SCATTER_BLOCK */
-int MPIR_TSP_Ireduce_scatter_block_intra_recexch(const void *sendbuf, void *recvbuf, int recvcount,
-                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                 MPIR_Request ** req, int k)
+int MPIR_TSP_Ireduce_scatter_block_intra_recexch(const void *sendbuf, void *recvbuf,
+                                                 MPI_Aint recvcount, MPI_Datatype datatype,
+                                                 MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req,
+                                                 int k)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos_prototypes.h
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos_prototypes.h
@@ -15,10 +15,11 @@
 #define MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch                MPIR_TSP_NAMESPACE(Ireduce_scatter_block_sched_intra_recexch)
 
 int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void *recvbuf,
-                                                       int recvcount, MPI_Datatype datatype,
+                                                       MPI_Aint recvcount, MPI_Datatype datatype,
                                                        MPI_Op op, MPIR_Comm * comm, int k,
                                                        MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Ireduce_scatter_block_intra_recexch(const void *sendbuf, void *recvbuf, int recvcount,
-                                                 MPI_Datatype datatype, MPI_Op op,
-                                                 MPIR_Comm * comm, MPIR_Request ** req, int k);
+int MPIR_TSP_Ireduce_scatter_block_intra_recexch(const void *sendbuf, void *recvbuf,
+                                                 MPI_Aint recvcount, MPI_Datatype datatype,
+                                                 MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req,
+                                                 int k);

--- a/src/mpi/coll/iscan/iscan.c
+++ b/src/mpi/coll/iscan/iscan.c
@@ -43,8 +43,9 @@ cvars:
 */
 
 
-int MPIR_Iscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request)
+int MPIR_Iscan_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                            MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -94,7 +95,7 @@ int MPIR_Iscan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_D
     goto fn_exit;
 }
 
-int MPIR_Iscan_intra_sched_auto(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iscan_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                 MPIR_Sched_t s)
 {
@@ -111,7 +112,7 @@ int MPIR_Iscan_intra_sched_auto(const void *sendbuf, void *recvbuf, int count,
     return mpi_errno;
 }
 
-int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, MPI_Aint count,
                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -162,7 +163,7 @@ int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count,
     goto fn_exit;
 }
 
-int MPIR_Iscan(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iscan/iscan_intra_gentran_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_intra_gentran_recursive_doubling.c
@@ -10,7 +10,7 @@
 #include "iscan_tsp_recursive_doubling_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iscan_intra_gentran_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iscan_intra_gentran_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm, MPIR_Request ** req)
 {

--- a/src/mpi/coll/iscan/iscan_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_intra_sched_recursive_doubling.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Iscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Iscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                               MPI_Datatype datatype, MPI_Op op,
                                               MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {

--- a/src/mpi/coll/iscan/iscan_intra_sched_smp.c
+++ b/src/mpi/coll/iscan/iscan_intra_sched_smp.c
@@ -6,8 +6,9 @@
 #include "mpiimpl.h"
 
 
-int MPIR_Iscan_intra_sched_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Iscan_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                               MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank = comm_ptr->rank;

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
@@ -11,8 +11,8 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a recursive exchange based scan */
-int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
+int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -123,7 +123,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
 
 
 /* Non-blocking recursive_doubling based SCAN */
-int MPIR_TSP_Iscan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iscan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                             MPI_Datatype datatype, MPI_Op op,
                                             MPIR_Comm * comm, MPIR_Request ** req)
 {

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos_prototypes.h
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos_prototypes.h
@@ -14,10 +14,10 @@
 #undef MPIR_TSP_Iscan_sched_intra_recursive_doubling
 #define MPIR_TSP_Iscan_sched_intra_recursive_doubling                MPIR_TSP_NAMESPACE(Iscan_sched_intra_recursive_doubling)
 
-int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
+int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   MPIR_Comm * comm_ptr, MPIR_TSP_sched_t * s);
 
-int MPIR_TSP_Iscan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
+int MPIR_TSP_Iscan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                             MPI_Datatype datatype, MPI_Op op,
                                             MPIR_Comm * comm_ptr, MPIR_Request ** req);

--- a/src/mpi/coll/iscatter/iscatter.c
+++ b/src/mpi/coll/iscatter/iscatter.c
@@ -76,8 +76,8 @@ struct shared_state {
 
 /* any non-MPI functions go here, especially non-static ones */
 
-int MPIR_Iscatter_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Iscatter_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -142,8 +142,8 @@ int MPIR_Iscatter_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype 
     goto fn_exit;
 }
 
-int MPIR_Iscatter_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iscatter_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                    int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -160,8 +160,8 @@ int MPIR_Iscatter_intra_sched_auto(const void *sendbuf, int sendcount, MPI_Datat
     goto fn_exit;
 }
 
-int MPIR_Iscatter_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iscatter_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                    int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int local_size, remote_size, sendtype_size, recvtype_size, nbytes;
@@ -197,8 +197,8 @@ int MPIR_Iscatter_inter_sched_auto(const void *sendbuf, int sendcount, MPI_Datat
     goto fn_exit;
 }
 
-int MPIR_Iscatter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iscatter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                             void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                              int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -214,8 +214,8 @@ int MPIR_Iscatter_sched_auto(const void *sendbuf, int sendcount, MPI_Datatype se
     return mpi_errno;
 }
 
-int MPIR_Iscatter_impl(const void *sendbuf, int sendcount,
-                       MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_Iscatter_impl(const void *sendbuf, MPI_Aint sendcount,
+                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                        MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                        MPIR_Request ** request)
 {
@@ -292,8 +292,8 @@ int MPIR_Iscatter_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
+int MPIR_Iscatter(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                   int root, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iscatter/iscatter_inter_sched_linear.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_sched_linear.c
@@ -13,9 +13,9 @@
  * Cost: p.alpha + n.beta
  */
 
-int MPIR_Iscatter_inter_sched_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Iscatter_inter_sched_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                     int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int remote_size;

--- a/src/mpi/coll/iscatter/iscatter_inter_sched_remote_send_local_scatter.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_sched_remote_send_local_scatter.c
@@ -14,9 +14,9 @@
  * where n is the total size of the data to be scattered from the root.
  */
 
-int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, int sendcount,
+int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
-                                                        int recvcount, MPI_Datatype recvtype,
+                                                        MPI_Aint recvcount, MPI_Datatype recvtype,
                                                         int root, MPIR_Comm * comm_ptr,
                                                         MPIR_Sched_t s)
 {

--- a/src/mpi/coll/iscatter/iscatter_intra_gentran_tree.c
+++ b/src/mpi/coll/iscatter/iscatter_intra_gentran_tree.c
@@ -10,8 +10,8 @@
 #include "iscatter_tsp_tree_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iscatter_intra_gentran_tree(const void *sendbuf, int sendcount,
-                                     MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_Iscatter_intra_gentran_tree(const void *sendbuf, MPI_Aint sendcount,
+                                     MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                      MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, int k,
                                      MPIR_Request ** request)
 {

--- a/src/mpi/coll/iscatter/iscatter_intra_sched_binomial.c
+++ b/src/mpi/coll/iscatter/iscatter_intra_sched_binomial.c
@@ -63,9 +63,10 @@ static int calc_curr_count(MPIR_Comm * comm, int tag, void *state)
 
    End Algorithm: MPI_Scatter
 */
-int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                                       MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint extent = 0;

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
@@ -11,8 +11,8 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a tree based scatter */
-int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, int sendcount,
-                                       MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                        MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                        int k, MPIR_TSP_sched_t * sched)
 {
@@ -182,8 +182,8 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, int sendcount,
 
 
 /* Non-blocking tree based scatter */
-int MPIR_TSP_Iscatter_intra_tree(const void *sendbuf, int sendcount,
-                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_TSP_Iscatter_intra_tree(const void *sendbuf, MPI_Aint sendcount,
+                                 MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                  MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                  MPIR_Request ** req, int k)
 {

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree_algos_prototypes.h
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree_algos_prototypes.h
@@ -14,11 +14,11 @@
 #undef MPIR_TSP_Iscatter_sched_intra_tree
 #define MPIR_TSP_Iscatter_sched_intra_tree                MPIR_TSP_NAMESPACE(Iscatter_sched_intra_tree)
 
-int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, int sendcount,
-                                       MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                        MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                        int k, MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Iscatter_intra_tree(const void *sendbuf, int sendcount,
-                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_TSP_Iscatter_intra_tree(const void *sendbuf, MPI_Aint sendcount,
+                                 MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                  MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                  MPIR_Request ** request, int k);

--- a/src/mpi/coll/iscatterv/iscatterv.c
+++ b/src/mpi/coll/iscatterv/iscatterv.c
@@ -58,7 +58,7 @@ cvars:
 
 
 int MPIR_Iscatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                 MPIR_Request ** request)
 {
@@ -115,7 +115,7 @@ int MPIR_Iscatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, cons
 }
 
 int MPIR_Iscatterv_intra_sched_auto(const void *sendbuf, const int sendcounts[], const int displs[],
-                                    MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                    MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                     MPIR_Sched_t s)
 {
@@ -134,7 +134,7 @@ int MPIR_Iscatterv_intra_sched_auto(const void *sendbuf, const int sendcounts[],
 }
 
 int MPIR_Iscatterv_inter_sched_auto(const void *sendbuf, const int sendcounts[], const int displs[],
-                                    MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                    MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                     MPIR_Sched_t s)
 {
@@ -153,7 +153,7 @@ int MPIR_Iscatterv_inter_sched_auto(const void *sendbuf, const int sendcounts[],
 }
 
 int MPIR_Iscatterv_sched_auto(const void *sendbuf, const int sendcounts[], const int displs[],
-                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                              MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -176,7 +176,7 @@ int MPIR_Iscatterv_sched_auto(const void *sendbuf, const int sendcounts[], const
 }
 
 int MPIR_Iscatterv_impl(const void *sendbuf, const int sendcounts[], const int displs[],
-                        MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                         MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                         MPIR_Request ** request)
 {
@@ -252,7 +252,7 @@ int MPIR_Iscatterv_impl(const void *sendbuf, const int sendcounts[], const int d
 }
 
 int MPIR_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[],
-                   MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                   MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iscatterv/iscatterv_allcomm_gentran_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_allcomm_gentran_linear.c
@@ -12,7 +12,7 @@
 
 int MPIR_Iscatterv_allcomm_gentran_linear(const void *sendbuf, const int sendcounts[],
                                           const int displs[], MPI_Datatype sendtype, void *recvbuf,
-                                          int recvcount, MPI_Datatype recvtype, int root,
+                                          MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                           MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iscatterv/iscatterv_allcomm_sched_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_allcomm_sched_linear.c
@@ -17,7 +17,7 @@
 */
 int MPIR_Iscatterv_allcomm_sched_linear(const void *sendbuf, const int sendcounts[],
                                         const int displs[], MPI_Datatype sendtype, void *recvbuf,
-                                        int recvcount, MPI_Datatype recvtype, int root,
+                                        MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                         MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iscatterv/iscatterv_tsp_linear_algos.h
+++ b/src/mpi/coll/iscatterv/iscatterv_tsp_linear_algos.h
@@ -13,8 +13,8 @@
 /* Routine to schedule a linear algorithm for scatterv */
 int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
                                             const int displs[], MPI_Datatype sendtype,
-                                            void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                            int root, MPIR_Comm * comm_ptr,
+                                            void *recvbuf, MPI_Aint recvcount,
+                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                             MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -83,7 +83,7 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendc
 /* Non-blocking linear algorithm for scatterv */
 int MPIR_TSP_Iscatterv_allcomm_linear(const void *sendbuf, const int sendcounts[],
                                       const int displs[], MPI_Datatype sendtype, void *recvbuf,
-                                      int recvcount, MPI_Datatype recvtype, int root,
+                                      MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                       MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iscatterv/iscatterv_tsp_linear_algos_prototypes.h
+++ b/src/mpi/coll/iscatterv/iscatterv_tsp_linear_algos_prototypes.h
@@ -16,10 +16,10 @@
 
 int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
                                             const int displs[], MPI_Datatype sendtype,
-                                            void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                            int root, MPIR_Comm * comm_ptr,
+                                            void *recvbuf, MPI_Aint recvcount,
+                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                             MPIR_TSP_sched_t * sched);
 int MPIR_TSP_Iscatterv_allcomm_linear(const void *sendbuf, const int sendcounts[],
                                       const int displs[], MPI_Datatype sendtype, void *recvbuf,
-                                      int recvcount, MPI_Datatype recvtype, int root,
+                                      MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                       MPIR_Comm * comm_ptr, MPIR_Request ** req);

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather.c
@@ -54,9 +54,9 @@ cvars:
 /* any non-MPI functions go here, especially non-static ones */
 
 
-int MPIR_Neighbor_allgather_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                         MPIR_Comm * comm_ptr)
+int MPIR_Neighbor_allgather_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -89,9 +89,9 @@ int MPIR_Neighbor_allgather_allcomm_auto(const void *sendbuf, int sendcount, MPI
     return mpi_errno;
 }
 
-int MPIR_Neighbor_allgather_impl(const void *sendbuf, int sendcount,
+int MPIR_Neighbor_allgather_impl(const void *sendbuf, MPI_Aint sendcount,
                                  MPI_Datatype sendtype, void *recvbuf,
-                                 int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
+                                 MPI_Aint recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -134,9 +134,9 @@ int MPIR_Neighbor_allgather_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Neighbor_allgather(const void *sendbuf, int sendcount,
+int MPIR_Neighbor_allgather(const void *sendbuf, MPI_Aint sendcount,
                             MPI_Datatype sendtype, void *recvbuf,
-                            int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
+                            MPI_Aint recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
@@ -5,9 +5,9 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr)
+int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
@@ -54,8 +54,9 @@ cvars:
 /* any non-MPI functions go here, especially non-static ones */
 
 
-int MPIR_Neighbor_allgatherv_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, const int recvcounts[], const int displs[],
+int MPIR_Neighbor_allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          const int recvcounts[], const int displs[],
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -90,7 +91,7 @@ int MPIR_Neighbor_allgatherv_allcomm_auto(const void *sendbuf, int sendcount, MP
     return mpi_errno;
 }
 
-int MPIR_Neighbor_allgatherv_impl(const void *sendbuf, int sendcount,
+int MPIR_Neighbor_allgatherv_impl(const void *sendbuf, MPI_Aint sendcount,
                                   MPI_Datatype sendtype, void *recvbuf,
                                   const int recvcounts[], const int displs[],
                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
@@ -136,7 +137,7 @@ int MPIR_Neighbor_allgatherv_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Neighbor_allgatherv(const void *sendbuf, int sendcount,
+int MPIR_Neighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                              MPI_Datatype sendtype, void *recvbuf,
                              const int recvcounts[], const int displs[],
                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr)

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
@@ -5,8 +5,9 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, const int recvcounts[], const int displs[],
+int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        const int recvcounts[], const int displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall.c
@@ -54,9 +54,9 @@ cvars:
 /* any non-MPI functions go here, especially non-static ones */
 
 
-int MPIR_Neighbor_alltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr)
+int MPIR_Neighbor_alltoall_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -89,9 +89,9 @@ int MPIR_Neighbor_alltoall_allcomm_auto(const void *sendbuf, int sendcount, MPI_
     return mpi_errno;
 }
 
-int MPIR_Neighbor_alltoall_impl(const void *sendbuf, int sendcount,
+int MPIR_Neighbor_alltoall_impl(const void *sendbuf, MPI_Aint sendcount,
                                 MPI_Datatype sendtype, void *recvbuf,
-                                int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
+                                MPI_Aint recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -134,8 +134,8 @@ int MPIR_Neighbor_alltoall_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Neighbor_alltoall(const void *sendbuf, int sendcount,
-                           MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_Neighbor_alltoall(const void *sendbuf, MPI_Aint sendcount,
+                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                            MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
@@ -5,9 +5,9 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr)
+int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;

--- a/src/mpi/coll/reduce/reduce.c
+++ b/src/mpi/coll/reduce/reduce.c
@@ -134,8 +134,9 @@ cvars:
 
 
 
-int MPIR_Reduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                             MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Reduce_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                             MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
+                             MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -192,7 +193,7 @@ int MPIR_Reduce_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_
     return mpi_errno;
 }
 
-int MPIR_Reduce_impl(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Reduce_impl(const void *sendbuf, void *recvbuf, MPI_Aint count,
                      MPI_Datatype datatype, MPI_Op op, int root,
                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -255,7 +256,7 @@ int MPIR_Reduce_impl(const void *sendbuf, void *recvbuf, int count,
     goto fn_exit;
 }
 
-int MPIR_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+int MPIR_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
                 MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/reduce/reduce_allcomm_nb.c
+++ b/src/mpi/coll/reduce/reduce_allcomm_nb.c
@@ -5,8 +5,9 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                           MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                           MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
+                           MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;

--- a/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
@@ -15,7 +15,7 @@
 
 int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
                                                void *recvbuf,
-                                               int count,
+                                               MPI_Aint count,
                                                MPI_Datatype datatype,
                                                MPI_Op op,
                                                int root,

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -11,7 +11,7 @@
  */
 int MPIR_Reduce_intra_binomial(const void *sendbuf,
                                void *recvbuf,
-                               int count,
+                               MPI_Aint count,
                                MPI_Datatype datatype,
                                MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -34,7 +34,7 @@
 */
 int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                                             void *recvbuf,
-                                            int count,
+                                            MPI_Aint count,
                                             MPI_Datatype datatype,
                                             MPI_Op op,
                                             int root,

--- a/src/mpi/coll/reduce/reduce_intra_smp.c
+++ b/src/mpi/coll/reduce/reduce_intra_smp.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                           MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
                           MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/reduce_local/reduce_local.c
+++ b/src/mpi/coll/reduce_local/reduce_local.c
@@ -8,7 +8,7 @@
 /* any utility functions should go here, usually prefixed with PMPI_LOCAL to
  * correctly handle weak symbols and the profiling interface */
 
-int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype datatype,
+int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
                       MPI_Op op)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/reduce_local/reduce_local.c
+++ b/src/mpi/coll/reduce_local/reduce_local.c
@@ -54,9 +54,12 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Dat
     }
 
     /* actually perform the reduction */
+    /* FIXME: properly support large count reduction */
+    MPIR_Assert(count <= INT_MAX);
+    int icount = (int) count;
 #ifdef HAVE_CXX_BINDING
     if (is_cxx_uop) {
-        (*MPIR_Process.cxx_call_op_fn) (inbuf, inoutbuf, count, datatype, uop);
+        (*MPIR_Process.cxx_call_op_fn) (inbuf, inoutbuf, icount, datatype, uop);
     } else
 #endif
     {
@@ -68,10 +71,10 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Dat
 
             (*uop_f77) ((void *) inbuf, inoutbuf, &lcount, &ldtype);
         } else {
-            (*uop) ((void *) inbuf, inoutbuf, &count, &datatype);
+            (*uop) ((void *) inbuf, inoutbuf, &icount, &datatype);
         }
 #else
-        (*uop) ((void *) inbuf, inoutbuf, &count, &datatype);
+        (*uop) ((void *) inbuf, inoutbuf, &icount, &datatype);
 #endif
     }
 

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
@@ -67,7 +67,7 @@ cvars:
 */
 
 
-int MPIR_Reduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, int recvcount,
+int MPIR_Reduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                            MPIR_Errflag_t * errflag)
 {
@@ -136,7 +136,7 @@ int MPIR_Reduce_scatter_block_allcomm_auto(const void *sendbuf, void *recvbuf, i
 }
 
 int MPIR_Reduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
-                                   int recvcount, MPI_Datatype datatype,
+                                   MPI_Aint recvcount, MPI_Datatype datatype,
                                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -211,7 +211,7 @@ int MPIR_Reduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
 }
 
 int MPIR_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
-                              int recvcount, MPI_Datatype datatype,
+                              MPI_Aint recvcount, MPI_Datatype datatype,
                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, int recvcount,
+int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                          MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
@@ -14,7 +14,7 @@
 
 int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *sendbuf,
                                                                 void *recvbuf,
-                                                                int recvcount,
+                                                                MPI_Aint recvcount,
                                                                 MPI_Datatype datatype,
                                                                 MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
@@ -22,7 +22,7 @@
 
 int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
                                                    void *recvbuf,
-                                                   int recvcount,
+                                                   MPI_Aint recvcount,
                                                    MPI_Datatype datatype,
                                                    MPI_Op op,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -22,7 +22,7 @@
  */
 int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
                                              void *recvbuf,
-                                             int recvcount,
+                                             MPI_Aint recvcount,
                                              MPI_Datatype datatype,
                                              MPI_Op op,
                                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -22,7 +22,7 @@
  */
 int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                                                        void *recvbuf,
-                                                       int recvcount,
+                                                       MPI_Aint recvcount,
                                                        MPI_Datatype datatype,
                                                        MPI_Op op,
                                                        MPIR_Comm * comm_ptr,

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -37,7 +37,7 @@
  */
 int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                                                       void *recvbuf,
-                                                      int recvcount,
+                                                      MPI_Aint recvcount,
                                                       MPI_Datatype datatype,
                                                       MPI_Op op,
                                                       MPIR_Comm * comm_ptr,

--- a/src/mpi/coll/scan/scan.c
+++ b/src/mpi/coll/scan/scan.c
@@ -42,8 +42,9 @@ cvars:
 */
 
 
-int MPIR_Scan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                           MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Scan_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
+                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                           MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -85,7 +86,7 @@ int MPIR_Scan_allcomm_auto(const void *sendbuf, void *recvbuf, int count, MPI_Da
     return mpi_errno;
 }
 
-int MPIR_Scan_impl(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Scan_impl(const void *sendbuf, void *recvbuf, MPI_Aint count,
                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -120,7 +121,7 @@ int MPIR_Scan_impl(const void *sendbuf, void *recvbuf, int count,
     goto fn_exit;
 }
 
-int MPIR_Scan(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/scan/scan_allcomm_nb.c
+++ b/src/mpi/coll/scan/scan_allcomm_nb.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -42,7 +42,7 @@
 
 int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
                                        void *recvbuf,
-                                       int count,
+                                       MPI_Aint count,
                                        MPI_Datatype datatype,
                                        MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 
-int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, int count,
+int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                         MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/scatter/scatter.c
+++ b/src/mpi/coll/scatter/scatter.c
@@ -66,8 +66,8 @@ cvars:
 */
 
 
-int MPIR_Scatter_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Scatter_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -120,8 +120,8 @@ int MPIR_Scatter_allcomm_auto(const void *sendbuf, int sendcount, MPI_Datatype s
     return mpi_errno;
 }
 
-int MPIR_Scatter_impl(const void *sendbuf, int sendcount,
-                      MPI_Datatype sendtype, void *recvbuf, int recvcount,
+int MPIR_Scatter_impl(const void *sendbuf, MPI_Aint sendcount,
+                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                       MPIR_Errflag_t * errflag)
 {
@@ -185,8 +185,8 @@ int MPIR_Scatter_impl(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-int MPIR_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                 void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Scatter(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/scatter/scatter_allcomm_nb.c
+++ b/src/mpi/coll/scatter/scatter_allcomm_nb.c
@@ -5,8 +5,8 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Scatter_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Scatter_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                            void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/scatter/scatter_inter_linear.c
+++ b/src/mpi/coll/scatter/scatter_inter_linear.c
@@ -12,8 +12,8 @@
  * Cost: p.alpha + n.beta
  */
 
-int MPIR_Scatter_inter_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int remote_size, mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -13,10 +13,11 @@
  * Cost: (lgp+1).alpha + n.((p-1)/p).beta + n.beta
  */
 
-int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, int sendcount,
+int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                 MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                 int root, MPIR_Comm * comm_ptr,
+                                                 MPIR_Errflag_t * errflag)
 {
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -26,8 +26,8 @@
 
 
 /* not declared static because a machine-specific function may call this one in some cases */
-int MPIR_Scatter_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     MPI_Status status;

--- a/src/mpi/coll/scatterv/scatterv.c
+++ b/src/mpi/coll/scatterv/scatterv.c
@@ -55,7 +55,7 @@ cvars:
 
 
 int MPIR_Scatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                               MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                MPIR_Errflag_t * errflag)
 {
@@ -100,7 +100,7 @@ int MPIR_Scatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const
 
 int MPIR_Scatterv_impl(const void *sendbuf, const int *sendcounts,
                        const int *displs, MPI_Datatype sendtype, void *recvbuf,
-                       int recvcount, MPI_Datatype recvtype, int root,
+                       MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                        MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -158,7 +158,7 @@ int MPIR_Scatterv_impl(const void *sendbuf, const int *sendcounts,
 
 int MPIR_Scatterv(const void *sendbuf, const int *sendcounts,
                   const int *displs, MPI_Datatype sendtype, void *recvbuf,
-                  int recvcount, MPI_Datatype recvtype, int root,
+                  MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -18,7 +18,7 @@
    Cost = (p-1).alpha + n.((p-1)/p).beta
 */
 int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const int *sendcounts, const int *displs,
-                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                 MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                  MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                  MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const int *sendcounts, const int *displs,
-                             MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                             MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                              MPIR_Errflag_t * errflag)
 {

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -20,7 +20,7 @@ static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
     return MPIR_Barrier_impl(comm, errflag);
 }
 
-static inline int MPID_Bcast(void *buffer, int count, MPI_Datatype datatype, int root,
+static inline int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                              MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
 #ifdef HAVE_LIBHCOLL
@@ -30,7 +30,7 @@ static inline int MPID_Bcast(void *buffer, int count, MPI_Datatype datatype, int
     return MPIR_Bcast_impl(buffer, count, datatype, root, comm, errflag);
 }
 
-static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, int count,
+static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                  MPIR_Errflag_t * errflag)
 {
@@ -41,8 +41,8 @@ static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, int count,
     return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
 }
 
-static inline int MPID_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
+static inline int MPID_Allgather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
 #ifdef HAVE_LIBHCOLL
@@ -54,7 +54,7 @@ static inline int MPID_Allgather(const void *sendbuf, int sendcount, MPI_Datatyp
                                     recvcount, recvtype, comm, errflag);
 }
 
-static inline int MPID_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+static inline int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, const int *recvcounts, const int *displs,
                                   MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
@@ -67,8 +67,8 @@ static inline int MPID_Allgatherv(const void *sendbuf, int sendcount, MPI_Dataty
     return mpi_errno;
 }
 
-static inline int MPID_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
+static inline int MPID_Scatter(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -80,7 +80,7 @@ static inline int MPID_Scatter(const void *sendbuf, int sendcount, MPI_Datatype 
 }
 
 static inline int MPID_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
-                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                 MPIR_Errflag_t * errflag)
 {
@@ -93,8 +93,8 @@ static inline int MPID_Scatterv(const void *sendbuf, const int *sendcounts, cons
     return mpi_errno;
 }
 
-static inline int MPID_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
+static inline int MPID_Gather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                               int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -105,7 +105,7 @@ static inline int MPID_Gather(const void *sendbuf, int sendcount, MPI_Datatype s
     return mpi_errno;
 }
 
-static inline int MPID_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+static inline int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const int *recvcounts, const int *displs,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                MPIR_Errflag_t * errflag)
@@ -119,8 +119,8 @@ static inline int MPID_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype 
     return mpi_errno;
 }
 
-static inline int MPID_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
+static inline int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                 MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -160,7 +160,7 @@ static inline int MPID_Alltoallw(const void *sendbuf, const int sendcounts[], co
     return mpi_errno;
 }
 
-static inline int MPID_Reduce(const void *sendbuf, void *recvbuf, int count,
+static inline int MPID_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                               MPI_Datatype datatype, MPI_Op op, int root,
                               MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
@@ -185,7 +185,7 @@ static inline int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf, const 
 }
 
 static inline int MPID_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                            int recvcount, MPI_Datatype datatype,
+                                            MPI_Aint recvcount, MPI_Datatype datatype,
                                             MPI_Op op, MPIR_Comm * comm_ptr,
                                             MPIR_Errflag_t * errflag)
 {
@@ -198,7 +198,7 @@ static inline int MPID_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
     return mpi_errno;
 }
 
-static inline int MPID_Scan(const void *sendbuf, void *recvbuf, int count,
+static inline int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                             MPIR_Errflag_t * errflag)
 {
@@ -210,7 +210,7 @@ static inline int MPID_Scan(const void *sendbuf, void *recvbuf, int count,
     return mpi_errno;
 }
 
-static inline int MPID_Exscan(const void *sendbuf, void *recvbuf, int count,
+static inline int MPID_Exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                               MPIR_Errflag_t * errflag)
 {
@@ -222,8 +222,8 @@ static inline int MPID_Exscan(const void *sendbuf, void *recvbuf, int count,
     return mpi_errno;
 }
 
-static inline int MPID_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
+static inline int MPID_Neighbor_allgather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                          void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                           MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -235,7 +235,7 @@ static inline int MPID_Neighbor_allgather(const void *sendbuf, int sendcount, MP
     return mpi_errno;
 }
 
-static inline int MPID_Neighbor_allgatherv(const void *sendbuf, int sendcount,
+static inline int MPID_Neighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
                                            const int recvcounts[], const int displs[],
                                            MPI_Datatype recvtype, MPIR_Comm * comm)
@@ -279,8 +279,8 @@ static inline int MPID_Neighbor_alltoallw(const void *sendbuf, const int sendcou
     return mpi_errno;
 }
 
-static inline int MPID_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
+static inline int MPID_Neighbor_alltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                         void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                          MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -292,8 +292,8 @@ static inline int MPID_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI
     return mpi_errno;
 }
 
-static inline int MPID_Ineighbor_allgather(const void *sendbuf, int sendcount,
-                                           MPI_Datatype sendtype, void *recvbuf, int recvcount,
+static inline int MPID_Ineighbor_allgather(const void *sendbuf, MPI_Aint sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                            MPI_Datatype recvtype, MPIR_Comm * comm,
                                            MPIR_Request **request)
 {
@@ -306,7 +306,7 @@ static inline int MPID_Ineighbor_allgather(const void *sendbuf, int sendcount,
     return mpi_errno;
 }
 
-static inline int MPID_Ineighbor_allgatherv(const void *sendbuf, int sendcount,
+static inline int MPID_Ineighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                             MPI_Datatype sendtype, void *recvbuf,
                                             const int recvcounts[], const int displs[],
                                             MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -321,8 +321,8 @@ static inline int MPID_Ineighbor_allgatherv(const void *sendbuf, int sendcount,
     return mpi_errno;
 }
 
-static inline int MPID_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
+static inline int MPID_Ineighbor_alltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                          void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                           MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -375,7 +375,7 @@ static inline int MPID_Ibarrier(MPIR_Comm * comm, MPIR_Request **request)
     return mpi_errno;
 }
 
-static inline int MPID_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root,
+static inline int MPID_Ibcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                               MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -385,8 +385,8 @@ static inline int MPID_Ibcast(void *buffer, int count, MPI_Datatype datatype, in
     return mpi_errno;
 }
 
-static inline int MPID_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
+static inline int MPID_Iallgather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                   MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -397,7 +397,7 @@ static inline int MPID_Iallgather(const void *sendbuf, int sendcount, MPI_Dataty
     return mpi_errno;
 }
 
-static inline int MPID_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+static inline int MPID_Iallgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int *recvcounts, const int *displs,
                                    MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request **request)
 {
@@ -410,7 +410,7 @@ static inline int MPID_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datat
     return mpi_errno;
 }
 
-static inline int MPID_Iallreduce(const void *sendbuf, void *recvbuf, int count,
+static inline int MPID_Iallreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                   MPIR_Request **request)
 {
@@ -422,8 +422,8 @@ static inline int MPID_Iallreduce(const void *sendbuf, void *recvbuf, int count,
     return mpi_errno;
 }
 
-static inline int MPID_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
+static inline int MPID_Ialltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                  MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -464,7 +464,7 @@ static inline int MPID_Ialltoallw(const void *sendbuf, const int sendcounts[],
     return mpi_errno;
 }
 
-static inline int MPID_Iexscan(const void *sendbuf, void *recvbuf, int count,
+static inline int MPID_Iexscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                MPIR_Request **request)
 {
@@ -476,8 +476,8 @@ static inline int MPID_Iexscan(const void *sendbuf, void *recvbuf, int count,
     return mpi_errno;
 }
 
-static inline int MPID_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
+static inline int MPID_Igather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                int root, MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -488,7 +488,7 @@ static inline int MPID_Igather(const void *sendbuf, int sendcount, MPI_Datatype 
     return mpi_errno;
 }
 
-static inline int MPID_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+static inline int MPID_Igatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, const int *recvcounts, const int *displs,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                 MPIR_Request **request)
@@ -502,7 +502,7 @@ static inline int MPID_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype
     return mpi_errno;
 }
 
-static inline int MPID_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
+static inline int MPID_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                              MPIR_Request **request)
 {
@@ -526,7 +526,7 @@ static inline int MPID_Ireduce_scatter(const void *sendbuf, void *recvbuf, const
     return mpi_errno;
 }
 
-static inline int MPID_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+static inline int MPID_Ireduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
                                MPI_Op op, int root, MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -537,7 +537,7 @@ static inline int MPID_Ireduce(const void *sendbuf, void *recvbuf, int count, MP
     return mpi_errno;
 }
 
-static inline int MPID_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+static inline int MPID_Iscan(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
                              MPI_Op op, MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -548,8 +548,8 @@ static inline int MPID_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_
     return mpi_errno;
 }
 
-static inline int MPID_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
+static inline int MPID_Iscatter(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                 int root, MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -562,7 +562,7 @@ static inline int MPID_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype
 
 static inline int MPID_Iscatterv(const void *sendbuf, const int *sendcounts,
                                  const int *displs, MPI_Datatype sendtype,
-                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                  int root, MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -309,11 +309,11 @@ Native API:
       NM*: comm, errflag
      SHM*: comm, errflag
   mpi_bcast : int
-      NM*: buffer, count-3, datatype, root, comm, errflag
-     SHM*: buffer, count-3, datatype, root, comm, errflag
+      NM*: buffer, count, datatype, root, comm, errflag
+     SHM*: buffer, count, datatype, root, comm, errflag
   mpi_allreduce : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, errflag
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
   mpi_allgather : int
       NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, errflag
      SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, errflag
@@ -342,8 +342,8 @@ Native API:
       NM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, errflag
      SHM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, errflag
   mpi_reduce : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, root, comm_ptr, errflag
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, root, comm_ptr, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag
+     SHM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag
   mpi_reduce_scatter : int
       NM*: sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag
      SHM*: sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag
@@ -351,11 +351,11 @@ Native API:
       NM*: sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, errflag
      SHM*: sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, errflag
   mpi_scan : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, errflag
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
   mpi_exscan : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, errflag
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
   mpi_neighbor_allgather : int
       NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm
      SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm
@@ -390,8 +390,8 @@ Native API:
       NM*: comm, req_p
      SHM*: comm, req_p
   mpi_ibcast : int
-      NM*: buffer, count-3, datatype, root, comm, req_p
-     SHM*: buffer, count-3, datatype, root, comm, req_p
+      NM*: buffer, count, datatype, root, comm, req_p
+     SHM*: buffer, count, datatype, root, comm, req_p
   mpi_iallgather : int
       NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
      SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
@@ -399,8 +399,8 @@ Native API:
       NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req_p
      SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req_p
   mpi_iallreduce : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
   mpi_ialltoall : int
       NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
      SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
@@ -411,8 +411,8 @@ Native API:
       NM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, req_p
      SHM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, req_p
   mpi_iexscan : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
   mpi_igather : int
       NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
      SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
@@ -426,11 +426,11 @@ Native API:
       NM*: sendbuf, recvbuf, recvcounts, datatype, op, comm, req_p
      SHM*: sendbuf, recvbuf, recvcounts, datatype, op, comm, req_p
   mpi_ireduce : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, root, comm_ptr, req_p
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, root, comm_ptr, req_p
+      NM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, req_p
+     SHM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, req_p
   mpi_iscan : int
-      NM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
-     SHM*: sendbuf, recvbuf, count-3, datatype, op, comm, req_p
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
   mpi_iscatter : int
       NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
      SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
@@ -476,7 +476,6 @@ PARAM:
     context_id: MPIR_Context_id_t
     context_offset: int
     count: MPI_Aint
-    count-3: int
     data: const void *
     data_sz: MPI_Aint
     datatype: MPI_Datatype
@@ -517,7 +516,7 @@ PARAM:
     rdispls: const int *
     rdispls-2: const MPI_Aint *
     recvbuf: void *
-    recvcount: int
+    recvcount: MPI_Aint
     recvcounts: const int *
     recvtype: MPI_Datatype
     recvtypes: const MPI_Datatype[]
@@ -534,7 +533,7 @@ PARAM:
     sdispls: const int *
     sdispls-2: const MPI_Aint *
     sendbuf: const void *
-    sendcount: int
+    sendcount: MPI_Aint
     sendcounts: const int *
     sendtype: MPI_Datatype
     sendtypes: const MPI_Datatype[]

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -167,29 +167,29 @@ int MPID_Comm_commit_pre_hook(MPIR_Comm *);
 int MPID_Comm_free_hook(MPIR_Comm *);
 int MPID_Comm_commit_post_hook(MPIR_Comm *);
 MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *, int, MPI_Datatype, int, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,
                                         MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *, void *, int, MPI_Datatype, MPI_Op,
+MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
                                             MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *, int, MPI_Datatype, void *, int,
+MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                             MPI_Datatype, MPIR_Comm *,
                                             MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *, int, MPI_Datatype, void *, const int *,
-                                             const int *, MPI_Datatype, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
+                                             const int *, const int *, MPI_Datatype, MPIR_Comm *,
                                              MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *, int, MPI_Datatype, void *, int,
+MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                           MPI_Datatype, int, MPIR_Comm *,
                                           MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *, const int *, const int *, MPI_Datatype,
-                                           void *, int, MPI_Datatype, int, MPIR_Comm *,
+                                           void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,
                                            MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *, int, MPI_Datatype, void *, int, MPI_Datatype,
-                                         int, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
+                                         MPI_Datatype, int, MPIR_Comm *,
                                          MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *, int, MPI_Datatype, void *, const int *,
+MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *, MPI_Aint, MPI_Datatype, void *, const int *,
                                           const int *, MPI_Datatype, int, MPIR_Comm *,
                                           MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *, int, MPI_Datatype, void *, int,
+MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                            MPI_Datatype, MPIR_Comm *,
                                            MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *, const int *, const int *, MPI_Datatype,
@@ -199,22 +199,22 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *, const int[], const int
                                             const MPI_Datatype[], void *, const int[], const int[],
                                             const MPI_Datatype[], MPIR_Comm *,
                                             MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *, void *, int, MPI_Datatype, MPI_Op, int,
+MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op, int,
                                          MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *, void *, const int[], MPI_Datatype,
                                                  MPI_Op, MPIR_Comm *,
                                                  MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *, void *, int, MPI_Datatype,
+MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *, void *, MPI_Aint, MPI_Datatype,
                                                        MPI_Op, MPIR_Comm *,
                                                        MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *, void *, int, MPI_Datatype, MPI_Op, MPIR_Comm *,
-                                       MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *, void *, int, MPI_Datatype, MPI_Op,
+MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
+                                       MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
                                          MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *, int, MPI_Datatype, void *, int,
-                                                     MPI_Datatype,
+MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *, MPI_Aint, MPI_Datatype, void *,
+                                                     MPI_Aint, MPI_Datatype,
                                                      MPIR_Comm *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgatherv(const void *, int, MPI_Datatype, void *,
+MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
                                                       const int[], const int[], MPI_Datatype,
                                                       MPIR_Comm *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallv(const void *, const int[], const int[],
@@ -225,18 +225,18 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallw(const void *, const int[], 
                                                      const MPI_Datatype[], void *, const int[],
                                                      const MPI_Aint[], const MPI_Datatype[],
                                                      MPIR_Comm *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoall(const void *, int, MPI_Datatype, void *, int,
-                                                    MPI_Datatype,
+MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoall(const void *, MPI_Aint, MPI_Datatype, void *,
+                                                    MPI_Aint, MPI_Datatype,
                                                     MPIR_Comm *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather(const void *, int, MPI_Datatype, void *, int,
-                                                      MPI_Datatype, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather(const void *, MPI_Aint, MPI_Datatype, void *,
+                                                      MPI_Aint, MPI_Datatype, MPIR_Comm *,
                                                       MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv(const void *, int, MPI_Datatype, void *,
+MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
                                                        const int[], const int[], MPI_Datatype,
                                                        MPIR_Comm *,
                                                        MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall(const void *, int, MPI_Datatype, void *, int,
-                                                     MPI_Datatype, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall(const void *, MPI_Aint, MPI_Datatype, void *,
+                                                     MPI_Aint, MPI_Datatype, MPIR_Comm *,
                                                      MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv(const void *, const int[], const int[],
                                                       MPI_Datatype, void *, const int[],
@@ -248,17 +248,17 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw(const void *, const int[],
                                                       MPIR_Comm *,
                                                       MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier(MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *, int, MPI_Datatype, int, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,
                                          MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Iallgather(const void *, int, MPI_Datatype, void *, int,
+MPL_STATIC_INLINE_PREFIX int MPID_Iallgather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                              MPI_Datatype, MPIR_Comm *,
                                              MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *, int, MPI_Datatype, void *, const int *,
-                                              const int *, MPI_Datatype, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
+                                              const int *, const int *, MPI_Datatype, MPIR_Comm *,
                                               MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce(const void *, void *, int, MPI_Datatype, MPI_Op,
+MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
                                              MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall(const void *, int, MPI_Datatype, void *, int,
+MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                             MPI_Datatype, MPIR_Comm *,
                                             MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv(const void *, const int[], const int[], MPI_Datatype,
@@ -268,29 +268,29 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw(const void *, const int[], const in
                                              const MPI_Datatype[], void *, const int[], const int[],
                                              const MPI_Datatype[], MPIR_Comm *,
                                              MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Iexscan(const void *, void *, int, MPI_Datatype, MPI_Op,
+MPL_STATIC_INLINE_PREFIX int MPID_Iexscan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
                                           MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Igather(const void *, int, MPI_Datatype, void *, int,
+MPL_STATIC_INLINE_PREFIX int MPID_Igather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                           MPI_Datatype, int, MPIR_Comm *,
                                           MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *, int, MPI_Datatype, void *, const int *,
-                                           const int *, MPI_Datatype, int, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *, MPI_Aint, MPI_Datatype, void *,
+                                           const int *, const int *, MPI_Datatype, int, MPIR_Comm *,
                                            MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block(const void *, void *, int, MPI_Datatype,
-                                                        MPI_Op, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block(const void *, void *, MPI_Aint,
+                                                        MPI_Datatype, MPI_Op, MPIR_Comm *,
                                                         MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter(const void *, void *, const int[], MPI_Datatype,
                                                   MPI_Op, MPIR_Comm *,
                                                   MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ireduce(const void *, void *, int, MPI_Datatype, MPI_Op, int,
+MPL_STATIC_INLINE_PREFIX int MPID_Ireduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op, int,
                                           MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Iscan(const void *, void *, int, MPI_Datatype, MPI_Op,
+MPL_STATIC_INLINE_PREFIX int MPID_Iscan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
                                         MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Iscatter(const void *, int, MPI_Datatype, void *, int,
+MPL_STATIC_INLINE_PREFIX int MPID_Iscatter(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                            MPI_Datatype, int, MPIR_Comm *,
                                            MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *, const int *, const int *, MPI_Datatype,
-                                            void *, int, MPI_Datatype, int, MPIR_Comm *,
+                                            void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,
                                             MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Abort(struct MPIR_Comm *comm, int mpi_errno, int exit_code, const char *error_msg);
 

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_coll.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_coll.h
@@ -11,30 +11,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Err
     return MPIR_Barrier_impl(comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                                 int root, MPIR_Comm * comm_ptr,
                                                 MPIR_Errflag_t * errflag)
 {
     return MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
-                                                    MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
+                                                    MPI_Aint count, MPI_Datatype datatype,
+                                                    MPI_Op op, MPIR_Comm * comm_ptr,
+                                                    MPIR_Errflag_t * errflag)
 {
     return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     return MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
                                recvcount, recvtype, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const int *recvcounts, const int *displs,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -44,16 +45,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int se
                                 recvcounts, displs, recvtype, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                 MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                 int root, MPIR_Comm * comm_ptr,
+                                                 MPIR_Errflag_t * errflag)
 {
     return MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
                             recvcount, recvtype, root, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   const int *recvcounts, const int *displs,
                                                   MPI_Datatype recvtype, int root,
@@ -63,10 +65,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendc
                              recvcounts, displs, recvtype, root, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  MPIR_Errflag_t * errflag)
 {
     return MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcount, recvtype, root, comm_ptr, errflag);
@@ -74,7 +77,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendc
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
                                                    const int *displs, MPI_Datatype sendtype,
-                                                   void *recvbuf, int recvcount,
+                                                   void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -82,9 +85,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const in
                               recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     return MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
@@ -112,7 +115,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const i
                                recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -129,38 +132,42 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                               int recvcount, MPI_Datatype datatype,
-                                                               MPI_Op op, MPIR_Comm * comm_ptr,
+                                                               MPI_Aint recvcount,
+                                                               MPI_Datatype datatype, MPI_Op op,
+                                                               MPIR_Comm * comm_ptr,
                                                                MPIR_Errflag_t * errflag)
 {
     return MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
                                           datatype, op, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     return MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op,
                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     return MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf,
+                                                             MPI_Aint sendcount,
                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
+                                                             MPI_Aint recvcount,
+                                                             MPI_Datatype recvtype,
                                                              MPIR_Comm * comm_ptr)
 {
     return MPIR_Neighbor_allgather_impl(sendbuf, sendcount, sendtype,
                                         recvbuf, recvcount, recvtype, comm_ptr);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf,
+                                                              MPI_Aint sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
                                                               const int recvcounts[],
                                                               const int displs[],
@@ -171,9 +178,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbu
                                          recvbuf, recvcounts, displs, recvtype, comm_ptr);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                            int recvcount, MPI_Datatype recvtype,
+                                                            MPI_Aint recvcount,
+                                                            MPI_Datatype recvtype,
                                                             MPIR_Comm * comm_ptr)
 {
     return MPIR_Neighbor_alltoall_impl(sendbuf, sendcount, sendtype,
@@ -207,9 +215,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf
                                         rdispls, recvtypes, comm_ptr);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbuf,
+                                                              MPI_Aint sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              int recvcount, MPI_Datatype recvtype,
+                                                              MPI_Aint recvcount,
+                                                              MPI_Datatype recvtype,
                                                               MPIR_Comm * comm_ptr,
                                                               MPIR_Request ** req)
 {
@@ -217,7 +227,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbu
                                          recvbuf, recvcount, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf,
+                                                               MPI_Aint sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
                                                                const int recvcounts[],
                                                                const int displs[],
@@ -229,9 +240,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendb
                                           recvbuf, recvcounts, displs, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf,
+                                                             MPI_Aint sendcount,
                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
+                                                             MPI_Aint recvcount,
+                                                             MPI_Datatype recvtype,
                                                              MPIR_Comm * comm_ptr,
                                                              MPIR_Request ** req)
 {
@@ -274,23 +287,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm_ptr, MPIR_Re
     return MPIR_Ibarrier_impl(comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                 int root, MPIR_Comm * comm_ptr,
-                                                 MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, MPI_Aint count,
+                                                 MPI_Datatype datatype, int root,
+                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     return MPIR_Ibcast_impl(buffer, count, datatype, root, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     return MPIR_Iallgather_impl(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcount, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       const int *recvcounts, const int *displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -300,16 +313,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int s
                                  recvcounts, displs, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
-                                                     MPI_Datatype datatype, MPI_Op op,
-                                                     MPIR_Comm * comm, MPIR_Request ** request)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf,
+                                                     MPI_Aint count, MPI_Datatype datatype,
+                                                     MPI_Op op, MPIR_Comm * comm,
+                                                     MPIR_Request ** request)
 {
     return MPIR_Iallreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, request);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     return MPIR_Ialltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
@@ -337,23 +351,24 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const 
                                 recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     return MPIR_Iexscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  MPIR_Request ** req)
 {
     return MPIR_Igather_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcount, recvtype, root, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int *recvcounts, const int *displs,
                                                    MPI_Datatype recvtype, int root,
@@ -364,7 +379,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, int send
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                                int recvcount,
+                                                                MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
                                                                 MPIR_Request ** req)
@@ -381,23 +396,24 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, v
     return MPIR_Ireduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  MPIR_Request ** req)
 {
     return MPIR_Ireduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     return MPIR_Iscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    int root, MPIR_Comm * comm,
                                                    MPIR_Request ** request)
 {
@@ -407,7 +423,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, int send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
                                                     const int *displs, MPI_Datatype sendtype,
-                                                    void *recvbuf, int recvcount,
+                                                    void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
                                                     MPIR_Comm * comm, MPIR_Request ** request)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_coll.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll.h
@@ -28,7 +28,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                                 int root, MPIR_Comm * comm,
                                                 MPIR_Errflag_t * errflag)
 {
@@ -49,9 +49,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Dat
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
-                                                    MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
+                                                    MPI_Aint count, MPI_Datatype datatype,
+                                                    MPI_Op op, MPIR_Comm * comm,
+                                                    MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -70,9 +71,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -93,7 +94,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sen
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const int *recvcounts, const int *displs,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -117,10 +118,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int se
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                 MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                 int root, MPIR_Comm * comm,
+                                                 MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -140,7 +142,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, int sendco
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   const int *recvcounts, const int *displs,
                                                   MPI_Datatype recvtype, int root, MPIR_Comm * comm,
@@ -165,10 +167,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendc
 
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                  int root, MPIR_Comm * comm,
+                                                  MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -190,7 +193,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendc
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
                                                    const int *displs, MPI_Datatype sendtype,
-                                                   void *recvbuf, int recvcount,
+                                                   void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
@@ -212,9 +215,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const in
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -286,7 +289,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const i
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
@@ -330,8 +333,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                               int recvcount, MPI_Datatype datatype,
-                                                               MPI_Op op, MPIR_Comm * comm,
+                                                               MPI_Aint recvcount,
+                                                               MPI_Datatype datatype, MPI_Op op,
+                                                               MPIR_Comm * comm,
                                                                MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -351,7 +355,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                                MPIR_Errflag_t * errflag)
 {
@@ -372,7 +376,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbu
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                                  MPIR_Errflag_t * errflag)
 {
@@ -393,9 +397,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recv
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf,
+                                                             MPI_Aint sendcount,
                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
+                                                             MPI_Aint recvcount,
+                                                             MPI_Datatype recvtype,
                                                              MPIR_Comm * comm)
 {
     int mpi_errno;
@@ -410,7 +416,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf,
+                                                              MPI_Aint sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
                                                               const int recvcounts[],
                                                               const int displs[],
@@ -428,10 +435,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbu
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                            int recvcount, MPI_Datatype recvtype,
-                                                            MPIR_Comm * comm)
+                                                            MPI_Aint recvcount,
+                                                            MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_NEIGHBOR_ALLTOALL);
@@ -484,9 +491,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbuf,
+                                                              MPI_Aint sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              int recvcount, MPI_Datatype recvtype,
+                                                              MPI_Aint recvcount,
+                                                              MPI_Datatype recvtype,
                                                               MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
@@ -500,7 +509,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbu
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf,
+                                                               MPI_Aint sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
                                                                const int recvcounts[],
                                                                const int displs[],
@@ -519,9 +529,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendb
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf,
+                                                             MPI_Aint sendcount,
                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
+                                                             MPI_Aint recvcount,
+                                                             MPI_Datatype recvtype,
                                                              MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
@@ -587,8 +599,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Reques
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                 int root, MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, MPI_Aint count,
+                                                 MPI_Datatype datatype, int root, MPIR_Comm * comm,
+                                                 MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IBCAST);
@@ -600,9 +613,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, int count, MPI_Da
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
@@ -616,7 +629,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, int se
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       const int *recvcounts, const int *displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -633,9 +646,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int s
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
-                                                     MPI_Datatype datatype, MPI_Op op,
-                                                     MPIR_Comm * comm, MPIR_Request ** request)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf,
+                                                     MPI_Aint count, MPI_Datatype datatype,
+                                                     MPI_Op op, MPIR_Comm * comm,
+                                                     MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IALLREDUCE);
@@ -647,9 +661,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
@@ -698,8 +712,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const 
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
@@ -712,10 +726,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *rec
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm, MPIR_Request ** req)
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                  int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IGATHER);
@@ -728,7 +742,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, int sendc
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int *recvcounts, const int *displs,
                                                    MPI_Datatype recvtype, int root,
@@ -746,7 +760,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, int send
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                                int recvcount,
+                                                                MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm,
                                                                 MPIR_Request ** req)
@@ -777,9 +791,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, v
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                  MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
+                                                  int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IREDUCE);
@@ -791,7 +805,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *rec
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                                 MPIR_Request ** req)
 {
@@ -805,9 +819,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvb
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    int root, MPIR_Comm * comm,
                                                    MPIR_Request ** request)
 {
@@ -824,7 +838,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, int send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
                                                     const int *displs, MPI_Datatype sendtype,
-                                                    void *recvbuf, int recvcount,
+                                                    void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
                                                     MPIR_Comm * comm, MPIR_Request ** request)
 {

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -29,7 +29,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Err
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                                 int root, MPIR_Comm * comm_ptr,
                                                 MPIR_Errflag_t * errflag)
 {
@@ -49,9 +49,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Dat
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
-                                                    MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
+                                                    MPI_Aint count, MPI_Datatype datatype,
+                                                    MPI_Op op, MPIR_Comm * comm_ptr,
+                                                    MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_ALLREDUCE);
@@ -69,9 +70,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
@@ -92,7 +93,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sen
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const int *recvcounts, const int *displs,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -109,10 +110,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int se
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                 MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                 int root, MPIR_Comm * comm_ptr,
+                                                 MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_GATHER);
@@ -125,7 +127,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, int sendco
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   const int *recvcounts, const int *displs,
                                                   MPI_Datatype recvtype, int root,
@@ -142,10 +144,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendc
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_SCATTER);
@@ -160,7 +163,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendc
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
                                                    const int *displs, MPI_Datatype sendtype,
-                                                   void *recvbuf, int recvcount,
+                                                   void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -175,9 +178,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const in
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
@@ -238,7 +241,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const i
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -276,8 +279,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                               int recvcount, MPI_Datatype datatype,
-                                                               MPI_Op op, MPIR_Comm * comm_ptr,
+                                                               MPI_Aint recvcount,
+                                                               MPI_Datatype datatype, MPI_Op op,
+                                                               MPIR_Comm * comm_ptr,
                                                                MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
@@ -291,7 +295,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -305,7 +309,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbu
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op,
                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -319,9 +323,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recv
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf,
+                                                             MPI_Aint sendcount,
                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
+                                                             MPI_Aint recvcount,
+                                                             MPI_Datatype recvtype,
                                                              MPIR_Comm * comm_ptr)
 {
     int mpi_errno;
@@ -335,7 +341,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf,
+                                                              MPI_Aint sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
                                                               const int recvcounts[],
                                                               const int displs[],
@@ -353,9 +360,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbu
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                            int recvcount, MPI_Datatype recvtype,
+                                                            MPI_Aint recvcount,
+                                                            MPI_Datatype recvtype,
                                                             MPIR_Comm * comm_ptr)
 {
     int mpi_errno;
@@ -411,9 +419,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbuf,
+                                                              MPI_Aint sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              int recvcount, MPI_Datatype recvtype,
+                                                              MPI_Aint recvcount,
+                                                              MPI_Datatype recvtype,
                                                               MPIR_Comm * comm_ptr,
                                                               MPIR_Request ** req)
 {
@@ -428,7 +438,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbu
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf,
+                                                               MPI_Aint sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
                                                                const int recvcounts[],
                                                                const int displs[],
@@ -448,9 +459,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendb
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf,
+                                                             MPI_Aint sendcount,
                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
+                                                             MPI_Aint recvcount,
+                                                             MPI_Datatype recvtype,
                                                              MPIR_Comm * comm_ptr,
                                                              MPIR_Request ** req)
 {
@@ -521,9 +534,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm_ptr, MPIR_Re
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                 int root, MPIR_Comm * comm_ptr,
-                                                 MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, MPI_Aint count,
+                                                 MPI_Datatype datatype, int root,
+                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IBCAST);
@@ -535,9 +548,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, int count, MPI_Da
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int mpi_errno;
@@ -551,7 +564,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, int se
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       const int *recvcounts, const int *displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -568,9 +581,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int s
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
-                                                     MPI_Datatype datatype, MPI_Op op,
-                                                     MPIR_Comm * comm, MPIR_Request ** request)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf,
+                                                     MPI_Aint count, MPI_Datatype datatype,
+                                                     MPI_Op op, MPIR_Comm * comm,
+                                                     MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IALLREDUCE);
@@ -582,9 +596,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int mpi_errno;
@@ -633,8 +647,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const 
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int mpi_errno;
@@ -647,10 +661,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *rec
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IGATHER);
@@ -663,7 +678,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, int sendc
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int *recvcounts, const int *displs,
                                                    MPI_Datatype recvtype, int root,
@@ -681,7 +696,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, int send
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                                int recvcount,
+                                                                MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
                                                                 MPIR_Request ** req)
@@ -713,9 +728,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, v
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IREDUCE);
@@ -727,7 +743,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *rec
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
@@ -741,9 +757,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvb
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    int root, MPIR_Comm * comm,
                                                    MPIR_Request ** request)
 {
@@ -760,7 +776,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, int send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
                                                     const int *displs, MPI_Datatype sendtype,
-                                                    void *recvbuf, int recvcount,
+                                                    void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
                                                     MPIR_Comm * comm, MPIR_Request ** request)
 {

--- a/src/mpid/ch4/shm/posix/posix_coll.h
+++ b/src/mpid/ch4/shm/posix/posix_coll.h
@@ -130,9 +130,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, MPIR_Errf
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
-                                                   int root, MPIR_Comm * comm,
-                                                   MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, MPI_Aint count,
+                                                   MPI_Datatype datatype, int root,
+                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -196,8 +196,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, int count, MPI_
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce(const void *sendbuf, void *recvbuf,
-                                                       int count, MPI_Datatype datatype, MPI_Op op,
-                                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                       MPI_Aint count, MPI_Datatype datatype,
+                                                       MPI_Op op, MPIR_Comm * comm,
+                                                       MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -265,9 +266,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce(const void *sendbuf, void
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
-                                                       int recvcount, MPI_Datatype recvtype,
+                                                       MPI_Aint recvcount, MPI_Datatype recvtype,
                                                        MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -288,7 +289,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather(const void *sendbuf, int 
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         const int *recvcounts, const int *displs,
                                                         MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -312,10 +313,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv(const void *sendbuf, int
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                    int root, MPIR_Comm * comm,
+                                                    MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -335,7 +337,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gather(const void *sendbuf, int sen
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const int *recvcounts, const int *displs,
                                                      MPI_Datatype recvtype, int root,
@@ -360,10 +362,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gatherv(const void *sendbuf, int se
 
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype, int root,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                     int root, MPIR_Comm * comm,
+                                                     MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -385,7 +388,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatter(const void *sendbuf, int se
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatterv(const void *sendbuf, const int *sendcounts,
                                                       const int *displs, MPI_Datatype sendtype,
-                                                      void *recvbuf, int recvcount,
+                                                      void *recvbuf, MPI_Aint recvcount,
                                                       MPI_Datatype recvtype, int root,
                                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
@@ -407,9 +410,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatterv(const void *sendbuf, const
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      int recvcount, MPI_Datatype recvtype,
+                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
                                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
@@ -482,9 +485,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallw(const void *sendbuf, cons
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
-                                                    MPI_Datatype datatype, MPI_Op op, int root,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce(const void *sendbuf, void *recvbuf,
+                                                    MPI_Aint count, MPI_Datatype datatype,
+                                                    MPI_Op op, int root, MPIR_Comm * comm,
+                                                    MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -577,7 +581,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_scatter(const void *sendbuf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_scatter_block(const void *sendbuf,
-                                                                  void *recvbuf, int recvcount,
+                                                                  void *recvbuf, MPI_Aint recvcount,
                                                                   MPI_Datatype datatype, MPI_Op op,
                                                                   MPIR_Comm * comm,
                                                                   MPIR_Errflag_t * errflag)
@@ -599,8 +603,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_scatter_block(const void *se
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scan(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scan(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -620,9 +624,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scan(const void *sendbuf, void *rec
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
-                                                    MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_exscan(const void *sendbuf, void *recvbuf,
+                                                    MPI_Aint count, MPI_Datatype datatype,
+                                                    MPI_Op op, MPIR_Comm * comm,
+                                                    MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -641,9 +646,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_exscan(const void *sendbuf, void *r
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_allgather(const void *sendbuf,
+                                                                MPI_Aint sendcount,
                                                                 MPI_Datatype sendtype,
-                                                                void *recvbuf, int recvcount,
+                                                                void *recvbuf, MPI_Aint recvcount,
                                                                 MPI_Datatype recvtype,
                                                                 MPIR_Comm * comm)
 {
@@ -659,7 +665,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_allgather(const void *send
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_allgatherv(const void *sendbuf,
+                                                                 MPI_Aint sendcount,
                                                                  MPI_Datatype sendtype,
                                                                  void *recvbuf,
                                                                  const int recvcounts[],
@@ -678,9 +685,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_allgatherv(const void *sen
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_alltoall(const void *sendbuf,
+                                                               MPI_Aint sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
-                                                               int recvcount, MPI_Datatype recvtype,
+                                                               MPI_Aint recvcount,
+                                                               MPI_Datatype recvtype,
                                                                MPIR_Comm * comm)
 {
     int mpi_errno;
@@ -736,9 +745,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_alltoallw(const void *send
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_allgather(const void *sendbuf,
+                                                                 MPI_Aint sendcount,
                                                                  MPI_Datatype sendtype,
-                                                                 void *recvbuf, int recvcount,
+                                                                 void *recvbuf, MPI_Aint recvcount,
                                                                  MPI_Datatype recvtype,
                                                                  MPIR_Comm * comm,
                                                                  MPIR_Request ** req)
@@ -755,7 +765,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_allgather(const void *sen
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_allgatherv(const void *sendbuf,
-                                                                  int sendcount,
+                                                                  MPI_Aint sendcount,
                                                                   MPI_Datatype sendtype,
                                                                   void *recvbuf,
                                                                   const int recvcounts[],
@@ -775,9 +785,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_allgatherv(const void *se
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_alltoall(const void *sendbuf,
+                                                                MPI_Aint sendcount,
                                                                 MPI_Datatype sendtype,
-                                                                void *recvbuf, int recvcount,
+                                                                void *recvbuf, MPI_Aint recvcount,
                                                                 MPI_Datatype recvtype,
                                                                 MPIR_Comm * comm,
                                                                 MPIR_Request ** req)
@@ -849,8 +860,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ibarrier(MPIR_Comm * comm, MPIR_Req
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                    int root, MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ibcast(void *buffer, MPI_Aint count,
+                                                    MPI_Datatype datatype, int root,
+                                                    MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_IBCAST);
@@ -862,9 +874,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ibcast(void *buffer, int count, MPI
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallgather(const void *sendbuf, MPI_Aint sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
-                                                        int recvcount, MPI_Datatype recvtype,
+                                                        MPI_Aint recvcount, MPI_Datatype recvtype,
                                                         MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
@@ -878,7 +890,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallgather(const void *sendbuf, int
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          const int *recvcounts, const int *displs,
                                                          MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -895,9 +907,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallgatherv(const void *sendbuf, in
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoall(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
-                                                       int recvcount, MPI_Datatype recvtype,
+                                                       MPI_Aint recvcount, MPI_Datatype recvtype,
                                                        MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
@@ -947,9 +959,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoallw(const void *sendbuf, con
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
-                                                     MPI_Datatype datatype, MPI_Op op,
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iexscan(const void *sendbuf, void *recvbuf,
+                                                     MPI_Aint count, MPI_Datatype datatype,
+                                                     MPI_Op op, MPIR_Comm * comm,
+                                                     MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_IEXSCAN);
@@ -961,10 +974,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iexscan(const void *sendbuf, void *
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_igather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_igather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype, int root,
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                     int root, MPIR_Comm * comm,
+                                                     MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_IGATHER);
@@ -977,7 +991,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_igather(const void *sendbuf, int se
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_igatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       const int *recvcounts, const int *displs,
                                                       MPI_Datatype recvtype, int root,
@@ -995,7 +1009,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_igatherv(const void *sendbuf, int s
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce_scatter_block(const void *sendbuf,
-                                                                   void *recvbuf, int recvcount,
+                                                                   void *recvbuf,
+                                                                   MPI_Aint recvcount,
                                                                    MPI_Datatype datatype, MPI_Op op,
                                                                    MPIR_Comm * comm,
                                                                    MPIR_Request ** req)
@@ -1026,9 +1041,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce_scatter(const void *sendbuf
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
-                                                     MPI_Datatype datatype, MPI_Op op, int root,
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce(const void *sendbuf, void *recvbuf,
+                                                     MPI_Aint count, MPI_Datatype datatype,
+                                                     MPI_Op op, int root, MPIR_Comm * comm,
+                                                     MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_IREDUCE);
@@ -1041,8 +1057,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce(const void *sendbuf, void *
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallreduce(const void *sendbuf, void *recvbuf,
-                                                        int count, MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm, MPIR_Request ** req)
+                                                        MPI_Aint count, MPI_Datatype datatype,
+                                                        MPI_Op op, MPIR_Comm * comm,
+                                                        MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_IALLREDUCE);
@@ -1054,8 +1071,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallreduce(const void *sendbuf, voi
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscan(const void *sendbuf, void *recvbuf,
+                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                    MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
@@ -1068,9 +1085,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscan(const void *sendbuf, void *re
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscatter(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      int recvcount, MPI_Datatype recvtype,
+                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
                                                       int root, MPIR_Comm * comm,
                                                       MPIR_Request ** request)
 {
@@ -1087,7 +1104,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscatter(const void *sendbuf, int s
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
                                                        const int *displs, MPI_Datatype sendtype,
-                                                       void *recvbuf, int recvcount,
+                                                       void *recvbuf, MPI_Aint recvcount,
                                                        MPI_Datatype recvtype, int root,
                                                        MPIR_Comm * comm, MPIR_Request ** request)
 {

--- a/src/mpid/ch4/shm/src/shm_am_fallback_coll.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_coll.h
@@ -11,30 +11,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Er
     return MPIR_Barrier_impl(comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
-                                                 int root, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
+                                                 MPI_Datatype datatype, int root,
+                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     return MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
-                                                     MPI_Datatype datatype, MPI_Op op,
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf,
+                                                     MPI_Aint count, MPI_Datatype datatype,
+                                                     MPI_Op op, MPIR_Comm * comm_ptr,
+                                                     MPIR_Errflag_t * errflag)
 {
     return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     return MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
                                recvcount, recvtype, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       const int *recvcounts, const int *displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -44,16 +45,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, int s
                                 recvcounts, displs, recvtype, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  MPIR_Errflag_t * errflag)
 {
     return MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
                             recvcount, recvtype, root, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int *recvcounts, const int *displs,
                                                    MPI_Datatype recvtype, int root,
@@ -63,10 +65,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, int send
                              recvcounts, displs, recvtype, root, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   MPIR_Errflag_t * errflag)
 {
     return MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcount, recvtype, root, comm_ptr, errflag);
@@ -74,7 +77,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, int send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
                                                     const int *displs, MPI_Datatype sendtype,
-                                                    void *recvbuf, int recvcount,
+                                                    void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -82,9 +85,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const i
                               recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     return MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
@@ -112,9 +115,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const 
                                recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  MPIR_Errflag_t * errflag)
 {
     return MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
 }
@@ -129,7 +133,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, v
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                                int recvcount,
+                                                                MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
                                                                 MPIR_Errflag_t * errflag)
@@ -138,30 +142,33 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
                                           datatype, op, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     return MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     return MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbuf,
+                                                              MPI_Aint sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              int recvcount, MPI_Datatype recvtype,
+                                                              MPI_Aint recvcount,
+                                                              MPI_Datatype recvtype,
                                                               MPIR_Comm * comm_ptr)
 {
     return MPIR_Neighbor_allgather_impl(sendbuf, sendcount, sendtype,
                                         recvbuf, recvcount, recvtype, comm_ptr);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendbuf,
+                                                               MPI_Aint sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
                                                                const int recvcounts[],
                                                                const int displs[],
@@ -172,9 +179,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendb
                                          recvbuf, recvcounts, displs, recvtype, comm_ptr);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf,
+                                                             MPI_Aint sendcount,
                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
+                                                             MPI_Aint recvcount,
+                                                             MPI_Datatype recvtype,
                                                              MPIR_Comm * comm_ptr)
 {
     return MPIR_Neighbor_alltoall_impl(sendbuf, sendcount, sendtype,
@@ -208,9 +217,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallw(const void *sendbu
                                         rdispls, recvtypes, comm_ptr);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendbuf,
+                                                               MPI_Aint sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
-                                                               int recvcount, MPI_Datatype recvtype,
+                                                               MPI_Aint recvcount,
+                                                               MPI_Datatype recvtype,
                                                                MPIR_Comm * comm_ptr,
                                                                MPIR_Request ** req)
 {
@@ -218,7 +229,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendb
                                          recvbuf, recvcount, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *sendbuf,
+                                                                MPI_Aint sendcount,
                                                                 MPI_Datatype sendtype,
                                                                 void *recvbuf,
                                                                 const int recvcounts[],
@@ -231,9 +243,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *send
                                           recvbuf, recvcounts, displs, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbuf,
+                                                              MPI_Aint sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              int recvcount, MPI_Datatype recvtype,
+                                                              MPI_Aint recvcount,
+                                                              MPI_Datatype recvtype,
                                                               MPIR_Comm * comm_ptr,
                                                               MPIR_Request ** req)
 {
@@ -277,23 +291,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm_ptr, MPIR_R
     return MPIR_Ibarrier_impl(comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibcast(void *buffer, MPI_Aint count,
+                                                  MPI_Datatype datatype, int root,
+                                                  MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     return MPIR_Ibcast_impl(buffer, count, datatype, root, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      int recvcount, MPI_Datatype recvtype,
+                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
                                                       MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     return MPIR_Iallgather_impl(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcount, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
                                                        const int *recvcounts, const int *displs,
                                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
@@ -303,16 +317,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, int 
                                  recvcounts, displs, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
-                                                      MPI_Datatype datatype, MPI_Op op,
-                                                      MPIR_Comm * comm, MPIR_Request ** request)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void *recvbuf,
+                                                      MPI_Aint count, MPI_Datatype datatype,
+                                                      MPI_Op op, MPIR_Comm * comm,
+                                                      MPIR_Request ** request)
 {
     return MPIR_Iallreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, request);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     return MPIR_Ialltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
@@ -340,23 +355,24 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf, const
                                 recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *recvbuf,
+                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                    MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     return MPIR_Iexscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   MPIR_Request ** req)
 {
     return MPIR_Igather_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcount, recvtype, root, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int *recvcounts, const int *displs,
                                                     MPI_Datatype recvtype, int root,
@@ -367,7 +383,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, int sen
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                                 int recvcount,
+                                                                 MPI_Aint recvcount,
                                                                  MPI_Datatype datatype, MPI_Op op,
                                                                  MPIR_Comm * comm_ptr,
                                                                  MPIR_Request ** req)
@@ -385,23 +401,24 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, 
     return MPIR_Ireduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *recvbuf,
+                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   MPIR_Request ** req)
 {
     return MPIR_Ireduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op,
                                                  MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     return MPIR_Iscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     int root, MPIR_Comm * comm,
                                                     MPIR_Request ** request)
 {
@@ -411,7 +428,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, int sen
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
                                                      const int *displs, MPI_Datatype sendtype,
-                                                     void *recvbuf, int recvcount,
+                                                     void *recvbuf, MPI_Aint recvcount,
                                                      MPI_Datatype recvtype, int root,
                                                      MPIR_Comm * comm, MPIR_Request ** request)
 {

--- a/src/mpid/ch4/shm/src/shm_coll.h
+++ b/src/mpid/ch4/shm/src/shm_coll.h
@@ -22,8 +22,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errfla
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
-                                                 int root, MPIR_Comm * comm,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
+                                                 MPI_Datatype datatype, int root, MPIR_Comm * comm,
                                                  MPIR_Errflag_t * errflag)
 {
     int ret;
@@ -38,8 +38,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, int count, MPI_Da
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf,
-                                                     int count, MPI_Datatype datatype, MPI_Op op,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                     MPI_Aint count, MPI_Datatype datatype,
+                                                     MPI_Op op, MPIR_Comm * comm,
+                                                     MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -52,9 +53,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
@@ -69,7 +70,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, int se
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       const int *recvcounts, const int *displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -87,10 +88,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, int s
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                   int root, MPIR_Comm * comm,
+                                                   MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -106,7 +108,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, int send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
                                                     const int *displs, MPI_Datatype sendtype,
-                                                    void *recvbuf, int recvcount,
+                                                    void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -122,10 +124,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                  int root, MPIR_Comm * comm,
+                                                  MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -139,7 +142,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, int sendc
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int *recvcounts, const int *displs,
                                                    MPI_Datatype recvtype, int root,
@@ -157,9 +160,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, int send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
@@ -212,9 +215,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -246,7 +250,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, v
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *sendbuf,
-                                                                void *recvbuf, int recvcount,
+                                                                void *recvbuf, MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
                                                                 MPIR_Errflag_t * errflag)
@@ -264,7 +268,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf,
-                                                int count, MPI_Datatype datatype, MPI_Op op,
+                                                MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
@@ -278,8 +282,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
@@ -293,9 +297,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *rec
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
-                                                              MPI_Datatype sendtype,
-                                                              void *recvbuf, int recvcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbuf,
+                                                              MPI_Aint sendcount,
+                                                              MPI_Datatype sendtype, void *recvbuf,
+                                                              MPI_Aint recvcount,
                                                               MPI_Datatype recvtype,
                                                               MPIR_Comm * comm)
 {
@@ -311,9 +316,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
-                                                               MPI_Datatype sendtype,
-                                                               void *recvbuf,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendbuf,
+                                                               MPI_Aint sendcount,
+                                                               MPI_Datatype sendtype, void *recvbuf,
                                                                const int *recvcounts,
                                                                const int *displs,
                                                                MPI_Datatype recvtype,
@@ -375,9 +380,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallw(const void *sendbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf,
+                                                             MPI_Aint sendcount,
                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
+                                                             MPI_Aint recvcount,
+                                                             MPI_Datatype recvtype,
                                                              MPIR_Comm * comm)
 {
     int ret;
@@ -392,9 +399,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
-                                                               MPI_Datatype sendtype,
-                                                               void *recvbuf, int recvcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendbuf,
+                                                               MPI_Aint sendcount,
+                                                               MPI_Datatype sendtype, void *recvbuf,
+                                                               MPI_Aint recvcount,
                                                                MPI_Datatype recvtype,
                                                                MPIR_Comm * comm,
                                                                MPIR_Request ** req)
@@ -412,7 +420,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendb
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *sendbuf,
-                                                                int sendcount,
+                                                                MPI_Aint sendcount,
                                                                 MPI_Datatype sendtype,
                                                                 void *recvbuf,
                                                                 const int *recvcounts,
@@ -433,9 +441,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
-                                                              MPI_Datatype sendtype,
-                                                              void *recvbuf, int recvcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbuf,
+                                                              MPI_Aint sendcount,
+                                                              MPI_Datatype sendtype, void *recvbuf,
+                                                              MPI_Aint recvcount,
                                                               MPI_Datatype recvtype,
                                                               MPIR_Comm * comm, MPIR_Request ** req)
 {
@@ -510,8 +519,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Reque
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                  int root, MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibcast(void *buffer, MPI_Aint count,
+                                                  MPI_Datatype datatype, int root, MPIR_Comm * comm,
+                                                  MPIR_Request ** req)
 {
     int ret;
 
@@ -524,9 +534,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibcast(void *buffer, int count, MPI_D
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      int recvcount, MPI_Datatype recvtype,
+                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
                                                       MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
@@ -541,7 +551,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, int s
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
                                                        const int *recvcounts, const int *displs,
                                                        MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -560,8 +570,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, int 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void *recvbuf,
-                                                      int count, MPI_Datatype datatype, MPI_Op op,
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+                                                      MPI_Aint count, MPI_Datatype datatype,
+                                                      MPI_Op op, MPIR_Comm * comm,
+                                                      MPIR_Request ** req)
 {
     int ret;
 
@@ -574,9 +585,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
@@ -629,8 +640,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf, const
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *recvbuf,
+                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                    MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
@@ -644,10 +655,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *re
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Request ** req)
+                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                   int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -661,7 +672,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, int send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int *recvcounts, const int *displs,
                                                     MPI_Datatype recvtype, int root,
@@ -680,7 +691,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, int sen
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sendbuf,
-                                                                 void *recvbuf, int recvcount,
+                                                                 void *recvbuf, MPI_Aint recvcount,
                                                                  MPI_Datatype datatype, MPI_Op op,
                                                                  MPIR_Comm * comm,
                                                                  MPIR_Request ** req)
@@ -713,9 +724,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *recvbuf,
+                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   MPIR_Request ** req)
 {
     int ret;
 
@@ -728,7 +740,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *re
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op,
                                                  MPIR_Comm * comm, MPIR_Request ** req)
 {
@@ -743,9 +755,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recv
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
@@ -762,7 +774,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, int sen
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
                                                      const int *displs, MPI_Datatype sendtype,
-                                                     void *recvbuf, int recvcount,
+                                                     void *recvbuf, MPI_Aint recvcount,
                                                      MPI_Datatype recvtype, int root,
                                                      MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -51,7 +51,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * err
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *buffer, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                         int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -103,7 +103,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *buffer, int count, MPI_Datatype da
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                             MPIR_Errflag_t * errflag)
 {
@@ -161,10 +161,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, 
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, int sendcount,
-                                            MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                            MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, MPI_Aint sendcount,
+                                            MPI_Datatype sendtype, void *recvbuf,
+                                            MPI_Aint recvcount, MPI_Datatype recvtype,
+                                            MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -214,7 +214,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
                                              const int *recvcounts, const int *displs,
                                              MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -269,8 +269,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, int sendcount,
-                                          MPI_Datatype sendtype, void *recvbuf, int recvcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, MPI_Aint sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                           MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                           MPIR_Errflag_t * errflag)
 {
@@ -323,7 +323,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, int sendcount,
 
 MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const int *sendcounts,
                                            const int *displs, MPI_Datatype sendtype,
-                                           void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                                           void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                            int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -375,9 +375,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const int *sendc
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                         int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *sendbuf, MPI_Aint sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
+                                         MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                                         MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -427,7 +428,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *sendbuf, int sendcount, MPI
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf,
                                           const int *recvcounts, const int *displs,
                                           MPI_Datatype recvtype, int root, MPIR_Comm * comm,
@@ -482,8 +483,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *sendbuf, int sendcount,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, int sendcount,
-                                           MPI_Datatype sendtype, void *recvbuf, int recvcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                            MPI_Datatype recvtype, MPIR_Comm * comm,
                                            MPIR_Errflag_t * errflag)
 {
@@ -646,7 +647,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *sendbuf, const int sendc
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
-                                         int count, MPI_Datatype datatype, MPI_Op op,
+                                         MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                          int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -755,7 +756,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *sendbuf, void *recv
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                       int recvcount, MPI_Datatype datatype,
+                                                       MPI_Aint recvcount, MPI_Datatype datatype,
                                                        MPI_Op op, MPIR_Comm * comm,
                                                        MPIR_Errflag_t * errflag)
 {
@@ -805,7 +806,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *sendbuf, void
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                        MPIR_Errflag_t * errflag)
 {
@@ -858,7 +859,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *sendbuf, void *recvbuf, int c
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                          MPIR_Errflag_t * errflag)
 {
@@ -906,9 +907,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *sendbuf, void *recvbuf, int
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm)
 {
     int ret;
@@ -923,7 +924,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *sendbuf, int se
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       const int *recvcounts, const int *displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm)
@@ -978,9 +979,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallw(const void *sendbuf, const 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
+                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm)
 {
     int ret;
@@ -995,9 +996,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoall(const void *sendbuf, int sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      int recvcount, MPI_Datatype recvtype,
+                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
                                                       MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
@@ -1012,7 +1013,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather(const void *sendbuf, int s
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
                                                        const int *recvcounts, const int *displs,
                                                        MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -1030,9 +1031,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv(const void *sendbuf, int 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
+                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
@@ -1100,7 +1101,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier(MPIR_Comm * comm, MPIR_Request ** req
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *buffer, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                          int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
@@ -1114,10 +1115,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *buffer, int count, MPI_Datatype d
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iallgather(const void *sendbuf, int sendcount,
-                                             MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                             MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPID_Iallgather(const void *sendbuf, MPI_Aint sendcount,
+                                             MPI_Datatype sendtype, void *recvbuf,
+                                             MPI_Aint recvcount, MPI_Datatype recvtype,
+                                             MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1131,7 +1132,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgather(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                               MPI_Datatype sendtype, void *recvbuf,
                                               const int *recvcounts, const int *displs,
                                               MPI_Datatype recvtype, MPIR_Comm * comm,
@@ -1149,7 +1150,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *sendbuf, int sendcount
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                              MPIR_Request ** req)
 {
@@ -1164,10 +1165,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce(const void *sendbuf, void *recvbuf,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall(const void *sendbuf, int sendcount,
-                                            MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                            MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall(const void *sendbuf, MPI_Aint sendcount,
+                                            MPI_Datatype sendtype, void *recvbuf,
+                                            MPI_Aint recvcount, MPI_Datatype recvtype,
+                                            MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1217,7 +1218,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw(const void *sendbuf, const int *sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iexscan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPID_Iexscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                           MPIR_Request ** req)
 {
@@ -1232,8 +1233,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iexscan(const void *sendbuf, void *recvbuf, in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Igather(const void *sendbuf, int sendcount,
-                                          MPI_Datatype sendtype, void *recvbuf, int recvcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Igather(const void *sendbuf, MPI_Aint sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                           MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                           MPIR_Request ** req)
 {
@@ -1249,7 +1250,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igather(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *sendbuf, int sendcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
                                            const int *recvcounts, const int *displs,
                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm,
@@ -1268,7 +1269,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *sendbuf, int sendcount,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                        int recvcount, MPI_Datatype datatype,
+                                                        MPI_Aint recvcount, MPI_Datatype datatype,
                                                         MPI_Op op, MPIR_Comm * comm,
                                                         MPIR_Request ** req)
 {
@@ -1298,7 +1299,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter(const void *sendbuf, void *rec
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ireduce(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPID_Ireduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                           MPI_Datatype datatype, MPI_Op op, int root,
                                           MPIR_Comm * comm, MPIR_Request ** req)
 {
@@ -1313,7 +1314,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce(const void *sendbuf, void *recvbuf, in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iscan(const void *sendbuf, void *recvbuf, int count,
+MPL_STATIC_INLINE_PREFIX int MPID_Iscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                         MPIR_Request ** req)
 {
@@ -1328,8 +1329,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscan(const void *sendbuf, void *recvbuf, int 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iscatter(const void *sendbuf, int sendcount,
-                                           MPI_Datatype sendtype, void *recvbuf, int recvcount,
+MPL_STATIC_INLINE_PREFIX int MPID_Iscatter(const void *sendbuf, MPI_Aint sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                            MPIR_Request ** req)
 {
@@ -1347,8 +1348,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatter(const void *sendbuf, int sendcount,
 
 MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *sendbuf, const int *sendcounts,
                                             const int *displs, MPI_Datatype sendtype,
-                                            void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                            int root, MPIR_Comm * comm, MPIR_Request ** req)
+                                            void *recvbuf, MPI_Aint recvcount,
+                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                                            MPIR_Request ** req)
 {
     int ret;
 

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -67,7 +67,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_beta(MPIR_Comm * co
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, MPI_Aint count,
                                                                  MPI_Datatype datatype,
                                                                  int root, MPIR_Comm * comm,
                                                                  MPIR_Errflag_t * errflag)
@@ -153,7 +153,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, i
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_beta(void *buffer, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_beta(void *buffer, MPI_Aint count,
                                                                 MPI_Datatype datatype,
                                                                 int root, MPIR_Comm * comm,
                                                                 MPIR_Errflag_t * errflag)
@@ -198,7 +198,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_beta(void *buffer, in
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_gamma(void *buffer, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_gamma(void *buffer, MPI_Aint count,
                                                                  MPI_Datatype datatype,
                                                                  int root, MPIR_Comm * comm,
                                                                  MPIR_Errflag_t * errflag)
@@ -215,7 +215,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_gamma(void *buffer, i
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_alpha(const void *sendbuf,
-                                                                     void *recvbuf, int count,
+                                                                     void *recvbuf, MPI_Aint count,
                                                                      MPI_Datatype datatype,
                                                                      MPI_Op op,
                                                                      MPIR_Comm * comm,
@@ -286,7 +286,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_alpha(const void 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_beta(const void *sendbuf,
-                                                                    void *recvbuf, int count,
+                                                                    void *recvbuf, MPI_Aint count,
                                                                     MPI_Datatype datatype,
                                                                     MPI_Op op,
                                                                     MPIR_Comm * comm,
@@ -304,7 +304,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_beta(const void *
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_gamma(const void *sendbuf,
-                                                                     void *recvbuf, int count,
+                                                                     void *recvbuf, MPI_Aint count,
                                                                      MPI_Datatype datatype,
                                                                      MPI_Op op,
                                                                      MPIR_Comm * comm,
@@ -326,7 +326,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_gamma(const void 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *sendbuf,
-                                                                  void *recvbuf, int count,
+                                                                  void *recvbuf, MPI_Aint count,
                                                                   MPI_Datatype datatype,
                                                                   MPI_Op op, int root,
                                                                   MPIR_Comm * comm,
@@ -413,7 +413,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sendbuf,
-                                                                 void *recvbuf, int count,
+                                                                 void *recvbuf, MPI_Aint count,
                                                                  MPI_Datatype datatype,
                                                                  MPI_Op op, int root,
                                                                  MPIR_Comm * comm,
@@ -552,7 +552,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_gamma(const void *sendbuf,
-                                                                  void *recvbuf, int count,
+                                                                  void *recvbuf, MPI_Aint count,
                                                                   MPI_Datatype datatype,
                                                                   MPI_Op op, int root,
                                                                   MPIR_Comm * comm,
@@ -570,10 +570,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_gamma(const void *se
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *sendbuf,
-                                                                    int sendcount,
+                                                                    MPI_Aint sendcount,
                                                                     MPI_Datatype sendtype,
                                                                     void *recvbuf,
-                                                                    int recvcount,
+                                                                    MPI_Aint recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm_ptr,
                                                                     MPIR_Errflag_t * errflag)
@@ -643,10 +643,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoallw_intra_composition_alpha(const void 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void *sendbuf,
-                                                                     int sendcount,
+                                                                     MPI_Aint sendcount,
                                                                      MPI_Datatype sendtype,
                                                                      void *recvbuf,
-                                                                     int recvcount,
+                                                                     MPI_Aint recvcount,
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm_ptr,
                                                                      MPIR_Errflag_t * errflag)
@@ -665,7 +665,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Allgatherv_intra_composition_alpha(const void *sendbuf,
-                                                                      int sendcount,
+                                                                      MPI_Aint sendcount,
                                                                       MPI_Datatype sendtype,
                                                                       void *recvbuf,
                                                                       const int *recvcounts,
@@ -688,9 +688,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgatherv_intra_composition_alpha(const void
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Gather_intra_composition_alpha(const void *sendbuf,
-                                                                  int sendcount,
+                                                                  MPI_Aint sendcount,
                                                                   MPI_Datatype sendtype,
-                                                                  void *recvbuf, int recvcount,
+                                                                  void *recvbuf, MPI_Aint recvcount,
                                                                   MPI_Datatype recvtype,
                                                                   int root, MPIR_Comm * comm,
                                                                   MPIR_Errflag_t * errflag)
@@ -709,7 +709,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Gather_intra_composition_alpha(const void *se
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Gatherv_intra_composition_alpha(const void *sendbuf,
-                                                                   int sendcount,
+                                                                   MPI_Aint sendcount,
                                                                    MPI_Datatype sendtype,
                                                                    void *recvbuf,
                                                                    const int *recvcounts,
@@ -732,10 +732,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Gatherv_intra_composition_alpha(const void *s
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Scatter_intra_composition_alpha(const void *sendbuf,
-                                                                   int sendcount,
+                                                                   MPI_Aint sendcount,
                                                                    MPI_Datatype sendtype,
                                                                    void *recvbuf,
-                                                                   int recvcount,
+                                                                   MPI_Aint recvcount,
                                                                    MPI_Datatype recvtype,
                                                                    int root, MPIR_Comm * comm,
                                                                    MPIR_Errflag_t * errflag)
@@ -758,7 +758,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scatterv_intra_composition_alpha(const void *
                                                                     const int *displs,
                                                                     MPI_Datatype sendtype,
                                                                     void *recvbuf,
-                                                                    int recvcount,
+                                                                    MPI_Aint recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     int root, MPIR_Comm * comm,
                                                                     MPIR_Errflag_t * errflag)
@@ -800,7 +800,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_scatter_intra_composition_alpha(const 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_scatter_block_intra_composition_alpha(const void
                                                                                 *sendbuf,
                                                                                 void *recvbuf,
-                                                                                int recvcount,
+                                                                                MPI_Aint recvcount,
                                                                                 MPI_Datatype
                                                                                 datatype,
                                                                                 MPI_Op op,
@@ -824,7 +824,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_scatter_block_intra_composition_alpha(
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *sendbuf,
                                                                 void *recvbuf,
-                                                                int count,
+                                                                MPI_Aint count,
                                                                 MPI_Datatype datatype,
                                                                 MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
@@ -980,7 +980,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_beta(const void *sendbuf,
                                                                void *recvbuf,
-                                                               int count,
+                                                               MPI_Aint count,
                                                                MPI_Datatype datatype,
                                                                MPI_Op op,
                                                                MPIR_Comm * comm_ptr,
@@ -999,7 +999,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_beta(const void *sendb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Exscan_intra_composition_alpha(const void *sendbuf,
                                                                   void *recvbuf,
-                                                                  int count,
+                                                                  MPI_Aint count,
                                                                   MPI_Datatype datatype,
                                                                   MPI_Op op,
                                                                   MPIR_Comm * comm_ptr,


### PR DESCRIPTION
## Pull Request Description

Make collective internally use `MPI_Aint` for count parameters.

[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
