### PR TITLE
mpl/thread/argobots: extend MPL_thread_self to support Pthreads

### DIFF
--- a/src/mpl/src/thread/mpl_thread_argobots.c
+++ b/src/mpl/src/thread/mpl_thread_argobots.c
@@ -52,7 +52,10 @@ static int thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * i
     info->func = func;
     info->data = data;
     /* Push this thread to the current ES's first pool. */
-    int err = ABT_thread_create(pool, thread_start, info, ABT_THREAD_ATTR_NULL, idp);
+    int err = ABT_thread_create(pool, thread_start, info, ABT_THREAD_ATTR_NULL, (ABT_thread *) idp);
+    /* We assume that the last bit of MPL_thread_id_t is 0 if it points to an
+     * Argobots thread.  Let's check it. */
+    assert(!(*idp & (MPL_thread_id_t) 0x1));
     return (err == ABT_SUCCESS) ? MPL_SUCCESS : MPL_ERR_THREAD;
 }
 


### PR DESCRIPTION
## Pull Request Description

Argobots synchronization objects (e.g., mutex) support external threads (= Pthreads) as well as Argobots threads. However, MPICH + Argobots does not utilize this because `MPL_thread_self()` (or `ABT_thread_self()` used in `MPL_thread_self()`) does not retrieve an external thread ID.

This PR updates `MPL_thread_self()` by saving an external thread ID (= Pthread ID) when it is called by an external thread. This needs to change the type of `MPL_thread_id_t`. This change allows MPICH+Argobots to deal with both Pthreads and Argobots threads as "threads". It widens the applicability of this programming paradigm.

## Expected Impact

This patch does not affect the default MPICH behavior that uses Pthreads.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
