### PR TITLE
init: update tag_ub after MPID_Init

### DIFF
--- a/src/mpi/init/local_proc_attrs.c
+++ b/src/mpi/init/local_proc_attrs.c
@@ -130,9 +130,18 @@ int MPII_init_local_proc_attrs(int *p_thread_required)
     /* Init communicator hints */
     MPIR_Comm_hint_init();
 
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPII_init_tag_ub(void)
+{
     /* Set tag_ub as function of tag_bits set by the device */
     MPIR_Process.attrs.tag_ub = MPIR_TAG_USABLE_BITS;
 
+    /* TODO: turn assertions into error code */
     /* Assert: tag_ub should be a power of 2 minus 1 */
     MPIR_Assert(((unsigned) MPIR_Process.
                  attrs.tag_ub & ((unsigned) MPIR_Process.attrs.tag_ub + 1)) == 0);
@@ -140,10 +149,7 @@ int MPII_init_local_proc_attrs(int *p_thread_required)
     /* Assert: tag_ub is at least the minimum asked for in the MPI spec */
     MPIR_Assert(MPIR_Process.attrs.tag_ub >= 32767);
 
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
+    return MPI_SUCCESS;
 }
 
 int MPII_finalize_local_proc_attrs(void)

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -49,6 +49,7 @@ void MPII_thread_mutex_destroy(void);
 
 int MPII_init_local_proc_attrs(int *p_thread_required);
 int MPII_finalize_local_proc_attrs(void);
+int MPII_init_tag_ub(void);
 
 void MPII_init_windows(void);
 void MPII_init_binding_cxx(void);

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -204,6 +204,10 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
      * should come here. */
     /**********************************************************************/
 
+    /* MPIR_Process.attr.tag_ub depends on tag_bits set by the device */
+    mpi_errno = MPII_init_tag_ub();
+    MPIR_ERR_CHECK(mpi_errno);
+
     /* pairtypes might need device hooks to be activated so the device
      * can keep track of their creation.  that's why we need to do
      * this after the device initialization.  */


### PR DESCRIPTION
## Pull Request Description

MPIR_Process.attrs.tag_ub depends on MPIR_Process.tag_bits, which is set
by the device, so we need update it after MPID_Init.

The bug is discovered by session tests for ch3:ofi, because the session
test uses string hash tag that can be in the upper tag space, and
ch3:ofi sets less tag_bits than default.



<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
