### PR TITLE
test/mpi: fix threads/init/mult_session

### DIFF
--- a/test/mpi/threads/init/mult_session.c
+++ b/test/mpi/threads/init/mult_session.c
@@ -18,6 +18,7 @@ MTEST_THREAD_RETURN_TYPE library_foo_test(void *p);
 int main(int argc, char *argv[])
 {
     int provided;
+    MTest_init_thread_pkg();
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 
     for (int i = 1; i < NTHREADS; i++) {
@@ -30,6 +31,7 @@ int main(int argc, char *argv[])
 
     MTest_Join_threads();
     MPI_Finalize();
+    MTest_finalize_thread_pkg();
 
     int errs = 0;
     for (int i = 0; i < NTHREADS; i++) {


### PR DESCRIPTION
## Pull Request Description

This PR fixes `threads/init/mult_session`. `MTest_init_thread_pkg()` and `MTest_finalize_thread_pkg()` must be called when a test is multithreaded; some threading packages (e.g., Argobots) need `MTest_init_thread_pkg()` and `MTest_init_thread_pkg()` to set up a testing environment.

The order of `MTest_init_thread_pkg()`, `MTest_finalize_thread_pkg()`, `MPI_Init_thread()`, and `MPI_Finalize()` follows that of `MTest_Init_thread()` and `MTest_Finalize()` (e.g., https://github.com/pmodels/mpich/blob/main/test/mpi/util/mtest.c#L79-L92).

This patch blocks #5046.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
