### PR TITLE
Fix mpl gpu init bug

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -931,6 +931,7 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **gpu_finalize: gpu_finalize failed
 **gpu_get_global_dev_ids: gpu_get_global_dev_ids failed
 **gpu_get_buffer_info: gpu_get_buffer_info failed
+**gpu_get_dev_count: gpu_get_dev_count failed
 
 ## GAVL tree related error messages
 **mpl_gavl_search: mpl_gavl_search failed

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -66,7 +66,7 @@ int MPL_gpu_unregister_host(const void *ptr);
 int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device);
 int MPL_gpu_free(void *ptr);
 
-int MPL_gpu_init(int *device_count, int *max_dev_id_ptr);
+int MPL_gpu_init(void);
 int MPL_gpu_finalize(void);
 
 int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -75,5 +75,6 @@ int MPL_gpu_get_global_dev_ids(int *global_ids, int count);
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len);
 
 int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr));
+int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id);
 
 #endif /* ifndef MPL_GPU_H_INCLUDED */

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -30,7 +30,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 {
     int ret = MPL_SUCCESS;
     if (!gpu_initialized) {
-        ret = MPL_gpu_init(&device_count, &max_dev_id);
+        ret = MPL_gpu_init();
     }
 
     *dev_cnt = device_count;
@@ -195,10 +195,9 @@ int MPL_gpu_free(void *ptr)
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_init(int *device_count, int *max_dev_id_ptr)
+int MPL_gpu_init()
 {
-    int count, max_dev_id = -1;
-    cudaError_t ret = cudaGetDeviceCount(&count);
+    cudaError_t ret = cudaGetDeviceCount(&device_count);
     CUDA_ERR_CHECK(ret);
 
     char *visible_devices = getenv("CUDA_VISIBLE_DEVICES");
@@ -207,7 +206,7 @@ int MPL_gpu_init(int *device_count, int *max_dev_id_ptr)
         char *devices = MPL_malloc(len + 1, MPL_MEM_OTHER);
         char *free_ptr = devices;
         memcpy(devices, visible_devices, len + 1);
-        for (int i = 0; i < count; i++) {
+        for (int i = 0; i < device_count; i++) {
             int global_dev_id;
             char *tmp = strtok(devices, ",");
             assert(tmp);
@@ -218,12 +217,14 @@ int MPL_gpu_init(int *device_count, int *max_dev_id_ptr)
         }
         MPL_free(free_ptr);
     } else {
-        max_dev_id = count - 1;
+        max_dev_id = device_count - 1;
     }
 
-    *max_dev_id_ptr = max_dev_id;
-    *device_count = count;
-
+    /* gpu shm module would cache gpu handle to accelerate intra-node
+     * communication; we must register hooks for memory-related functions
+     * in cuda, such as cudaFree and cuMemFree, to track user behaviors on
+     * the memory buffer and invalidate cached handle/buffer respectively
+     * for result correctness. */
     gpu_mem_hook_init();
     gpu_initialized = 1;
 

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -15,12 +15,28 @@ typedef struct gpu_free_hook {
     struct gpu_free_hook *next;
 } gpu_free_hook_s;
 
+static int gpu_initialized = 0;
+static int device_count = -1;
+static int max_dev_id = -1;
+
 static gpu_free_hook_s *free_hook_chain = NULL;
 
 static CUresult CUDAAPI(*sys_cuMemFree) (CUdeviceptr dptr);
 static cudaError_t CUDARTAPI(*sys_cudaFree) (void *dptr);
 
 static int gpu_mem_hook_init();
+
+int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
+{
+    int ret = MPL_SUCCESS;
+    if (!gpu_initialized) {
+        ret = MPL_gpu_init(&device_count, &max_dev_id);
+    }
+
+    *dev_cnt = device_count;
+    *dev_id = max_dev_id;
+    return ret;
+}
 
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
@@ -209,6 +225,7 @@ int MPL_gpu_init(int *device_count, int *max_dev_id_ptr)
     *device_count = count;
 
     gpu_mem_hook_init();
+    gpu_initialized = 1;
 
   fn_exit:
     return MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -5,6 +5,12 @@
 
 #include "mpl.h"
 
+int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
+{
+    *dev_cnt = *dev_id = -1;
+    return MPL_SUCCESS;
+}
+
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     abort();

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -64,7 +64,7 @@ int MPL_gpu_free(void *ptr)
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_init(int *device_count, int *max_dev_id_ptr)
+int MPL_gpu_init()
 {
     return MPL_SUCCESS;
 }

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -33,7 +33,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 {
     int ret = MPL_SUCCESS;
     if (!gpu_initialized) {
-        ret = MPL_gpu_init(&device_count, &max_dev_id);
+        ret = MPL_gpu_init();
     }
 
     *dev_cnt = device_count;
@@ -41,14 +41,14 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
     return ret;
 }
 
-int MPL_gpu_init(int *device_count_ptr, int *max_dev_id_ptr)
+int MPL_gpu_init()
 {
     int ret_error;
     ret_error = gpu_ze_init_driver();
     if (ret_error != MPL_SUCCESS)
         goto fn_fail;
 
-    *max_dev_id_ptr = *device_count_ptr = global_ze_device_count;
+    max_dev_id = device_count = global_ze_device_count;
     gpu_initialized = 1;
 
   fn_exit:

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -10,6 +10,10 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 
 #ifdef MPL_HAVE_ZE
 
+static int gpu_initialized = 0;
+static int device_count;
+static int max_dev_id;
+
 /* Level-zero API v1.0:
  * http://spec.oneapi.com/level-zero/latest/index.html
  */
@@ -25,6 +29,18 @@ static int gpu_ze_init_driver(void);
             goto fn_fail; \
     } while (0)
 
+int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
+{
+    int ret = MPL_SUCCESS;
+    if (!gpu_initialized) {
+        ret = MPL_gpu_init(&device_count, &max_dev_id);
+    }
+
+    *dev_cnt = device_count;
+    *dev_id = max_dev_id;
+    return ret;
+}
+
 int MPL_gpu_init(int *device_count_ptr, int *max_dev_id_ptr)
 {
     int ret_error;
@@ -33,6 +49,7 @@ int MPL_gpu_init(int *device_count_ptr, int *max_dev_id_ptr)
         goto fn_fail;
 
     *max_dev_id_ptr = *device_count_ptr = global_ze_device_count;
+    gpu_initialized = 1;
 
   fn_exit:
     return MPL_SUCCESS;


### PR DESCRIPTION
## Pull Request Description
This patch fixes issue #5048.
It adds `MPL_gpu_get_dev_count` to provide device count and maximal device id info to gpu shm module in MPICH; then, `MPL_gpu_init` and `MPL_gpu_finalize` are moved up to `MPII_Init_thread` and `MPII_Finalize` functions. 

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
