### PR TITLE
test: fix a few gpu testing bug

### DIFF
--- a/test/mpi/pt2pt/sendself.c
+++ b/test/mpi/pt2pt/sendself.c
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
         }
 
         err = MPI_Wait(&req, MPI_STATUS_IGNORE);
-        MTestCopyContent(recvbuf, recvbuf_h, recv_obj.DTP_bufsize, sendmem);
+        MTestCopyContent(recvbuf, recvbuf_h, recv_obj.DTP_bufsize, recvmem);
         err = DTP_obj_buf_check(recv_obj, recvbuf_h, 0, 1, count[0]);
         if (err != DTP_SUCCESS) {
             if (errs < 10) {

--- a/test/mpi/rma/lock_x_dt.c
+++ b/test/mpi/rma/lock_x_dt.c
@@ -218,7 +218,7 @@ static int run_test(MPI_Comm comm, MPI_Win win, DTP_obj_s orig_obj, void *origbu
         if (err != DTP_SUCCESS)
             errs++;
 
-        err = DTP_obj_buf_init(target_obj, targetbuf, 1, 2, count);
+        err = DTP_obj_buf_init(target_obj, targetbuf_h, 1, 2, count);
         if (err != DTP_SUCCESS)
             errs++;
 


### PR DESCRIPTION
## Pull Request Description
Fix a few bugs/typos in the GPU testing code.

In addition, `datatype/dpack_large 72` is failing due to yaksa opening Cuda stream for each device *each process*. It will be fixed once we skip the yaksa GPU init for non-GPU tests.

Need limit `MPITEST_MAXBUFFER` or it will exhaust GPU memory. This will depend on the number of processes. The current default `0x40 000 000` is too big for the Jenkins GPU node. `0x1 000 000` seems okay for 4 processes.

[skip warnings]
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
