### PR TITLE
romio: Fix mpi.h include for VPATH build

### DIFF
--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1554,7 +1554,7 @@ elif test $FROM_MPICH = yes ; then
    # set the compilers to the ones in MPICH bin directory (main_top_builddir/bin)
    TEST_CC='$(bindir)/mpicc'
    TEST_F77='$(bindir)/mpifort'
-   MPI_H_INCLUDE="-I${main_top_builddir}/src/include"
+   MPI_H_INCLUDE="-I${main_top_builddir}/src/include -I${main_top_srcdir}/src/include"
    ROMIO_INCLUDE=""
    USER_CFLAGS=""
    USER_FFLAGS=""


### PR DESCRIPTION
## Pull Request Description

Since the addition of mpi_proto.h as a sub-header of mpi.h, VPATH
builds have been broken. Add the location of mpi_proto.h to fix it.

Reported-by: Sudheer Chunduri <sudheer@anl.gov>

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix VPATH builds with ROMIO.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
