### PR TITLE
coll: use MPI_Aint for v-collective array parameters

### DIFF
--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -71,33 +71,33 @@ int MPIR_Allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
 /******************************** Allgatherv ********************************/
 /* intracomm-only functions */
 int MPIR_Allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, const int *recvcounts, const int *displs,
-                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                 MPIR_Errflag_t * errflag);
+                                 void *recvbuf, const MPI_Aint * recvcounts,
+                                 const MPI_Aint * displs, MPI_Datatype recvtype,
+                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 int MPIR_Allgatherv_intra_brucks(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, const int *recvcounts, const int *displs,
-                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                 MPIR_Errflag_t * errflag);
+                                 void *recvbuf, const MPI_Aint * recvcounts,
+                                 const MPI_Aint * displs, MPI_Datatype recvtype,
+                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
-                                             const int *recvcounts, const int *displs,
+                                             const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                              MPIR_Errflag_t * errflag);
 int MPIR_Allgatherv_intra_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int *recvcounts, const int *displs,
+                               void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
 int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts, const int *displs,
-                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                    MPIR_Errflag_t * errflag);
+                                                    const MPI_Aint * recvcounts,
+                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
 int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int *recvcounts, const int *displs,
+                               void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                MPIR_Errflag_t * errflag);
 
@@ -161,65 +161,70 @@ int MPIR_Alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
 
 /******************************** Alltoallv ********************************/
 /* intracomm-only functions */
-int MPIR_Alltoallv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+int MPIR_Alltoallv_allcomm_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
+                                const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                 MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const int *sendcounts,
-                                                   const int *sdispls, MPI_Datatype sendtype,
-                                                   void *recvbuf, const int *recvcounts,
-                                                   const int *rdispls, MPI_Datatype recvtype,
+int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MPI_Aint * sendcounts,
+                                                   const MPI_Aint * sdispls, MPI_Datatype sendtype,
+                                                   void *recvbuf, const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * rdispls, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                   MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                   const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcounts,
+                                   const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
+                                   const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                    MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
-int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const int *sendcounts,
-                                           const int *sdispls, MPI_Datatype sendtype, void *recvbuf,
-                                           const int *recvcounts, const int *rdispls,
-                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                           MPIR_Errflag_t * errflag);
+int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint * sendcounts,
+                                           const MPI_Aint * sdispls, MPI_Datatype sendtype,
+                                           void *recvbuf, const MPI_Aint * recvcounts,
+                                           const MPI_Aint * rdispls, MPI_Datatype recvtype,
+                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                              MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                              const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
+                              const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
+                              const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                               MPIR_Errflag_t * errflag);
 
 
 /******************************** Alltoallw ********************************/
 /* intracomm-only functions */
-int MPIR_Alltoallw_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                const MPI_Datatype * sendtypes, void *recvbuf,
-                                const int *recvcounts, const int *rdispls,
-                                const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const int *sendcounts,
-                                                   const int *sdispls,
+int MPIR_Alltoallw_allcomm_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                const MPI_Aint * sdispls, const MPI_Datatype * sendtypes,
+                                void *recvbuf, const MPI_Aint * recvcounts,
+                                const MPI_Aint * rdispls, const MPI_Datatype * recvtypes,
+                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MPI_Aint * sendcounts,
+                                                   const MPI_Aint * sdispls,
                                                    const MPI_Datatype * sendtypes, void *recvbuf,
-                                                   const int *recvcounts, const int *rdispls,
+                                                   const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * rdispls,
                                                    const MPI_Datatype * recvtypes,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                   const MPI_Datatype * sendtypes, void *recvbuf,
-                                   const int *recvcounts, const int *rdispls,
-                                   const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint * sendcounts,
+                                   const MPI_Aint * sdispls, const MPI_Datatype * sendtypes,
+                                   void *recvbuf, const MPI_Aint * recvcounts,
+                                   const MPI_Aint * rdispls, const MPI_Datatype * recvtypes,
+                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
-int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const int *sendcounts,
-                                           const int *sdispls, const MPI_Datatype * sendtypes,
-                                           void *recvbuf, const int *recvcounts, const int *rdispls,
-                                           const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                           MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint * sendcounts,
+                                           const MPI_Aint * sdispls, const MPI_Datatype * sendtypes,
+                                           void *recvbuf, const MPI_Aint * recvcounts,
+                                           const MPI_Aint * rdispls, const MPI_Datatype * recvtypes,
+                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                              const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
-                              const int *rdispls, const MPI_Datatype * recvtypes,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
+                              const MPI_Aint * sdispls, const MPI_Datatype * sendtypes,
+                              void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                              const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
+                              MPIR_Errflag_t * errflag);
 
 
 /******************************** Barrier ********************************/
@@ -303,7 +308,7 @@ int MPIR_Gather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype
 /******************************** Gatherv ********************************/
 /* intracomm-only functions */
 int MPIR_Gatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, const int *recvcounts, const int *displs,
+                              void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                               MPIR_Errflag_t * errflag);
 
@@ -311,11 +316,11 @@ int MPIR_Gatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
 
 /* anycomm functions */
 int MPIR_Gatherv_allcomm_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, const int *recvcounts, const int *displs,
+                                void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                 MPIR_Errflag_t * errflag);
 int MPIR_Gatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, const int *recvcounts, const int *displs,
+                            void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                             MPIR_Errflag_t * errflag);
 
@@ -377,61 +382,65 @@ int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, M
 /* request-based functions */
 int MPIR_Iallgatherv_intra_gentran_brucks(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int displs[],
+                                          const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int k,
                                           MPIR_Request ** request);
 int MPIR_Iallgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, const int *recvcounts, const int *displs,
-                                  MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                  MPIR_Request ** request);
+                                  void *recvbuf, const MPI_Aint * recvcounts,
+                                  const MPI_Aint * displs, MPI_Datatype recvtype,
+                                  MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
 int MPIR_Iallgatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, const int *recvcounts, const int *displs,
+                                void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iallgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
-                                      MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                      const int *displs, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      const MPI_Aint * recvcounts, const MPI_Aint * displs,
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int displs[],
+                                        const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                         MPIR_Sched_t s);
 int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    const int recvcounts[], const int displs[],
-                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                    MPIR_Sched_t s);
+                                                    const MPI_Aint recvcounts[],
+                                                    const MPI_Aint displs[], MPI_Datatype recvtype,
+                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Iallgatherv_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount,
-                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                      const int displs[], MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      const MPI_Aint recvcounts[], const MPI_Aint displs[],
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Iallgatherv_intra_gentran_recexch_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts, const int *displs,
-                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                    int k, MPIR_Request ** request);
+                                                    const MPI_Aint * recvcounts,
+                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                    MPIR_Comm * comm_ptr, int k,
+                                                    MPIR_Request ** request);
 int MPIR_Iallgatherv_intra_gentran_recexch_halving(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts, const int *displs,
-                                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                   int k, MPIR_Request ** request);
+                                                   const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                   MPIR_Comm * comm_ptr, int k,
+                                                   MPIR_Request ** request);
 int MPIR_Iallgatherv_intra_gentran_ring(const void *sendbuf, MPI_Aint sendcount,
-                                        MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                        const int *displs, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Request ** request);
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        const MPI_Aint * recvcounts, const MPI_Aint * displs,
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                        MPIR_Request ** request);
 
 /* sched-based intercomm-only functions */
 int MPIR_Iallgatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
-                                      MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                      const int *displs, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      const MPI_Aint * recvcounts, const MPI_Aint * displs,
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
-                                                           const int *recvcounts, const int *displs,
+                                                           const MPI_Aint * recvcounts,
+                                                           const MPI_Aint * displs,
                                                            MPI_Datatype recvtype,
                                                            MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
@@ -554,112 +563,116 @@ int MPIR_Ialltoall_inter_sched_pairwise_exchange(const void *sendbuf, MPI_Aint s
 
 /******************************** Ialltoallv ********************************/
 /* request-based functions */
-int MPIR_Ialltoallv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                 MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                 const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+int MPIR_Ialltoallv_allcomm_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                 const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
+                                 const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                  MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ialltoallv_sched_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                               MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                               const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s);
+int MPIR_Ialltoallv_sched_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                               const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
+                               const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ialltoallv_intra_sched_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                     MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                     const int *rdispls, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoallv_intra_sched_blocked(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
-int MPIR_Ialltoallv_intra_sched_inplace(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
-int MPIR_Ialltoallv_intra_gentran_scattered(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], MPI_Datatype sendtype,
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ialltoallv_intra_sched_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                     const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
+                                     const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ialltoallv_intra_sched_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ialltoallv_intra_sched_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ialltoallv_intra_gentran_scattered(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                            void *recvbuf, const MPI_Aint recvcounts[],
+                                            const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                             MPIR_Comm * comm_ptr, int batch_size, int bblock,
                                             MPIR_Request ** request);
-int MPIR_Ialltoallv_intra_gentran_blocked(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int rdispls[],
-                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int bblock,
+int MPIR_Ialltoallv_intra_gentran_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                          void *recvbuf, const MPI_Aint recvcounts[],
+                                          const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                          MPIR_Comm * comm_ptr, int bblock,
                                           MPIR_Request ** request);
-int MPIR_Ialltoallv_intra_gentran_inplace(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int rdispls[],
-                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                          MPIR_Request ** request);
+int MPIR_Ialltoallv_intra_gentran_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                          void *recvbuf, const MPI_Aint recvcounts[],
+                                          const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                          MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ialltoallv_inter_sched_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                     MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                     const int *rdispls, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoallv_inter_sched_pairwise_exchange(const void *sendbuf, const int sendcounts[],
-                                                  const int sdispls[], MPI_Datatype sendtype,
-                                                  void *recvbuf, const int recvcounts[],
-                                                  const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ialltoallv_inter_sched_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                     const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
+                                     const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ialltoallv_inter_sched_pairwise_exchange(const void *sendbuf, const MPI_Aint sendcounts[],
+                                                  const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                                  void *recvbuf, const MPI_Aint recvcounts[],
+                                                  const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Ialltoallw ********************************/
 /* request-based functions */
-int MPIR_Ialltoallw_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                 const MPI_Datatype * sendtypes, void *recvbuf,
-                                 const int *recvcounts, const int *rdispls,
-                                 const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                 MPIR_Request ** request);
-int MPIR_Ialltoallw_intra_gentran_blocked(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], const MPI_Datatype sendtypes[],
-                                          void *recvbuf, const int recvcounts[],
-                                          const int rdispls[], const MPI_Datatype recvtypes[],
+int MPIR_Ialltoallw_allcomm_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                 const MPI_Aint * sdispls, const MPI_Datatype * sendtypes,
+                                 void *recvbuf, const MPI_Aint * recvcounts,
+                                 const MPI_Aint * rdispls, const MPI_Datatype * recvtypes,
+                                 MPIR_Comm * comm_ptr, MPIR_Request ** request);
+int MPIR_Ialltoallw_intra_gentran_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                          void *recvbuf, const MPI_Aint recvcounts[],
+                                          const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                           MPIR_Comm * comm_ptr, int bblock, MPIR_Request ** req);
-int MPIR_Ialltoallw_intra_gentran_inplace(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], const MPI_Datatype sendtypes[],
-                                          void *recvbuf, const int recvcounts[],
-                                          const int rdispls[], const MPI_Datatype recvtypes[],
+int MPIR_Ialltoallw_intra_gentran_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                          void *recvbuf, const MPI_Aint recvcounts[],
+                                          const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                           MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ialltoallw_sched_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                               const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
-                               const int *rdispls, const MPI_Datatype * recvtypes,
-                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ialltoallw_sched_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                               const MPI_Aint * sdispls, const MPI_Datatype * sendtypes,
+                               void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                               const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
+                               MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ialltoallw_intra_sched_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                     const MPI_Datatype * sendtypes, void *recvbuf,
-                                     const int *recvcounts, const int *rdispls,
-                                     const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
-int MPIR_Ialltoallw_intra_sched_blocked(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], const MPI_Datatype sendtypes[],
-                                        void *recvbuf, const int recvcounts[], const int rdispls[],
-                                        const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
-int MPIR_Ialltoallw_intra_sched_inplace(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], const MPI_Datatype sendtypes[],
-                                        void *recvbuf, const int recvcounts[], const int rdispls[],
-                                        const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+int MPIR_Ialltoallw_intra_sched_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                     const MPI_Aint * sdispls, const MPI_Datatype * sendtypes,
+                                     void *recvbuf, const MPI_Aint * recvcounts,
+                                     const MPI_Aint * rdispls, const MPI_Datatype * recvtypes,
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ialltoallw_intra_sched_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ialltoallw_intra_sched_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ialltoallw_inter_sched_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                     const MPI_Datatype * sendtypes, void *recvbuf,
-                                     const int *recvcounts, const int *rdispls,
-                                     const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
-int MPIR_Ialltoallw_inter_sched_pairwise_exchange(const void *sendbuf, const int sendcounts[],
-                                                  const int sdispls[],
+int MPIR_Ialltoallw_inter_sched_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                     const MPI_Aint * sdispls, const MPI_Datatype * sendtypes,
+                                     void *recvbuf, const MPI_Aint * recvcounts,
+                                     const MPI_Aint * rdispls, const MPI_Datatype * recvtypes,
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ialltoallw_inter_sched_pairwise_exchange(const void *sendbuf, const MPI_Aint sendcounts[],
+                                                  const MPI_Aint sdispls[],
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
-                                                  const int recvcounts[], const int rdispls[],
+                                                  const MPI_Aint recvcounts[],
+                                                  const MPI_Aint rdispls[],
                                                   const MPI_Datatype recvtypes[],
                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
@@ -775,37 +788,38 @@ int MPIR_Igather_inter_sched_short(const void *sendbuf, MPI_Aint sendcount, MPI_
 /******************************** Igatherv ********************************/
 /* request-based functions */
 int MPIR_Igatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int *recvcounts, const int *displs,
+                               void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                MPIR_Request ** request);
 int MPIR_Igatherv_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
                                          MPI_Datatype sendtype, void *recvbuf,
-                                         const int *recvcounts, const int *displs,
+                                         const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                          MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                          MPIR_Request ** request);
 
 /* sched-based functions */
 int MPIR_Igatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, const int *recvcounts, const int *displs,
+                             void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Igatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, const int *recvcounts, const int *displs,
-                                   MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
+                                   void *recvbuf, const MPI_Aint * recvcounts,
+                                   const MPI_Aint * displs, MPI_Datatype recvtype, int root,
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Igatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, const int *recvcounts, const int *displs,
-                                   MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
+                                   void *recvbuf, const MPI_Aint * recvcounts,
+                                   const MPI_Aint * displs, MPI_Datatype recvtype, int root,
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
-                                       MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                       const int *displs, MPI_Datatype recvtype, int root,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       const MPI_Aint * recvcounts, const MPI_Aint * displs,
+                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                                       MPIR_Sched_t s);
 
 
 /******************************** Ineighbor_allgather ********************************/
@@ -848,42 +862,42 @@ int MPIR_Ineighbor_allgather_allcomm_sched_linear(const void *sendbuf, MPI_Aint 
 /* request-based functions */
 int MPIR_Ineighbor_allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
-                                           const int recvcounts[], const int displs[],
+                                           const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                            MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                            MPIR_Request ** request);
 int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     const int recvcounts[], const int displs[],
-                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                     MPIR_Request ** request);
+                                                     const MPI_Aint recvcounts[],
+                                                     const MPI_Aint displs[], MPI_Datatype recvtype,
+                                                     MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
 int MPIR_Ineighbor_allgatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                          MPI_Datatype sendtype, void *recvbuf,
-                                         const int recvcounts[], const int displs[],
+                                         const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                          MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ineighbor_allgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
-                                               const int recvcounts[], const int displs[],
+                                               const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ineighbor_allgatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
-                                               const int recvcounts[], const int displs[],
+                                               const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Ineighbor_allgatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   const int recvcounts[], const int displs[],
-                                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                   MPIR_Sched_t s);
+                                                   const MPI_Aint recvcounts[],
+                                                   const MPI_Aint displs[], MPI_Datatype recvtype,
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Ineighbor_alltoall ********************************/
@@ -923,89 +937,92 @@ int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, MPI_Aint s
 
 /******************************** Ineighbor_alltoallv ********************************/
 /* request-based functions */
-int MPIR_Ineighbor_alltoallv_allcomm_auto(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int rdispls[],
-                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                          MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallv_allcomm_gentran_linear(const void *sendbuf, const int sendcounts[],
-                                                    const int sdispls[], MPI_Datatype sendtype,
-                                                    void *recvbuf, const int recvcounts[],
-                                                    const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ineighbor_alltoallv_allcomm_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                          void *recvbuf, const MPI_Aint recvcounts[],
+                                          const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                          MPIR_Comm * comm_ptr, MPIR_Request ** request);
+int MPIR_Ineighbor_alltoallv_allcomm_gentran_linear(const void *sendbuf,
+                                                    const MPI_Aint sendcounts[],
+                                                    const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                                    void *recvbuf, const MPI_Aint recvcounts[],
+                                                    const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ineighbor_alltoallv_sched_auto(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallv_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ineighbor_alltoallv_intra_sched_auto(const void *sendbuf, const int sendcounts[],
-                                              const int sdispls[], MPI_Datatype sendtype,
-                                              void *recvbuf, const int recvcounts[],
-                                              const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ineighbor_alltoallv_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                              const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                              void *recvbuf, const MPI_Aint recvcounts[],
+                                              const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ineighbor_alltoallv_inter_sched_auto(const void *sendbuf, const int sendcounts[],
-                                              const int sdispls[], MPI_Datatype sendtype,
-                                              void *recvbuf, const int recvcounts[],
-                                              const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ineighbor_alltoallv_inter_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                              const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                              void *recvbuf, const MPI_Aint recvcounts[],
+                                              const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Ineighbor_alltoallv_allcomm_sched_linear(const void *sendbuf, const int sendcounts[],
-                                                  const int sdispls[], MPI_Datatype sendtype,
-                                                  void *recvbuf, const int recvcounts[],
-                                                  const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ineighbor_alltoallv_allcomm_sched_linear(const void *sendbuf, const MPI_Aint sendcounts[],
+                                                  const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                                  void *recvbuf, const MPI_Aint recvcounts[],
+                                                  const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Ineighbor_alltoallw ********************************/
 /* request-based functions */
-int MPIR_Ineighbor_alltoallw_allcomm_auto(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_allcomm_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                           const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                          void *recvbuf, const int recvcounts[],
+                                          void *recvbuf, const MPI_Aint recvcounts[],
                                           const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                           MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallw_allcomm_gentran_linear(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_allcomm_gentran_linear(const void *sendbuf,
+                                                    const MPI_Aint sendcounts[],
                                                     const MPI_Aint sdispls[],
                                                     const MPI_Datatype sendtypes[], void *recvbuf,
-                                                    const int recvcounts[],
+                                                    const MPI_Aint recvcounts[],
                                                     const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
                                                     MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ineighbor_alltoallw_sched_auto(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                         const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                        void *recvbuf, const int recvcounts[],
+                                        void *recvbuf, const MPI_Aint recvcounts[],
                                         const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                         MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ineighbor_alltoallw_intra_sched_auto(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                               const MPI_Aint sdispls[],
                                               const MPI_Datatype sendtypes[], void *recvbuf,
-                                              const int recvcounts[], const MPI_Aint rdispls[],
+                                              const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
                                               MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ineighbor_alltoallw_inter_sched_auto(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_inter_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                               const MPI_Aint sdispls[],
                                               const MPI_Datatype sendtypes[], void *recvbuf,
-                                              const int recvcounts[], const MPI_Aint rdispls[],
+                                              const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
                                               MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Ineighbor_alltoallw_allcomm_sched_linear(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_allcomm_sched_linear(const void *sendbuf, const MPI_Aint sendcounts[],
                                                   const MPI_Aint sdispls[],
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
-                                                  const int recvcounts[], const MPI_Aint rdispls[],
+                                                  const MPI_Aint recvcounts[],
+                                                  const MPI_Aint rdispls[],
                                                   const MPI_Datatype recvtypes[],
                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
@@ -1055,46 +1072,46 @@ int MPIR_Ireduce_inter_sched_local_reduce_remote_send(const void *sendbuf, void 
 
 /******************************** Ireduce_scatter ********************************/
 /* request-based functions */
-int MPIR_Ireduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                      MPIR_Request ** request);
+int MPIR_Ireduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf,
+                                      const MPI_Aint * recvcounts, MPI_Datatype datatype, MPI_Op op,
+                                      MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ireduce_scatter_sched_auto(const void *sendbuf, void *recvbuf, const int *recvcounts,
+int MPIR_Ireduce_scatter_sched_auto(const void *sendbuf, void *recvbuf, const MPI_Aint * recvcounts,
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                     MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ireduce_scatter_intra_sched_auto(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_intra_sched_auto(const void *sendbuf, void *recvbuf,
+                                          const MPI_Aint * recvcounts, MPI_Datatype datatype,
+                                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_intra_sched_noncommutative(const void *sendbuf, void *recvbuf,
-                                                    const int *recvcounts, MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm_ptr,
-                                                    MPIR_Sched_t s);
+                                                    const MPI_Aint * recvcounts,
+                                                    MPI_Datatype datatype, MPI_Op op,
+                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_intra_sched_pairwise(const void *sendbuf, void *recvbuf,
-                                              const int *recvcounts, MPI_Datatype datatype,
+                                              const MPI_Aint * recvcounts, MPI_Datatype datatype,
                                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf,
-                                                        const int *recvcounts,
+                                                        const MPI_Aint * recvcounts,
                                                         MPI_Datatype datatype, MPI_Op op,
                                                         MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_intra_sched_recursive_halving(const void *sendbuf, void *recvbuf,
-                                                       const int *recvcounts, MPI_Datatype datatype,
-                                                       MPI_Op op, MPIR_Comm * comm_ptr,
-                                                       MPIR_Sched_t s);
+                                                       const MPI_Aint * recvcounts,
+                                                       MPI_Datatype datatype, MPI_Op op,
+                                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_intra_gentran_recexch(const void *sendbuf, void *recvbuf,
-                                               const int *recvcounts, MPI_Datatype datatype,
+                                               const MPI_Aint * recvcounts, MPI_Datatype datatype,
                                                MPI_Op op, MPIR_Comm * comm_ptr, int k,
                                                MPIR_Request ** request);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ireduce_scatter_inter_sched_auto(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_inter_sched_auto(const void *sendbuf, void *recvbuf,
+                                          const MPI_Aint * recvcounts, MPI_Datatype datatype,
+                                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(const void *sendbuf,
                                                                   void *recvbuf,
-                                                                  const int *recvcounts,
+                                                                  const MPI_Aint * recvcounts,
                                                                   MPI_Datatype datatype, MPI_Op op,
                                                                   MPIR_Comm * comm_ptr,
                                                                   MPIR_Sched_t s);
@@ -1210,38 +1227,38 @@ int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, MPI
 
 /******************************** Iscatterv ********************************/
 /* request-based functions */
-int MPIR_Iscatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                                MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                MPIR_Request ** request);
-int MPIR_Iscatterv_allcomm_gentran_linear(const void *sendbuf, const int *sendcounts,
-                                          const int *displs, MPI_Datatype sendtype, void *recvbuf,
-                                          MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                          MPIR_Comm * comm_ptr, MPIR_Request ** request);
+int MPIR_Iscatterv_allcomm_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
+                                MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                                MPIR_Comm * comm_ptr, MPIR_Request ** request);
+int MPIR_Iscatterv_allcomm_gentran_linear(const void *sendbuf, const MPI_Aint * sendcounts,
+                                          const MPI_Aint * displs, MPI_Datatype sendtype,
+                                          void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                          int root, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Iscatterv_sched_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                              MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                              MPIR_Sched_t s);
+int MPIR_Iscatterv_sched_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                              const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
+                              MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Iscatterv_intra_sched_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                                    MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
+int MPIR_Iscatterv_intra_sched_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                    const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
+                                    MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based intercomm-only functions */
-int MPIR_Iscatterv_inter_sched_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                                    MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
+int MPIR_Iscatterv_inter_sched_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                    const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
+                                    MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Iscatterv_allcomm_sched_linear(const void *sendbuf, const int *sendcounts,
-                                        const int *displs, MPI_Datatype sendtype, void *recvbuf,
-                                        MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Iscatterv_allcomm_sched_linear(const void *sendbuf, const MPI_Aint * sendcounts,
+                                        const MPI_Aint * displs, MPI_Datatype sendtype,
+                                        void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                        int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Neighbor_allgather ********************************/
@@ -1262,7 +1279,7 @@ int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
 /* intracomm-only functions */
 int MPIR_Neighbor_allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int displs[],
+                                          const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 /* intercomm-only functions */
@@ -1270,7 +1287,7 @@ int MPIR_Neighbor_allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcoun
 /* anycomm functions */
 int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int displs[],
+                                        const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 
@@ -1290,34 +1307,36 @@ int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
 
 /******************************** Neighbor_alltoallv ********************************/
 /* intracomm-only functions */
-int MPIR_Neighbor_alltoallv_allcomm_auto(const void *sendbuf, const int sendcounts[],
-                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                         const int recvcounts[], const int rdispls[],
-                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
+int MPIR_Neighbor_alltoallv_allcomm_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                         const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                         void *recvbuf, const MPI_Aint recvcounts[],
+                                         const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                         MPIR_Comm * comm_ptr);
 
 /* intercomm-only functions */
 
 /* anycomm functions */
-int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const int sendcounts[],
-                                       const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                       const int recvcounts[], const int rdispls[],
-                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
+int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
+                                       const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                       void *recvbuf, const MPI_Aint recvcounts[],
+                                       const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                       MPIR_Comm * comm_ptr);
 
 
 /******************************** Neighbor_alltoallw ********************************/
 /* intracomm-only functions */
-int MPIR_Neighbor_alltoallw_allcomm_auto(const void *sendbuf, const int sendcounts[],
+int MPIR_Neighbor_alltoallw_allcomm_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                          const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                         void *recvbuf, const int recvcounts[],
+                                         void *recvbuf, const MPI_Aint recvcounts[],
                                          const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                          MPIR_Comm * comm_ptr);
 
 /* intercomm-only functions */
 
 /* anycomm functions */
-int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const int sendcounts[],
+int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
                                        const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                       void *recvbuf, const int recvcounts[],
+                                       void *recvbuf, const MPI_Aint recvcounts[],
                                        const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                        MPIR_Comm * comm_ptr);
 
@@ -1354,34 +1373,34 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Dat
 
 /******************************** Reduce_scatter ********************************/
 /* intracomm-only functions */
-int MPIR_Reduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf,
+                                     const MPI_Aint * recvcounts, MPI_Datatype datatype, MPI_Op op,
+                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
-                                             const int *recvcounts, MPI_Datatype datatype,
+                                             const MPI_Aint * recvcounts, MPI_Datatype datatype,
                                              MPI_Op op, MPIR_Comm * comm_ptr,
                                              MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                       MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
+                                       const MPI_Aint * recvcounts, MPI_Datatype datatype,
+                                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
-                                                 const int *recvcounts, MPI_Datatype datatype,
+                                                 const MPI_Aint * recvcounts, MPI_Datatype datatype,
                                                  MPI_Op op, MPIR_Comm * comm_ptr,
                                                  MPIR_Errflag_t * errflag);
 int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvbuf,
-                                                const int *recvcounts, MPI_Datatype datatype,
+                                                const MPI_Aint * recvcounts, MPI_Datatype datatype,
                                                 MPI_Op op, MPIR_Comm * comm_ptr,
                                                 MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
 int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int *recvcounts,
+                                                          const MPI_Aint * recvcounts,
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm_ptr,
                                                           MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const int *recvcounts,
+int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const MPI_Aint * recvcounts,
                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                    MPIR_Errflag_t * errflag);
 
@@ -1463,21 +1482,21 @@ int MPIR_Scatter_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
 
 /******************************** Scatterv ********************************/
 /* intracomm-only functions */
-int MPIR_Scatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                               MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                               MPIR_Errflag_t * errflag);
+int MPIR_Scatterv_allcomm_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                               const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
+                               MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* intercomm-only functions */
 
 /* anycomm functions */
-int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const int *sendcounts, const int *displs,
-                                 MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                 MPIR_Errflag_t * errflag);
-int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const int *sendcounts, const int *displs,
-                             MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                             MPIR_Errflag_t * errflag);
+int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcounts,
+                                 const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
+                                 MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
+                             const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
+                             MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 #endif /* MPIR_COLL_H_INCLUDED */

--- a/src/include/mpir_csel.h
+++ b/src/include/mpir_csel.h
@@ -75,8 +75,8 @@ typedef struct {
             MPI_Aint sendcount;
             MPI_Datatype sendtype;
             void *recvbuf;
-            const int *recvcounts;
-            const int *displs;
+            const MPI_Aint *recvcounts;
+            const MPI_Aint *displs;
             MPI_Datatype recvtype;
         } allgatherv, iallgatherv, neighbor_allgatherv, ineighbor_allgatherv;
         struct {
@@ -96,31 +96,31 @@ typedef struct {
         } alltoall, ialltoall, neighbor_alltoall, ineighbor_alltoall;
         struct {
             const void *sendbuf;
-            const int *sendcounts;
-            const int *sdispls;
+            const MPI_Aint *sendcounts;
+            const MPI_Aint *sdispls;
             MPI_Datatype sendtype;
             void *recvbuf;
-            const int *recvcounts;
-            const int *rdispls;
+            const MPI_Aint *recvcounts;
+            const MPI_Aint *rdispls;
             MPI_Datatype recvtype;
         } alltoallv, ialltoallv, neighbor_alltoallv, ineighbor_alltoallv;
         struct {
             const void *sendbuf;
-            const int *sendcounts;
-            const int *sdispls;
+            const MPI_Aint *sendcounts;
+            const MPI_Aint *sdispls;
             const MPI_Datatype *sendtypes;
             void *recvbuf;
-            const int *recvcounts;
-            const int *rdispls;
+            const MPI_Aint *recvcounts;
+            const MPI_Aint *rdispls;
             const MPI_Datatype *recvtypes;
         } alltoallw, ialltoallw;
         struct {
             const void *sendbuf;
-            const int *sendcounts;
+            const MPI_Aint *sendcounts;
             const MPI_Aint *sdispls;
             const MPI_Datatype *sendtypes;
             void *recvbuf;
-            const int *recvcounts;
+            const MPI_Aint *recvcounts;
             const MPI_Aint *rdispls;
             const MPI_Datatype *recvtypes;
         } neighbor_alltoallw, ineighbor_alltoallw;
@@ -154,8 +154,8 @@ typedef struct {
             MPI_Aint sendcount;
             MPI_Datatype sendtype;
             void *recvbuf;
-            const int *recvcounts;
-            const int *displs;
+            const MPI_Aint *recvcounts;
+            const MPI_Aint *displs;
             MPI_Datatype recvtype;
             int root;
         } gatherv, igatherv;
@@ -170,7 +170,7 @@ typedef struct {
         struct {
             const void *sendbuf;
             void *recvbuf;
-            const int *recvcounts;
+            const MPI_Aint *recvcounts;
             MPI_Datatype datatype;
             MPI_Op op;
         } reduce_scatter, ireduce_scatter;
@@ -190,8 +190,8 @@ typedef struct {
         } scan, iscan;
         struct {
             const void *sendbuf;
-            const int *sendcounts;
-            const int *displs;
+            const MPI_Aint *sendcounts;
+            const MPI_Aint *displs;
             MPI_Datatype sendtype;
             MPI_Aint recvcount;
             void *recvbuf;

--- a/src/mpi/coll/allgatherv/allgatherv.c
+++ b/src/mpi/coll/allgatherv/allgatherv.c
@@ -70,8 +70,8 @@ int MPIR_Allgatherv_allcomm_auto(const void *sendbuf,
                                  MPI_Aint sendcount,
                                  MPI_Datatype sendtype,
                                  void *recvbuf,
-                                 const int *recvcounts,
-                                 const int *displs,
+                                 const MPI_Aint * recvcounts,
+                                 const MPI_Aint * displs,
                                  MPI_Datatype recvtype,
                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -137,7 +137,7 @@ int MPIR_Allgatherv_allcomm_auto(const void *sendbuf,
 }
 
 int MPIR_Allgatherv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                         void *recvbuf, const int *recvcounts, const int *displs,
+                         void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -206,8 +206,8 @@ int MPIR_Allgatherv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype s
 }
 
 int MPIR_Allgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                    void *recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                    void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
+                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int *recvcounts, const int *displs,
+                               void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
+++ b/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
@@ -17,8 +17,8 @@
 
 int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts, const int
-                                                    *displs, MPI_Datatype recvtype,
+                                                    const MPI_Aint * recvcounts, const MPI_Aint
+                                                    * displs, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int remote_size, mpi_errno, root, rank;
@@ -94,7 +94,7 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Ain
 
     newcomm_ptr = comm_ptr->local_comm;
 
-    mpi_errno = MPIR_Type_indexed_impl(remote_size, recvcounts, displs, recvtype, &newtype);
+    mpi_errno = MPIR_Type_indexed_c_impl(remote_size, recvcounts, displs, recvtype, &newtype);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Type_commit_impl(&newtype);

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -20,8 +20,8 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                  MPI_Aint sendcount,
                                  MPI_Datatype sendtype,
                                  void *recvbuf,
-                                 const int *recvcounts,
-                                 const int *displs,
+                                 const MPI_Aint * recvcounts,
+                                 const MPI_Aint * displs,
                                  MPI_Datatype recvtype,
                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -22,8 +22,8 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                                              MPI_Aint sendcount,
                                              MPI_Datatype sendtype,
                                              void *recvbuf,
-                                             const int *recvcounts,
-                                             const int *displs,
+                                             const MPI_Aint * recvcounts,
+                                             const MPI_Aint * displs,
                                              MPI_Datatype recvtype,
                                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
@@ -26,8 +26,8 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
                                MPI_Aint sendcount,
                                MPI_Datatype sendtype,
                                void *recvbuf,
-                               const int *recvcounts,
-                               const int *displs,
+                               const MPI_Aint * recvcounts,
+                               const MPI_Aint * displs,
                                MPI_Datatype recvtype,
                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/alltoallv/alltoallv.c
+++ b/src/mpi/coll/alltoallv/alltoallv.c
@@ -54,9 +54,10 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-int MPIR_Alltoallv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+int MPIR_Alltoallv_allcomm_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
+                                const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                 MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -116,9 +117,9 @@ int MPIR_Alltoallv_allcomm_auto(const void *sendbuf, const int *sendcounts, cons
     goto fn_exit;
 }
 
-int MPIR_Alltoallv_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                        MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                        const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+int MPIR_Alltoallv_impl(const void *sendbuf, const MPI_Aint * sendcounts, const MPI_Aint * sdispls,
+                        MPI_Datatype sendtype, void *recvbuf, const MPI_Aint * recvcounts,
+                        const MPI_Aint * rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                         MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -182,9 +183,10 @@ int MPIR_Alltoallv_impl(const void *sendbuf, const int *sendcounts, const int *s
     goto fn_exit;
 }
 
-int MPIR_Alltoallv(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                   MPI_Datatype sendtype, void *recvbuf, const int *recvcounts, const int *rdispls,
-                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Alltoallv(const void *sendbuf, const MPI_Aint * sendcounts, const MPI_Aint * sdispls,
+                   MPI_Datatype sendtype, void *recvbuf, const MPI_Aint * recvcounts,
+                   const MPI_Aint * rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                   MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
@@ -5,10 +5,10 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                              MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                              const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t * errflag)
+int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
+                              const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
+                              const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;

--- a/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
@@ -19,11 +19,11 @@
  * FIXME: change algorithm to match intracommunicator alltoallv
  */
 
-int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const int *sendcounts,
-                                           const int *sdispls, MPI_Datatype sendtype, void *recvbuf,
-                                           const int *recvcounts, const int *rdispls,
-                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                           MPIR_Errflag_t * errflag)
+int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint * sendcounts,
+                                           const MPI_Aint * sdispls, MPI_Datatype sendtype,
+                                           void *recvbuf, const MPI_Aint * recvcounts,
+                                           const MPI_Aint * rdispls, MPI_Datatype recvtype,
+                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int local_size, remote_size, max_size, i;
     MPI_Aint send_extent, recv_extent;

--- a/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
@@ -18,10 +18,10 @@
  * time and there will be multiple repeated malloc/free's rather than
  * maintaining a single buffer across the whole loop.  Something like
  * MADRE is probably the best solution for the MPI_IN_PLACE scenario. */
-int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const int *sendcounts,
-                                                   const int *sdispls, MPI_Datatype sendtype,
-                                                   void *recvbuf, const int *recvcounts,
-                                                   const int *rdispls, MPI_Datatype recvtype,
+int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MPI_Aint * sendcounts,
+                                                   const MPI_Aint * sdispls, MPI_Datatype sendtype,
+                                                   void *recvbuf, const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * rdispls, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int comm_size, i, j;

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -21,9 +21,10 @@
  * *** Modification: We post only a small number of isends and irecvs
  * at a time and wait on them as suggested by Tony Ladd. ***
 */
-int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                   MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                   const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcounts,
+                                   const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
+                                   const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                    MPIR_Errflag_t * errflag)
 {
     int comm_size, i;

--- a/src/mpi/coll/alltoallw/alltoallw.c
+++ b/src/mpi/coll/alltoallw/alltoallw.c
@@ -54,11 +54,11 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-int MPIR_Alltoallw_allcomm_auto(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                                const MPI_Datatype sendtypes[], void *recvbuf,
-                                const int recvcounts[], const int rdispls[],
-                                const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                MPIR_Errflag_t * errflag)
+int MPIR_Alltoallw_allcomm_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                void *recvbuf, const MPI_Aint recvcounts[],
+                                const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -117,9 +117,9 @@ int MPIR_Alltoallw_allcomm_auto(const void *sendbuf, const int sendcounts[], con
     goto fn_exit;
 }
 
-int MPIR_Alltoallw_impl(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                        const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
-                        const int rdispls[], const MPI_Datatype recvtypes[],
+int MPIR_Alltoallw_impl(const void *sendbuf, const MPI_Aint sendcounts[], const MPI_Aint sdispls[],
+                        const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Aint recvcounts[],
+                        const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                         MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -183,9 +183,9 @@ int MPIR_Alltoallw_impl(const void *sendbuf, const int sendcounts[], const int s
     goto fn_exit;
 }
 
-int MPIR_Alltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                   const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
-                   const int rdispls[], const MPI_Datatype recvtypes[],
+int MPIR_Alltoallw(const void *sendbuf, const MPI_Aint sendcounts[], const MPI_Aint sdispls[],
+                   const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Aint recvcounts[],
+                   const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
@@ -5,10 +5,11 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                              const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
-                              const int rdispls[], const MPI_Datatype recvtypes[],
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
+                              const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                              void *recvbuf, const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
+                              const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
+                              MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;

--- a/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
@@ -19,10 +19,10 @@
  * FIXME: change algorithm to match intracommunicator alltoallv
  */
 
-int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const int sendcounts[],
-                                           const int sdispls[], const MPI_Datatype sendtypes[],
-                                           void *recvbuf, const int recvcounts[],
-                                           const int rdispls[], const MPI_Datatype recvtypes[],
+int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint sendcounts[],
+                                           const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                           void *recvbuf, const MPI_Aint recvcounts[],
+                                           const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int local_size, remote_size, max_size, i;

--- a/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
@@ -17,10 +17,11 @@
  * single buffer across the whole loop.  Something like MADRE is probably the
  * best solution for the MPI_IN_PLACE scenario.
  */
-int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const int sendcounts[],
-                                                   const int sdispls[],
+int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                                   const MPI_Aint sdispls[],
                                                    const MPI_Datatype sendtypes[], void *recvbuf,
-                                                   const int recvcounts[], const int rdispls[],
+                                                   const MPI_Aint recvcounts[],
+                                                   const MPI_Aint rdispls[],
                                                    const MPI_Datatype recvtypes[],
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -19,11 +19,11 @@
  * *** Modification: We post only a small number of isends and irecvs at a time
  * and wait on them as suggested by Tony Ladd. ***
  */
-int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                                   const MPI_Datatype sendtypes[], void *recvbuf,
-                                   const int recvcounts[], const int rdispls[],
-                                   const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t * errflag)
+int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcounts[],
+                                   const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                   void *recvbuf, const MPI_Aint recvcounts[],
+                                   const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int comm_size, i;
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/gatherv/gatherv.c
+++ b/src/mpi/coll/gatherv/gatherv.c
@@ -54,7 +54,7 @@ cvars:
 */
 
 int MPIR_Gatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, const int *recvcounts, const int *displs,
+                              void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                               MPIR_Errflag_t * errflag)
 {
@@ -99,7 +99,7 @@ int MPIR_Gatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
 
 int MPIR_Gatherv_impl(const void *sendbuf, MPI_Aint sendcount,
                       MPI_Datatype sendtype, void *recvbuf,
-                      const int *recvcounts, const int *displs,
+                      const MPI_Aint * recvcounts, const MPI_Aint * displs,
                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                       MPIR_Errflag_t * errflag)
 {
@@ -158,7 +158,7 @@ int MPIR_Gatherv_impl(const void *sendbuf, MPI_Aint sendcount,
 }
 
 int MPIR_Gatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                 void *recvbuf, const int *recvcounts, const int *displs,
+                 void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                  MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -39,8 +39,8 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
                                 MPI_Aint sendcount,
                                 MPI_Datatype sendtype,
                                 void *recvbuf,
-                                const int *recvcounts,
-                                const int *displs,
+                                const MPI_Aint * recvcounts,
+                                const MPI_Aint * displs,
                                 MPI_Datatype recvtype,
                                 int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 int MPIR_Gatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, const int *recvcounts, const int *displs,
+                            void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                             MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/iallgatherv/iallgatherv.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv.c
@@ -118,9 +118,9 @@ cvars:
 */
 
 int MPIR_Iallgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, const int *recvcounts, const int *displs,
-                                  MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                  MPIR_Request ** request)
+                                  void *recvbuf, const MPI_Aint * recvcounts,
+                                  const MPI_Aint * displs, MPI_Datatype recvtype,
+                                  MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -218,9 +218,9 @@ int MPIR_Iallgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_D
 }
 
 int MPIR_Iallgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
-                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                      const int displs[], MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      const MPI_Aint recvcounts[], const MPI_Aint displs[],
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, comm_size, total_count, recvtype_size;
@@ -267,9 +267,9 @@ int MPIR_Iallgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
 }
 
 int MPIR_Iallgatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
-                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                      const int displs[], MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      const MPI_Aint recvcounts[], const MPI_Aint displs[],
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -282,7 +282,7 @@ int MPIR_Iallgatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
 }
 
 int MPIR_Iallgatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, const int recvcounts[], const int displs[],
+                                void *recvbuf, const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -301,7 +301,7 @@ int MPIR_Iallgatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
 }
 
 int MPIR_Iallgatherv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                          void *recvbuf, const int recvcounts[], const int displs[],
+                          void *recvbuf, const MPI_Aint recvcounts[], const MPI_Aint displs[],
                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -433,7 +433,7 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype 
 }
 
 int MPIR_Iallgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                     void *recvbuf, const int recvcounts[], const int displs[],
+                     void *recvbuf, const MPI_Aint recvcounts[], const MPI_Aint displs[],
                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallgatherv/iallgatherv.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv.h
@@ -8,6 +8,7 @@
 
 #include "mpiimpl.h"
 
-int MPII_Iallgatherv_is_displs_ordered(int size, const int recvcounts[], const int displs[]);
+int MPII_Iallgatherv_is_displs_ordered(int size, const MPI_Aint recvcounts[],
+                                       const MPI_Aint displs[]);
 
 #endif /* IALLGATHERV_H_INCLUDED */

--- a/src/mpi/coll/iallgatherv/iallgatherv_inter_sched_remote_gather_local_bcast.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_inter_sched_remote_gather_local_bcast.c
@@ -18,8 +18,8 @@
 
 int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
-                                                           const int recvcounts[],
-                                                           const int displs[],
+                                                           const MPI_Aint recvcounts[],
+                                                           const MPI_Aint displs[],
                                                            MPI_Datatype recvtype,
                                                            MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
@@ -70,7 +70,7 @@ int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, 
 
     newcomm_ptr = comm_ptr->local_comm;
 
-    mpi_errno = MPIR_Type_indexed_impl(remote_size, recvcounts, displs, recvtype, &newtype);
+    mpi_errno = MPIR_Type_indexed_c_impl(remote_size, recvcounts, displs, recvtype, &newtype);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Type_commit_impl(&newtype);

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_brucks.c
@@ -12,7 +12,7 @@
 
 int MPIR_Iallgatherv_intra_gentran_brucks(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int displs[],
+                                          const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int k,
                                           MPIR_Request ** request)
 {

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_recexch_doubling.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_recexch_doubling.c
@@ -12,9 +12,9 @@
 
 int MPIR_Iallgatherv_intra_gentran_recexch_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts, const int *displs,
-                                                    MPI_Datatype recvtype, MPIR_Comm * comm, int k,
-                                                    MPIR_Request ** req)
+                                                    const MPI_Aint * recvcounts,
+                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                    MPIR_Comm * comm, int k, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_recexch_halving.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_recexch_halving.c
@@ -12,9 +12,9 @@
 
 int MPIR_Iallgatherv_intra_gentran_recexch_halving(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts, const int *displs,
-                                                   MPI_Datatype recvtype, MPIR_Comm * comm, int k,
-                                                   MPIR_Request ** req)
+                                                   const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                   MPIR_Comm * comm, int k, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_gentran_ring.c
@@ -12,7 +12,7 @@
 
 int MPIR_Iallgatherv_intra_gentran_ring(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype sendtype, void *recvbuf,
-                                        const int *recvcounts, const int *displs,
+                                        const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                         MPI_Datatype recvtype, MPIR_Comm * comm,
                                         MPIR_Request ** req)
 {

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
@@ -7,7 +7,7 @@
 
 int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int displs[],
+                                        const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
@@ -7,9 +7,9 @@
 
 int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    const int recvcounts[], const int displs[],
-                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                    MPIR_Sched_t s)
+                                                    const MPI_Aint recvcounts[],
+                                                    const MPI_Aint displs[], MPI_Datatype recvtype,
+                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank, i, j, k;

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_ring.c
@@ -6,9 +6,9 @@
 #include "mpiimpl.h"
 
 int MPIR_Iallgatherv_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount,
-                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                      const int displs[], MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      const MPI_Aint recvcounts[], const MPI_Aint displs[],
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, total_count;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
@@ -32,7 +32,7 @@
 int
 MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int displs[],
+                                        const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm,
                                         MPIR_TSP_sched_t * sched, int k)
 {
@@ -317,9 +317,10 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
 
 /* Non-blocking brucks based Allgatherv */
 int MPIR_TSP_Iallgatherv_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
-                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                      const int displs[], MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Request ** req, int k)
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      const MPI_Aint recvcounts[], const MPI_Aint displs[],
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Request ** req, int k)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_IALLGATHERV_INTRA_BRUCKS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TSP_IALLGATHERV_INTRA_BRUCKS);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos_prototypes.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos_prototypes.h
@@ -16,10 +16,11 @@
 
 int MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                             MPI_Datatype sendtype, void *recvbuf,
-                                            const int recvcounts[], const int displs[],
+                                            const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                             MPI_Datatype recvtype, MPIR_Comm * comm,
                                             MPIR_TSP_sched_t * s, int k);
 int MPIR_TSP_Iallgatherv_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
-                                      MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                      const int displs[], MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Request ** request, int k);
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      const MPI_Aint recvcounts[], const MPI_Aint displs[],
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Request ** request, int k);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
@@ -14,8 +14,9 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int nranks,
                                                            int log_pofk, int T, void *recvbuf,
                                                            MPI_Datatype recvtype,
                                                            size_t recv_extent,
-                                                           const int *recvcounts, const int *displs,
-                                                           int tag, MPIR_Comm * comm,
+                                                           const MPI_Aint * recvcounts,
+                                                           const MPI_Aint * displs, int tag,
+                                                           MPIR_Comm * comm,
                                                            MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -66,8 +67,8 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int nranks,
 int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int *step1_recvfrom,
                                                    int step1_nrecvs, int is_inplace, int rank,
                                                    int tag, const void *sendbuf, void *recvbuf,
-                                                   size_t recv_extent, const int *recvcounts,
-                                                   const int *displs, MPI_Datatype recvtype,
+                                                   size_t recv_extent, const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
                                                    int n_invtcs, int *invtx, MPIR_Comm * comm,
                                                    MPIR_TSP_sched_t * sched)
 {
@@ -105,8 +106,8 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
                                                    int **step2_nbrs, int rank, int nranks, int k,
                                                    int p_of_k, int log_pofk, int T, int *nrecvs_,
                                                    int **recv_id_, int tag, void *recvbuf,
-                                                   size_t recv_extent, const int *recvcounts,
-                                                   const int *displs, MPI_Datatype recvtype,
+                                                   size_t recv_extent, const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
                                                    int is_dist_halving, MPIR_Comm * comm,
                                                    MPIR_TSP_sched_t * sched)
 {
@@ -183,9 +184,9 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
 
 int MPIR_TSP_Iallgatherv_sched_intra_recexch_step3(int step1_sendto, int *step1_recvfrom,
                                                    int step1_nrecvs, int step2_nphases,
-                                                   void *recvbuf, const int *recvcounts, int nranks,
-                                                   int k, int nrecvs, int *recv_id, int tag,
-                                                   MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                   void *recvbuf, const MPI_Aint * recvcounts,
+                                                   int nranks, int k, int nrecvs, int *recv_id,
+                                                   int tag, MPI_Datatype recvtype, MPIR_Comm * comm,
                                                    MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -216,7 +217,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step3(int step1_sendto, int *step1_
 /* Routine to schedule a recursive exchange based allgather */
 int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
-                                             const int *recvcounts, const int *displs,
+                                             const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                              MPI_Datatype recvtype, MPIR_Comm * comm,
                                              int is_dist_halving, int k, MPIR_TSP_sched_t * sched)
 {
@@ -327,9 +328,10 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, MPI_Aint sendc
 
 /* Non-blocking recexch based Allgather */
 int MPIR_TSP_Iallgatherv_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
-                                       MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                       const int *displs, MPI_Datatype recvtype, MPIR_Comm * comm,
-                                       MPIR_Request ** req, int algo_type, int k)
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       const MPI_Aint * recvcounts, const MPI_Aint * displs,
+                                       MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req,
+                                       int algo_type, int k)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos_prototypes.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos_prototypes.h
@@ -26,15 +26,16 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int nranks,
                                                            int log_pofk, int T, void *recvbuf,
                                                            MPI_Datatype recvtype,
                                                            size_t recv_extent,
-                                                           const int *recvcounts, const int *displs,
-                                                           int tag, MPIR_Comm * comm,
+                                                           const MPI_Aint * recvcounts,
+                                                           const MPI_Aint * displs, int tag,
+                                                           MPIR_Comm * comm,
                                                            MPIR_TSP_sched_t * sched);
 
 int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int *step1_recvfrom,
                                                    int step1_nrecvs, int is_inplace, int rank,
                                                    int tag, const void *sendbuf, void *recvbuf,
-                                                   size_t recv_extent, const int *recvcounts,
-                                                   const int *displs, MPI_Datatype recvtype,
+                                                   size_t recv_extent, const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
                                                    int n_invtcs, int *invtx, MPIR_Comm * comm,
                                                    MPIR_TSP_sched_t * sched);
 
@@ -42,25 +43,26 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
                                                    int **step2_nbrs, int rank, int nranks, int k,
                                                    int p_of_k, int log_pofk, int T, int *nrecvs_,
                                                    int **recv_id_, int tag, void *recvbuf,
-                                                   size_t recv_extent, const int *recvcounts,
-                                                   const int *displs, MPI_Datatype recvtype,
+                                                   size_t recv_extent, const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
                                                    int is_dist_halving, MPIR_Comm * comm,
                                                    MPIR_TSP_sched_t * sched);
 
 int MPIR_TSP_Iallgatherv_sched_intra_recexch_step3(int step1_sendto, int *step1_recvfrom,
                                                    int step1_nrecvs, int step2_nphases,
-                                                   void *recvbuf, const int *recvcounts, int nranks,
-                                                   int k, int nrecvs, int *recv_id, int tag,
-                                                   MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                   void *recvbuf, const MPI_Aint * recvcounts,
+                                                   int nranks, int k, int nrecvs, int *recv_id,
+                                                   int tag, MPI_Datatype recvtype, MPIR_Comm * comm,
                                                    MPIR_TSP_sched_t * sched);
 
 int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
-                                             const int *recvcounts, const int *displs,
+                                             const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                              MPI_Datatype recvtype, MPIR_Comm * comm,
                                              int is_dist_halving, int k, MPIR_TSP_sched_t * sched);
 
 int MPIR_TSP_Iallgatherv_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
-                                       MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                       const int *displs, MPI_Datatype recvtype, MPIR_Comm * comm,
-                                       MPIR_Request ** req, int allgatherv_type, int k);
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       const MPI_Aint * recvcounts, const MPI_Aint * displs,
+                                       MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req,
+                                       int allgatherv_type, int k);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
@@ -13,7 +13,7 @@
 /* Routine to schedule a recursive exchange based allgatherv */
 int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf,
-                                          const int *recvcounts, const int *displs,
+                                          const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                           MPI_Datatype recvtype, MPIR_Comm * comm,
                                           MPIR_TSP_sched_t * sched)
 {
@@ -148,8 +148,9 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
 
 /* Non-blocking ring based Allgatherv */
 int MPIR_TSP_Iallgatherv_intra_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                    void *recvbuf, const int *recvcounts, const int *displs,
-                                    MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req)
+                                    void *recvbuf, const MPI_Aint * recvcounts,
+                                    const MPI_Aint * displs, MPI_Datatype recvtype,
+                                    MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos_prototypes.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos_prototypes.h
@@ -16,10 +16,11 @@
 
 int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf,
-                                          const int *recvcounts, const int *displs,
+                                          const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                           MPI_Datatype recvtype, MPIR_Comm * comm,
                                           MPIR_TSP_sched_t * sched);
 
 int MPIR_TSP_Iallgatherv_intra_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                    void *recvbuf, const int *recvcounts, const int *displs,
-                                    MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req);
+                                    void *recvbuf, const MPI_Aint * recvcounts,
+                                    const MPI_Aint * displs, MPI_Datatype recvtype,
+                                    MPIR_Comm * comm, MPIR_Request ** req);

--- a/src/mpi/coll/iallgatherv/iallgatherv_utils.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_utils.c
@@ -11,7 +11,8 @@
  * algorithms can only handle ordered array of data and hence this function for
  * checking whether the data is ordered.
  */
-int MPII_Iallgatherv_is_displs_ordered(int size, const int recvcounts[], const int displs[])
+int MPII_Iallgatherv_is_displs_ordered(int size, const MPI_Aint recvcounts[],
+                                       const MPI_Aint displs[])
 {
     int i, pos = 0;
     for (i = 0; i < size; i++) {

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv_algos.h
@@ -36,7 +36,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     int p_of_k, log_pofk, T;
     int per_nbr_buffer = 0, rem = 0;
     int nvtcs, sink_id, *recv_id = NULL, *vtcs = NULL;
-    int *send_id = NULL, *reduce_id = NULL, *cnts = NULL, *displs = NULL;
+    int *send_id = NULL, *reduce_id = NULL;
+    MPI_Aint *cnts = NULL, *displs = NULL;
     bool in_step2 = false;
     void *tmp_recvbuf;
     void **step1_recvbuf = NULL;
@@ -108,8 +109,10 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Start Step2"));
 
     if (in_step2) {
-        MPIR_CHKLMEM_MALLOC(cnts, int *, sizeof(int) * nranks, mpi_errno, "cnts", MPL_MEM_COLL);
-        MPIR_CHKLMEM_MALLOC(displs, int *, sizeof(int) * nranks, mpi_errno, "displs", MPL_MEM_COLL);
+        MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, sizeof(MPI_Aint) * nranks, mpi_errno, "cnts",
+                            MPL_MEM_COLL);
+        MPIR_CHKLMEM_MALLOC(displs, MPI_Aint *, sizeof(MPI_Aint) * nranks, mpi_errno, "displs",
+                            MPL_MEM_COLL);
         int idx = 0;
         rem = nranks - p_of_k;
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_ring_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_ring_algos.h
@@ -24,7 +24,8 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
     int nranks, is_inplace, rank;
     size_t extent;
     MPI_Aint lb, true_extent;
-    int *cnts, *displs, recv_id, *reduce_id, nvtcs, vtcs;
+    MPI_Aint *cnts, *displs;
+    int recv_id, *reduce_id, nvtcs, vtcs;
     int send_rank, recv_rank, total_count;
     void *tmpbuf;
     int tag;
@@ -41,8 +42,10 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
     extent = MPL_MAX(extent, true_extent);
 
-    MPIR_CHKLMEM_MALLOC(cnts, int *, nranks * sizeof(int), mpi_errno, "cnts", MPL_MEM_COLL);
-    MPIR_CHKLMEM_MALLOC(displs, int *, nranks * sizeof(int), mpi_errno, "displs", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, nranks * sizeof(MPI_Aint), mpi_errno, "cnts",
+                        MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(displs, MPI_Aint *, nranks * sizeof(MPI_Aint), mpi_errno, "displs",
+                        MPL_MEM_COLL);
 
     for (i = 0; i < nranks; i++)
         cnts[i] = 0;

--- a/src/mpi/coll/ialltoallv/ialltoallv.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv.c
@@ -81,9 +81,10 @@ cvars:
 
 /* any non-MPI functions go here, especially non-static ones */
 
-int MPIR_Ialltoallv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                 MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                 const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+int MPIR_Ialltoallv_allcomm_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                 const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
+                                 const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                  MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -173,9 +174,9 @@ int MPIR_Ialltoallv_allcomm_auto(const void *sendbuf, const int *sendcounts, con
     goto fn_exit;
 }
 
-int MPIR_Ialltoallv_intra_sched_auto(const void *sendbuf, const int sendcounts[],
-                                     const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                     const int recvcounts[], const int rdispls[],
+int MPIR_Ialltoallv_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                     const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf,
+                                     const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -195,9 +196,9 @@ int MPIR_Ialltoallv_intra_sched_auto(const void *sendbuf, const int sendcounts[]
     return mpi_errno;
 }
 
-int MPIR_Ialltoallv_inter_sched_auto(const void *sendbuf, const int sendcounts[],
-                                     const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                     const int recvcounts[], const int rdispls[],
+int MPIR_Ialltoallv_inter_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                     const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf,
+                                     const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -209,10 +210,10 @@ int MPIR_Ialltoallv_inter_sched_auto(const void *sendbuf, const int sendcounts[]
     return mpi_errno;
 }
 
-int MPIR_Ialltoallv_sched_auto(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                               MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                               const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s)
+int MPIR_Ialltoallv_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                               const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf,
+                               const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -229,9 +230,9 @@ int MPIR_Ialltoallv_sched_auto(const void *sendbuf, const int sendcounts[], cons
     return mpi_errno;
 }
 
-int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                         MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                         const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+int MPIR_Ialltoallv_impl(const void *sendbuf, const MPI_Aint sendcounts[], const MPI_Aint sdispls[],
+                         MPI_Datatype sendtype, void *recvbuf, const MPI_Aint recvcounts[],
+                         const MPI_Aint rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                          MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -349,9 +350,9 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
     goto fn_exit;
 }
 
-int MPIR_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                    MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                    const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+int MPIR_Ialltoallv(const void *sendbuf, const MPI_Aint sendcounts[], const MPI_Aint sdispls[],
+                    MPI_Datatype sendtype, void *recvbuf, const MPI_Aint recvcounts[],
+                    const MPI_Aint rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                     MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ialltoallv/ialltoallv_inter_sched_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_inter_sched_pairwise_exchange.c
@@ -5,10 +5,10 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Ialltoallv_inter_sched_pairwise_exchange(const void *sendbuf, const int sendcounts[],
-                                                  const int sdispls[], MPI_Datatype sendtype,
-                                                  void *recvbuf, const int recvcounts[],
-                                                  const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ialltoallv_inter_sched_pairwise_exchange(const void *sendbuf, const MPI_Aint sendcounts[],
+                                                  const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                                  void *recvbuf, const MPI_Aint recvcounts[],
+                                                  const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     /* Intercommunicator alltoallv. We use a pairwise exchange algorithm

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_gentran_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_gentran_blocked.c
@@ -10,11 +10,11 @@
 #include "ialltoallv_tsp_blocked_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ialltoallv_intra_gentran_blocked(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int rdispls[],
-                                          MPI_Datatype recvtype, MPIR_Comm * comm, int bblock,
-                                          MPIR_Request ** req)
+int MPIR_Ialltoallv_intra_gentran_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                          void *recvbuf, const MPI_Aint recvcounts[],
+                                          const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, int bblock, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_gentran_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_gentran_inplace.c
@@ -10,11 +10,11 @@
 #include "ialltoallv_tsp_inplace_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ialltoallv_intra_gentran_inplace(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int rdispls[],
-                                          MPI_Datatype recvtype, MPIR_Comm * comm,
-                                          MPIR_Request ** req)
+int MPIR_Ialltoallv_intra_gentran_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                          void *recvbuf, const MPI_Aint recvcounts[],
+                                          const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_gentran_scattered.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_gentran_scattered.c
@@ -10,10 +10,10 @@
 #include "ialltoallv_tsp_scattered_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ialltoallv_intra_gentran_scattered(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], MPI_Datatype sendtype,
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ialltoallv_intra_gentran_scattered(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                            void *recvbuf, const MPI_Aint recvcounts[],
+                                            const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                             MPIR_Comm * comm, int batch_size, int bblock,
                                             MPIR_Request ** req)
 {

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_blocked.c
@@ -5,10 +5,11 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Ialltoallv_intra_sched_blocked(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ialltoallv_intra_sched_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size;

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_inplace.c
@@ -5,10 +5,11 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Ialltoallv_intra_sched_inplace(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ialltoallv_intra_sched_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int max_count;
     void *tmp_buf = NULL;

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked_algos.h
@@ -11,10 +11,10 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a recursive exchange based alltoallv */
-int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], MPI_Datatype sendtype,
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], MPI_Datatype recvtype,
+int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                            void *recvbuf, const MPI_Aint recvcounts[],
+                                            const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                             MPIR_Comm * comm, int bblock, MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -85,11 +85,11 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendc
 
 
 /* Non-blocking blocked based ALLTOALLV */
-int MPIR_TSP_Ialltoallv_intra_blocked(const void *sendbuf, const int sendcounts[],
-                                      const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                      const int recvcounts[], const int rdispls[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm, int bblock,
-                                      MPIR_Request ** req)
+int MPIR_TSP_Ialltoallv_intra_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                      const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                      void *recvbuf, const MPI_Aint recvcounts[],
+                                      const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                      MPIR_Comm * comm, int bblock, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked_algos_prototypes.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked_algos_prototypes.h
@@ -14,14 +14,14 @@
 #undef MPIR_TSP_Ialltoallv_sched_intra_blocked
 #define MPIR_TSP_Ialltoallv_sched_intra_blocked                MPIR_TSP_NAMESPACE(Ialltoallv_sched_intra_blocked)
 
-int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], MPI_Datatype sendtype,
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], MPI_Datatype recvtype,
+int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                            void *recvbuf, const MPI_Aint recvcounts[],
+                                            const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                             MPIR_Comm * comm, int bblock, MPIR_TSP_sched_t * s);
 
-int MPIR_TSP_Ialltoallv_intra_blocked(const void *sendbuf, const int sendcounts[],
-                                      const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                      const int recvcounts[], const int rdispls[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm, int bblock,
-                                      MPIR_Request ** req);
+int MPIR_TSP_Ialltoallv_intra_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                      const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                      void *recvbuf, const MPI_Aint recvcounts[],
+                                      const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                      MPIR_Comm * comm, int bblock, MPIR_Request ** req);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace_algos.h
@@ -11,10 +11,10 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a recursive exchange based alltoallv */
-int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], MPI_Datatype sendtype,
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], MPI_Datatype recvtype,
+int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                            void *recvbuf, const MPI_Aint recvcounts[],
+                                            const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                             MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -81,10 +81,11 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendc
 
 
 /* Non-blocking inplace based ALLTOALLV */
-int MPIR_TSP_Ialltoallv_intra_inplace(const void *sendbuf, const int sendcounts[],
-                                      const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                      const int recvcounts[], const int rdispls[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req)
+int MPIR_TSP_Ialltoallv_intra_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                      const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                      void *recvbuf, const MPI_Aint recvcounts[],
+                                      const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                      MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace_algos_prototypes.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace_algos_prototypes.h
@@ -14,13 +14,14 @@
 #undef MPIR_TSP_Ialltoallv_sched_intra_inplace
 #define MPIR_TSP_Ialltoallv_sched_intra_inplace                MPIR_TSP_NAMESPACE(Ialltoallv_sched_intra_inplace)
 
-int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], MPI_Datatype sendtype,
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], MPI_Datatype recvtype,
+int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                            void *recvbuf, const MPI_Aint recvcounts[],
+                                            const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                             MPIR_Comm * comm, MPIR_TSP_sched_t * s);
 
-int MPIR_TSP_Ialltoallv_intra_inplace(const void *sendbuf, const int sendcounts[],
-                                      const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                      const int recvcounts[], const int rdispls[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req);
+int MPIR_TSP_Ialltoallv_intra_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                      const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                      void *recvbuf, const MPI_Aint recvcounts[],
+                                      const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                      MPIR_Comm * comm, MPIR_Request ** req);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
@@ -11,10 +11,10 @@
 
 /* Routine to schedule a scattered based alltoallv */
 /* Alltoallv doesn't support MPI_IN_PLACE */
-int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const int sendcounts[],
-                                              const int sdispls[], MPI_Datatype sendtype,
-                                              void *recvbuf, const int recvcounts[],
-                                              const int rdispls[], MPI_Datatype recvtype,
+int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Aint sendcounts[],
+                                              const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                              void *recvbuf, const MPI_Aint recvcounts[],
+                                              const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                               MPIR_Comm * comm, int batch_size, int bblock,
                                               MPIR_TSP_sched_t * sched)
 {
@@ -108,11 +108,12 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const int sen
 }
 
 /* Scattered sliding window based Alltoallv */
-int MPIR_TSP_Ialltoallv_intra_scattered(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm, int batch_size,
-                                        int bblock, MPIR_Request ** req)
+int MPIR_TSP_Ialltoallv_intra_scattered(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                        MPIR_Comm * comm, int batch_size, int bblock,
+                                        MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos_prototypes.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos_prototypes.h
@@ -14,15 +14,16 @@
 #undef MPIR_TSP_Ialltoallv_sched_intra_scattered
 #define MPIR_TSP_Ialltoallv_sched_intra_scattered           MPIR_TSP_NAMESPACE(Ialltoallv_sched_intra_scattered)
 
-int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const int sendcounts[],
-                                              const int sdispls[], MPI_Datatype sendtype,
-                                              void *recvbuf, const int recvcounts[],
-                                              const int rdispls[], MPI_Datatype recvtype,
+int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Aint sendcounts[],
+                                              const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                              void *recvbuf, const MPI_Aint recvcounts[],
+                                              const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                               MPIR_Comm * comm, int batch_size, int bblock,
                                               MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Ialltoallv_intra_scattered(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm, int batch_size,
-                                        int bblock, MPIR_Request ** req);
+int MPIR_TSP_Ialltoallv_intra_scattered(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                        MPIR_Comm * comm, int batch_size, int bblock,
+                                        MPIR_Request ** req);

--- a/src/mpi/coll/ialltoallw/ialltoallw.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw.c
@@ -56,11 +56,11 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-int MPIR_Ialltoallw_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                 const MPI_Datatype * sendtypes, void *recvbuf,
-                                 const int *recvcounts, const int *rdispls,
-                                 const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                 MPIR_Request ** request)
+int MPIR_Ialltoallw_allcomm_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                 const MPI_Aint * sdispls, const MPI_Datatype * sendtypes,
+                                 void *recvbuf, const MPI_Aint * recvcounts,
+                                 const MPI_Aint * rdispls, const MPI_Datatype * recvtypes,
+                                 MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -138,11 +138,11 @@ int MPIR_Ialltoallw_allcomm_auto(const void *sendbuf, const int *sendcounts, con
     goto fn_exit;
 }
 
-int MPIR_Ialltoallw_intra_sched_auto(const void *sendbuf, const int sendcounts[],
-                                     const int sdispls[], const MPI_Datatype sendtypes[],
-                                     void *recvbuf, const int recvcounts[], const int rdispls[],
-                                     const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+int MPIR_Ialltoallw_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                     const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                     void *recvbuf, const MPI_Aint recvcounts[],
+                                     const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -159,11 +159,11 @@ int MPIR_Ialltoallw_intra_sched_auto(const void *sendbuf, const int sendcounts[]
     return mpi_errno;
 }
 
-int MPIR_Ialltoallw_inter_sched_auto(const void *sendbuf, const int sendcounts[],
-                                     const int sdispls[], const MPI_Datatype sendtypes[],
-                                     void *recvbuf, const int recvcounts[], const int rdispls[],
-                                     const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+int MPIR_Ialltoallw_inter_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                     const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                     void *recvbuf, const MPI_Aint recvcounts[],
+                                     const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -174,9 +174,9 @@ int MPIR_Ialltoallw_inter_sched_auto(const void *sendbuf, const int sendcounts[]
     return mpi_errno;
 }
 
-int MPIR_Ialltoallw_sched_auto(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                               const MPI_Datatype sendtypes[], void *recvbuf,
-                               const int recvcounts[], const int rdispls[],
+int MPIR_Ialltoallw_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                               const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                               void *recvbuf, const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -194,10 +194,10 @@ int MPIR_Ialltoallw_sched_auto(const void *sendbuf, const int sendcounts[], cons
     return mpi_errno;
 }
 
-int MPIR_Ialltoallw_impl(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                         const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
-                         const int rdispls[], const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                         MPIR_Request ** request)
+int MPIR_Ialltoallw_impl(const void *sendbuf, const MPI_Aint sendcounts[], const MPI_Aint sdispls[],
+                         const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Aint recvcounts[],
+                         const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                         MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -298,9 +298,9 @@ int MPIR_Ialltoallw_impl(const void *sendbuf, const int sendcounts[], const int 
     goto fn_exit;
 }
 
-int MPIR_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                    const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
-                    const int rdispls[], const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
+int MPIR_Ialltoallw(const void *sendbuf, const MPI_Aint sendcounts[], const MPI_Aint sdispls[],
+                    const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Aint recvcounts[],
+                    const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
                     MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ialltoallw/ialltoallw_inter_sched_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_inter_sched_pairwise_exchange.c
@@ -5,10 +5,11 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Ialltoallw_inter_sched_pairwise_exchange(const void *sendbuf, const int sendcounts[],
-                                                  const int sdispls[],
+int MPIR_Ialltoallw_inter_sched_pairwise_exchange(const void *sendbuf, const MPI_Aint sendcounts[],
+                                                  const MPI_Aint sdispls[],
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
-                                                  const int recvcounts[], const int rdispls[],
+                                                  const MPI_Aint recvcounts[],
+                                                  const MPI_Aint rdispls[],
                                                   const MPI_Datatype recvtypes[],
                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_gentran_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_gentran_blocked.c
@@ -10,10 +10,10 @@
 #include "ialltoallw_tsp_blocked_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ialltoallw_intra_gentran_blocked(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], const MPI_Datatype sendtypes[],
-                                          void *recvbuf, const int recvcounts[],
-                                          const int rdispls[], const MPI_Datatype recvtypes[],
+int MPIR_Ialltoallw_intra_gentran_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                          void *recvbuf, const MPI_Aint recvcounts[],
+                                          const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                           MPIR_Comm * comm, int bblock, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_gentran_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_gentran_inplace.c
@@ -10,10 +10,10 @@
 #include "ialltoallw_tsp_inplace_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ialltoallw_intra_gentran_inplace(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], const MPI_Datatype sendtypes[],
-                                          void *recvbuf, const int recvcounts[],
-                                          const int rdispls[], const MPI_Datatype recvtypes[],
+int MPIR_Ialltoallw_intra_gentran_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                          void *recvbuf, const MPI_Aint recvcounts[],
+                                          const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                           MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_blocked.c
@@ -19,11 +19,11 @@
  * *** Modification: We post only a small number of isends and irecvs at a time
  * and wait on them as suggested by Tony Ladd. ***
  */
-int MPIR_Ialltoallw_intra_sched_blocked(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], const MPI_Datatype sendtypes[],
-                                        void *recvbuf, const int recvcounts[], const int rdispls[],
-                                        const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s)
+int MPIR_Ialltoallw_intra_sched_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, i;

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
@@ -17,11 +17,11 @@
  * single buffer across the whole loop.  Something like MADRE is probably the
  * best solution for the MPI_IN_PLACE scenario.
  */
-int MPIR_Ialltoallw_intra_sched_inplace(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], const MPI_Datatype sendtypes[],
-                                        void *recvbuf, const int recvcounts[], const int rdispls[],
-                                        const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s)
+int MPIR_Ialltoallw_intra_sched_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, i, j;

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked_algos.h
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked_algos.h
@@ -11,11 +11,12 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a recursive exchange based alltoallv */
-int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], const MPI_Datatype sendtypes[],
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], const MPI_Datatype recvtypes[],
-                                            MPIR_Comm * comm, int bblock, MPIR_TSP_sched_t * sched)
+int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint sdispls[],
+                                            const MPI_Datatype sendtypes[], void *recvbuf,
+                                            const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
+                                            const MPI_Datatype recvtypes[], MPIR_Comm * comm,
+                                            int bblock, MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int tag;
@@ -81,11 +82,11 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendc
 
 
 /* Non-blocking blocked based ALLTOALLW */
-int MPIR_TSP_Ialltoallw_intra_blocked(const void *sendbuf, const int sendcounts[],
-                                      const int sdispls[], const MPI_Datatype sendtypes[],
-                                      void *recvbuf, const int recvcounts[], const int rdispls[],
-                                      const MPI_Datatype recvtypes[], MPIR_Comm * comm, int bblock,
-                                      MPIR_Request ** req)
+int MPIR_TSP_Ialltoallw_intra_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                      const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                      void *recvbuf, const MPI_Aint recvcounts[],
+                                      const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                      MPIR_Comm * comm, int bblock, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked_algos_prototypes.h
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked_algos_prototypes.h
@@ -14,14 +14,15 @@
 #undef MPIR_TSP_Ialltoallw_sched_intra_blocked
 #define MPIR_TSP_Ialltoallw_sched_intra_blocked                MPIR_TSP_NAMESPACE(Ialltoallw_sched_intra_blocked)
 
-int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], const MPI_Datatype sendtypes[],
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], const MPI_Datatype recvtypes[],
-                                            MPIR_Comm * comm, int bblock, MPIR_TSP_sched_t * s);
+int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint sdispls[],
+                                            const MPI_Datatype sendtypes[], void *recvbuf,
+                                            const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
+                                            const MPI_Datatype recvtypes[], MPIR_Comm * comm,
+                                            int bblock, MPIR_TSP_sched_t * s);
 
-int MPIR_TSP_Ialltoallw_intra_blocked(const void *sendbuf, const int sendcounts[],
-                                      const int sdispls[], const MPI_Datatype sendtypes[],
-                                      void *recvbuf, const int recvcounts[], const int rdispls[],
-                                      const MPI_Datatype recvtypes[], MPIR_Comm * comm, int bblock,
-                                      MPIR_Request ** req);
+int MPIR_TSP_Ialltoallw_intra_blocked(const void *sendbuf, const MPI_Aint sendcounts[],
+                                      const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                      void *recvbuf, const MPI_Aint recvcounts[],
+                                      const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                      MPIR_Comm * comm, int bblock, MPIR_Request ** req);

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace_algos.h
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace_algos.h
@@ -11,11 +11,12 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule inplace algorithm for  alltoallw */
-int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], const MPI_Datatype sendtypes[],
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], const MPI_Datatype recvtypes[],
-                                            MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
+int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint sdispls[],
+                                            const MPI_Datatype sendtypes[], void *recvbuf,
+                                            const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
+                                            const MPI_Datatype recvtypes[], MPIR_Comm * comm,
+                                            MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int tag;
@@ -86,10 +87,10 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendc
 
 
 /* Non-blocking inplace based ALLTOALLW */
-int MPIR_TSP_Ialltoallw_intra_inplace(const void *sendbuf, const int sendcounts[],
-                                      const int sdispls[], const MPI_Datatype sendtypes[],
-                                      void *recvbuf, const int recvcounts[],
-                                      const int rdispls[], const MPI_Datatype recvtypes[],
+int MPIR_TSP_Ialltoallw_intra_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                      const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                      void *recvbuf, const MPI_Aint recvcounts[],
+                                      const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                       MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace_algos_prototypes.h
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace_algos_prototypes.h
@@ -14,14 +14,15 @@
 #undef MPIR_TSP_Ialltoallw_sched_intra_inplace
 #define MPIR_TSP_Ialltoallw_sched_intra_inplace                MPIR_TSP_NAMESPACE(Ialltoallw_sched_intra_inplace)
 
-int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], const MPI_Datatype sendtypes[],
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], const MPI_Datatype recvtypes[],
-                                            MPIR_Comm * comm, MPIR_TSP_sched_t * s);
+int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint sdispls[],
+                                            const MPI_Datatype sendtypes[], void *recvbuf,
+                                            const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
+                                            const MPI_Datatype recvtypes[], MPIR_Comm * comm,
+                                            MPIR_TSP_sched_t * s);
 
-int MPIR_TSP_Ialltoallw_intra_inplace(const void *sendbuf, const int sendcounts[],
-                                      const int sdispls[], const MPI_Datatype sendtypes[],
-                                      void *recvbuf, const int recvcounts[], const int rdispls[],
-                                      const MPI_Datatype recvtypes[], MPIR_Comm * comm,
-                                      MPIR_Request ** req);
+int MPIR_TSP_Ialltoallw_intra_inplace(const void *sendbuf, const MPI_Aint sendcounts[],
+                                      const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                      void *recvbuf, const MPI_Aint recvcounts[],
+                                      const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                      MPIR_Comm * comm, MPIR_Request ** req);

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv_algos.h
@@ -23,7 +23,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
     int size, rank, tag;
     int i, j, x, is_contig;
     void *tmp_buf = NULL;
-    int *cnts, *displs;
+    MPI_Aint *cnts, *displs;
     size_t nbytes;
     int tree_type;
     MPIR_Treealgo_tree_t my_tree, parents_tree;
@@ -56,8 +56,8 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
     extent = MPL_MAX(extent, true_extent);
 
     nbytes = type_size * count;
-    MPIR_CHKLMEM_MALLOC(cnts, int *, sizeof(int) * size, mpi_errno, "cnts", MPL_MEM_COLL);      /* to store counts of each rank */
-    MPIR_CHKLMEM_MALLOC(displs, int *, sizeof(int) * size, mpi_errno, "displs", MPL_MEM_COLL);  /* to store displs of each rank */
+    MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, sizeof(MPI_Aint) * size, mpi_errno, "cnts", MPL_MEM_COLL);    /* to store counts of each rank */
+    MPIR_CHKLMEM_MALLOC(displs, MPI_Aint *, sizeof(MPI_Aint) * size, mpi_errno, "displs", MPL_MEM_COLL);        /* to store displs of each rank */
 
     total_count = 0;
     for (i = 0; i < size; i++)

--- a/src/mpi/coll/igatherv/igatherv.c
+++ b/src/mpi/coll/igatherv/igatherv.c
@@ -55,7 +55,7 @@ cvars:
 */
 
 int MPIR_Igatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int *recvcounts, const int *displs,
+                               void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                MPIR_Request ** request)
 {
@@ -112,9 +112,9 @@ int MPIR_Igatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 }
 
 int MPIR_Igatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, const int recvcounts[], const int displs[],
-                                   MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s)
+                                   void *recvbuf, const MPI_Aint recvcounts[],
+                                   const MPI_Aint displs[], MPI_Datatype recvtype, int root,
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -131,9 +131,9 @@ int MPIR_Igatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_
 }
 
 int MPIR_Igatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, const int recvcounts[], const int displs[],
-                                   MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s)
+                                   void *recvbuf, const MPI_Aint recvcounts[],
+                                   const MPI_Aint displs[], MPI_Datatype recvtype, int root,
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -150,7 +150,7 @@ int MPIR_Igatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_
 }
 
 int MPIR_Igatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, const int recvcounts[], const int displs[],
+                             void *recvbuf, const MPI_Aint recvcounts[], const MPI_Aint displs[],
                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -167,7 +167,7 @@ int MPIR_Igatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
 }
 
 int MPIR_Igatherv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                       void *recvbuf, const int recvcounts[], const int displs[],
+                       void *recvbuf, const MPI_Aint recvcounts[], const MPI_Aint displs[],
                        MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                        MPIR_Request ** request)
 {
@@ -243,7 +243,7 @@ int MPIR_Igatherv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sen
 }
 
 int MPIR_Igatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype, void *recvbuf,
-                  const int recvcounts[], const int displs[], MPI_Datatype recvtype,
+                  const MPI_Aint recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype,
                   int root, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/igatherv/igatherv_allcomm_gentran_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_gentran_linear.c
@@ -12,7 +12,7 @@
 
 int MPIR_Igatherv_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
                                          MPI_Datatype sendtype, void *recvbuf,
-                                         const int recvcounts[], const int displs[],
+                                         const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                          MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                          MPIR_Request ** request)
 {

--- a/src/mpi/coll/igatherv/igatherv_allcomm_sched_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_sched_linear.c
@@ -12,9 +12,10 @@
  */
 
 int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
-                                       MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                       const int displs[], MPI_Datatype recvtype, int root,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       const MPI_Aint recvcounts[], const MPI_Aint displs[],
+                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                                       MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;

--- a/src/mpi/coll/igatherv/igatherv_tsp_linear_algos.h
+++ b/src/mpi/coll/igatherv/igatherv_tsp_linear_algos.h
@@ -23,7 +23,7 @@
 */
 int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
-                                           const int recvcounts[], const int displs[],
+                                           const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                            MPIR_TSP_sched_t * sched)
 {
@@ -94,9 +94,9 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
 
 /* Non-blocking linear algorithm for gatherv */
 int MPIR_TSP_Igatherv_allcomm_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, const int recvcounts[], const int displs[],
-                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                     MPIR_Request ** req)
+                                     void *recvbuf, const MPI_Aint recvcounts[],
+                                     const MPI_Aint displs[], MPI_Datatype recvtype, int root,
+                                     MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/igatherv/igatherv_tsp_linear_algos_prototypes.h
+++ b/src/mpi/coll/igatherv/igatherv_tsp_linear_algos_prototypes.h
@@ -16,10 +16,10 @@
 
 int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
-                                           const int recvcounts[], const int displs[],
+                                           const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                            MPIR_TSP_sched_t * sched);
 int MPIR_TSP_Igatherv_allcomm_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, const int recvcounts[], const int displs[],
-                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                     MPIR_Request ** request);
+                                     void *recvbuf, const MPI_Aint recvcounts[],
+                                     const MPI_Aint displs[], MPI_Datatype recvtype, int root,
+                                     MPIR_Comm * comm_ptr, MPIR_Request ** request);

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
@@ -58,7 +58,7 @@ cvars:
 
 int MPIR_Ineighbor_allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
-                                           const int recvcounts[], const int displs[],
+                                           const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                            MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                            MPIR_Request ** request)
 {
@@ -115,7 +115,7 @@ int MPIR_Ineighbor_allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcou
 
 int MPIR_Ineighbor_allgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
-                                               const int recvcounts[], const int displs[],
+                                               const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                MPIR_Sched_t s)
 {
@@ -135,7 +135,7 @@ int MPIR_Ineighbor_allgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sen
 
 int MPIR_Ineighbor_allgatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
-                                               const int recvcounts[], const int displs[],
+                                               const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                MPIR_Sched_t s)
 {
@@ -155,7 +155,7 @@ int MPIR_Ineighbor_allgatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sen
 
 int MPIR_Ineighbor_allgatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                          MPI_Datatype sendtype, void *recvbuf,
-                                         const int recvcounts[], const int displs[],
+                                         const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                          MPIR_Sched_t s)
 {
@@ -176,7 +176,7 @@ int MPIR_Ineighbor_allgatherv_sched_auto(const void *sendbuf, MPI_Aint sendcount
 
 int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, MPI_Aint sendcount,
                                    MPI_Datatype sendtype, void *recvbuf,
-                                   const int recvcounts[], const int displs[],
+                                   const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                    MPIR_Request ** request)
 {
@@ -262,7 +262,7 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, MPI_Aint sendcount,
 
 int MPIR_Ineighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                               MPI_Datatype sendtype, void *recvbuf,
-                              const int recvcounts[], const int displs[],
+                              const MPI_Aint recvcounts[], const MPI_Aint displs[],
                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_gentran_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_gentran_linear.c
@@ -12,9 +12,9 @@
 
 int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     const int recvcounts[], const int displs[],
-                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                     MPIR_Request ** request)
+                                                     const MPI_Aint recvcounts[],
+                                                     const MPI_Aint displs[], MPI_Datatype recvtype,
+                                                     MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_sched_linear.c
@@ -14,9 +14,9 @@
 
 int MPIR_Ineighbor_allgatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   const int recvcounts[], const int displs[],
-                                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                   MPIR_Sched_t s)
+                                                   const MPI_Aint recvcounts[],
+                                                   const MPI_Aint displs[], MPI_Datatype recvtype,
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
@@ -14,7 +14,8 @@
 /* Routine to schedule linear algorithm fir neighbor_allgatherv */
 int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
-                                                       const int recvcounts[], const int displs[],
+                                                       const MPI_Aint recvcounts[],
+                                                       const MPI_Aint displs[],
                                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                        MPIR_TSP_sched_t * sched)
 {
@@ -66,9 +67,9 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
 /* Non-blocking linear algo based neighbor_allgatherv */
 int MPIR_TSP_Ineighbor_allgatherv_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 const int recvcounts[], const int displs[],
-                                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                 MPIR_Request ** req)
+                                                 const MPI_Aint recvcounts[],
+                                                 const MPI_Aint displs[], MPI_Datatype recvtype,
+                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_TSP_sched_t *sched;

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos_prototypes.h
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos_prototypes.h
@@ -16,11 +16,12 @@
 
 int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
-                                                       const int recvcounts[], const int displs[],
+                                                       const MPI_Aint recvcounts[],
+                                                       const MPI_Aint displs[],
                                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                        MPIR_TSP_sched_t * sched);
 int MPIR_TSP_Ineighbor_allgatherv_allcomm_linear(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 const int recvcounts[], const int displs[],
-                                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                 MPIR_Request ** req);
+                                                 const MPI_Aint recvcounts[],
+                                                 const MPI_Aint displs[], MPI_Datatype recvtype,
+                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req);

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
@@ -56,11 +56,11 @@ cvars:
 */
 
 
-int MPIR_Ineighbor_alltoallv_allcomm_auto(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int rdispls[],
-                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                          MPIR_Request ** request)
+int MPIR_Ineighbor_alltoallv_allcomm_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                          void *recvbuf, const MPI_Aint recvcounts[],
+                                          const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                          MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -118,10 +118,10 @@ int MPIR_Ineighbor_alltoallv_allcomm_auto(const void *sendbuf, const int sendcou
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoallv_intra_sched_auto(const void *sendbuf, const int sendcounts[],
-                                              const int sdispls[], MPI_Datatype sendtype,
-                                              void *recvbuf, const int recvcounts[],
-                                              const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ineighbor_alltoallv_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                              const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                              void *recvbuf, const MPI_Aint recvcounts[],
+                                              const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                               MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -139,10 +139,10 @@ int MPIR_Ineighbor_alltoallv_intra_sched_auto(const void *sendbuf, const int sen
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoallv_inter_sched_auto(const void *sendbuf, const int sendcounts[],
-                                              const int sdispls[], MPI_Datatype sendtype,
-                                              void *recvbuf, const int recvcounts[],
-                                              const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ineighbor_alltoallv_inter_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                              const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                              void *recvbuf, const MPI_Aint recvcounts[],
+                                              const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                               MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -160,10 +160,10 @@ int MPIR_Ineighbor_alltoallv_inter_sched_auto(const void *sendbuf, const int sen
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoallv_sched_auto(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], MPI_Datatype sendtype,
-                                        void *recvbuf, const int recvcounts[],
-                                        const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ineighbor_alltoallv_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                        void *recvbuf, const MPI_Aint recvcounts[],
+                                        const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                         MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -183,10 +183,10 @@ int MPIR_Ineighbor_alltoallv_sched_auto(const void *sendbuf, const int sendcount
     return mpi_errno;
 }
 
-int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
-                                  const int sdispls[], MPI_Datatype sendtype,
-                                  void *recvbuf, const int recvcounts[],
-                                  const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const MPI_Aint sendcounts[],
+                                  const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                  void *recvbuf, const MPI_Aint recvcounts[],
+                                  const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                   MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -271,10 +271,10 @@ int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[],
-                             const int sdispls[], MPI_Datatype sendtype,
-                             void *recvbuf, const int recvcounts[],
-                             const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ineighbor_alltoallv(const void *sendbuf, const MPI_Aint sendcounts[],
+                             const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                             void *recvbuf, const MPI_Aint recvcounts[],
+                             const MPI_Aint rdispls[], MPI_Datatype recvtype,
                              MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_gentran_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_gentran_linear.c
@@ -10,10 +10,11 @@
 #include "ineighbor_alltoallv_tsp_linear_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ineighbor_alltoallv_allcomm_gentran_linear(const void *sendbuf, const int sendcounts[],
-                                                    const int sdispls[], MPI_Datatype sendtype,
-                                                    void *recvbuf, const int recvcounts[],
-                                                    const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ineighbor_alltoallv_allcomm_gentran_linear(const void *sendbuf,
+                                                    const MPI_Aint sendcounts[],
+                                                    const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                                    void *recvbuf, const MPI_Aint recvcounts[],
+                                                    const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_sched_linear.c
@@ -12,10 +12,10 @@
  * neighbor.
  */
 
-int MPIR_Ineighbor_alltoallv_allcomm_sched_linear(const void *sendbuf, const int sendcounts[],
-                                                  const int sdispls[], MPI_Datatype sendtype,
-                                                  void *recvbuf, const int recvcounts[],
-                                                  const int rdispls[], MPI_Datatype recvtype,
+int MPIR_Ineighbor_alltoallv_allcomm_sched_linear(const void *sendbuf, const MPI_Aint sendcounts[],
+                                                  const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                                  void *recvbuf, const MPI_Aint recvcounts[],
+                                                  const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
@@ -12,11 +12,13 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule linear algorithm for neighbor_alltoallv */
-int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
-                                                      const int sdispls[], MPI_Datatype sendtype,
-                                                      void *recvbuf, const int recvcounts[],
-                                                      const int rdispls[], MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm_ptr,
+int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
+                                                      const MPI_Aint sendcounts[],
+                                                      const MPI_Aint sdispls[],
+                                                      MPI_Datatype sendtype, void *recvbuf,
+                                                      const MPI_Aint recvcounts[],
+                                                      const MPI_Aint rdispls[],
+                                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                       MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -68,10 +70,10 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const
 
 
 /* Non-blocking linear algo based neighbor_alltoallv */
-int MPIR_TSP_Ineighbor_alltoallv_allcomm_linear(const void *sendbuf, const int sendcounts[],
-                                                const int sdispls[], MPI_Datatype sendtype,
-                                                void *recvbuf, const int recvcounts[],
-                                                const int rdispls[], MPI_Datatype recvtype,
+int MPIR_TSP_Ineighbor_alltoallv_allcomm_linear(const void *sendbuf, const MPI_Aint sendcounts[],
+                                                const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                                void *recvbuf, const MPI_Aint recvcounts[],
+                                                const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos_prototypes.h
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos_prototypes.h
@@ -14,14 +14,16 @@
 #undef MPIR_TSP_Ineighor_alltoallv_sched_allcomm_linear
 #define MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear  MPIR_TSP_NAMESPACE(Ineighbor_alltoallv_sched_allcomm_linear)
 
-int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
-                                                      const int sdispls[], MPI_Datatype sendtype,
-                                                      void *recvbuf, const int recvcounts[],
-                                                      const int rdispls[], MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm_ptr,
+int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
+                                                      const MPI_Aint sendcounts[],
+                                                      const MPI_Aint sdispls[],
+                                                      MPI_Datatype sendtype, void *recvbuf,
+                                                      const MPI_Aint recvcounts[],
+                                                      const MPI_Aint rdispls[],
+                                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                       MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Ineighbor_alltoallv_allcomm_linear(const void *sendbuf, const int sendcounts[],
-                                                const int sdispls[], MPI_Datatype sendtype,
-                                                void *recvbuf, const int recvcounts[],
-                                                const int rdispls[], MPI_Datatype recvtype,
+int MPIR_TSP_Ineighbor_alltoallv_allcomm_linear(const void *sendbuf, const MPI_Aint sendcounts[],
+                                                const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                                void *recvbuf, const MPI_Aint recvcounts[],
+                                                const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req);

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
@@ -56,9 +56,9 @@ cvars:
 */
 
 
-int MPIR_Ineighbor_alltoallw_allcomm_auto(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_allcomm_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                           const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                          void *recvbuf, const int recvcounts[],
+                                          void *recvbuf, const MPI_Aint recvcounts[],
                                           const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                           MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
@@ -118,10 +118,10 @@ int MPIR_Ineighbor_alltoallw_allcomm_auto(const void *sendbuf, const int sendcou
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoallw_intra_sched_auto(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                               const MPI_Aint sdispls[],
                                               const MPI_Datatype sendtypes[], void *recvbuf,
-                                              const int recvcounts[], const MPI_Aint rdispls[],
+                                              const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
                                               MPIR_Sched_t s)
 {
@@ -140,10 +140,10 @@ int MPIR_Ineighbor_alltoallw_intra_sched_auto(const void *sendbuf, const int sen
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoallw_inter_sched_auto(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_inter_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                               const MPI_Aint sdispls[],
                                               const MPI_Datatype sendtypes[], void *recvbuf,
-                                              const int recvcounts[], const MPI_Aint rdispls[],
+                                              const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
                                               MPIR_Sched_t s)
 {
@@ -162,9 +162,9 @@ int MPIR_Ineighbor_alltoallw_inter_sched_auto(const void *sendbuf, const int sen
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoallw_sched_auto(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                         const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                        void *recvbuf, const int recvcounts[],
+                                        void *recvbuf, const MPI_Aint recvcounts[],
                                         const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                         MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
@@ -185,10 +185,10 @@ int MPIR_Ineighbor_alltoallw_sched_auto(const void *sendbuf, const int sendcount
     return mpi_errno;
 }
 
-int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const MPI_Aint sendcounts[],
                                   const MPI_Aint sdispls[],
                                   const MPI_Datatype sendtypes[],
-                                  void *recvbuf, const int recvcounts[],
+                                  void *recvbuf, const MPI_Aint recvcounts[],
                                   const MPI_Aint rdispls[],
                                   const MPI_Datatype recvtypes[],
                                   MPIR_Comm * comm_ptr, MPIR_Request ** request)
@@ -275,10 +275,10 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
     goto fn_exit;
 }
 
-int MPIR_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw(const void *sendbuf, const MPI_Aint sendcounts[],
                              const MPI_Aint sdispls[],
                              const MPI_Datatype sendtypes[], void *recvbuf,
-                             const int recvcounts[], const MPI_Aint rdispls[],
+                             const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                              const MPI_Datatype recvtypes[],
                              MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_gentran_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_gentran_linear.c
@@ -10,10 +10,11 @@
 #include "ineighbor_alltoallw_tsp_linear_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Ineighbor_alltoallw_allcomm_gentran_linear(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_allcomm_gentran_linear(const void *sendbuf,
+                                                    const MPI_Aint sendcounts[],
                                                     const MPI_Aint sdispls[],
                                                     const MPI_Datatype sendtypes[], void *recvbuf,
-                                                    const int recvcounts[],
+                                                    const MPI_Aint recvcounts[],
                                                     const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
                                                     MPIR_Comm * comm_ptr, MPIR_Request ** request)

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_sched_linear.c
@@ -12,10 +12,11 @@
  * neighbor.
  */
 
-int MPIR_Ineighbor_alltoallw_allcomm_sched_linear(const void *sendbuf, const int sendcounts[],
+int MPIR_Ineighbor_alltoallw_allcomm_sched_linear(const void *sendbuf, const MPI_Aint sendcounts[],
                                                   const MPI_Aint sdispls[],
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
-                                                  const int recvcounts[], const MPI_Aint rdispls[],
+                                                  const MPI_Aint recvcounts[],
+                                                  const MPI_Aint rdispls[],
                                                   const MPI_Datatype recvtypes[],
                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
@@ -12,10 +12,11 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule linear algorithm for neighbor_alltoallw */
-int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
+int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
+                                                      const MPI_Aint sendcounts[],
                                                       const MPI_Aint sdispls[],
                                                       const MPI_Datatype sendtypes[], void *recvbuf,
-                                                      const int recvcounts[],
+                                                      const MPI_Aint recvcounts[],
                                                       const MPI_Aint rdispls[],
                                                       const MPI_Datatype recvtypes[],
                                                       MPIR_Comm * comm_ptr,
@@ -72,10 +73,11 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const
 
 
 /* Non-blocking linear algo based neighbor_alltoallw */
-int MPIR_TSP_Ineighbor_alltoallw_allcomm_linear(const void *sendbuf, const int sendcounts[],
+int MPIR_TSP_Ineighbor_alltoallw_allcomm_linear(const void *sendbuf, const MPI_Aint sendcounts[],
                                                 const MPI_Aint sdispls[],
                                                 const MPI_Datatype sendtypes[], void *recvbuf,
-                                                const int recvcounts[], const MPI_Aint rdispls[],
+                                                const MPI_Aint recvcounts[],
+                                                const MPI_Aint rdispls[],
                                                 const MPI_Datatype recvtypes[],
                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos_prototypes.h
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos_prototypes.h
@@ -14,17 +14,19 @@
 #undef MPIR_TSP_Ineighor_alltoallw_sched_allcomm_linear
 #define MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear  MPIR_TSP_NAMESPACE(Ineighbor_alltoallw_sched_allcomm_linear)
 
-int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
+int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
+                                                      const MPI_Aint sendcounts[],
                                                       const MPI_Aint sdispls[],
                                                       const MPI_Datatype sendtypes[], void *recvbuf,
-                                                      const int recvcounts[],
+                                                      const MPI_Aint recvcounts[],
                                                       const MPI_Aint rdispls[],
                                                       const MPI_Datatype recvtypes[],
                                                       MPIR_Comm * comm_ptr,
                                                       MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Ineighbor_alltoallw_allcomm_linear(const void *sendbuf, const int sendcounts[],
+int MPIR_TSP_Ineighbor_alltoallw_allcomm_linear(const void *sendbuf, const MPI_Aint sendcounts[],
                                                 const MPI_Aint sdispls[],
                                                 const MPI_Datatype sendtypes[], void *recvbuf,
-                                                const int recvcounts[], const MPI_Aint rdispls[],
+                                                const MPI_Aint recvcounts[],
+                                                const MPI_Aint rdispls[],
                                                 const MPI_Datatype recvtypes[],
                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
@@ -68,9 +68,9 @@ cvars:
 */
 
 
-int MPIR_Ireduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                      MPIR_Request ** request)
+int MPIR_Ireduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf,
+                                      const MPI_Aint * recvcounts, MPI_Datatype datatype, MPI_Op op,
+                                      MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -144,8 +144,8 @@ int MPIR_Ireduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf, const 
 }
 
 int MPIR_Ireduce_scatter_intra_sched_auto(const void *sendbuf, void *recvbuf,
-                                          const int recvcounts[], MPI_Datatype datatype, MPI_Op op,
-                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                          const MPI_Aint recvcounts[], MPI_Datatype datatype,
+                                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -209,8 +209,8 @@ int MPIR_Ireduce_scatter_intra_sched_auto(const void *sendbuf, void *recvbuf,
 }
 
 int MPIR_Ireduce_scatter_inter_sched_auto(const void *sendbuf, void *recvbuf,
-                                          const int recvcounts[], MPI_Datatype datatype, MPI_Op op,
-                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                          const MPI_Aint recvcounts[], MPI_Datatype datatype,
+                                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -221,7 +221,7 @@ int MPIR_Ireduce_scatter_inter_sched_auto(const void *sendbuf, void *recvbuf,
     return mpi_errno;
 }
 
-int MPIR_Ireduce_scatter_sched_auto(const void *sendbuf, void *recvbuf, const int recvcounts[],
+int MPIR_Ireduce_scatter_sched_auto(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                     MPIR_Sched_t s)
 {
@@ -238,7 +238,7 @@ int MPIR_Ireduce_scatter_sched_auto(const void *sendbuf, void *recvbuf, const in
     return mpi_errno;
 }
 
-int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int recvcounts[],
+int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                               MPIR_Request ** request)
 {
@@ -339,7 +339,7 @@ int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int recv
     goto fn_exit;
 }
 
-int MPIR_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[],
+int MPIR_Ireduce_scatter(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                          MPIR_Request ** request)
 {

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_inter_sched_remote_reduce_local_scatterv.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_inter_sched_remote_reduce_local_scatterv.c
@@ -14,7 +14,7 @@
 
 int MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(const void *sendbuf,
                                                                   void *recvbuf,
-                                                                  const int recvcounts[],
+                                                                  const MPI_Aint recvcounts[],
                                                                   MPI_Datatype datatype, MPI_Op op,
                                                                   MPIR_Comm * comm_ptr,
                                                                   MPIR_Sched_t s)
@@ -23,7 +23,7 @@ int MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(const void *se
     int rank, root, local_size, total_count, i;
     MPI_Aint true_extent, true_lb = 0, extent;
     void *tmp_buf = NULL;
-    int *disps = NULL;
+    MPI_Aint *disps = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
     MPIR_SCHED_CHKPMEM_DECL(2);
 
@@ -38,8 +38,8 @@ int MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(const void *se
         /* In each group, rank 0 allocates a temp. buffer for the
          * reduce */
 
-        MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, local_size * sizeof(int), mpi_errno, "disps",
-                                  MPL_MEM_BUFFER);
+        MPIR_SCHED_CHKPMEM_MALLOC(disps, MPI_Aint *, local_size * sizeof(MPI_Aint), mpi_errno,
+                                  "disps", MPL_MEM_BUFFER);
 
         total_count = 0;
         for (i = 0; i < local_size; i++) {

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_gentran_recexch.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_gentran_recexch.c
@@ -11,7 +11,7 @@
 #include "tsp_undef.h"
 
 int MPIR_Ireduce_scatter_intra_gentran_recexch(const void *sendbuf, void *recvbuf,
-                                               const int *recvcounts, MPI_Datatype datatype,
+                                               const MPI_Aint * recvcounts, MPI_Datatype datatype,
                                                MPI_Op op, MPIR_Comm * comm, int k,
                                                MPIR_Request ** req)
 {

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_noncommutative.c
@@ -21,8 +21,9 @@
  * Cost = lgp.alpha + n.(lgp-(p-1)/p).beta + n.(lgp-(p-1)/p).gamma
  */
 int MPIR_Ireduce_scatter_intra_sched_noncommutative(const void *sendbuf, void *recvbuf,
-                                                    const int recvcounts[], MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                    const MPI_Aint recvcounts[],
+                                                    MPI_Datatype datatype, MPI_Op op,
+                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size = comm_ptr->local_size;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_pairwise.c
@@ -13,7 +13,7 @@
  * from (rank-i).
  */
 int MPIR_Ireduce_scatter_intra_sched_pairwise(const void *sendbuf, void *recvbuf,
-                                              const int recvcounts[], MPI_Datatype datatype,
+                                              const MPI_Aint recvcounts[], MPI_Datatype datatype,
                                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_doubling.c
@@ -17,7 +17,7 @@
  * Cost = lgp.alpha + n.(lgp-(p-1)/p).beta + n.(lgp-(p-1)/p).gamma
  */
 int MPIR_Ireduce_scatter_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf,
-                                                        const int recvcounts[],
+                                                        const MPI_Aint recvcounts[],
                                                         MPI_Datatype datatype, MPI_Op op,
                                                         MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_halving.c
@@ -34,7 +34,7 @@
  * Cost = (p-1).alpha + n.((p-1)/p).beta + n.((p-1)/p).gamma
  */
 int MPIR_Ireduce_scatter_intra_sched_recursive_halving(const void *sendbuf, void *recvbuf,
-                                                       const int recvcounts[],
+                                                       const MPI_Aint recvcounts[],
                                                        MPI_Datatype datatype, MPI_Op op,
                                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
@@ -42,10 +42,10 @@ Input Parameters:
 
 */
 int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *tmp_recvbuf,
-                                                       const int *recvcounts, int *displs,
-                                                       MPI_Datatype datatype, MPI_Op op,
-                                                       size_t extent, int tag, MPIR_Comm * comm,
-                                                       int k, int is_dist_halving,
+                                                       const MPI_Aint * recvcounts,
+                                                       MPI_Aint * displs, MPI_Datatype datatype,
+                                                       MPI_Op op, size_t extent, int tag,
+                                                       MPIR_Comm * comm, int k, int is_dist_halving,
                                                        int step2_nphases, int **step2_nbrs,
                                                        int rank, int nranks, int sink_id,
                                                        int is_out_vtcs, int *reduce_id_,
@@ -128,7 +128,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
 
 /* Routine to schedule a recursive exchange based reduce_scatter with distance halving in each phase */
 int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recvbuf,
-                                                 const int *recvcounts, MPI_Datatype datatype,
+                                                 const MPI_Aint * recvcounts, MPI_Datatype datatype,
                                                  MPI_Op op, MPIR_Comm * comm, int k,
                                                  int is_dist_halving, MPIR_TSP_sched_t * sched)
 {
@@ -145,7 +145,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
     int dtcopy_id = -1, recv_id = -1, reduce_id = -1, sink_id = -1;
     int nvtcs, vtcs[2];
     void *tmp_recvbuf = NULL, *tmp_results = NULL;
-    int *displs;
+    MPI_Aint *displs;
     int tag;
     MPIR_CHKLMEM_DECL(1);
 
@@ -174,7 +174,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         return mpi_errno;
     }
 
-    MPIR_CHKLMEM_MALLOC(displs, int *, nranks * sizeof(int),
+    MPIR_CHKLMEM_MALLOC(displs, MPI_Aint *, nranks * sizeof(MPI_Aint),
                         mpi_errno, "displs buffer", MPL_MEM_COLL);
     displs[0] = 0;
     for (i = 1; i < nranks; i++) {
@@ -289,8 +289,8 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
 
 /* Non-blocking recursive exchange based Reduce_scatter */
 int MPIR_TSP_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
-                                           const int *recvcounts, MPI_Datatype datatype, MPI_Op op,
-                                           MPIR_Comm * comm, MPIR_Request ** req, int k,
+                                           const MPI_Aint * recvcounts, MPI_Datatype datatype,
+                                           MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req, int k,
                                            int rs_type)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos_prototypes.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos_prototypes.h
@@ -17,21 +17,21 @@
 #define MPIR_TSP_Ireduce_scatter_sched_intra_recexch                MPIR_TSP_NAMESPACE(Ireduce_scatter_sched_intra_recexch)
 
 int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *tmp_recvbuf,
-                                                       const int *recvcounts, int *displs,
-                                                       MPI_Datatype datatype, MPI_Op op,
-                                                       size_t extent, int tag, MPIR_Comm * comm,
-                                                       int k, int is_dist_halving,
+                                                       const MPI_Aint * recvcounts,
+                                                       MPI_Aint * displs, MPI_Datatype datatype,
+                                                       MPI_Op op, size_t extent, int tag,
+                                                       MPIR_Comm * comm, int k, int is_dist_halving,
                                                        int step2_nphases, int **step2_nbrs,
                                                        int rank, int nranks, int sink_id,
                                                        int is_out_vtcs, int *reduce_id_,
                                                        MPIR_TSP_sched_t * sched);
 
 int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recvbuf,
-                                                 const int *recvcounts, MPI_Datatype datatype,
+                                                 const MPI_Aint * recvcounts, MPI_Datatype datatype,
                                                  MPI_Op op, MPIR_Comm * comm, int k,
                                                  int is_dist_halving, MPIR_TSP_sched_t * sched);
 
 int MPIR_TSP_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
-                                           const int *recvcounts, MPI_Datatype datatype, MPI_Op op,
-                                           MPIR_Comm * comm, MPIR_Request ** req, int k,
+                                           const MPI_Aint * recvcounts, MPI_Datatype datatype,
+                                           MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req, int k,
                                            int rs_type);

--- a/src/mpi/coll/iscatterv/iscatterv.c
+++ b/src/mpi/coll/iscatterv/iscatterv.c
@@ -57,10 +57,10 @@ cvars:
 /* any non-MPI functions go here, especially non-static ones */
 
 
-int MPIR_Iscatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                                MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                MPIR_Request ** request)
+int MPIR_Iscatterv_allcomm_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                                const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
+                                MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                                MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -114,10 +114,10 @@ int MPIR_Iscatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, cons
     goto fn_exit;
 }
 
-int MPIR_Iscatterv_intra_sched_auto(const void *sendbuf, const int sendcounts[], const int displs[],
-                                    MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s)
+int MPIR_Iscatterv_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                    const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf,
+                                    MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -133,10 +133,10 @@ int MPIR_Iscatterv_intra_sched_auto(const void *sendbuf, const int sendcounts[],
     goto fn_exit;
 }
 
-int MPIR_Iscatterv_inter_sched_auto(const void *sendbuf, const int sendcounts[], const int displs[],
-                                    MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s)
+int MPIR_Iscatterv_inter_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                    const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf,
+                                    MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -152,9 +152,10 @@ int MPIR_Iscatterv_inter_sched_auto(const void *sendbuf, const int sendcounts[],
     goto fn_exit;
 }
 
-int MPIR_Iscatterv_sched_auto(const void *sendbuf, const int sendcounts[], const int displs[],
-                              MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Iscatterv_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                              const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf,
+                              MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -175,7 +176,7 @@ int MPIR_Iscatterv_sched_auto(const void *sendbuf, const int sendcounts[], const
     goto fn_exit;
 }
 
-int MPIR_Iscatterv_impl(const void *sendbuf, const int sendcounts[], const int displs[],
+int MPIR_Iscatterv_impl(const void *sendbuf, const MPI_Aint sendcounts[], const MPI_Aint displs[],
                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                         MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                         MPIR_Request ** request)
@@ -251,7 +252,7 @@ int MPIR_Iscatterv_impl(const void *sendbuf, const int sendcounts[], const int d
     goto fn_exit;
 }
 
-int MPIR_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[],
+int MPIR_Iscatterv(const void *sendbuf, const MPI_Aint sendcounts[], const MPI_Aint displs[],
                    MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {

--- a/src/mpi/coll/iscatterv/iscatterv_allcomm_gentran_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_allcomm_gentran_linear.c
@@ -10,10 +10,10 @@
 #include "iscatterv_tsp_linear_algos_prototypes.h"
 #include "tsp_undef.h"
 
-int MPIR_Iscatterv_allcomm_gentran_linear(const void *sendbuf, const int sendcounts[],
-                                          const int displs[], MPI_Datatype sendtype, void *recvbuf,
-                                          MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                          MPIR_Comm * comm_ptr, MPIR_Request ** request)
+int MPIR_Iscatterv_allcomm_gentran_linear(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint displs[], MPI_Datatype sendtype,
+                                          void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                          int root, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/iscatterv/iscatterv_allcomm_sched_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_allcomm_sched_linear.c
@@ -15,10 +15,10 @@
  *
  * Cost = (p-1).alpha + n.((p-1)/p).beta
 */
-int MPIR_Iscatterv_allcomm_sched_linear(const void *sendbuf, const int sendcounts[],
-                                        const int displs[], MPI_Datatype sendtype, void *recvbuf,
-                                        MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Iscatterv_allcomm_sched_linear(const void *sendbuf, const MPI_Aint sendcounts[],
+                                        const MPI_Aint displs[], MPI_Datatype sendtype,
+                                        void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                        int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size;

--- a/src/mpi/coll/iscatterv/iscatterv_tsp_linear_algos.h
+++ b/src/mpi/coll/iscatterv/iscatterv_tsp_linear_algos.h
@@ -11,8 +11,8 @@
 #include "tsp_namespace_def.h"
 
 /* Routine to schedule a linear algorithm for scatterv */
-int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
-                                            const int displs[], MPI_Datatype sendtype,
+int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint displs[], MPI_Datatype sendtype,
                                             void *recvbuf, MPI_Aint recvcount,
                                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                             MPIR_TSP_sched_t * sched)
@@ -81,8 +81,8 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendc
 
 
 /* Non-blocking linear algorithm for scatterv */
-int MPIR_TSP_Iscatterv_allcomm_linear(const void *sendbuf, const int sendcounts[],
-                                      const int displs[], MPI_Datatype sendtype, void *recvbuf,
+int MPIR_TSP_Iscatterv_allcomm_linear(const void *sendbuf, const MPI_Aint sendcounts[],
+                                      const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf,
                                       MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                       MPIR_Comm * comm, MPIR_Request ** req)
 {

--- a/src/mpi/coll/iscatterv/iscatterv_tsp_linear_algos_prototypes.h
+++ b/src/mpi/coll/iscatterv/iscatterv_tsp_linear_algos_prototypes.h
@@ -14,12 +14,12 @@
 #undef MPIR_TSP_Iscatterv_sched_allcomm_linear
 #define MPIR_TSP_Iscatterv_sched_allcomm_linear       MPIR_TSP_NAMESPACE(Iscatterv_sched_allcomm_linear)
 
-int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
-                                            const int displs[], MPI_Datatype sendtype,
+int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint displs[], MPI_Datatype sendtype,
                                             void *recvbuf, MPI_Aint recvcount,
                                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
                                             MPIR_TSP_sched_t * sched);
-int MPIR_TSP_Iscatterv_allcomm_linear(const void *sendbuf, const int sendcounts[],
-                                      const int displs[], MPI_Datatype sendtype, void *recvbuf,
+int MPIR_TSP_Iscatterv_allcomm_linear(const void *sendbuf, const MPI_Aint sendcounts[],
+                                      const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf,
                                       MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                                       MPIR_Comm * comm_ptr, MPIR_Request ** req);

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
@@ -56,7 +56,7 @@ cvars:
 
 int MPIR_Neighbor_allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int displs[],
+                                          const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -93,7 +93,7 @@ int MPIR_Neighbor_allgatherv_allcomm_auto(const void *sendbuf, MPI_Aint sendcoun
 
 int MPIR_Neighbor_allgatherv_impl(const void *sendbuf, MPI_Aint sendcount,
                                   MPI_Datatype sendtype, void *recvbuf,
-                                  const int recvcounts[], const int displs[],
+                                  const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -139,7 +139,7 @@ int MPIR_Neighbor_allgatherv_impl(const void *sendbuf, MPI_Aint sendcount,
 
 int MPIR_Neighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                              MPI_Datatype sendtype, void *recvbuf,
-                             const int recvcounts[], const int displs[],
+                             const MPI_Aint recvcounts[], const MPI_Aint displs[],
                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int displs[],
+                                        const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv.c
@@ -54,10 +54,11 @@ cvars:
 /* any non-MPI functions go here, especially non-static ones */
 
 
-int MPIR_Neighbor_alltoallv_allcomm_auto(const void *sendbuf, const int sendcounts[],
-                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                         const int recvcounts[], const int rdispls[],
-                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
+int MPIR_Neighbor_alltoallv_allcomm_auto(const void *sendbuf, const MPI_Aint sendcounts[],
+                                         const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                         void *recvbuf, const MPI_Aint recvcounts[],
+                                         const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                         MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -92,10 +93,11 @@ int MPIR_Neighbor_alltoallv_allcomm_auto(const void *sendbuf, const int sendcoun
     return mpi_errno;
 }
 
-int MPIR_Neighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
-                                 const int sdispls[], MPI_Datatype sendtype,
-                                 void *recvbuf, const int recvcounts[],
-                                 const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
+int MPIR_Neighbor_alltoallv_impl(const void *sendbuf, const MPI_Aint sendcounts[],
+                                 const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                 void *recvbuf, const MPI_Aint recvcounts[],
+                                 const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                 MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -142,10 +144,10 @@ int MPIR_Neighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
     goto fn_exit;
 }
 
-int MPIR_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[],
-                            const int sdispls[], MPI_Datatype sendtype,
-                            void *recvbuf, const int recvcounts[],
-                            const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
+int MPIR_Neighbor_alltoallv(const void *sendbuf, const MPI_Aint sendcounts[],
+                            const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                            void *recvbuf, const MPI_Aint recvcounts[],
+                            const MPI_Aint rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
@@ -5,10 +5,11 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const int sendcounts[],
-                                       const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                       const int recvcounts[], const int rdispls[],
-                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
+int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
+                                       const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                       void *recvbuf, const MPI_Aint recvcounts[],
+                                       const MPI_Aint rdispls[], MPI_Datatype recvtype,
+                                       MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;

--- a/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw.c
+++ b/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw.c
@@ -54,9 +54,9 @@ cvars:
 /* any non-MPI functions go here, especially non-static ones */
 
 
-int MPIR_Neighbor_alltoallw_allcomm_auto(const void *sendbuf, const int sendcounts[],
+int MPIR_Neighbor_alltoallw_allcomm_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                          const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                         void *recvbuf, const int recvcounts[],
+                                         void *recvbuf, const MPI_Aint recvcounts[],
                                          const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                          MPIR_Comm * comm_ptr)
 {
@@ -93,10 +93,10 @@ int MPIR_Neighbor_alltoallw_allcomm_auto(const void *sendbuf, const int sendcoun
     return mpi_errno;
 }
 
-int MPIR_Neighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
+int MPIR_Neighbor_alltoallw_impl(const void *sendbuf, const MPI_Aint sendcounts[],
                                  const MPI_Aint sdispls[],
                                  const MPI_Datatype sendtypes[], void *recvbuf,
-                                 const int recvcounts[],
+                                 const MPI_Aint recvcounts[],
                                  const MPI_Aint rdispls[],
                                  const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr)
 {
@@ -145,10 +145,10 @@ int MPIR_Neighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
     goto fn_exit;
 }
 
-int MPIR_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[],
+int MPIR_Neighbor_alltoallw(const void *sendbuf, const MPI_Aint sendcounts[],
                             const MPI_Aint sdispls[],
                             const MPI_Datatype sendtypes[], void *recvbuf,
-                            const int recvcounts[], const MPI_Aint rdispls[],
+                            const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                             const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
@@ -5,9 +5,9 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const int sendcounts[],
+int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
                                        const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                       void *recvbuf, const int recvcounts[],
+                                       void *recvbuf, const MPI_Aint recvcounts[],
                                        const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                        MPIR_Comm * comm_ptr)
 {

--- a/src/mpi/coll/reduce_scatter/reduce_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter.c
@@ -79,9 +79,9 @@ cvars:
 */
 
 
-int MPIR_Reduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Errflag_t * errflag)
+int MPIR_Reduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf,
+                                     const MPI_Aint * recvcounts, MPI_Datatype datatype, MPI_Op op,
+                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -148,7 +148,7 @@ int MPIR_Reduce_scatter_allcomm_auto(const void *sendbuf, void *recvbuf, const i
 }
 
 int MPIR_Reduce_scatter_impl(const void *sendbuf, void *recvbuf,
-                             const int recvcounts[], MPI_Datatype datatype,
+                             const MPI_Aint recvcounts[], MPI_Datatype datatype,
                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -220,7 +220,7 @@ int MPIR_Reduce_scatter_impl(const void *sendbuf, void *recvbuf,
 }
 
 int MPIR_Reduce_scatter(const void *sendbuf, void *recvbuf,
-                        const int recvcounts[], MPI_Datatype datatype,
+                        const MPI_Aint recvcounts[], MPI_Datatype datatype,
                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const int recvcounts[],
+int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                    MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
@@ -13,7 +13,7 @@
  */
 
 int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int recvcounts[],
+                                                          const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm_ptr,
                                                           MPIR_Errflag_t * errflag)
@@ -22,7 +22,7 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
     int mpi_errno_ret = MPI_SUCCESS;
     MPI_Aint true_extent, true_lb = 0, extent;
     void *tmp_buf = NULL;
-    int *disps = NULL;
+    MPI_Aint *disps = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
     MPIR_CHKLMEM_DECL(2);
 
@@ -37,7 +37,7 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
         /* In each group, rank 0 allocates a temp. buffer for the
          * reduce */
 
-        MPIR_CHKLMEM_MALLOC(disps, int *, local_size * sizeof(int), mpi_errno, "disps",
+        MPIR_CHKLMEM_MALLOC(disps, MPI_Aint *, local_size * sizeof(MPI_Aint), mpi_errno, "disps",
                             MPL_MEM_BUFFER);
 
         total_count = 0;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
@@ -21,7 +21,7 @@
  * Cost = lgp.alpha + n.(lgp-(p-1)/p).beta + n.(lgp-(p-1)/p).gamma
  */
 int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
-                                             const int recvcounts[], MPI_Datatype datatype,
+                                             const MPI_Aint recvcounts[], MPI_Datatype datatype,
                                              MPI_Op op, MPIR_Comm * comm_ptr,
                                              MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -13,9 +13,9 @@
  * process sends n/p amount of data to (rank+i) and receives n/p amount of data
  * from (rank-i).
  */
-int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf, const int recvcounts[],
-                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                       MPIR_Errflag_t * errflag)
+int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
+                                       const MPI_Aint recvcounts[], MPI_Datatype datatype,
+                                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -18,7 +18,7 @@
  * Cost = lgp.alpha + n.(lgp-(p-1)/p).beta + n.(lgp-(p-1)/p).gamma
  */
 int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
-                                                 const int recvcounts[], MPI_Datatype datatype,
+                                                 const MPI_Aint recvcounts[], MPI_Datatype datatype,
                                                  MPI_Op op, MPIR_Comm * comm_ptr,
                                                  MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -35,7 +35,7 @@
  * Cost = (p-1).alpha + n.((p-1)/p).beta + n.((p-1)/p).gamma
  */
 int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvbuf,
-                                                const int recvcounts[], MPI_Datatype datatype,
+                                                const MPI_Aint recvcounts[], MPI_Datatype datatype,
                                                 MPI_Op op, MPIR_Comm * comm_ptr,
                                                 MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/scatterv/scatterv.c
+++ b/src/mpi/coll/scatterv/scatterv.c
@@ -54,10 +54,10 @@ cvars:
 */
 
 
-int MPIR_Scatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                               MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                               MPIR_Errflag_t * errflag)
+int MPIR_Scatterv_allcomm_auto(const void *sendbuf, const MPI_Aint * sendcounts,
+                               const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
+                               MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -98,8 +98,8 @@ int MPIR_Scatterv_allcomm_auto(const void *sendbuf, const int *sendcounts, const
     return mpi_errno;
 }
 
-int MPIR_Scatterv_impl(const void *sendbuf, const int *sendcounts,
-                       const int *displs, MPI_Datatype sendtype, void *recvbuf,
+int MPIR_Scatterv_impl(const void *sendbuf, const MPI_Aint * sendcounts,
+                       const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
                        MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                        MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -156,8 +156,8 @@ int MPIR_Scatterv_impl(const void *sendbuf, const int *sendcounts,
     goto fn_exit;
 }
 
-int MPIR_Scatterv(const void *sendbuf, const int *sendcounts,
-                  const int *displs, MPI_Datatype sendtype, void *recvbuf,
+int MPIR_Scatterv(const void *sendbuf, const MPI_Aint * sendcounts,
+                  const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
                   MPI_Aint recvcount, MPI_Datatype recvtype, int root,
                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -17,10 +17,10 @@
 
    Cost = (p-1).alpha + n.((p-1)/p).beta
 */
-int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const int *sendcounts, const int *displs,
-                                 MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                 MPIR_Errflag_t * errflag)
+int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcounts,
+                                 const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
+                                 MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int rank, comm_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;

--- a/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
@@ -5,10 +5,10 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const int *sendcounts, const int *displs,
-                             MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                             MPIR_Errflag_t * errflag)
+int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
+                             const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
+                             MPI_Aint recvcount, MPI_Datatype recvtype, int root,
+                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;

--- a/src/mpi/coll/src/csel.c
+++ b/src/mpi/coll/src/csel.c
@@ -831,7 +831,7 @@ static inline bool is_block_regular(MPIR_Csel_coll_sig_s coll_info)
 {
     bool is_regular = true;
     int i = 0;
-    const int *recvcounts = NULL;
+    const MPI_Aint *recvcounts = NULL;
 
     switch (coll_info.coll_type) {
         case MPIR_CSEL_COLL_TYPE__REDUCE_SCATTER:

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -55,7 +55,7 @@ static inline int MPID_Allgather(const void *sendbuf, MPI_Aint sendcount, MPI_Da
 }
 
 static inline int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, const int *recvcounts, const int *displs,
+                                  void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                   MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -79,7 +79,7 @@ static inline int MPID_Scatter(const void *sendbuf, MPI_Aint sendcount, MPI_Data
     return mpi_errno;
 }
 
-static inline int MPID_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
+static inline int MPID_Scatterv(const void *sendbuf, const MPI_Aint * sendcounts, const MPI_Aint * displs,
                                 MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                 MPIR_Errflag_t * errflag)
@@ -106,7 +106,7 @@ static inline int MPID_Gather(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
 }
 
 static inline int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int *recvcounts, const int *displs,
+                               void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                MPIR_Errflag_t * errflag)
 {
@@ -131,9 +131,9 @@ static inline int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
     return mpi_errno;
 }
 
-static inline int MPID_Alltoallv(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                 MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                 const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm,
+static inline int MPID_Alltoallv(const void *sendbuf, const MPI_Aint * sendcounts, const MPI_Aint * sdispls,
+                                 MPI_Datatype sendtype, void *recvbuf, const MPI_Aint * recvcounts,
+                                 const MPI_Aint * rdispls, MPI_Datatype recvtype, MPIR_Comm * comm,
                                  MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -145,9 +145,9 @@ static inline int MPID_Alltoallv(const void *sendbuf, const int *sendcounts, con
     return mpi_errno;
 }
 
-static inline int MPID_Alltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[],
+static inline int MPID_Alltoallw(const void *sendbuf, const MPI_Aint sendcounts[], const MPI_Aint sdispls[],
                                  const MPI_Datatype sendtypes[], void *recvbuf,
-                                 const int recvcounts[], const int rdispls[],
+                                 const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                  const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
                                  MPIR_Errflag_t * errflag)
 {
@@ -172,7 +172,7 @@ static inline int MPID_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count
     return mpi_errno;
 }
 
-static inline int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[],
+static inline int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                       MPIR_Errflag_t * errflag)
 {
@@ -237,7 +237,7 @@ static inline int MPID_Neighbor_allgather(const void *sendbuf, MPI_Aint sendcoun
 
 static inline int MPID_Neighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
-                                           const int recvcounts[], const int displs[],
+                                           const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                            MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -249,10 +249,10 @@ static inline int MPID_Neighbor_allgatherv(const void *sendbuf, MPI_Aint sendcou
     return mpi_errno;
 }
 
-static inline int MPID_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], MPI_Datatype sendtype,
-                                          void *recvbuf, const int recvcounts[],
-                                          const int rdispls[], MPI_Datatype recvtype,
+static inline int MPID_Neighbor_alltoallv(const void *sendbuf, const MPI_Aint sendcounts[],
+                                          const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                          void *recvbuf, const MPI_Aint recvcounts[],
+                                          const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                           MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -264,9 +264,9 @@ static inline int MPID_Neighbor_alltoallv(const void *sendbuf, const int sendcou
     return mpi_errno;
 }
 
-static inline int MPID_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[],
+static inline int MPID_Neighbor_alltoallw(const void *sendbuf, const MPI_Aint sendcounts[],
                                           const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                          void *recvbuf, const int recvcounts[],
+                                          void *recvbuf, const MPI_Aint recvcounts[],
                                           const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                           MPIR_Comm * comm)
 {
@@ -308,7 +308,7 @@ static inline int MPID_Ineighbor_allgather(const void *sendbuf, MPI_Aint sendcou
 
 static inline int MPID_Ineighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                             MPI_Datatype sendtype, void *recvbuf,
-                                            const int recvcounts[], const int displs[],
+                                            const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                             MPI_Datatype recvtype, MPIR_Comm * comm,
                                             MPIR_Request **request)
 {
@@ -334,10 +334,10 @@ static inline int MPID_Ineighbor_alltoall(const void *sendbuf, MPI_Aint sendcoun
     return mpi_errno;
 }
 
-static inline int MPID_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[],
-                                           const int sdispls[], MPI_Datatype sendtype,
-                                           void *recvbuf, const int recvcounts[],
-                                           const int rdispls[], MPI_Datatype recvtype,
+static inline int MPID_Ineighbor_alltoallv(const void *sendbuf, const MPI_Aint sendcounts[],
+                                           const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                           void *recvbuf, const MPI_Aint recvcounts[],
+                                           const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                            MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -350,9 +350,9 @@ static inline int MPID_Ineighbor_alltoallv(const void *sendbuf, const int sendco
     return mpi_errno;
 }
 
-static inline int MPID_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[],
+static inline int MPID_Ineighbor_alltoallw(const void *sendbuf, const MPI_Aint sendcounts[],
                                            const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                           void *recvbuf, const int recvcounts[],
+                                           void *recvbuf, const MPI_Aint recvcounts[],
                                            const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                            MPIR_Comm * comm, MPIR_Request **request)
 {
@@ -398,7 +398,7 @@ static inline int MPID_Iallgather(const void *sendbuf, MPI_Aint sendcount, MPI_D
 }
 
 static inline int MPID_Iallgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, const int *recvcounts, const int *displs,
+                                   void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                    MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -434,10 +434,10 @@ static inline int MPID_Ialltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Da
     return mpi_errno;
 }
 
-static inline int MPID_Ialltoallv(const void *sendbuf, const int sendcounts[],
-                                  const int sdispls[], MPI_Datatype sendtype,
-                                  void *recvbuf, const int recvcounts[],
-                                  const int rdispls[], MPI_Datatype recvtype,
+static inline int MPID_Ialltoallv(const void *sendbuf, const MPI_Aint sendcounts[],
+                                  const MPI_Aint sdispls[], MPI_Datatype sendtype,
+                                  void *recvbuf, const MPI_Aint recvcounts[],
+                                  const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                   MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -449,10 +449,10 @@ static inline int MPID_Ialltoallv(const void *sendbuf, const int sendcounts[],
     return mpi_errno;
 }
 
-static inline int MPID_Ialltoallw(const void *sendbuf, const int sendcounts[],
-                                  const int sdispls[], const MPI_Datatype sendtypes[],
-                                  void *recvbuf, const int recvcounts[],
-                                  const int rdispls[], const MPI_Datatype recvtypes[],
+static inline int MPID_Ialltoallw(const void *sendbuf, const MPI_Aint sendcounts[],
+                                  const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                  void *recvbuf, const MPI_Aint recvcounts[],
+                                  const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                   MPIR_Comm * comm, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -489,7 +489,7 @@ static inline int MPID_Igather(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 }
 
 static inline int MPID_Igatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, const int *recvcounts, const int *displs,
+                                void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                 MPIR_Request **request)
 {
@@ -514,7 +514,7 @@ static inline int MPID_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
     return mpi_errno;
 }
 
-static inline int MPID_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[],
+static inline int MPID_Ireduce_scatter(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                        MPIR_Request **request)
 {
@@ -560,8 +560,8 @@ static inline int MPID_Iscatter(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
     return mpi_errno;
 }
 
-static inline int MPID_Iscatterv(const void *sendbuf, const int *sendcounts,
-                                 const int *displs, MPI_Datatype sendtype,
+static inline int MPID_Iscatterv(const void *sendbuf, const MPI_Aint * sendcounts,
+                                 const MPI_Aint * displs, MPI_Datatype sendtype,
                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                  int root, MPIR_Comm * comm, MPIR_Request **request)
 {

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -500,7 +500,7 @@ PARAM:
     datatype_p: MPIR_Datatype *
     disp_unit: int
     disp_unit_p: int *
-    displs: const int *
+    displs: const MPI_Aint *
     errflag: MPIR_Errflag_t *
     flag: int *
     group: MPIR_Group *
@@ -532,11 +532,11 @@ PARAM:
     port_name-2: char *
     ptr: void *
     rank: int
-    rdispls: const int *
+    rdispls: const MPI_Aint *
     rdispls-2: const MPI_Aint *
     recvbuf: void *
     recvcount: MPI_Aint
-    recvcounts: const int *
+    recvcounts: const MPI_Aint *
     recvtype: MPI_Datatype
     recvtypes: const MPI_Datatype[]
     remote_lupids: int **
@@ -549,11 +549,11 @@ PARAM:
     result_datatype: MPI_Datatype
     root: int
     rreq: MPIR_Request *
-    sdispls: const int *
+    sdispls: const MPI_Aint *
     sdispls-2: const MPI_Aint *
     sendbuf: const void *
     sendcount: MPI_Aint
-    sendcounts: const int *
+    sendcounts: const MPI_Aint *
     sendtype: MPI_Datatype
     sendtypes: const MPI_Datatype[]
     size: int

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -185,34 +185,36 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *, MPI_Aint, MPI_Datatype
                                             MPI_Datatype, MPIR_Comm *,
                                             MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
-                                             const int *, const int *, MPI_Datatype, MPIR_Comm *,
+                                             const MPI_Aint *, const MPI_Aint *, MPI_Datatype,
+                                             MPIR_Comm *,
                                              MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                           MPI_Datatype, int, MPIR_Comm *,
                                           MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *, const int *, const int *, MPI_Datatype,
-                                           void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,
-                                           MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *, const MPI_Aint *, const MPI_Aint *,
+                                           MPI_Datatype, void *, MPI_Aint, MPI_Datatype, int,
+                                           MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                          MPI_Datatype, int, MPIR_Comm *,
                                          MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *, MPI_Aint, MPI_Datatype, void *, const int *,
-                                          const int *, MPI_Datatype, int, MPIR_Comm *,
-                                          MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *, MPI_Aint, MPI_Datatype, void *,
+                                          const MPI_Aint *, const MPI_Aint *, MPI_Datatype, int,
+                                          MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                            MPI_Datatype, MPIR_Comm *,
                                            MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *, const int *, const int *, MPI_Datatype,
-                                            void *, const int *, const int *, MPI_Datatype,
-                                            MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *, const int[], const int[],
-                                            const MPI_Datatype[], void *, const int[], const int[],
-                                            const MPI_Datatype[], MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *, const MPI_Aint *, const MPI_Aint *,
+                                            MPI_Datatype, void *, const MPI_Aint *,
+                                            const MPI_Aint *, MPI_Datatype, MPIR_Comm *,
+                                            MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *, const MPI_Aint[], const MPI_Aint[],
+                                            const MPI_Datatype[], void *, const MPI_Aint[],
+                                            const MPI_Aint[], const MPI_Datatype[], MPIR_Comm *,
                                             MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op, int,
                                          MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *, void *, const int[], MPI_Datatype,
-                                                 MPI_Op, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *, void *, const MPI_Aint[],
+                                                 MPI_Datatype, MPI_Op, MPIR_Comm *,
                                                  MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *, void *, MPI_Aint, MPI_Datatype,
                                                        MPI_Op, MPIR_Comm *,
@@ -225,15 +227,18 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *, MPI_Aint, MPI
                                                      MPI_Aint, MPI_Datatype,
                                                      MPIR_Comm *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
-                                                      const int[], const int[], MPI_Datatype,
+                                                      const MPI_Aint[], const MPI_Aint[],
+                                                      MPI_Datatype,
                                                       MPIR_Comm *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallv(const void *, const int[], const int[],
-                                                     MPI_Datatype, void *, const int[], const int[],
+MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallv(const void *, const MPI_Aint[],
+                                                     const MPI_Aint[], MPI_Datatype, void *,
+                                                     const MPI_Aint[], const MPI_Aint[],
                                                      MPI_Datatype,
                                                      MPIR_Comm *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallw(const void *, const int[], const MPI_Aint[],
-                                                     const MPI_Datatype[], void *, const int[],
-                                                     const MPI_Aint[], const MPI_Datatype[],
+MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallw(const void *, const MPI_Aint[],
+                                                     const MPI_Aint[], const MPI_Datatype[], void *,
+                                                     const MPI_Aint[], const MPI_Aint[],
+                                                     const MPI_Datatype[],
                                                      MPIR_Comm *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoall(const void *, MPI_Aint, MPI_Datatype, void *,
                                                     MPI_Aint, MPI_Datatype,
@@ -242,20 +247,21 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather(const void *, MPI_Aint, MP
                                                       MPI_Aint, MPI_Datatype, MPIR_Comm *,
                                                       MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
-                                                       const int[], const int[], MPI_Datatype,
-                                                       MPIR_Comm *,
+                                                       const MPI_Aint[], const MPI_Aint[],
+                                                       MPI_Datatype, MPIR_Comm *,
                                                        MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall(const void *, MPI_Aint, MPI_Datatype, void *,
                                                      MPI_Aint, MPI_Datatype, MPIR_Comm *,
                                                      MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv(const void *, const int[], const int[],
-                                                      MPI_Datatype, void *, const int[],
-                                                      const int[], MPI_Datatype, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv(const void *, const MPI_Aint[],
+                                                      const MPI_Aint[], MPI_Datatype, void *,
+                                                      const MPI_Aint[], const MPI_Aint[],
+                                                      MPI_Datatype, MPIR_Comm *,
                                                       MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw(const void *, const int[], const MPI_Aint[],
-                                                      const MPI_Datatype[], void *, const int[],
+MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw(const void *, const MPI_Aint[],
                                                       const MPI_Aint[], const MPI_Datatype[],
-                                                      MPIR_Comm *,
+                                                      void *, const MPI_Aint[], const MPI_Aint[],
+                                                      const MPI_Datatype[], MPIR_Comm *,
                                                       MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier(MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,
@@ -264,19 +270,21 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgather(const void *, MPI_Aint, MPI_Datatyp
                                              MPI_Datatype, MPIR_Comm *,
                                              MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
-                                              const int *, const int *, MPI_Datatype, MPIR_Comm *,
+                                              const MPI_Aint *, const MPI_Aint *, MPI_Datatype,
+                                              MPIR_Comm *,
                                               MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
                                              MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                             MPI_Datatype, MPIR_Comm *,
                                             MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv(const void *, const int[], const int[], MPI_Datatype,
-                                             void *, const int[], const int[], MPI_Datatype,
-                                             MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw(const void *, const int[], const int[],
-                                             const MPI_Datatype[], void *, const int[], const int[],
-                                             const MPI_Datatype[], MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv(const void *, const MPI_Aint[], const MPI_Aint[],
+                                             MPI_Datatype, void *, const MPI_Aint[],
+                                             const MPI_Aint[], MPI_Datatype, MPIR_Comm *,
+                                             MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw(const void *, const MPI_Aint[], const MPI_Aint[],
+                                             const MPI_Datatype[], void *, const MPI_Aint[],
+                                             const MPI_Aint[], const MPI_Datatype[], MPIR_Comm *,
                                              MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Iexscan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
                                           MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
@@ -284,13 +292,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igather(const void *, MPI_Aint, MPI_Datatype, 
                                           MPI_Datatype, int, MPIR_Comm *,
                                           MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *, MPI_Aint, MPI_Datatype, void *,
-                                           const int *, const int *, MPI_Datatype, int, MPIR_Comm *,
-                                           MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+                                           const MPI_Aint *, const MPI_Aint *, MPI_Datatype, int,
+                                           MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block(const void *, void *, MPI_Aint,
                                                         MPI_Datatype, MPI_Op, MPIR_Comm *,
                                                         MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter(const void *, void *, const int[], MPI_Datatype,
-                                                  MPI_Op, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter(const void *, void *, const MPI_Aint[],
+                                                  MPI_Datatype, MPI_Op, MPIR_Comm *,
                                                   MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op, int,
                                           MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
@@ -299,9 +307,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscan(const void *, void *, MPI_Aint, MPI_Data
 MPL_STATIC_INLINE_PREFIX int MPID_Iscatter(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                            MPI_Datatype, int, MPIR_Comm *,
                                            MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *, const int *, const int *, MPI_Datatype,
-                                            void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,
-                                            MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *, const MPI_Aint *, const MPI_Aint *,
+                                            MPI_Datatype, void *, MPI_Aint, MPI_Datatype, int,
+                                            MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Abort(struct MPIR_Comm *comm, int mpi_errno, int exit_code, const char *error_msg);
 
 /* This function is not exposed to the upper layers but functions in a way

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_coll.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_coll.h
@@ -37,9 +37,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Ain
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     const int *recvcounts, const int *displs,
-                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                     MPIR_Errflag_t * errflag)
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     return MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcounts, displs, recvtype, comm_ptr, errflag);
@@ -57,9 +57,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint s
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  const int *recvcounts, const int *displs,
-                                                  MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                  const MPI_Aint * recvcounts,
+                                                  const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  MPIR_Errflag_t * errflag)
 {
     return MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcounts, displs, recvtype, root, comm_ptr, errflag);
@@ -75,8 +76,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint 
                              recvcount, recvtype, root, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
-                                                   const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MPI_Aint * sendcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
@@ -94,20 +95,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint
                               recvcount, recvtype, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                    const int *sdispls, MPI_Datatype sendtype,
-                                                    void *recvbuf, const int *recvcounts,
-                                                    const int *rdispls, MPI_Datatype recvtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
+                                                    const MPI_Aint * sendcounts,
+                                                    const MPI_Aint * sdispls, MPI_Datatype sendtype,
+                                                    void *recvbuf, const MPI_Aint * recvcounts,
+                                                    const MPI_Aint * rdispls, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     return MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                recvbuf, recvcounts, rdispls, recvtype, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const int sendcounts[],
-                                                    const int sdispls[],
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
+                                                    const MPI_Aint sendcounts[],
+                                                    const MPI_Aint sdispls[],
                                                     const MPI_Datatype sendtypes[], void *recvbuf,
-                                                    const int recvcounts[], const int rdispls[],
+                                                    const MPI_Aint recvcounts[],
+                                                    const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -123,7 +127,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                         const int recvcounts[],
+                                                         const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
                                                          MPIR_Comm * comm_ptr,
                                                          MPIR_Errflag_t * errflag)
@@ -169,8 +173,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf,
                                                               MPI_Aint sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              const int recvcounts[],
-                                                              const int displs[],
+                                                              const MPI_Aint recvcounts[],
+                                                              const MPI_Aint displs[],
                                                               MPI_Datatype recvtype,
                                                               MPIR_Comm * comm_ptr)
 {
@@ -189,11 +193,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf,
-                                                             const int sendcounts[],
-                                                             const int sdispls[],
+                                                             const MPI_Aint sendcounts[],
+                                                             const MPI_Aint sdispls[],
                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                             const int recvcounts[],
-                                                             const int rdispls[],
+                                                             const MPI_Aint recvcounts[],
+                                                             const MPI_Aint rdispls[],
                                                              MPI_Datatype recvtype,
                                                              MPIR_Comm * comm_ptr)
 {
@@ -202,10 +206,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf,
-                                                             const int sendcounts[],
+                                                             const MPI_Aint sendcounts[],
                                                              const MPI_Aint sdispls[],
                                                              const MPI_Datatype sendtypes[],
-                                                             void *recvbuf, const int recvcounts[],
+                                                             void *recvbuf,
+                                                             const MPI_Aint recvcounts[],
                                                              const MPI_Aint rdispls[],
                                                              const MPI_Datatype recvtypes[],
                                                              MPIR_Comm * comm_ptr)
@@ -230,8 +235,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbu
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf,
                                                                MPI_Aint sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
-                                                               const int recvcounts[],
-                                                               const int displs[],
+                                                               const MPI_Aint recvcounts[],
+                                                               const MPI_Aint displs[],
                                                                MPI_Datatype recvtype,
                                                                MPIR_Comm * comm_ptr,
                                                                MPIR_Request ** req)
@@ -253,11 +258,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbuf,
-                                                              const int sendcounts[],
-                                                              const int sdispls[],
+                                                              const MPI_Aint sendcounts[],
+                                                              const MPI_Aint sdispls[],
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              const int recvcounts[],
-                                                              const int rdispls[],
+                                                              const MPI_Aint recvcounts[],
+                                                              const MPI_Aint rdispls[],
                                                               MPI_Datatype recvtype,
                                                               MPIR_Comm * comm_ptr,
                                                               MPIR_Request ** req)
@@ -268,10 +273,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbu
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbuf,
-                                                              const int sendcounts[],
+                                                              const MPI_Aint sendcounts[],
                                                               const MPI_Aint sdispls[],
                                                               const MPI_Datatype sendtypes[],
-                                                              void *recvbuf, const int recvcounts[],
+                                                              void *recvbuf,
+                                                              const MPI_Aint recvcounts[],
                                                               const MPI_Aint rdispls[],
                                                               const MPI_Datatype recvtypes[],
                                                               MPIR_Comm * comm_ptr,
@@ -305,7 +311,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, MPI_Ai
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                       MPIR_Request ** req)
 {
@@ -330,20 +337,25 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, MPI_Ain
                                recvcount, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls, MPI_Datatype sendtype,
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * sdispls,
+                                                     MPI_Datatype sendtype, void *recvbuf,
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * rdispls,
+                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                                     MPIR_Request ** req)
 {
     return MPIR_Ialltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                 recvbuf, recvcounts, rdispls, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * sdispls,
                                                      const MPI_Datatype sendtypes[], void *recvbuf,
-                                                     const int *recvcounts, const int *rdispls,
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * rdispls,
                                                      const MPI_Datatype recvtypes[],
                                                      MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
@@ -370,9 +382,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, MPI_Aint 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts, const int *displs,
-                                                   MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                   const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   MPIR_Request ** req)
 {
     return MPIR_Igatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                               recvcounts, displs, recvtype, root, comm_ptr, req);
@@ -389,7 +402,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *send
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int recvcounts[],
+                                                          const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
@@ -421,8 +434,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, MPI_Aint
                               recvcount, recvtype, root, comm, request);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
-                                                    const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf,
+                                                    const MPI_Aint * sendcounts,
+                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
                                                     MPIR_Comm * comm, MPIR_Request ** request)

--- a/src/mpid/ch4/netmod/ofi/ofi_coll.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll.h
@@ -96,9 +96,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Ain
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     const int *recvcounts, const int *displs,
-                                                     MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t * errflag)
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -144,8 +144,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint s
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  const int *recvcounts, const int *displs,
-                                                  MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                                                  const MPI_Aint * recvcounts,
+                                                  const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                  int root, MPIR_Comm * comm,
                                                   MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -191,8 +192,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint 
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
-                                                   const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MPI_Aint * sendcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
@@ -238,10 +239,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                    const int *sdispls, MPI_Datatype sendtype,
-                                                    void *recvbuf, const int *recvcounts,
-                                                    const int *rdispls, MPI_Datatype recvtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
+                                                    const MPI_Aint * sendcounts,
+                                                    const MPI_Aint * sdispls, MPI_Datatype sendtype,
+                                                    void *recvbuf, const MPI_Aint * recvcounts,
+                                                    const MPI_Aint * rdispls, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -263,10 +265,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const i
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const int sendcounts[],
-                                                    const int sdispls[],
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
+                                                    const MPI_Aint sendcounts[],
+                                                    const MPI_Aint sdispls[],
                                                     const MPI_Datatype sendtypes[], void *recvbuf,
-                                                    const int recvcounts[], const int rdispls[],
+                                                    const MPI_Aint recvcounts[],
+                                                    const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
@@ -311,7 +315,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                         const int recvcounts[],
+                                                         const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
                                                          MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
@@ -419,8 +423,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf,
                                                               MPI_Aint sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              const int recvcounts[],
-                                                              const int displs[],
+                                                              const MPI_Aint recvcounts[],
+                                                              const MPI_Aint displs[],
                                                               MPI_Datatype recvtype,
                                                               MPIR_Comm * comm)
 {
@@ -452,11 +456,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf,
-                                                             const int sendcounts[],
-                                                             const int sdispls[],
+                                                             const MPI_Aint sendcounts[],
+                                                             const MPI_Aint sdispls[],
                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                             const int recvcounts[],
-                                                             const int rdispls[],
+                                                             const MPI_Aint recvcounts[],
+                                                             const MPI_Aint rdispls[],
                                                              MPI_Datatype recvtype,
                                                              MPIR_Comm * comm)
 {
@@ -472,10 +476,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf,
-                                                             const int sendcounts[],
+                                                             const MPI_Aint sendcounts[],
                                                              const MPI_Aint sdispls[],
                                                              const MPI_Datatype sendtypes[],
-                                                             void *recvbuf, const int recvcounts[],
+                                                             void *recvbuf,
+                                                             const MPI_Aint recvcounts[],
                                                              const MPI_Aint rdispls[],
                                                              const MPI_Datatype recvtypes[],
                                                              MPIR_Comm * comm)
@@ -512,8 +517,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbu
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf,
                                                                MPI_Aint sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
-                                                               const int recvcounts[],
-                                                               const int displs[],
+                                                               const MPI_Aint recvcounts[],
+                                                               const MPI_Aint displs[],
                                                                MPI_Datatype recvtype,
                                                                MPIR_Comm * comm,
                                                                MPIR_Request ** req)
@@ -548,11 +553,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbuf,
-                                                              const int sendcounts[],
-                                                              const int sdispls[],
+                                                              const MPI_Aint sendcounts[],
+                                                              const MPI_Aint sdispls[],
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              const int recvcounts[],
-                                                              const int rdispls[],
+                                                              const MPI_Aint recvcounts[],
+                                                              const MPI_Aint rdispls[],
                                                               MPI_Datatype recvtype,
                                                               MPIR_Comm * comm, MPIR_Request ** req)
 {
@@ -568,10 +573,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbu
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbuf,
-                                                              const int sendcounts[],
+                                                              const MPI_Aint sendcounts[],
                                                               const MPI_Aint sdispls[],
                                                               const MPI_Datatype sendtypes[],
-                                                              void *recvbuf, const int recvcounts[],
+                                                              void *recvbuf,
+                                                              const MPI_Aint recvcounts[],
                                                               const MPI_Aint rdispls[],
                                                               const MPI_Datatype recvtypes[],
                                                               MPIR_Comm * comm, MPIR_Request ** req)
@@ -631,7 +637,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, MPI_Ai
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
                                                       MPIR_Request ** req)
 {
@@ -677,11 +684,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, MPI_Ain
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls, MPI_Datatype sendtype,
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * sdispls,
+                                                     MPI_Datatype sendtype, void *recvbuf,
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * rdispls,
+                                                     MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                     MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IALLTOALLV);
@@ -694,10 +704,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf, const 
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * sdispls,
                                                      const MPI_Datatype sendtypes[], void *recvbuf,
-                                                     const int *recvcounts, const int *rdispls,
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * rdispls,
                                                      const MPI_Datatype recvtypes[],
                                                      MPIR_Comm * comm, MPIR_Request ** req)
 {
@@ -744,9 +756,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, MPI_Aint 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts, const int *displs,
-                                                   MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Request ** req)
+                                                   const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                   int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IGATHERV);
@@ -777,7 +789,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *send
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int recvcounts[],
+                                                          const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm, MPIR_Request ** req)
 {
@@ -836,8 +848,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, MPI_Aint
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
-                                                    const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf,
+                                                    const MPI_Aint * sendcounts,
+                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
                                                     MPIR_Comm * comm, MPIR_Request ** request)

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -95,9 +95,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Ain
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     const int *recvcounts, const int *displs,
-                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                     MPIR_Errflag_t * errflag)
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_ALLGATHERV);
@@ -129,9 +129,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint s
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  const int *recvcounts, const int *displs,
-                                                  MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                  const MPI_Aint * recvcounts,
+                                                  const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_GATHERV);
@@ -161,8 +162,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint 
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
-                                                   const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MPI_Aint * sendcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
@@ -200,10 +201,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                    const int *sdispls, MPI_Datatype sendtype,
-                                                    void *recvbuf, const int *recvcounts,
-                                                    const int *rdispls, MPI_Datatype recvtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
+                                                    const MPI_Aint * sendcounts,
+                                                    const MPI_Aint * sdispls, MPI_Datatype sendtype,
+                                                    void *recvbuf, const MPI_Aint * recvcounts,
+                                                    const MPI_Aint * rdispls, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
@@ -223,10 +225,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const i
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const int sendcounts[],
-                                                    const int sdispls[],
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
+                                                    const MPI_Aint sendcounts[],
+                                                    const MPI_Aint sdispls[],
                                                     const MPI_Datatype sendtypes[], void *recvbuf,
-                                                    const int recvcounts[], const int rdispls[],
+                                                    const MPI_Aint recvcounts[],
+                                                    const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -262,7 +266,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                         const int recvcounts[],
+                                                         const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
                                                          MPIR_Comm * comm_ptr,
                                                          MPIR_Errflag_t * errflag)
@@ -344,8 +348,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf,
                                                               MPI_Aint sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              const int recvcounts[],
-                                                              const int displs[],
+                                                              const MPI_Aint recvcounts[],
+                                                              const MPI_Aint displs[],
                                                               MPI_Datatype recvtype,
                                                               MPIR_Comm * comm_ptr)
 {
@@ -378,11 +382,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf,
-                                                             const int sendcounts[],
-                                                             const int sdispls[],
+                                                             const MPI_Aint sendcounts[],
+                                                             const MPI_Aint sdispls[],
                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                             const int recvcounts[],
-                                                             const int rdispls[],
+                                                             const MPI_Aint recvcounts[],
+                                                             const MPI_Aint rdispls[],
                                                              MPI_Datatype recvtype,
                                                              MPIR_Comm * comm_ptr)
 {
@@ -399,10 +403,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf,
-                                                             const int sendcounts[],
+                                                             const MPI_Aint sendcounts[],
                                                              const MPI_Aint sdispls[],
                                                              const MPI_Datatype sendtypes[],
-                                                             void *recvbuf, const int recvcounts[],
+                                                             void *recvbuf,
+                                                             const MPI_Aint recvcounts[],
                                                              const MPI_Aint rdispls[],
                                                              const MPI_Datatype recvtypes[],
                                                              MPIR_Comm * comm_ptr)
@@ -441,8 +446,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbu
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf,
                                                                MPI_Aint sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
-                                                               const int recvcounts[],
-                                                               const int displs[],
+                                                               const MPI_Aint recvcounts[],
+                                                               const MPI_Aint displs[],
                                                                MPI_Datatype recvtype,
                                                                MPIR_Comm * comm_ptr,
                                                                MPIR_Request ** req)
@@ -479,11 +484,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbuf,
-                                                              const int sendcounts[],
-                                                              const int sdispls[],
+                                                              const MPI_Aint sendcounts[],
+                                                              const MPI_Aint sdispls[],
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              const int recvcounts[],
-                                                              const int rdispls[],
+                                                              const MPI_Aint recvcounts[],
+                                                              const MPI_Aint rdispls[],
                                                               MPI_Datatype recvtype,
                                                               MPIR_Comm * comm_ptr,
                                                               MPIR_Request ** req)
@@ -501,10 +506,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbu
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbuf,
-                                                              const int sendcounts[],
+                                                              const MPI_Aint sendcounts[],
                                                               const MPI_Aint sdispls[],
                                                               const MPI_Datatype sendtypes[],
-                                                              void *recvbuf, const int recvcounts[],
+                                                              void *recvbuf,
+                                                              const MPI_Aint recvcounts[],
                                                               const MPI_Aint rdispls[],
                                                               const MPI_Datatype recvtypes[],
                                                               MPIR_Comm * comm_ptr,
@@ -566,7 +572,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, MPI_Ai
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                       MPIR_Request ** req)
 {
@@ -612,11 +619,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, MPI_Ain
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls, MPI_Datatype sendtype,
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * sdispls,
+                                                     MPI_Datatype sendtype, void *recvbuf,
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * rdispls,
+                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                                     MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IALLTOALLV);
@@ -629,10 +639,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf, const 
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * sdispls,
                                                      const MPI_Datatype sendtypes[], void *recvbuf,
-                                                     const int *recvcounts, const int *rdispls,
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * rdispls,
                                                      const MPI_Datatype recvtypes[],
                                                      MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
@@ -680,9 +692,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, MPI_Aint 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts, const int *displs,
-                                                   MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                   const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IGATHERV);
@@ -713,7 +726,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *send
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int recvcounts[],
+                                                          const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
@@ -774,8 +787,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, MPI_Aint
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
-                                                    const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf,
+                                                    const MPI_Aint * sendcounts,
+                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
                                                     MPIR_Comm * comm, MPIR_Request ** request)

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -24,7 +24,7 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
     ucp_mem_h mem_h;
     int cntr = 0;
     size_t rkey_size = 0;
-    int *rkey_sizes = NULL, *recv_disps = NULL, i;
+    MPI_Aint *rkey_sizes = NULL, *recv_disps = NULL, i;
     char *rkey_buffer = NULL, *rkey_recv_buff = NULL;
     struct ucx_share *share_data = NULL;
     ucp_mem_map_params_t mem_map_params;
@@ -68,13 +68,13 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
         MPIDI_UCX_CHK_STATUS(status);
     }
 
-    rkey_sizes = (int *) MPL_malloc(sizeof(int) * comm_ptr->local_size, MPL_MEM_OTHER);
-    rkey_sizes[comm_ptr->rank] = (int) rkey_size;
-    mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 1, MPI_INT, rkey_sizes, 1, MPI_INT, comm_ptr, &err);
+    rkey_sizes = (MPI_Aint *) MPL_malloc(sizeof(MPI_Aint) * comm_ptr->local_size, MPL_MEM_OTHER);
+    rkey_sizes[comm_ptr->rank] = (MPI_Aint) rkey_size;
+    mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 1, MPI_AINT, rkey_sizes, 1, MPI_AINT, comm_ptr, &err);
 
     MPIR_ERR_CHECK(mpi_errno);
 
-    recv_disps = (int *) MPL_malloc(sizeof(int) * comm_ptr->local_size, MPL_MEM_OTHER);
+    recv_disps = (MPI_Aint *) MPL_malloc(sizeof(MPI_Aint) * comm_ptr->local_size, MPL_MEM_OTHER);
 
 
     for (i = 0; i < comm_ptr->local_size; i++) {

--- a/src/mpid/ch4/shm/posix/posix_coll.h
+++ b/src/mpid/ch4/shm/posix/posix_coll.h
@@ -291,7 +291,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather(const void *sendbuf, MPI_
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
-                                                        const int *recvcounts, const int *displs,
+                                                        const MPI_Aint * recvcounts,
+                                                        const MPI_Aint * displs,
                                                         MPI_Datatype recvtype, MPIR_Comm * comm,
                                                         MPIR_Errflag_t * errflag)
 {
@@ -339,9 +340,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gather(const void *sendbuf, MPI_Ain
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                     const int *recvcounts, const int *displs,
-                                                     MPI_Datatype recvtype, int root,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                     int root, MPIR_Comm * comm,
+                                                     MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -386,11 +388,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatter(const void *sendbuf, MPI_Ai
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatterv(const void *sendbuf, const int *sendcounts,
-                                                      const int *displs, MPI_Datatype sendtype,
-                                                      void *recvbuf, MPI_Aint recvcount,
-                                                      MPI_Datatype recvtype, int root,
-                                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatterv(const void *sendbuf,
+                                                      const MPI_Aint * sendcounts,
+                                                      const MPI_Aint * displs,
+                                                      MPI_Datatype sendtype, void *recvbuf,
+                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                      int root, MPIR_Comm * comm,
+                                                      MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -433,11 +437,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall(const void *sendbuf, MPI_A
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                       const int *sdispls, MPI_Datatype sendtype,
-                                                       void *recvbuf, const int *recvcounts,
-                                                       const int *rdispls, MPI_Datatype recvtype,
-                                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallv(const void *sendbuf,
+                                                       const MPI_Aint * sendcounts,
+                                                       const MPI_Aint * sdispls,
+                                                       MPI_Datatype sendtype, void *recvbuf,
+                                                       const MPI_Aint * recvcounts,
+                                                       const MPI_Aint * rdispls,
+                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                       MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
 
@@ -458,11 +465,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallv(const void *sendbuf, cons
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallw(const void *sendbuf, const int sendcounts[],
-                                                       const int sdispls[],
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallw(const void *sendbuf,
+                                                       const MPI_Aint sendcounts[],
+                                                       const MPI_Aint sdispls[],
                                                        const MPI_Datatype sendtypes[],
-                                                       void *recvbuf, const int recvcounts[],
-                                                       const int rdispls[],
+                                                       void *recvbuf, const MPI_Aint recvcounts[],
+                                                       const MPI_Aint rdispls[],
                                                        const MPI_Datatype recvtypes[],
                                                        MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
@@ -558,7 +566,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce(const void *sendbuf, void *r
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                            const int recvcounts[],
+                                                            const MPI_Aint recvcounts[],
                                                             MPI_Datatype datatype, MPI_Op op,
                                                             MPIR_Comm * comm,
                                                             MPIR_Errflag_t * errflag)
@@ -669,8 +677,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_allgatherv(const void *sen
                                                                  MPI_Aint sendcount,
                                                                  MPI_Datatype sendtype,
                                                                  void *recvbuf,
-                                                                 const int recvcounts[],
-                                                                 const int displs[],
+                                                                 const MPI_Aint recvcounts[],
+                                                                 const MPI_Aint displs[],
                                                                  MPI_Datatype recvtype,
                                                                  MPIR_Comm * comm)
 {
@@ -704,12 +712,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_alltoall(const void *sendb
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_alltoallv(const void *sendbuf,
-                                                                const int sendcounts[],
-                                                                const int sdispls[],
+                                                                const MPI_Aint sendcounts[],
+                                                                const MPI_Aint sdispls[],
                                                                 MPI_Datatype sendtype,
                                                                 void *recvbuf,
-                                                                const int recvcounts[],
-                                                                const int rdispls[],
+                                                                const MPI_Aint recvcounts[],
+                                                                const MPI_Aint rdispls[],
                                                                 MPI_Datatype recvtype,
                                                                 MPIR_Comm * comm)
 {
@@ -725,11 +733,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_alltoallv(const void *send
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_neighbor_alltoallw(const void *sendbuf,
-                                                                const int sendcounts[],
+                                                                const MPI_Aint sendcounts[],
                                                                 const MPI_Aint sdispls[],
                                                                 const MPI_Datatype sendtypes[],
                                                                 void *recvbuf,
-                                                                const int recvcounts[],
+                                                                const MPI_Aint recvcounts[],
                                                                 const MPI_Aint rdispls[],
                                                                 const MPI_Datatype recvtypes[],
                                                                 MPIR_Comm * comm)
@@ -768,8 +776,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_allgatherv(const void *se
                                                                   MPI_Aint sendcount,
                                                                   MPI_Datatype sendtype,
                                                                   void *recvbuf,
-                                                                  const int recvcounts[],
-                                                                  const int displs[],
+                                                                  const MPI_Aint recvcounts[],
+                                                                  const MPI_Aint displs[],
                                                                   MPI_Datatype recvtype,
                                                                   MPIR_Comm * comm,
                                                                   MPIR_Request ** req)
@@ -805,12 +813,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_alltoall(const void *send
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_alltoallv(const void *sendbuf,
-                                                                 const int sendcounts[],
-                                                                 const int sdispls[],
+                                                                 const MPI_Aint sendcounts[],
+                                                                 const MPI_Aint sdispls[],
                                                                  MPI_Datatype sendtype,
                                                                  void *recvbuf,
-                                                                 const int recvcounts[],
-                                                                 const int rdispls[],
+                                                                 const MPI_Aint recvcounts[],
+                                                                 const MPI_Aint rdispls[],
                                                                  MPI_Datatype recvtype,
                                                                  MPIR_Comm * comm,
                                                                  MPIR_Request ** req)
@@ -827,11 +835,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_alltoallv(const void *sen
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_alltoallw(const void *sendbuf,
-                                                                 const int sendcounts[],
+                                                                 const MPI_Aint sendcounts[],
                                                                  const MPI_Aint sdispls[],
                                                                  const MPI_Datatype sendtypes[],
                                                                  void *recvbuf,
-                                                                 const int recvcounts[],
+                                                                 const MPI_Aint recvcounts[],
                                                                  const MPI_Aint rdispls[],
                                                                  const MPI_Datatype recvtypes[],
                                                                  MPIR_Comm * comm,
@@ -892,7 +900,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallgather(const void *sendbuf, MPI
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
-                                                         const int *recvcounts, const int *displs,
+                                                         const MPI_Aint * recvcounts,
+                                                         const MPI_Aint * displs,
                                                          MPI_Datatype recvtype, MPIR_Comm * comm,
                                                          MPIR_Request ** req)
 {
@@ -923,11 +932,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoall(const void *sendbuf, MPI_
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
-                                                        const int *sdispls, MPI_Datatype sendtype,
-                                                        void *recvbuf, const int *recvcounts,
-                                                        const int *rdispls, MPI_Datatype recvtype,
-                                                        MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoallv(const void *sendbuf,
+                                                        const MPI_Aint * sendcounts,
+                                                        const MPI_Aint * sdispls,
+                                                        MPI_Datatype sendtype, void *recvbuf,
+                                                        const MPI_Aint * recvcounts,
+                                                        const MPI_Aint * rdispls,
+                                                        MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                        MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_IALLTOALLV);
@@ -940,11 +952,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoallv(const void *sendbuf, con
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
-                                                        const int *sdispls,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoallw(const void *sendbuf,
+                                                        const MPI_Aint * sendcounts,
+                                                        const MPI_Aint * sdispls,
                                                         const MPI_Datatype sendtypes[],
-                                                        void *recvbuf, const int *recvcounts,
-                                                        const int *rdispls,
+                                                        void *recvbuf, const MPI_Aint * recvcounts,
+                                                        const MPI_Aint * rdispls,
                                                         const MPI_Datatype recvtypes[],
                                                         MPIR_Comm * comm, MPIR_Request ** req)
 {
@@ -993,7 +1006,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_igather(const void *sendbuf, MPI_Ai
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, int root,
                                                       MPIR_Comm * comm, MPIR_Request ** req)
 {
@@ -1027,7 +1041,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce_scatter_block(const void *s
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                             const int recvcounts[],
+                                                             const MPI_Aint recvcounts[],
                                                              MPI_Datatype datatype, MPI_Op op,
                                                              MPIR_Comm * comm, MPIR_Request ** req)
 {
@@ -1102,11 +1116,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscatter(const void *sendbuf, MPI_A
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
-                                                       const int *displs, MPI_Datatype sendtype,
-                                                       void *recvbuf, MPI_Aint recvcount,
-                                                       MPI_Datatype recvtype, int root,
-                                                       MPIR_Comm * comm, MPIR_Request ** request)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscatterv(const void *sendbuf,
+                                                       const MPI_Aint * sendcounts,
+                                                       const MPI_Aint * displs,
+                                                       MPI_Datatype sendtype, void *recvbuf,
+                                                       MPI_Aint recvcount, MPI_Datatype recvtype,
+                                                       int root, MPIR_Comm * comm,
+                                                       MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_ISCATTERV);

--- a/src/mpid/ch4/shm/src/shm_am_fallback_coll.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_coll.h
@@ -37,7 +37,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, MPI_Ai
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                       MPIR_Errflag_t * errflag)
 {
@@ -57,9 +58,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, MPI_Aint 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts, const int *displs,
-                                                   MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                   const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   MPIR_Errflag_t * errflag)
 {
     return MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcounts, displs, recvtype, root, comm_ptr, errflag);
@@ -75,8 +77,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, MPI_Aint
                              recvcount, recvtype, root, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
-                                                    const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
+                                                    const MPI_Aint * sendcounts,
+                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
@@ -94,20 +97,25 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, MPI_Ain
                               recvcount, recvtype, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls, MPI_Datatype sendtype,
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * sdispls,
+                                                     MPI_Datatype sendtype, void *recvbuf,
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * rdispls,
+                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                                     MPIR_Errflag_t * errflag)
 {
     return MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                recvbuf, recvcounts, rdispls, recvtype, comm_ptr, errflag);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const int sendcounts[],
-                                                     const int sdispls[],
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
+                                                     const MPI_Aint sendcounts[],
+                                                     const MPI_Aint sdispls[],
                                                      const MPI_Datatype sendtypes[], void *recvbuf,
-                                                     const int recvcounts[], const int rdispls[],
+                                                     const MPI_Aint recvcounts[],
+                                                     const MPI_Aint rdispls[],
                                                      const MPI_Datatype recvtypes[],
                                                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
@@ -124,7 +132,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *rec
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int recvcounts[],
+                                                          const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm_ptr,
                                                           MPIR_Errflag_t * errflag)
@@ -170,8 +178,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbu
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendbuf,
                                                                MPI_Aint sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
-                                                               const int recvcounts[],
-                                                               const int displs[],
+                                                               const MPI_Aint recvcounts[],
+                                                               const MPI_Aint displs[],
                                                                MPI_Datatype recvtype,
                                                                MPIR_Comm * comm_ptr)
 {
@@ -191,11 +199,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallv(const void *sendbuf,
-                                                              const int sendcounts[],
-                                                              const int sdispls[],
+                                                              const MPI_Aint sendcounts[],
+                                                              const MPI_Aint sdispls[],
                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                              const int recvcounts[],
-                                                              const int rdispls[],
+                                                              const MPI_Aint recvcounts[],
+                                                              const MPI_Aint rdispls[],
                                                               MPI_Datatype recvtype,
                                                               MPIR_Comm * comm_ptr)
 {
@@ -204,10 +212,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallv(const void *sendbu
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallw(const void *sendbuf,
-                                                              const int sendcounts[],
+                                                              const MPI_Aint sendcounts[],
                                                               const MPI_Aint sdispls[],
                                                               const MPI_Datatype sendtypes[],
-                                                              void *recvbuf, const int recvcounts[],
+                                                              void *recvbuf,
+                                                              const MPI_Aint recvcounts[],
                                                               const MPI_Aint rdispls[],
                                                               const MPI_Datatype recvtypes[],
                                                               MPIR_Comm * comm_ptr)
@@ -233,8 +242,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *send
                                                                 MPI_Aint sendcount,
                                                                 MPI_Datatype sendtype,
                                                                 void *recvbuf,
-                                                                const int recvcounts[],
-                                                                const int displs[],
+                                                                const MPI_Aint recvcounts[],
+                                                                const MPI_Aint displs[],
                                                                 MPI_Datatype recvtype,
                                                                 MPIR_Comm * comm_ptr,
                                                                 MPIR_Request ** req)
@@ -256,11 +265,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbu
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallv(const void *sendbuf,
-                                                               const int sendcounts[],
-                                                               const int sdispls[],
+                                                               const MPI_Aint sendcounts[],
+                                                               const MPI_Aint sdispls[],
                                                                MPI_Datatype sendtype, void *recvbuf,
-                                                               const int recvcounts[],
-                                                               const int rdispls[],
+                                                               const MPI_Aint recvcounts[],
+                                                               const MPI_Aint rdispls[],
                                                                MPI_Datatype recvtype,
                                                                MPIR_Comm * comm_ptr,
                                                                MPIR_Request ** req)
@@ -271,11 +280,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallv(const void *sendb
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallw(const void *sendbuf,
-                                                               const int sendcounts[],
+                                                               const MPI_Aint sendcounts[],
                                                                const MPI_Aint sdispls[],
                                                                const MPI_Datatype sendtypes[],
                                                                void *recvbuf,
-                                                               const int recvcounts[],
+                                                               const MPI_Aint recvcounts[],
                                                                const MPI_Aint rdispls[],
                                                                const MPI_Datatype recvtypes[],
                                                                MPIR_Comm * comm_ptr,
@@ -309,7 +318,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, MPI_A
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
-                                                       const int *recvcounts, const int *displs,
+                                                       const MPI_Aint * recvcounts,
+                                                       const MPI_Aint * displs,
                                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
                                                        MPIR_Request ** req)
 {
@@ -334,20 +344,25 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, MPI_Ai
                                recvcount, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
-                                                      const int *sdispls, MPI_Datatype sendtype,
-                                                      void *recvbuf, const int *recvcounts,
-                                                      const int *rdispls, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm_ptr, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf,
+                                                      const MPI_Aint * sendcounts,
+                                                      const MPI_Aint * sdispls,
+                                                      MPI_Datatype sendtype, void *recvbuf,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * rdispls,
+                                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                                      MPIR_Request ** req)
 {
     return MPIR_Ialltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                 recvbuf, recvcounts, rdispls, recvtype, comm_ptr, req);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
-                                                      const int *sdispls,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf,
+                                                      const MPI_Aint * sendcounts,
+                                                      const MPI_Aint * sdispls,
                                                       const MPI_Datatype sendtypes[], void *recvbuf,
-                                                      const int *recvcounts, const int *rdispls,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * rdispls,
                                                       const MPI_Datatype recvtypes[],
                                                       MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
@@ -374,9 +389,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, MPI_Aint
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts, const int *displs,
-                                                    MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                    const MPI_Aint * recvcounts,
+                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                    int root, MPIR_Comm * comm_ptr,
+                                                    MPIR_Request ** req)
 {
     return MPIR_Igatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                               recvcounts, displs, recvtype, root, comm_ptr, req);
@@ -393,7 +409,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sen
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                           const int recvcounts[],
+                                                           const MPI_Aint recvcounts[],
                                                            MPI_Datatype datatype, MPI_Op op,
                                                            MPIR_Comm * comm_ptr,
                                                            MPIR_Request ** req)
@@ -426,8 +442,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, MPI_Ain
                               recvcount, recvtype, root, comm, request);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
-                                                     const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatterv(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * displs, MPI_Datatype sendtype,
                                                      void *recvbuf, MPI_Aint recvcount,
                                                      MPI_Datatype recvtype, int root,
                                                      MPIR_Comm * comm, MPIR_Request ** request)

--- a/src/mpid/ch4/shm/src/shm_coll.h
+++ b/src/mpid/ch4/shm/src/shm_coll.h
@@ -72,7 +72,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, MPI_Ai
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
                                                       MPIR_Errflag_t * errflag)
 {
@@ -106,8 +107,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, MPI_Aint
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
-                                                    const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
+                                                    const MPI_Aint * sendcounts,
+                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
@@ -144,9 +146,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, MPI_Aint 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts, const int *displs,
-                                                   MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                   const MPI_Aint * recvcounts,
+                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                   int root, MPIR_Comm * comm,
+                                                   MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -177,11 +180,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, MPI_Ain
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls, MPI_Datatype sendtype,
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * sdispls,
+                                                     MPI_Datatype sendtype, void *recvbuf,
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * rdispls,
+                                                     MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                     MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -195,11 +201,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf, const 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls,
-                                                     const MPI_Datatype sendtypes[],
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * sdispls,
+                                                     const MPI_Datatype sendtypes[], void *recvbuf,
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * rdispls,
                                                      const MPI_Datatype recvtypes[],
                                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
@@ -232,7 +239,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *rec
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int *recvcounts,
+                                                          const MPI_Aint * recvcounts,
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm_ptr,
                                                           MPIR_Errflag_t * errflag)
@@ -319,8 +326,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbu
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendbuf,
                                                                MPI_Aint sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
-                                                               const int *recvcounts,
-                                                               const int *displs,
+                                                               const MPI_Aint * recvcounts,
+                                                               const MPI_Aint * displs,
                                                                MPI_Datatype recvtype,
                                                                MPIR_Comm * comm)
 {
@@ -337,12 +344,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendb
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallv(const void *sendbuf,
-                                                              const int *sendcounts,
-                                                              const int *sdispls,
+                                                              const MPI_Aint * sendcounts,
+                                                              const MPI_Aint * sdispls,
                                                               MPI_Datatype sendtype,
                                                               void *recvbuf,
-                                                              const int *recvcounts,
-                                                              const int *rdispls,
+                                                              const MPI_Aint * recvcounts,
+                                                              const MPI_Aint * rdispls,
                                                               MPI_Datatype recvtype,
                                                               MPIR_Comm * comm)
 {
@@ -359,11 +366,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallv(const void *sendbu
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallw(const void *sendbuf,
-                                                              const int *sendcounts,
+                                                              const MPI_Aint * sendcounts,
                                                               const MPI_Aint * sdispls,
                                                               const MPI_Datatype * sendtypes,
                                                               void *recvbuf,
-                                                              const int *recvcounts,
+                                                              const MPI_Aint * recvcounts,
                                                               const MPI_Aint * rdispls,
                                                               const MPI_Datatype * recvtypes,
                                                               MPIR_Comm * comm)
@@ -423,8 +430,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *send
                                                                 MPI_Aint sendcount,
                                                                 MPI_Datatype sendtype,
                                                                 void *recvbuf,
-                                                                const int *recvcounts,
-                                                                const int *displs,
+                                                                const MPI_Aint * recvcounts,
+                                                                const MPI_Aint * displs,
                                                                 MPI_Datatype recvtype,
                                                                 MPIR_Comm * comm,
                                                                 MPIR_Request ** req)
@@ -461,12 +468,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbu
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallv(const void *sendbuf,
-                                                               const int *sendcounts,
-                                                               const int *sdispls,
+                                                               const MPI_Aint * sendcounts,
+                                                               const MPI_Aint * sdispls,
                                                                MPI_Datatype sendtype,
                                                                void *recvbuf,
-                                                               const int *recvcounts,
-                                                               const int *rdispls,
+                                                               const MPI_Aint * recvcounts,
+                                                               const MPI_Aint * rdispls,
                                                                MPI_Datatype recvtype,
                                                                MPIR_Comm * comm,
                                                                MPIR_Request ** req)
@@ -484,11 +491,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallv(const void *sendb
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallw(const void *sendbuf,
-                                                               const int *sendcounts,
+                                                               const MPI_Aint * sendcounts,
                                                                const MPI_Aint * sdispls,
                                                                const MPI_Datatype * sendtypes,
                                                                void *recvbuf,
-                                                               const int *recvcounts,
+                                                               const MPI_Aint * recvcounts,
                                                                const MPI_Aint * rdispls,
                                                                const MPI_Datatype * recvtypes,
                                                                MPIR_Comm * comm,
@@ -553,7 +560,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, MPI_A
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
-                                                       const int *recvcounts, const int *displs,
+                                                       const MPI_Aint * recvcounts,
+                                                       const MPI_Aint * displs,
                                                        MPI_Datatype recvtype, MPIR_Comm * comm,
                                                        MPIR_Request ** req)
 {
@@ -602,11 +610,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, MPI_Ai
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
-                                                      const int *sdispls, MPI_Datatype sendtype,
-                                                      void *recvbuf, const int *recvcounts,
-                                                      const int *rdispls, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf,
+                                                      const MPI_Aint * sendcounts,
+                                                      const MPI_Aint * sdispls,
+                                                      MPI_Datatype sendtype, void *recvbuf,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * rdispls,
+                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                      MPIR_Request ** req)
 {
     int ret;
 
@@ -620,11 +631,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf, const
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
-                                                      const int *sdispls,
-                                                      const MPI_Datatype sendtypes[],
-                                                      void *recvbuf, const int *recvcounts,
-                                                      const int *rdispls,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf,
+                                                      const MPI_Aint * sendcounts,
+                                                      const MPI_Aint * sdispls,
+                                                      const MPI_Datatype sendtypes[], void *recvbuf,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * rdispls,
                                                       const MPI_Datatype recvtypes[],
                                                       MPIR_Comm * comm, MPIR_Request ** req)
 {
@@ -674,9 +686,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, MPI_Aint
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts, const int *displs,
-                                                    MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm, MPIR_Request ** req)
+                                                    const MPI_Aint * recvcounts,
+                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
+                                                    int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -709,7 +721,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sen
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                           const int *recvcounts,
+                                                           const MPI_Aint * recvcounts,
                                                            MPI_Datatype datatype, MPI_Op op,
                                                            MPIR_Comm * comm, MPIR_Request ** req)
 {
@@ -772,8 +784,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, MPI_Ain
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
-                                                     const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatterv(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * displs, MPI_Datatype sendtype,
                                                      void *recvbuf, MPI_Aint recvcount,
                                                      MPI_Datatype recvtype, int root,
                                                      MPIR_Comm * comm_ptr, MPIR_Request ** req)

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -216,7 +216,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, MPI_Aint sendco
 
 MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
-                                             const int *recvcounts, const int *displs,
+                                             const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                              MPI_Datatype recvtype, MPIR_Comm * comm,
                                              MPIR_Errflag_t * errflag)
 {
@@ -321,8 +321,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, MPI_Aint sendcoun
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const int *sendcounts,
-                                           const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const MPI_Aint * sendcounts,
+                                           const MPI_Aint * displs, MPI_Datatype sendtype,
                                            void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                            int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
@@ -430,7 +430,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *sendbuf, MPI_Aint sendcount
 
 MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf,
-                                          const int *recvcounts, const int *displs,
+                                          const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                           MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                           MPIR_Errflag_t * errflag)
 {
@@ -534,10 +534,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcou
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *sendbuf, const int *sendcounts,
-                                            const int *sdispls, MPI_Datatype sendtype,
-                                            void *recvbuf, const int *recvcounts,
-                                            const int *rdispls, MPI_Datatype recvtype,
+MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *sendbuf, const MPI_Aint * sendcounts,
+                                            const MPI_Aint * sdispls, MPI_Datatype sendtype,
+                                            void *recvbuf, const MPI_Aint * recvcounts,
+                                            const MPI_Aint * rdispls, MPI_Datatype recvtype,
                                             MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -590,11 +590,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *sendbuf, const int *send
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], const MPI_Datatype sendtypes[],
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], const MPI_Datatype recvtypes[],
-                                            MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *sendbuf, const MPI_Aint sendcounts[],
+                                            const MPI_Aint sdispls[],
+                                            const MPI_Datatype sendtypes[], void *recvbuf,
+                                            const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
+                                            const MPI_Datatype recvtypes[], MPIR_Comm * comm,
+                                            MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -706,7 +707,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                 const int recvcounts[], MPI_Datatype datatype,
+                                                 const MPI_Aint recvcounts[], MPI_Datatype datatype,
                                                  MPI_Op op, MPIR_Comm * comm,
                                                  MPIR_Errflag_t * errflag)
 {
@@ -926,7 +927,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *sendbuf, MPI_Ai
 
 MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int ret;
@@ -941,11 +943,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgatherv(const void *sendbuf, MPI_A
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls, MPI_Datatype sendtype,
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm)
+MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallv(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
+                                                     const MPI_Aint * sdispls,
+                                                     MPI_Datatype sendtype, void *recvbuf,
+                                                     const MPI_Aint * recvcounts,
+                                                     const MPI_Aint * rdispls,
+                                                     MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int ret;
 
@@ -959,10 +963,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallv(const void *sendbuf, const 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallw(const void *sendbuf, const int *sendcounts,
+MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallw(const void *sendbuf,
+                                                     const MPI_Aint * sendcounts,
                                                      const MPI_Aint * sdispls,
                                                      const MPI_Datatype * sendtypes, void *recvbuf,
-                                                     const int *recvcounts,
+                                                     const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      const MPI_Datatype * recvtypes,
                                                      MPIR_Comm * comm)
@@ -1015,7 +1020,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather(const void *sendbuf, MPI_A
 
 MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
-                                                       const int *recvcounts, const int *displs,
+                                                       const MPI_Aint * recvcounts,
+                                                       const MPI_Aint * displs,
                                                        MPI_Datatype recvtype, MPIR_Comm * comm,
                                                        MPIR_Request ** req)
 {
@@ -1048,11 +1054,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall(const void *sendbuf, MPI_Ai
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                      const int *sdispls, MPI_Datatype sendtype,
-                                                      void *recvbuf, const int *recvcounts,
-                                                      const int *rdispls, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv(const void *sendbuf,
+                                                      const MPI_Aint * sendcounts,
+                                                      const MPI_Aint * sdispls,
+                                                      MPI_Datatype sendtype, void *recvbuf,
+                                                      const MPI_Aint * recvcounts,
+                                                      const MPI_Aint * rdispls,
+                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                      MPIR_Request ** req)
 {
     int ret;
 
@@ -1067,10 +1076,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv(const void *sendbuf, const
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw(const void *sendbuf, const int *sendcounts,
+MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw(const void *sendbuf,
+                                                      const MPI_Aint * sendcounts,
                                                       const MPI_Aint * sdispls,
-                                                      const MPI_Datatype * sendtypes,
-                                                      void *recvbuf, const int *recvcounts,
+                                                      const MPI_Datatype * sendtypes, void *recvbuf,
+                                                      const MPI_Aint * recvcounts,
                                                       const MPI_Aint * rdispls,
                                                       const MPI_Datatype * recvtypes,
                                                       MPIR_Comm * comm, MPIR_Request ** req)
@@ -1134,7 +1144,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgather(const void *sendbuf, MPI_Aint sendc
 
 MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *sendbuf, MPI_Aint sendcount,
                                               MPI_Datatype sendtype, void *recvbuf,
-                                              const int *recvcounts, const int *displs,
+                                              const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                               MPI_Datatype recvtype, MPIR_Comm * comm,
                                               MPIR_Request ** req)
 {
@@ -1182,10 +1192,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall(const void *sendbuf, MPI_Aint sendco
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv(const void *sendbuf, const int *sendcounts,
-                                             const int *sdispls, MPI_Datatype sendtype,
-                                             void *recvbuf, const int *recvcounts,
-                                             const int *rdispls, MPI_Datatype recvtype,
+MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv(const void *sendbuf, const MPI_Aint * sendcounts,
+                                             const MPI_Aint * sdispls, MPI_Datatype sendtype,
+                                             void *recvbuf, const MPI_Aint * recvcounts,
+                                             const MPI_Aint * rdispls, MPI_Datatype recvtype,
                                              MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
@@ -1200,11 +1210,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv(const void *sendbuf, const int *sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw(const void *sendbuf, const int *sendcounts,
-                                             const int *sdispls, const MPI_Datatype * sendtypes,
-                                             void *recvbuf, const int *recvcounts,
-                                             const int *rdispls, const MPI_Datatype * recvtypes,
-                                             MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw(const void *sendbuf, const MPI_Aint * sendcounts,
+                                             const MPI_Aint * sdispls,
+                                             const MPI_Datatype * sendtypes, void *recvbuf,
+                                             const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
+                                             const MPI_Datatype * recvtypes, MPIR_Comm * comm,
+                                             MPIR_Request ** req)
 {
     int ret;
 
@@ -1252,7 +1263,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igather(const void *sendbuf, MPI_Aint sendcoun
 
 MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
-                                           const int *recvcounts, const int *displs,
+                                           const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                            MPIR_Request ** req)
 {
@@ -1285,8 +1296,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block(const void *sendbuf, voi
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                  const int *recvcounts, MPI_Datatype datatype,
-                                                  MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req)
+                                                  const MPI_Aint * recvcounts,
+                                                  MPI_Datatype datatype, MPI_Op op,
+                                                  MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1346,8 +1358,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatter(const void *sendbuf, MPI_Aint sendcou
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *sendbuf, const int *sendcounts,
-                                            const int *displs, MPI_Datatype sendtype,
+MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *sendbuf, const MPI_Aint * sendcounts,
+                                            const MPI_Aint * displs, MPI_Datatype sendtype,
                                             void *recvbuf, MPI_Aint recvcount,
                                             MPI_Datatype recvtype, int root, MPIR_Comm * comm,
                                             MPIR_Request ** req)

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -592,12 +592,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoallv_intra_composition_alpha(const void *sendbuf,
-                                                                     const int *sendcounts,
-                                                                     const int *sdispls,
+                                                                     const MPI_Aint * sendcounts,
+                                                                     const MPI_Aint * sdispls,
                                                                      MPI_Datatype sendtype,
                                                                      void *recvbuf,
-                                                                     const int *recvcounts,
-                                                                     const int *rdispls,
+                                                                     const MPI_Aint * recvcounts,
+                                                                     const MPI_Aint * rdispls,
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm_ptr,
                                                                      MPIR_Errflag_t * errflag)
@@ -616,13 +616,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoallv_intra_composition_alpha(const void 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoallw_intra_composition_alpha(const void *sendbuf,
-                                                                     const int sendcounts[],
-                                                                     const int sdispls[],
+                                                                     const MPI_Aint sendcounts[],
+                                                                     const MPI_Aint sdispls[],
                                                                      const MPI_Datatype
                                                                      sendtypes[],
                                                                      void *recvbuf,
-                                                                     const int recvcounts[],
-                                                                     const int rdispls[],
+                                                                     const MPI_Aint recvcounts[],
+                                                                     const MPI_Aint rdispls[],
                                                                      const MPI_Datatype
                                                                      recvtypes[],
                                                                      MPIR_Comm * comm_ptr,
@@ -668,8 +668,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgatherv_intra_composition_alpha(const void
                                                                       MPI_Aint sendcount,
                                                                       MPI_Datatype sendtype,
                                                                       void *recvbuf,
-                                                                      const int *recvcounts,
-                                                                      const int *displs,
+                                                                      const MPI_Aint * recvcounts,
+                                                                      const MPI_Aint * displs,
                                                                       MPI_Datatype recvtype,
                                                                       MPIR_Comm * comm_ptr,
                                                                       MPIR_Errflag_t * errflag)
@@ -712,8 +712,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Gatherv_intra_composition_alpha(const void *s
                                                                    MPI_Aint sendcount,
                                                                    MPI_Datatype sendtype,
                                                                    void *recvbuf,
-                                                                   const int *recvcounts,
-                                                                   const int *displs,
+                                                                   const MPI_Aint * recvcounts,
+                                                                   const MPI_Aint * displs,
                                                                    MPI_Datatype recvtype,
                                                                    int root, MPIR_Comm * comm,
                                                                    MPIR_Errflag_t * errflag)
@@ -754,8 +754,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scatter_intra_composition_alpha(const void *s
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Scatterv_intra_composition_alpha(const void *sendbuf,
-                                                                    const int *sendcounts,
-                                                                    const int *displs,
+                                                                    const MPI_Aint * sendcounts,
+                                                                    const MPI_Aint * displs,
                                                                     MPI_Datatype sendtype,
                                                                     void *recvbuf,
                                                                     MPI_Aint recvcount,
@@ -778,7 +778,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scatterv_intra_composition_alpha(const void *
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_scatter_intra_composition_alpha(const void *sendbuf,
                                                                           void *recvbuf,
-                                                                          const int
+                                                                          const MPI_Aint
                                                                           recvcounts[],
                                                                           MPI_Datatype
                                                                           datatype, MPI_Op op,

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -57,8 +57,8 @@ int MPIDU_bc_allgather(MPIR_Comm * allgather_comm, void *bc, int bc_len, int sam
         return mpi_errno;
     }
 
-    int *recv_cnts = MPL_calloc(num_nodes, sizeof(int), MPL_MEM_OTHER);
-    int *recv_offs = MPL_calloc(num_nodes, sizeof(int), MPL_MEM_OTHER);
+    MPI_Aint *recv_cnts = MPL_calloc(num_nodes, sizeof(MPI_Aint), MPL_MEM_OTHER);
+    MPI_Aint *recv_offs = MPL_calloc(num_nodes, sizeof(MPI_Aint), MPL_MEM_OTHER);
     for (i = 0; i < size; i++) {
         int node_id = MPIR_Process.node_map[i];
         recv_cnts[node_id]++;


### PR DESCRIPTION
## Pull Request Description

Last PR (#5044 ) switched to use `MPI_Aint` for all internal collective routines. This PR does the same for the counts/displs array for v-collectives.

Also added python code to generate MPI_Aint impl prototypes and generate
code to do counts array swap before calling MPIR_Xxx



<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
