### PR TITLE
config: configure test/mpi independently

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5031,7 +5031,6 @@ PAC_GET_EXENAME("mpifort", MPIFORT_NAME)
 PAC_GET_EXENAME("mpif90", MPIF90_NAME)
 PAC_GET_EXENAME("mpif77", MPIF77_NAME)
 
-AC_CONFIG_SUBDIRS([test/mpi])
 dnl
 dnl Generate the Makefiles from Makefile.in
 dnl Also generate mpi.h from mpi.h.in so that we can eliminate all ifdefs

--- a/test/mpi/autogen.sh
+++ b/test/mpi/autogen.sh
@@ -4,6 +4,8 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
+autoreconf -ivf
+
 # Create and/or update the f90 tests
 printf "Create or update the Fortran 90 tests derived from the Fortran 77 tests... "
 for dir in f77/* ; do


### PR DESCRIPTION
## Pull Request Description

We used to configure test/mpi as a sub-configure of mpich. For one, this
wastes build (configure) time when user has no intention to run the full
testsuite. For two, this complicates the build script since
test/mpi/configure.ac need deal with two very difference situation --
configured standalone or configured from mpich.

Since we'll need installing the mpich before running the test suite
anyway, it makes little sense to configure test suite during the build
of mpich. While we may need add additional feature tests to detect
enable/disabled mpich features, it is necessary to fully support
independent MPI testing anyway.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
