### PR TITLE
config: configure test/mpi independently

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3992,7 +3992,6 @@ PAC_GET_EXENAME("mpifort", MPIFORT_NAME)
 PAC_GET_EXENAME("mpif90", MPIF90_NAME)
 PAC_GET_EXENAME("mpif77", MPIF77_NAME)
 
-AC_CONFIG_SUBDIRS([test/mpi])
 dnl
 dnl Generate the Makefiles from Makefile.in
 dnl Also generate mpi.h from mpi.h.in so that we can eliminate all ifdefs

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,9 +9,11 @@
 SUBDIRS = mpi commands .
 
 # Test both the MPI routines and the MPICH command scripts
-testing:
+testing: mpi/Makefile
 	(NOXMLCLOSE=YES && export NOXMLCLOSE && cd mpi && $(MAKE) testing)
 	(XMLFILE=../mpi/summary.xml && XMLCONTINUE=YES && \
 	export XMLFILE && export XMLCONTINUE && \
 	cd commands && $(MAKE) testing)
 
+mpi/Makefile:
+	cd mpi && ./autogen.sh && ./configure --with-mpi=${prefix}

--- a/test/mpi/autogen.sh
+++ b/test/mpi/autogen.sh
@@ -25,6 +25,9 @@ check_copy version.m4     ../../maint/version.m4
 check_copy confdb         ../../confdb
 check_copy dtpools/confdb ../../confdb
 
+echo "Running autoreconf in dtpools"
+(cd dtpools && autoreconf -ivf)
+
 # Create and/or update the f90 tests
 printf "Create or update the Fortran 90 tests derived from the Fortran 77 tests... "
 for dir in f77/* ; do
@@ -57,4 +60,5 @@ for dir in errors/f77/* ; do
 done
 echo "done"
 
+echo "Running autoreconf in ."
 autoreconf -ivf

--- a/test/mpi/autogen.sh
+++ b/test/mpi/autogen.sh
@@ -4,6 +4,27 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
+check_copy() {
+    name=$1
+    orig=$2
+    printf "Checking $name... "
+    if test ! -e $name ; then
+        if test -e $orig; then
+            cp -a $orig $name
+            echo "copy from $orig"
+        else
+            echo "missing"
+            exit 1
+        fi
+    else
+        echo "found"
+    fi
+}
+
+check_copy version.m4     ../../maint/version.m4
+check_copy confdb         ../../confdb
+check_copy dtpools/confdb ../../confdb
+
 # Create and/or update the f90 tests
 printf "Create or update the Fortran 90 tests derived from the Fortran 77 tests... "
 for dir in f77/* ; do

--- a/test/mpi/autogen.sh
+++ b/test/mpi/autogen.sh
@@ -35,3 +35,5 @@ for dir in errors/f77/* ; do
     fi
 done
 echo "done"
+
+autoreconf -ivf

--- a/test/mpi/basic/adapt.c
+++ b/test/mpi/basic/adapt.c
@@ -90,7 +90,7 @@ void PrintOptions(void);
 int DetermineLatencyReps(ArgStruct * p);
 int DetermineLatencyReps012(ArgStruct * p);
 
-void PrintOptions()
+void PrintOptions(void)
 {
     printf("\n");
     printf("Usage: adapt flags\n");

--- a/test/mpi/basic/netmpi.c
+++ b/test/mpi/basic/netmpi.c
@@ -85,7 +85,7 @@ double TestSyncTime(ArgStruct * p);
 void PrintOptions(void);
 int DetermineLatencyReps(ArgStruct * p);
 
-void PrintOptions()
+void PrintOptions(void)
 {
     printf("\n");
     printf("Usage: netpipe flags\n");
@@ -464,7 +464,7 @@ int main(int argc, char *argv[])
 
 
 /* Return the current time in seconds, using a double precision number. 	 */
-double When()
+double When(void)
 {
     return MPI_Wtime();
 }

--- a/test/mpi/coll/allred.c
+++ b/test/mpi/coll/allred.c
@@ -8,8 +8,8 @@
  *        will occur as the number of processors is increased.
  */
 
-#include "mpi.h"
 #include "mpitest.h"
+#include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/mpi/coll/allred2.c
+++ b/test/mpi/coll/allred2.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mpitest.h"
 #include "mtest_dtp.h"
 
 /*

--- a/test/mpi/coll/bcast.c
+++ b/test/mpi/coll/bcast.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mpitest.h"
 #include "dtpools.h"
 #include "mtest_dtp.h"
 #include <assert.h>

--- a/test/mpi/coll/nonblocking2.c
+++ b/test/mpi/coll/nonblocking2.c
@@ -34,7 +34,6 @@ static void sum_fn(void *invec, void *inoutvec, int *len, MPI_Datatype * datatyp
     int i;
     int *in = invec;
     int *inout = inoutvec;
-    int stride;
 
     if (*datatype == MPI_INT) {
         for (i = 0; i < *len; ++i) {

--- a/test/mpi/coll/op_coll.c
+++ b/test/mpi/coll/op_coll.c
@@ -5,10 +5,10 @@
 
 /* A test of all op-based collectives with support for GPU buffers */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include "mpitest.h"
 #include "mtest_dtp.h"
 
 #define COUNT (10)

--- a/test/mpi/coll/p_alltoall.c
+++ b/test/mpi/coll/p_alltoall.c
@@ -36,7 +36,6 @@ int main(int argc, char **argv)
     MPI_Comm comm;
     int iters = 10;
     int j = 0;
-    int root = 1;
     int count = 1;              /* sendcount and recvcount. */
 
     MTest_Init(&argc, &argv);

--- a/test/mpi/coll/p_barrier.c
+++ b/test/mpi/coll/p_barrier.c
@@ -12,7 +12,7 @@ int main(int argc, char *argv[])
 {
     MPI_Request req;
     MPI_Info info;
-    int rank, i, done;
+    int rank, i;
 
     MTest_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/test/mpi/coll/reduce.c
+++ b/test/mpi/coll/reduce.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mpitest.h"
 #include "mtest_dtp.h"
 
 /*

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -608,15 +608,6 @@ AC_SUBST(mpix)
 # to noninst_PROGRAMS to skip building the tests when we do strict MPI test
 AM_CONDITIONAL([BUILD_MPIX_TESTS], [test "$enable_strictmpi" = "no"])
 
-# preserve these values across a reconfigure
-AC_ARG_VAR([WRAPPER_CFLAGS],[])
-AC_ARG_VAR([WRAPPER_CPPFLAGS],[])
-AC_ARG_VAR([WRAPPER_LDFLAGS],[])
-AC_ARG_VAR([WRAPPER_LIBS],[])
-AC_ARG_VAR([WRAPPER_FFLAGS],[])
-AC_ARG_VAR([WRAPPER_FCFLAGS],[])
-AC_ARG_VAR([WRAPPER_CXXFLAGS],[])
-
 dnl We cannot use AC_C_LONG_DOUBLE
 dnl because it does not support cross-compilation.  Instead, we use the
 dnl same test in the MPICH configure.

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1280,9 +1280,20 @@ fi
 # Running C++ compiler tests
 AC_PROG_CXX
 if test "$enable_cxx" = yes ; then
-    if test -z "$CXX" ; then
+    AC_MSG_CHECKING([that we can build MPI programs with CXX binding])
+    AC_LANG_PUSH([C++])
+    AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([#include "mpi.h"], [
+            MPI::Init(NULL, NULL);
+            MPI::Finalize();
+        ])
+    ],[
+        AC_MSG_RESULT(yes)
+    ],[
         enable_cxx=no
-    fi
+        AC_MSG_RESULT(no)
+    ])
+    AC_LANG_POP([C++])
 fi
 # Simple tests for which other languages we can handle
 cxxdir="#"

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -972,57 +972,6 @@ if test "$buildingF77" = "yes" ; then
         MPI_SIZEOF_AINT=$ac_cv_sizeof_void_p
     fi
     if test -z "$MPI_SIZEOF_OFFSET" ; then
-        # We have to try and get the size of offset anyway, since
-        # it is not the same as void * (it depends on the available
-        # file systems).  Since we want to avoid using the MPI linker,
-        # we could do the following:
-        #    Use the mpi compiler to compile the file, using the mpi
-        #    header but no MPI calls
-        #    Use the regular C linker to link the program
-        # However, we do this only if the environment variable BASECC
-        # has been provided.  Else we can try the following:
-        # use
-        #    sed -n 's/typedef \(.*\) MPI_Offset *;/\1/p' mpi.h
-        # to extract the type corresponding to MPI_Offset and then
-        # just use that.
-dnl         AC_CACHE_CHECK([the sizeof MPI_Offset],ac_cv_sizeof_MPI_Offset,[
-dnl              ac_cv_sizeof_MPI_Offset=unknown
-dnl              rm -f conftest*
-dnl              cat >>conftest.c <<EOF
-dnl #include "mpi.h"
-dnl #include <stdio.h>
-dnl int main( int argc, char **argv )
-dnl {
-dnl     MPI_Offset a;
-dnl     FILE *f = fopen("conftestval", "w" );
-dnl     if (! f) exit(1);
-dnl     fprintf( f, "%ld\n", (long)sizeof(MPI_Offset) );
-dnl     fclose(f);
-dnl     return 0;
-dnl }
-dnl EOF
-dnl             # FIXME.  Check for BASECC
-dnl             # Note: This assumes that CC has been set to the C compiler for
-dnl             # MPI Programs, and that either any necessary include paths are
-dnl             # already set or they are in CPPFLAGS (preferred) or CFLAGS.
-dnl             if AC_TRY_EVAL(ac_link) && test -s conftest$ac_exeext ; then
-dnl                 if ./conftest$ac_exeext ; then
-dnl                     #success
-dnl                     ac_cv_sizeof_MPI_Offset=`cat conftestval`
-dnl                 else
-dnl                     # failure
-dnl                     AC_MSG_WARN([Unable to run the program to determine the size of MPI_Offset])
-dnl                     echo "configure: failed program was:" >&AS_MESSAGE_LOG_FD
-dnl                     cat conftest.c >&AS_MESSAGE_LOG_FD
-dnl                 fi
-dnl             else
-dnl                 # failure
-dnl                 AC_MSG_WARN([Unable to build the program to determine the size of MPI_Offset])
-dnl                 echo "configure: failed program was:" >&AS_MESSAGE_LOG_FD
-dnl                 cat conftest.c >&AS_MESSAGE_LOG_FD
-dnl             fi
-dnl             rm -f conftest*
-dnl         ])
         AC_CHECK_SIZEOF([MPI_Offset],[],[#include "mpi.h"])
         if test "$ac_cv_sizeof_MPI_Offset" = "unknown" \
              -o "$ac_cv_sizeof_MPI_Offset" -eq 0 ; then

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -423,6 +423,8 @@ AC_PROG_CC
 AC_PROG_CC_C99
 AM_PROG_CC_C_O
 
+AC_USE_SYSTEM_EXTENSIONS
+
 # Ensure that we can compile an MPI program before we go any further
 # We don't use a cached value here because this is a sanity check
 AC_MSG_CHECKING([whether we can compile and link MPI programs in C])

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -403,10 +403,8 @@ else
         AC_PATH_PROG(MPIEXEC,$MPIEXEC_NAME)
     fi
 fi
-# Make sure we export CC before configuring DTPools, since MPI is
-# needed to build the library.
-export CC
-AC_CONFIG_SUBDIRS([dtpools])
+
+PAC_CONFIG_SUBDIR_ARGS([dtpools])
 
 # Running C compiler tests
 AC_PROG_CC

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -229,12 +229,9 @@ AC_ARG_ENABLE(threads,
         serialized - User serializes calls to MPI (MPI_THREAD_SERIALIZED)
         multiple - Fully multi-threaded (MPI_THREAD_MULTIPLE)
 
-        The default is funneled.  If enabled and no level is
+        The default is to run check. If enabled and no level is
         specified, the level is set to multiple.  If disabled, the
-        level is set to single.  If the environment variable
-        MPICH_THREAD_LEVEL is set, that thread level is used (this is
-        to let MPICH build for the correct thread support without
-        requiring a specific --enable-threads argument.],,
+        level is set to single.],,
         [enable_threads=default])
 
 AC_ARG_ENABLE(xfail,
@@ -358,37 +355,23 @@ if test -n "$F90" -o -n "$F90FLAGS" ; then
     AC_MSG_ERROR([F90 and F90FLAGS are replaced by FC and FCFLAGS respectively in this configure, please unset F90/F90FLAGS and set FC/FCFLAGS instead and rerun configure again.])
 fi
 
-# ------------------------------------------------------------------------
-dnl use AC_ARG_VAR to mark FROM_MPICH as "precious" to autoconf so that
-dnl automatic re-runs of config.status preserve its value correctly
-AC_ARG_VAR([FROM_MPICH],[should be set to "yes" if this configure script is being invoked by the main MPICH configure])
-AC_ARG_VAR([MPICH_THREAD_LEVEL],
-           [the MPI thread level supported by the enclosing MPICH build (when built within MPICH)])
-# ------------------------------------------------------------------------
-
+# check whether to enable thread tests
+#
 if test "$enable_threads" = "yes" ; then
     enable_threads=multiple
 elif test "$enable_threads" = "no" ; then
     enable_threads=single
 elif test "$enable_threads" = default ; then
-    if test -n "$MPICH_THREAD_LEVEL" ; then
-        case $MPICH_THREAD_LEVEL in
-            MPI_THREAD_MULTIPLE)
-            enable_threads=multiple
-            ;;
-            MPI_THREAD_SERIALIZED)
-            enable_threads=serialized
-            ;;
-            MPI_THREAD_FUNNELED)
-            enable_threads=funneled
-            ;;
-            MPI_THREAD_SINGLE)
-            enable_threads=single
-            ;;
-        esac
-    else
-        enable_threads=funneled
-    fi
+    # I believe AC_TRY_RUN here is OK. The worst case (for cross compile) will result in
+    # multi-thread tests disabled. By pass by explicitly configure with --enable-threads=xxx
+    AC_TRY_RUN(AC_LANG_PROGRAM([#include "mpi.h"],[
+            int provided = MPI_THREAD_SINGLE;
+            MPI_Init_thread(0,0,MPI_THREAD_MULTIPLE,&provided);
+            MPI_Finalize();
+            if (provided != MPI_THREAD_MULTIPLE) exit(1);
+        ]),
+        [enable_threads=multiple], [enable_threads=single], [enable_threads=single]
+    )
 fi
 
 # errordir is substituted into the testlist file as errors when the
@@ -454,23 +437,6 @@ AC_SUBST(MPILIBLOC)
 AC_ARG_VAR([MPICH_ENABLE_FC],["yes" if the enclosing MPICH build supports modern Fortran])
 AC_ARG_VAR([MPICH_ENABLE_CXX],["yes" if the enclosing MPICH build supports C++])
 
-# If we're building from MPICH, check the MPICH_ENABLE_xxx environment
-# variables for enable defaults
-if test "$FROM_MPICH" = yes ; then
-    if test -n "$MPICH_ENABLE_FC" ; then
-        enable_f77=$MPICH_ENABLE_FC
-        enable_fc=$MPICH_ENABLE_FC
-    fi
-    if test -n "$MPICH_ENABLE_CXX" ; then
-        enable_cxx=$MPICH_ENABLE_CXX
-    fi
-    namepub_tests="#"
-    if test -n "$nameserv_name" ; then
-        namepub_tests=""
-    fi
-    AC_SUBST(namepub_tests)
-fi
-
 # Some MPI-2 implementations (including some of the MPICH shared-memory
 # channels and BG/L) leave out the dynamic process routines.  This
 # allows tests to avoid reporting failure for these routines.
@@ -522,8 +488,8 @@ fi
 # based on earlier versions of MPICH.
 MPI_HAS_MPIX=no
 #
-# Hack to detect build from within MPICH.  Ensure strictmpi not selected.
-if test "$FROM_MPICH" = "yes" -a "$enable_strictmpi" = "no" ; then
+# If MPI is derived from MPICH and strictmpi not selected, let's test mpix extensions.
+if test "$MPI_IS_MPICH" = "yes" -a "$enable_strictmpi" = "no" ; then
    MPI_HAS_MPIX=yes
 fi
 AC_SUBST(MPI_HAS_MPIX)
@@ -556,24 +522,7 @@ PAC_GET_EXENAME("mpifort", MPIFORT_NAME)
 PAC_GET_EXENAME("mpicxx", MPICXX_NAME)
 PAC_GET_EXENAME("mpiexec", MPIEXEC_NAME)
 
-if test "$FROM_MPICH" = "yes" ; then
-    # perform configure tests with the normal compilers ($CC/$F77/etc), but use
-    # the WRAPPER_xFLAGS computed by MPICH as our flags instead.  Then at the
-    # end of configure we will empty out these flags and set our compilers to
-    # the installed compiler wrappers
-    CFLAGS="$WRAPPER_CFLAGS"
-    CPPFLAGS="$WRAPPER_CPPFLAGS"
-    LDFLAGS="$WRAPPER_LDFLAGS"
-    FFLAGS="$WRAPPER_FFLAGS"
-    FCFLAGS="$WRAPPER_FCFLAGS"
-    CXXFLAGS="$WRAPPER_CXXFLAGS"
-
-    # WRAPPER_LIBS contains currently non-existent libs like "-lopa" and "-lmpl"
-    # right now, so set LIBS to the user-specified libs for now.
-    # FIXME Does this need to be an AC_ARG_VAR?
-    LIBS="$MPICH_LIBS"
-
-elif test -n "$with_mpi" ; then
+if test -n "$with_mpi" ; then
     if test -z "$MPICC" ; then
         CC=$with_mpi/bin/$MPICC_NAME
     else
@@ -639,25 +588,24 @@ AC_PROG_CC
 AC_PROG_CC_C99
 AM_PROG_CC_C_O
 
-# Note that some versions of autoconf will insist that the compiler
-# produce executables at this point, which is why we must do something
-# special for building within MPICH
-
 # Ensure that we can compile an MPI program before we go any further
 # We don't use a cached value here because this is a sanity check
-# The exception is if we are executing this configure from within the
-# MPICH configure - in that case, the
-if test "$FROM_MPICH" != "yes" ; then
-    AC_MSG_CHECKING([whether we can compile and link MPI programs in C])
-    AC_LINK_IFELSE([
-AC_LANG_PROGRAM([#include "mpi.h"],[MPI_Init(0,0);MPI_Finalize();])
+AC_MSG_CHECKING([whether we can compile and link MPI programs in C])
+AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([#include "mpi.h"],[MPI_Init(0,0);MPI_Finalize();])
     ],[mpi_compile_works=yes],[mpi_compile_works=no])
 AC_MSG_RESULT($mpi_compile_works)
 
-    if test "$mpi_compile_works" != "yes" ; then
-       AC_MSG_ERROR([Unable to compile and/or link an MPI program!  Check config.log])
-    fi
+if test "$mpi_compile_works" != "yes" ; then
+    AC_MSG_ERROR([Unable to compile and/or link an MPI program!  Check config.log])
 fi
+
+# Check whether we are testing MPI derived from MPICH
+MPI_IS_MPICH=no
+AC_MSG_CHECKING([Is the MPI derived from MPICH])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[return 1 + MPICH;])],
+    [MPI_IS_MPICH=yes],[MPI_IS_MPICH=no])
+
 dnl We cannot use AC_C_LONG_DOUBLE
 dnl because it does not support cross-compilation.  Instead, we use the
 dnl same test in the MPICH configure.
@@ -934,42 +882,25 @@ AC_CHECK_FUNCS(getrusage)
 # Check for the MPI Version.  This test assumes at least MPI 2.0.  For
 # some tests, we need to know if we are MPI 2.1 or MPI 2.2,
 # particularly for new routines in Fortran
-if test "$FROM_MPICH" != "yes" ; then
-    AC_CACHE_CHECK([that MPI program can be compiled],pac_cv_mpi_compile_ok,[
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[MPI_Init(0,0);MPI_Finalize();])],pac_cv_mpi_compile_ok=yes,pac_cv_mpi_compile_ok=no)])
-    if test "$pac_cv_mpi_compile_ok" != yes ; then
-        AC_MSG_ERROR([Unable to compile an MPI program containing mpi.h!])
-    fi
-    AC_CACHE_CHECK([for major version of MPI],pac_cv_mpi_major_version,[
-for pac_cv_mpi_major_version in 3 2 1 unknown ; do
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[
+AC_CACHE_CHECK([for major version of MPI],pac_cv_mpi_major_version,[
+    for pac_cv_mpi_major_version in 3 2 1 unknown ; do
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[
 #if MPI_VERSION == $pac_cv_mpi_major_version
     ''' force failure '''
 #endif])],,break)
-done
+    done
 ])
 
-    AC_CACHE_CHECK([for minor version of MPI],pac_cv_mpi_minor_version,[
-for pac_cv_mpi_minor_version in 4 3 2 1 0 unknown ; do
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[
+AC_CACHE_CHECK([for minor version of MPI],pac_cv_mpi_minor_version,[
+    for pac_cv_mpi_minor_version in 4 3 2 1 0 unknown ; do
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[
 #if MPI_SUBVERSION == $pac_cv_mpi_minor_version
     ''' force failure '''
 #endif])],,break)
-done
+    done
 ])
 MPI_VERSION=$pac_cv_mpi_major_version
 MPI_SUBVERSION=$pac_cv_mpi_minor_version
-else
-    # We are within the MPICH build.  Extract the MPI versions from
-    # mpi.h.in
-    if test ! -f $mpich_top_srcdir/src/include/mpi.h.in ; then
-        AC_MSG_ERROR([Could not find the required mpi.h.in file!])
-    fi
-    MPI_VERSION=`grep MPI_VERSION $mpich_top_srcdir/src/include/mpi.h.in | \
-                      sed -e 's/#define *MPI_VERSION *\([0-4]\).*/\1/g'`
-    MPI_SUBVERSION=`grep MPI_SUBVERSION $mpich_top_srcdir/src/include/mpi.h.in | \
-                      sed -e 's/#define *MPI_SUBVERSION *\([0-9]\).*/\1/g'`
-fi
 
 AC_SUBST(MPI_VERSION)
 AC_SUBST(MPI_SUBVERSION)
@@ -987,14 +918,7 @@ fi
 f77dir="#"
 AC_SUBST(f77dir)
 buildingF77=no
-if test "$FROM_MPICH" = yes ; then
-    if test "$enable_f77" = yes ; then
-       # Assume success
-        otherlangs="$otherlangs f77"
-        f77dir=f77
-        buildingF77=yes
-    fi
-elif test "$enable_f77" = yes ; then
+if test "$enable_f77" = yes ; then
     AC_MSG_CHECKING([that we can build MPI programs with Fortran 77])
     AC_LANG_PUSH([Fortran 77])
     AC_LINK_IFELSE([
@@ -1307,13 +1231,7 @@ if test "$enable_fc" = yes ; then
     # Make sure that the compilers are compatible.  This
     # will also make sure that the program named in FC is
     # a working Fortran 90 compiler
-    # Only check if we're *not* building within MPICH
-    # (MPICH will have made the test)
-    # FIXME: Do we want to check only simple routine names
-    # (those without an underscore?)
-    if test "$FROM_MPICH" != yes ; then
-        PAC_FC_AND_F77_COMPATIBLE(enable_fc=yes,enable_fc=no)
-    fi
+    PAC_FC_AND_F77_COMPATIBLE(enable_fc=yes,enable_fc=no)
 fi
 
 if test "$enable_fc" = yes ; then
@@ -1381,12 +1299,7 @@ if test "$enable_fc" = yes ; then
     PAC_FC_MODULE
 fi
 #
-if test "$FROM_MPICH" = yes ; then
-    if test "$enable_fc" = yes ; then
-        otherlangs="$otherlangs f90"
-        f90dir=f90
-    fi
-elif test "$enable_fc" = yes ; then
+if test "$enable_fc" = yes ; then
     AC_MSG_CHECKING([that we can build MPI programs with Fortran 90])
     AC_LANG_PUSH([Fortran])
     AC_LINK_IFELSE([
@@ -1408,15 +1321,27 @@ elif test "$enable_fc" = yes ; then
     AC_LANG_POP([Fortran])
 fi
 
-if test "$enable_f08" = "yes" ; then
-    PAC_FC_2008_SUPPORT([enable_f08=yes],[enable_f08=no])
-fi
-
 f08dir="#"
 AC_SUBST(f08dir)
-# FIXME if $FROM_MPICH is no, we should test build an MPI F08 program
-if test "$enable_f08" = "yes" -a "$FROM_MPICH" = "yes" ; then
-   f08dir=f08
+if test "$enable_f08" = "yes" ; then
+    AC_MSG_CHECKING([that we can build MPI programs with use mpi_f08])
+    AC_LANG_PUSH([Fortran])
+    AC_LINK_IFELSE([
+        AC_LANG_SOURCE([
+            program main
+            use mpi_f08
+            integer ierr
+            call mpi_init(ierr)
+            call mpi_finalize(ierr)
+            end
+        ])
+    ],[
+        AC_MSG_RESULT(yes)
+        f08dir=f08
+    ],[
+        AC_MSG_RESULT(no)
+    ])
+    AC_LANG_POP([Fortran])
 fi
 
 # Running C++ compiler tests
@@ -1433,15 +1358,7 @@ cxxdir="#"
 # us to detect that and to skip the test when it is not supported.
 nocxxdistgraph="#"
 AC_SUBST(cxxdir)
-if test "$FROM_MPICH" = yes ; then
-    if test "$enable_cxx" = yes ; then
-        otherlangs="$otherlangs cxx"
-        cxxdir=cxx
-        # MPICH ABI removed support for MPI::Distgraphcomm, so
-        # nocxxdistgraph is left as #, which comments out the test
-        # in cxx/topol/testlist.in
-    fi
-elif test "$enable_cxx" = yes ; then
+if test "$enable_cxx" = yes ; then
     AC_MSG_CHECKING([that we can build MPI programs with C++])
     AC_LANG_PUSH([C++])
     AC_LINK_IFELSE([
@@ -1525,17 +1442,12 @@ iodir="#"
 if test "$enable_romio" != no ; then
     iodir=io
     AC_DEFINE(HAVE_MPI_IO,1,[Define if MPI-IO (really ROMIO) is included])
-    if test "$FROM_MPICH" = yes ; then
-        # MPICH no longer uses and MPIO_Request
-        pac_cv_have_mpio_request=no
-    else
-        AC_CACHE_CHECK([whether MPIO_Request is defined for MPI IO],
-        pac_cv_have_mpio_request,[
-            AC_COMPILE_IFELSE([
-                AC_LANG_PROGRAM([#include "mpi.h"],[MPIO_Request r;])
-            ],[pac_cv_have_mpio_request=yes],[pac_cv_have_mpio_request=no])
-        ])
-    fi
+    AC_CACHE_CHECK([whether MPIO_Request is defined for MPI IO],
+    pac_cv_have_mpio_request,[
+        AC_COMPILE_IFELSE([
+            AC_LANG_PROGRAM([#include "mpi.h"],[MPIO_Request r;])
+        ],[pac_cv_have_mpio_request=yes],[pac_cv_have_mpio_request=no])
+    ])
     if test "$pac_cv_have_mpio_request" = no ; then
         AC_DEFINE(MPIO_USES_MPI_REQUEST,,[Define if MPI IO uses MPI_Request])
     fi
@@ -1546,39 +1458,23 @@ impldir="#"
 #
 # Check for implementation to enable implementation-specific options
 if test $enable_strictmpi != "yes" ; then
-   # Is this MPICH?
-   if test "$FROM_MPICH" = yes ; then
-      impldir="mpich"
-   else
-       AC_CACHE_CHECK([Is the MPI derived from MPICH],
-       pac_cv_ismpich,[
-           AC_COMPILE_IFELSE([
-               AC_LANG_PROGRAM([#include "mpi.h"],[return 1 + MPICH;])
-           ],[pac_cv_ismpich=yes],[pac_cv_ismpich=no])
-       ])
-       if test "$pac_cv_ismpich" = "yes" ; then
-           impldir="mpich"
-       fi
-   fi
+    if test "$MPI_IS_MPICH" = "yes" ; then
+        impldir="mpich"
+    fi
 fi
 AC_SUBST(impldir)
 #
 # MPI_INTEGER16 is mentioned in only one place in MPI 2.1, and some
 # implementations may have missed it.  Check to see if it is available in
 # C.
-if test "$FROM_MPICH" = yes ; then
-   # MPICH correctly includes this type.
-   pac_cv_have_mpi_integer16=yes
-else
-    AC_CACHE_CHECK([whether MPI_INTEGER16 is available],
-    pac_cv_have_mpi_integer16,[
-        AC_COMPILE_IFELSE([
-            AC_LANG_PROGRAM([#include "mpi.h"],[
-                MPI_Datatype t = MPI_INTEGER16;
-            ])
-        ],[pac_cv_have_mpi_integer16=yes],[pac_cv_have_mpi_integer16=no])
-    ])
-fi
+AC_CACHE_CHECK([whether MPI_INTEGER16 is available],
+pac_cv_have_mpi_integer16,[
+    AC_COMPILE_IFELSE([
+        AC_LANG_PROGRAM([#include "mpi.h"],[
+            MPI_Datatype t = MPI_INTEGER16;
+        ])
+    ],[pac_cv_have_mpi_integer16=yes],[pac_cv_have_mpi_integer16=no])
+])
 if test "$pac_cv_have_mpi_integer16" = yes ; then
     AC_DEFINE(HAVE_MPI_INTEGER16,1,[Define if MPI_INTEGER16 is available])
 fi
@@ -1624,60 +1520,9 @@ dnl the location of the source of the MPI implementation into the XML
 dnl summary file
 AC_SUBST(MPI_SOURCE)
 
-if test "$FROM_MPICH" = yes ; then
-    # Set compilers/flags to be substituted in output files, e.g. Makefiles.
-    LDFLAGS="$saveLDFLAGS"
-    # note that the default definition of bindir is
-    #    '${exec_prefix}/bin'
-    # so even if prefix is set, exec prefix is not until
-    # the very last moment (i.e., not here).
-    if test "X$exec_prefix" = "XNONE" ; then
-        saveExec_prefix=$exec_prefix
-        if test "X$prefix" = "XNONE" ; then
-            # Use the default
-            exec_prefix=$ac_default_prefix
-        else
-            exec_prefix=$prefix
-        fi
-        # Evaluate with the current setting of exec_prefix
-        eval mpibindir=${bindir}
-        exec_prefix=$saveExec_prefix
-    else
-        eval mpibindir=${bindir}
-    fi
-
-    # we did our tests with the base compilers, now point the make system at the
-    # installed compiler wrappers for actually building the tests
-    CC=$mpibindir/$MPICC_NAME
-    F77=$mpibindir/$MPIF77_NAME
-    FC=$mpibindir/$MPIFORT_NAME
-    CXX=$mpibindir/$MPICXX_NAME
-    if test -z "$MPIEXEC" ; then
-        MPIEXEC=$mpibindir/$MPIEXEC_NAME
-    fi
-
-    # Zero out the flags, since they are already contained in the compiler
-    # wrapper scripts.  Note that this will kill any flags that have been added
-    # to the xFLAGS only in this script.
-    #
-    # The only real flags we seem to add in this script relate to cray
-    # pointer support in Fortran, so we include that var here where
-    # appropriate.
-    #
-    # The other case are the performance tests - for datatype performance,
-    # compiling with optimization is important.
-    CFLAGS=""
-    CPPFLAGS=""
-    LDFLAGS=""
-    LIBS=""
-    FFLAGS="$CRAYPTR_FFLAGS"
-    FCFLAGS="$CRAYPTR_FCFLAGS"
-    CXXFLAGS=""
-else
-    # We need either mpiexec or mpirun.  If we don't find them,
-    # the user will need to determine how to run a program
-    AC_PATH_PROG(MPIEXEC,$MPIEXEC_NAME)
-fi
+# We need either mpiexec or mpirun.  If we don't find them,
+# the user will need to determine how to run a program
+AC_PATH_PROG(MPIEXEC,$MPIEXEC_NAME)
 
 # TODO: use variables such as has_f77 etc. instead of double use $f77dir etc.
 AM_CONDITIONAL([HAS_F77], [test $f77dir = f77])

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -6,12 +6,12 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ(2.67)
 dnl
-dnl aclocal_cache.m4, included by sowing/confdb/aclocal.m4, fixes 
+dnl aclocal_cache.m4, included by sowing/confdb/aclocal.m4, fixes
 dnl bugs in autoconf caching.
 dnl
 dnl
 dnl Environment variables that affect behavior of the test configure
-dnl MPICH_FAST 
+dnl MPICH_FAST
 dnl
 dnl The file name here refers to a file in the source being configured
 dnl FIXME this is the old style, needs updating to new style
@@ -46,9 +46,9 @@ AM_MAINTAINER_MODE([enable])
 # Non-verbose make by default
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-if test -z "$mpich_top_srcdir" ; then 
+if test -z "$mpich_top_srcdir" ; then
     if test -z "$top_srcdir" ; then
-       use_top_srcdir=$srcdir   
+       use_top_srcdir=$srcdir
     else
        use_top_srcdir=$top_srcdir
     fi
@@ -56,9 +56,9 @@ if test -z "$mpich_top_srcdir" ; then
     /*) ;;
     *)
         use_top_srcdir=`(cd $use_top_srcdir && pwd)`
-        ;;        
+        ;;
     esac
-    if test -f $use_top_srcdir/../../maint/version.m4 ; then 
+    if test -f $use_top_srcdir/../../maint/version.m4 ; then
         mpich_top_srcdir=`cd $use_top_srcdir && cd ../.. && pwd`
     fi
 fi
@@ -73,7 +73,7 @@ AC_ARG_VAR([main_top_srcdir],[path to the MPICH top-level source directory (if p
 # since some of the Makefile targets require it.
 if test "X$main_top_srcdir" = "X" -a "$USE_MAINTAINER_MODE" = "yes" ; then
     if test -z "$top_srcdir" ; then
-       use_top_srcdir=$srcdir   
+       use_top_srcdir=$srcdir
     else
        use_top_srcdir=$top_srcdir
     fi
@@ -82,19 +82,19 @@ if test "X$main_top_srcdir" = "X" -a "$USE_MAINTAINER_MODE" = "yes" ; then
     /*) ;;
     *)
         use_top_srcdir=`(cd $use_top_srcdir && pwd)`
-        ;;        
+        ;;
     esac
     # Now, see if we can find the f77tof90 routine
     if test -x $use_top_srcdir/maint/f77tof90 ; then
         main_top_srcdir=$use_top_srcdir
-    else 
+    else
         AC_MSG_ERROR([Unable to find main source file - reconfigure using --disable-maintainer_mode])
     fi
 fi
 
 AC_ARG_ENABLE(echo,
-	[AS_HELP_STRING([--enable-echo],[Turn on strong echoing. The default is enable=no.])],
-	[set -x])
+        [AC_HELP_STRING([--enable-echo],[Turn on strong echoing. The default is enable=no.])],
+        [set -x])
 
 AC_ARG_ENABLE(fortran,
 [  --enable-fortran=option - Control the level of Fortran support in the MPICH implementation.
@@ -142,105 +142,105 @@ fi
 AC_SUBST(DTP_SWITCH)
 
 AC_ARG_ENABLE(cxx,
-	[AS_HELP_STRING([--enable-cxx],[Turn on C++ tests (default)])],,[enable_cxx=yes])
+        [AC_HELP_STRING([--enable-cxx],[Turn on C++ tests (default)])],,[enable_cxx=yes])
 
 AC_ARG_ENABLE(romio,
-	[AS_HELP_STRING([--enable-romio],[Enable ROMIO MPI I/O implementation])],,
-	[enable_romio=yes])
+        [AC_HELP_STRING([--enable-romio],[Enable ROMIO MPI I/O implementation])],,
+        [enable_romio=yes])
 
 AC_ARG_ENABLE(spawn,
-	[AS_HELP_STRING([--enable-spawn],
-		[Enable tests of the dynamic process parts of MPI-2 (default)])],,
-	[enable_spawn=yes])
+        [AC_HELP_STRING([--enable-spawn],
+                [Enable tests of the dynamic process parts of MPI-2 (default)])],,
+        [enable_spawn=yes])
 
 AC_ARG_ENABLE(rma,
-	[AS_HELP_STRING([--enable-rma],[Enable tests of the one sided parts of MPI-2 (default)])],,
-	[enable_rma=yes])
+        [AC_HELP_STRING([--enable-rma],[Enable tests of the one sided parts of MPI-2 (default)])],,
+        [enable_rma=yes])
 
 AC_ARG_ENABLE(part,
-	[AS_HELP_STRING([--enable-part],[Enable tests of partitioned communication of MPI-4 (default)])],,
-	[enable_part=yes])
+        [AS_HELP_STRING([--enable-part],[Enable tests of partitioned communication of MPI-4 (default)])],,
+        [enable_part=yes])
 
 AC_ARG_ENABLE(long-double-complex,
-	[AS_HELP_STRING([--enable-long-double-complex],
-		[Enable tests involving MPI_LONG_DOUBLE_COMPLEX (default)])],,
-	[enable_long_double_complex=yes])
+        [AS_HELP_STRING([--enable-long-double-complex],
+                [Enable tests involving MPI_LONG_DOUBLE_COMPLEX (default)])],,
+        [enable_long_double_complex=yes])
 AC_ARG_ENABLE(long-double,
-	[AS_HELP_STRING([--enable-long-double-complex],
-		[Enable tests involving MPI_LONG_DOUBLE and related types (default)])],,
-	[enable_long_double=yes])
+        [AS_HELP_STRING([--enable-long-double-complex],
+                [Enable tests involving MPI_LONG_DOUBLE and related types (default)])],,
+        [enable_long_double=yes])
 
 AC_ARG_ENABLE(checkerrors,
-	[AS_HELP_STRING([--enable-checkerrors],
-		[Add some tests for checking for errors in user programs])],,
-	[enable_checkerrors=yes])
+        [AS_HELP_STRING([--enable-checkerrors],
+                [Add some tests for checking for errors in user programs])],,
+        [enable_checkerrors=yes])
 
 AC_ARG_ENABLE(perftest,
-	[AS_HELP_STRING([--enable-perftest],
-		[Include tests for basic performance consistency (default)])],,
-	[enable_perftest=yes])
+        [AS_HELP_STRING([--enable-perftest],
+                [Include tests for basic performance consistency (default)])],,
+        [enable_perftest=yes])
 
 AC_ARG_ENABLE(large-tests,
-	[AS_HELP_STRING([--enable-large-tests],
-		[Enable tests which require large (>2GB per proc) amount of memory])],,
-	[enable_large_tests=no])
+        [AS_HELP_STRING([--enable-large-tests],
+                [Enable tests which require large (>2GB per proc) amount of memory])],,
+        [enable_large_tests=no])
 
 AC_ARG_ENABLE(ft-tests,
-	[AS_HELP_STRING([--enable-ft-tests],
-		[Include tests for fault tolerance (default no)])],,
-	[enable_ft_tests=no])
+        [AS_HELP_STRING([--enable-ft-tests],
+                [Include tests for fault tolerance (default no)])],,
+        [enable_ft_tests=no])
 
 AC_ARG_ENABLE(comm-overlap-tests,
-	[AS_HELP_STRING([--enable-comm-overlap-tests],
-		[Include tests for communicator overlap (default)])],,
-	[enable_comm_overlap_tests=yes])
+        [AS_HELP_STRING([--enable-comm-overlap-tests],
+                [Include tests for communicator overlap (default)])],,
+        [enable_comm_overlap_tests=yes])
 
 AC_ARG_ENABLE(checkfaults,
-	[AS_HELP_STRING([--enable-checkfaults],
-		[Add some tests for checking on handling of faults in user programs])],,
-	[enable_checkfaults=no])
+        [AS_HELP_STRING([--enable-checkfaults],
+                [Add some tests for checking on handling of faults in user programs])],,
+        [enable_checkfaults=no])
 
 AC_ARG_ENABLE(checkpointing,
-	[AS_HELP_STRING([--enable-checkpointing],
-		[Add some tests for checkpointing])],,
-	[enable_checkpointing=no])
+        [AS_HELP_STRING([--enable-checkpointing],
+                [Add some tests for checkpointing])],,
+        [enable_checkpointing=no])
 
 AC_ARG_ENABLE(fast,
-	[AS_HELP_STRING([--enable-fast],
-		[Indicates that the MPI implementation may have been
-		built for fastest operation, such as building without
-		error checking.  Has the effect of
-		--enable-checkerrors=no])],,)
+        [AS_HELP_STRING([--enable-fast],
+                [Indicates that the MPI implementation may have been
+                built for fastest operation, such as building without
+                error checking.  Has the effect of
+                --enable-checkerrors=no])],,)
 
 AC_ARG_ENABLE(strictmpi,
-	[AS_HELP_STRING([--enable-strictmpi],
-		[Only test for operations specifically defined by the
-		MPI standard.  This turns off tests for some common
-		extensions, including for combinations of predefined
-		datatypes and predefined MPI_Op s.])],,
-	[enable_strictmpi=no])
+        [AS_HELP_STRING([--enable-strictmpi],
+                [Only test for operations specifically defined by the
+                MPI standard.  This turns off tests for some common
+                extensions, including for combinations of predefined
+                datatypes and predefined MPI_Op s.])],,
+        [enable_strictmpi=no])
 
 AC_ARG_ENABLE(threads,
-	[--enable-threads=level - Specify the level of thread support expected from the
-				MPI implementation.  The following levels are supported.
+        [--enable-threads=level - Specify the level of thread support expected from the
+                                MPI implementation.  The following levels are supported.
 
-	single - No threads (MPI_THREAD_SINGLE)
-	funneled - Only the main thread calls MPI (MPI_THREAD_FUNNELED)
-	serialized - User serializes calls to MPI (MPI_THREAD_SERIALIZED)
-	multiple - Fully multi-threaded (MPI_THREAD_MULTIPLE)
+        single - No threads (MPI_THREAD_SINGLE)
+        funneled - Only the main thread calls MPI (MPI_THREAD_FUNNELED)
+        serialized - User serializes calls to MPI (MPI_THREAD_SERIALIZED)
+        multiple - Fully multi-threaded (MPI_THREAD_MULTIPLE)
 
-	The default is funneled.  If enabled and no level is
-	specified, the level is set to multiple.  If disabled, the
-	level is set to single.  If the environment variable
-	MPICH_THREAD_LEVEL is set, that thread level is used (this is
-	to let MPICH build for the correct thread support without
-	requiring a specific --enable-threads argument.],,
-	[enable_threads=default])
+        The default is funneled.  If enabled and no level is
+        specified, the level is set to multiple.  If disabled, the
+        level is set to single.  If the environment variable
+        MPICH_THREAD_LEVEL is set, that thread level is used (this is
+        to let MPICH build for the correct thread support without
+        requiring a specific --enable-threads argument.],,
+        [enable_threads=default])
 
 AC_ARG_ENABLE(xfail,
-	[AS_HELP_STRING([--enable-xfail],
-		[Run tests marked for expected failure])],,
-	[enable_xfail=no])
+        [AC_HELP_STRING([--enable-xfail],
+                [Run tests marked for expected failure])],,
+        [enable_xfail=no])
 
 AC_ARG_ENABLE(gpu-tests-only,
         [AS_HELP_STRING([--enable-gpu-tests-only],
@@ -265,13 +265,13 @@ cmd="$PYTHON $srcdir/maint/gen_coll_cvar.py"
 AC_CONFIG_COMMANDS([collcvartests],[$cmd_gen_coll],[cmd_gen_coll="$cmd"])
 
 AC_ARG_WITH(mpi,
-	[AS_HELP_STRING([--with-mpi=dir],
-		[Use the selected MPI; compilation scripts for mpicc,
-		mpifort and mpicxx should be in dir/bin])],,)
+        [AC_HELP_STRING([--with-mpi=dir],
+                [Use the selected MPI; compilation scripts for mpicc,
+                mpifort and mpicxx should be in dir/bin])],,)
 
 AC_ARG_WITH(pm,
-	AS_HELP_STRING([--with-pm=name],
-		[Specify the process manager for MPICH.  "no" or "none" are
+        AC_HELP_STRING([--with-pm=name],
+                [Specify the process manager for MPICH.  "no" or "none" are
                  valid values.  Multiple process managers may be specified as
                  long as they all use the same pmi interface by separating them
                  with colons.  The mpiexec for the first named process manager
@@ -314,17 +314,17 @@ else
 fi
 
 AC_ARG_WITH(config-args,
-	[AS_HELP_STRING([--with-config-args=filename],
-		[Specify configure argument file that contains the
-		values of variables that configure reads,
-		e.g. CC,CFLAGS,F77,FFLAGS,FC,FCFLAGS....  If the
-		filename does not begin with / (absolute path), . or
-		.. (relative path), the filename will be assumed to be
-		$top_srcdir/configargs/<filename>.cfg.])],,
-	[with_config_args=no])
+        [AC_HELP_STRING([--with-config-args=filename],
+                [Specify configure argument file that contains the
+                values of variables that configure reads,
+                e.g. CC,CFLAGS,F77,FFLAGS,FC,FCFLAGS....  If the
+                filename does not begin with / (absolute path), . or
+                .. (relative path), the filename will be assumed to be
+                $top_srcdir/configargs/<filename>.cfg.])],,
+        [with_config_args=no])
 
 if test "$with_config_args" != "no" ; then
-    case "$with_config_args" in 
+    case "$with_config_args" in
         /*|../*|./*)
             config_args_file="$with_config_args"
             ;;
@@ -366,13 +366,13 @@ AC_ARG_VAR([MPICH_THREAD_LEVEL],
            [the MPI thread level supported by the enclosing MPICH build (when built within MPICH)])
 # ------------------------------------------------------------------------
 
-if test "$enable_threads" = "yes" ; then 
+if test "$enable_threads" = "yes" ; then
     enable_threads=multiple
 elif test "$enable_threads" = "no" ; then
     enable_threads=single
 elif test "$enable_threads" = default ; then
     if test -n "$MPICH_THREAD_LEVEL" ; then
-        case $MPICH_THREAD_LEVEL in 
+        case $MPICH_THREAD_LEVEL in
             MPI_THREAD_MULTIPLE)
             enable_threads=multiple
             ;;
@@ -422,12 +422,12 @@ else
 fi
 AC_SUBST(comm_overlap)
 
-# 
+#
 # Only run the threads tests if multiple is specified
 if test "$enable_threads" = "multiple" -o "$enable_threads" = "runtime" ; then
     threadsdir="threads"
 fi
-# 
+#
 # Only run the checkpointing tests if enabled
 ckpointdir="#ckpoint"
 if test "$enable_checkpointing" = "yes" ; then
@@ -473,7 +473,7 @@ fi
 
 # Some MPI-2 implementations (including some of the MPICH shared-memory
 # channels and BG/L) leave out the dynamic process routines.  This
-# allows tests to avoid reporting failure for these routines.  
+# allows tests to avoid reporting failure for these routines.
 # This can be controlled by either a --disable-spawn argument or by
 # setting the environment variable MPI_NO_SPAWN to yes.
 AC_ARG_VAR([MPI_NO_SPAWN],[set to "yes" to disable dynamic process tests])
@@ -604,11 +604,11 @@ else
     fi
     if test "x$MPICC" != "x" ; then
         CC=$MPICC
-    fi 
+    fi
     if test -z "$MPIF77" ; then
         AC_PATH_PROG(MPIF77,$MPIF77_NAME mpf77)
     fi
-    if test "x$MPIF77" != "x" ; then 
+    if test "x$MPIF77" != "x" ; then
         F77=$MPIF77
     fi
     if test -z "$MPIFC" ; then
@@ -618,13 +618,13 @@ else
         FC=$MPIFC
     fi
     if test -z "$MPICXX" ; then
-        # We left mpiCC off of this list because mpicc and mpiCC are the 
+        # We left mpiCC off of this list because mpicc and mpiCC are the
         # same on Mac OSX systems.
         AC_PATH_PROG(MPICXX,$MPICXX_NAME mpCC)
     fi
     if test "x$MPICXX" != "x" ; then
         CXX=$MPICXX
-    fi 
+    fi
     if test -z "$MPIEXEC" ; then
         AC_PATH_PROG(MPIEXEC,$MPIEXEC_NAME)
     fi
@@ -645,8 +645,8 @@ AM_PROG_CC_C_O
 
 # Ensure that we can compile an MPI program before we go any further
 # We don't use a cached value here because this is a sanity check
-# The exception is if we are executing this configure from within the 
-# MPICH configure - in that case, the 
+# The exception is if we are executing this configure from within the
+# MPICH configure - in that case, the
 if test "$FROM_MPICH" != "yes" ; then
     AC_MSG_CHECKING([whether we can compile and link MPI programs in C])
     AC_LINK_IFELSE([
@@ -664,7 +664,7 @@ dnl same test in the MPICH configure.
 # Check on support for long double and long long types.  Do this before the
 # structure alignment test because it will test for including those
 # types as well
-# 
+#
 # If --disable-long-double is selected, then bypass this test.
 # Some MPI implementations may choose to not support long double because
 # their C compilers are inconsistent on the length of long double (this
@@ -685,7 +685,7 @@ AC_CACHE_CHECK([whether long long is supported],pac_cv_have_long_long,[
         AC_LANG_PROGRAM([],[long long a;])
     ],[pac_cv_have_long_long=yes],[pac_cv_have_long_long=no])
 ])
-if test "$pac_cv_have_long_long" = yes ; then 
+if test "$pac_cv_have_long_long" = yes ; then
     AC_DEFINE(HAVE_LONG_LONG,1,[Define if compiler supports long long])
 fi
 #
@@ -903,7 +903,7 @@ case $with_thread_package in
         THREAD_PACKAGE_NAME=THREAD_PACKAGE_NONE
         ;;
     *)
-	AC_MSG_ERROR([The specified thread package, $with_thread_package, is not supported.])
+        AC_MSG_ERROR([The specified thread package, $with_thread_package, is not supported.])
         ;;
 esac
 
@@ -943,7 +943,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[MPI_Init(0,0);MPI_Finaliz
     AC_CACHE_CHECK([for major version of MPI],pac_cv_mpi_major_version,[
 for pac_cv_mpi_major_version in 3 2 1 unknown ; do
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[
-#if MPI_VERSION == $pac_cv_mpi_major_version 
+#if MPI_VERSION == $pac_cv_mpi_major_version
     ''' force failure '''
 #endif])],,break)
 done
@@ -952,7 +952,7 @@ done
     AC_CACHE_CHECK([for minor version of MPI],pac_cv_mpi_minor_version,[
 for pac_cv_mpi_minor_version in 4 3 2 1 0 unknown ; do
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[
-#if MPI_SUBVERSION == $pac_cv_mpi_minor_version 
+#if MPI_SUBVERSION == $pac_cv_mpi_minor_version
     ''' force failure '''
 #endif])],,break)
 done
@@ -960,15 +960,15 @@ done
 MPI_VERSION=$pac_cv_mpi_major_version
 MPI_SUBVERSION=$pac_cv_mpi_minor_version
 else
-    # We are within the MPICH build.  Extract the MPI versions from 
-    # mpi.h.in	
+    # We are within the MPICH build.  Extract the MPI versions from
+    # mpi.h.in
     if test ! -f $mpich_top_srcdir/src/include/mpi.h.in ; then
         AC_MSG_ERROR([Could not find the required mpi.h.in file!])
     fi
     MPI_VERSION=`grep MPI_VERSION $mpich_top_srcdir/src/include/mpi.h.in | \
-    		      sed -e 's/#define *MPI_VERSION *\([0-4]\).*/\1/g'`
+                      sed -e 's/#define *MPI_VERSION *\([0-4]\).*/\1/g'`
     MPI_SUBVERSION=`grep MPI_SUBVERSION $mpich_top_srcdir/src/include/mpi.h.in | \
-    		      sed -e 's/#define *MPI_SUBVERSION *\([0-9]\).*/\1/g'`
+                      sed -e 's/#define *MPI_SUBVERSION *\([0-9]\).*/\1/g'`
 fi
 
 AC_SUBST(MPI_VERSION)
@@ -980,9 +980,9 @@ if test "$enable_f77" = yes ; then
     # If there is no working F77, then set enable_f77 to no
     if test -z "$F77" ; then
         enable_f77=no
-    fi    
+    fi
 fi
-# Simple tests for which other languages we can handle.  
+# Simple tests for which other languages we can handle.
 # Use these only when configuring separate from an MPICH build
 f77dir="#"
 AC_SUBST(f77dir)
@@ -1017,7 +1017,7 @@ elif test "$enable_f77" = yes ; then
     AC_LANG_POP([Fortran 77])
 fi
 #
-# At least one test (C++ test of C and Fortran datatypes) needs to 
+# At least one test (C++ test of C and Fortran datatypes) needs to
 # know if Fortran is supported
 if test "$f77dir" = "f77" ; then
     AC_DEFINE(HAVE_FORTRAN_BINDING,1,[Define if Fortran is supported])
@@ -1040,17 +1040,17 @@ if test "$buildingF77" = "yes" ; then
         # Aint should be an address-sized integer, the same as void*
         # We use a test on the size of void * to avoid any complications
         # in dealing with running programs containing MPI headers (e.g.,
-        # the IBM MPI changes the main entry point so that MPI 
+        # the IBM MPI changes the main entry point so that MPI
         # programs cannot be run on the host node)
         AC_CHECK_SIZEOF(void *)
         MPI_SIZEOF_AINT=$ac_cv_sizeof_void_p
     fi
     if test -z "$MPI_SIZEOF_OFFSET" ; then
-        # We have to try and get the size of offset anyway, since 
+        # We have to try and get the size of offset anyway, since
         # it is not the same as void * (it depends on the available
         # file systems).  Since we want to avoid using the MPI linker,
         # we could do the following:
-        #    Use the mpi compiler to compile the file, using the mpi 
+        #    Use the mpi compiler to compile the file, using the mpi
         #    header but no MPI calls
         #    Use the regular C linker to link the program
         # However, we do this only if the environment variable BASECC
@@ -1077,7 +1077,7 @@ dnl }
 dnl EOF
 dnl             # FIXME.  Check for BASECC
 dnl             # Note: This assumes that CC has been set to the C compiler for
-dnl             # MPI Programs, and that either any necessary include paths are 
+dnl             # MPI Programs, and that either any necessary include paths are
 dnl             # already set or they are in CPPFLAGS (preferred) or CFLAGS.
 dnl             if AC_TRY_EVAL(ac_link) && test -s conftest$ac_exeext ; then
 dnl                 if ./conftest$ac_exeext ; then
@@ -1106,7 +1106,7 @@ dnl         ])
              MPI_SIZEOF_OFFSET=$ac_cv_sizeof_MPI_Offset
         fi
     fi
-    
+
     AC_LANG_PUSH([Fortran 77])
     AC_CACHE_CHECK([whether integer*4 is supported],pac_cv_fort_integer4,[
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,[      integer*4 i])],
@@ -1148,20 +1148,20 @@ dnl         ])
     cat > f77/init/checksizes.c <<EOF
 #include "mpi.h"
 #include <stdio.h>
-int main( int argc, char **argv ) 
+int main( int argc, char **argv )
 {
   int fsizeof_aint   = $MPI_SIZEOF_AINT;
   int fsizeof_offset = $MPI_SIZEOF_OFFSET;
   int err = 0, rc = 0;
-  
+
   MPI_Init( &argc, &argv );
   if (sizeof(MPI_Aint) != fsizeof_aint) {
-     printf( "Sizeof MPI_Aint is %d but Fortran thinks it is %d\n", 
+     printf( "Sizeof MPI_Aint is %d but Fortran thinks it is %d\n",
              (int)sizeof(MPI_Aint), fsizeof_aint );
      err++;
   }
   if (sizeof(MPI_Offset) != fsizeof_offset) {
-     printf( "Sizeof MPI_Offset is %d but Fortran thinks it is %d\n", 
+     printf( "Sizeof MPI_Offset is %d but Fortran thinks it is %d\n",
              (int)sizeof(MPI_Offset), fsizeof_offset );
      err++;
   }
@@ -1178,7 +1178,7 @@ EOF
 
     # Check that the Fortran compiler will allow us to pass arguments
     # of different types (e.g., for MPI_Send)
-    # Any strict Fortran compiler will require that the arguments be 
+    # Any strict Fortran compiler will require that the arguments be
     # the same type - currently, the NAG Fortran compiler (nagfor) is known
     # to enforce this.
     # We could set the FFLAGS/FCFLAGS values with the option that disables
@@ -1186,22 +1186,22 @@ EOF
     # instead we tell the user and exit.
     PAC_PROG_F77_MISMATCHED_ARGS(addarg,yes)
     if test "X$addarg" != "X" ; then
-        # We could add the names of all of the MPI routines that 
-        # accept different types.  Instead, we fail cleanly.  
-        # Some Fortran compilers allow you to turn off checking for 
+        # We could add the names of all of the MPI routines that
+        # accept different types.  Instead, we fail cleanly.
+        # Some Fortran compilers allow you to turn off checking for
         # mismatched arguments for *all* routines.  Adding an argument
-	# that turns off checking for *everything* is not something that 
-	# configure should do - if the user wants this, they can follow
-	# the instructions in the following error message.
-	AC_MSG_ERROR([The Fortran compiler $F77 does not accept programs that call the same routine with arguments of different types without the option $addarg.  Rerun configure with FFLAGS=$addarg])
+        # that turns off checking for *everything* is not something that
+        # configure should do - if the user wants this, they can follow
+        # the instructions in the following error message.
+        AC_MSG_ERROR([The Fortran compiler $F77 does not accept programs that call the same routine with arguments of different types without the option $addarg.  Rerun configure with FFLAGS=$addarg])
     fi
 
-    # Check whether we need -lU77 to get iargc and getarg, which 
+    # Check whether we need -lU77 to get iargc and getarg, which
     # are used for a few of the tests in spawn (U77 was needed with
-    # the native compilers on HPUX.  See the aclocal_f77(old).m4 file, 
+    # the native compilers on HPUX.  See the aclocal_f77(old).m4 file,
     # which has a much more complete set of tests.
     #
-    # FIXME: if we can't figure out how to get iargc/getarg, then 
+    # FIXME: if we can't figure out how to get iargc/getarg, then
     # we should really turn off those spawn tests
     # Even better is to limit this to the F200x version, where there is
     # an interface to the command line.
@@ -1238,10 +1238,10 @@ EOF
     if test -n "$F77_GETARG_LIBS" ; then
         AC_MSG_RESULT($F77_GETARG_LIBS)
     else
-        if test "$pac_cv_getarg_needs_u77" = "unavailable" ; then 
+        if test "$pac_cv_getarg_needs_u77" = "unavailable" ; then
             AC_MSG_RESULT([getarg and/or iargc are not available.  Some spawn tests will fail to link])
-	    F77SPAWNARGTEST="#"
-        else 
+            F77SPAWNARGTEST="#"
+        else
             AC_MSG_RESULT([none needed])
         fi
     fi
@@ -1249,8 +1249,8 @@ EOF
     # FIXME: Currently, we hope that FC accepts the same library
     FC_GETARG_LIBS="$F77_GETARG_LIBS"
     AC_SUBST(FC_GETARG_LIBS)
-    # F77SPAWNARGTEST is set to "#" to comment out tests in 
-    # f77/spawn/testlist.in that require non-standard extensions to 
+    # F77SPAWNARGTEST is set to "#" to comment out tests in
+    # f77/spawn/testlist.in that require non-standard extensions to
     # access the commandline
     AC_SUBST(F77SPAWNARGTEST)
 
@@ -1304,12 +1304,12 @@ fi
 dnl If enable_fc=yes up to this point then enable_f77=yes also
 dnl PAC_PROG_FC and PAC_PROG_FC_WORKS return OK
 if test "$enable_fc" = yes ; then
-    # Make sure that the compilers are compatible.  This 
+    # Make sure that the compilers are compatible.  This
     # will also make sure that the program named in FC is
     # a working Fortran 90 compiler
-    # Only check if we're *not* building within MPICH 
+    # Only check if we're *not* building within MPICH
     # (MPICH will have made the test)
-    # FIXME: Do we want to check only simple routine names 
+    # FIXME: Do we want to check only simple routine names
     # (those without an underscore?)
     if test "$FROM_MPICH" != yes ; then
         PAC_FC_AND_F77_COMPATIBLE(enable_fc=yes,enable_fc=no)
@@ -1332,7 +1332,7 @@ if test "$enable_fc" = yes ; then
     # The Fortran90 tests rely on free-form input which needs to be tested
     # before any test that may modify FCFLAGS, e.g. the cray-pointer test.
     # The order of the tests is important in compiler like g95.
-    # Recent experience showed that the IBM xlf compiler, at least on 
+    # Recent experience showed that the IBM xlf compiler, at least on
     # some systems, requires -qfree=f90 instead of -qfree .  At this
     # writing (11/27/12), this Autoconf macro still uses -qfree and has
     # no mechanism for extension.  This test may fail in that case; if
@@ -1361,9 +1361,9 @@ if test "$enable_fc" = yes ; then
     AC_MSG_RESULT($pac_cv_fc_has_args)
     if test "$pac_cv_fc_has_args" != "yes" ; then
         F03SPAWNARGTEST="#"
-    fi      
-    # F03SPAWNARGTEST is set to "#" to comment out tests in 
-    # f90/spawn/testlist.in that require Fortran 2003 features to 
+    fi
+    # F03SPAWNARGTEST is set to "#" to comment out tests in
+    # f90/spawn/testlist.in that require Fortran 2003 features to
     # access the commandline
     AC_SUBST(F03SPAWNARGTEST)
     AC_LANG_POP([Fortran])
@@ -1438,8 +1438,8 @@ if test "$FROM_MPICH" = yes ; then
         otherlangs="$otherlangs cxx"
         cxxdir=cxx
         # MPICH ABI removed support for MPI::Distgraphcomm, so
-	# nocxxdistgraph is left as #, which comments out the test
-	# in cxx/topol/testlist.in
+        # nocxxdistgraph is left as #, which comments out the test
+        # in cxx/topol/testlist.in
     fi
 elif test "$enable_cxx" = yes ; then
     AC_MSG_CHECKING([that we can build MPI programs with C++])
@@ -1499,7 +1499,7 @@ if test "$enable_cxx" = yes ; then
         fi
         # Warning: the autoconf macros will fall back onto /lib/cpp for
         # C and C++ preprocessing *without* checking that /lib/cpp even
-        # exists.  
+        # exists.
         if test "$CXXCPP" = "/lib/cpp" ; then
             if test ! -x "/lib/cpp" ; then
                 AC_MSG_WARN([Warning: Autoconf error, could not find a C++ Preprocessor.  Using false for the preprocessor so that tests will continue.])
@@ -1509,8 +1509,8 @@ if test "$enable_cxx" = yes ; then
     fi
 
     AX_CXX_NAMESPACE_STD
-   
-    if test "$ac_cv_cxx_namespaces" != yes ; then 
+
+    if test "$ac_cv_cxx_namespaces" != yes ; then
         AC_MSG_WARN([The compiler $CXX does not support C++ namespaces.  This may cause problems for the tests])
     fi
     AC_LANG_POP([C++])
@@ -1528,7 +1528,7 @@ if test "$enable_romio" != no ; then
     if test "$FROM_MPICH" = yes ; then
         # MPICH no longer uses and MPIO_Request
         pac_cv_have_mpio_request=no
-    else 
+    else
         AC_CACHE_CHECK([whether MPIO_Request is defined for MPI IO],
         pac_cv_have_mpio_request,[
             AC_COMPILE_IFELSE([
@@ -1564,7 +1564,7 @@ fi
 AC_SUBST(impldir)
 #
 # MPI_INTEGER16 is mentioned in only one place in MPI 2.1, and some
-# implementations may have missed it.  Check to see if it is available in 
+# implementations may have missed it.  Check to see if it is available in
 # C.
 if test "$FROM_MPICH" = yes ; then
    # MPICH correctly includes this type.
@@ -1579,11 +1579,11 @@ else
         ],[pac_cv_have_mpi_integer16=yes],[pac_cv_have_mpi_integer16=no])
     ])
 fi
-if test "$pac_cv_have_mpi_integer16" = yes ; then 
+if test "$pac_cv_have_mpi_integer16" = yes ; then
     AC_DEFINE(HAVE_MPI_INTEGER16,1,[Define if MPI_INTEGER16 is available])
 fi
 
-# MPI_Aint was intended as an address-sized int.  However, MPI didn't 
+# MPI_Aint was intended as an address-sized int.  However, MPI didn't
 # specify this - MPI_Aint must be large enough to hold an address-sized
 # integer, but it can be larger.  To get clean compilation in some places,
 # we need a pointer-sized integer.  The following code looks for one.
@@ -1608,7 +1608,7 @@ done
 AC_MSG_RESULT($POINTERINT)
 AC_DEFINE_UNQUOTED(POINTERINT_t,$POINTERINT,[POINTERINT_t is a pointer-sized integer])
 
-# Find perl; used to create some of the tests from template and 
+# Find perl; used to create some of the tests from template and
 # definition files
 AC_PATH_PROG(PERL,perl)
 AC_SUBST(PERL)
@@ -1627,10 +1627,10 @@ AC_SUBST(MPI_SOURCE)
 if test "$FROM_MPICH" = yes ; then
     # Set compilers/flags to be substituted in output files, e.g. Makefiles.
     LDFLAGS="$saveLDFLAGS"
-    # note that the default definition of bindir is 
+    # note that the default definition of bindir is
     #    '${exec_prefix}/bin'
     # so even if prefix is set, exec prefix is not until
-    # the very last moment (i.e., not here). 
+    # the very last moment (i.e., not here).
     if test "X$exec_prefix" = "XNONE" ; then
         saveExec_prefix=$exec_prefix
         if test "X$prefix" = "XNONE" ; then
@@ -1702,7 +1702,7 @@ AC_OUTPUT(maint/testmerge \
           attr/testlist \
           util/Makefile \
           coll/Makefile \
-	  coll/testlist \
+          coll/testlist \
           comm/Makefile \
           comm/testlist \
           datatype/Makefile \
@@ -1737,7 +1737,7 @@ AC_OUTPUT(maint/testmerge \
           f77/pt2pt/Makefile \
           f77/info/Makefile \
           f77/spawn/Makefile \
-	  f77/spawn/testlist \
+          f77/spawn/testlist \
           f77/spawn/type1aint.h \
           f77/rma/Makefile \
           f77/ext/Makefile \
@@ -1747,7 +1747,7 @@ AC_OUTPUT(maint/testmerge \
           f77/io/iodisp.h \
           f77/io/ioaint.h \
           f77/io/testlist \
-	  f77/profile/Makefile \
+          f77/profile/Makefile \
           f90/Makefile \
           f90/attr/Makefile \
           f90/datatype/Makefile \
@@ -1760,25 +1760,25 @@ AC_OUTPUT(maint/testmerge \
           f90/rma/Makefile \
           f90/info/Makefile \
           f90/spawn/Makefile \
-	  f90/spawn/testlist \
+          f90/spawn/testlist \
           f90/timer/Makefile \
           f90/ext/Makefile \
           f90/ext/testlist \
           f90/io/Makefile \
           f90/io/testlist \
           f90/misc/Makefile \
-	      f90/profile/Makefile \
-	  f08/Makefile \
-	      f08/attr/Makefile \
-	      f08/datatype/Makefile \
-	      f08/coll/Makefile \
-	      f08/comm/Makefile \
-	      f08/pt2pt/Makefile \
-	      f08/rma/Makefile \
-	      f08/subarray/Makefile \
-	      f08/topo/Makefile \
-	      f08/io/Makefile \
-	      f08/io/testlist \
+              f90/profile/Makefile \
+          f08/Makefile \
+              f08/attr/Makefile \
+              f08/datatype/Makefile \
+              f08/coll/Makefile \
+              f08/comm/Makefile \
+              f08/pt2pt/Makefile \
+              f08/rma/Makefile \
+              f08/subarray/Makefile \
+              f08/topo/Makefile \
+              f08/io/Makefile \
+              f08/io/testlist \
           f08/init/Makefile \
           f08/info/Makefile \
           f08/spawn/Makefile \
@@ -1793,7 +1793,7 @@ AC_OUTPUT(maint/testmerge \
           cxx/pt2pt/Makefile \
           cxx/comm/Makefile \
           cxx/coll/Makefile \
-	  cxx/errhan/Makefile \
+          cxx/errhan/Makefile \
           cxx/info/Makefile \
           cxx/datatype/Makefile \
           cxx/datatype/testlist \
@@ -1802,7 +1802,7 @@ AC_OUTPUT(maint/testmerge \
           cxx/rma/Makefile \
           cxx/spawn/Makefile \
           cxx/spawn/testlist \
-	  cxx/topo/Makefile \
+          cxx/topo/Makefile \
           threads/Makefile \
           threads/pt2pt/Makefile \
           threads/comm/Makefile \
@@ -1837,18 +1837,18 @@ AC_OUTPUT(maint/testmerge \
           errors/f77/io/addsize.h \
           errors/f77/io/iooffset.h \
           errors/f90/Makefile \
-	  errors/f90/io/Makefile \
+          errors/f90/io/Makefile \
           errors/f08/Makefile \
-	  errors/f08/io/Makefile \
-	  ckpoint/Makefile \
-	  ft/Makefile \
+          errors/f08/io/Makefile \
+          ckpoint/Makefile \
+          ft/Makefile \
           manual/Makefile \
           manual/manyconnect \
           manual/mpi_t/Makefile \
           perf/Makefile \
           testlist \
           cxx/testlist \
-	  cxx/topo/testlist \
+          cxx/topo/testlist \
           f77/testlist \
           f90/testlist \
           f08/testlist \

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -145,8 +145,7 @@ AC_ARG_ENABLE(cxx,
         [AC_HELP_STRING([--enable-cxx],[Turn on C++ tests (default)])],,[enable_cxx=yes])
 
 AC_ARG_ENABLE(romio,
-        [AC_HELP_STRING([--enable-romio],[Enable ROMIO MPI I/O implementation])],,
-        [enable_romio=yes])
+        [AC_HELP_STRING([--enable-romio],[Enable MPI I/O tests])])
 
 AC_ARG_ENABLE(namepub,
         [AC_HELP_STRING([--enable-namepub],
@@ -881,6 +880,17 @@ MPI_SUBVERSION=$pac_cv_mpi_minor_version
 AC_SUBST(MPI_VERSION)
 AC_SUBST(MPI_SUBVERSION)
 
+AC_MSG_CHECKING([whether MPI-IO is available])
+AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([#include "mpi.h"],[
+            MPI_File fh;
+            MPI_Init(0,0);
+            MPI_File_open(MPI_COMM_WORLD,"/dev/null",MPI_MODE_WRONLY,MPI_INFO_NULL,&fh);
+            MPI_File_close(&fh);
+            MPI_Finalize();])
+    ],[mpi_io_works=yes],[mpi_io_works=no])
+AC_MSG_RESULT($mpi_io_works)
+
 # Running Fortran 77 compiler tests
 AC_PROG_F77
 if test "$enable_f77" = yes ; then
@@ -1356,6 +1366,11 @@ if test "$enable_cxx" = yes ; then
         AC_MSG_WARN([The compiler $CXX does not support C++ namespaces.  This may cause problems for the tests])
     fi
     AC_LANG_POP([C++])
+
+    dnl for util/mtest_cxx.cxx
+    if test "$mpi_io_works" = "yes" ; then
+        AC_DEFINE(HAVE_MPI_IO,1,[Define if MPI-IO (really ROMIO) is included])
+    fi
 fi
 
 AC_LANG_C
@@ -1364,9 +1379,10 @@ LT_INIT()
 
 # IO
 iodir="#"
-if test "$enable_romio" != no ; then
+if test "$enable_romio" != no -a "$mpi_io_works" = yes ; then
     iodir=io
-    AC_DEFINE(HAVE_MPI_IO,1,[Define if MPI-IO (really ROMIO) is included])
+
+    dnl for io/async.c
     AC_CACHE_CHECK([whether MPIO_Request is defined for MPI IO],
     pac_cv_have_mpio_request,[
         AC_COMPILE_IFELSE([

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -350,6 +350,97 @@ if test "$with_config_args" != "no" ; then
     fi
 fi
 
+# Attach program prefix and suffix to executable names
+PAC_GET_EXENAME("mpicc", MPICC_NAME)
+PAC_GET_EXENAME("mpif77", MPIF77_NAME)
+PAC_GET_EXENAME("mpifort", MPIFORT_NAME)
+PAC_GET_EXENAME("mpicxx", MPICXX_NAME)
+PAC_GET_EXENAME("mpiexec", MPIEXEC_NAME)
+
+if test -n "$with_mpi" ; then
+    if test -z "$MPICC" ; then
+        CC=$with_mpi/bin/$MPICC_NAME
+    else
+        CC=$MPICC
+    fi
+    if test -z "$MPIF77" ; then
+        F77=$with_mpi/bin/$MPIF77_NAME
+    else
+        F77=$MPIF77
+    fi
+    if test -z "$MPIFC" ; then
+        FC=$with_mpi/bin/$MPIFORT_NAME
+    else
+        FC=$MPIFC
+    fi
+    if test -z "$MPICXX" ; then
+        CXX=$with_mpi/bin/$MPICXX_NAME
+    else
+        CXX=$MPICXX
+    fi
+    if test -z "$MPIEXEC" ; then
+        MPIEXEC=$with_mpi/bin/$MPIEXEC_NAME
+    fi
+else
+    # Try to use mpicc etc names
+    if test -z "$MPICC" ; then
+        AC_PATH_PROG(MPICC,$MPICC_NAME mpcc)
+    fi
+    if test "x$MPICC" != "x" ; then
+        CC=$MPICC
+    fi
+    if test -z "$MPIF77" ; then
+        AC_PATH_PROG(MPIF77,$MPIF77_NAME mpf77)
+    fi
+    if test "x$MPIF77" != "x" ; then
+        F77=$MPIF77
+    fi
+    if test -z "$MPIFC" ; then
+        AC_PATH_PROG(MPIFC,$MPIFORT_NAME mpftn)
+    fi
+    if test "x$MPIFC" != "x" ; then
+        FC=$MPIFC
+    fi
+    if test -z "$MPICXX" ; then
+        # We left mpiCC off of this list because mpicc and mpiCC are the
+        # same on Mac OSX systems.
+        AC_PATH_PROG(MPICXX,$MPICXX_NAME mpCC)
+    fi
+    if test "x$MPICXX" != "x" ; then
+        CXX=$MPICXX
+    fi
+    if test -z "$MPIEXEC" ; then
+        AC_PATH_PROG(MPIEXEC,$MPIEXEC_NAME)
+    fi
+fi
+# Make sure we export CC before configuring DTPools, since MPI is
+# needed to build the library.
+export CC
+AC_CONFIG_SUBDIRS([dtpools])
+
+# Running C compiler tests
+AC_PROG_CC
+AC_PROG_CC_C99
+AM_PROG_CC_C_O
+
+# Ensure that we can compile an MPI program before we go any further
+# We don't use a cached value here because this is a sanity check
+AC_MSG_CHECKING([whether we can compile and link MPI programs in C])
+AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([#include "mpi.h"],[MPI_Init(0,0);MPI_Finalize();])
+    ],[mpi_compile_works=yes],[mpi_compile_works=no])
+AC_MSG_RESULT($mpi_compile_works)
+
+if test "$mpi_compile_works" != "yes" ; then
+    AC_MSG_ERROR([Unable to compile and/or link an MPI program!  Check config.log])
+fi
+
+# Check whether we are testing MPI derived from MPICH
+MPI_IS_MPICH=no
+AC_MSG_CHECKING([Is the MPI derived from MPICH])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[return 1 + MPICH;])],
+    [MPI_IS_MPICH=yes],[MPI_IS_MPICH=no])
+
 # First, determine whether we are/can support the language bindings
 #
 # Since F90/F90FLAGS are replaced by FC/FCFLAGS, rather than silently
@@ -525,97 +616,6 @@ AC_ARG_VAR([WRAPPER_LIBS],[])
 AC_ARG_VAR([WRAPPER_FFLAGS],[])
 AC_ARG_VAR([WRAPPER_FCFLAGS],[])
 AC_ARG_VAR([WRAPPER_CXXFLAGS],[])
-
-# Attach program prefix and suffix to executable names
-PAC_GET_EXENAME("mpicc", MPICC_NAME)
-PAC_GET_EXENAME("mpif77", MPIF77_NAME)
-PAC_GET_EXENAME("mpifort", MPIFORT_NAME)
-PAC_GET_EXENAME("mpicxx", MPICXX_NAME)
-PAC_GET_EXENAME("mpiexec", MPIEXEC_NAME)
-
-if test -n "$with_mpi" ; then
-    if test -z "$MPICC" ; then
-        CC=$with_mpi/bin/$MPICC_NAME
-    else
-        CC=$MPICC
-    fi
-    if test -z "$MPIF77" ; then
-        F77=$with_mpi/bin/$MPIF77_NAME
-    else
-        F77=$MPIF77
-    fi
-    if test -z "$MPIFC" ; then
-        FC=$with_mpi/bin/$MPIFORT_NAME
-    else
-        FC=$MPIFC
-    fi
-    if test -z "$MPICXX" ; then
-        CXX=$with_mpi/bin/$MPICXX_NAME
-    else
-        CXX=$MPICXX
-    fi
-    if test -z "$MPIEXEC" ; then
-        MPIEXEC=$with_mpi/bin/$MPIEXEC_NAME
-    fi
-else
-    # Try to use mpicc etc names
-    if test -z "$MPICC" ; then
-        AC_PATH_PROG(MPICC,$MPICC_NAME mpcc)
-    fi
-    if test "x$MPICC" != "x" ; then
-        CC=$MPICC
-    fi
-    if test -z "$MPIF77" ; then
-        AC_PATH_PROG(MPIF77,$MPIF77_NAME mpf77)
-    fi
-    if test "x$MPIF77" != "x" ; then
-        F77=$MPIF77
-    fi
-    if test -z "$MPIFC" ; then
-        AC_PATH_PROG(MPIFC,$MPIFORT_NAME mpftn)
-    fi
-    if test "x$MPIFC" != "x" ; then
-        FC=$MPIFC
-    fi
-    if test -z "$MPICXX" ; then
-        # We left mpiCC off of this list because mpicc and mpiCC are the
-        # same on Mac OSX systems.
-        AC_PATH_PROG(MPICXX,$MPICXX_NAME mpCC)
-    fi
-    if test "x$MPICXX" != "x" ; then
-        CXX=$MPICXX
-    fi
-    if test -z "$MPIEXEC" ; then
-        AC_PATH_PROG(MPIEXEC,$MPIEXEC_NAME)
-    fi
-fi
-# Make sure we export CC before configuring DTPools, since MPI is
-# needed to build the library.
-export CC
-AC_CONFIG_SUBDIRS([dtpools])
-
-# Running C compiler tests
-AC_PROG_CC
-AC_PROG_CC_C99
-AM_PROG_CC_C_O
-
-# Ensure that we can compile an MPI program before we go any further
-# We don't use a cached value here because this is a sanity check
-AC_MSG_CHECKING([whether we can compile and link MPI programs in C])
-AC_LINK_IFELSE([
-        AC_LANG_PROGRAM([#include "mpi.h"],[MPI_Init(0,0);MPI_Finalize();])
-    ],[mpi_compile_works=yes],[mpi_compile_works=no])
-AC_MSG_RESULT($mpi_compile_works)
-
-if test "$mpi_compile_works" != "yes" ; then
-    AC_MSG_ERROR([Unable to compile and/or link an MPI program!  Check config.log])
-fi
-
-# Check whether we are testing MPI derived from MPICH
-MPI_IS_MPICH=no
-AC_MSG_CHECKING([Is the MPI derived from MPICH])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[return 1 + MPICH;])],
-    [MPI_IS_MPICH=yes],[MPI_IS_MPICH=no])
 
 dnl We cannot use AC_C_LONG_DOUBLE
 dnl because it does not support cross-compilation.  Instead, we use the

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -148,6 +148,11 @@ AC_ARG_ENABLE(romio,
         [AC_HELP_STRING([--enable-romio],[Enable ROMIO MPI I/O implementation])],,
         [enable_romio=yes])
 
+AC_ARG_ENABLE(namepub,
+        [AC_HELP_STRING([--enable-namepub],
+                [Enable tests of the dynamic process parts of MPI-2 (default)])],,
+        [enable_namepub=yes])
+
 AC_ARG_ENABLE(spawn,
         [AC_HELP_STRING([--enable-spawn],
                 [Enable tests of the dynamic process parts of MPI-2 (default)])],,
@@ -436,6 +441,12 @@ AC_SUBST(MPILIBLOC)
 # more variables that must be marked precious for proper re-configure operation
 AC_ARG_VAR([MPICH_ENABLE_FC],["yes" if the enclosing MPICH build supports modern Fortran])
 AC_ARG_VAR([MPICH_ENABLE_CXX],["yes" if the enclosing MPICH build supports C++])
+
+namepub_tests="#"
+if test "$enable_namepub" = "yes" ; then
+    namepub_tests=""
+fi
+AC_SUBST(namepub_tests)
 
 # Some MPI-2 implementations (including some of the MPICH shared-memory
 # channels and BG/L) leave out the dynamic process routines.  This

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -226,18 +226,9 @@ AC_ARG_ENABLE(strictmpi,
         [enable_strictmpi=no])
 
 AC_ARG_ENABLE(threads,
-        [--enable-threads=level - Specify the level of thread support expected from the
-                                MPI implementation.  The following levels are supported.
-
-        single - No threads (MPI_THREAD_SINGLE)
-        funneled - Only the main thread calls MPI (MPI_THREAD_FUNNELED)
-        serialized - User serializes calls to MPI (MPI_THREAD_SERIALIZED)
-        multiple - Fully multi-threaded (MPI_THREAD_MULTIPLE)
-
-        The default is to run check. If enabled and no level is
-        specified, the level is set to multiple.  If disabled, the
-        level is set to single.],,
-        [enable_threads=default])
+        [AS_HELP_STRING([--enable-threads],
+                [Whether to enable multi-thread tests])],,
+        [enable_threads=yes])
 
 AC_ARG_ENABLE(xfail,
         [AC_HELP_STRING([--enable-xfail],
@@ -453,25 +444,6 @@ if test -n "$F90" -o -n "$F90FLAGS" ; then
     AC_MSG_ERROR([F90 and F90FLAGS are replaced by FC and FCFLAGS respectively in this configure, please unset F90/F90FLAGS and set FC/FCFLAGS instead and rerun configure again.])
 fi
 
-# check whether to enable thread tests
-#
-if test "$enable_threads" = "yes" ; then
-    enable_threads=multiple
-elif test "$enable_threads" = "no" ; then
-    enable_threads=single
-elif test "$enable_threads" = default ; then
-    # I believe AC_TRY_RUN here is OK. The worst case (for cross compile) will result in
-    # multi-thread tests disabled. By pass by explicitly configure with --enable-threads=xxx
-    AC_TRY_RUN(AC_LANG_PROGRAM([#include "mpi.h"],[
-            int provided = MPI_THREAD_SINGLE;
-            MPI_Init_thread(0,0,MPI_THREAD_MULTIPLE,&provided);
-            MPI_Finalize();
-            if (provided != MPI_THREAD_MULTIPLE) exit(1);
-        ]),
-        [enable_threads=multiple], [enable_threads=single], [enable_threads=single]
-    )
-fi
-
 # errordir is substituted into the testlist file as errors when the
 # tests should check error handling and as a comment (#) otherwise.
 errordir="#"
@@ -503,10 +475,10 @@ else
 fi
 AC_SUBST(comm_overlap)
 
-#
-# Only run the threads tests if multiple is specified
-if test "$enable_threads" = "multiple" -o "$enable_threads" = "runtime" ; then
-    threadsdir="threads"
+# The multi-thread tests can be disabled by --disable-threads
+threadsdir="threads"
+if test "$enable_threads" = "no"; then
+    threadsdir="#threads"
 fi
 #
 # Only run the checkpointing tests if enabled

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -859,7 +859,7 @@ AC_CHECK_FUNCS(getrusage)
 # some tests, we need to know if we are MPI 2.1 or MPI 2.2,
 # particularly for new routines in Fortran
 AC_CACHE_CHECK([for major version of MPI],pac_cv_mpi_major_version,[
-    for pac_cv_mpi_major_version in 3 2 1 unknown ; do
+    for pac_cv_mpi_major_version in 4 3 2 1 unknown ; do
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[
 #if MPI_VERSION == $pac_cv_mpi_major_version
     ''' force failure '''

--- a/test/mpi/datatype/hvecblklen.c
+++ b/test/mpi/datatype/hvecblklen.c
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
 {
     MPI_Datatype dt, dt2, newtype;
     int position, psize, insize, outsize;
-    signed char *inbuf = 0, *outbuf = 0, *pbuf = 0, *p;
+    char *inbuf = 0, *outbuf = 0, *pbuf = 0, *p;
     int i, j, k;
     int errs = 0;
     int veccount = 16, stride = 16;

--- a/test/mpi/datatype/pack_external.c
+++ b/test/mpi/datatype/pack_external.c
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
 
         const char *ref = get_pack_buffer(dt_list[i]);
         if (mpi_type_is_bool(dt_list[i].mpi_type)) {
-            /* Many C compilers will covert boolean values on assignment, e.g. 2->1,
+            /* Many C compilers will convert boolean values on assignment, e.g. 2->1,
              * but some compilers does not, e.g. Solaris suncc.
              * Current MPICH relies on compiler conversion. For other compilers, it is
              * probably not critical as long as the rount trip check (below) passes.
@@ -244,10 +244,10 @@ int main(int argc, char **argv)
                    get_mpi_type_name(dt_list[i].mpi_type));
             errs++;
             const char *p = pack_buf + OFFSET;
-            for (int i = 0; i < size; i++) {
-                if (ref[i] != p[i]) {
-                    printf("    pack_buf[%d] is 0x%02x, expect 0x%02x\n", i, p[i] & 0xff,
-                           ref[i] & 0xff);
+            for (int j = 0; j < size; j++) {
+                if (ref[j] != p[j]) {
+                    printf("    pack_buf[%d] is 0x%02x, expect 0x%02x\n", j, p[j] & 0xff,
+                           ref[j] & 0xff);
                 }
             }
         }

--- a/test/mpi/datatype/vecblklen.c
+++ b/test/mpi/datatype/vecblklen.c
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
 {
     MPI_Datatype dt, dt2, newtype;
     int position, psize, insize, outsize;
-    signed char *inbuf = 0, *outbuf = 0, *pbuf = 0, *p;
+    char *inbuf = 0, *outbuf = 0, *pbuf = 0, *p;
     int i, j, k;
     int errs = 0;
     int veccount = 16, stride = 16;

--- a/test/mpi/impls/mpich/threads/pt2pt/sendrecv_vci_hint.c
+++ b/test/mpi/impls/mpich/threads/pt2pt/sendrecv_vci_hint.c
@@ -69,8 +69,8 @@ MTEST_THREAD_RETURN_TYPE run_send_recv_test(void *arg)
 }
 
 /* Launch multiple threads, apply provided comm hints, run send/recv */
-int comm_hint_test(const char **comm_hints, const char **comm_hints_vals, int n_hints,
-                   bool test_set_value, bool maintain_msg_order)
+static int comm_hint_test(const char **comm_hints, const char **comm_hints_vals, int n_hints,
+                          bool test_set_value, bool maintain_msg_order)
 {
     int i, j, errs = 0, nprocs, rank, flag;
     struct thread_param params[NTHREADS];
@@ -142,7 +142,7 @@ int comm_hint_test(const char **comm_hints, const char **comm_hints_vals, int n_
 
 int main(int argc, char **argv)
 {
-    int i, pmode, nprocs, errs = 0, err, count = 0, iter = 0;
+    int pmode, nprocs, errs = 0, err;
     const char *hints_1[2];
     const char *hints_1_vals[2];
 

--- a/test/mpi/include/mtest_dtp.h
+++ b/test/mpi/include/mtest_dtp.h
@@ -8,6 +8,8 @@
 
 #include "dtpools.h"
 #include "mtest_common.h"
+#include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 
 typedef enum {

--- a/test/mpi/init/session_psets.c
+++ b/test/mpi/init/session_psets.c
@@ -7,6 +7,7 @@
 #include "mpi.h"
 #include <stdio.h>
 #include <assert.h>
+#include <string.h>
 
 /* This is adapted example 10.9 from MPI Standard 4.0
  * This example illustrates the use of Process Set query functions to select a

--- a/test/mpi/io/zero_count.c
+++ b/test/mpi/io/zero_count.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     int errs = 0;
     int len, rank, get_size;
     char buf[10];
-    const char *filename = argv[0];
+    const char *filename = __FILE__;
     MPI_File fh;
     MPI_Status status;
 

--- a/test/mpi/manual/mpi_t/nem_fbox_fallback_to_queue_count.c
+++ b/test/mpi/manual/mpi_t/nem_fbox_fallback_to_queue_count.c
@@ -37,7 +37,7 @@ MPI_T_pvar_handle fbox_handle;
  * Question: Do we really want to write pvars other than reset?
  */
 void blank_test(void);
-void blank_test()
+void blank_test(void)
 {
     uint64_t temp[2] = { -1 };
 
@@ -118,7 +118,7 @@ static void send_first_test(void)
  *        workaround.
  */
 void recv_first_test(void);
-void recv_first_test()
+void recv_first_test(void)
 {
     uint64_t nem_fbox_fall_back_to_queue_count[2] = { -1 };
 

--- a/test/mpi/manual/mpi_t/unexpected_recvq_buffer_size.c
+++ b/test/mpi/manual/mpi_t/unexpected_recvq_buffer_size.c
@@ -31,7 +31,7 @@ MPI_T_pvar_handle uqsize_handle;
 
 /* The first receive will block waiting for the last send, since messages from
  * a given rank are received in order. */
-static void reversed_tags_test()
+static void reversed_tags_test(void)
 {
     size_t unexpected_recvq_buffer_size;
 
@@ -69,7 +69,7 @@ static void reversed_tags_test()
 /* Rendezvous-based messages will never be unexpected (except for the initial RTS,
  * which has an empty buffer anyhow).
  */
-static void rndv_test()
+static void rndv_test(void)
 {
     size_t unexpected_recvq_buffer_size;
 

--- a/test/mpi/manual/singjoin.c
+++ b/test/mpi/manual/singjoin.c
@@ -60,7 +60,8 @@ int opt_port = 0;
 SOCKET_FD_TYPE server_routine(int portnum)
 {
     SOCKET_FD_TYPE listenfd, peer_fd;
-    int ret, peer_addr_size;
+    int ret;
+    socklen_t peer_addr_size;
     struct sockaddr_in server_addr, peer_addr;
 
     listenfd = socket(AF_INET, SOCK_STREAM, 0);

--- a/test/mpi/manual/tchandlers.c
+++ b/test/mpi/manual/tchandlers.c
@@ -78,7 +78,7 @@ void startWatchdog(int seconds)
     pthread_create(&theThread, NULL, threadLooper, NULL);
 }
 
-void strokeWatchdog()
+void strokeWatchdog(void)
 {
     sWatchdogStrokeCount++;
 }

--- a/test/mpi/manual/tcutil.c
+++ b/test/mpi/manual/tcutil.c
@@ -50,7 +50,7 @@ void safeSleep(double seconds)
     }
 }
 
-void printStackTrace()
+void printStackTrace(void)
 {
     static char cmd[512];
     snprintf(cmd, 512, "/bin/sh -c \"/home/eellis/bin/pstack1 %d\"", getpid());

--- a/test/mpi/mpi_t/mpit_isendirecv.c
+++ b/test/mpi/mpi_t/mpit_isendirecv.c
@@ -20,7 +20,6 @@ static MPI_T_pvar_handle nsc_handle, nrc_handle, snsc_handle, snrc_handle;
 static MPI_T_pvar_session session;
 static int elems = 1000000;
 static MPI_Request *reqs;
-static int num_nics = 1;
 static int enable_striping = 1;
 static int enable_hashing = 0;
 static int num_nodes = 0;
@@ -118,23 +117,24 @@ static int compare_vars(int rank, int target, int num_nics)
         if (rank < num_pairs) {
             if (expected_mapping[0].nic_sent_bytes_count[idx] != nic_sent_bytes_count[idx]) {
                 printf
-                    ("rank=%d --> target=%d: Actual sent byte count=%ld through NIC %d does not match with the "
-                     "expected sent byte count=%ld\n", rank, target, nic_sent_bytes_count[idx], idx,
-                     expected_mapping[0].nic_sent_bytes_count[idx]);
+                    ("rank=%d --> target=%d: Actual sent byte count=%llu through NIC %d does not match with the "
+                     "expected sent byte count=%llu\n", rank, target, nic_sent_bytes_count[idx],
+                     idx, expected_mapping[0].nic_sent_bytes_count[idx]);
                 errs++;
             }
             if (expected_mapping[0].nic_recvd_bytes_count[idx] != nic_recvd_bytes_count[idx]) {
                 printf
-                    ("rank=%d --> target=%d: Actual received byte count=%ld through NIC %d does not match with the "
-                     "expected received byte count=%ld\n", rank, target, nic_recvd_bytes_count[idx],
-                     idx, expected_mapping[0].nic_recvd_bytes_count[idx]);
+                    ("rank=%d --> target=%d: Actual received byte count=%llu through NIC %d does not match with the "
+                     "expected received byte count=%llu\n", rank, target,
+                     nic_recvd_bytes_count[idx], idx,
+                     expected_mapping[0].nic_recvd_bytes_count[idx]);
                 errs++;
             }
             if (expected_mapping[0].striped_nic_sent_bytes_count[idx] !=
                 striped_nic_sent_bytes_count[idx]) {
                 printf
-                    ("rank=%d --> target=%d: Actual striped sent byte count=%ld through NIC %d does not match with the "
-                     "expected striped sent byte count=%ld\n", rank, target,
+                    ("rank=%d --> target=%d: Actual striped sent byte count=%llu through NIC %d does not match with the "
+                     "expected striped sent byte count=%llu\n", rank, target,
                      striped_nic_sent_bytes_count[idx], idx,
                      expected_mapping[0].striped_nic_sent_bytes_count[idx]);
                 return -1;
@@ -142,8 +142,8 @@ static int compare_vars(int rank, int target, int num_nics)
             if (expected_mapping[0].striped_nic_recvd_bytes_count[idx] !=
                 striped_nic_recvd_bytes_count[idx]) {
                 printf
-                    ("rank=%d --> target=%d: Actual striped received byte count=%ld through NIC %d does not match with the "
-                     "expected striped received byte count=%ld\n", rank, target,
+                    ("rank=%d --> target=%d: Actual striped received byte count=%llu through NIC %d does not match with the "
+                     "expected striped received byte count=%llu\n", rank, target,
                      striped_nic_recvd_bytes_count[idx], idx,
                      expected_mapping[0].striped_nic_recvd_bytes_count[idx]);
                 return -1;
@@ -151,23 +151,24 @@ static int compare_vars(int rank, int target, int num_nics)
         } else if (rank < num_pairs * 2) {
             if (expected_mapping[1].nic_sent_bytes_count[idx] != nic_sent_bytes_count[idx]) {
                 printf
-                    ("rank=%d --> target=%d: Actual sent byte count=%ld through NIC %d does not match with the "
-                     "expected sent byte count=%ld\n", rank, target, nic_sent_bytes_count[idx], idx,
-                     expected_mapping[1].nic_sent_bytes_count[idx]);
+                    ("rank=%d --> target=%d: Actual sent byte count=%llu through NIC %d does not match with the "
+                     "expected sent byte count=%llu\n", rank, target, nic_sent_bytes_count[idx],
+                     idx, expected_mapping[1].nic_sent_bytes_count[idx]);
                 errs++;
             }
             if (expected_mapping[1].nic_recvd_bytes_count[idx] != nic_recvd_bytes_count[idx]) {
                 printf
-                    ("rank=%d --> target=%d: Actual received byte count=%ld through NIC %d does not match with the "
-                     "expected received byte count=%ld\n", rank, target, nic_recvd_bytes_count[idx],
-                     idx, expected_mapping[1].nic_recvd_bytes_count[idx]);
+                    ("rank=%d --> target=%d: Actual received byte count=%llu through NIC %d does not match with the "
+                     "expected received byte count=%llu\n", rank, target,
+                     nic_recvd_bytes_count[idx], idx,
+                     expected_mapping[1].nic_recvd_bytes_count[idx]);
                 errs++;
             }
             if (expected_mapping[1].striped_nic_sent_bytes_count[idx] !=
                 striped_nic_sent_bytes_count[idx]) {
                 printf
-                    ("rank=%d --> target=%d: Actual striped sent byte count=%ld through NIC %d does not match with the "
-                     "expected striped sent byte count=%ld\n", rank, target,
+                    ("rank=%d --> target=%d: Actual striped sent byte count=%llu through NIC %d does not match with the "
+                     "expected striped sent byte count=%llu\n", rank, target,
                      striped_nic_sent_bytes_count[idx], idx,
                      expected_mapping[1].striped_nic_sent_bytes_count[idx]);
                 return -1;
@@ -175,8 +176,8 @@ static int compare_vars(int rank, int target, int num_nics)
             if (expected_mapping[1].striped_nic_recvd_bytes_count[idx] !=
                 striped_nic_recvd_bytes_count[idx]) {
                 printf
-                    ("rank=%d --> target=%d: Actual striped received byte count=%ld through NIC %d does not match with the "
-                     "expected striped received byte count=%ld\n", rank, target,
+                    ("rank=%d --> target=%d: Actual striped received byte count=%llu through NIC %d does not match with the "
+                     "expected striped received byte count=%llu\n", rank, target,
                      striped_nic_recvd_bytes_count[idx], idx,
                      expected_mapping[1].striped_nic_recvd_bytes_count[idx]);
                 return -1;
@@ -202,6 +203,7 @@ int main(int argc, char *argv[])
     int readonly, continuous, atomic;
     MPI_T_enum enumtype;
     int nsc_idx = -1, nrc_idx = -1, snsc_idx = -1, snrc_idx = -1;
+    int num_nics = 1;
 
     int required, provided;
     int errs = 0;

--- a/test/mpi/mpi_t/qmpi_test.c
+++ b/test/mpi/mpi_t/qmpi_test.c
@@ -40,7 +40,7 @@ QMPI_Finalize_t *next_finalize_fn[2];
 int next_finalize_id[2];
 
 __attribute__ ((constructor))
-void static_register_my_tool()
+void static_register_my_tool(void)
 {
     if (MPI_SUCCESS == QMPI_Register_tool_name("test_tool", &test_init_function_pointer)) {
         qmpi_on = 1;

--- a/test/mpi/part/pingping.c
+++ b/test/mpi/part/pingping.c
@@ -72,7 +72,6 @@ int main(int argc, char *argv[])
     int minsize = 2, nmsg, maxmsg;
     int seed, testsize;
     MPI_Aint sendcnt, recvcnt;
-    MPI_Aint maxbufsize;
     MPI_Comm comm;
     DTP_pool_s dtp;
     struct mtest_obj send, recv;
@@ -89,8 +88,6 @@ int main(int argc, char *argv[])
     basic_type = MTestArgListGetString(head, "type");
     sendmem = MTestArgListGetMemType(head, "sendmem");
     recvmem = MTestArgListGetMemType(head, "recvmem");
-
-    maxbufsize = MTestDefaultMaxBufferSize();
 
     err = DTP_pool_create(basic_type, sendcnt, seed, &dtp);
     if (err != DTP_SUCCESS) {

--- a/test/mpi/part/pingping.c
+++ b/test/mpi/part/pingping.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mpitest.h"
 #include "mtest_dtp.h"
 #include "dtpools.h"
 #include <assert.h>

--- a/test/mpi/pt2pt/inactivereq.c
+++ b/test/mpi/pt2pt/inactivereq.c
@@ -78,7 +78,7 @@ static int test_recv_init(int src_rank, const char *test_name)
     return errs;
 }
 
-static void test_proc_null()
+static void test_proc_null(void)
 {
     MPI_Request r;
     MPI_Status s;

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mpitest.h"
 #include "dtpools.h"
 #include "mtest_dtp.h"
 #include <assert.h>

--- a/test/mpi/pt2pt/sendrecv1.c
+++ b/test/mpi/pt2pt/sendrecv1.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mpitest.h"
 #include "dtpools.h"
 #include "mtest_dtp.h"
 #include <assert.h>

--- a/test/mpi/pt2pt/sendself.c
+++ b/test/mpi/pt2pt/sendself.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mpitest.h"
 #include "dtpools.h"
 #include "mtest_dtp.h"
 #include <assert.h>

--- a/test/mpi/rma/accfence1.c
+++ b/test/mpi/rma/accfence1.c
@@ -3,11 +3,11 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "mpitest.h"
 #include "dtpools.h"
 #include "mtest_dtp.h"
 #include <assert.h>

--- a/test/mpi/rma/accpscw1.c
+++ b/test/mpi/rma/accpscw1.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mpitest.h"
 #include "dtpools.h"
 #include "mtest_dtp.h"
 #include <assert.h>

--- a/test/mpi/rma/epochtest.c
+++ b/test/mpi/rma/epochtest.c
@@ -19,10 +19,10 @@
  *     fence                 fence
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mpitest.h"
 #include "dtpools.h"
 #include "mtest_dtp.h"
 #include <assert.h>

--- a/test/mpi/rma/fence.c
+++ b/test/mpi/rma/fence.c
@@ -3,12 +3,12 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <limits.h>
-#include "mpitest.h"
 #include "dtpools.h"
 #include "mtest_dtp.h"
 #include <assert.h>

--- a/test/mpi/rma/lock_x_dt.c
+++ b/test/mpi/rma/lock_x_dt.c
@@ -3,11 +3,11 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-#include "mpitest.h"
 #include "dtpools.h"
 #include "mtest_dtp.h"
 

--- a/test/mpi/rma/overlap_wins_rma.c
+++ b/test/mpi/rma/overlap_wins_rma.c
@@ -158,7 +158,7 @@ static void print_target_data(void)
     fflush(stdout);
 }
 
-static int run_test()
+static int run_test(void)
 {
     int errors = 0;
     int i, x;

--- a/test/mpi/rma/putpscw1.c
+++ b/test/mpi/rma/putpscw1.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mpitest.h"
 #include "dtpools.h"
 #include "mtest_dtp.h"
 #include <assert.h>

--- a/test/mpi/rma/win_shared_rma_flush_load.c
+++ b/test/mpi/rma/win_shared_rma_flush_load.c
@@ -99,7 +99,7 @@ static int check_local_result(int iter)
 #define check_local_result(iter) (0)
 #endif
 
-static int run_test()
+static int run_test(void)
 {
     int i = 0, x = 0;
     int errors = 0;

--- a/test/mpi/rma/wrma_flush_get.c
+++ b/test/mpi/rma/wrma_flush_get.c
@@ -100,7 +100,7 @@ static int check_local_result(int iter)
 #define check_local_result(iter) (0)
 #endif
 
-static int run_test()
+static int run_test(void)
 {
     int i = 0, x = 0;
     int errors = 0;

--- a/test/mpi/threads/perf/mt_rma_msgrate.c
+++ b/test/mpi/threads/perf/mt_rma_msgrate.c
@@ -49,7 +49,6 @@ MTEST_THREAD_RETURN_TYPE thread_fn(void *arg)
     int win_i, win_post_i, win_posts;
     void *buf, *result_buf;
     MPI_Request requests[WINDOW_SIZE];
-    MPI_Status statuses[WINDOW_SIZE];
     double t_start, t_end;
 
     tid = (int) (long) arg;

--- a/test/mpi/threads/pt2pt/mt_pers_sendrecv_impl.c
+++ b/test/mpi/threads/pt2pt/mt_pers_sendrecv_impl.c
@@ -69,7 +69,6 @@ int test_pers_sendrecv(int id, int iter, int count, int *buff, MPI_Comm comm, in
     if (errs > 0)
         fprintf(stderr, "thread %d: %d errors found in received data\n", id, errs);
 
-  fn_exit:
     return errs;
 }
 

--- a/test/mpi/threads/pt2pt/mt_probe_impl.c
+++ b/test/mpi/threads/pt2pt/mt_probe_impl.c
@@ -224,7 +224,6 @@ int test_probe_normal(int id, int iter, int count, int *buff, MPI_Comm comm, int
 
     }
 
-  fn_exit:
     return errs;
 }
 

--- a/test/mpi/threads/spawn/th_taskmanager.c
+++ b/test/mpi/threads/spawn/th_taskmanager.c
@@ -147,7 +147,6 @@ int main(int argc, char *argv[])
         CHECK_SUCCESS(MPI_Comm_disconnect(&parent));
     }
 
-  fn_exit:
     /* Do not call MTest_Finalize (and thus MTest_Init) to avoid printing extra
      * "No Errors" as many as spawned MPI processes. */
     MPI_Finalize();

--- a/test/mpi/util/mtest_common.c
+++ b/test/mpi/util/mtest_common.c
@@ -4,7 +4,9 @@
  */
 
 #include "mpitest.h"
+#include "mtest_common.h"
 #include <assert.h>
+#include <string.h>
 
 /* ------------------------------------------------------------------------ */
 /* Utilities related to test environment */
@@ -15,7 +17,7 @@
    It is taking the simplest solution here: default to 2GB, unless user set via
    environment variable -- MPITEST_MAXBUFFER
 */
-MPI_Aint MTestDefaultMaxBufferSize()
+MPI_Aint MTestDefaultMaxBufferSize(void)
 {
     MPI_Aint max_size = 1073741824;
     if (sizeof(void *) == 4) {
@@ -697,7 +699,7 @@ void MTestCopyContent(const void *sbuf, void *dbuf, size_t size, mtest_mem_type_
     }
 }
 
-void MTest_finalize_gpu()
+void MTest_finalize_gpu(void)
 {
 #ifdef HAVE_ZE
     if (ndevices != -1) {


### PR DESCRIPTION
## Pull Request Description
We used to configure test/mpi as a sub-configure of mpich. For one, this
wastes build (configure) time when user has no intention to run the full
testsuite. For two, this complicates the build script since
test/mpi/configure.ac need deal with two very difference situation --
configured standalone or configured from mpich.

Since we'll need installing the mpich before running the test suite
anyway, it makes little sense to configure test suite during the build
of mpich. While we may need add additional feature tests to detect
enable/disabled mpich features, it is necessary to fully support
independent MPI testing anyway.



[skip warnings]
## Expected Impact
1. `./autogen.sh && ./configure ... && make install` will not run `autogen` or `configure` in `test/mpi`, thus not wasting time if there is no intent to run the full testsuite.
2. Assuming `mpicc/mpiexec` is in the path, one can `cd test/mpi && ./autogen.sh && ./configure && make testing` to run the testsuite. This makes the testsuite standalone and can be used test any mpi installation.
3. After steps in `1.`, one can just `make testing` to run the testsuite without setting paths. Basically, `make testing`  runs steps in `2.` pass `--with-mpi=[prefix]` to the `configure`. This effectively recovers the current convenience.
4. CI testing scripts may be used to pass explicit `--enable/disable` options in mpich configure to be passed down to `test/mpi/configure`. This no longer works. One needs to do step `2.` separately in order to customize options for testing -- shouldn't be an issue for job scripts. We enable all tests by default, and run feature testing on `mpicc` etc to disable the tests that feature is not present. Explicit `--disable-xxx` will always work.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
