### PR TITLE
request: fix start of MPI_Send_init to MPI_PROC_NULL

### DIFF
--- a/src/mpid/ch4/src/ch4_startall.h
+++ b/src/mpid/ch4/src/ch4_startall.h
@@ -88,7 +88,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Startall(int count, MPIR_Request * requests[])
     for (i = 0; i < count; i++) {
         MPIR_Request *const preq = requests[i];
         /* continue if the source/dest is MPI_PROC_NULL */
-        if (MPIDIG_REQUEST(preq, rank) == MPI_PROC_NULL)
+        if (MPIDI_PREQUEST(preq, rank) == MPI_PROC_NULL)
             continue;
 
         switch (preq->kind) {

--- a/test/mpi/pt2pt/inactivereq.c
+++ b/test/mpi/pt2pt/inactivereq.c
@@ -79,6 +79,27 @@ int test_recv_init(int src_rank, const char *test_name)
     return errs;
 }
 
+void test_proc_null()
+{
+    MPI_Request r;
+    MPI_Status s;
+    int errs = 0;
+    int flag;
+    int buf[10];
+    int tag = 27;
+
+    MPI_Recv_init(buf, 10, MPI_INT, MPI_PROC_NULL, tag, MPI_COMM_WORLD, &r);
+    MPI_Start(&r);
+    MPI_Wait(&r, &s);
+    MPI_Request_free(&r);
+
+    MPI_Send_init(buf, 10, MPI_INT, MPI_PROC_NULL, tag, MPI_COMM_WORLD, &r);
+    MPI_Start(&r);
+    MPI_Wait(&r, &s);
+
+    MPI_Request_free(&r);
+}
+
 int main(int argc, char *argv[])
 {
     MPI_Request r;
@@ -165,8 +186,6 @@ int main(int argc, char *argv[])
         printf("Status not empty after MPI_Wait (send)\n");
     }
 
-
-
     MPI_Request_free(&r);
 
     if (rank == 0)
@@ -181,6 +200,7 @@ int main(int argc, char *argv[])
         MTestPrintfMsg(1, "Create a persistent receive (ANY_SOURCE) request\n");
 
     errs += test_recv_init(MPI_ANY_SOURCE, "recv-anysource");
+    test_proc_null();
 
   fn_exit:
     MTest_Finalize(errs);


### PR DESCRIPTION
## Pull Request Description
There was an error in ch4_startall.h at L21 in which MPIDIG_REQUEST was being used. This was incorrect and was swapped to MPIDI_PREQUEST.

## TODO
* [x] Confirm user reported bug
* [x] Implement Fix
* [x] Create Tests

Fixes #5053 

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
