### PR TITLE
warnings: potential incompatible pointers

### DIFF
--- a/src/mpi_t/events_impl.c
+++ b/src/mpi_t/events_impl.c
@@ -132,12 +132,12 @@ void MPIR_T_event_instance(int event_index, MPI_T_cb_safety cb_safety, void *dat
 static MPI_Count default_timestamp(void)
 {
     MPL_time_t t;
-    MPI_Count ticks;
+    long long ticks;
 
     MPL_wtime(&t);
     MPL_wtime_to_ticks(&t, &ticks);
 
-    return ticks;
+    return (MPI_Count) ticks;
 }
 
 void MPIR_T_events_finalize(void)


### PR DESCRIPTION
## Pull Request Description
MPL_wtime_to_ticks uses long long pointers, and on 64-bit system,
MPI_Count is long. Although they are the same size, the compiler warns
about incompatible pointer type. This is true since it is not guaranteed
for all systems. Use long long and then convert to MPI_Count in stead.

Alternatively, we could make MPL_wtime_to_ticks to directly return the
integer.



<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
