### PR TITLE
mpit: add HAVE_ERROR_CHECKING guard for event_instance.kind

### DIFF
--- a/src/mpi_t/events_impl.c
+++ b/src/mpi_t/events_impl.c
@@ -108,7 +108,9 @@ void MPIR_T_event_instance(int event_index, MPI_T_cb_safety cb_safety, void *dat
                 MPIR_T_source_t *source;
                 MPIR_T_event_instance_t event_instance;
                 HASH_FIND_INT(sources, &event->source_index, source);
+#ifdef HAVE_ERROR_CHECKING
                 event_instance.kind = MPIR_T_EVENT_INSTANCE;
+#endif
                 event_instance.event = event;
                 MPIR_T_source_get_timestamp_impl(event->source_index, &event_instance.timestamp);
                 event_instance.data = data;


### PR DESCRIPTION
The "kind" field in the MPIR_T_event_instance_t struct is only defined
when HAVE_ERROR_CHECKING is defined. Thus we need add the macro guard
around initializing this field.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
