### PR TITLE
init: allow session to work with MPI_THREAD_SINGLE

### DIFF
--- a/src/mpi/init/init_impl.c
+++ b/src/mpi/init/init_impl.c
@@ -65,14 +65,12 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
     int mpi_errno = MPI_SUCCESS;
     MPIR_Session *session_ptr = NULL;
 
-    /* Until we identify all the functions that may share states across sessions and
-     * protect them approprately, we require THREAD_MULTIPLE to support sessions */
-
     int provided;
+    /* Let's try ask for MPI_THREAD_MULTIPLE, but it probably still works with
+     * MPI_THREAD_SINGLE since we use MPL_Initlock_lock for cross-session locks.
+     */
     mpi_errno = MPII_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, &provided, &session_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-
-    MPIR_Assert(provided == MPI_THREAD_MULTIPLE);
 
     session_ptr->thread_level = provided;
 


### PR DESCRIPTION


## Pull Request Description

Now that we use MPL_initlock for init and finalize, it is okay to work
with MPI_THREAD_SINGLE as long as user still access MPI in single
thread.

## Expected Impact
[skip warnings]
## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
