### PR TITLE
mpi_t: Fix type of dropped_count argument

### DIFF
--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -702,7 +702,7 @@ typedef enum MPI_T_source_order {
 
 typedef void (MPI_T_event_cb_function)(MPI_T_event_instance event_instance, MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, void *user_data);
 typedef void (MPI_T_event_free_cb_function)(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, void *user_data);
-typedef void (MPI_T_event_dropped_cb_function)(int count, MPI_T_event_registration event_registration, int source_index, MPI_T_cb_safety cb_safety, void *user_data);
+typedef void (MPI_T_event_dropped_cb_function)(MPI_Count count, MPI_T_event_registration event_registration, int source_index, MPI_T_cb_safety cb_safety, void *user_data);
 
 /* Handle conversion types/functions */
 

--- a/src/include/mpitimpl.h
+++ b/src/include/mpitimpl.h
@@ -1305,7 +1305,7 @@ typedef struct MPIR_T_event_registration_s {
     void *obj_handle;
     MPIR_T_event_cb_t callbacks[4];     /* one for each safety level */
     MPI_T_event_dropped_cb_function *dropped_cb;
-    int dropped_count;
+    MPI_Count dropped_count;
 
     struct MPIR_T_event_registration_s *next;
 } MPIR_T_event_registration_t;


### PR DESCRIPTION
## Pull Request Description

An MPI-4.0 errata ticket changed the type of this argument from
int to MPI_Count.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
