### PR TITLE
mpi_t: Update argument name for MPI_T_category_changed

### DIFF
--- a/src/binding/apis_mapping.txt
+++ b/src/binding/apis_mapping.txt
@@ -176,6 +176,7 @@ LIS_KIND_MAP:
     TYPECLASS: integer
     TYPECLASS_SIZE: integer
     UPDATE_MODE: state
+    UPDATE_NUMBER: integer
     VARARGS: \\ldots
     VARIABLE_SCOPE: integer
     VERSION: integer
@@ -364,6 +365,7 @@ BASE_C_KIND_MAP:
     TYPECLASS: int
     TYPECLASS_SIZE: int
     UPDATE_MODE: int
+    UPDATE_NUMBER: int
     VARARGS: \\ldots
     VARIABLE_SCOPE: int
     VERSION: int
@@ -592,6 +594,7 @@ BASE_F90_KIND_MAP:
     TYPECLASS: INTEGER
     TYPECLASS_SIZE: INTEGER
     UPDATE_MODE: INTEGER
+    UPDATE_NUMBER: None
     VARARGS: None
     VARIABLE_SCOPE: None
     VERSION: INTEGER

--- a/src/binding/c/mpit_api.txt
+++ b/src/binding/c/mpit_api.txt
@@ -9,7 +9,7 @@ MPI_T_category_changed:
     from the second call is higher, then some categories have been added or expanded.
 */
 {
-    *stamp = cat_stamp;
+    *update_number = cat_stamp;
 }
 
 MPI_T_category_get_categories:

--- a/src/binding/mpi_standard_api.txt
+++ b/src/binding/mpi_standard_api.txt
@@ -2049,7 +2049,7 @@ MPI_TYPE_NULL_DELETE_FN:
     extra_state: EXTRA_STATE
     ierror: ERROR_CODE_SHOW_INTENT, direction=out, suppress=c_parameter
 MPI_T_category_changed:
-    stamp: TIMESTAMP, direction=out, [a virtual time stamp to indicate the last change to the categories]
+    update_number: UPDATE_NUMBER, direction=out, [update number]
 MPI_T_category_get_categories:
     cat_index: CAT_INDEX, [index of the category to be queried, in the range $0$ and $num_cat-1$]
     len: ARRAY_LENGTH, [the length of the indices array]

--- a/src/mpi_t/errnames.txt
+++ b/src/mpi_t/errnames.txt
@@ -67,7 +67,7 @@
 **mpi_t_category_get_categories: MPI_T_category_get_categories failed
 **mpi_t_category_get_categories %d %d %p: MPI_T_category_get_categories(cat_index=%d, len=%d, indices=%p)
 **mpi_t_category_changed: MPI_T_category_changed failed
-**mpi_t_category_changed %p: MPI_T_category_changed(stamp=%p)
+**mpi_t_category_changed %p: MPI_T_category_changed(update_number=%p)
 **mpi_t_cvar_get_index: mpi_t_cvar_get_index failed
 **mpi_t_cvar_get_index %p %p: mpi_t_cvar_get_index(name=%p, cvar_index=%p)
 **mpi_t_pvar_get_index: mpi_t_pvar_get_index failed


### PR DESCRIPTION
## Pull Request Description

MPI-4.0 updates the name of this argument from stamp to
update_number. There was a feeling that users may misinterpret the old
name as time-based, when it is not intended that way.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

None. This is just a name change. No functionality is altered.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
