### PR TITLE
hydra: clean CFLAGS before configure hwloc

### DIFF
--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -407,7 +407,10 @@ for hydra_topolib in ${hydra_topolibs}; do
                 fi
 		if test "$with_hwloc" = "embedded" ; then
                     hydra_use_embedded_hwloc=yes
+                    PAC_PUSH_FLAG([CFLAGS])
+                    CFLAGS=""
                     PAC_CONFIG_SUBDIR_ARGS([tools/topo/hwloc/hwloc], [--enable-embedded-mode --disable-visibility],[], [AC_MSG_ERROR(embedded hwloc configure failed)])
+                    PAC_POP_FLAG([CFLAGS])
                     dnl Note that single quote is intentional to pass the variable as is
                     hwloc_srcdir="tools/topo/hwloc/hwloc"
                     hwloc_includedir='-I${srcdir}/${hwloc_srcdir}/include -I${builddir}/${hwloc_srcdir}/include'


### PR DESCRIPTION
## Pull Request Description

We sanitize CFLAGS in mpich before configure hwloc, but neglected to do
so in hydra. The CFLAGS may carry strict warning flags that is not clean
for hydra. This currently breaks the strict build in freeBSD-32.



<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact
[skip warnings]
## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
