### PR TITLE
xfail: tests that are too expensive for ARM

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -177,3 +177,9 @@
 * * * ch3:ofi * sed -i  "s+\(^\S.*\)+\1 xfail=ticket0+g" test/mpi/threads/part/testlist
 * * * ch3:sock * sed -i  "s+\(^\S.*\)+\1 xfail=ticket0+g" test/mpi/threads/part/testlist
 * * * ch3:tcp * sed -i  "s+\(^\S.*\)+\1 xfail=ticket0+g" test/mpi/threads/part/testlist
+
+# Job-sepecific xfails
+# Our Arm servers are too slow for some tests
+mpich-main-arm.* * * * * sed -i "s+\(^sendflood .*\)+\1 xfail=ticket0+g"        test/mpi/pt2pt/testlist
+mpich-main-arm.* * * * * sed -i "s+\(^nonblocking3 .*\)+\1 xfail=ticket0+g"     test/mpi/coll/testlist
+mpich-main-arm.* * * * * sed -i "s+\(^alltoall .*\)+\1 xfail=ticket0+g"         test/mpi/threads/pt2pt/testlist


### PR DESCRIPTION

## Pull Request Description

Our ARM jenkins server is too weak to handle some tests. Add them to
xfails.

Unfortunately it is based on job names, thus can't be directly tested per-PR.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
