### PR TITLE
ch4: suppress "may be uninitialized" warnings

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -589,6 +589,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
             /* Force packing of GPU buffer in host memory */
             need_packing = true;
         }
+        offset = 0;
     } else {
         /* we are issuing deferred op. If the offset == 0, this is the first segment and we need to
          * send am_hdr */
@@ -618,7 +619,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
                 goto fn_exit;
             }
         }
-        mpi_errno = MPIR_Typerep_pack(buf, count, datatype, (issue_deferred ? offset : 0), send_buf,
+        mpi_errno = MPIR_Typerep_pack(buf, count, datatype, offset, send_buf,
                                       send_size, &packed_size);
         MPIR_ERR_CHECK(mpi_errno);
         send_size = packed_size;
@@ -629,7 +630,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
         send_req->pack_buffer = send_buf;
     } else {
         MPIDI_Datatype_check_lb(datatype, dt_true_lb);
-        send_buf = (char *) buf + dt_true_lb + (issue_deferred ? offset : 0);
+        send_buf = (char *) buf + dt_true_lb + offset;
         MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.am_hdr_buf_pool, (void **) &send_req);
         MPIR_Assert(send_req);
         send_req->sreq = sreq;


### PR DESCRIPTION
## Pull Request Description

Some old compilers are not able to see that we are not using
unintialized state here, and honestly the code had a bit too much hidden
braches to easily read. Split the MPIDI_progress_state_init into two
functions rather than using a constant argument to have different
behavior for different callers.

## Reference
It fixes following warning:
```
In directory: /var/lib/jenkins-slave/workspace/mpich-warnings/compiler/gcc-9/config/ch4-ucx/label/centos64_review
  CC       src/util/lib_libmpi_la-mpir_localproc.lo
In file included from ./src/mpid/ch4/include/mpidch4.h:356,
                 from ./src/mpid/ch4/include/mpidpost.h:10,
                 from ./src/include/mpiimpl.h:245,
                 from src/mpi/pt2pt/sendrecv.c:6:
src/mpi/pt2pt/sendrecv.c: In function ‘MPIR_Sendrecv_impl’:
./src/mpid/ch4/src/ch4_progress.h:39:8: warning: ‘progress_state.progress_counts[0]’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   39 |     if (state->progress_counts[idx] != MPIDI_global.progress_counts[state->vci[idx]]) {
      |        ^
src/mpi/pt2pt/sendrecv.c:51:29: note: ‘progress_state.progress_counts[0]’ was declared here
   51 |         MPID_Progress_state progress_state;
      |                             ^~~~~~~~~~~~~~
  CC       src/util/lib_libmpi_la-mpir_nettopo.lo
In file included from ./src/mpid/ch4/include/mpidch4.h:356,
                 from ./src/mpid/ch4/include/mpidpost.h:10,
                 from ./src/include/mpiimpl.h:245,
                 from src/mpi/spawn/spawn_impl.c:6:
src/mpi/spawn/spawn_impl.c: In function ‘MPIR_Comm_disconnect_impl’:
./src/mpid/ch4/src/ch4_progress.h:39:8: warning: ‘progress_state.progress_counts[0]’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   39 |     if (state->progress_counts[idx] != MPIDI_global.progress_counts[state->vci[idx]]) {
      |        ^
src/mpi/spawn/spawn_impl.c:195:29: note: ‘progress_state.progress_counts[0]’ was declared here
  195 |         MPID_Progress_state progress_state;
      |                             ^~~~~~~~~~~~~~
            
```
[skip warnings]
## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] You or your company has a signed contributor's agreement on file with Argonne
* [x] For non-Argonne authors, request an explicit comment from your companies PR approval manager
