### PR TITLE
hydra: extend -bind-to user option

### DIFF
--- a/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
+++ b/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
@@ -14,74 +14,79 @@ struct HYDT_topo_hwloc_info HYDT_topo_hwloc_info = { 0 };
 static hwloc_topology_t topology;
 static int hwloc_initialized = 0;
 
+/* ---- handle_user_binding routines ---- */
+static int count_num_bind_entries(const char *str)
+{
+    const char *s = str;
+    int num_bind_entries = 0;
+    while (true) {
+        if (!*s || *s == ',') {
+            num_bind_entries++;
+        }
+        /* next char */
+        if (!*s) {
+            break;
+        } else {
+            s++;
+        }
+    }
+    return num_bind_entries;
+}
+
+static hwloc_bitmap_t parse_bindset_str(const char *str)
+{
+    hwloc_bitmap_t bindset;
+    bindset = hwloc_bitmap_alloc();
+    hwloc_bitmap_zero(bindset);
+
+    const char *s = str;
+    while (true) {
+        /* expect digit */
+        if (!isdigit(*s)) {
+            break;
+        }
+
+        /* number */
+        int num = 0;
+        while (*s && isdigit(*s)) {
+            num = num * 10 + (*s) - '0';
+            s++;
+        }
+        hwloc_bitmap_set(bindset, num);
+
+        /* expect '+' or break */
+        if (*s == '+') {
+            s++;
+        }
+    }
+    return bindset;
+}
+
 static HYD_status handle_user_binding(const char *binding)
 {
-    int i, j, k, num_bind_entries, *bind_entry_lengths;
-    char *bindstr, **bind_entries;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
     HYDU_ASSERT(hwloc_initialized, status);
 
-    num_bind_entries = 1;
-    for (i = 0; binding[i]; i++)
-        if (binding[i] == ',')
-            num_bind_entries++;
-    HYDU_MALLOC_OR_JUMP(bind_entries, char **, num_bind_entries * sizeof(char *), status);
-    HYDU_MALLOC_OR_JUMP(bind_entry_lengths, int *, num_bind_entries * sizeof(int), status);
+    int num_bind_entries = count_num_bind_entries(binding);
 
-    for (i = 0; i < num_bind_entries; i++)
-        bind_entry_lengths[i] = 0;
-
-    j = 0;
-    for (i = 0; binding[i]; i++) {
-        if (binding[i] != ',')
-            bind_entry_lengths[j]++;
-        else
-            j++;
-    }
-
-    for (i = 0; i < num_bind_entries; i++) {
-        HYDU_MALLOC_OR_JUMP(bind_entries[i], char *, bind_entry_lengths[i] * sizeof(char), status);
-    }
-
-    j = 0;
-    k = 0;
-    for (i = 0; binding[i]; i++) {
-        if (binding[i] != ',')
-            bind_entries[j][k++] = binding[i];
-        else {
-            bind_entries[j][k] = 0;
-            j++;
-            k = 0;
-        }
-    }
-    bind_entries[j][k++] = 0;
-
-    /* initialize bitmaps */
     HYDU_MALLOC_OR_JUMP(HYDT_topo_hwloc_info.bitmap, hwloc_bitmap_t *,
                         num_bind_entries * sizeof(hwloc_bitmap_t), status);
 
-    for (i = 0; i < num_bind_entries; i++) {
-        HYDT_topo_hwloc_info.bitmap[i] = hwloc_bitmap_alloc();
-        hwloc_bitmap_zero(HYDT_topo_hwloc_info.bitmap[i]);
-        bindstr = strtok(bind_entries[i], "+");
-        while (bindstr) {
-            hwloc_bitmap_set(HYDT_topo_hwloc_info.bitmap[i], atoi(bindstr));
-            bindstr = strtok(NULL, "+");
+    const char *s = binding;
+    for (int i = 0; i < num_bind_entries; i++) {
+        HYDT_topo_hwloc_info.bitmap[i] = parse_bindset_str(s);
+        while (*s && *s != ',') {
+            s++;
         }
+        /* skip ',' */
+        s++;
     }
 
     HYDT_topo_hwloc_info.num_bitmaps = num_bind_entries;
     HYDT_topo_hwloc_info.user_binding = 1;
-
-    /* free temporary memory */
-    for (i = 0; i < num_bind_entries; i++) {
-        MPL_free(bind_entries[i]);
-    }
-    MPL_free(bind_entries);
-    MPL_free(bind_entry_lengths);
 
   fn_exit:
     HYDU_FUNC_EXIT();
@@ -90,6 +95,8 @@ static HYD_status handle_user_binding(const char *binding)
   fn_fail:
     goto fn_exit;
 }
+
+/* ---- end handle_user_binding routines ---- */
 
 static HYD_status handle_rr_binding(void)
 {

--- a/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
+++ b/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
@@ -48,11 +48,28 @@ static hwloc_bitmap_t parse_bindset_str(const char *str)
 
         /* number */
         int num = 0;
+        int num2 = 0;
         while (*s && isdigit(*s)) {
             num = num * 10 + (*s) - '0';
             s++;
         }
-        hwloc_bitmap_set(bindset, num);
+        /* potentially second number */
+        if (*s && *s == '-') {
+            s++;
+            while (*s && isdigit(*s)) {
+                num2 = num2 * 10 + (*s) - '0';
+                s++;
+            }
+            if (num > num2) {
+                num2 = num;
+            }
+        } else {
+            num2 = num;
+        }
+        /* set the bindset */
+        for (int j = num; j <= num2; j++) {
+            hwloc_bitmap_set(bindset, j);
+        }
 
         /* expect '+' or break */
         if (*s == '+') {


### PR DESCRIPTION
## Pull Request Description

The current user bind-to syntax is 
```
     -bind-to user:0+2,1+4,3,2`
```
, so for 64 core node and if user want to bind 1st process to 1st core,
and rest of the processes to all remaining cores, user have to specify
```
    -bind-to user:0,1+2+...+63,1+2+...+63
```
This is very clunky, and this PR extends the syntax to allow:
```
    -bind-to user:0,1-63x63
```

## Impact

This is after the extension:
```
$ HYDRA_TOPO_DEBUG=1 mpirun -bind-to user:0,2x2,2-4+8x3 -n 6 date

process 0 binding: 1000000000000000
process 1 binding: 0010000000000000
process 2 binding: 0010000000000000
process 3 binding: 0011100010000000
process 4 binding: 0011100010000000
process 5 binding: 0011100010000000
Wed Mar  3 16:28:05 CST 2021
Wed Mar  3 16:28:05 CST 2021
Wed Mar  3 16:28:05 CST 2021
Wed Mar  3 16:28:05 CST 2021
Wed Mar  3 16:28:05 CST 2021
Wed Mar  3 16:28:05 CST 2021
```

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
