### PR TITLE
runtests: add environment MPITEST_EXECARG

### DIFF
--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -196,6 +196,9 @@ if (defined($ENV{'MPITEST_PPNMAX'})) {
 if (defined($ENV{'MPITEST_TIMELIMITARG'})) {
     $timelimitArg = $ENV{'MPITEST_TIMELIMITARG'};
 }
+if (defined($ENV{'MPITEST_MPIEXECARG'})) {
+    $g_opt->{mpiexecargs} = $ENV{'MPITEST_MPIEXECARG'};
+}
 
 #---------------------------------------------------------------------------
 # Process arguments and override any defaults
@@ -722,6 +725,9 @@ sub RunMPIProgram {
     my $progArgs = join(' ', @{$test_opt->{args}});
     my $progEnv = join(' ', @{$test_opt->{envs}});
     my $mpiexecArgs = join(' ', @{$test_opt->{mpiexecargs}});
+    if (!$mpiexecArgs and $g_opt->{mpiexecargs}) {
+        $mpiexecArgs = $g_opt->{mpiexecargs};
+    }
 
     my $found_error   = 0;
     my $found_noerror = 0;


### PR DESCRIPTION
## Pull Request Description
This is to allow running tests with certain `mpiexec` options, such as
bindings.

## Background

I am testing this because I suspect there is a bug in `src/mpid/ch4/shm/src/topotree.c`, where each process allocates initial shared memory based on `topo_depth`. However, when the processes are bind to different levels, different processes will end up accessing different shmem size, resulting in memory errors.

[skip warnings]

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
