### PR TITLE
romio: fix when used in -Wpedantic build environments

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -1545,7 +1545,7 @@ static void ADIOI_W_Exchange_data_alltoallv(ADIO_File fd, const void *buf, char 
         for (i = 0; i < nprocs; i++) {
             if (send_size[i]) {
                 sbuf_ptr = all_send_buf + sdispls[i];
-                memcpy(sbuf_ptr, buf + buf_idx[i], send_size[i]);
+                memcpy(sbuf_ptr, (char *) buf + buf_idx[i], send_size[i]);
                 buf_idx[i] += send_size[i];
             }
         }


### PR DESCRIPTION
typecasting a (void*) due to compiler complaint when -Wpedantic is used

Signed-off-by: Mark Allen <markalle@us.ibm.com>