### PR TITLE
ch4/ofi: make sure to use ctx[0]'s issued_cntr

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -227,7 +227,12 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_cntr_incr(MPIR_Win * win)
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr(int vni)
 {
+#ifdef MPIDI_OFI_VNI_USE_DOMAIN
     MPIDI_OFI_global.ctx[vni].rma_issued_cntr++;
+#else
+    /* NOTE: shared with ctx[0] */
+    MPIDI_OFI_global.ctx[0].rma_issued_cntr++;
+#endif
 }
 
 /* Externs:  see util.c for definition */


### PR DESCRIPTION
## Pull Request Description
When using Scalable context as vni context, it shares rma_cmpl_cntr with
context 0. While we can copy the rma_cmpl_cntr, we can't do that with
issued_cntr because it is not a pointer. So we need to use ctx[0]'s
issued cntr during `win_init_global` and `MPIDI_OFI_cntr_incr`.

NOTE: spread the logic of "USE_DOMAIN" and "SEP CTX" to multiple places
is not ideal.


Fixes issue mentioned in https://github.com/pmodels/mpich/pull/4770#issuecomment-789813639

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
