### PR TITLE
Op equal

### DIFF
--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -312,6 +312,7 @@ typedef int MPI_Op;
 #define MPI_MAXLOC  (MPI_Op)(0x5800000c)
 #define MPI_REPLACE (MPI_Op)(0x5800000d)
 #define MPI_NO_OP   (MPI_Op)(0x5800000e)
+#define MPIX_EQUAL  (MPI_Op)(0x5800000f)
 
 /* Permanent key values */
 /* C Versions (return pointer to value),

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -36,6 +36,7 @@ typedef enum MPIR_Op_kind {
     MPIR_OP_KIND__MINLOC = 12,
     MPIR_OP_KIND__REPLACE = 13,
     MPIR_OP_KIND__NO_OP = 14,
+    MPIR_OP_KIND__EQUAL = 15,
     MPIR_OP_KIND__USER_NONCOMMUTE = 32,
     MPIR_OP_KIND__USER = 33
 } MPIR_Op_kind;
@@ -106,7 +107,7 @@ typedef struct MPIR_Op {
      MPID_DEV_OP_DECL
 #endif
 } MPIR_Op;
-#define MPIR_OP_N_BUILTIN 14
+#define MPIR_OP_N_BUILTIN 15
 extern MPIR_Op MPIR_Op_builtin[MPIR_OP_N_BUILTIN];
 extern MPIR_Op MPIR_Op_direct[];
 extern MPIR_Object_alloc_t MPIR_Op_mem;
@@ -158,6 +159,7 @@ void MPIR_MAXLOC(void *, void *, int *, MPI_Datatype *);
 void MPIR_MINLOC(void *, void *, int *, MPI_Datatype *);
 void MPIR_REPLACE(void *, void *, int *, MPI_Datatype *);
 void MPIR_NO_OP(void *, void *, int *, MPI_Datatype *);
+void MPIR_EQUAL(void *, void *, int *, MPI_Datatype *);
 
 int MPIR_MAXF_check_dtype(MPI_Datatype);
 int MPIR_MINF_check_dtype(MPI_Datatype);
@@ -173,6 +175,7 @@ int MPIR_MAXLOC_check_dtype(MPI_Datatype);
 int MPIR_MINLOC_check_dtype(MPI_Datatype);
 int MPIR_REPLACE_check_dtype(MPI_Datatype);
 int MPIR_NO_OP_check_dtype(MPI_Datatype);
+int MPIR_EQUAL_check_dtype(MPI_Datatype);
 
 #define MPIR_Op_add_ref_if_not_builtin(op)               \
     do {                                                 \

--- a/src/mpi/coll/allreduce/allreduce.c
+++ b/src/mpi/coll/allreduce/allreduce.c
@@ -86,7 +86,8 @@ MPI_User_function *MPIR_Op_table[] = {
     MPIR_BAND, MPIR_LOR, MPIR_BOR,
     MPIR_LXOR, MPIR_BXOR,
     MPIR_MINLOC, MPIR_MAXLOC,
-    MPIR_REPLACE, MPIR_NO_OP
+    MPIR_REPLACE, MPIR_NO_OP,
+    MPIR_EQUAL
 };
 
 MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[] = {
@@ -96,7 +97,8 @@ MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[] = {
     MPIR_BAND_check_dtype, MPIR_LOR_check_dtype, MPIR_BOR_check_dtype,
     MPIR_LXOR_check_dtype, MPIR_BXOR_check_dtype,
     MPIR_MINLOC_check_dtype, MPIR_MAXLOC_check_dtype,
-    MPIR_REPLACE_check_dtype, MPIR_NO_OP_check_dtype
+    MPIR_REPLACE_check_dtype, MPIR_NO_OP_check_dtype,
+    MPIR_EQUAL_check_dtype
 };
 
 

--- a/src/mpi/coll/allreduce/allreduce.c
+++ b/src/mpi/coll/allreduce/allreduce.c
@@ -77,31 +77,6 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-/* The order of entries in this table must match the definitions in
-   mpi.h.in */
-MPI_User_function *MPIR_Op_table[] = {
-    NULL, MPIR_MAXF,
-    MPIR_MINF, MPIR_SUM,
-    MPIR_PROD, MPIR_LAND,
-    MPIR_BAND, MPIR_LOR, MPIR_BOR,
-    MPIR_LXOR, MPIR_BXOR,
-    MPIR_MINLOC, MPIR_MAXLOC,
-    MPIR_REPLACE, MPIR_NO_OP,
-    MPIR_EQUAL
-};
-
-MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[] = {
-    NULL, MPIR_MAXF_check_dtype,
-    MPIR_MINF_check_dtype, MPIR_SUM_check_dtype,
-    MPIR_PROD_check_dtype, MPIR_LAND_check_dtype,
-    MPIR_BAND_check_dtype, MPIR_LOR_check_dtype, MPIR_BOR_check_dtype,
-    MPIR_LXOR_check_dtype, MPIR_BXOR_check_dtype,
-    MPIR_MINLOC_check_dtype, MPIR_MAXLOC_check_dtype,
-    MPIR_REPLACE_check_dtype, MPIR_NO_OP_check_dtype,
-    MPIR_EQUAL_check_dtype
-};
-
-
 int MPIR_Allreduce_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                 MPIR_Errflag_t * errflag)

--- a/src/mpi/coll/op/Makefile.mk
+++ b/src/mpi/coll/op/Makefile.mk
@@ -19,4 +19,5 @@ mpi_core_sources += \
     src/mpi/coll/op/opminloc.c       \
     src/mpi/coll/op/opmaxloc.c       \
     src/mpi/coll/op/opno_op.c        \
-    src/mpi/coll/op/opreplace.c
+    src/mpi/coll/op/opreplace.c      \
+    src/mpi/coll/op/opequal.c

--- a/src/mpi/coll/op/opequal.c
+++ b/src/mpi/coll/op/opequal.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+/* Equal structures */
+/* For reusing code, using int type instead of bool*/
+typedef struct MPIR_2int_eqltype {
+    int value;
+    int is_equal;
+} MPIR_2int_eqltype;
+
+typedef struct MPIR_floatint_eqltype {
+    float value;
+    int is_equal;
+} MPIR_floatint_eqltype;
+
+typedef struct MPIR_longint_eqltype {
+    long value;
+    int is_equal;
+} MPIR_longint_eqltype;
+
+typedef struct MPIR_shortint_eqltype {
+    short value;
+    int is_equal;
+} MPIR_shortint_eqltype;
+
+typedef struct MPIR_doubleint_eqltype {
+    double value;
+    int is_equal;
+} MPIR_doubleint_eqltype;
+
+#if defined(HAVE_LONG_DOUBLE)
+typedef struct MPIR_longdoubleint_eqltype {
+    long double value;
+    int is_equal;
+} MPIR_longdoubleint_eqltype;
+#endif
+
+#define MPIR_EQUAL_FLOAT_PRECISION 1e-6
+
+#define MPIR_EQUAL_FLOAT_COMPARE(_aValue, _bValue)              \
+    (((_aValue <= _bValue + MPIR_EQUAL_FLOAT_PRECISION)         \
+    && (_aValue >= _bValue - MPIR_EQUAL_FLOAT_PRECISION))?      \
+    1:0)
+
+/* If a child found unequal, its parent sticks to unequal. */
+/* Values of is_equal: 1 equal 0 not equal, init using any value other than 0.*/
+#define MPIR_EQUAL_C_CASE_INT(c_type_) {                \
+        c_type_ *a = (c_type_ *)inoutvec;               \
+        c_type_ *b = (c_type_ *)invec;                  \
+        for (i = 0; i < len; ++i) {                         \
+            if (0 == b[i].is_equal || 0 == a[i].is_equal){    \
+                a[i].is_equal = 0;            			\
+            }else if (a[i].value != b[i].value){        \
+                a[i].is_equal = 0;                       \
+            }else{                                      \
+                a[i].is_equal = 1;                       \
+            }                                           \
+        }                                               \
+    }                                                   \
+    break
+
+#define MPIR_EQUAL_C_CASE_FLOAT(c_type_) {              \
+        c_type_ *a = (c_type_ *)inoutvec;               \
+        c_type_ *b = (c_type_ *)invec;                  \
+        for (i = 0; i < len; ++i) {                         \
+            if (0 == b[i].is_equal || 0 == a[i].is_equal){    \
+                a[i].is_equal = 0;            			\
+            }else if (!MPIR_EQUAL_FLOAT_COMPARE(a[i].value, b[i].value)){        \
+                a[i].is_equal = 0;                       \
+            }else{                                      \
+                a[i].is_equal = 1;                       \
+            }                                           \
+        }                                               \
+    }                                                   \
+    break
+
+#define MPIR_EQUAL_F_CASE(f_type_) {                    \
+        f_type_ *a = (f_type_ *)inoutvec;               \
+        f_type_ *b = (f_type_ *)invec;                  \
+        for (i = 0; i < flen; i += 2) {                       \
+            if(0 == b[i+1] || 0 == a[i+1]){             \
+                a[i+1] = 0;                        		\
+            }else if (a[i] != b[i]){                    \
+                a[i+1] = 0;                             \
+            }else{                                      \
+                a[i+1] = 1;                             \
+            }                                           \
+        }                                               \
+    }                                                   \
+    break
+
+void MPIR_EQUAL_user_defined_datatype_compare(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+{
+	int mpi_errno = MPI_SUCCESS;
+	int i, j, size, len = *Len, is_equal; 
+	int data_len = 0, type_len = 0;
+	int num_ints, num_adds, num_types, combiner, *ints;
+	void *invec_i_pos, *invec_i_bool_pos, *inoutvec_i_pos, *inoutvec_i_bool_pos;
+	MPI_Aint *adds = NULL;
+	MPI_Aint lb, extent;
+	MPI_Datatype *types;
+
+	 /* decode */
+	MPIR_Type_get_envelope(*type, &num_ints, &num_adds, &num_types, &combiner);
+
+	if(num_types < 2 || combiner != MPI_COMBINER_STRUCT) /*At least 2 elements is required, data, result*/
+	{
+		MPIR_ERR_SET1(mpi_errno, MPI_ERR_OP, "**opundefined", "**opundefined %s", "MPIX_EQUAL");
+		return;
+	}
+
+	ints = (int *)malloc(num_ints * sizeof(*ints));
+
+	if (num_adds || (num_ints != num_adds+1))/*ints[0] is the length*/
+	{
+	    adds = (MPI_Aint *)malloc(num_adds * sizeof(*adds));
+	}
+	else /*adds is required to avoid impacts of struct alignment*/
+	{
+		MPIR_ERR_SET1(mpi_errno, MPI_ERR_OP, "**opundefined", "**opundefined %s", "MPIX_EQUAL");
+		return;
+	}
+
+	types = (MPI_Datatype *)malloc(num_types * sizeof(*types));
+
+	mpi_errno = MPIR_Type_get_contents(*type, num_ints, num_adds, num_types, ints, adds, types);
+
+	if(types[num_types-1] != MPI_INT) /*The last element has to be int*/
+	{
+		MPIR_ERR_SET1(mpi_errno, MPI_ERR_OP, "**opundefined", "**opundefined %s", "MPIX_EQUAL");
+		return;
+	}
+
+	MPIR_Type_get_extent_impl(*type, &lb, &extent);
+	type_len = extent - lb;
+
+	for (i = 0; i < len; ++i)    	
+	{
+		invec_i_pos = invec + i*type_len;
+		invec_i_bool_pos = invec_i_pos + adds[num_adds-1];
+		inoutvec_i_pos = inoutvec + i*type_len;
+		inoutvec_i_bool_pos = inoutvec_i_pos + adds[num_adds-1];
+		if((*(int*)invec_i_bool_pos == 0) ||
+			(*(int*)inoutvec_i_bool_pos == 0))
+		{
+			*(int*)inoutvec_i_bool_pos  = 0;
+		}
+		else
+		{/*compare the content of the struct*/
+			is_equal = 1;
+			for(j = 0; j < num_adds-1; ++j)
+			{
+				MPI_Type_size(types[j], &size); 
+				data_len = ints[j + 1] * size;
+
+				if(memcmp(invec_i_pos+adds[j], inoutvec_i_pos+adds[j], data_len))
+					is_equal = 0;
+			}
+
+			*(int*)inoutvec_i_bool_pos  = is_equal;
+		}
+	}
+}
+
+void MPIR_EQUAL(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+{
+    int i, len = *Len;
+
+#ifdef HAVE_FORTRAN_BINDING
+#ifndef HAVE_NO_FORTRAN_MPI_TYPES_IN_C
+    int flen = len * 2;         /* used for Fortran types */
+#endif
+#endif
+    
+    switch (*type) {
+            /* first the C types */
+        case MPI_2INT:
+            MPIR_EQUAL_C_CASE_INT(MPIR_2int_eqltype);
+        case MPI_FLOAT_INT:
+            MPIR_EQUAL_C_CASE_FLOAT(MPIR_floatint_eqltype);
+        case MPI_LONG_INT:
+            MPIR_EQUAL_C_CASE_INT(MPIR_longint_eqltype);
+        case MPI_SHORT_INT:
+            MPIR_EQUAL_C_CASE_INT(MPIR_shortint_eqltype);
+        case MPI_DOUBLE_INT:
+            MPIR_EQUAL_C_CASE_FLOAT(MPIR_doubleint_eqltype);
+#if defined(HAVE_LONG_DOUBLE)
+        case MPI_LONG_DOUBLE_INT:
+            MPIR_EQUAL_C_CASE_FLOAT(MPIR_longdoubleint_eqltype);
+#endif
+
+            /* now the Fortran types */
+#ifdef HAVE_FORTRAN_BINDING
+#ifndef HAVE_NO_FORTRAN_MPI_TYPES_IN_C
+        case MPI_2INTEGER:
+            MPIR_EQUAL_F_CASE(MPI_Fint);
+#endif
+#endif
+        default:
+            //MPIR_Assert(0);
+            MPIR_EQUAL_user_defined_datatype_compare(invec, inoutvec, Len, type);
+            break;
+    }
+
+}
+
+
+int MPIR_EQUAL_check_dtype(MPI_Datatype type)
+{
+	//To support user defined datatypes, no actual type check now.
+    int mpi_errno = MPI_SUCCESS;
+
+    switch (type) {
+            /* first the C types */
+        case MPI_2INT:
+        case MPI_FLOAT_INT:
+        case MPI_LONG_INT:
+        case MPI_SHORT_INT:
+        case MPI_DOUBLE_INT:
+#if defined(HAVE_LONG_DOUBLE)
+        case MPI_LONG_DOUBLE_INT:
+#endif
+            /* now the Fortran types */
+#ifdef HAVE_FORTRAN_BINDING
+#ifndef HAVE_NO_FORTRAN_MPI_TYPES_IN_C
+        case MPI_2INTEGER:
+#endif
+#endif
+            break;
+
+        default:
+        	break;
+            //MPIR_ERR_SET1(mpi_errno, MPI_ERR_OP, "**opundefined", "**opundefined %s", "MPI_EQUAL");
+    }
+
+    return mpi_errno;
+}

--- a/src/mpi/coll/op/oputil.c
+++ b/src/mpi/coll/op/oputil.c
@@ -24,7 +24,33 @@ static op_name_t mpi_ops[] = {
     {MPI_MINLOC, "minloc"},
     {MPI_MAXLOC, "maxloc"},
     {MPI_REPLACE, "replace"},
-    {MPI_NO_OP, "no_op"}
+    {MPI_NO_OP, "no_op"},
+    {MPIX_EQUAL, "equal"}
+};
+
+
+/* The order of entries in this table must match the definitions in
+   mpi.h.in */
+MPI_User_function *MPIR_Op_table[] = {
+    NULL, MPIR_MAXF,
+    MPIR_MINF, MPIR_SUM,
+    MPIR_PROD, MPIR_LAND,
+    MPIR_BAND, MPIR_LOR, MPIR_BOR,
+    MPIR_LXOR, MPIR_BXOR,
+    MPIR_MINLOC, MPIR_MAXLOC,
+    MPIR_REPLACE, MPIR_NO_OP,
+    MPIR_EQUAL
+};
+
+MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[] = {
+    NULL, MPIR_MAXF_check_dtype,
+    MPIR_MINF_check_dtype, MPIR_SUM_check_dtype,
+    MPIR_PROD_check_dtype, MPIR_LAND_check_dtype,
+    MPIR_BAND_check_dtype, MPIR_LOR_check_dtype, MPIR_BOR_check_dtype,
+    MPIR_LXOR_check_dtype, MPIR_BXOR_check_dtype,
+    MPIR_MINLOC_check_dtype, MPIR_MAXLOC_check_dtype,
+    MPIR_REPLACE_check_dtype, MPIR_NO_OP_check_dtype,
+    MPIR_EQUAL_check_dtype
 };
 
 MPI_Datatype MPIR_Op_builtin_search_by_shortname(const char *short_name)

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -1435,6 +1435,8 @@ static const char *GetMPIOpString(MPI_Op o)
             return "MPI_REPLACE";
         case MPI_NO_OP:
             return "MPI_NO_OP";
+        case MPIX_EQUAL:
+            return "MPIX_EQUAL";
     }
     /* FIXME: default is not thread safe */
     MPL_snprintf(default_str, sizeof(default_str), "op=0x%x", o);


### PR DESCRIPTION
## Pull Request Description
Adding a new MPI operator MPI_EQUAL.
Equal, as a logistic comparison is not supported yet. There are many cases users need to compare data among processes.
The current solutions are either using MPI_Allgather() or similar approachs. A customised MPI operator might be helpful but it takes time and rarely being considered.

The MPI_EQUAL operator support comparing arrays of int, float, long, short, double, long double, and user defined struct.

##Expected Impact
A new operator MPIX_EQUAL for MPI_Reduce and MPI_Allreduce.
MPIR_Op_table moved to oputil.c from allreduce/allreduce.c

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
