### PR TITLE
hydra: fix error checking for strtol

### DIFF
--- a/src/pm/hydra/pm/pmiserv/pmip_utils.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_utils.c
@@ -562,8 +562,9 @@ static HYD_status exec_args_fn(char *arg, char ***argv)
 
     for (exec = HYD_pmcd_pmip.exec_list; exec->next; exec = exec->next);
 
+    errno = 0;
     count = strtol(**argv, NULL, 10);
-    if (errno == ERANGE || errno == EINVAL)
+    if (errno != 0)
         HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "Exec arg not convertible to integer\n");
     for (i = 0; i < count; i++) {
         (*argv)++;


### PR DESCRIPTION
## Pull Request Description
We need set errno to 0 before strtol in order to correctly check error
based on errno.

Fixes #4944


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
