### PR TITLE
hydra: fix an bug in freeing published entries

### DIFF
--- a/src/pm/hydra/tools/nameserver/hydra_nameserver.c
+++ b/src/pm/hydra/tools/nameserver/hydra_nameserver.c
@@ -206,8 +206,9 @@ static HYD_status request_cb(int fd, HYD_event_t events, void *userp)
                 for (tmp = publish_list; tmp->next && strcmp(tmp->next->name, name);
                      tmp = tmp->next);
                 if (tmp->next) {
+                    struct HYDT_ns_publish *next_entry = tmp->next;
                     tmp->next = tmp->next->next;
-                    free_publish_element(tmp->next);
+                    free_publish_element(next_entry);
                     success = 1;
                 }
             }

--- a/src/pm/hydra/tools/nameserver/hydra_nameserver.txt
+++ b/src/pm/hydra/tools/nameserver/hydra_nameserver.txt
@@ -1,8 +1,13 @@
-/*D hydra_nameserver - Internal executable used by Hydra
+/*D hydra_nameserver - program to support MPI's name publishing features with hydra
 
-   Description:
-    This executable is designed to not be run directly by users, but to
-    support the Hydra process manager. As such, no documentation will be
-    provided here.
-
+Description:
+    Hydra is the default name service for MPI's name publishing features
+    (MPI_PUBLISH_NAME/MPI_LOOKUP_NAME). For programs launched by separate
+    hydra instances, a separate nameserver mechanism need be launched in
+    order for the name publishing to work across multiple process managers.
+    This can be achieved with hydra_nameserver. For example:
+    .vb
+        shell@myhost1$ hydra_nameserver &
+        shell@myhost1$ mpiexec -hosts myhost1,myhost2 -n 4 -nameserver myhost1 ./a.out
+    .ve
 D*/


### PR DESCRIPTION
## Pull Request Description

The old code changes the tmp entry before freeing its next one. The fix
saves tmp before modifying it.

Also provide man page documentation for `hydra_nameserver`.

Fixes #5058

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
