### PR TITLE
misc: fix spelling mistakes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,12 +22,12 @@
 
 # MPI_Info objects can be accessed before MPI_Init{_thread}.
 
-# Generate C API interface functions inlcuding man page notes and error
+# Generate C API interface functions including man page notes and error
   checking using Python scripts.
 
 # Generate Fortran mpi_f08 binding using Python scripts.
 
-# Support explict --without-cuda configure option.
+# Support explicit --without-cuda configure option.
 
 ===============================================================================
                                Changes in 3.4
@@ -36,7 +36,7 @@
 # ch4 replaces ch3 as the default device configuration. If no network
   module is specified at configuration-time, MPICH will search the
   user environment in order to select one to build. The user will be
-  prompted to choose if no preferred network library is dectected.
+  prompted to choose if no preferred network library is detected.
 
 # Add support for Yaksa datatype engine (default in ch4).
 
@@ -211,7 +211,7 @@
  # Added experimental support for Open Fabrics Interfaces (OFI) version 1.0.0.
    https://github.com/ofiwg/libfabric (thanks to Intel for code contribution)
 
- # The Myrinet MX network module, which had a life cyle from 1.1 till
+ # The Myrinet MX network module, which had a life cycle from 1.1 till
    3.1.2, has now been deleted.
 
  # Several other minor bug fixes, memory leak fixes, and code cleanup.
@@ -1227,7 +1227,7 @@ www.mcs.anl.gov/mpi/mpich2/mpich2_1_0_6changes.htm.
 
 - Many enhancements to MPE
 
-- Enhanced support for features and idiosyncracies of Fortran 77 and 
+- Enhanced support for features and idiosyncrasies of Fortran 77 and 
   Fortran 90 compilers, including gfortran, g95, and xlf
 
 - Enhanced support for C++ compilers that do not fully support abstract
@@ -1241,13 +1241,13 @@ www.mcs.anl.gov/mpi/mpich2/mpich2_1_0_6changes.htm.
 - Man pages for mpiexec and mpif90
 
 - Enhancements for developers, including a more flexible and general 
-  mechanism for inserting logging and information messages, controlable
+  mechanism for inserting logging and information messages, controllable
   with --mpich-dbg-xxx command line arguments or MPICH_DBG_XXX environment
   variables.
 
 - Note to developers: 
   This release contains many changes to the structure of the CH3
-  device implementation (in src/mpid/ch3), including signficant
+  device implementation (in src/mpid/ch3), including significant
   reworking of the files (many files have been combined into fewer files
   representing logical grouping of functions).  The next release of 
   MPICH2 will contain even more significant changes to the device 
@@ -1278,7 +1278,7 @@ www.mcs.anl.gov/mpi/mpich2/mpich2_1_0_6changes.htm.
     and provides count of real drawables in preview drawables.
 
   - new slog2 tools, slog2filter and slog2updater, which both are logfile
-    format convertors.  slog2filter removes undesirable categories of
+    format converters.  slog2filter removes undesirable categories of
     drawables as well as alters the slog2 file structure.  slog2updater
     is a slog2filter that reads in older logfile format, 2.0.5, and 
     writes out the latest format 2.0.6.

--- a/CHANGES
+++ b/CHANGES
@@ -1595,7 +1595,7 @@ www.mcs.anl.gov/mpi/mpich2/mpich2_1_0_6changes.htm.
 - The CH3 interface and device now provide a mechanism for using RDMA (remote
   direct memory access) to transfer data between processes.
 
-- Logging capabilities for MPI and internal routines have been readded.  See
+- Logging capabilities for MPI and internal routines have been re-added.  See
   the documentation in doc/logging for details.
 
 - A "meminit" option was added to --enable-g to force all bytes associated with

--- a/README.vin
+++ b/README.vin
@@ -725,7 +725,7 @@ If the C compiler that is used to build MPICH libraries supports both
 multiple weak symbols and multiple aliases of common symbols, the
 Fortran binding can support multiple Fortran compilers. The
 multiple weak symbols support allow MPICH to provide different name
-mangling scheme (of subroutine names) required by differen Fortran
+mangling scheme (of subroutine names) required by different Fortran
 compilers. The multiple aliases of common symbols support enables
 MPICH to equal different common block symbols of the MPI Fortran
 constant, e.g. MPI_IN_PLACE, MPI_STATUS_IGNORE. So they are understood

--- a/autogen.sh
+++ b/autogen.sh
@@ -873,7 +873,7 @@ if [ $do_geterrmsgs = "yes" ] ; then
             fi
             rm -f .err .err2
         else
-            # Incase it exists but has zero size
+            # In case it exists but has zero size
             rm -f .err
         fi
 	if [ -s unusederr.txt ] ; then

--- a/confdb/aclocal_attr_alias.m4
+++ b/confdb/aclocal_attr_alias.m4
@@ -344,7 +344,7 @@ dnl AC_LINK_IFELSE, so "diff" approach is used instead.
 dnl Using diff of compiler(linker) output requires a reference output file
 dnl as the base of diff.  The process of creating this reference output file
 dnl has to be exactly the same as the testing process, because pgf77 has
-dnl the following weird behavour
+dnl the following weird behavior
 dnl pgf77 -o ftest ftest.f         => when $?=0 with zero stderr output
 dnl pgf77 -o ftest ftest.f dummy.o => when $?=0 with non-zero stderr output.
 dnl                                   stderr has "ftest.f:".

--- a/confdb/aclocal_attr_alias.m4
+++ b/confdb/aclocal_attr_alias.m4
@@ -113,12 +113,12 @@ mpif_cmblk_t MPIFCMB;
    define aliased symbols if they are in the same file.
 */
 /*
-    We can't do the following comparision in one test:
+    We can't do the following comparison in one test:
 
-    ilogical = (( &mpifcmb == ptr && &MPIFCMB == ptr ) ? TRUE : FALSE) ;
+    illogical = (( &mpifcmb == ptr && &MPIFCMB == ptr ) ? TRUE : FALSE) ;
 
     because some compiler, like gcc 4.4.2's -O* optimizes the code
-    such that the ilogical expression is FALSE. The likely reason is that
+    such that the illogical expression is FALSE. The likely reason is that
     mpifcmb and MPIFCMB are defined in the same scope in which C optimizer
     may have treated them as different objects (with different addresses),
     &mpifcmb != &MPIFCMB, before actually running the test and hence the
@@ -304,7 +304,7 @@ AC_LANG_POP(C)
 dnl
 dnl PAC_F2C_ATTR_ALIGNED_SIZE(ARRAY_SIZE, [OUTPUT_VAR], [MIN_ALIGNMENT])
 dnl
-dnl ARRAY_SIZE    : Size of the integer array within the fortran commmon block.
+dnl ARRAY_SIZE    : Size of the integer array within the fortran common block.
 dnl OUTPUT_VAR    : Optional variable to be set.
 dnl                 if test succeeds, set OUTPUT_VAR=$pac_f2c_attr_aligned_str.
 dnl                 if test fails, set OUTPUT_VAR="unknown".
@@ -337,7 +337,7 @@ dnl i.e. ac_fc_werror_flag=yes, because compiler like pgf77 at version 10.x)
 dnl has non-zero stderr output if a fortran program is used in the linking.
 dnl The stderr contains the name of fortran program even if the linking is
 dnl successful.  We could avoid the non-zero stderr output in pgf77 by
-dnl compiling everthing into object files and linking all the object files
+dnl compiling everything into object files and linking all the object files
 dnl with pgf77.  Doing that would need us to use AC_TRY_EVAL instead of
 dnl AC_LINK_IFELSE, so "diff" approach is used instead.
 #

--- a/confdb/aclocal_cxx.m4
+++ b/confdb/aclocal_cxx.m4
@@ -1,5 +1,5 @@
 dnl This is from crypt.to/autoconf-archive, slightly modified.
-dnl It defines bool as int if it is not availalbe
+dnl It defines bool as int if it is not available
 dnl
 AC_DEFUN([AX_CXX_BOOL],
 [AC_CACHE_CHECK(whether the compiler recognizes bool as a built-in type,

--- a/confdb/aclocal_f77.m4
+++ b/confdb/aclocal_f77.m4
@@ -695,7 +695,7 @@ AC_LANG_POP([Fortran 77])
 dnl PAC_PROG_F77_IN_C_LIBS
 dnl
 dnl Find the essential libraries that are needed to use the C linker to 
-dnl create a program that includes a trival Fortran code.  
+dnl create a program that includes a trivial Fortran code.  
 dnl
 dnl For example, all pgf90 compiled objects include a reference to the
 dnl symbol pgf90_compiled, found in libpgf90 .

--- a/confdb/aclocal_f77old.m4
+++ b/confdb/aclocal_f77old.m4
@@ -112,7 +112,7 @@ EOF
     if test "$NOG2C" != "1" ; then
         trial_LIBS="$trial_LIBS -lg2c"
     fi
-    # Discard libs that are not availble:
+    # Discard libs that are not available:
     save_IFS="$IFS"
     # Make sure that IFS includes a space, or the tests that run programs
     # may fail

--- a/confdb/aclocal_fc.m4
+++ b/confdb/aclocal_fc.m4
@@ -123,7 +123,7 @@ fi # is not cross compiling
 dnl
 dnl ------------------------------------------------------------------------
 dnl Special characteristics that have no autoconf counterpart but that
-dnl we need as part of the Fortran 90 support.  To distinquish these, they
+dnl we need as part of the Fortran 90 support.  To distinguish these, they
 dnl have a [PAC] prefix.
 dnl 
 dnl At least one version of the Cray compiler needs the option -em to
@@ -274,7 +274,7 @@ AC_COMPILE_IFELSE([],[
 rm -rf conftest.dSYM
 rm -f conftest.$ac_ext
 
-dnl Create the conftest here so the test isn't created everytime inside loop.
+dnl Create the conftest here so the test isn't created every time inside loop.
 AC_LANG_CONFTEST([AC_LANG_PROGRAM([],[use conf])])
 
 # Save the original FCFLAGS
@@ -312,7 +312,7 @@ if test "X$pac_cv_fc_module_incflag" = "X" ; then
         #     fullpathname.pc
         # The "fullpathname.pc" is generated, I believe, when a module is 
         # compiled.  
-        # Intel compilers use a wierd system: -cl,filename.pcl .  If no file is
+        # Intel compilers use a weird system: -cl,filename.pcl .  If no file is
         # specified, work.pcl and work.pc are created.  However, if you specify
         # a file, it must contain the name of a file ending in .pc .  Ugh!
         pac_cv_fc_module_incflag="unknown"
@@ -1143,7 +1143,7 @@ END INTERFACE TEST_ASSUMED_RANK_ASYNC
 
 CONTAINS
 
-! Test TS 29113 asychronous attribute and optional
+! Test TS 29113 asynchronous attribute and optional
 SUBROUTINE test1(buf, count, ierr)
     INTEGER, ASYNCHRONOUS :: buf(*)
     INTEGER               :: count

--- a/confdb/aclocal_make.m4
+++ b/confdb/aclocal_make.m4
@@ -3,7 +3,7 @@ dnl We need routines to check that make works.  Possible problems with
 dnl make include
 dnl
 dnl It is really gnumake, and contrary to the documentation on gnumake,
-dnl it insists on screaming everytime a directory is changed.  The fix
+dnl it insists on screaming every time a directory is changed.  The fix
 dnl is to add the argument --no-print-directory to the make
 dnl
 dnl It is really BSD 4.4 make, and can't handle 'include'.  For some

--- a/confdb/aclocal_romio.m4
+++ b/confdb/aclocal_romio.m4
@@ -63,7 +63,7 @@ Turning off Fortran (-nof77 being assumed)])
         WDEF="-D$FORTRANNAMES"
     fi
     # Delete confftest files with any extension.  This catches the case
-    # where auxillary files, such as coverage files, are removed.
+    # where auxiliary files, such as coverage files, are removed.
     rm -f confftest.*
     ])dnl
 dnl
@@ -804,7 +804,7 @@ EOF
   $CC $USER_CFLAGS -I$MPI_INCLUDE_DIR -o conftest$EXEEXT mpitest.c $MPI_LIB > /dev/null 2>&1
   if test -x conftest$EXEEXT ; then
      AC_MSG_RESULT(yes)
-     AC_DEFINE(HAVE_MPI_GREQUEST,1,[Define if generalized requests avaliable])
+     AC_DEFINE(HAVE_MPI_GREQUEST,1,[Define if generalized requests available])
      DEFINE_HAVE_MPI_GREQUEST="#define HAVE_MPI_GREQUEST 1"
   else
      AC_MSG_RESULT(no)
@@ -827,7 +827,7 @@ EOF
   $CC $USER_CFLAGS -I$MPI_INCLUDE_DIR -o conftest$EXEEXT mpitest.c $MPI_LIB > /dev/null 2>&1
   if test -x conftest$EXEEXT ; then
      AC_MSG_RESULT(yes)
-     AC_DEFINE(HAVE_MPI_GREQUEST_EXTENTIONS,1,[Define if non-standard generalized requests extensions avaliable])
+     AC_DEFINE(HAVE_MPI_GREQUEST_EXTENTIONS,1,[Define if non-standard generalized requests extensions available])
      DEFINE_HAVE_MPI_GREQUEST_EXTENSIONS="#define HAVE_MPI_GREQUEST_EXTENSIONS 1"
   else
      AC_MSG_RESULT(no)

--- a/confdb/aclocal_runlog.m4
+++ b/confdb/aclocal_runlog.m4
@@ -16,7 +16,7 @@ dnl to config.log, i.e. AC_TRY_EVAL does not log anything to config.log.
 dnl If autoconf provides AC_COMMAND_IFELSE or AC_EVAL_IFELSE,
 dnl AC_COMMAND_IFELSE dnl should be replaced by the official autoconf macros.
 dnl
-dnl PAC_COMMAND_IFELSE(COMMMAND,[ACTION-IF-RUN-OK],[ACTION-IF-RUN-FAIL])
+dnl PAC_COMMAND_IFELSE(COMMAND,[ACTION-IF-RUN-OK],[ACTION-IF-RUN-FAIL])
 dnl
 AC_DEFUN([PAC_COMMAND_IFELSE],[
 AS_IF([PAC_RUNLOG([$1])],[

--- a/confdb/aclocal_shl.m4
+++ b/confdb/aclocal_shl.m4
@@ -367,7 +367,7 @@ dnl This macro ensures that all of the necessary substitutions are
 dnl made by any subdirectory configure (which may simply SUBST the
 dnl necessary values rather than trying to determine them from scratch)
 dnl This is a more robust (and, in the case of libtool, only 
-dnl managable) method.
+dnl manageable) method.
 AC_DEFUN([PAC_CC_SUBDIR_SHLIBS],[
 	AC_SUBST(CC_SHL)
         AC_SUBST(C_LINK_SHL)

--- a/confdb/aclocal_shl.m4
+++ b/confdb/aclocal_shl.m4
@@ -192,7 +192,7 @@ case "$enable_sharedlibs" in
 	# our base approach.  Disabling for now
 	dnl LT_PREREQ([2.2.6])
         dnl LT_INIT([disable-shared])
-	AC_MSG_ERROR([To use this test verison, edit aclocal_shl.m4])
+	AC_MSG_ERROR([To use this test version, edit aclocal_shl.m4])
         # Likely to be
         # either CC or CC_SHL is libtool $cc
         CC_SHL='${LIBTOOL} --mode=compile ${CC}'

--- a/configure.ac
+++ b/configure.ac
@@ -687,7 +687,7 @@ dnl lead to weird AM_CONDITIONAL errors and potentially other problems.
 # support for this language. This should save a bit of configure time and also
 # prevent user complaints like ticket #1570.
 #
-# NOTE: we are skipping overiding CXX as some modules (e.g. ucx) may depend on CXX
+# NOTE: we are skipping overriding CXX as some modules (e.g. ucx) may depend on CXX
 #
 AS_IF([test "x$enable_f77" = "xno"],[F77=no])
 AS_IF([test "x$enable_fc"  = "xno"],[FC=no])
@@ -1153,7 +1153,7 @@ fi
 # * MPID_MAX_THREAD_LEVEL, set in one of the device subconfigure.m4,
 #    determines the maximum thread level, typically MPI_THREAD_MULTIPLE.
 #    If missing, equivallent to single.
-# * --enable-threads, explict user config option, raise error if beyond
+# * --enable-threads, explicit user config option, raise error if beyond
 #    MPID_MAX_THREAD_LEVEL.
 #    It default to MPID_MAX_THREAD_LEVEL.
 # * MPICH_THREAD_LEVEL is set by enable_threads
@@ -1461,7 +1461,7 @@ if test "$enable_romio" = "yes" ; then
        # make it possible to "#include" mpio.h at build time
        #
        # This ought to be sufficient, but there is also a symlink setup in
-       # src/include to accomodate current mpicc limitations.  See
+       # src/include to accommodate current mpicc limitations.  See
        # src/mpi/Makefile.mk for more info.
        PAC_APPEND_FLAG([-I${main_top_builddir}/src/mpi/romio/include],[CPPFLAGS])
 
@@ -1601,7 +1601,7 @@ AC_SUBST(pm_name)
 
 # Step 2:
 # Once we've selected the process manager (or managers), we can
-# check that we have a compatible PMI implemenatation.
+# check that we have a compatible PMI implementation.
 # with-pmi
 if test "$with_pmi" != "no" ; then
     if test "$with_pmi" = "default" -o "$with_pmi" = "yes" ; then
@@ -2675,11 +2675,11 @@ PAC_C_GNU_ATTRIBUTE
 PAC_C_BUILTIN_EXPECT
 PAC_C_STATIC_ASSERT
 
-# We need to check for the endianess in order to implement the
+# We need to check for the endianness in order to implement the
 # "external32" representations.  This defines "WORDS_BIGENDIAN when
 # the system is bigendian.
 # As of autoconf 2.62, this macro takes an additional argument for systems
-# that can produce object files for either endianess.
+# that can produce object files for either endianness.
 # With the as-always-incompatible-with-every-version autoconf, the
 # arguments for this macro *changed* in 2.62 to
 # (if-bigendian,if-littleendian,unknown,universal)
@@ -2702,7 +2702,7 @@ case $byteOrdering in
     AC_DEFINE(WORDS_UNIVERSAL_ENDIAN,1,[Define if configure will not tell us, for universal binaries])
     ;;
     unknown)
-    AC_MSG_ERROR([Unable to determine endianess])
+    AC_MSG_ERROR([Unable to determine endianness])
     ;;
 esac
 
@@ -3143,7 +3143,7 @@ fi
 if test -n "$MPIR_REAL16_CTYPE" ; then
     AC_DEFINE_UNQUOTED(MPIR_REAL16_CTYPE,$MPIR_REAL16_CTYPE,[C type to use for MPI_REAL16])
 fi
-# For complex 8/16/32, we assume that these are 2 consequetive real4/8/16
+# For complex 8/16/32, we assume that these are 2 consecutive real4/8/16
 #
 # Search for the integer types
 for type in char short int long long_long ; do
@@ -4675,7 +4675,7 @@ AC_ARG_ENABLE(checkpointing,
 )
 
 # Update the cache first with the results of the previous configure steps
-# We don't use the subdir cache because ensuring that the cache is consistant
+# We don't use the subdir cache because ensuring that the cache is consistent
 # with the way in which configure wishes to use it is very difficult and
 # too prone to error.
 dnl PAC_SUBDIR_CACHE(always)
@@ -5219,7 +5219,7 @@ if test "X$enable_shared" = "Xyes" ; then
 fi
 
 # Set F08 versions of datatypes, which have type MPI_Datatype and are not integers anymore.
-# If the correspoinding F77 datatypes exist, i.e., not MPI_DATATYPE_NULL, we simply use their
+# If the corresponding F77 datatypes exist, i.e., not MPI_DATATYPE_NULL, we simply use their
 # integer value (already converted into decimal) in F08 counterparts. Otherwise, we use
 # MPI_VAL value of F08 MPI_DATATYPE_NULL.
 # We put the code at the end to ensure all F77 datatypes have been set.

--- a/doc/installguide/install.tex.vin
+++ b/doc/installguide/install.tex.vin
@@ -338,7 +338,7 @@ for details. A typical example is:
 to ensure that the process with rank 0 runs on your workstation.
 
 The arguments between `:'s in this syntax are called ``argument sets,''
-since they apply to a set of processes.  More argments are described in
+since they apply to a set of processes.  More arguments are described in
 the \textit{User's Guide}.
 
 \end{enumerate}

--- a/doc/installguide/install.tex.vin
+++ b/doc/installguide/install.tex.vin
@@ -402,7 +402,7 @@ format).
 For more details of \texttt{--enable-fast}, see the output of
 \texttt{configure --help}. 
 Any other complicated optimization flags for MPICH libraries have
-to be set throught \texttt{MPICHLIB\_xFLAGS}.  \texttt{CFLAGS} and friends
+to be set through \texttt{MPICHLIB\_xFLAGS}.  \texttt{CFLAGS} and friends
 are empty by default.
 
 For example, to build a production MPICH environment with \texttt{-O3} for all
@@ -631,7 +631,7 @@ different mechanisms by which your processes are started.  An interface
 (called PMI) isolates the MPICH library code from the process manager.
 Currently three process managers are distributed with MPICH
 \begin{description}
-\item[hydra] This is the default process manager tha natively uses the
+\item[hydra] This is the default process manager that natively uses the
 existing daemons on the system such as ssh, slurm, pbs.
 \item[gforker] This is a simple process manager that creates all
   processes on a single machine.  It is useful both for debugging and

--- a/doc/mansrc/mpiconsts.txt
+++ b/doc/mansrc/mpiconsts.txt
@@ -321,7 +321,7 @@ Window flavors:
 
 Window Memory Model:
 +I MPI_WIN_SEPARATE - Separate public and private copies of window memory
-- MPI_WIN_UNIFIED - The publich and private copies are identical (by which
+- MPI_WIN_UNIFIED - The public and private copies are identical (by which
  we mean that updates are eventually observed without additional RMA operations)
 
 Window Lock Types:

--- a/doc/mansrc/mpiconsts.txt
+++ b/doc/mansrc/mpiconsts.txt
@@ -179,7 +179,7 @@ standard.
  The predefined operations are
 
 +I  MPI_MAX - return the maximum
-.  MPI_MIN - return the minumum
+.  MPI_MIN - return the minimum
 .  MPI_SUM - return the sum
 .  MPI_PROD - return the product
 .  MPI_LAND - return the logical and
@@ -403,7 +403,7 @@ Special value for error codes array:
 .    MPI_T_PVAR_CLASS_PERCENTAGE    - percentage utilization of a resource
 .    MPI_T_PVAR_CLASS_HIGHWATERMARK - high watermark of a resource
 .    MPI_T_PVAR_CLASS_LOWWATERMARK  - low watermark of a resource
-.    MPI_T_PVAR_CLASS_COUNTER       - number of occurances of an event
+.    MPI_T_PVAR_CLASS_COUNTER       - number of occurrences of an event
 .    MPI_T_PVAR_CLASS_AGGREGATE     - aggregate value over an event (e.g.,
  sum of all memory allocations)
 .    MPI_T_PVAR_CLASS_TIMER         - aggretate time spent executing event

--- a/doc/notes/agent/agent.txt
+++ b/doc/notes/agent/agent.txt
@@ -76,7 +76,7 @@ Isend/Irecv scenerio
 Persistent requests
 
 - We need to allow the method the opportunity to register memory reused in a
-  persistant sent.  We suggest accomplishing this by calling CA_register_mem()
+  persistent sent.  We suggest accomplishing this by calling CA_register_mem()
   during the MPI_<op>_init() and CA_unregister_mem() during the
   MPI_Request_free().
 
@@ -134,7 +134,7 @@ receives (which is the approach we should reward :)).
 
 - we decided to use a single unexpected queue since having multiple unexpected
   queues requires timestamp to order the messages.  the timestamp counter is a
-  point of global contention, just like the global unexpect queue.
+  point of global contention, just like the global unexpected queue.
 
 - this same argument can be applied to the posted queue case, but allowing for
   multiple queues here creates a much nicer search situation for the case where

--- a/doc/notes/agent/outline.txt
+++ b/doc/notes/agent/outline.txt
@@ -87,11 +87,11 @@
     Theoretically, a MPI communicator could be tagged to allow
     unrealiable delivery, QoS, etc.  We haven't thought much what
     impact this has on our design, but we probably don't want to
-    prevent these capabilites.
+    prevent these capabilities.
 
 * Communication subsystem components
 
-  - virtual connnections
+  - virtual connections
 
     allows late binding to a communication device (method)
 
@@ -148,7 +148,7 @@
 
   - reliability
 
-    Under a default environemnt, MPI messages are inherently reliable
+    Under a default environment, MPI messages are inherently reliable
     which means that some methods may need concern themselves with
     acknowledgments and retransmission if the underlying network does
     not guarantee reliability.

--- a/doc/notes/agent/send-sm.txt
+++ b/doc/notes/agent/send-sm.txt
@@ -155,7 +155,7 @@ Action [Post Send Data],
     // at one time, amortizing the cost of checking for buffers and checking
     // flow control over a set of outgoing packets.  We are uncertain how
     // packing multiple buffers then posting multiple sends will affect
-    // peformance, but clearly amortizing costs when sending straight out of
+    // performance, but clearly amortizing costs when sending straight out of
     // the user buffer will be a win.
 
     if there are more data packets to send

--- a/doc/notes/agent/vc-sm.txt
+++ b/doc/notes/agent/vc-sm.txt
@@ -7,12 +7,12 @@ State [Unbound]
 
 State [Bound, Unconnected]
     Event [VC-Open]
-	/* An operation involved outgoing communcation was requested for this
+	/* An operation involved outgoing communication was requested for this
 	 * virtual connection.  Before we can perform such a request, we need
 	 * to establish a real connection with the destination process.  We
 	 * also may need to initialize at least the receive side state machine
 	 * now so that any unexpected incoming packets arriving shortly after
-	 * connection establishment are properly handled.  We could intialize
+	 * connection establishment are properly handled.  We could initialize
 	 * send state machine, but it can't actually start sending until the
 	 * connection has been established.
 	 */

--- a/doc/notes/binding_c.txt
+++ b/doc/notes/binding_c.txt
@@ -16,7 +16,7 @@ src/binding/c/errnames.txt, and src/include/mpir_impl.h.
 ## Master API config file
 
 The master config file -- maint/mpi_standards_api.txt is a direct
-transcription from mpi-standard repository. It contains entries as follwing:
+transcription from mpi-standard repository. It contains entries as following:
 
 ---- quote ----
 MPI_Send:
@@ -118,7 +118,7 @@ The above example customizes the function, MPI_Example, with a short description
 extra man page notes, custom error checking code, early_return code, and custom
 body of routine.
 
-The customizations are place holders to allow flexibility dealing with arbitary
+The customizations are place holders to allow flexibility dealing with arbitrary
 complex code that it is too complex to deal with within the python script.
 However, for most functions, most of the custom parts can be omitted. For example,
 the following:

--- a/doc/notes/binding_c.txt
+++ b/doc/notes/binding_c.txt
@@ -83,7 +83,7 @@ MPI_Example:
 */
 /*
     Multiple such "comment" blocks are allowed. The first block adds notes to the
-    top fo the man page (after the generated parameter info). The rest of the blocks
+    top of the man page (after the generated parameter info). The rest of the blocks
     are concatenated a follows the generated notes.
 
     Typical functions will all include .ThreadSafe and .Fortran notes, unless

--- a/doc/notes/ch4_api.txt
+++ b/doc/notes/ch4_api.txt
@@ -32,7 +32,7 @@ PARAM:
     ...
 ---- end of ch4_api.txt
 
-Section headings, i.e. "Non Native API", "Native API", and "PARAM", need start at the begining of the line immediately followed by ':'. All other specifications require to be start with some spaces.
+Section headings, i.e. "Non Native API", "Native API", and "PARAM", need start at the beginning of the line immediately followed by ':'. All other specifications require to be start with some spaces.
 
 The api is specified with "name", followed by ':', followed by "return type". Flexible spaces are allowed.
 

--- a/doc/notes/coll/collective.txt
+++ b/doc/notes/coll/collective.txt
@@ -66,7 +66,7 @@ Brian's notes from this file:
 reminder: envelope = (context (communicator), source_rank, tag)
 
 QUESTION: what exactly are the semantics of a block?  Sends to the same
-destination are definitely ordered.  Sends to different desinations could
+destination are definitely ordered.  Sends to different destinations could
 proceed in parallel.  Should they?
 
 example:

--- a/doc/notes/mpi.txt
+++ b/doc/notes/mpi.txt
@@ -136,7 +136,7 @@ Concepts
 
   - virtual connection structures
 
-  - low-level connnection management (sockets, etc.) should be handled
+  - low-level connection management (sockets, etc.) should be handled
     entirely by the device and probably driven by a state machine
 
 
@@ -304,7 +304,7 @@ Structures that cross layers
   layers, but not vice versa.  To increase cache locality and reduce memory
   allocation, the device (and methods) report the amount of space they need in
   these structures so that the highest layer can allocate sufficient space.
-  pointer arithmatic, etc.
+  pointer arithmetic, etc.
 
 Virtual connection
 

--- a/doc/notes/pt2pt/pt2pt.txt
+++ b/doc/notes/pt2pt/pt2pt.txt
@@ -58,7 +58,7 @@ MPI_Start(request, error)
   the right thing (tm).
 
 - we chose not to convert handles to structure pointers since the handles may
-  cointain quick access to common information avoiding pointer dereferences.
+  contain quick access to common information avoiding pointer dereferences.
   in some cases, an associated structure may not even exist.
 
   the implication here is that many of the non-persistent MPI_Xsend routines
@@ -85,7 +85,7 @@ MPI_Ssend(buf, count, datatype, dest, tag, comm, error)
      as much data as possible.  If the entire message could not be sent
      "immediately" then queue the request for later processing. (We need a
      progress engine to ensure that later happens.  */
-  /* Build up a segement unless the datatype is "trivial" */
+  /* Build up a segment unless the datatype is "trivial" */
 
 
   /* Wait until entire message is sent */
@@ -174,7 +174,7 @@ MPI_Ssend(buf, count, datatype, dest, tag, comm, error)
 reminder: envelope = (context (communicator), source_rank, tag)
 
 QUESTION: what exactly are the semantics of a block?  Sends to the same
-destination are definitely ordered.  Sends to different desinations could
+destination are definitely ordered.  Sends to different destinations could
 proceed in parallel.  Should they?
 
 example:

--- a/doc/notes/rma/dm-mt.c
+++ b/doc/notes/rma/dm-mt.c
@@ -76,7 +76,7 @@ MPID_Win_fence(assert, win)
 	 * operation should block, but it needs to guarantee that forward
 	 * progress is being made on both the incoming RHCs and locally posted
 	 * operations.  Whatever the correct interface is, we either need to
-	 * pass in dwin or declare/cast the counters unsed the above while
+	 * pass in dwin or declare/cast the counters used in the above while
 	 * statement as volatile.
 	 */
 	MPID_Win_wait(dwin);

--- a/doc/notes/rma/dm.c
+++ b/doc/notes/rma/dm.c
@@ -212,7 +212,7 @@ MPI_Accumulate(origin_addr, origin_count, origin_datatype,
     {
 	target_offset = win.displ * target_disp;
 	target_addr = win.base + target_offset;
-	/* peform requested operation */
+	/* perform requested operation */
     }
     else if (origin_byte_count < EAGER_MAX)
     {

--- a/doc/notes/rma/dm.txt
+++ b/doc/notes/rma/dm.txt
@@ -76,7 +76,7 @@ MPID_Win_fence
   Q: Should we perform a barrier here?  If we eliminate the barrier,
   then all processes still waiting for operations to complete will
   have to enqueue incoming requests from the next epoch until the
-  operations from the currrent epoch are complete.  Not performing the
+  operations from the current epoch are complete.  Not performing the
   barrier complicates the RMA operations, but the performance benefit
   may be significant for some cases.  (What are they?  How common are
   they?)

--- a/doc/notes/rma/gen.txt
+++ b/doc/notes/rma/gen.txt
@@ -46,7 +46,7 @@
   Q: How do the three synchronization mechanisms play together?  What
   is required in order to switch from one mechanism to another?  The
   standard talks about this briefly, but I am still somewhat confused
-  about what happens when a transistions occurs from active (fence)
+  about what happens when a transitions occurs from active (fence)
   synchronization to scalable or passive synchronization.  It seems as
   though active synchronization always has open access and exposure
   epochs unless the assertion MPI_MODE_NOSUCCEED is specified.

--- a/doc/notes/rma/meetings.txt
+++ b/doc/notes/rma/meetings.txt
@@ -217,7 +217,7 @@ another example, looking at shmem combined with remote access
 two pairs of processes on same nodes
 
 shared memory lock on single node allows one process to look directly into the
-window information so that he doesn't ahve to go through the agent of the other
+window information so that he doesn't have to go through the agent of the other
 process on the local node.  that same lock will be used by the communication
 agent for a given process to ensure that things are kept sane in the off-node
 case; in other words, this lock is utilized by processes on the same node
@@ -325,7 +325,7 @@ have as much as we do in the fence case.
 
 the accumulate is odd as usual.  if you're the only person in the target's
 group, then you don't have to do the element-wise locking/atomicity (or
-window-wise locking/unlocking depending on implementaiton).
+window-wise locking/unlocking depending on implementation).
 
 brian: it would be helpful for the origin to know if he needs to lock or not
 during accumulate operations.  this would allow him to know if he needs to lock
@@ -482,7 +482,7 @@ operation was requested during this access epoch.  After Win_complete() detects
 that all get operations have completed, if the flag is not set, it will
 decrements the reference counts of the logged datatypes and free the access
 epoch structure.  If the flag is set, the datatype reference counts may only be
-decremented once an explicit ackowledgement has been received from the target
+decremented once an explicit acknowledgement has been received from the target
 informing the origin that all operations requested by that access
 epoch have been completed.
 

--- a/doc/notes/rma/mpi.txt
+++ b/doc/notes/rma/mpi.txt
@@ -50,7 +50,7 @@ MPI_Win_create
   (MPIR_Win).
 
   * Create a copy of the communcator provided by the user so the
-    window has its own communcation context.
+    window has its own communication context.
   
   Q: Which layer (MPI/ADI3) should manage (be responsible for
   creating, destroying, etc.) the MPIR_Win object?

--- a/doc/notes/rma/passive-acc.txt
+++ b/doc/notes/rma/passive-acc.txt
@@ -23,7 +23,7 @@ Important issues with passive target accumulate
 
     Unless multiple threads (and processors) are present on the target
     system to process accumulation operations, serialization is
-    eminent, and the best optmization is to not have a ton of
+    eminent, and the best optimization is to not have a ton of
     multi-threading optimizations in the way slowing things down.  This
     suggests that two implementations may be necessary: one using
     threads and one that doesn't.

--- a/doc/notes/rma/pt-rma.txt
+++ b/doc/notes/rma/pt-rma.txt
@@ -1,6 +1,6 @@
 Below is the current design for passive target RMA on top of CH3.
 
-We assume that there is some asychronous agent (thread) that
+We assume that there is some asynchronous agent (thread) that
 periodically pokes the progress engine, i.e., periodically calls
 MPID_Progress_test(). We need to do a general poke of the progress
 engine because we don't know whether there will be passive target RMA

--- a/doc/notes/rma/rajeev-rma-notes.txt
+++ b/doc/notes/rma/rajeev-rma-notes.txt
@@ -11,7 +11,7 @@ aware of and makes progress on one-sided as well as send-recv ops.
 
 * An asynchronous agent kicks in periodically. The agent could be a
 thread, process, or signal handler. The agent calls the general
-progress function MPID_Make_progress and therefore makes progres on
+progress function MPID_Make_progress and therefore makes progress on
 everything. 
  (Q: If the agent is a process, how does it access the request queue
 on the main MPI process?)

--- a/doc/notes/rma/shm.txt
+++ b/doc/notes/rma/shm.txt
@@ -89,9 +89,9 @@ MPID_shm_Win_fence
 
   * set (or clear) preceding put flag based on the assertions
 
-    NOTE: To reduce unncessary cache and write buffer flushes, the
+    NOTE: To reduce unnecessary cache and write buffer flushes, the
     barrier (above) could be replaced with an alltoall gather of the
-    operation occuring between node pairs.  Using this information, we
+    operation occurring between node pairs.  Using this information, we
     could eliminate flushes except when an operation actually affected
     the local window.
 

--- a/doc/notes/rma/tutorial.txt
+++ b/doc/notes/rma/tutorial.txt
@@ -38,13 +38,13 @@ Communication operations (requests)
 * MPI_Put(origin_addr, origin_count, origin_datatype,
           target_rank, target_disp, target_count, target_datatype, win)
 
-  * target buffer must not overlap with other communcation operations during
+  * target buffer must not overlap with other communication operations during
     the same exposure epoch
 
 * MPI_Get(origin_addr, origin_count, origin_datatype,
           target_rank, target_disp, target_count, target_datatype, win)
 
-  * target buffer must not overlap with other communcation operations during
+  * target buffer must not overlap with other communication operations during
     the same exposure epoch
 
 * MPI_Accumulate(origin_addr, origin_count, origin_datatype,

--- a/doc/notes/rma/util.c
+++ b/doc/notes/rma/util.c
@@ -16,7 +16,7 @@ MPIR_Copy_data(src_addr, src_count, src_datatype,
 	 * this is a safe operation.
 	 *
 	 * NOTE: This code assumes that the (dest_count, dest_datatype)
-	 * represents enough space to accomodate (src_count, src_datatype) and
+	 * represents enough space to accommodate (src_count, src_datatype) and
 	 * that enough space exists in the dest buffer to cover (dest_count,
 	 * dest_datatype).  This implies that truncation and buffer overruns
 	 * errors must be caught before this routine is called.
@@ -40,7 +40,7 @@ MPIR_Copy_data(src_addr, src_count, src_datatype,
     else if (MPIR_Datatype_iscontig(src_count, src_datatype))
     {
         /*
-	 * The data arrangment at the src buffer is contiguous, but not at the
+	 * The data arrangement at the src buffer is contiguous, but not at the
 	 * dest.  We should be able to "unpack" the data directly into the dest
 	 * buffer.
 	 */
@@ -48,7 +48,7 @@ MPIR_Copy_data(src_addr, src_count, src_datatype,
     else if (MPIR_Datatype_iscontig(dest_count, dest_datatype))
     {
         /*
-	 * The data arrangment at the dest buffer is contiguous, but not at the
+	 * The data arrangement at the dest buffer is contiguous, but not at the
 	 * src.  We should be able to "pack" the data directly into the dest
 	 * buffer.
 	 */
@@ -139,7 +139,7 @@ MPIR_Win_verify_dt_op_compat(src_count, src_datatype,
     {
 	/* 
 	 * NOTE: The standard does not define what the application should
-	 * expect when truncation occurs.  We could peform the operation on as
+	 * expect when truncation occurs.  We could perform the operation on as
 	 * much data as possible before rc =ing an error, but that would only
 	 * delay reporting the error to the application.  Besides, a portable
 	 * application cannot rely on any of the operations being completed, so

--- a/doc/userguide/user.tex.vin
+++ b/doc/userguide/user.tex.vin
@@ -318,7 +318,7 @@ separated  by commas), with their current values, to the processes being run by
 \item[\texttt{-genv <name> <value>}]The \item{-genv} options have the same
 meaning as their corresponding \texttt{-env} version, except they apply to all
 executables, not just the current executable (in the case that the colon
-syntax is used to specify multiple execuables).
+syntax is used to specify multiple executables).
 \item[\texttt{-genvnone}]Like \texttt{-envnone}, but for all executables
 \item[\texttt{-genvlist <list>}]Like \texttt{-envlist}, but for all executables
 \item[\texttt{-usize <n>}]Specify the value returned for the value of the
@@ -330,7 +330,7 @@ attribute \texttt{MPI\_UNIVERSE\_SIZE}.
 exited if there is an abnormal exit
 \end{description}
 
-In addition to the commandline argments, the \texttt{gforker} \texttt{mpiexec}
+In addition to the commandline arguments, the \texttt{gforker} \texttt{mpiexec}
 provides a number of environment variables that can be used to control the
 behavior of \texttt{mpiexec}:
 

--- a/examples/developers/README
+++ b/examples/developers/README
@@ -1,3 +1,3 @@
 This directory contains programs that may be useful for developers.  These
 are not example programs; rather, they may be used to explore the 
-behavior of the MPI implemenation in some special cases.
+behavior of the MPI implementation in some special cases.

--- a/examples/pmandel.c
+++ b/examples/pmandel.c
@@ -865,7 +865,7 @@ void check_mand_params(int *m_max_iterations,
 
     if (*m_max_iterations == NOVALUE) {
         /* grab unspecified limit */
-        printf("Enter max interations to do: ");
+        printf("Enter max iterations to do: ");
         scanf("%d", &*m_max_iterations);
     }
 #endif
@@ -1341,7 +1341,7 @@ file's magic number is the two characters "P2".
 - Width * height gray values, each in ASCII decimal, between
 0  and  the  specified  maximum  value,  separated by whi-
 tespace, starting at the top-left corner of  the  graymap,
-proceding  in  normal English reading order.  A value of 0
+proceeding  in  normal English reading order.  A value of 0
 means black, and the maximum value means white.
 
 - Characters from a "#" to the next end-of-line are  ignored

--- a/examples/pmandel.c
+++ b/examples/pmandel.c
@@ -125,7 +125,7 @@ const char *default_filename = "pmandel.pgm";
                              abs(z=z^2+c) > diverge_value
    -julia        Plot a Julia set instead of a Mandelbrot set
    -jx # -jy #   The Julia point that defines the set
-   -alternate #    Plot an alternate Mandelbrot equation (varient 1 or 2 so far)
+   -alternate #    Plot an alternate Mandelbrot equation (variant 1 or 2 so far)
 */
 
 int myid;
@@ -881,7 +881,7 @@ void check_mand_params(int *m_max_iterations,
 #if PROMPT
     if (*m_pixels_across == NOVALUE || *m_pixels_down == NOVALUE) {
         /* grab unspecified limits */
-        printf("Enter pixel size (horizonal by vertical, i.e. 256 256): ");
+        printf("Enter pixel size (horizontal by vertical, i.e. 256 256): ");
         scanf(" %d %d", &*m_pixels_across, &*m_pixels_down);
     }
 #endif

--- a/examples/pmandel_fence.c
+++ b/examples/pmandel_fence.c
@@ -990,7 +990,7 @@ void check_mand_params(int *m_max_iterations,
 
     if (*m_max_iterations == NOVALUE) {
         /* grab unspecified limit */
-        printf("Enter max interations to do: ");
+        printf("Enter max iterations to do: ");
         scanf("%d", &*m_max_iterations);
     }
 #endif

--- a/examples/pmandel_fence.c
+++ b/examples/pmandel_fence.c
@@ -125,7 +125,7 @@ const char *default_filename = "pmandel.pgm";
                              abs(z=z^2+c) > diverge_value
    -julia        Plot a Julia set instead of a Mandelbrot set
    -jx # -jy #   The Julia point that defines the set
-   -alternate #    Plot an alternate Mandelbrot equation (varient 1 or 2 so far)
+   -alternate #    Plot an alternate Mandelbrot equation (variant 1 or 2 so far)
 */
 
 int myid;
@@ -1006,7 +1006,7 @@ void check_mand_params(int *m_max_iterations,
 #if PROMPT
     if (*m_pixels_across == NOVALUE || *m_pixels_down == NOVALUE) {
         /* grab unspecified limits */
-        printf("Enter pixel size (horizonal by vertical, i.e. 256 256): ");
+        printf("Enter pixel size (horizontal by vertical, i.e. 256 256): ");
         scanf(" %d %d", &*m_pixels_across, &*m_pixels_down);
     }
 #endif

--- a/examples/pmandel_service.c
+++ b/examples/pmandel_service.c
@@ -113,7 +113,7 @@ const char *default_filename = "pmandel.pgm";
                              abs(z=z^2+c) > diverge_value
    -julia        Plot a Julia set instead of a Mandelbrot set
    -jx # -jy #   The Julia point that defines the set
-   -alternate #    Plot an alternate Mandelbrot equation (varient 1 or 2 so far)
+   -alternate #    Plot an alternate Mandelbrot equation (variant 1 or 2 so far)
 */
 
 int myid;
@@ -846,7 +846,7 @@ void check_mand_params(int *m_max_iterations,
 #if PROMPT
     if (*m_pixels_across == NOVALUE || *m_pixels_down == NOVALUE) {
         /* grab unspecified limits */
-        printf("Enter pixel size (horizonal by vertical, i.e. 256 256): ");
+        printf("Enter pixel size (horizontal by vertical, i.e. 256 256): ");
         scanf(" %d %d", &*m_pixels_across, &*m_pixels_down);
     }
 #endif

--- a/examples/pmandel_service.c
+++ b/examples/pmandel_service.c
@@ -830,7 +830,7 @@ void check_mand_params(int *m_max_iterations,
 
     if (*m_max_iterations == NOVALUE) {
         /* grab unspecified limit */
-        printf("Enter max interations to do: ");
+        printf("Enter max iterations to do: ");
         scanf("%d", &*m_max_iterations);
     }
 #endif

--- a/examples/pmandel_spaserv.c
+++ b/examples/pmandel_spaserv.c
@@ -119,7 +119,7 @@ const char *default_filename = "pmandel.pgm";
                              abs(z=z^2+c) > diverge_value
    -julia        Plot a Julia set instead of a Mandelbrot set
    -jx # -jy #   The Julia point that defines the set
-   -alternate #    Plot an alternate Mandelbrot equation (varient 1 or 2 so far)
+   -alternate #    Plot an alternate Mandelbrot equation (variant 1 or 2 so far)
 */
 
 int myid;
@@ -877,7 +877,7 @@ void check_mand_params(int *m_max_iterations,
 #if PROMPT
     if (*m_pixels_across == NOVALUE || *m_pixels_down == NOVALUE) {
         /* grab unspecified limits */
-        printf("Enter pixel size (horizonal by vertical, i.e. 256 256): ");
+        printf("Enter pixel size (horizontal by vertical, i.e. 256 256): ");
         scanf(" %d %d", &*m_pixels_across, &*m_pixels_down);
     }
 #endif

--- a/examples/pmandel_spaserv.c
+++ b/examples/pmandel_spaserv.c
@@ -861,7 +861,7 @@ void check_mand_params(int *m_max_iterations,
 
     if (*m_max_iterations == NOVALUE) {
         /* grab unspecified limit */
-        printf("Enter max interations to do: ");
+        printf("Enter max iterations to do: ");
         scanf("%d", &*m_max_iterations);
     }
 #endif

--- a/examples/pmandel_spawn.c
+++ b/examples/pmandel_spawn.c
@@ -943,7 +943,7 @@ void check_mand_params(int *m_max_iterations,
 
     if (*m_max_iterations == NOVALUE) {
         /* grab unspecified limit */
-        printf("Enter max interations to do: ");
+        printf("Enter max iterations to do: ");
         scanf("%d", &*m_max_iterations);
     }
 #endif
@@ -1429,7 +1429,7 @@ file's magic number is the two characters "P2".
 - Width * height gray values, each in ASCII decimal, between
 0  and  the  specified  maximum  value,  separated by whi-
 tespace, starting at the top-left corner of  the  graymap,
-proceding  in  normal English reading order.  A value of 0
+proceeding  in  normal English reading order.  A value of 0
 means black, and the maximum value means white.
 
 - Characters from a "#" to the next end-of-line are  ignored

--- a/examples/pmandel_spawn.c
+++ b/examples/pmandel_spawn.c
@@ -127,7 +127,7 @@ const char *default_filename = "pmandel.pgm";
                              abs(z=z^2+c) > diverge_value
    -julia        Plot a Julia set instead of a Mandelbrot set
    -jx # -jy #   The Julia point that defines the set
-   -alternate #    Plot an alternate Mandelbrot equation (varient 1 or 2 so far)
+   -alternate #    Plot an alternate Mandelbrot equation (variant 1 or 2 so far)
 */
 
 int myid;
@@ -491,7 +491,7 @@ int main(int argc, char *argv[])
         }
     } else {
         for (;;) {
-            /*printf("child[%d] receiveing bounds.\n", pid);fflush(stdout); */
+            /*printf("child[%d] receiving bounds.\n", pid);fflush(stdout); */
             MPI_Recv(&x_min, 1, MPI_DOUBLE, 0, 0, parent, MPI_STATUS_IGNORE);
             MPI_Recv(&x_max, 1, MPI_DOUBLE, 0, 0, parent, MPI_STATUS_IGNORE);
             MPI_Recv(&y_min, 1, MPI_DOUBLE, 0, 0, parent, MPI_STATUS_IGNORE);
@@ -959,7 +959,7 @@ void check_mand_params(int *m_max_iterations,
 #if PROMPT
     if (*m_pixels_across == NOVALUE || *m_pixels_down == NOVALUE) {
         /* grab unspecified limits */
-        printf("Enter pixel size (horizonal by vertical, i.e. 256 256): ");
+        printf("Enter pixel size (horizontal by vertical, i.e. 256 256): ");
         scanf(" %d %d", &*m_pixels_across, &*m_pixels_down);
     }
 #endif

--- a/maint/Version.base.m4
+++ b/maint/Version.base.m4
@@ -6,7 +6,7 @@ m4_init
 dnl get the real version values
 m4_include([maint/version.m4])dnl
 
-dnl The m4sugar langauage switches the default diversion to "KILL", and causes
+dnl The m4sugar language switches the default diversion to "KILL", and causes
 dnl all normal output to be thrown away.  We switch to the default (0) diversion
 dnl to restore output.
 m4_divert_push([])dnl

--- a/maint/checkbuilds.in
+++ b/maint/checkbuilds.in
@@ -284,7 +284,7 @@ sub RunTest {
 	return;
     }
     # Clean the installation and build directories
-    # Even better would be to remove the installation directory alltogether,
+    # Even better would be to remove the installation directory altogether,
     # but we should only do that if explicitly requested (we could
     # *require* an empty directory for the tests instead)
     if (-d "$instdir/lib") {

--- a/maint/createcoverage.in
+++ b/maint/createcoverage.in
@@ -148,7 +148,7 @@ EOF
     esac
 done
 
-# Move everthing into a device-specific directory
+# Move everything into a device-specific directory
 webloc="$weblocbase/$device"
 if [ "$update_web" = yes ] ; then
     if [ ! -d $webloc ] ; then mkdir -p $webloc ; fi

--- a/maint/createhtmlindex.in
+++ b/maint/createhtmlindex.in
@@ -14,7 +14,7 @@ chop $WWWRoot;
 # $URLBase = "http://";
 # End of line character (\r\n is DOS-friendly)
 $eol = "\r\n";
-# Number of colums in table of names
+# Number of columns in table of names
 $TableCols = 3;
 #
 # Process arguments for any changes

--- a/maint/docnotes
+++ b/maint/docnotes
@@ -1,6 +1,6 @@
 This file contains the named document blocks for use in generating the 
 documentation.  This is divided into several main blocks:
-   Threads and interrups/signals
+   Threads and interrupts/signals
    Fortran
    Misc MPI (e.g., status null)
    Error classes
@@ -256,7 +256,7 @@ N*/
 N*/
 /*N MPI_ERR_PERM_KEY
 . MPI_ERR_ARG - Invalid argument; the error code associated with this
-  error indicates an attempt to free or chnage an MPI permanent keyval (e.g., 
+  error indicates an attempt to free or change an MPI permanent keyval (e.g., 
   'MPI_TAG_UB').
 N*/
 /*N MPI_ERR_UNKNOWN
@@ -301,7 +301,7 @@ N*/
   to indicate which requests have not completed.  In most cases, only
   one request with an error will be detected in each call to an MPI routine
   that tests multiple requests.  The requests that have not been processed
-  (because an error occured in one of the requests) will have their
+  (because an error occurred in one of the requests) will have their
   'MPI_ERROR' field marked with 'MPI_ERR_PENDING'.
 N*/
 /*N MPI_ERR_PENDING
@@ -314,7 +314,7 @@ N*/
   'MPI_Start' or 'MPI_Startall', not a persistent request.
 N*/
 /*N MPI_ERR_BUFFER_ALIAS
-.   MPI_ERR_BUFFER - This error class is associcated with an error code that
+.   MPI_ERR_BUFFER - This error class is associated with an error code that
     indicates that two buffer arguments are `aliased`; that is, the 
     describe overlapping storage (often the exact same storage).  This
     is prohibited in MPI (because it is prohibited by the Fortran 

--- a/maint/docnotes
+++ b/maint/docnotes
@@ -99,7 +99,7 @@ N*/
 N*/
 
 /*N FortStatusArray
- The 'status' argument must be declared as an array of sise 'MPI_STATUS_SIZE',
+ The 'status' argument must be declared as an array of size 'MPI_STATUS_SIZE',
  as in 'integer status(MPI_STATUS_SIZE,10)' (assuming no more than 10 
  requests are provided as input).
 N*/

--- a/maint/extractcvars.in
+++ b/maint/extractcvars.in
@@ -57,7 +57,7 @@ Supported options:
     --help              - this output (optional)
     --debug             - enable some debugging output (optional)
     --namespace=STR     - use STR as variable/type prefix in generated code (optional, default=$ns)
-    --alt-namespace=STR - use STR as alternaive variable/type prefix in generated code (optional, default=$alt_ns)
+    --alt-namespace=STR - use STR as alternative variable/type prefix in generated code (optional, default=$alt_ns)
     --header=STR        - specify the header file name (optional, default=$header_file)
     --c-file=STR        - specify the C file name (optional, default=$c_file)
     --readme-file=STR   - specify the readme file name (optional, default=$readme_file)

--- a/maint/extracterrmsgs
+++ b/maint/extracterrmsgs
@@ -94,7 +94,7 @@ else {
 }
 # Setup before processing the files
 if ($build_test_pgm && -d "test/mpi/errhan") {
-    # Get current directory incase we need it for the error message
+    # Get current directory in case we need it for the error message
     my $curdir = `pwd`;
     open( TESTFD, ">test/mpi/errhan/errcode.c" ) or die "Cannot create test program errcode.c in $curdir/test/mpi/errhan\n";
     print TESTFD "/*\
@@ -180,7 +180,7 @@ typedef struct msgpair {
 }
 #
 # We also need a way to create the records
-# We then hash these on the first occurance (or precompute the hashes?)
+# We then hash these on the first occurrence (or precompute the hashes?)
 #
 # The error messages are output in the following form:
 # typedef struct {const char short[], const long[]} namemap;
@@ -206,7 +206,7 @@ sub CreateErrMsgMapping {
 	s/#.*$//;
 	my ($mpiname,$num,$shortmsg) = split(/\s\s*/);
 	if (!defined($shortmsg)) {
-	    # Incase there is no short message entry (!)
+	    # In case there is no short message entry (!)
 	    $shortmsg = "";
 	}
 	if ($shortmsg ne "")
@@ -255,7 +255,7 @@ sub CreateErrMsgMapping {
 	    $seenfile = $generic_loc{$key};
 	    if ($key =~ /^\*\*/) {
 		# If the message begins with text, assume that it is a 
-		# litteral message
+		# literal message
 		print STDERR "Shortname $key for generic messages has no expansion (first seen in file $seenfile)\n";
 		print STDERR "(Add expansion to $sourcefile)\n";
 	    }
@@ -281,8 +281,8 @@ sub CreateErrMsgMapping {
     # Generate the mapping of short to long names
     print $OUTFD "\nstatic const int generic_msgs_len = $num;\n";
 
-    # The sentinals should be hardcoded into the source file that
-    # uses this file to ensure that the sentinal tests are ok.
+    # The sentinels should be hardcoded into the source file that
+    # uses this file to ensure that the sentinel tests are ok.
     my $sentinal1 = "0xacebad03";
     my $sentinal2 = "0xcb0bfa11";
     print $OUTFD "static const msgpair generic_err_msgs[] = {\n";
@@ -541,7 +541,7 @@ sub AddTestCall {
 # Read an errnames file.  This allows us to distribute the errnames.txt
 # files in the relevant modules, rather than making them part of one
 # single main file.
-# This updates the global hashs longnames and longnamesDefined
+# This updates the global hashes longnames and longnamesDefined
 #  ReadErrnamesFile( filename )
 # ==========================================================================
 sub ReadErrnamesFile {

--- a/maint/extractstates.in
+++ b/maint/extractstates.in
@@ -425,7 +425,7 @@ sub CheckAllInfo {
 		# There are two possibilities: 
 		# One of the values is cached and the other is an exception
 		# value, in which case we reject the cached value
-		# The other possiblity is a conflict, which we report.
+		# The other possibility is a conflict, which we report.
 		
 		print STDERR "\nInconsistent value for state of $key:\n";
 		print STDERR "Old : $stateNames{$key} in $stateLoc{$key}\n";

--- a/maint/extractstrings.in
+++ b/maint/extractstrings.in
@@ -9,7 +9,7 @@
 # of routines for processing files and maintaining a cache of the results.
 # It uses a more sophisticated
 # approach to avoid rescanning all files by keeping track of local changes
-# It does this on a directory-by-directory basis as a comprimise between
+# It does this on a directory-by-directory basis as a compromise between
 # doing the minimal work but limiting the number and size of the "extra"
 # files.  In this case, for each directory, the following dot file is 
 # produced (with a <name> provided depending on use:
@@ -58,7 +58,7 @@
 # Data structures
 # Within a directory
 #   fileInfo{filename} = extracted info
-#   filesUpdated[]     = array of file names that match critera
+#   filesUpdated[]     = array of file names that match criteria
 #   fileInCache{filename} = comparison info
 #   
 # -------------------------------------------------------------------------

--- a/maint/gcovmerge.in
+++ b/maint/gcovmerge.in
@@ -23,7 +23,7 @@ open (I2, "<$f2" ) || die "Cannot open $f2";
 while (!eof(I1) && !eof(I2)) {
     $s1 = <I1>;
     $s2 = <I2>;
-    # The following apply to the preceeding line, and in the case of
+    # The following apply to the preceding line, and in the case of
     # a macro, there may be multiple lines.  In the merge case, 
     # we don't have a good way to interpret these, so we skip them
     # ^\s*branch\s+\d+\s+never executed

--- a/maint/gen_binding_f08.py
+++ b/maint/gen_binding_f08.py
@@ -12,7 +12,7 @@ from local_python import RE
 def main():
     binding_dir = "src/binding"
     f08_dir = "src/binding/fortran/use_mpi_f08"
-    func_list = load_C_func_list(binding_dir, True) # supress noise
+    func_list = load_C_func_list(binding_dir, True) # suppress noise
     # FIXME: until romio interface is generated
     func_list.extend(get_mpiio_func_list())
     func_list.extend(get_type_create_f90_func_list())

--- a/maint/genstates.in
+++ b/maint/genstates.in
@@ -234,7 +234,7 @@ close HFILE;
 # FIXME: This is RLOG specific and should be placed in the appropriate 
 # RLOG directory, not common.  
 # FIXME: It would also make more sense for the RLOG_Describe_state routine
-# to perform the random color assignement when provided with an empty
+# to perform the random color assignment when provided with an empty
 # or null color string, rather than including all of this code in what is
 # otherwise an RLOG-specific file.
 

--- a/maint/getcoverage.in
+++ b/maint/getcoverage.in
@@ -60,13 +60,13 @@ $annoteFiles = 0;
 $annoteBaseDir = "";
 %AnnoteFilesMap = ();   # Clear the list of files 
 %AnnoteMissed   = ();   # Clear the mapping of filenames to "missed;total" lines
-%AnnoteFilesToOrig = (); # Map from annoted file key to original name (used for
+%AnnoteFilesToOrig = (); # Map from annotated file key to original name (used for
                          # indexing into AnnoteMissed)
 $gDebug = 0;
 $gDebugDetail = 0;
 
 # The line leaders are used to provide a common set of expressions to match
-# the begining of a line.  This matches the output from the gcov tools.
+# the beginning of a line.  This matches the output from the gcov tools.
 # There are two of these because the output from the tools associtated with
 # gcc version 2.x and 3.x are different.
 # As, apparently is 4.x.
@@ -783,7 +783,7 @@ sub ExpandDir {
 	    $otherdirs[$#otherdirs+1] = "$dir/$filename";
 	}
 	elsif ($filename =~ /(.*\.gcov)$/) {
-	    # Check for the presense of a "merged" gcov file and use instead
+	    # Check for the presence of a "merged" gcov file and use instead
 	    if (-f "$dir/$filename.merge") {
 		$files[$#files + 1] = "$dir/$filename.merge";
 	    }

--- a/maint/getcoverage.in
+++ b/maint/getcoverage.in
@@ -979,7 +979,7 @@ sub skipBlock {
 	    /^$lineLeader4\/\*\s+--END $blockName--\s+\*\//) {
 	    last; 
 	}
-	# If we match the following but not the preceeding, there are extra 
+	# If we match the following but not the preceding, there are extra 
 	# spaces in the comment
 	if (/^\s*\/\*\s*--\s*END\s+$blockName\s*--\s*\*\/\s*/ ||
 	    /^\s*-:\s*\d+:\s*\/\*\s*--\s*END\s+$blockName\s*--\s*\*\/\s*/) {

--- a/maint/hooks/pre-commit-check-for-rebasing.sh
+++ b/maint/hooks/pre-commit-check-for-rebasing.sh
@@ -7,7 +7,7 @@
 # This hook prevent from pushing a branch that is not rebased on
 # latest MPICH main branch.
 #
-# It fetchs the hash of the latest main branch from github and compares
+# It fetches the hash of the latest main branch from github and compares
 # the local branch. It returns 1 if either the hash of the latest
 # main branch does not exist in the local git repo or the branch needs
 # rebasing.

--- a/maint/local_perl/lib/YAML/Tiny.pm
+++ b/maint/local_perl/lib/YAML/Tiny.pm
@@ -700,13 +700,13 @@ I said B<human-readable> and not B<geek-readable>. The sort of files that
 your average manager or secretary should be able to look at and make
 sense of.
 
-L<YAML::Tiny> does not generate comments, it won't necesarily preserve the
+L<YAML::Tiny> does not generate comments, it won't necessarily preserve the
 order of your hashes, and it will normalise if reading in and writing out
 again.
 
 It only supports a very basic subset of the full YAML specification.
 
-Usage is targetted at files like Perl's META.yml, for which a small and
+Usage is targeted at files like Perl's META.yml, for which a small and
 easily-embeddable module is extremely attractive.
 
 Features will only be added if they are human readable, and can be written
@@ -746,7 +746,7 @@ JSON, with the additional limitation that only simple keys are supported.
 
 As a result, all possible YAML Tiny documents should be able to be
 transformed into an equivalent JSON document, although the reverse is
-not necesarily true (but will be true in simple cases).
+not necessarily true (but will be true in simple cases).
 
 As a result of these simplifications the YAML Tiny specification should
 be implementable in a relatively small amount of code in any language
@@ -804,7 +804,7 @@ B<Loading Failure Points>
 
 YAML Tiny parsers and emitters are not expected to recover from adapt to
 errors. The specific error modality of any implementation is not dictated
-(return codes, exceptions, etc) but is expected to be consistant.
+(return codes, exceptions, etc) but is expected to be consistent.
 
 =head2 4. Syntax
 
@@ -905,7 +905,7 @@ Indentation spaces work as per the YAML specification in all cases.
 Comments work as per the YAML specification in all simple cases.
 Support for indented multi-line comments is B<not> required.
 
-Seperation spaces work as per the YAML specification in all cases.
+Separation spaces work as per the YAML specification in all cases.
 
 B<YAML Tiny Character Stream>
 
@@ -938,7 +938,7 @@ Support for the document boundary marker "---" is required.
 
 Support for the document boundary market "..." is B<not> required.
 
-If necesary, a document boundary should simply by indicated with a
+If necessary, a document boundary should simply by indicated with a
 "---" marker, with not preceding "..." marker.
 
 Support for empty streams (containing no documents) is required.
@@ -961,7 +961,7 @@ Support for nodes optional anchor and tag properties are B<not> required.
 
 Support for node anchors is B<not> required.
 
-Supprot for node tags is B<not> required.
+Support for node tags is B<not> required.
 
 Support for alias nodes is B<not> required.
 

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -756,7 +756,7 @@ def check_large_parameters(func):
 
     # Set func['_poly_impl']
     if 'poly_impl' in func:
-        # always prefer explict .poly_impl directive
+        # always prefer explicit .poly_impl directive
         func['_poly_impl'] = func['poly_impl']
     elif 'code-large_count' in func:
         # { -- large_count } code block exist
@@ -2113,7 +2113,7 @@ def get_impl_param(func, param):
 
 def get_polymorph_param_and_arg(s):
     # s is a polymorph spec, e.g. "MPIR_Attr_type attr_type=MPIR_ATTR_PTR"
-    # Note: we assum limit of single extra param for now (which is sufficient)
+    # Note: we assume limit of single extra param for now (which is sufficient)
     RE.match(r'^\s*(.+?)\s*(\w+)\s*=\s*(.+)', s)
     extra_param = RE.m.group(1) + ' ' + RE.m.group(2)
     extra_arg = RE.m.group(3)

--- a/maint/local_python/binding_common.py
+++ b/maint/local_python/binding_common.py
@@ -24,7 +24,7 @@ def split_line_with_break(s, tail, N=100):
         tlist.append(s)
         n = len(s)
     elif RE.match(r'(.*?\()(.*)', s):
-        # line with function pattern, match indent at openning parenthesis
+        # line with function pattern, match indent at opening parenthesis
         s_lead, s_next = RE.m.group(1,2)
         n_lead = len(s_lead)
 

--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -77,7 +77,7 @@ def dump_f08_wrappers_c(func):
                 p5 = func['parameters'][i + 4]
                 dump_buf(p['name'], True)
                 dump_buf(p2['name'], False)
-                # arbitary: only recvbuf may be sub-array
+                # arbitrary: only recvbuf may be sub-array
                 if RE.match(r'mpi_i?reduce_scatter', func['name'], re.IGNORECASE):
                     dump_p(p3)
                     dump_p(p4)
@@ -420,7 +420,7 @@ def dump_f08_wrappers_f(func):
                 need_check_int_kind = True
                 if not has_comm_size:
                     if RE.search(r'alltoallw', func['name'], re.IGNORECASE):
-                        # always need the lenght for types array
+                        # always need the length for types array
                         use_list = convert_list_pre
                     else:
                         use_list = convert_list_1

--- a/maint/parse.sub
+++ b/maint/parse.sub
@@ -207,7 +207,7 @@ sub StripComments {
 	    $comment_line = $1;
 	    $curline =~ s/\/\*.*?\*\///s;
 	    print "Removed comment, now is $curline\n" if $debug;
-	    # Keep looking for comments incase the line has multiple 
+	    # Keep looking for comments in case the line has multiple 
 	    # comments
 	}
 	else {

--- a/maint/spellcheck.sh
+++ b/maint/spellcheck.sh
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+skip_words="inout,improbe,nd,alse,ans,parm,parms,stange,faught,gord,hellow,creat,outweights,configury,numer,thrid,offsetp"
+skip_files=".git,*.tex,*.bib,*.sty,*.f,confdb/config.*"
+
+opts=(--ignore-words-list="$skip_words" --skip="$skip_files" --write-changes)
+filelist=""
+all=0
+for arg in $@; do
+    if [ "$arg" = "-all" ]; then
+        all=1
+    elif [ "$arg" = "-i" ]; then
+        opts+=( --interactive=3 )
+    else
+        filelist="$filelist $arg"
+    fi
+done
+
+if [ "$all" = "1" ]; then
+    codespell ${opts[@]}
+elif [ -n "$filelist" ] ; then
+    codespell ${opts[@]} $filelist
+else
+    echo "Usage: $0 [-i] filelist"
+    echo "   or: $0 [-i] -all"
+    exit
+fi

--- a/src/binding/c/comm_api.txt
+++ b/src/binding/c/comm_api.txt
@@ -6,7 +6,7 @@ MPI_Comm_compare:
     .extra: ignore_revoked_comm
 /*
     .N ThreadSafe
-    (To perform the communicator comparisions, this routine may need to
+    (To perform the communicator comparisons, this routine may need to
     allocate some memory.  Memory allocation is not interrupt-safe, and hence
     this routine is only thread-safe.)
 */
@@ -43,7 +43,7 @@ MPI_Comm_dup:
       particularly useful for (a) attributes that describe some property
       of the group associated with the communicator, such as its
       interconnection topology and (b) communicators that are given back
-      to the user; the attibutes in this case can track subsequent
+      to the user; the attributes in this case can track subsequent
       'MPI_Comm_dup' operations on this communicator.
 */
 
@@ -211,7 +211,7 @@ MPI_Intercomm_create:
        'local_leader' in the 'local_comm'.
 
       The MPI 1.1 Standard contains two mutually exclusive comments on the
-      input intercommunicators.  One says that their repective groups must be
+      input intercommunicators.  One says that their respective groups must be
       disjoint; the other that the leaders can be the same process.  After
       some discussion by the MPI Forum, it has been decided that the groups must
       be disjoint.  Note that the `reason` given for this in the standard is

--- a/src/binding/c/mpit_api.txt
+++ b/src/binding/c/mpit_api.txt
@@ -287,7 +287,7 @@ MPI_T_pvar_get_index:
 }
 
 MPI_T_pvar_get_info:
-    .desc: Get the inforamtion about a performance variable
+    .desc: Get the information about a performance variable
     .skip: validate-ANY
     .error: MPI_T_ERR_INVALID_INDEX
 { -- error_check --

--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -340,7 +340,7 @@ MPI_Recv:
 
     /* MT: Note that MPID_Recv may release the SINGLE_CS if it
      * decides to block internally.  MPID_Recv in that case will
-     * re-aquire the SINGLE_CS before returnning */
+     * re-aquire the SINGLE_CS before returning */
     mpi_errno = MPID_Recv(buf, count, datatype, source, tag, comm_ptr,
                           MPIR_CONTEXT_INTRA_PT2PT, status, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)

--- a/src/binding/c/request_api.txt
+++ b/src/binding/c/request_api.txt
@@ -37,7 +37,7 @@ MPIX_Grequest_start:
     query_fn: FUNCTION_SMALL, func_type=MPI_Grequest_query_function, [callback function invoked when request status is queried]
     free_fn: FUNCTION_SMALL, func_type=MPI_Grequest_free_function, [callback function invoked when request is freed]
     cancel_fn: FUNCTION_SMALL, func_type=MPI_Grequest_cancel_function, [callback function invoked when request is cancelled]
-    poll_fn: FUNCTION_SMALL, func_type=MPIX_Grequest_poll_function, [callback function invoked when request completeion is tested]
+    poll_fn: FUNCTION_SMALL, func_type=MPIX_Grequest_poll_function, [callback function invoked when request completion is tested]
     wait_fn: FUNCTION_SMALL, func_type=MPIX_Grequest_wait_function, [callback function invoked when request is waited on]
     extra_state: EXTRA_STATE, [extra state]
     request: REQUEST, direction=out, [generalized request]
@@ -58,7 +58,7 @@ MPIX_Grequest_class_create:
     query_fn: FUNCTION_SMALL, func_type=MPI_Grequest_query_function, [callback function invoked when request status is queried]
     free_fn: FUNCTION_SMALL, func_type=MPI_Grequest_free_function, [callback function invoked when request is freed]
     cancel_fn: FUNCTION_SMALL, func_type=MPI_Grequest_cancel_function, [callback function invoked when request is cancelled]
-    poll_fn: FUNCTION_SMALL, func_type=MPIX_Grequest_poll_function, [callback function invoked when request completeion is tested]
+    poll_fn: FUNCTION_SMALL, func_type=MPIX_Grequest_poll_function, [callback function invoked when request completion is tested]
     wait_fn: FUNCTION_SMALL, func_type=MPIX_Grequest_wait_function, [callback function invoked when request is waited on]
     greq_class: GREQUEST_CLASS, direction=out, [generalized request class]
 
@@ -282,7 +282,7 @@ MPI_Waitsome:
     .desc: Waits for some given MPI Requests to complete
 /*
     Notes:
-    The array of indicies are in the range '0' to 'incount - 1' for C and
+    The array of indices are in the range '0' to 'incount - 1' for C and
     in the range '1' to 'incount' for Fortran.
 
     Null requests are ignored; if all requests are null, then the routine

--- a/src/binding/c/rma_api.txt
+++ b/src/binding/c/rma_api.txt
@@ -562,7 +562,7 @@ MPI_Win_start:
     The 'assert' argument is used to indicate special conditions for the
     fence that an implementation may use to optimize the 'MPI_Win_start'
     operation.  The value zero is always correct.  Other assertion values
-    may be or''ed together.  Assertions tha are valid for 'MPI_Win_start' are\:
+    may be or''ed together.  Assertions that are valid for 'MPI_Win_start' are\:
 
     . MPI_MODE_NOCHECK - the matching calls to 'MPI_WIN_POST' have already
       completed on all target processes when the call to 'MPI_WIN_START' is made.

--- a/src/binding/cxx/buildiface
+++ b/src/binding/cxx/buildiface
@@ -1837,7 +1837,7 @@ sub clean_args {
 
 # Print out the constants.
 # PrintConstants( FD, giveValue )
-# if GiveValue is true, defint the value, otherwise, make it external
+# if GiveValue is true, define the value, otherwise, make it external
 sub PrintConstants {    
     my ($OUTFD, $giveValue) = @_;
     my $extern = "extern ";

--- a/src/binding/cxx/buildiface
+++ b/src/binding/cxx/buildiface
@@ -39,7 +39,7 @@
 #       COVERAGE_EXIT(Name,argcount); }
 # The COVERAGE_ENTER and EXIT can be used as macros to invoke code to keep
 # track of each entry and exit.  The argcount is the number of parameters,
-# and can be used to distinquish between routines with the same name but
+# and can be used to distinguish between routines with the same name but
 # different number of arguments.
 #
 # (const applies only if the function does not modify its object (e.g., 
@@ -55,7 +55,7 @@
 #   Pass by reference to process routine
 # 
 # Notes:
-#   "NULL" isn't the rigth way to specify a NULL pointer in C++; use "0" (this 
+#   "NULL" isn't the right way to specify a NULL pointer in C++; use "0" (this 
 #   will have the correct type and some C++ compilers don't recognize NULL
 #   unless you include header files that needed it and are otherwise unneeded
 #   by the C++ interface)
@@ -1077,7 +1077,7 @@ if ($do_DistGraphComm) {
 	'Dist_graph_neighbors_count';
 }
 
-# These routines must be defered because their implementations need 
+# These routines must be deferred because their implementations need 
 # definitions of classes that must be made later than the class that they
 # are in.  In particular, these need both datatypes and communicators.
 %defer_definition = ( 'Pack' => Datatype, 
@@ -1101,7 +1101,7 @@ if ($do_DistGraphComm) {
     $class_has_no_compare{'Distgraphcomm'} = 1;
 }
 
-# These classes do not have a default intialization
+# These classes do not have a default initialization
 # These use the Full class name
 %class_has_no_default = ( 'Status' => 1 );
 
@@ -1110,7 +1110,7 @@ if ($do_DistGraphComm) {
 # derived from the ReadInterface
 if ($doFuncspec) {
     &ReadFuncSpec( "cxxdecl3.dat" );
-    # Use the MPI C++ binding names for the defered definitions
+    # Use the MPI C++ binding names for the deferred definitions
     $defer_definition{"Create_cart"}  = "Comm";
     $defer_definition{"Create_graph"} = "Comm";
     $defer_definition{"Get_parent"}   = "Comm";
@@ -1531,7 +1531,7 @@ EOT
 sub print_args { 
     my $OUTFD = $_[0];
     my @parms = split(/\s*,\s*/, $_[1] );  # the original parameter list
-    my $class_type = $_[2];                # Is this a Comm, Info, or othe 
+    my $class_type = $_[2];                # Is this a Comm, Info, or other 
                                            # class?  Use to find the position
                                            # of the "this" entry in the C 
                                            # version of the routine.
@@ -1725,7 +1725,7 @@ sub print_call_args {
 	}
 	elsif ($count == $return_parm_pos) {
 	    # We may need to pass the address of a temporary object
-	    # We'll unilateraly assume this for now
+	    # We'll unilaterally assume this for now
 	    # This must be first, so that it has a priority over the
 	    # class pos location.
 	    if ($parm =~ /MPI_/ && !($parm =~ /MPI_Offset/) &&
@@ -3866,7 +3866,7 @@ sub EndClass {
 #   f) return result value, if any
 #   
 # The handling of the temporary variables is done by calling a named routine
-# for each parameter that identifies itself as requring special processing
+# for each parameter that identifies itself as requiring special processing
 # ----------------------------------------------------------------------------
 #
 # PrintRoutineDef( outfd, class, routine, arginfo, defonly )
@@ -4453,7 +4453,7 @@ sub bool_out_ctocxx {
     
     print $OUTFD "$indent    $cxxoutvar = $cinvar ? true : false;\n";
 }
-# conver to C int
+# convert to C int
 sub bool_in_cxxtoc {
 #    my $cxxinvar = $_[0];
 #    my $coutvar  = $_[1];
@@ -5146,7 +5146,7 @@ sub ReadFuncSpec {
 }
 # ----------------------------------------------------------------------------
 # Special debugging:
-# Somethimes it is valuable to debug just a single routine.  This interface
+# Sometimes it is valuable to debug just a single routine.  This interface
 # makes that relatively easy
 sub debugPrint {
     my ($routine, $str) = @_;

--- a/src/binding/cxx/cov2html.in
+++ b/src/binding/cxx/cov2html.in
@@ -67,7 +67,7 @@ sub DebugWriteCovData {
 # Read a source file and annotate it based on the information in the
 # srchash
 #
-# There are three states for the annoted file:
+# There are three states for the annotated file:
 #   nocode  - not within a coverage block
 #   incov   - within AND covered
 #   uncov   - within and NOT covered

--- a/src/binding/cxx/cxxtodecl
+++ b/src/binding/cxx/cxxtodecl
@@ -28,7 +28,7 @@
 		  "base-Init_thread" => 1,
 		  "base-Init" => 1,
 		  );
-# These functions are primarily from MPI-1, and follow a differnt rule.
+# These functions are primarily from MPI-1, and follow a different rule.
 # ?? Should these have a place in the definition file instead of here?
 %FuncHasClassAtEnd = ( 
 		       "comm-Send" => 1,

--- a/src/binding/cxx/mpicovsimple.cxx
+++ b/src/binding/cxx/mpicovsimple.cxx
@@ -146,7 +146,7 @@ int MPIX_Coverage::FileMerge( const char filename[] )
 	// If this becomes a problem, we can merge the two
 	// into a single output
 	while (infile) {
-	    fp.count = -1;  // Set a sentinal on eof in infile
+	    fp.count = -1;  // Set a sentinel on eof in infile
 	    infile >> fp.name >> fp.argcount >> fp.count >> fp.sourceFile >>
 		fp.firstLine >> fp.lastLine;
 	    if (fp.count == -1) break;

--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -1485,7 +1485,7 @@ sub print_args {
             # (even if an array, because at the Fortran level, it
             # is still a pointer to a character variable; the length
             # of each entry in the array is the "d" value).
-            # FORT_END_LEN and FORT_MIXED_LEN contain the necessary comman
+            # FORT_END_LEN and FORT_MIXED_LEN contain the necessary command
             # if they are prsent at all.
             print "    parm is a character string\n" if $debug;
             if ($prototype_only) {

--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -76,7 +76,7 @@ our $prototype_file_a = "../../../include/mpi.h.in";
 our $prototype_file_b = "../../../include/mpi_proto.h";
 
 # Global hashes used for definitions and to record the locations of the
-# defintions.
+# definitions.
 %mpidef = ();
 %mpidefFile = ();
 %mpiRoutinesFile = ();
@@ -86,7 +86,7 @@ our $prototype_file_b = "../../../include/mpi_proto.h";
 # Notes on this string.  Some symbols need to be initialized at runtime.
 # These are typically the addresses of the "special" Fortran symbols,
 # such as MPIR_F_MPI_BOTTOM.  Because MPI-2 requires that MPI_Init and
-# MPI_Init_thread, called in *any* language, initalize MPI for *all*
+# MPI_Init_thread, called in *any* language, initialize MPI for *all*
 # languages, we can't depend on having the Fortran versions of MPI_Init or
 # MPI_Init_thread called before these values might be used in a Fortran
 # wrapper function.
@@ -360,7 +360,7 @@ foreach $_ (@ARGV) {
 );
 
 #
-# Special routines have very different calling seqences in C and Fortran
+# Special routines have very different calling sequences in C and Fortran
 # or different behavior.
 # Init and Init thread have different arg lists (no argc, argv)
 # Pcontrol has no varargs
@@ -3161,7 +3161,7 @@ sub blankpad_ctof {
     my $outvar  = $_[1];
 
     # find the null character.  Replace with blanks from there to the
-    # end of the string.  The declared lenght is given by a variable
+    # end of the string.  The declared length is given by a variable
     # whose name is derived from outvar
     $strlen = $outvar;
     $strlen =~ s/^v/d/;
@@ -3203,7 +3203,7 @@ sub blankpadonflag_ctof {
     my $outvar  = $_[1];
 
     # find the null character.  Replace with blanks from there to the
-    # end of the string.  The declared lenght is given by a variable
+    # end of the string.  The declared length is given by a variable
     # whose name is derived from outvar
     $strlen = $outvar;
     $strlen =~ s/^v/d/;
@@ -3478,7 +3478,7 @@ sub chararray2_ftoc {
         pdata = (char *)$malloc( arglen, MPL_MEM_OTHER );
         p$count\[k\] = pargs;
         pargs\[argcnt\] = 0;  /* Null terminate end */
-        /* Copy each argument to consequtive locations in pdata,
+        /* Copy each argument to consecutive locations in pdata,
            and set the corresponding pointer entry */
         p = v$count + k * d$count;
         for (i=0; i<argcnt; i++) {
@@ -5252,7 +5252,7 @@ sub ReplaceIfDifferent {
 # We wish to have the option of adding a special init call for some
 # variables.  This lets us ensure that MPI routines that need special
 # symbols (such as MPI_BOTTOM or MPI_IN_PLACE) can initialize them without
-# requiring any Fortran routines be called from the C verison of MPI_Init
+# requiring any Fortran routines be called from the C version of MPI_Init
 # (this can cause problems if the Fortran object file includes references
 # to compiler-specific symbols, making it difficult and inconvenient at
 # best to link C programs)

--- a/src/binding/fortran/use_mpi/binding.sub
+++ b/src/binding/fortran/use_mpi/binding.sub
@@ -72,7 +72,7 @@ sub ReadInterface {
                 print STDERR "Duplicate prototypes for $routine_name\n";
                 next;
             }
-            # Seperate argument types and names
+            # Separate argument types and names
             my ($argtypes, $argnames) = &separate_args_and_append_ierror($args);
             # # Handle special cases
             # my $testname = $routine_name . "_args";

--- a/src/binding/fortran/use_mpi/buildiface
+++ b/src/binding/fortran/use_mpi/buildiface
@@ -984,7 +984,7 @@ EOT
 print MAKEFD <<EOT;
 # FIXME: We may want to edit the mpif.h to convert Fortran77-specific
 # items (such as an integer*8 used for file offsets) into the
-# corresponding Fortran 90 KIND type, to accomodate compilers that
+# corresponding Fortran 90 KIND type, to accommodate compilers that
 # reject non-standard features such as integer*8 (such as the Intel
 # Fortran compiler with -std95).
 # We need the MPI constants in a separate module for some of the
@@ -1244,7 +1244,7 @@ EOT
 # Print arguments in a pair of braces and end with a new line.
 # $fd : File handle to print to.
 # $curlen : Length of the current line.
-# $indent : Indention length of the following lines when they exist.
+# $indent : Indentation length of the following lines when they exist.
 # $line_length : Maximal length of a line.
 # @argnames : argument names to print out.
 sub PrintArgBrace {

--- a/src/binding/fortran/use_mpi/create_f90_util.c
+++ b/src/binding/fortran/use_mpi/create_f90_util.c
@@ -60,7 +60,7 @@ int MPIR_Create_unnamed_predefined(MPI_Datatype old, int combiner,
                                     MPI_ERR_INTERN, "**f90typetoomany", 0);
     }
     if (nAlloc == 0) {
-        /* Install the finalize callback that frees these datatyeps.
+        /* Install the finalize callback that frees these datatypes.
          * Set the priority high enough that this will be executed
          * before the handle allocation check */
         MPIR_Add_finalize(MPIR_FreeF90Datatypes, 0, 2);

--- a/src/binding/fortran/use_mpi/manfort.txt
+++ b/src/binding/fortran/use_mpi/manfort.txt
@@ -8,7 +8,7 @@ MPI_SIZEOF) that exist only in F90, and on the F90 extended support)
  This routine is part of the extended Fortran support, described in
  Sections 10.2.4 and 10.2.5 in the MPI-2 Standard.  Full support for these
  features `cannot` be efficiently implemented within the Fortran 90
- language and would require a nonportable interation with specific
+ language and would require a nonportable iteration with specific
  Fortran 90 compilers.  MPICH has chosen to offer many of the features
  of the extended Fortran support, but there are limitations.
  For example, some routines may accept only scalars or one-dimensional

--- a/src/binding/fortran/use_mpi_f08/buildiface
+++ b/src/binding/fortran/use_mpi_f08/buildiface
@@ -197,7 +197,7 @@ sub print_param {
         $value =~ s/\(MPI_[A-Za-z0-9]*\s*\)//;
         print "cast removal: $value\n" if $debug;
     }
-    # Remove any surrounding () around nubmers or placeholders like @MPI_COMPLEX@
+    # Remove any surrounding () around numbers or placeholders like @MPI_COMPLEX@
     if ($value =~ /\(\s*[-a-fx0-9\w@]*\)/) {
         $value =~ s/\(\s*([-a-fx0-9\w@]*)\s*\)/$1/;
         print "paren removal: $value\n" if $debug;

--- a/src/binding/fortran/use_mpi_f08/buildiface
+++ b/src/binding/fortran/use_mpi_f08/buildiface
@@ -33,7 +33,7 @@ my $pmpi_dir = "wrappers_f/profiling";
 
 # Some of the following variables and subroutines are adapted from F77
 # buildiface. They are used to parse files like mpi.h.in and mpio.h.in,
-# store MPI definitions and print them in Fortran soure code.
+# store MPI definitions and print them in Fortran source code.
 # The main driver part follows the subroutines.
 
 my %mpidef; # Map MPI constant names to values

--- a/src/binding/fortran/use_mpi_f08/mpi_c_interface_glue.f90
+++ b/src/binding/fortran/use_mpi_f08/mpi_c_interface_glue.f90
@@ -41,7 +41,7 @@ end interface
 
 contains
 
-! Copy Fortran string to C charater array, assuming the C array is one-char
+! Copy Fortran string to C character array, assuming the C array is one-char
 ! longer for the terminating null char.
 ! fstring : the Fortran input string
 ! cstring : the C output string (with memory already allocated)
@@ -69,7 +69,7 @@ subroutine MPIR_Fortran_string_f2c(fstring, cstring)
     cstring(j) = C_NULL_CHAR
 end subroutine MPIR_Fortran_string_f2c
 
-! Copy C charater array to Fortran string
+! Copy C character array to Fortran string
 subroutine MPIR_Fortran_string_c2f(cstring, fstring)
     implicit none
     character(kind=c_char), intent(in) :: cstring(:)

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/cdesc.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/cdesc.c
@@ -32,7 +32,7 @@ int cdesc_create_datatype(CFI_cdesc_t * cdesc, int oldcount, MPI_Datatype oldtyp
         MPIR_Assert(cdesc->rank <= MAX_RANK);
         PMPI_Type_size(oldtype, &size);
         /* When cdesc->elem_len != size, things suddenly become complicated. Generally, it is hard to create
-         * a composite datatype based on two datatypes. Currently we don't support it and doubt it is usefull.
+         * a composite datatype based on two datatypes. Currently we don't support it and doubt it is useful.
          */
         MPIR_Assert(cdesc->elem_len == size);
     }
@@ -55,7 +55,7 @@ int cdesc_create_datatype(CFI_cdesc_t * cdesc, int oldcount, MPI_Datatype oldtyp
         if (extent > cdesc->dim[i].extent) {
             extent = cdesc->dim[i].extent;
         } else {
-            /* Up to now, we have accumlated enough elements */
+            /* Up to now, we have accumulated enough elements */
             done = 1;
         }
 

--- a/src/env/mpicc.bash.in
+++ b/src/env/mpicc.bash.in
@@ -35,7 +35,7 @@ libdir=__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__
 
 # Default settings for compiler, flags, and libraries.
 # Determined by a combination of environment variables and tests within
-# configure (e.g., determining whehter -lsocket is needee)
+# configure (e.g., determining whether -lsocket is needee)
 CC="@CC@"
 MPICH_VERSION="@MPICH_VERSION@"
 
@@ -87,7 +87,7 @@ fi
 # Argument processing.
 # This is somewhat awkward because of the handling of arguments within
 # the shell.  We want to handle arguments that include spaces without 
-# loosing the spacing (an alternative would be to use a more powerful
+# losing the spacing (an alternative would be to use a more powerful
 # scripting language that would allow us to retain the array of values, 
 # which the basic (rather than enhanced) Bourne shell does not.  
 #
@@ -237,7 +237,7 @@ fi
 # -----------------------------------------------------------------------
 #
 # A temporary statement to invoke the compiler
-# Place the -L before any args incase there are any mpi libraries in there.
+# Place the -L before any args in case there are any mpi libraries in there.
 # Eventually, we'll want to move this after any non-MPI implementation 
 # libraries.
 # We use a single invocation of the compiler.  This will be adequate until

--- a/src/env/mpicc.sh.in
+++ b/src/env/mpicc.sh.in
@@ -35,7 +35,7 @@ libdir=__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__
 
 # Default settings for compiler, flags, and libraries.
 # Determined by a combination of environment variables and tests within
-# configure (e.g., determining whehter -lsocket is needee)
+# configure (e.g., determining whether -lsocket is needee)
 CC="@CC@"
 MPICH_VERSION="@MPICH_VERSION@"
 
@@ -87,7 +87,7 @@ fi
 # Argument processing.
 # This is somewhat awkward because of the handling of arguments within
 # the shell.  We want to handle arguments that include spaces without 
-# loosing the spacing (an alternative would be to use a more powerful
+# losing the spacing (an alternative would be to use a more powerful
 # scripting language that would allow us to retain the array of values, 
 # which the basic (rather than enhanced) Bourne shell does not.  
 #
@@ -246,7 +246,7 @@ fi
 # -----------------------------------------------------------------------
 #
 # A temporary statement to invoke the compiler
-# Place the -L before any args incase there are any mpi libraries in there.
+# Place the -L before any args in case there are any mpi libraries in there.
 # Eventually, we'll want to move this after any non-MPI implementation 
 # libraries.
 # We use a single invocation of the compiler.  This will be adequate until

--- a/src/env/mpicc.txt
+++ b/src/env/mpicc.txt
@@ -52,7 +52,7 @@
     The MPI library may be used with any compiler that uses the same 
     lengths for basic data objects (such as 'long double') and that 
     uses compatible run-time libraries.  On many systems, the various
-    compilers are compatible and may be used interchangably.  There are 
+    compilers are compatible and may be used interchangeably.  There are 
     exceptions; if you use the 'MPICH_CC' environment variable or the 
     '\-cc=name' command-line argument to override the choice of compiler
     and encounter problems, try reconfiguring MPICH with the new compiler

--- a/src/env/mpicxx.bash.in
+++ b/src/env/mpicxx.bash.in
@@ -84,7 +84,7 @@ fi
 # Argument processing.
 # This is somewhat awkward because of the handling of arguments within
 # the shell.  We want to handle arguments that include spaces without 
-# loosing the spacing (an alternative would be to use a more powerful
+# losing the spacing (an alternative would be to use a more powerful
 # scripting language that would allow us to retain the array of values, 
 # which the basic (rather than enhanced) Bourne shell does not.  
 #
@@ -241,7 +241,7 @@ if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
 fi
 
 # A temporary statement to invoke the compiler
-# Place the -L before any args incase there are any mpi libraries in there.
+# Place the -L before any args in case there are any mpi libraries in there.
 # Eventually, we'll want to move this after any non-MPI implementation 
 # libraries
 if [ "$linking" = yes ] ; then

--- a/src/env/mpicxx.sh.in
+++ b/src/env/mpicxx.sh.in
@@ -84,7 +84,7 @@ fi
 # Argument processing.
 # This is somewhat awkward because of the handling of arguments within
 # the shell.  We want to handle arguments that include spaces without 
-# loosing the spacing (an alternative would be to use a more powerful
+# losing the spacing (an alternative would be to use a more powerful
 # scripting language that would allow us to retain the array of values, 
 # which the basic (rather than enhanced) Bourne shell does not.  
 #
@@ -250,7 +250,7 @@ if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
 fi
 
 # A temporary statement to invoke the compiler
-# Place the -L before any args incase there are any mpi libraries in there.
+# Place the -L before any args in case there are any mpi libraries in there.
 # Eventually, we'll want to move this after any non-MPI implementation 
 # libraries
 if [ "$linking" = yes ] ; then

--- a/src/env/mpicxx.txt
+++ b/src/env/mpicxx.txt
@@ -52,7 +52,7 @@
     The MPI library may be used with any compiler that uses the same 
     lengths for basic data objects (such as 'long double') and that 
     uses compatible run-time libraries.  On many systems, the various
-    compilers are compatible and may be used interchangably.  There are 
+    compilers are compatible and may be used interchangeably.  There are 
     exceptions; if you use the 'MPICH_CXX' environment variable or the 
     '\-cxx=name' command-line argument to override the choice of compiler
     and encounter problems, try reconfiguring MPICH with the new compiler, 

--- a/src/env/mpiexec.txt
+++ b/src/env/mpiexec.txt
@@ -65,7 +65,7 @@ The MPI standard specifies the following arguments and their meanings\:
 . \-genv <name> <value> - The '\-genv' options have the same meaning as their
  corresponding '\-env' version, except they apply to all executables, not just
  the current executable (in the case that the colon syntax is used to specify
- multiple execuables).
+ multiple executables).
 .  \-genvnone - Like '\-envnone', but for all executables
 .  \-genvlist <list> - Like '\-envlist', but for all executables
 .  \-usize <n> - Specify the value returned for the value of the attribute

--- a/src/env/mpif77.bash.in
+++ b/src/env/mpif77.bash.in
@@ -37,7 +37,7 @@ libdir=__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__
 
 # Default settings for compiler, flags, and libraries
 # Determined by a combination of environment variables and tests within
-# configure (e.g., determining whehter -lsocket is needee)
+# configure (e.g., determining whether -lsocket is needee)
 F77="@F77@"
 F77CPP="@F77CPP@"
 MPICH_VERSION="@MPICH_VERSION@"
@@ -90,7 +90,7 @@ fi
 # Argument processing.
 # This is somewhat awkward because of the handling of arguments within
 # the shell.  We want to handle arguments that include spaces without 
-# loosing the spacing (an alternative would be to use a more powerful
+# losing the spacing (an alternative would be to use a more powerful
 # scripting language that would allow us to retain the array of values, 
 # which the basic (rather than enhanced) Bourne shell does not.  
 #
@@ -292,7 +292,7 @@ if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
 fi
 
 # A temporary statement to invoke the compiler
-# Place the -L before any args incase there are any mpi libraries in there.
+# Place the -L before any args in case there are any mpi libraries in there.
 # Eventually, we'll want to move this after any non-MPI implementation 
 # libraries
 #

--- a/src/env/mpif77.sh.in
+++ b/src/env/mpif77.sh.in
@@ -37,7 +37,7 @@ libdir=__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__
 
 # Default settings for compiler, flags, and libraries
 # Determined by a combination of environment variables and tests within
-# configure (e.g., determining whehter -lsocket is needee)
+# configure (e.g., determining whether -lsocket is needee)
 F77="@F77@"
 F77CPP="@F77CPP@"
 MPICH_VERSION="@MPICH_VERSION@"
@@ -90,7 +90,7 @@ fi
 # Argument processing.
 # This is somewhat awkward because of the handling of arguments within
 # the shell.  We want to handle arguments that include spaces without 
-# loosing the spacing (an alternative would be to use a more powerful
+# losing the spacing (an alternative would be to use a more powerful
 # scripting language that would allow us to retain the array of values, 
 # which the basic (rather than enhanced) Bourne shell does not.  
 #
@@ -314,7 +314,7 @@ if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
 fi
 
 # A temporary statement to invoke the compiler
-# Place the -L before any args incase there are any mpi libraries in there.
+# Place the -L before any args in case there are any mpi libraries in there.
 # Eventually, we'll want to move this after any non-MPI implementation 
 # libraries
 #

--- a/src/env/mpif77.txt
+++ b/src/env/mpif77.txt
@@ -47,7 +47,7 @@
     The MPI library may be used with any compiler that uses the same 
     lengths for basic data objects (such as 'long double') and that 
     uses compatible run-time libraries.  On many systems, the various
-    compilers are compatible and may be used interchangably.  There are 
+    compilers are compatible and may be used interchangeably.  There are 
     exceptions; if you use the 'MPICH_F77' environment variable or the 
     '\-f77=name' command-line argument to override the choice of compiler
     and encounter problems, try reconfiguring MPICH with the new compiler 

--- a/src/env/mpifort.bash.in
+++ b/src/env/mpifort.bash.in
@@ -37,7 +37,7 @@ modincdir=@modincdir@
 
 # Default settings for compiler, flags, and libraries
 # Determined by a combination of environment variables and tests within
-# configure (e.g., determining whehter -lsocket is needee)
+# configure (e.g., determining whether -lsocket is needee)
 FC="@FC@"
 FCCPP="@FCCPP@"
 #
@@ -103,7 +103,7 @@ fi
 # Argument processing.
 # This is somewhat awkward because of the handling of arguments within
 # the shell.  We want to handle arguments that include spaces without
-# loosing the spacing (an alternative would be to use a more powerful
+# losing the spacing (an alternative would be to use a more powerful
 # scripting language that would allow us to retain the array of values,
 # which the basic (rather than enhanced) Bourne shell does not.
 #
@@ -333,7 +333,7 @@ if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
 fi
 
 # A temporary statement to invoke the compiler
-# Place the -L before any args incase there are any mpi libraries in there.
+# Place the -L before any args in case there are any mpi libraries in there.
 # Eventually, we'll want to move this after any non-MPI implementation
 # libraries
 if [ "$linking" = yes ] ; then

--- a/src/env/mpifort.sh.in
+++ b/src/env/mpifort.sh.in
@@ -37,7 +37,7 @@ modincdir=@modincdir@
 
 # Default settings for compiler, flags, and libraries
 # Determined by a combination of environment variables and tests within
-# configure (e.g., determining whehter -lsocket is needee)
+# configure (e.g., determining whether -lsocket is needee)
 FC="@FC@"
 FCCPP="@FCCPP@"
 #
@@ -103,7 +103,7 @@ fi
 # Argument processing.
 # This is somewhat awkward because of the handling of arguments within
 # the shell.  We want to handle arguments that include spaces without
-# loosing the spacing (an alternative would be to use a more powerful
+# losing the spacing (an alternative would be to use a more powerful
 # scripting language that would allow us to retain the array of values,
 # which the basic (rather than enhanced) Bourne shell does not.
 #
@@ -350,7 +350,7 @@ if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
 fi
 
 # A temporary statement to invoke the compiler
-# Place the -L before any args incase there are any mpi libraries in there.
+# Place the -L before any args in case there are any mpi libraries in there.
 # Eventually, we'll want to move this after any non-MPI implementation
 # libraries
 if [ "$linking" = yes ] ; then

--- a/src/env/mpifort.txt
+++ b/src/env/mpifort.txt
@@ -47,7 +47,7 @@
     The MPI library may be used with any compiler that uses the same
     lengths for basic data objects (such as 'long double') and that
     uses compatible run-time libraries.  On many systems, the various
-    compilers are compatible and may be used interchangably.  There are
+    compilers are compatible and may be used interchangeably.  There are
     exceptions; if you use the 'MPICH_FC' environment variable or the
     '\-fc=name' command-line argument to override the choice of compiler
     and encounter problems, try reconfiguring MPICH with the new compiler

--- a/src/env/mpivars.c
+++ b/src/env/mpivars.c
@@ -337,7 +337,7 @@ const char *mpit_scopeToStr(int scope)
             p = "SCOPE_ALL_EQ";
             break;
         default:
-            p = "Unrecoginized scope";
+            p = "Unrecognized scope";
             break;
     }
     return p;

--- a/src/env/mpixxx_opts.conf.in
+++ b/src/env/mpixxx_opts.conf.in
@@ -7,7 +7,7 @@ Usage: $MYCMD [options] file....
 Available $MYCMD options:
     -echo         - Show exactly what this program is doing.
                     This option should normally not be used.
-    -show         - Show the commands that would be used without runnning them.
+    -show         - Show the commands that would be used without running them.
     -compile-info - Show how to compile a program.
     -link-info    - Show how to link a program.
     -v            - Version info of $MYCMD and its native compiler $NC.

--- a/src/env/parkill.in
+++ b/src/env/parkill.in
@@ -96,7 +96,7 @@ while (<FD>) {
     my $procfile = "/proc/$pid/cmdline";
     print "Looking for $procfile\n" if $debug;
     # We *CANNOT USE* -s with a file in /proc because -s filename returns
-    # false alwyas ! (BUG BUG BUG).  Instead, we try to open and read from it
+    # false always ! (BUG BUG BUG).  Instead, we try to open and read from it
     $rc = open PFD, "<$procfile";
     if ($rc) {
 	my $cmdline = <PFD>;

--- a/src/glue/romio/glue_romio.c
+++ b/src/glue/romio/glue_romio.c
@@ -18,7 +18,7 @@ int MPIR_Ext_dbg_romio_terse_enabled = 0;
 int MPIR_Ext_dbg_romio_typical_enabled = 0;
 int MPIR_Ext_dbg_romio_verbose_enabled = 0;
 
-/* NOTE: we'll lazily initilize this mutex */
+/* NOTE: we'll lazily initialize this mutex */
 static MPL_thread_mutex_t romio_mutex;
 static MPL_atomic_int_t romio_mutex_initialized = MPL_ATOMIC_INT_T_INITIALIZER(0);
 

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -918,7 +918,7 @@ typedef int (MPIX_Grequest_wait_function)(int, void **, double, MPI_Status *);
 #define MPIX_ERR_PROC_FAILED          MPICH_ERR_FIRST_MPIX+1 /* Process failure */
 #define MPIX_ERR_PROC_FAILED_PENDING  MPICH_ERR_FIRST_MPIX+2 /* A failure has caused this request
                                                               * to be pending */
-#define MPIX_ERR_REVOKED              MPICH_ERR_FIRST_MPIX+3 /* The communciation object has been revoked */
+#define MPIX_ERR_REVOKED              MPICH_ERR_FIRST_MPIX+3 /* The communication object has been revoked */
 #define MPIX_ERR_EAGAIN               MPICH_ERR_FIRST_MPIX+4 /* Operation could not be issued */
 #define MPIX_ERR_NOREQ                MPICH_ERR_FIRST_MPIX+5 /* Cannot allocate request */
 

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -73,13 +73,13 @@ int usleep(useconds_t usec);
 #define PMPI_LOCAL
 #endif
 
-/* Fix for universal endianess added in autoconf 2.62 */
+/* Fix for universal endianness added in autoconf 2.62 */
 #ifdef WORDS_UNIVERSAL_ENDIAN
 #if defined(__BIG_ENDIAN__)
 #elif defined(__LITTLE_ENDIAN__)
 #define WORDS_LITTLEENDIAN
 #else
-#error 'Universal endianess defined without __BIG_ENDIAN__ or __LITTLE_ENDIAN__'
+#error 'Universal endianness defined without __BIG_ENDIAN__ or __LITTLE_ENDIAN__'
 #endif
 #endif
 

--- a/src/include/mpir_assert.h
+++ b/src/include/mpir_assert.h
@@ -25,7 +25,7 @@ int MPIR_Assert_fail_fmt(const char *cond, const char *file_name, int line_num, 
  *
  * Similar to assert() except that it performs an MPID_Abort() when the
  * assertion fails.  Also, for Windows, it doesn't popup a
- * mesage box on a remote machine.
+ * message box on a remote machine.
  */
 #if (defined(__COVERITY__) || defined(__KLOCWORK__))
 #include <assert.h>

--- a/src/include/mpir_attr.h
+++ b/src/include/mpir_attr.h
@@ -138,7 +138,7 @@ typedef void *MPII_Attr_val_t;
   Notes:
   Attributes don''t have 'ref_count's because they don''t have reference
   count semantics.  That is, there are no shallow copies or duplicates
-  of an attibute.  An attribute is copied when the communicator that
+  of an attribute.  An attribute is copied when the communicator that
   it is attached to is duplicated.  Subsequent operations, such as
   'MPI_Comm_attr_free', can change the attribute list for one of the
   communicators but not the other, making it impractical to keep the

--- a/src/include/mpir_attr_generic.h
+++ b/src/include/mpir_attr_generic.h
@@ -133,7 +133,7 @@ extern "C" {
   Language bindings for MPI
 
   A few operations in MPI need to know how to marshal the callback into the calling
-  lanuage calling convention. The marshaling code is provided by a thunk layer which
+  language calling convention. The marshaling code is provided by a thunk layer which
   implements the correct behavior.  Examples of these callback functions are the
   keyval attribute copy and delete functions.
 

--- a/src/include/mpir_bsend.h
+++ b/src/include/mpir_bsend.h
@@ -20,7 +20,7 @@
  * The following datastructures are used:
  *
  *  BsendMsg_t  - Describes a user message, including the values of tag
- *                and datatype (*could* be used incase the data is already
+ *                and datatype (*could* be used in case the data is already
  *                contiguous; see below)
  *  BsendData_t - Describes a segment of the user buffer.  This data structure
  *                contains a BsendMsg_t for segments that contain a user

--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -63,7 +63,7 @@ typedef struct MPIR_Datatype_contents {
   Most were not chosen because any benefit in performance or memory
   efficiency was outweighed by the added complexity of the implementation.
 
-  A number of fields contain only boolean inforation ('is_contig',
+  A number of fields contain only boolean information ('is_contig',
   'is_committed').  These
   could be combined and stored in a single bit vector.
 

--- a/src/include/mpir_errcodes.h
+++ b/src/include/mpir_errcodes.h
@@ -40,7 +40,7 @@ int MPIR_Delete_error_code_impl(int code);
    is-fatal?: the error is fatal and should not be returned to the user
 
    Note that error codes must also be positive integers, so we lose one
-   bit (if they aren't positive, the comparisons agains MPI_ERR_LASTCODE
+   bit (if they aren't positive, the comparisons against MPI_ERR_LASTCODE
    and the value of the attribute MPI_LASTUSEDCODE will fail).
  */
 

--- a/src/include/mpir_handlemem.h
+++ b/src/include/mpir_handlemem.h
@@ -263,7 +263,7 @@ static inline void *MPIR_Handle_obj_alloc(MPIR_Object_alloc_t * objmem)
 }
 
 /* Beyond direct objects (a single static block), indirect objects are allocated by blocks,
- * each block initialized with an array of objects upto max_indices. `max_blocks` depends
+ * each block initialized with an array of objects up to max_indices. `max_blocks` depends
  * on the bit size in the object handle. Request objects need extra bits to support multiple
  * request pools, so it will have lower `max_blocks` than default (HANDLE_NUM_BLOCKS).
  * While `max_indices` is also limited by handle bits, we also need balance the runtime cost.

--- a/src/include/mpir_info.h
+++ b/src/include/mpir_info.h
@@ -40,7 +40,7 @@
   that must be handled.  In particular, multiple threads are allowed to
   update the same info value.  Thus, all of the update routines must be thread
   safe; the simple implementation used in the MPICH implementation uses locks.
-  Note that the 'MPI_Info_delete' call does not need a lock; the defintion of
+  Note that the 'MPI_Info_delete' call does not need a lock; the definition of
   thread-safety means that any order of the calls functions correctly; since
   it invalid either to delete the same 'MPI_Info' twice or to modify an
   'MPI_Info' that has been deleted, only one thread at a time can call

--- a/src/include/mpir_mem.h
+++ b/src/include/mpir_mem.h
@@ -50,7 +50,7 @@ extern "C" {
 
   Rules for memory management:
 
-  MPICH explicity prohibits the appearence of 'malloc', 'free',
+  MPICH explicitly prohibits the appearance of 'malloc', 'free',
   'calloc', 'realloc', or 'strdup' in any code implementing a device or
   MPI call (of course, users may use any of these calls in their code).
   Instead, you must use 'MPL_malloc' etc.; if these are defined

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -393,7 +393,7 @@ typedef MPL_atomic_int_t Handle_ref_count;
  * cases.
  *
  * All *active* (in use) objects have the handle as the first value; objects
- * with referene counts have the reference count as the second value.  See
+ * with reference counts have the reference count as the second value.  See
  * MPIR_Object_add_ref and MPIR_Object_release_ref.
  *
  * NOTE: This macro *must* be invoked as the very first element of the structure! */

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -55,7 +55,7 @@ typedef enum MPIR_Op_kind {
   We need to include a Fortran version, since those arguments will
   have type 'MPI_Fint *' instead.  We also need to add a test to the
   test suite for this case; in fact, we need tests for each of the handle
-  types to ensure that the transfered handle works correctly.
+  types to ensure that the transferred handle works correctly.
 
   This is part of the collective module because user-defined operations
   are valid only for the collective computation routines and not for

--- a/src/include/mpir_op_util.h
+++ b/src/include/mpir_op_util.h
@@ -32,7 +32,7 @@ MPIR_OP_TYPE_GROUP(C_INTEGER)
     MPIR_OP_TYPE_GROUP(FORTRAN_INTEGER)
 #undef MPIR_OP_TYPE_MACRO
 #endif
-/* op_macro_ is a 2-arg macro or function that preforms the reduction
+/* op_macro_ is a 2-arg macro or function that performs the reduction
    operation on a single element */
 /* FIXME: This code may penalize the performance on many platforms as
    a work-around for a compiler bug in some versions of xlc.  It

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -13,7 +13,7 @@
 
 categories :
     - name : REQUEST
-      description : A category for requests mangement variables
+      description : A category for requests management variables
 
 cvars:
     - name        : MPIR_CVAR_REQUEST_POLL_FREQ
@@ -651,7 +651,7 @@ MPL_STATIC_INLINE_PREFIX int MPIR_Grequest_poll(MPIR_Request * request_ptr, MPI_
     return mpi_errno;
 }
 
-/* local reuqest array size in MPI_Start_all and MPI_{Test,Wait}{all,any,some} */
+/* local request array size in MPI_Start_all and MPI_{Test,Wait}{all,any,some} */
 #define MPIR_REQUEST_PTR_ARRAY_SIZE 64
 
 int MPIR_Test_state(MPIR_Request * request, int *flag, MPI_Status * status,

--- a/src/include/mpir_status.h
+++ b/src/include/mpir_status.h
@@ -11,7 +11,7 @@
  * "count_hi_and_cancelled" field represents the 'cancelled' object.
  * The 'count' object is split between the "count_lo" and
  * "count_hi_and_cancelled" fields, with the lower order bits going
- * into the "count_lo" field, and the higher order bits goin into the
+ * into the "count_lo" field, and the higher order bits going into the
  * "count_hi_and_cancelled" field.  This gives us 2N-1 bits for the
  * 'count' object, where N is the size of int.  However, the value
  * returned to the user is bounded by the definition on MPI_Count. */

--- a/src/include/mpir_tags.h
+++ b/src/include/mpir_tags.h
@@ -46,7 +46,7 @@
 
 /* These macros must be used carefully. These macros will not work with
  * negative tags. By definition, users are not to use negative tags and the
- * only negative tag in MPICH is MPI_ANY_TAG which is checked seperately, but
+ * only negative tag in MPICH is MPI_ANY_TAG which is checked separately, but
  * if there is a time where negative tags become more common, this setup won't
  * work anymore. */
 

--- a/src/include/mpir_topo.h
+++ b/src/include/mpir_topo.h
@@ -7,7 +7,7 @@
 #define MPIR_TOPO_H_INCLUDED
 
 /*
- * The following struture allows the device detailed control over the
+ * The following structure allows the device detailed control over the
  * functions that are used to implement the topology routines.  If either
  * the pointer to this structure is null or any individual entry is null,
  * the default function is used (this follows exactly the same rules as the

--- a/src/include/mpit.h
+++ b/src/include/mpit.h
@@ -127,7 +127,7 @@ static inline cvar_table_entry_t *LOOKUP_CVAR_BY_NAME(const char *cvar_name)
 #define MPIR_T_PVAR_STMT(MODULE, stmt_) \
     PVAR_GATED_ACTION(MODULE, stmt_)
 
-/* The following are interfaces for each pvar classe,
+/* The following are interfaces for each pvar class,
  * basically including delcaration, access and registration.
  */
 

--- a/src/include/mpit.h
+++ b/src/include/mpit.h
@@ -28,7 +28,7 @@ extern UT_array *pvar_table;
 /* Hash tables to quick locate category, cvar, pvar indices by their names */
 extern name2index_hash_t *cat_hash;
 extern name2index_hash_t *cvar_hash;
-/* pvar names are unique per pvar class. So we use multiple hashs */
+/* pvar names are unique per pvar class. So we use multiple hashes */
 extern name2index_hash_t *pvar_hashs[MPIR_T_PVAR_CLASS_NUMBER];
 
 /* See description in mpit.c */
@@ -99,7 +99,7 @@ static inline cvar_table_entry_t *LOOKUP_CVAR_BY_NAME(const char *cvar_name)
     } while (0)
 
 /* Register a static cvar. A static pvar has NO binding and its address
- * and count are known at registeration time.
+ * and count are known at registration time.
  * Attention: name_ is a token not a string
 */
 #define MPIR_T_CVAR_REGISTER_STATIC(dtype_, name_, addr_, count_, verb_, \
@@ -111,7 +111,7 @@ static inline cvar_table_entry_t *LOOKUP_CVAR_BY_NAME(const char *cvar_name)
     } while (0)
 
 /* Register a dynamic cvar, which may have object binding and whose
- * address and count may be unknown at registeration time. It is
+ * address and count may be unknown at registration time. It is
  * developers' duty to provide self-contained arguments.
 */
 #define MPIR_T_CVAR_REGISTER_DYNAMIC(dtype_, name_, addr_, count_, etype_, \
@@ -128,7 +128,7 @@ static inline cvar_table_entry_t *LOOKUP_CVAR_BY_NAME(const char *cvar_name)
     PVAR_GATED_ACTION(MODULE, stmt_)
 
 /* The following are interfaces for each pvar classe,
- * basically including delcaration, access and registeration.
+ * basically including delcaration, access and registration.
  */
 
 /* STATE */

--- a/src/include/mpit_err.h
+++ b/src/include/mpit_err.h
@@ -15,7 +15,7 @@
  *   setting error code that relying on MPI error utility functions are also
  *   inapproprate, therefore, we have separate error macros for MPI tool interfaces.
  *
- *   On the other hand, due to the contraints, the error handling in tool
+ *   On the other hand, due to the constraints, the error handling in tool
  *   interface are rather simplified. Since it cannot fail, the failing diagnosis
  *   message is not going to be used, and the application developers are supposed
  *   to check return values and handle errors according to their application logic.

--- a/src/include/mpit_mem.h
+++ b/src/include/mpit_mem.h
@@ -12,7 +12,7 @@
 
 /* Rationale:
  *   push allocated pointers onto a stack
- *   free them on failiure or
+ *   free them on failure or
  *   commit (dismiss) the stack on success.
  */
 

--- a/src/include/mpitimpl.h
+++ b/src/include/mpitimpl.h
@@ -297,7 +297,7 @@ typedef struct MPIR_T_pvar_handle_s {
     /* Bytes of an element of datatype */
     int bytes;
 
-    /* Basic flags copied from pvar info + auxilary flags in pvar handle */
+    /* Basic flags copied from pvar info + auxiliary flags in pvar handle */
     int flags;
 
     /* Store info here in case we need other fields */
@@ -313,7 +313,7 @@ typedef struct MPIR_T_pvar_handle_s {
      *
      * For pvars of counter, timer or aggregate type, we cache their value at
      * the last start time in offset, their current value in current, and
-     * their accumlated value in accum. Generally, when such a pvar is running,
+     * their accumulated value in accum. Generally, when such a pvar is running,
      * reading the pvar should return
      *      accum[i] + current[i] - offset[i], 0 <= i < count - 1.
      * When the pvar is stopped, reading just returns accum.

--- a/src/mpi/attr/attr_impl.c
+++ b/src/mpi/attr/attr_impl.c
@@ -86,7 +86,7 @@ int MPIR_Type_create_keyval_impl(MPI_Type_copy_attr_function * type_copy_attr_fn
     keyval_ptr->delfn.user_function = type_delete_attr_fn;
     keyval_ptr->delfn.proxy = MPII_Attr_delete_c_proxy;
 
-    /* Tell finalize to check for attributes on permenant types */
+    /* Tell finalize to check for attributes on permanent types */
     MPII_Datatype_attr_finalize();
 
     MPIR_OBJ_PUBLISH_HANDLE(*type_keyval, keyval_ptr->handle);
@@ -164,7 +164,7 @@ int MPIR_Comm_get_attr_impl(MPIR_Comm * comm_ptr, int comm_keyval, void *attribu
          * integer because, even for the Fortran keyvals, the C interface is
          * used which stores the result in a pointer (hence we need a
          * pointer-sized int).  Thus we use intptr_t instead of MPI_Fint.
-         * On some 64-bit plaforms, such as Solaris-SPARC, using an MPI_Fint
+         * On some 64-bit platforms, such as Solaris-SPARC, using an MPI_Fint
          * will cause the value to placed into the high, rather than low,
          * end of the output value. */
 #endif
@@ -268,7 +268,7 @@ int MPIR_Comm_get_attr_impl(MPIR_Comm * comm_ptr, int comm_keyval, void *attribu
                 *(intptr_t *) attr_val_p = *(int *) *(void **) attr_val_p;
             else if (outAttrType == MPIR_ATTR_INT) {
                 /* *(int*)attr_val_p = *(int *)*(void **)attr_val_p; */
-                /* This is correct, because the cooresponding code
+                /* This is correct, because the corresponding code
                  * in the Fortran interface expects to find a pointer-length
                  * integer value.  Thus, this works for both big and little
                  * endian systems. Any changes made here must have

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -233,7 +233,7 @@ int MPIR_Attr_delete_list(int handle, MPIR_Attribute ** attr)
          * storage */
         new_p = p->next;
 
-        /* Check the sentinals first */
+        /* Check the sentinels first */
         /* --BEGIN ERROR HANDLING-- */
         if (p->pre_sentinal != 0 || p->post_sentinal != 0) {
             MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**attrsentinal");

--- a/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
+++ b/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
@@ -130,7 +130,7 @@ int MPII_Recexchalgo_get_neighbors(int rank, int nranks, int *k_,
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "step 1 nbr computation completed"));
 
     /* Step 2 */
-    if (*step1_sendto == -1) {  /* calulate step2_nbrs only for participating ranks */
+    if (*step1_sendto == -1) {  /* calculate step2_nbrs only for participating ranks */
         int *digit = (int *) MPL_malloc(sizeof(int) * log_p_of_k, MPL_MEM_COLL);
         MPIR_Assert(digit != NULL);
         int temprank = newrank;

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -80,7 +80,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
      *
      * Do subdivision.  There are two phases:
      * 1. Wait for arrival of data.  Because of the power of two nature
-     * of the subtree roots, the source of this message is alwyas the
+     * of the subtree roots, the source of this message is always the
      * process whose relative rank has the least significant 1 bit CLEARED.
      * That is, process 4 (100) receives from process 0, process 7 (111)
      * from process 6 (110), etc.
@@ -127,7 +127,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
     }
 
     /* This process is responsible for all processes that have bits
-     * set from the LSB upto (but not including) mask.  Because of
+     * set from the LSB up to (but not including) mask.  Because of
      * the "not including", we start by shifting mask back down one.
      *
      * We can easily change to a different algorithm at any power of two

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -87,7 +87,7 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
     }
 
     /* This process is responsible for all processes that have bits
-     * set from the LSB upto (but not including) mask.  Because of
+     * set from the LSB up to (but not including) mask.  Because of
      * the "not including", we start by shifting mask back down
      * one. */
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
@@ -119,7 +119,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             qsort(step2_nbrs[phase], k - 1, sizeof(int), MPII_Algo_compare_int);
         }
         /* copy the data to a temporary buffer so that sends ands recvs
-         * can be posted simultaneosly */
+         * can be posted simultaneously */
         if (count != 0) {
             if (phase == 0) {   /* wait for Step 1 to complete */
                 nvtcs = 1;
@@ -241,7 +241,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                 }
                 MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                                 (MPL_DBG_FDEST,
-                                 "reducing data with count %d dependent %d nvtcs coutner %d right neighbor",
+                                 "reducing data with count %d dependent %d nvtcs counter %d right neighbor",
                                  count, nvtcs, counter));
                 if (is_commutative) {
                     reduce_id[counter] =

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.h
@@ -25,7 +25,7 @@ Input Parameters:
 . dtcopy_id - id of previous data copy from scheduler (integer)
 . recv_id - array to store ids of the receives from the scheduler (integer array)
 . reduce_id - array to store ids of the reduces from the scheduler (integer array)
-. vtcs - array to specify depencies of a call to the scheduler (integer array)
+. vtcs - array to specify dependencies of a call to the scheduler (integer array)
 . step1_sendto - partner to send my data in step1 (integer)
 . in_step2 - variable to check if I participate in step2 or not (bool)
 . step1_nrecvs - number of partners to receive data from in step1 (integer)

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
@@ -158,7 +158,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
                                                            datatype, op, sched, nvtcs, vtcs);
             } else {    /* wait for the previous allreduce to complete */
 
-                /* NOTE: Make sure that knomial tree is being constructed differently for allreduce for optimal performace.
+                /* NOTE: Make sure that knomial tree is being constructed differently for allreduce for optimal performance.
                  * In bcast, leftmost subtree is the largest while it should be the opposite in case of allreduce */
 
                 if (i > 0) {

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
@@ -66,9 +66,9 @@ brucks_sched_pup(int pack, void *rbuf, void *pupbuf, MPI_Datatype rtype, int cou
     pow_k_phase = MPL_ipow(k, phase);
     /* first offset where the phase'th bit has value digitval */
     offset = pow_k_phase * digitval;
-    /* number of consecutive occurences of digitval */
+    /* number of consecutive occurrences of digitval */
     nconsecutive_occurrences = pow_k_phase;
-    /* distance between non-consecutive occurences of digitval */
+    /* distance between non-consecutive occurrences of digitval */
     delta = (k - 1) * pow_k_phase;
 
     dtcopy_id = MPL_malloc(sizeof(int) * comm_size, MPL_MEM_COLL);      /* NOTE: We do not need this much large array - make it more accurate */
@@ -173,7 +173,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
 
     /* calculate largest power of k that is smaller than 'size'.
      * This is used for allocating temporary space for sending
-     * and receving data. */
+     * and receiving data. */
     p_of_k = 1;
     for (i = 0; i < nphases - 1; i++) {
         p_of_k *= k;
@@ -229,7 +229,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
 
     MPIR_TSP_sched_fence(sched);
 
-    /* Step 2: Allocate buffer space for packing/receving data for every phase */
+    /* Step 2: Allocate buffer space for packing/receiving data for every phase */
     delta = 1;
     MPIR_CHKLMEM_MALLOC(tmp_sbuf, void ***, sizeof(void **) * nphases, mpi_errno, "tmp_sbuf",
                         MPL_MEM_COLL);

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
@@ -167,7 +167,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                      (char *) recvbuf + copy_dst * recvcount * recvtype_extent,
                                      recvcount, recvtype, sched, 1, &recv_id[i % 3]);
 
-        /* swap sbuf and rbuf - using data_buf as intermeidate buffer */
+        /* swap sbuf and rbuf - using data_buf as intermediate buffer */
         data_buf = sbuf;
         sbuf = rbuf;
         rbuf = data_buf;

--- a/src/mpi/coll/ialltoallw/ialltoallw.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw.c
@@ -22,8 +22,8 @@ cvars:
         sched_auto - Internal algorithm selection for sched-based algorithms
         sched_blocked           - Force blocked algorithm
         sched_inplace           - Force inplace algorithm
-        gentran_blocked   - Force genereic transport based blocked algorithm
-        gentran_inplace   - Force genereic transport based inplace algorithm
+        gentran_blocked   - Force generic transport based blocked algorithm
+        gentran_inplace   - Force generic transport based inplace algorithm
 
     - name        : MPIR_CVAR_IALLTOALLW_INTER_ALGORITHM
       category    : COLLECTIVE

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
@@ -109,7 +109,7 @@ int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype 
     }
 
     /* This process is responsible for all processes that have bits
-     * set from the LSB upto (but not including) mask.  Because of
+     * set from the LSB up to (but not including) mask.  Because of
      * the "not including", we start by shifting mask back down one.
      *
      * We can easily change to a different algorithm at any power of two

--- a/src/mpi/coll/ibcast/ibcast_utils.c
+++ b/src/mpi/coll/ibcast/ibcast_utils.c
@@ -114,7 +114,7 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
     }
 
     /* This process is responsible for all processes that have bits
-     * set from the LSB upto (but not including) mask.  Because of the
+     * set from the LSB up to (but not including) mask.  Because of the
      * "not including", we start by shifting mask back down one. */
 
     mask >>= 1;

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -43,7 +43,7 @@ extern MPIR_Tree_type_t MPIR_Ibcast_tree_type;
 extern void *MPIR_Csel_root;
 extern char MPII_coll_generic_json[];
 
-/* Function to initialze communicators for collectives */
+/* Function to initialize communicators for collectives */
 int MPIR_Coll_comm_init(MPIR_Comm * comm);
 
 /* Function to cleanup any communicators for collectives */

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
@@ -97,7 +97,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
     MPIR_ERR_CHECK(mpi_errno);
     num_children = my_tree.num_children;
 
-    /* identify my locaion in the tree */
+    /* identify my location in the tree */
     is_tree_root = (rank == tree_root) ? 1 : 0;
     is_tree_leaf = (num_children == 0) ? 1 : 0;
     is_tree_intermediate = (!is_tree_leaf && !is_tree_root);
@@ -206,7 +206,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
                                                            datatype, op, sched, nvtcs, vtcs);
             } else {    /* wait for the previous reduce to complete */
 
-                /* NOTE: Make sure that knomial tree is being constructed differently for reduce for optimal performace.
+                /* NOTE: Make sure that knomial tree is being constructed differently for reduce for optimal performance.
                  * In bcast, leftmost subtree is the largest while it should be the opposite in case of reduce */
 
                 if (i > 0) {

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
@@ -37,7 +37,7 @@ Input Parameters:
 . is_out_vtcs - variable to denote if there is going to be an outgoing vertices
                 in the scheduler from this function (integer)
 . reduce_id - array with ids of reduces from the scheduler (integer array)
-. vtcs - array to specify depencies of a call to the scheduler (integer array)
+. vtcs - array to specify dependencies of a call to the scheduler (integer array)
 - sched - scheduler (handle)
 
 */

--- a/src/mpi/coll/iscan/iscan_intra_sched_smp.c
+++ b/src/mpi/coll/iscan/iscan_intra_sched_smp.c
@@ -118,7 +118,7 @@ int MPIR_Iscan_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint coun
      * scan result. for example, to node 3, it will have reduce result
      * of rank 1,2,3,4,5,6 in tempbuf.
      * then we should broadcast this result in the local node, and
-     * reduce it with recvbuf to get final result if nessesary. */
+     * reduce it with recvbuf to get final result if necessary. */
 
     if (MPIR_Get_internode_rank(comm_ptr, rank) != 0) {
         /* we aren't on "node 0", so our node leader (possibly us) received

--- a/src/mpi/coll/iscatter/iscatter_intra_sched_binomial.c
+++ b/src/mpi/coll/iscatter/iscatter_intra_sched_binomial.c
@@ -182,7 +182,7 @@ int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
     }
 
     /* This process is responsible for all processes that have bits
-     * set from the LSB upto (but not including) mask.  Because of
+     * set from the LSB up to (but not including) mask.  Because of
      * the "not including", we start by shifting mask back down
      * one. */
 

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -140,7 +140,7 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
      * scan result. for example, to node 3, it will have reduce result
      * of rank 1,2,3,4,5,6 in tempbuf.
      * then we should broadcast this result in the local node, and
-     * reduce it with recvbuf to get final result if nessesary. */
+     * reduce it with recvbuf to get final result if necessary. */
 
     if (comm_ptr->node_comm != NULL) {
         mpi_errno = MPIR_Bcast(&noneed, 1, MPI_INT, 0, comm_ptr->node_comm, errflag);

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -150,7 +150,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
     }
 
     /* This process is responsible for all processes that have bits
-     * set from the LSB upto (but not including) mask.  Because of
+     * set from the LSB up to (but not including) mask.  Because of
      * the "not including", we start by shifting mask back down
      * one. */
 

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -154,7 +154,7 @@ int MPIR_Coll_safe_to_block(void)
     return MPII_Gentran_scheds_are_pending() == false;
 }
 
-/* Function to initialze communicators for collectives */
+/* Function to initialize communicators for collectives */
 int MPIR_Coll_comm_init(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -140,7 +140,7 @@ static void vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t
                     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                                     (MPL_DBG_FDEST,
                                      "  --> GENTRAN transport (selective sink) performed"));
-                    /* Nothin to do, just record completion */
+                    /* Nothing to do, just record completion */
                     vtx_record_completion(vtxp, sched);
                 }
                 break;
@@ -148,7 +148,7 @@ static void vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t
                     vtx_record_issue(vtxp, sched);
                     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                                     (MPL_DBG_FDEST, "  --> GENTRAN transport (sink) performed"));
-                    /* Nothin to do, just record completion */
+                    /* Nothing to do, just record completion */
                     vtx_record_completion(vtxp, sched);
                 }
                 break;
@@ -156,7 +156,7 @@ static void vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t
                     vtx_record_issue(vtxp, sched);
                     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                                     (MPL_DBG_FDEST, "  --> GENTRAN transport (fence) performed"));
-                    /* Nothin to do, just record completion */
+                    /* Nothing to do, just record completion */
                     vtx_record_completion(vtxp, sched);
                 }
                 break;
@@ -353,7 +353,7 @@ void MPII_Genutil_vtx_add_dependencies(MPII_Genutil_sched_t * sched, int vtx_id,
     }
 
     /* check if there was any fence operation and add appropriate dependencies.
-     * The application will never explicity specify a dependency on it,
+     * The application will never explicitly specify a dependency on it,
      * the transport has to make sure that the dependency on the fence operation is met */
     if (sched->last_fence != -1 && sched->last_fence != vtx_id) {
         /* add the last fence vertex as an incoming vertex to vtx */

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -367,7 +367,7 @@ void MPII_Genutil_sched_fence(MPII_Genutil_sched_t * sched)
     int fence_id;
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Gentran: scheduling a fence"));
 
-    /* fence operation is an extension to fence, so we can resuse the fence call */
+    /* fence operation is an extension to fence, so we can reuse the fence call */
     fence_id = MPII_Genutil_sched_sink(sched);
     /* change the vertex kind from SINK to FENCE */
     vtx_t *sched_fence = (vtx_t *) utarray_eltptr(sched->vtcs, fence_id);

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -1101,7 +1101,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
-        /* Extract the context and group sign informatin */
+        /* Extract the context and group sign information */
         final_context_id = comm_info[0];
     }
 

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -351,7 +351,7 @@ int MPIR_Comm_create_intra(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
      * so it must be created before we decide if this process is a
      * member of the group */
     /* In the multi-threaded case, MPIR_Get_contextid_sparse assumes that the
-     * calling routine already holds the single criticial section */
+     * calling routine already holds the single critical section */
     mpi_errno = MPIR_Get_contextid_sparse(comm_ptr, &new_context_id,
                                           group_ptr->rank == MPI_UNDEFINED);
     MPIR_ERR_CHECK(mpi_errno);
@@ -441,7 +441,7 @@ int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
      * so it must be created before we decide if this process is a
      * member of the group */
     /* In the multi-threaded case, MPIR_Get_contextid_sparse assumes that the
-     * calling routine already holds the single criticial section */
+     * calling routine already holds the single critical section */
     if (!comm_ptr->local_comm) {
         MPII_Setup_intercomm_localcomm(comm_ptr);
     }
@@ -1065,7 +1065,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
                     (MPL_DBG_FDEST, "About to get contextid (local_size=%d) on rank %d",
                      local_comm_ptr->local_size, local_comm_ptr->rank));
     /* In the multi-threaded case, MPIR_Get_contextid_sparse assumes that the
-     * calling routine already holds the single criticial section */
+     * calling routine already holds the single critical section */
     /* TODO: Make sure this is tag-safe */
     mpi_errno = MPIR_Get_contextid_sparse(local_comm_ptr, &recvcontext_id, FALSE);
     MPIR_ERR_CHECK(mpi_errno);
@@ -1274,7 +1274,7 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
 
     /* printf("About to get context id \n"); fflush(stdout); */
     /* In the multi-threaded case, MPIR_Get_contextid_sparse assumes that the
-     * calling routine already holds the single criticial section */
+     * calling routine already holds the single critical section */
     new_context_id = 0;
     mpi_errno = MPIR_Get_contextid_sparse((*new_intracomm_ptr), &new_context_id, FALSE);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/comm/comm_split.c
+++ b/src/mpi/comm/comm_split.c
@@ -41,7 +41,7 @@ static int sorttype_compare(const void *v1, const void *v2)
 #endif
 
 /* Sort the entries in keytable into increasing order by key.  A stable
-   sort should be used incase the key values are not unique. */
+   sort should be used in case the key values are not unique. */
 static void MPIU_Sort_inttable(sorttype * keytable, int size)
 {
     sorttype tmp;
@@ -198,7 +198,7 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
      * processes whose color is MPI_UNDEFINED will not influence the
      * resulting context id (by passing ignore_id==TRUE). */
     /* In the multi-threaded case, MPIR_Get_contextid_sparse assumes that the
-     * calling routine already holds the single criticial section */
+     * calling routine already holds the single critical section */
     mpi_errno = MPIR_Get_contextid_sparse(local_comm_ptr, &new_context_id, !in_newcomm);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(new_context_id != 0);

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -28,7 +28,7 @@ int MPIR_Comm_split_type(MPIR_Comm * user_comm_ptr, int split_type, int key,
     }
 
     if (split_type == MPI_COMM_TYPE_SHARED) {
-        /* NOTE: MPIR_Comm_split_impl will typically call device layer fuction.
+        /* NOTE: MPIR_Comm_split_impl will typically call device layer function.
          * Currently ch4 calls MPIR_Comm_split_type_by_node, which checks
          * the "shmem_topo" infohints. Thus doesn't run the fallback code here.
          * On the otherhand, ch3:sock will directly execute code here. */

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -309,9 +309,9 @@ struct gcn_state {
 struct gcn_state *next_gcn = NULL;
 
 /* All pending context_id allocations are added to a list. The context_id allocations are ordered
- * according to the context_id of of parrent communicator and the tag, wherby blocking context_id
+ * according to the context_id of of parent communicator and the tag, wherby blocking context_id
  * allocations  can have the same tag, while nonblocking operations cannot. In the non-blocking
- * case, the user is reponsible for the right tags if "comm_create_group" is used */
+ * case, the user is responsible for the right tags if "comm_create_group" is used */
 static void add_gcn_to_list(struct gcn_state *new_state)
 {
     struct gcn_state *tmp = NULL;
@@ -426,7 +426,7 @@ int MPIR_Get_contextid_sparse_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr
             /*If we are here, at least one element must be in the list, at least myself */
 
             /* only the first element in the list can own the mask. However, maybe the mask is used
-             * by another thread, which added another allcoation to the list bevore. So we have to check,
+             * by another thread, which added another allcoation to the list before. So we have to check,
              * if the mask is used and mark, if we own it */
             if (mask_in_use || &st != next_gcn) {
                 memset(st.local_mask, 0, MPIR_MAX_CONTEXT_MASK * sizeof(int));
@@ -597,7 +597,7 @@ int MPIR_Get_contextid_sparse_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr
         }
         if (st.first_iter == 1) {
             st.first_iter = 0;
-            /* to avoid deadlocks, the element is not added to the list bevore the first iteration */
+            /* to avoid deadlocks, the element is not added to the list before the first iteration */
             if (!ignore_id && *context_id == 0) {
                 MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_CTX_MUTEX);
                 MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_CTX_MUTEX);

--- a/src/mpi/datatype/type_create.c
+++ b/src/mpi/datatype/type_create.c
@@ -18,7 +18,7 @@
  * The last set, are wrapper routines to support types created on top of other types,
  * e.g. large count datatypes
  *
- * The functions within each set follows the same ordering, i.e. contigous,
+ * The functions within each set follows the same ordering, i.e. contiguous,
  * vector, indexed_block, indexed, struct, dup, resized.
  */
 
@@ -305,7 +305,7 @@ int MPIR_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
         mpi_errno = MPIR_Typerep_create_dup(oldtype, new_dtp);
         MPIR_ERR_CHECK(mpi_errno);
 
-        /* if old_dtp is commited, user will not call `MPI_Type_commit` on the new type,
+        /* if old_dtp is committed, user will not call `MPI_Type_commit` on the new type,
          * but the device still need be notified (e.g. ucx need register the type) */
         if (old_dtp->is_committed) {
             MPID_Type_commit_hook(new_dtp);
@@ -528,7 +528,7 @@ int MPIR_Type_create_indexed_block_impl(int count,
         p_disp = (MPI_Aint *) array_of_displacements;
     } else {
         MPIR_CHKLMEM_MALLOC_ORJUMP(p_disp, MPI_Aint *, count * sizeof(MPI_Aint), mpi_errno,
-                                   "aint displacment array", MPL_MEM_BUFFER);
+                                   "aint displacement array", MPL_MEM_BUFFER);
         for (int i = 0; i < count; i++) {
             p_disp[i] = array_of_displacements[i];
         }
@@ -680,7 +680,7 @@ int MPIR_Type_indexed_impl(int count, const int *array_of_blocklengths,
         MPIR_CHKLMEM_MALLOC_ORJUMP(p_blkl, MPI_Aint *, count * sizeof(MPI_Aint), mpi_errno,
                                    "aint blocklengths array", MPL_MEM_BUFFER);
         MPIR_CHKLMEM_MALLOC_ORJUMP(p_disp, MPI_Aint *, count * sizeof(MPI_Aint), mpi_errno,
-                                   "aint displacments array", MPL_MEM_BUFFER);
+                                   "aint displacements array", MPL_MEM_BUFFER);
         for (int i = 0; i < count; i++) {
             p_blkl[i] = array_of_blocklengths[i];
             p_disp[i] = array_of_displacements[i];

--- a/src/mpi/datatype/type_debug.c
+++ b/src/mpi/datatype/type_debug.c
@@ -18,7 +18,7 @@
  *
  */
 
-static void contents_printf(MPI_Datatype type, int depth, int acount);
+static void contents_printf(MPI_Datatype type, int depth, int array_ct);
 static char *depth_spacing(int depth) ATTRIBUTE((unused));
 
 #define NR_TYPE_CUTOFF 6        /* Number of types to display before truncating
@@ -360,7 +360,7 @@ static char *depth_spacing(int depth)
     }
 }
 
-static void contents_printf(MPI_Datatype type, int depth, int acount)
+static void contents_printf(MPI_Datatype type, int depth, int array_ct)
 {
     int i;
     MPIR_Datatype *dtp;
@@ -411,14 +411,14 @@ static void contents_printf(MPI_Datatype type, int depth, int acount)
             MPIR_Assert((ints != NULL) && (types != NULL));
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST, "# %scontig ct = %d\n",
                                                 depth_spacing(depth), *ints));
-            contents_printf(*types, depth + 1, acount);
+            contents_printf(*types, depth + 1, array_ct);
             return;
         case MPI_COMBINER_VECTOR:
             MPIR_Assert((ints != NULL) && (types != NULL));
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                                 "# %svector ct = %d, blk = %d, str = %d\n",
                                                 depth_spacing(depth), ints[0], ints[1], ints[2]));
-            contents_printf(*types, depth + 1, acount);
+            contents_printf(*types, depth + 1, array_ct);
             return;
         case MPI_COMBINER_HVECTOR:
             MPIR_Assert((ints != NULL) && (aints != NULL) && (types != NULL));
@@ -427,52 +427,52 @@ static void contents_printf(MPI_Datatype type, int depth, int acount)
                                                 MPI_AINT_FMT_DEC_SPEC "\n",
                                                 depth_spacing(depth), ints[0],
                                                 ints[1], (MPI_Aint) aints[0]));
-            contents_printf(*types, depth + 1, acount);
+            contents_printf(*types, depth + 1, array_ct);
             return;
         case MPI_COMBINER_INDEXED:
             MPIR_Assert((ints != NULL) && (types != NULL));
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST, "# %sindexed ct = %d:",
                                                 depth_spacing(depth), ints[0]));
-            for (i = 0; i < acount && i < ints[0]; i++) {
+            for (i = 0; i < array_ct && i < ints[0]; i++) {
                 MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                                     "# %s  indexed [%d]: blk = %d, disp = %d\n",
                                                     depth_spacing(depth),
                                                     i,
                                                     ints[i + 1], ints[i + (cp->nr_ints / 2) + 1]));
-                contents_printf(*types, depth + 1, acount);
+                contents_printf(*types, depth + 1, array_ct);
             }
             return;
         case MPI_COMBINER_HINDEXED:
             MPIR_Assert((ints != NULL) && (aints != NULL) && (types != NULL));
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST, "# %shindexed ct = %d:",
                                                 depth_spacing(depth), ints[0]));
-            for (i = 0; i < acount && i < ints[0]; i++) {
+            for (i = 0; i < array_ct && i < ints[0]; i++) {
                 MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                                     "# %s  hindexed [%d]: blk = %d, disp = "
                                                     MPI_AINT_FMT_DEC_SPEC "\n",
                                                     depth_spacing(depth), i,
                                                     (int) ints[i + 1], (MPI_Aint) aints[i]));
-                contents_printf(*types, depth + 1, acount);
+                contents_printf(*types, depth + 1, array_ct);
             }
             return;
         case MPI_COMBINER_STRUCT:
             MPIR_Assert((ints != NULL) && (aints != NULL) && (types != NULL));
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST, "# %sstruct ct = %d:",
                                                 depth_spacing(depth), (int) ints[0]));
-            for (i = 0; i < acount && i < ints[0]; i++) {
+            for (i = 0; i < array_ct && i < ints[0]; i++) {
                 MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                                     "# %s  struct[%d]: blk = %d, disp = "
                                                     MPI_AINT_FMT_DEC_SPEC "\n",
                                                     depth_spacing(depth), i,
                                                     (int) ints[i + 1], (MPI_Aint) aints[i]));
-                contents_printf(types[i], depth + 1, acount);
+                contents_printf(types[i], depth + 1, array_ct);
             }
             return;
         case MPI_COMBINER_SUBARRAY:
             MPIR_Assert((ints != NULL) && (types != NULL));
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST, "# %ssubarray ct = %d:",
                                                 depth_spacing(depth), (int) ints[0]));
-            for (i = 0; i < acount && i < ints[0]; i++) {
+            for (i = 0; i < array_ct && i < ints[0]; i++) {
                 MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                                     "# %s  sizes[%d] = %d subsizes[%d] = %d starts[%d] = %d\n",
                                                     depth_spacing(depth),
@@ -480,7 +480,7 @@ static void contents_printf(MPI_Datatype type, int depth, int acount)
                                                     i, (int) ints[i + ints[0] + 1],
                                                     i, (int) ints[2 * ints[0] + 1]));
             }
-            contents_printf(*types, depth + 1, acount);
+            contents_printf(*types, depth + 1, array_ct);
             return;
 
         case MPI_COMBINER_RESIZED:
@@ -489,7 +489,7 @@ static void contents_printf(MPI_Datatype type, int depth, int acount)
                             (MPL_DBG_FDEST,
                              "# %sresized lb = " MPI_AINT_FMT_DEC_SPEC " extent = "
                              MPI_AINT_FMT_DEC_SPEC "\n", depth_spacing(depth), aints[0], aints[1]));
-            contents_printf(*types, depth + 1, acount);
+            contents_printf(*types, depth + 1, array_ct);
             return;
         default:
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST, "# %sunhandled combiner",

--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -553,7 +553,7 @@ static int blkidx_m2m(MPI_Aint * blocks_p,
         cbufp = (char *) paramp->userbuf + rel_off + offsetarray[curblock];
 
         /* there was some casting going on here at one time but now all types
-         * are promoted ot big values */
+         * are promoted to big values */
         if (blocklen > blocks_left)
             blocklen = blocks_left;
 

--- a/src/mpi/debugger/dbexample.c
+++ b/src/mpi/debugger/dbexample.c
@@ -12,7 +12,7 @@
 /* style: allow:printf:2 sig:0 */
 
 /*
- * This program provides a convienient way to test some of the debugger
+ * This program provides a convenient way to test some of the debugger
  * interface functionality, including message queues and named communicators
  */
 

--- a/src/mpi/debugger/dbginit.c
+++ b/src/mpi/debugger/dbginit.c
@@ -85,7 +85,7 @@ void *MPIR_Breakpoint(void);
 
 /*
  * In addition to the discussion in the paper "A Standard Interface for Debugger
- * Access to Message Queue Inforation in MPI" and the more recent paper "An
+ * Access to Message Queue Information in MPI" and the more recent paper "An
  * Interface to Support the Identification of Dynamic {MPI} 2 Processes for
  * Scalable Parallel Debugging", there are a few features that have become
  * defacto standard.  These include the "proctable" (a relic of the way

--- a/src/mpi/debugger/dll_mpich.c
+++ b/src/mpi/debugger/dll_mpich.c
@@ -232,7 +232,7 @@ int mqs_setup_image(mqs_image * image, const mqs_image_callbacks * icb)
 
 /*
  * Setup information needed to access the queues.  If successful, return
- * mqs_ok.  If not, return an erro rcode.  Also set the message pointer
+ * mqs_ok.  If not, return an error rcode.  Also set the message pointer
  * with an explanatory message if there is a problem; otherwise, set it
  * to NULL.
  *

--- a/src/mpi/debugger/mpi2_interface.h
+++ b/src/mpi/debugger/mpi2_interface.h
@@ -41,7 +41,7 @@ typedef unsigned char MPI2DD_BYTE_T;
 #define MPI2DD_MPIFLAG_PARTIAL_ATTACH_OK 0x40
 
 /* These structures are defined so that the debugger can find items
-   easily, even in the absense of detailed symbol table information,
+   easily, even in the absence of detailed symbol table information,
    since the layout is fixed. */
 
 typedef struct MPI2DD_PROCDESC {

--- a/src/mpi/debugger/mpi2_interface.txt
+++ b/src/mpi/debugger/mpi2_interface.txt
@@ -81,7 +81,7 @@ MPI2DD_BYTE_T debug_state
 
 MPI2DD_UINT32_T debugger_flags
 
-     The bits in this field are initalized by the MPI implementation
+     The bits in this field are initialized by the MPI implementation
      and may be modified by the debugger.
 
      #define MPI2DD_FLAG_GATE    0x01

--- a/src/mpi/errhan/baseerrnames.txt
+++ b/src/mpi/errhan/baseerrnames.txt
@@ -35,7 +35,7 @@ MPI_ERR_UNKNOWN     13      **unknown
 MPI_ERR_INTERN      16      **intern
 # Multiple completion has two special error classes 
 MPI_ERR_IN_STATUS   17      **instatus
-MPI_ERR_PENDING     18      **inpending
+MPI_ERR_PENDING     18      **pending
 MPIX_ERR_PROC_FAILED_PENDING 19 **failure_pending
 # New MPI-2 Error classes 
 MPI_ERR_FILE        27      **file

--- a/src/mpi/errhan/errhan_impl.c
+++ b/src/mpi/errhan/errhan_impl.c
@@ -436,7 +436,7 @@ int MPIR_File_call_cxx_errhandler(MPI_File * fh, int *errorcode,
                                   void (*c_errhandler) (MPI_File *, int *, ...))
 {
     /* ROMIO will contain a reference to this routine, so if there is
-     * no C++ support, it will never be called but it must be availavle. */
+     * no C++ support, it will never be called but it must be available. */
 #ifdef HAVE_CXX_BINDING
     void *fh1 = (void *) fh;
     (*MPIR_Process.cxx_call_errfn) (1, fh1, errorcode, (void (*)(void)) c_errhandler);

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -323,7 +323,7 @@ be in the range 0 to %d
 **intern %s:Internal MPI error!  %s
 **internrc:Internal MPI error!  Unexpected return code from internal function.
 **instatus:See the MPI_ERROR field in MPI_Status for the error code
-**inpending:Pending request (no error)
+**pending:Pending request (no error)
 **unknowngpid:Internal MPI error: Unknown gpid
 **unknowngpid %d %d:Internal MPI error: Unknown gpid (%d)%d
 **request:Invalid MPI_Request

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -904,7 +904,7 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **mpir_wingetattr %W %d %p %p:MPII_Win_get_attr(%W, win_keyval=%d, attribute_val=%p, flag=%p) failed
 
 
-# Datarep conversion function not supported by ROMIO (Temproary until implemented)
+# Datarep conversion function not supported by ROMIO (Temporary until implemented)
 **drconvnotsupported:Read and Write datarep conversions are currently not supported by MPI-IO
 
 # Argobots related error messages

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -80,7 +80,7 @@ cvars:
  *
  * MPICH_ERROR_MSG__NONE - No text messages at all
  * MPICH_ERROR_MSG__CLASS - Only messages for the MPI error classes
- * MPICH_ERROR_MSG__GENERIC - Only predefiend messages for the MPI error codes
+ * MPICH_ERROR_MSG__GENERIC - Only predefined messages for the MPI error codes
  * MPICH_ERROR_MSG__ALL - Instance specific error messages (and error message
  *                       stack)
  *
@@ -483,7 +483,7 @@ static int checkValidErrcode(int error_class, const char fcname[], int *errcode_
 }
 
 /* Append an error code, error2, to the end of a list of messages in the error
-   ring whose head endcoded in error1_code.  An error code pointing at the
+   ring whose head encoded in error1_code.  An error code pointing at the
    combination is returned.  If the list of messages does not terminate cleanly
    (i.e. ring wrap has occurred), then the append is not performed. and error1
    is returned (although it may include the class of error2 if the class of
@@ -1255,7 +1255,7 @@ static int FindSpecificMsgIndex(const char msg[])
 {
     int i, c;
     for (i = 0; i < specific_msgs_len; i++) {
-        /* Check the sentinals to insure that the values are ok first */
+        /* Check the sentinels to insure that the values are ok first */
         if (specific_err_msgs[i].sentinal1 != 0xacebad03 ||
             specific_err_msgs[i].sentinal2 != 0xcb0bfa11) {
             /* Something bad has happened! Don't risk trying the
@@ -1999,7 +1999,7 @@ static int FindGenericMsgIndex(const char msg[])
 {
     int i, c;
     for (i = 0; i < generic_msgs_len; i++) {
-        /* Check the sentinals to insure that the values are ok first */
+        /* Check the sentinels to insure that the values are ok first */
         if (generic_err_msgs[i].sentinal1 != 0xacebad03 ||
             generic_err_msgs[i].sentinal2 != 0xcb0bfa11) {
             /* Something bad has happened! Don't risk trying the

--- a/src/mpi/init/init_bindings.c
+++ b/src/mpi/init/init_bindings.c
@@ -31,7 +31,7 @@ MPI_F08_status MPIR_F08_MPI_STATUSES_IGNORE_OBJ[1];
 int MPIR_F08_MPI_IN_PLACE;
 int MPIR_F08_MPI_BOTTOM;
 
-/* Althought the two STATUS pointers are required but the MPI3.0,  they are not used in MPICH F08 binding */
+/* Although the two STATUS pointers are required but the MPI3.0,  they are not used in MPICH F08 binding */
 MPI_F08_status *MPI_F08_STATUS_IGNORE = &MPIR_F08_MPI_STATUS_IGNORE_OBJ;
 MPI_F08_status *MPI_F08_STATUSES_IGNORE = &MPIR_F08_MPI_STATUSES_IGNORE_OBJ[0];
 

--- a/src/mpi/init/init_windows.c
+++ b/src/mpi/init/init_windows.c
@@ -58,7 +58,7 @@ void MPII_init_windows(void)
     _CrtSetReportHook2(_CRT_RPTHOOK_INSTALL, assert_hook);
 #ifdef _WIN64
     {
-        /* FIXME: (Windows) This severly degrades performance but fixes alignment
+        /* FIXME: (Windows) This severely degrades performance but fixes alignment
          * issues with the datatype code. */
         /* Prevent misaligned faults on Win64 machines */
         UINT mode, old_mode;

--- a/src/mpi/init/local_proc_attrs.c
+++ b/src/mpi/init/local_proc_attrs.c
@@ -43,7 +43,7 @@ int MPII_init_local_proc_attrs(int *p_thread_required)
 
 #ifdef HAVE_ERROR_CHECKING
     /* Because the PARAM system has not been initialized, temporarily
-     * uncondtionally enable error checks.  Once the PARAM system is
+     * unconditionally enable error checks.  Once the PARAM system is
      * initialized, this may be reset */
     MPIR_Process.do_error_checks = 1;
 #if (HAVE_ERROR_CHECKING == MPID_ERROR_LEVEL_RUNTIME)
@@ -73,7 +73,7 @@ int MPII_init_local_proc_attrs(int *p_thread_required)
 
     /* "Allocate" from the reserved space for builtin communicators and
      * (partially) initialize predefined communicators.  comm_parent is
-     * intially NULL and will be allocated by the device if the process group
+     * initially NULL and will be allocated by the device if the process group
      * was started using one of the MPI_Comm_spawn functions. */
     MPIR_Process.comm_world = MPIR_Comm_builtin + 0;
     MPII_Comm_init(MPIR_Process.comm_world);

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -58,14 +58,14 @@ MPL_atomic_int_t MPIR_world_model_state = MPL_ATOMIC_INT_T_INITIALIZER(0);
 /* Use init_lock to protect concurrent init/finalize (include session init/finalize) */
 static MPL_initlock_t init_lock = MPL_INITLOCK_INITIALIZER;
 
-/* Use init_counter to track when we are initilizing for the first time or
+/* Use init_counter to track when we are initializing for the first time or
  * when we are finalize for the last time and need cleanup states */
 /* Note: we are not using atomic variable since it is always accessed under init_lock */
 static int init_counter;
 
 /* TODO: currently the world model is not distinguished with session model, neither between
  * sessions, in that there is no session pointer attached to communicators, datatypes, etc.
- * To properly reflect the session semantics, we may need to always assoicate a session
+ * To properly reflect the session semantics, we may need to always associate a session
  * pointer to all MPI objects (other than info) and add runtime validation checks everywhere.
  */
 
@@ -120,7 +120,7 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     }
     /**********************************************************************/
     /* Section 1: base components that other components rely on.
-     * These need to be intialized first.  They have strong
+     * These need to be initialized first.  They have strong
      * dependencies between each other, which makes it a pain to
      * maintain them.  Hopefully, the number of such components is
      * small. */

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -52,7 +52,7 @@ static void MPIR_Bsend_dump(void);
  * taking advantage of the "alignpad"), but this would require more changes.
  */
 static struct BsendBuffer {
-    void *buffer;               /* Pointer to the begining of the user-
+    void *buffer;               /* Pointer to the beginning of the user-
                                  * provided buffer */
     MPI_Aint buffer_size;       /* Size of the user-provided buffer */
     void *origbuffer;           /* Pointer to the buffer provided by
@@ -251,7 +251,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
 
             /* Pack the data into the buffer */
             /* We may want to optimize for the special case of
-             * either primative or contiguous types, and just
+             * either primitive or contiguous types, and just
              * use MPIR_Memcpy and the provided datatype */
             msg->count = 0;
             if (dtype != MPI_PACKED) {
@@ -290,7 +290,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
             }
             break;
         }
-        /* If we found a buffer or we're in the seccond pass, then break.
+        /* If we found a buffer or we're in the second pass, then break.
          * Note that the test on phere is redundant, as the code breaks
          * out of the loop in the test above if a block p is found. */
         if (p || pass == 1)
@@ -368,7 +368,7 @@ static void MPIR_Bsend_free_segment(MPII_Bsend_data_t * p)
                                               ((char *) p) + p->total_size));
 
     MPL_DBG_MSG_D(MPIR_DBG_BSEND, TYPICAL,
-                  "At the begining of free_segment with size %llu:",
+                  "At the beginning of free_segment with size %llu:",
                   (unsigned long long) p->total_size);
     MPL_DBG_STMT(MPIR_DBG_BSEND, TYPICAL, MPIR_Bsend_dump());
 

--- a/src/mpi/rma/rmatypeutil.c
+++ b/src/mpi/rma/rmatypeutil.c
@@ -38,7 +38,7 @@ int MPIR_Type_is_rma_atomic(MPI_Datatype type)
 }
 
 
-/* Returns true if (a == b) when interepreted using the given datatype.
+/* Returns true if (a == b) when interpreted using the given datatype.
  * Currently, this is only defined for RMA atomic types.
  */
 int MPIR_Compare_equal(const void *a, const void *b, MPI_Datatype type)

--- a/src/mpi/rma/winutil.c
+++ b/src/mpi/rma/winutil.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-/* FIXME: Move this into wincreate (having a separate file is unneccessary,
+/* FIXME: Move this into wincreate (having a separate file is unnecessary,
    and it leads to a false "missing coverage" report) */
 #ifndef MPIR_WIN_PREALLOC
 #define MPIR_WIN_PREALLOC 8

--- a/src/mpi/romio/Makefile.am
+++ b/src/mpi/romio/Makefile.am
@@ -77,7 +77,7 @@ libromio_la_SOURCES = $(romio_mpi_sources) $(romio_other_sources) $(glue_sources
 ## MPICH, these are the objects that need to go into libmpi, while the foo.o
 ## objects should go into libpmpi.  Furthermore, the -D option for ROMIO's
 ## source files is different and inverted (in the boolean sense) compared with
-## MPICH's defintion.  And ROMIO was dumping all of the symbols into the main
+## MPICH's definition.  And ROMIO was dumping all of the symbols into the main
 ## libmpi library, regardless of the separate profiling library's existence.
 ##
 ## Annoying, right?

--- a/src/mpi/romio/README
+++ b/src/mpi/romio/README
@@ -171,7 +171,7 @@ Major Changes Version 1.0.2:
   directly between the user's buffer and the storage devices, bypassing 
   the file-system cache. This can improve performance significantly on 
   systems with high disk bandwidth. Without high disk bandwidth,
-  regular I/O (that uses the file-system cache) perfoms better.
+  regular I/O (that uses the file-system cache) performs better.
   ROMIO, therefore, does not use direct I/O by default. The user can
   turn on direct I/O (separately for reading and writing) either by
   using environment variables or by using MPI's hints mechanism (info). 

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
@@ -114,7 +114,7 @@ int ADIOI_GPFS_Calc_aggregator(ADIO_File fd,
      * * wkliao: implementation for file domain alignment
      * fd_start[] and fd_end[] have been aligned with file lock
      * boundaries when returned from ADIOI_Calc_file_domains() so cannot
-     * just use simple arithmatic as above *
+     * just use simple arithmetic as above *
      * rank_index = 0;
      * while (off > fd_end[rank_index]) rank_index++;
      * }
@@ -234,7 +234,7 @@ void ADIOI_GPFS_Calc_file_domains(ADIO_File fd,
     int naggs = nprocs_for_coll;
 
     /* Tweak the file domains so that no fd is smaller than a threshold.  We
-     * have to strike a balance between efficency and parallelism: somewhere
+     * have to strike a balance between efficiency and parallelism: somewhere
      * between 10k processes sending 32-byte requests and one process sending a
      * 320k request is a (system-dependent) sweet spot
 

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_flush.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_flush.c
@@ -25,7 +25,7 @@ void ADIOI_GPFS_Flush(ADIO_File fd, int *error_code)
      * to flush, we can consult the 'fd->hints->ranklist[]' array.  For now, a
      * flush from one process should suffice */
 
-    /* ensure all other proceses are done writing. On many platforms MPI_Reduce
+    /* ensure all other processes are done writing. On many platforms MPI_Reduce
      * is fastest because it has the lightest constraints. On Blue Gene, BARRIER
      * is optimized  */
     MPI_Barrier(fd->comm);

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -168,7 +168,7 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
         ADIO_Offset my_count_size = 0;
         /* One-sided aggregation needs the amount of data per rank as well
          * because the difference in starting and ending offsets for 1 byte is
-         * 0 the same as 0 bytes so it cannot be distiguished.
+         * 0 the same as 0 bytes so it cannot be distinguished.
          */
         if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
             count_sizes = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_tuning.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_tuning.c
@@ -75,7 +75,7 @@ double gpfsmpio_prof_cr[GPFSMPIO_CIO_LAST + 1];
  *   - any integer
  *   - Default is 8
  *
- * - GPFSMPIO_PTHREADIO - Enables a very simple form of asyncronous io where a
+ * - GPFSMPIO_PTHREADIO - Enables a very simple form of asynchronous io where a
  *   pthread is spawned to do the posix writes while the main thread does the
  *   data aggregation - useful for large files where multiple rounds are
  *   required (more that the cb_buffer_size of data per aggregator).   User
@@ -111,7 +111,7 @@ double gpfsmpio_prof_cr[GPFSMPIO_CIO_LAST + 1];
  *   - Default is 0
  *
  * - GPFSMPIO_BRIDGERINGAGG - Relevant only to BGQ.  Aggregator placement
- *   optimization whch forms a 5-d ring around the bridge node starting at
+ *   optimization which forms a 5-d ring around the bridge node starting at
  *   GPFSMPIO_BRIDGERINGAGG hops away.  Experimental performance results
  *   suggest best value is 1 and only in conjunction with GPFSMPIO_P2PCONTIG
  *   and GPFSMPIO_BALANCECONTIG.  The number of aggregators selected is still

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_tuning.h
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_tuning.h
@@ -40,7 +40,7 @@ enum {
     GPFSMPIO_CIO_T_OTHREQ,      /* time for ADIOI_Calc_others_req(), short Alltoall */
     GPFSMPIO_CIO_T_DEXCH,       /* time for I/O data exchange */
     /* the next DEXCH_* timers capture finer-grained portions of T_DEXCH */
-    GPFSMPIO_CIO_T_DEXCH_RECV_EXCH,     /* time for each process to exchange recieve
+    GPFSMPIO_CIO_T_DEXCH_RECV_EXCH,     /* time for each process to exchange receive
                                          * size info with everyone else */
     GPFSMPIO_CIO_T_DEXCH_SETUP, /* time for setup portion of I/O data exchange */
     GPFSMPIO_CIO_T_DEXCH_NET,   /* time for network portion of I/O data exchange */

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -157,7 +157,7 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
         ADIO_Offset my_count_size = 0;
         /* One-sided aggregation needs the amount of data per rank as well
          * because the difference in starting and ending offsets for 1 byte is
-         * 0 the same as 0 bytes so it cannot be distiguished.
+         * 0 the same as 0 bytes so it cannot be distinguished.
          */
         if ((romio_write_aggmethod == 1) || (romio_write_aggmethod == 2)) {
             count_sizes = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
@@ -1053,7 +1053,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, const void *buf, char *write_buf
      * processes are operating on noncontigous data.  But holes can also show
      * up at the beginning or end of the file domain (see John Bent ROMIO REQ
      * #835). Missing these holes would result in us writing more data than
-     * recieved by everyone else. */
+     * received by everyone else. */
     *hole = 0;
     if (off != srt_off[0])      /* hole at the front */
         *hole = 1;

--- a/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_aggrs.c
+++ b/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_aggrs.c
@@ -92,7 +92,7 @@ int ADIOI_BG_gen_agg_ranklist(ADIO_File fd, int n_aggrs_per_pset)
     procInfo = ADIOI_BG_ProcInfo_new();
     ADIOI_BG_persInfo_init(confInfo, procInfo, s, r, n_aggrs_per_pset, fd->comm);
 
-    /* Gather BG personality infomation onto process 0 */
+    /* Gather BG personality information onto process 0 */
     /* if (r == 0) */
     all_procInfo = ADIOI_BG_ProcInfo_new_n(s);
 

--- a/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_aggrs.h
+++ b/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_aggrs.h
@@ -29,7 +29,7 @@
 #define GPFS_SUPER_MAGIC (0x47504653)
 #endif
 
-    /* generate a list of I/O aggregators that utilizes BG-PSET orginization. */
+    /* generate a list of I/O aggregators that utilizes BG-PSET organization. */
 int ADIOI_BG_gen_agg_ranklist(ADIO_File fd, int n_aggrs_per_pset);
 
 #endif /* AD_BG_AGGRS_H_INCLUDED */

--- a/src/mpi/romio/adio/ad_gpfs/pe/ad_pe_aggrs.c
+++ b/src/mpi/romio/adio/ad_gpfs/pe/ad_pe_aggrs.c
@@ -36,7 +36,7 @@
  *  . the ranks of the aggregators :        fd->hints->ranklist
  * If MP_IONODEFILE is defined, POE determines all tasks on every node listed
  * in the node file and defines MP_IOTASKLIST with them, making them all
- * aggregators.  Alternatively, the user can explictly set MP_IOTASKLIST
+ * aggregators.  Alternatively, the user can explicitly set MP_IOTASKLIST
  * themselves.  The format of the MP_IOTASKLIST is a colon-delimited list of
  * task ids, the first entry being the total number of aggregators, for example
  * to specify 4 aggregators on task ids 0,8,16,24  the value would be:

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_lock.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_lock.c
@@ -169,7 +169,7 @@ int llapi_ladvise_lock(ADIO_File fd, unsigned long long flags, int num_advise,
     }
 
 
-    /* Simply save the new start/end extents, forget what we aleady had locked
+    /* Simply save the new start/end extents, forget what we already had locked
      * since lustre may reclaim it at any time. */
     fd->hints->fs_hints.lustre.lock_ahead_start_extent = ladvise_hdr->lah_advise[0].lla_start;
     fd->hints->fs_hints.lustre.lock_ahead_end_extent =

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_open.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_open.c
@@ -119,7 +119,7 @@ void ADIOI_LUSTRE_Open(ADIO_File fd, int *error_code)
 
     /* Pascal Deveze reports that, even though we pass a
      * "GETSTRIPE" (read) flag to the ioctl, if some of the values of this
-     * struct are uninitialzed, the call can give an error.  zero it out in case
+     * struct are uninitialized, the call can give an error.  zero it out in case
      * there are other members that must be initialized and in case
      * lov_user_md struct changes in future */
     memset(lum, 0, lumlen);

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -119,7 +119,7 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
 
     orig_fp = fd->fp_ind;
 
-    /* IO patten identification if cb_write isn't disabled */
+    /* IO pattern identification if cb_write isn't disabled */
     if (fd->hints->cb_write != ADIOI_HINT_DISABLE) {
         /* For this process's request, calculate the list of offsets and
          * lengths in the file and determine the start and end offsets.

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -139,7 +139,7 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
         ADIO_Offset my_count_size = 0;
         /* One-sided aggregation needs the amount of data per rank as well
          * because the difference in starting and ending offsets for 1 byte is
-         * 0 the same as 0 bytes so it cannot be distiguished.
+         * 0 the same as 0 bytes so it cannot be distinguished.
          */
         if ((romio_write_aggmethod == 1) || (romio_write_aggmethod == 2)) {
             count_sizes = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
@@ -1086,7 +1086,7 @@ static void ADIOI_LUSTRE_IterateOneSided(ADIO_File fd, const void *buf, int *str
     fd->hints->cb_nodes = numStripedAggs;
 
     /* Declare ADIOI_OneSidedStripeParms here - these parameters will be locally managed
-     * for this invokation of ADIOI_LUSTRE_IterateOneSided.  This will allow for concurrent
+     * for this invocation of ADIOI_LUSTRE_IterateOneSided.  This will allow for concurrent
      * one-sided collective writes via multi-threading as well as multiple communicators.
      */
     ADIOI_OneSidedStripeParms stripeParms;
@@ -1100,7 +1100,7 @@ static void ADIOI_LUSTRE_IterateOneSided(ADIO_File fd, const void *buf, int *str
     stripeParms.lastFlatBufIndice = 0;
     stripeParms.lastIndiceOffset = 0;
 
-    /* The general algorithm here is to divide the file up into segements, a segment
+    /* The general algorithm here is to divide the file up into segments, a segment
      * being defined as a contiguous region of the file which has up to one occurrence
      * of each stripe - the data for each stripe being written out by a particular
      * aggregator.  The segmentLen is the maximum size in bytes of each segment

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs.c
@@ -22,7 +22,7 @@ struct ADIOI_Fns_struct ADIO_NFS_operations = {
     ADIOI_NFS_WriteStrided,     /* WriteStrided */
     ADIOI_GEN_Close,    /* Close */
     /* Even with lockd running and NFS mounted 'noac', we have been unable to
-     * gaurantee correct behavior over NFS with asyncronous I/O operations */
+     * guarantee correct behavior over NFS with asynchronous I/O operations */
     ADIOI_FAKE_IreadContig,     /* IreadContig */
     ADIOI_FAKE_IwriteContig,    /* IwriteContig */
     ADIOI_NFS_ReadDone, /* ReadDone */

--- a/src/mpi/romio/adio/ad_panfs/ad_panfs_open6.c
+++ b/src/mpi/romio/adio/ad_panfs/ad_panfs_open6.c
@@ -130,7 +130,7 @@ void ADIOI_PANFS_Open6(ADIO_File fd, int *error_code)
                         myname);
                 layout_max_faults = 2;
             }
-            /* as of 6.0.x release, we only support RS enconding */
+            /* as of 6.0.x release, we only support RS encoding */
             if (layout_encoding != PAN_FS_CLIENT_LAYOUT_RAIDN_ENCODING_RS) {
                 FPRINTF(stderr,
                         "%s: panfs_layout_encoding is not a valid value: %u. Setting to default of %u\n",

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_aio.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_aio.c
@@ -115,7 +115,7 @@ void ADIOI_PVFS2_AIO_contig(ADIO_File fd, void *buf, int count,
     }
     /* --END ERROR HANDLING-- */
 
-    /* posted. defered completion */
+    /* posted. deferred completion */
     if (ret == 0) {
         if (ADIOI_PVFS2_greq_class == 0) {
             MPIX_Grequest_class_create(ADIOI_GEN_aio_query_fn,

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_common.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_common.c
@@ -57,7 +57,7 @@ void ADIOI_PVFS2_Init(int *error_code)
     }
 
     /* for consistency, we should disable the pvfs2 ncache.  If the
-     * environtment variable is already set, assume a  user knows it
+     * environment variable is already set, assume a  user knows it
      * won't be a problem */
     ncache_timeout = getenv("PVFS2_NCACHE_TIMEOUT");
     if (ncache_timeout == NULL)

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_flush.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_flush.c
@@ -27,7 +27,7 @@ void ADIOI_PVFS2_Flush(ADIO_File fd, int *error_code)
 
 
     /* unlike ADIOI_PVFS2_Resize, MPI_File_sync() does not perform any
-     * syncronization */
+     * synchronization */
     MPI_Reduce(&dummy_in, &dummy, 1, MPI_INT, MPI_SUM, fd->hints->ranklist[0], fd->comm);
 
     /* io_worker computed in ADIO_Open */

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io_dtype.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io_dtype.c
@@ -27,7 +27,7 @@ int ADIOI_PVFS2_StridedDtypeIO(ADIO_File fd, void *buf, int count,
     PVFS_size pvfs_disp = -1;
     ADIOI_Flatlist_node *flat_file_p;
 
-    /* Use for offseting the PVFS2 filetype */
+    /* Use for offsetting the PVFS2 filetype */
     int pvfs_blk = 1;
     ADIOI_PVFS2_fs *pvfs_fs;
     static char myname[] = "ADIOI_PVFS2_STRIDED_DTYPE";
@@ -167,7 +167,7 @@ int ADIOI_PVFS2_StridedDtypeIO(ADIO_File fd, void *buf, int count,
 #ifdef HAVE_STATUS_SET_BYTES
     MPIR_Status_set_bytes(status, datatype, resp_io.total_completed);
     /* This is a temporary way of filling in status. The right way is to
-     * keep track of how much data was actually acccessed by
+     * keep track of how much data was actually accessed by
      * ADIOI_BUFFERED operations */
 #endif
     return ret;
@@ -352,7 +352,7 @@ int convert_mpi_pvfs2_dtype(MPI_Datatype * mpi_dtype, PVFS_Request * pvfs_dtype)
         int has_lb_ub = 0;
 
         /* When converting into a PVFS_Request_struct, we no longer
-         * can use MPI_LB and MPI_UB.  Therfore, we have to do the
+         * can use MPI_LB and MPI_UB.  Therefore, we have to do the
          * following.
          * We simply ignore all the MPI_LB and MPI_UB types and
          * get the lb and extent and pass it on through a

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_read.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_read.c
@@ -125,7 +125,7 @@ void ADIOI_PVFS2_ReadStrided(ADIO_File fd, void *buf, int count,
      * - 'true' Datatype (from avery)
      * - new List I/O (from avery)
      * - classic List I/O  (the one that's always been in ROMIO)
-     * I imagine we'll keep Datatype as an optional optimization, and afer a
+     * I imagine we'll keep Datatype as an optional optimization, and after a
      * release or two promote it to the default
      */
     int ret = -1;

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_read_list_classic.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_read_list_classic.c
@@ -182,7 +182,7 @@ void ADIOI_PVFS2_OldReadStrided(ADIO_File fd, void *buf, int count,
 #ifdef HAVE_STATUS_SET_BYTES
         MPIR_Status_set_bytes(status, datatype, bufsize);
         /* This isa temporary way of filling in status.  The right way is to
-         * keep tracke of how much data was actually read adn placed in buf
+         * keep tracke of how much data was actually read and placed in buf
          * by ADIOI_BUFFERED_READ. */
 #endif
 
@@ -846,7 +846,7 @@ void ADIOI_PVFS2_OldReadStrided(ADIO_File fd, void *buf, int count,
      * at empty region at offset N+1)
      *
      * As we discussed on mpich-discuss in may/june 2009, the code below might
-     * look wierd, but by putting fp_ind at the last byte written, the next
+     * look weird, but by putting fp_ind at the last byte written, the next
      * time we run through the strided code we'll update the fp_ind to the
      * right location. */
     if (file_ptr_type == ADIO_INDIVIDUAL) {

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_resize.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_resize.c
@@ -28,7 +28,7 @@ void ADIOI_PVFS2_Resize(ADIO_File fd, ADIO_Offset size, int *error_code)
     /* MPI-IO semantics treat conflicting MPI_File_set_size requests the
      * same as conflicting write requests. Thus, a resize from one
      * process does not have to be visible to the other processes until a
-     * syncronization point is reached */
+     * synchronization point is reached */
 
     if (rank == fd->hints->ranklist[0]) {
         ret = PVFS_sys_truncate(pvfs_fs->object_ref, size, &(pvfs_fs->credentials));

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_write.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_write.c
@@ -137,7 +137,7 @@ void ADIOI_PVFS2_WriteStrided(ADIO_File fd, const void *buf, int count,
      * - 'true' Datatype (from avery)
      * - new List I/O (from avery)
      * - classic List I/O  (the one that's always been in ROMIO)
-     * I imagine we'll keep Datatype as an optional optimization, and afer a
+     * I imagine we'll keep Datatype as an optional optimization, and after a
      * release or two promote it to the default
      */
 

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_write_list_classic.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_write_list_classic.c
@@ -896,7 +896,7 @@ void ADIOI_PVFS2_OldWriteStrided(ADIO_File fd, const void *buf, int count,
      * at empty region at offset N+1).
      *
      * As we discussed on mpich-discuss in may/june 2009, the code below might
-     * look wierd, but by putting fp_ind at the last byte written, the next
+     * look weird, but by putting fp_ind at the last byte written, the next
      * time we run through the strided code we'll update the fp_ind to the
      * right location. */
     if (file_ptr_type == ADIO_INDIVIDUAL) {

--- a/src/mpi/romio/adio/common/ad_aggregate.c
+++ b/src/mpi/romio/adio/common/ad_aggregate.c
@@ -87,7 +87,7 @@ int ADIOI_Calc_aggregator(ADIO_File fd,
         /* wkliao: implementation for file domain alignment
          * fd_start[] and fd_end[] have been aligned with file lock
          * boundaries when returned from ADIOI_Calc_file_domains() so cannot
-         * just use simple arithmatic as above */
+         * just use simple arithmetic as above */
         rank_index = 0;
         while (off > fd_end[rank_index])
             rank_index++;
@@ -164,7 +164,7 @@ void ADIOI_Calc_file_domains(ADIO_Offset * st_offsets, ADIO_Offset
     /* ceiling division as in HPF block distribution */
 
     /* Tweak the file domains so that no fd is smaller than a threshold.  We
-     * have to strike a balance between efficency and parallelism: somewhere
+     * have to strike a balance between efficiency and parallelism: somewhere
      * between 10k processes sending 32-byte requests and one process sending a
      * 320k request is a (system-dependent) sweet spot */
 

--- a/src/mpi/romio/adio/common/ad_coll_build_req_new.c
+++ b/src/mpi/romio/adio/common/ad_coll_build_req_new.c
@@ -913,7 +913,7 @@ int ADIOI_Build_client_reqs(ADIO_File fd,
                         break;
                     case REAL_OFF:
                         /* Set the ol list for the memtypes that will
-                         * map to each aggregator, coaslescing if
+                         * map to each aggregator, coalescing if
                          * possible. */
                         agg_next_off_idx = agg_ol_cur_ct_arr[cur_off_proc];
                         if (agg_mem_next_off_arr[cur_off_proc] != agg_mem_st_reg) {
@@ -1212,7 +1212,7 @@ int ADIOI_Build_client_pre_req(ADIO_File fd,
                         break;
                     case REAL_OFF:
                         /* Set the ol list for the memtype that
-                         * will map to our aggregator, coaslescing
+                         * will map to our aggregator, coalescing
                          * if possible. */
                         agg_next_off_idx = agg_ol_cur_ct;
                         if (agg_mem_next_off != agg_mem_st_reg) {
@@ -1370,7 +1370,7 @@ static int process_pre_req(ADIO_File fd,
             break;
         case REAL_OFF:
             /* Set the ol list for the memtype that will map to our
-             * aggregator, coaslescing if possible. */
+             * aggregator, coalescing if possible. */
             for (i = 0; i < my_mem_view_state_p->pre_ol_ct; i++) {
                 agg_disp_arr[i] = my_mem_view_state_p->pre_disp_arr[i];
                 agg_blk_arr[i] = my_mem_view_state_p->pre_blk_arr[i];
@@ -1612,7 +1612,7 @@ int ADIOI_Build_client_req(ADIO_File fd,
                         break;
                     case REAL_OFF:
                         /* Set the ol list for the memtype that
-                         * will map to our aggregator, coaslescing
+                         * will map to our aggregator, coalescing
                          * if possible. */
                         agg_next_off_idx = agg_ol_cur_ct;
                         if (agg_mem_next_off != agg_mem_st_reg) {

--- a/src/mpi/romio/adio/common/ad_coll_exch_new.c
+++ b/src/mpi/romio/adio/common/ad_coll_exch_new.c
@@ -157,7 +157,7 @@ void ADIOI_Exch_file_views(int myrank, int nprocs, int file_ptr_type,
      * send_count_arr */
 
     if (memtype_is_contig) {
-        /* if memory is contigous, we now replace memtype_sz and
+        /* if memory is contiguous, we now replace memtype_sz and
          * memtype_extent with the full access size */
         memtype_sz *= count;
         memtype_extent = memtype_sz;

--- a/src/mpi/romio/adio/common/ad_fstype.c
+++ b/src/mpi/romio/adio/common/ad_fstype.c
@@ -203,7 +203,7 @@ Output Parameters:
 /* In a strict ANSI environment, S_ISLNK may not be defined.  Fix that
    here.  We assume that S_ISLNK is *always* defined as a macro.  If
    that is not universally true, then add a test to the romio
-   configure that trys to link a program that references S_ISLNK */
+   configure that tries to link a program that references S_ISLNK */
 #if !defined(S_ISLNK)
 #if defined(S_IFLNK)
      /* Check for the link bit */
@@ -306,7 +306,7 @@ static void ADIO_FileSysType_fncall(const char *filename, int *fstype, int *erro
 #endif
     static char myname[] = "ADIO_RESOLVEFILETYPE_FNCALL";
 
-/* NFS can get stuck and end up returing ESTALE "forever" */
+/* NFS can get stuck and end up returning ESTALE "forever" */
 #define MAX_ESTALE_RETRY 10000
     int retry_cnt;
 

--- a/src/mpi/romio/adio/common/ad_hints.c
+++ b/src/mpi/romio/adio/common/ad_hints.c
@@ -251,7 +251,7 @@ void ADIOI_GEN_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
                                          &(fd->hints->striping_unit), myname, error_code);
     }
 
-    /* Begin hint post-processig: some hints take precidence over or conflict
+    /* Begin hint post-processig: some hints take precedence over or conflict
      * with others, or aren't supported by some file systems */
 
     /* handle cb_config_list default value here; avoids an extra

--- a/src/mpi/romio/adio/common/ad_iwrite_coll.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_coll.c
@@ -1084,7 +1084,7 @@ static void ADIOI_W_Iexchange_data_hole(ADIOI_NBC_Request * nbc_req, int *error_
      * processes are operating on noncontigous data.  But holes can also show
      * up at the beginning or end of the file domain (see John Bent ROMIO REQ
      * #835). Missing these holes would result in us writing more data than
-     * recieved by everyone else. */
+     * received by everyone else. */
 
     *hole = 0;
     if (sum) {

--- a/src/mpi/romio/adio/common/ad_open.c
+++ b/src/mpi/romio/adio/common/ad_open.c
@@ -125,7 +125,7 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
 
     /* Instead of repeatedly allocating this buffer in collective read/write,
      * allocating up-front might make memory management on small platforms
-     * (e.g. Blue Gene) more efficent */
+     * (e.g. Blue Gene) more efficient */
 
     fd->io_buf = ADIOI_Malloc(fd->hints->cb_buffer_size);
     /* deferred open:
@@ -140,7 +140,7 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
     }
     if (ADIO_Feature(fd, ADIO_SCALABLE_OPEN))
         /* disable deferred open on these fs so that scalable broadcast
-         * will always use the propper communicator */
+         * will always use the proper communicator */
         fd->hints->deferred_open = 0;
 
 
@@ -249,7 +249,7 @@ int is_aggregator(int rank, ADIO_File fd)
 
 /*
  * If file system implements some version of two-phase -- doesn't have to be
- * generic -- we can still carry out the defered open optimization
+ * generic -- we can still carry out the deferred open optimization
  */
 static int uses_generic_read(ADIO_File fd)
 {

--- a/src/mpi/romio/adio/common/ad_opencoll.c
+++ b/src/mpi/romio/adio/common/ad_opencoll.c
@@ -165,7 +165,7 @@ void ADIOI_GEN_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code
     if (fd->access_mode != orig_amode_excl)
         fd->access_mode = orig_amode_excl;
 
-    /* broadcast information to all proceses in
+    /* broadcast information to all processes in
      * communicator, not just those who participated in open */
 
     stats_type = make_stats_type(fd);

--- a/src/mpi/romio/adio/common/ad_opencoll_failsafe.c
+++ b/src/mpi/romio/adio/common/ad_opencoll_failsafe.c
@@ -25,7 +25,7 @@ void ADIOI_FAILSAFE_OpenColl(ADIO_File fd, int rank, int access_mode, int *error
             fd->access_mode = access_mode;
 
             /* if the lower-level file system tries to communicate, COMM_SELF
-             * will ensure it doesn't get stuck waiting for non-existant
+             * will ensure it doesn't get stuck waiting for non-existent
              * participants */
             tmp_comm = fd->comm;
             fd->comm = MPI_COMM_SELF;

--- a/src/mpi/romio/adio/common/ad_read_str_naive.c
+++ b/src/mpi/romio/adio/common/ad_read_str_naive.c
@@ -110,7 +110,7 @@ void ADIOI_GEN_ReadStrided_naive(ADIO_File fd, void *buf, int count,
         /* First we're going to calculate a set of values for use in all
          * the noncontiguous in file cases:
          * start_off - starting byte position of data in file
-         * end_offset - last byte offset to be acessed in the file
+         * end_offset - last byte offset to be accessed in the file
          * st_n_filetypes - how far into the file we start in terms of
          *                  whole filetypes
          * st_index - index of block in first filetype that we will be

--- a/src/mpi/romio/adio/common/ad_tuning.c
+++ b/src/mpi/romio/adio/common/ad_tuning.c
@@ -39,9 +39,9 @@ int romio_tunegather;
  *   libraries like PNETCDF which may count on read-modify-write functionality for certain
  *   features (like fill values).  Possible values:
  *   - 0 - Normal two-phase collective IO is used.
- *   - 1 - A separate one-sided MPI_Put or MPI_Get is used for each contigous chunk of data
+ *   - 1 - A separate one-sided MPI_Put or MPI_Get is used for each contiguous chunk of data
  *         for a compute to write to or read from the collective buffer on the aggregator.
- *   - 2 - An MPI derived datatype is created using all the contigous chunks and just one
+ *   - 2 - An MPI derived datatype is created using all the contiguous chunks and just one
  *         call to MPI_Put or MPI_Get is done with the derived datatype.  On Blue Gene /Q
  *         optimal performance for this is achieved when paired with PAMID_TYPED_ONESIDED=1.
  *   - Default is 0

--- a/src/mpi/romio/adio/common/ad_write_coll.c
+++ b/src/mpi/romio/adio/common/ad_write_coll.c
@@ -607,7 +607,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, void *buf, char *write_buf,
      * processes are operating on noncontigous data.  But holes can also show
      * up at the beginning or end of the file domain (see John Bent ROMIO REQ
      * #835). Missing these holes would result in us writing more data than
-     * recieved by everyone else. */
+     * received by everyone else. */
 
     *hole = 0;
     if (sum) {

--- a/src/mpi/romio/adio/common/ad_write_str_naive.c
+++ b/src/mpi/romio/adio/common/ad_write_str_naive.c
@@ -110,7 +110,7 @@ void ADIOI_GEN_WriteStrided_naive(ADIO_File fd, const void *buf, int count,
         /* First we're going to calculate a set of values for use in all
          * the noncontiguous in file cases:
          * start_off - starting byte position of data in file
-         * end_offset - last byte offset to be acessed in the file
+         * end_offset - last byte offset to be accessed in the file
          * st_n_filetypes - how far into the file we start in terms of
          *                  whole filetypes
          * st_index - index of block in first filetype that we will be

--- a/src/mpi/romio/adio/common/iscontig.c
+++ b/src/mpi/romio/adio/common/iscontig.c
@@ -13,7 +13,7 @@ void ADIOI_Datatype_iscontig(MPI_Datatype datatype, int *flag)
 {
     MPIR_Datatype_iscontig(datatype, flag);
 
-    /* if the datatype is reported as contigous, check if the true_lb is
+    /* if the datatype is reported as contiguous, check if the true_lb is
      * non-zero, and if so, mark the datatype as noncontiguous */
     if (*flag) {
         MPI_Aint true_extent, true_lb;

--- a/src/mpi/romio/adio/common/lock.c
+++ b/src/mpi/romio/adio/common/lock.c
@@ -96,7 +96,7 @@ int ADIOI_GEN_SetLock(ADIO_File fd, int cmd, int type, ADIO_Offset offset, int w
      * ADIO_Offsets.  */
 /* FIXME: This is a temporary hack until we use flock64 where
    available. It also doesn't fix the broken Solaris header sys/types.h
-   header file, which declars off_t as a UNION ! Configure tests to
+   header file, which declares off_t as a UNION ! Configure tests to
    see if the off64_t is a union if large file support is requested;
    if so, it does not select large file support.
 */

--- a/src/mpi/romio/adio/common/onesided_aggregation.c
+++ b/src/mpi/romio/adio/common/onesided_aggregation.c
@@ -19,8 +19,8 @@
  * file domains within aggregators corresponding to the target data blocks.  It
  * is designed to be initialized with a starting point for a given file domain
  * with an aggregator, after which the data access for data written to a given
- * file domain from this compute is linear and uninterupted, and this serves as
- * a key optimization for feeding the target aggs.  For contigous source data
+ * file domain from this compute is linear and uninterrupted, and this serves as
+ * a key optimization for feeding the target aggs.  For contiguous source data
  * the starting point is a single-value offset, for non-contiguous data it is
  * the number of extents, the index into the flattened buffer and the remnant
  * length beyond the flattened buffer index.  The validity of the usage of this
@@ -64,7 +64,7 @@ int ADIOI_OneSidedCleanup(ADIO_File fd)
     return ret;
 }
 
-/* This funtion packs a contigous buffer of data from the non-contgious source
+/* This function packs a contiguous buffer of data from the non-contgious source
  * buffer for a specified chunk of data and advances the FDSourceBufferState
  * machinery, so subsequent calls with the FDSourceBufferState will return the
  * next linear chunk.
@@ -193,7 +193,7 @@ inline static void nonContigSourceDataBufferAdvance(char *sourceDataBuffer,
  * the collective buffer to the file system.  In this fashion the synchronization can be minimized as that
  * only needs to occur during the actual read from or write to the file system.  In the case of gpfs
  * this function is called just once.  The ADIOI_OneSidedStripeParms parameter is used to save the
- * state and re-use variables thru repetative calls to help in the case of lustre to avoid costly
+ * state and re-use variables thru repetitive calls to help in the case of lustre to avoid costly
  * recomputation, for consistency gpfs utilizes it as well but doesn't use some aspects of it.  This
  * function was originally first written for gpfs only and then modified to support lustre.
  */
@@ -406,7 +406,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
     int numTargetAggs = 0;
 
     /* This data structure holds the beginning offset and len list index for the range to be written
-     * coresponding to the round and target agg.  Initialize to -1 to denote being unset.
+     * corresponding to the round and target agg.  Initialize to -1 to denote being unset.
      */
     int **targetAggsForMyDataFirstOffLenIndex =
         (int **) ADIOI_Malloc(numberOfRounds * sizeof(int *));
@@ -417,7 +417,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
     }
 
     /* This data structure holds the ending offset and len list index for the range to be written
-     * coresponding to the round and target agg.
+     * corresponding to the round and target agg.
      */
     int **targetAggsForMyDataLastOffLenIndex =
         (int **) ADIOI_Malloc(numberOfRounds * sizeof(int *));
@@ -728,7 +728,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                         targetAggsForMyDataFirstOffLenIndex[targetAggsForMyDataCurrentRoundIter
                                                             [numTargetAggs]][numTargetAggs] =
                             blockIter;
-                        /* For the first additonal file domain the source buffer offset
+                        /* For the first additional file domain the source buffer offset
                          * will be incremented relative to the state of this first main
                          * loop but for subsequent full file domains the offset will be
                          * incremented by the size
@@ -1030,7 +1030,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
 
     /* This is the second main loop of the algorithm, actually nested loop of target aggs within rounds.  There are 2 flavors of this.
      * For romio_write_aggmethod of 1 each nested iteration for the target
-     * agg does an mpi_put on a contiguous chunk using a primative datatype
+     * agg does an mpi_put on a contiguous chunk using a primitive datatype
      * determined using the data structures from the first main loop.  For
      * romio_write_aggmethod of 2 each nested iteration for the target agg
      * builds up data to use in created a derived data type for 1 mpi_put that is done for the target agg for each round.
@@ -1781,7 +1781,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
     int numSourceAggs = 0;
 
     /* This data structure holds the beginning offset and len list index for the range to be read
-     * coresponding to the round and source agg. Initialize to -1 to denote being unset.
+     * corresponding to the round and source agg. Initialize to -1 to denote being unset.
      */
     int **sourceAggsForMyDataFirstOffLenIndex =
         (int **) ADIOI_Malloc(numberOfRounds * sizeof(int *));
@@ -1792,7 +1792,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
     }
 
     /* This data structure holds the ending offset and len list index for the range to be read
-     * coresponding to the round and source agg.
+     * corresponding to the round and source agg.
      */
     int **sourceAggsForMyDataLastOffLenIndex =
         (int **) ADIOI_Malloc(numberOfRounds * sizeof(int *));
@@ -2083,7 +2083,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
                             blockIter;
 
 
-                        /* For the first additonal file domain the source buffer offset
+                        /* For the first additional file domain the source buffer offset
                          * will be incremented relative to the state of this first main
                          * loop but for subsequent full file domains the offset will be
                          * incremented by the size of the file domain.
@@ -2275,7 +2275,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
 
 
     /* This is the second main loop of the algorithm, actually nested loop of target aggs within rounds.  There are 2 flavors of this.
-     * For romio_read_aggmethod of 1 each nested iteration for the source agg does an mpi_put on a contiguous chunk using a primative datatype
+     * For romio_read_aggmethod of 1 each nested iteration for the source agg does an mpi_put on a contiguous chunk using a primitive datatype
      * determined using the data structures from the first main loop.  For romio_read_aggmethod of 2 each nested iteration for the source agg
      * builds up data to use in created a derived data type for 1 mpi_put that is done for the target agg for each round.
      * To support lustre there will need to be an additional layer of nesting for the multiple file domains

--- a/src/mpi/romio/adio/common/system_hints.c
+++ b/src/mpi/romio/adio/common/system_hints.c
@@ -71,7 +71,7 @@ static int find_file(void)
 }
 
 /* parse the file-of-hints.  Format is zero or more lines of "<key> <value>\n".
- * A # in collumn zero is a comment and the line will be ignored.  Do our best
+ * A # in column zero is a comment and the line will be ignored.  Do our best
  * to ignore badly formed lines too.
  *
  * The caller provides an 'info' object.  Each key-value pair found by the

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -428,7 +428,7 @@ int MPIO_Err_create_code(int lastcode, int fatal, const char fcname[],
 int MPIO_Err_return_file(MPI_File mpi_fh, int error_code);
 int MPIO_Err_return_comm(MPI_Comm mpi_comm, int error_code);
 
-/* request managment helper functions */
+/* request management helper functions */
 void MPIO_Completed_request_create(MPI_File * fh, MPI_Offset nbytes,
                                    int *error_code, MPI_Request * request);
 

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -362,7 +362,7 @@ void ADIOI_SetFunctions(ADIO_File fd);
 ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype type);
 void ADIOI_Flatten(MPI_Datatype type, ADIOI_Flatlist_node * flat,
                    ADIO_Offset st_offset, MPI_Count * curr_index);
-/* callbakcs for attribute-style flattened tracking */
+/* callbacks for attribute-style flattened tracking */
 int ADIOI_Flattened_type_copy(MPI_Datatype oldtype,
                               int type_keyval, void *extra_state, void *attribute_val_in,
                               void *attribute_val_out, int *flag);
@@ -701,7 +701,7 @@ typedef struct ADIOI_OneSidedStripeParms {
     /* onesided algorithm.                                          */
     int lastStripedWriteCall;   /* whether this is the last call in the last segment of the  */
     /* onesided algorithm.                                        */
-    int iWasUsedStripingAgg;    /* whether this rank was ever a used agg for this striping segement */
+    int iWasUsedStripingAgg;    /* whether this rank was ever a used agg for this striping segment */
     int numStripesUsed;         /* the number of stripes packed into an aggregator */
     /* These 2 elements are the offset and lengths in the file corresponding to the actual stripes */
     ADIO_Offset *stripeWriteOffsets;

--- a/src/mpi/romio/adio/include/adioi_errmsg.h
+++ b/src/mpi/romio/adio/include/adioi_errmsg.h
@@ -41,7 +41,7 @@ MPI_ERR_REQUEST
 
 MPI_ERR_IO
     MPIR_ERR_ETYPE_FRACTIONAL "Only an integral number of etypes can be accessed"
-    MPIR_ERR_NO_FSTYPE "Can't determine the file-system type. Check the filename/path you provided and try again. Otherwise, prefix the filename with a string to indicate the type of file sytem (piofs:, pfs:, nfs:, ufs:, hfs:, xfs:, sfs:, pvfs:, panfs: ftp: gsiftp:)"
+    MPIR_ERR_NO_FSTYPE "Can't determine the file-system type. Check the filename/path you provided and try again. Otherwise, prefix the filename with a string to indicate the type of file system (piofs:, pfs:, nfs:, ufs:, hfs:, xfs:, sfs:, pvfs:, panfs: ftp: gsiftp:)"
     MPIR_ERR_NO_UFS "ROMIO has not been configured to use the UFS file system"
     MPIR_ERR_NO_NFS "ROMIO has not been configured to use the NFS file system"
     MPIR_ERR_NO_XFS "ROMIO has not been configured to use the XFS file system"

--- a/src/mpi/romio/adio/include/mpiu_external32.h
+++ b/src/mpi/romio/adio/include/mpiu_external32.h
@@ -12,7 +12,7 @@ int MPIU_read_external32_conversion_fn(void *userbuf, MPI_Datatype datatype,
                                        int count, void *filebuf);
 int MPIU_datatype_full_size(MPI_Datatype datatype, MPI_Aint * size);
 
-/* given a buffer, count, and datatype, return an apropriately sized and
+/* given a buffer, count, and datatype, return an appropriately sized and
  *  * external32-formatted buffer, suitable for handing off to a subsequent write
  *   * routine */
 int MPIU_external32_buffer_setup(const void *buf, int count, MPI_Datatype type, void **newbuf);

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -232,7 +232,7 @@ AC_ARG_WITH(mpi-impl,[
 --with-mpi-impl=name - Specify MPI implementation to build ROMIO for],,)
 dnl
 AC_ARG_WITH(mpi, [
---with-mpi=path   - Path to instalation of MPI (headers, libs, etc)],,)
+--with-mpi=path   - Path to installation of MPI (headers, libs, etc)],,)
 dnl
 if test "$enable_f77" != "yes" ; then
    NOF77=1
@@ -708,7 +708,7 @@ if test "x$HAVE_WEAK_SYMBOLS" = "x0" ; then
 fi
 
 
-# weird: we have conflated "buid ROMIO's versions of the fortran bindings" and
+# weird: we have conflated "build ROMIO's versions of the fortran bindings" and
 # "build ROMIO"s fortran I/O tests". Of course the common situaiton is that we
 # are building as part of MPICH, which builds its own fortran bindings, but we
 # still want tests built

--- a/src/mpi/romio/mpi-io/mpir_cst_filesys.c
+++ b/src/mpi/romio/mpi-io/mpir_cst_filesys.c
@@ -123,7 +123,7 @@ static int comm_split_filesystem_heuristic(MPI_Comm comm, int key,
      *
      * note that this scheme works really well for traditional linux clusters:
      * think nodes with a local scratch drive.  this scheme works less well for
-     * a deeper heirarchy.  what if the directory in question was hosted by an
+     * a deeper hierarchy.  what if the directory in question was hosted by an
      * i/o forwarding agent?
      */
 
@@ -153,7 +153,7 @@ static int comm_split_filesystem_heuristic(MPI_Comm comm, int key,
      * which group can see what files */
 
     /* here come a bunch of assumptions:
-     * - file system layouts are homogenous: if one system has /scratch,
+     * - file system layouts are homogeneous: if one system has /scratch,
      *   all have /scratch
      * - a globally visible parallel file system will have the same name
      *   everywhere: e.g /gpfs/users/something
@@ -215,12 +215,12 @@ static int comm_split_filesystem_heuristic(MPI_Comm comm, int key,
     }
     MPI_Bcast(&globally_visible, 1, MPI_INT, challenge_rank, comm);
 
-    /*   with the above assumptions, we have two cases for a flie
+    /*   with the above assumptions, we have two cases for a file
      *   created on one process:
      *   -- either a process not in the group can access it (node-local
      *      storage of some sort)
      *   -- or a process not in the group cannot access it (globally
-     *      accessable parallel file system) */
+     *      accessible parallel file system) */
 
     if (globally_visible) {
         MPI_Comm_dup(comm, newcomm);

--- a/src/mpi/romio/mpi-io/mpiu_external32.c
+++ b/src/mpi/romio/mpi-io/mpiu_external32.c
@@ -129,7 +129,7 @@ int MPIU_datatype_full_size(MPI_Datatype datatype, MPI_Aint * size)
     return error_code;
 }
 
-/* given a buffer, count, and datatype, return an apropriately allocated, sized
+/* given a buffer, count, and datatype, return an appropriately allocated, sized
  * and external32-formatted buffer, suitable for handing off to a subsequent
  * write routine.  Caller is responsible for freeing 'newbuf' */
 int MPIU_external32_buffer_setup(const void *buf, int count, MPI_Datatype type, void **newbuf)

--- a/src/mpi/romio/test-internal/Makefile.am
+++ b/src/mpi/romio/test-internal/Makefile.am
@@ -10,7 +10,7 @@
 # override the normal compilers for the tests
 CC = $(TEST_CC)
 
-# because := is not universally avalible, we have to play games to use the
+# because := is not universally available, we have to play games to use the
 # user-specified LDFLAGS and OUR_LIBS env. variables (if set)
 OUR_LIBS = $(TEST_LIBNAME) $(MPI_LIB) $(ROMIO_LIBLIST)
 

--- a/src/mpi/romio/test/Makefile.am
+++ b/src/mpi/romio/test/Makefile.am
@@ -11,7 +11,7 @@
 CC = $(TEST_CC)
 F77 = $(TEST_F77)
 
-# because := is not universally avalible, we have to play games to use the
+# because := is not universally available, we have to play games to use the
 # user-specified LDFLAGS and OUR_LIBS env. variables (if set)
 OUR_LIBS = $(TEST_LIBNAME) $(MPI_LIB)
 

--- a/src/mpi/romio/test/aggregation1.c
+++ b/src/mpi/romio/test/aggregation1.c
@@ -6,7 +6,7 @@
 /* Test case from John Bent (ROMIO req #835)
  * Aggregation code was not handling certain access patterns when collective
  * buffering forced */
-#define _XOPEN_SOURCE 500       /* strdup not in string.h otherwsie */
+#define _XOPEN_SOURCE 500       /* strdup not in string.h otherwise */
 #include <unistd.h>
 #include <stdlib.h>
 #include <mpi.h>

--- a/src/mpi/romio/test/creat_excl.c
+++ b/src/mpi/romio/test/creat_excl.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <stdlib.h>
 /*
- * the new defered open code made some changes to the way we manage CREAT|EXCL,
+ * the new deferred open code made some changes to the way we manage CREAT|EXCL,
  * so test out that code path */
 
 struct options {

--- a/src/mpi/romio/test/error.c
+++ b/src/mpi/romio/test/error.c
@@ -11,7 +11,7 @@
 /* many calls are deliberately passed bogus values, are expected to fail, and
  * then checked to see if we get the right error message.  Other
  * calls are expected to succeed but the preciese return string is not checked.  This
- * rouine and MPI_CHECK macro handle these unexpected error cases */
+ * routine and MPI_CHECK macro handle these unexpected error cases */
 static void handle_error(int errcode, const char *str)
 {
     char msg[MPI_MAX_ERROR_STRING];

--- a/src/mpi/romio/test/file_info.c
+++ b/src/mpi/romio/test/file_info.c
@@ -56,7 +56,7 @@ hint_defaults BLUEGENE_DEFAULTS = {
 
 /* Test will print out information about unexpected hint keys or values that
  * differ from the default.  Since this is often interesting but rarely an
- * error, default will be to increment error cound for true error conditions
+ * error, default will be to increment error count for true error conditions
  * but not print out these "interesting" non-error cases. */
 
 static int verbose = 0;

--- a/src/mpi/romio/test/file_info.c
+++ b/src/mpi/romio/test/file_info.c
@@ -56,7 +56,7 @@ hint_defaults BLUEGENE_DEFAULTS = {
 
 /* Test will print out information about unexpected hint keys or values that
  * differ from the default.  Since this is often interesting but rarely an
- * error, default will be to increment errror cound for true error conditions
+ * error, default will be to increment error cound for true error conditions
  * but not print out these "interesting" non-error cases. */
 
 static int verbose = 0;

--- a/src/mpi/romio/test/noncontig_coll2.c
+++ b/src/mpi/romio/test/noncontig_coll2.c
@@ -14,7 +14,7 @@
  *
  * . generalized file writing/reading to handle arbitrary number of processors
  * . provides the "cb_config_list" hint with several permutations of the
- *   avaliable processors.
+ *   available processors.
  *   [ makes use of code copied from ROMIO's ADIO code to collect the names of
  *   the processors ]
  */

--- a/src/mpi/topo/dims_create.c
+++ b/src/mpi/topo/dims_create.c
@@ -113,7 +113,7 @@ static int MPIR_Dims_create_init(void)
    store all of the factors for a large number (grows *faster* than n
    factorial). */
 #define MAX_FACTORS 10
-/* 2^20 is a millon */
+/* 2^20 is a million */
 #define MAX_DIMS    20
 
 typedef struct Factors {
@@ -334,7 +334,7 @@ static int factor_to_divisors(int nf, Factors * factors, int ndiv, int divs[])
  *
  * First, distribute factors to dims[0..nd-1].  The purpose is to get the
  * initial factors set and to ensure that the smallest dimension is > 1.
- * Second, distibute the remaining factors, starting with the largest, to
+ * Second, distribute the remaining factors, starting with the largest, to
  * the elements of dims with the smallest index i such that
  *   dims[i-1] > dims[i]*val
  * or to dims[0] if no i satisfies.

--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -20,7 +20,7 @@ static int MPIR_Topology_delete_fn(MPI_Comm, int, void *, void *);
 static int MPIR_Topology_finalize(void *);
 
 /*
-  Return a poiner to the topology structure on a communicator.
+  Return a pointer to the topology structure on a communicator.
   Returns null if no topology structure is defined
 */
 MPIR_Topology *MPIR_Topology_get(MPIR_Comm * comm_ptr)

--- a/src/mpi_t/mpit.c
+++ b/src/mpi_t/mpit.c
@@ -47,7 +47,7 @@ void MPIR_T_enum_create(const char *enum_name, MPI_T_enum * handle)
     (*handle) = e;
 }
 
-/* Add an item to an exisiting enum.
+/* Add an item to an existing enum.
  * IN: handle, handle to the enum
  * IN: item_name, name of the item
  * IN: item_value, value associated with item_name
@@ -68,7 +68,7 @@ void MPIR_T_enum_add_item(MPI_T_enum handle, const char *item_name, int item_val
 
 /* Create a new category with name <cat_name>.
  * The new category is pushed at the back of cat_table.
- * Aslo, a new hash entry is added for the category in cat_hash.
+ * Also, a new hash entry is added for the category in cat_hash.
  * Return the newly created category.
  */
 static cat_table_entry_t *MPIR_T_cat_create(const char *cat_name)
@@ -103,7 +103,7 @@ static cat_table_entry_t *MPIR_T_cat_create(const char *cat_name)
 /* Add a pvar to an existing or new category
  * IN: cat_name, name of the category
  * IN: pvar_index, index of the pvar as defined by MPI_T_pvar_handle_alloc()
- * If cat_name is NULL or a empty string, nothing happpens.
+ * If cat_name is NULL or a empty string, nothing happens.
  */
 int MPIR_T_cat_add_pvar(const char *cat_name, int pvar_index)
 {
@@ -137,7 +137,7 @@ int MPIR_T_cat_add_pvar(const char *cat_name, int pvar_index)
 /* Add a cvar to an existing or new category
  * IN: cat_name, name of the category
  * IN: cvar_index, index of the cvar as defined by MPI_T_cvar_handle_alloc()
- * If cat_name is NULL or a empty string, nothing happpens.
+ * If cat_name is NULL or a empty string, nothing happens.
  */
 int MPIR_T_cat_add_cvar(const char *cat_name, int cvar_index)
 {
@@ -257,7 +257,7 @@ int MPIR_T_cat_add_desc(const char *cat_name, const char *cat_desc)
 /* Add an event to an existing or new category
  * IN: cat_name, name of the category
  * IN: event_index, index of the event
- * If cat_name is NULL or a empty string, nothing happpens.
+ * If cat_name is NULL or a empty string, nothing happens.
  */
 int MPIR_T_cat_add_event(const char *cat_name, int event_index)
 {
@@ -291,8 +291,8 @@ int MPIR_T_cat_add_event(const char *cat_name, int event_index)
  *
  * IN: dtype, MPI datatype for this cvar
  * IN: name, Name of the cvar
- * IN: addr, Pointer to the cvar if known at registeration, otherwise NULL.
- * IN: count, # of elements of this cvar if known at registeration, otherwise 0.
+ * IN: addr, Pointer to the cvar if known at registration, otherwise NULL.
+ * IN: count, # of elements of this cvar if known at registration, otherwise 0.
  * IN: etype, MPI_T_enum or MPI_T_ENUM_NULL
  * IN: verb, MPI_T_PVAR_VERBOSITY_*
  * IN: binding, MPI_T_BIND_*
@@ -376,8 +376,8 @@ void MPIR_T_CVAR_REGISTER_impl(MPI_Datatype dtype, const char *name, const void 
  * IN: varclass, MPI_T_PVAR_CLASS_*
  * IN: dtype, MPI datatype for this pvar
  * IN: name, Name of the pvar
- * IN: addr, Pointer to the pvar if known at registeration, otherwise NULL.
- * IN: count, # of elements of this pvar if known at registeration, otherwise 0.
+ * IN: addr, Pointer to the pvar if known at registration, otherwise NULL.
+ * IN: count, # of elements of this pvar if known at registration, otherwise 0.
  * IN: etype, MPI_T_enum or MPI_T_ENUM_NULL
  * IN: verb, MPI_T_PVAR_VERBOSITY_*
  * IN: binding, MPI_T_BIND_*

--- a/src/mpi_t/pvar_impl.c
+++ b/src/mpi_t/pvar_impl.c
@@ -277,7 +277,7 @@ int MPIR_T_pvar_read_impl(MPI_T_pvar_session session, MPI_T_pvar_handle handle, 
         MPIR_Memcpy(buf, handle->accum, handle->bytes * handle->count);
     } else if (MPIR_T_pvar_is_watermark(handle)) {
         /* Callback and array are not allowed for watermarks, since they
-         * can not gurantee correct semantics of watermarks.
+         * can not guarantee correct semantics of watermarks.
          */
         MPIR_Assert(handle->get_value == NULL && handle->count == 1);
 
@@ -497,7 +497,7 @@ int MPIR_T_pvar_stop_impl(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
             handle->get_value(handle->addr, handle->obj_handle, handle->count, handle->current);
         }
 
-        /* Substract offset from current, and accumulate the result to accum */
+        /* Subtract offset from current, and accumulate the result to accum */
         switch (handle->datatype) {
             case MPI_UNSIGNED_LONG_LONG:
                 for (i = 0; i < handle->count; i++) {

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
@@ -34,7 +34,7 @@
    not really a fair comparison for studying the impact of atomic instructions.
    [goodell@ 2009-01-16] */
 
-#define MPID_NEM_OFFSETOF(struc, field) ((int)(&((struc *)0)->field))
+#define MPID_NEM_OFFSETOF(struct, field) ((int)(&((struct *)0)->field))
 #define MPID_NEM_CACHE_LINE_LEN MPL_CACHELINE_SIZE
 #define MPID_NEM_NUM_CELLS      64
 #define MPID_NEM_CELL_LEN       (64*1024)

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
@@ -364,7 +364,7 @@ int MPID_nem_ofi_cm_init(MPIDI_PG_t * pg_p, int pg_rank ATTRIBUTE((unused)))
 
 /* ------------------------------------------------------------------------ */
 /* MPID_nem_ofi_cm_finalize                                                 */
-/* Clean up and cancle the requests initiated by the cm_init routine        */
+/* Clean up and cancel the requests initiated by the cm_init routine        */
 /* ------------------------------------------------------------------------ */
 int MPID_nem_ofi_cm_finalize()
 {

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
@@ -29,13 +29,13 @@
  * <tag> has the following format:
  * tag<delim>tag_value<separ>\0
  * where "tag" is constant string (3 chars),
- * <delim>  and <separ> are one-char delimeters (2 chars),
+ * <delim>  and <separ> are one-char delimiters (2 chars),
  * tag_value is integer value (12 chars are enough for max value).
  *
  * <business card> has the following format:
  * OFI<delim>address<separ>
  * where "OFI" is constant string (3 chars),
- * <delim>  and <separ> are one-char delimeters (2 chars).
+ * <delim>  and <separ> are one-char delimiters (2 chars).
  * address is variable string.
  *
  * Address is provider specific and have encoded form

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_progress.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_progress.c
@@ -42,7 +42,7 @@ int MPID_nem_ofi_poll(int in_blocking_poll)
         /* ----------------------------------------------------- */
         /* Poll the completion queue                             */
         /* The strategy here is                                  */
-        /* ret>0 successfull poll, events returned               */
+        /* ret>0 successful poll, events returned               */
         /* ret==0 empty poll, no events/no error                 */
         /* ret<0, error, but some error instances should not     */
         /* cause MPI to terminate                                */

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged.c
@@ -27,7 +27,7 @@ MPID_nem_ofi_send_callback(cq_tagged_entry_t * wc ATTRIBUTE((unused)), MPIR_Requ
 #include "ofi_tagged_template.c"
 
 /* ------------------------------------------------------------------------ */
-/* Receive callback called after sending a syncronous send acknowledgement. */
+/* Receive callback called after sending a synchronous send acknowledgement. */
 /* ------------------------------------------------------------------------ */
 static inline int MPID_nem_ofi_sync_recv_callback(cq_tagged_entry_t * wc ATTRIBUTE((unused)),
                                                   MPIR_Request * rreq)
@@ -115,7 +115,7 @@ int MPID_nem_ofi_anysource_matched(MPIR_Request * rreq)
     /* ----------------------------------------------------- */
     ret = fi_cancel((fid_t) gl_data.endpoint, &(REQ_OFI(rreq)->ofi_context));
     if (ret == 0) {
-        /* Cancel succeded. This means that the actual message has been
+        /* Cancel succeeded. This means that the actual message has been
          *  received via nemesis shared memory. We need to return
          *  matched=False. The request will be completed at the nemesis level.
          *

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged_template.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged_template.c
@@ -143,7 +143,7 @@ static inline int ADD_SUFFIX(send_normal) (struct MPIDI_VC * vc,
 
     if (send_type == MPIDI_OFI_SYNC_SEND) {
         /* ---------------------------------------------------- */
-        /* For syncronous send, we post a receive to catch the  */
+        /* For synchronous send, we post a receive to catch the  */
         /* match ack, but use the tag protocol bits to avoid    */
         /* matching with MPI level messages.                    */
         /* ---------------------------------------------------- */

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
@@ -440,7 +440,7 @@ static int send_id_info(const sockconn_t * const sc)
 
 /*     store ending NULL also */
 /*     FIXME better keep pg_id_len itself as part of MPIDI_Process.my_pg structure to */
-/*     avoid computing the length of string everytime this function is called. */
+/*     avoid computing the length of string every time this function is called. */
 
     MPL_VG_MEM_INIT(&hdr, sizeof(hdr));
 
@@ -502,7 +502,7 @@ static int send_tmpvc_info(const sockconn_t * const sc)
 
 /*     store ending NULL also */
 /*     FIXME better keep pg_id_len itself as part of MPIDI_Process.my_pg structure to */
-/*     avoid computing the length of string everytime this function is called. */
+/*     avoid computing the length of string every time this function is called. */
 
     MPL_VG_MEM_INIT(&hdr, sizeof(hdr));
 
@@ -1735,7 +1735,7 @@ int MPID_nem_tcp_sm_finalize(void)
 }
 
 /*
- N1: create a new listener fd?? While doing so, if we bind it to the same port used befor,
+ N1: create a new listener fd?? While doing so, if we bind it to the same port used before,
 then it is ok. Else,the new port number(and thus the business card) has to be communicated
 to the other processes (in same and different pg's), which is not quite simple to do.
 Evaluate the need for it by testing and then do it, if needed.
@@ -1844,7 +1844,7 @@ int MPID_nem_tcp_connpoll(int in_blocking_poll)
 
   N3:  find_free_entry is called within the while loop. It may cause the table to expand. So,
   the arguments passed for this callback function may get invalidated. So, it is imperative
-  that we obtain sc pointer and plfd pointer everytime within the while loop.
+  that we obtain sc pointer and plfd pointer every time within the while loop.
   Accordingly, the parameters are named unused1 and unused2 for clarity.
 */
 int MPID_nem_tcp_state_listening_handler(struct pollfd *const unused_1, sockconn_t * const unused_2)

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_utility.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_utility.c
@@ -110,7 +110,7 @@ there is an error in the socket or whether the peer has closed it (i.e we have r
 EOF and hence recv returns 0). Either way, we deccide the socket fd is not usable any
 more. So, same return code is used.
 A design decision is not to write also, if the peer has closed the socket. Please note that
-write will still be succesful, even if the peer has sent us FIN. Only the subsequent
+write will still be successful, even if the peer has sent us FIN. Only the subsequent
 write will fail. So, this function is made tight enough and this should be called
 before doing any read/write at least in the connection establishment state machine code.
 

--- a/src/mpid/ch3/channels/nemesis/src/ch3_istartmsg.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_istartmsg.c
@@ -16,7 +16,7 @@
  * the entire message is successfully sent, then NULL is returned.
  * Otherwise a request is allocated, the header is copied into the
  * request, and a pointer to the request is returned.  An error
- * condition also results in a request be allocated and the errror
+ * condition also results in a request be allocated and the error
  * being returned in the status field of the request.
  */
 int MPIDI_CH3_iStartMsg (MPIDI_VC_t *vc, void *hdr, intptr_t hdr_sz, MPIR_Request **sreq_ptr)

--- a/src/mpid/ch3/channels/nemesis/src/ch3_istartmsgv.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_istartmsgv.c
@@ -17,11 +17,11 @@
  * pointed to by the iovec (which is assumed to be a MPIDI_CH3_Pkt_t)
  * are copied into the request, and a pointer to the request is
  * returned.  An error condition also results in a request be
- * allocated and the errror being returned in the status field of the
+ * allocated and the error being returned in the status field of the
  * request.
  */
 
-/* NOTE - The completion action associated with a request created by CH3_iStartMsgv() is alway null (onDataAvail = 0).  This
+/* NOTE - The completion action associated with a request created by CH3_iStartMsgv() is always null (onDataAvail = 0).  This
    implies that CH3_iStartMsgv() can only be used when the entire message can be described by a single iovec of size
    MPL_IOV_LIMIT. */
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -84,7 +84,7 @@ static int MPID_nem_init_stats(int n_local_ranks)
         MPI_UNSIGNED_LONG_LONG,
         nem_fbox_fall_back_to_queue_count, /* name */
         MPID_nem_fbox_fall_back_to_queue_count, /* address */
-        n_local_ranks, /* count, known at pvar registeration time */
+        n_local_ranks, /* count, known at pvar registration time */
         MPI_T_VERBOSITY_USER_DETAIL,
         MPI_T_BIND_NO_OBJECT,
         MPIR_T_PVAR_FLAG_CONTINUOUS, /* flags */
@@ -314,7 +314,7 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    /* Register detroy hooks after netmod init so the netmod hooks get called
+    /* Register destroy hooks after netmod init so the netmod hooks get called
        before nemesis hooks. */
     mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(MPIDI_CH3I_comm_destroy, NULL);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt.c
@@ -508,7 +508,7 @@ static int do_cts(MPIDI_VC_t *vc, MPIR_Request *rreq, int *complete)
 
     MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"posted request found");
 
-    /* determine amount of data to be transfered and check for truncation */
+    /* determine amount of data to be transferred and check for truncation */
     MPIDI_Datatype_get_info(rreq->dev.user_count, rreq->dev.datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
     if (rreq->ch.lmt_data_sz > data_sz)
     {

--- a/src/mpid/ch3/channels/nemesis/subconfigure.m4
+++ b/src/mpid/ch3/channels/nemesis/subconfigure.m4
@@ -183,7 +183,7 @@ AC_CHECK_FUNCS(srand)
 #    AC_MSG_ERROR([cannot support shared memory:  need either sysv shared memory functions or mmap in order to support shared memory])
 #fi
 
-AC_ARG_ENABLE(nemesis-shm-collectives, [--enable-nemesis-shm-collectives - enables use of shared memory for collective comunication within a node],
+AC_ARG_ENABLE(nemesis-shm-collectives, [--enable-nemesis-shm-collectives - enables use of shared memory for collective communication within a node],
     AC_DEFINE(ENABLED_SHM_COLLECTIVES, 1, [Define to enable shared-memory collectives]))
 
 

--- a/src/mpid/ch3/channels/sock/include/mpidu_sock.h
+++ b/src/mpid/ch3/channels/sock/include/mpidu_sock.h
@@ -243,7 +243,7 @@ Notes:
 This function only closes the first open socket of a sock_set and returns the
 user pointer of the sock-info structure. To close all sockets, the function must
 be called repeatedly, untiluser_ptr == NULL. The reason for this is
-that the overlying protocoll may need the user_ptr for further cleanup.
+that the overlying protocol may need the user_ptr for further cleanup.
 
 @*/
 int MPIDI_CH3I_Sock_close_open_sockets(struct MPIDI_CH3I_Sock_set *sock_set, void **user_ptr);
@@ -510,7 +510,7 @@ If any other operations are posted on the specified sock, they will be terminate
 terminated operation.  All such events will be delivered by MPIDI_CH3I_Sock_wait() prior to the delivery of the MPIDI_CH3I_SOCK_OP_CLOSE
 event.
 
-The sock object is destroyed just prior to the MPIDI_CH3I_SOCK_OP_CLOSE event being returned by MPIDI_CH3I_Sock_wait().  Any oustanding
+The sock object is destroyed just prior to the MPIDI_CH3I_SOCK_OP_CLOSE event being returned by MPIDI_CH3I_Sock_wait().  Any outstanding
 references to the sock object held by the application should be considered invalid and not used again.
 
 Thread safety:
@@ -841,7 +841,7 @@ MPIDI_CH3I_Sock_wakeup() may not be called from within a progress update functio
 progress update function.
 
 The implementation should strive to only wakeup a MPIDI_CH3I_Sock_wait() that is already blocking; however, it is acceptable (although
-undesireable) for it wakeup a MPIDI_CH3I_Sock_wait() that is called in the future.
+undesirable) for it wakeup a MPIDI_CH3I_Sock_wait() that is called in the future.
 
 Module:
 Utility-Sock

--- a/src/mpid/ch3/channels/sock/src/ch3_isendv.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_isendv.c
@@ -61,8 +61,8 @@ int MPIDI_CH3_iSendv(MPIDI_VC_t * vc, MPIR_Request * sreq, struct iovec * iov, i
              * channel, thus insuring that the progress engine does
              * also try to write */
 
-            /* FIXME: the current code only agressively writes the first IOV.
-             * Eventually it should be changed to agressively write
+            /* FIXME: the current code only aggressively writes the first IOV.
+             * Eventually it should be changed to aggressively write
              * as much as possible.  Ideally, the code would be shared between
              * the send routines and the progress engine. */
             rc = MPIDI_CH3I_Sock_writev(vcch->sock, iov, n_iov, &nb);

--- a/src/mpid/ch3/channels/sock/src/ch3_istartmsg.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_istartmsg.c
@@ -35,7 +35,7 @@ static MPIR_Request *create_request(void *hdr, intptr_t hdr_sz, size_t nb)
  * entire message is successfully sent, then NULL is
  * returned.  Otherwise a request is allocated, the header is copied into the
  * request, and a pointer to the request is returned.
- * An error condition also results in a request be allocated and the errror
+ * An error condition also results in a request be allocated and the error
  * being returned in the status field of the request.
  */
 int MPIDI_CH3_iStartMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, MPIR_Request ** sreq_ptr)

--- a/src/mpid/ch3/channels/sock/src/ch3_istartmsgv.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_istartmsgv.c
@@ -45,7 +45,7 @@ static MPIR_Request *create_request(struct iovec * iov, int iov_count, int iov_o
  * pointed to by the iovec (which is assumed to be a
  * MPIDI_CH3_Pkt_t) are copied into the request, and a pointer to the request
  * is returned.  An error condition also results in a
- * request be allocated and the errror being returned in the status field of
+ * request be allocated and the error being returned in the status field of
  * the request.
  */
 
@@ -56,7 +56,7 @@ static MPIR_Request *create_request(struct iovec * iov, int iov_count, int iov_o
    seems like a flaw in the CH3 API. */
 
 /* NOTE - The completion action associated with a request created by
-   CH3_iStartMsgv() is alway MPIDI_CH3_CA_COMPLETE.  This
+   CH3_iStartMsgv() is always MPIDI_CH3_CA_COMPLETE.  This
    implies that CH3_iStartMsgv() can only be used when the entire message can
    be described by a single iovec of size
    MPL_IOV_LIMIT. */

--- a/src/mpid/ch3/channels/sock/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_progress.c
@@ -373,7 +373,7 @@ static int MPIDI_CH3I_Progress_handle_sock_event(MPIDI_CH3I_Sock_event_t * event
                 MPIDI_CH3I_Connection_t *conn = (MPIDI_CH3I_Connection_t *) event->user_ptr;
                 /* If we have a READ event on a discarded connection, we probably have
                  * an error on this connection, if the remote side is closed due to
-                 * MPI_Finalize. Since the connection is discareded (and therefore not needed)
+                 * MPI_Finalize. Since the connection is discarded (and therefore not needed)
                  * it can be closed and the error can be ignored */
                 if (conn->state == CONN_STATE_DISCARD) {
                     MPIDI_CH3_Sockconn_handle_close_event(conn);

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -3241,7 +3241,7 @@ int MPIDI_CH3I_Sock_wait(struct MPIDI_CH3I_Sock_set *sock_set, int millisecond_t
                                  pollfds_active_elems, millisecond_timeout);
                     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_POLL);
 
-                    /* Reaquire the lock before processing any of the
+                    /* Reacquire the lock before processing any of the
                      * information returned from poll */
                     MPL_DBG_MSG(MPIR_DBG_OTHER, TYPICAL,
                                 "Enter global critical section (sock_wait)");

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -775,7 +775,7 @@ static int MPIDI_CH3I_Socki_sock_alloc(struct MPIDI_CH3I_Sock_set *sock_set,
 
     /*
      * No free elements were found.  Larger pollfd and pollinfo arrays need to
-     * be allocated and the existing data transfered over.
+     * be allocated and the existing data transferred over.
      */
     if (avail_elem == sock_set->poll_array_sz) {
         int elem;
@@ -3179,7 +3179,7 @@ int MPIDI_CH3I_Sock_wait(struct MPIDI_CH3I_Sock_set *sock_set, int millisecond_t
              *
              * FIXME: If the attempt to set the socket back to blocking fails,
              * we presently ignore it.  Should we return an
-             * error?  We need to define acceptible data loss at close time.
+             * error?  We need to define acceptable data loss at close time.
              * MS Windows has worse problems with this, so it
              * may not be possible to make any guarantees.
              */

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -13,7 +13,7 @@
 /*                    auxiliary functions                      */
 /* =========================================================== */
 
-/* immed_copy() copys data from origin buffer to
+/* immed_copy() copies data from origin buffer to
    IMMED packet header. */
 static inline int immed_copy(void *src, void *dest, size_t len)
 {

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -92,8 +92,8 @@ typedef struct MPIDI_PG
        find a particular process group. */
     void * id;
 
-    /* Flag to mark a procress group which is finalizing. This means thay
-       the VCs for this process group are closing, (normally becuase
+    /* Flag to mark a procress group which is finalizing. This means they
+       the VCs for this process group are closing, (normally because
        MPI_Finalize was called). This is required to avoid a reconnection
        of the VCs when the PG is closed due to unused elements in the event
        queue  */
@@ -391,7 +391,7 @@ extern MPIDI_Process_t MPIDI_Process;
 /* Note: In the current implementation, the mpid_xsend.c routines that
    make use of MPIDI_VC_FAI_send_seqnum are all protected by the 
    SINGLE_CS_ENTER/EXIT macros, so all uses of this macro are 
-   alreay within a critical section when needed.  If/when we move to
+   already within a critical section when needed.  If/when we move to
    a finer-grain model, we'll need to examine whether this requires
    a separate lock. */
 #if defined(MPID_USE_SEQUENCE_NUMBERS)
@@ -679,7 +679,7 @@ typedef struct MPIDI_VC
     MPIDI_CH3_Pkt_send_container_t * msg_reorder_queue;
 #endif
 
-    /* rendezvous function pointers.  Called to send a rendevous
+    /* rendezvous function pointers.  Called to send a rendezvous
        message or when one is matched */
     int (* rndvSend_fn)( struct MPIR_Request **sreq_p, const void * buf, MPI_Aint count,
                          MPI_Datatype datatype, int dt_contig, intptr_t data_sz,
@@ -1186,7 +1186,7 @@ int MPIDI_CH3I_Get_accumulate(const void *origin_addr, int origin_count,
     void MPIDI_CH3I_Progress_wakeup(void);
     /* MT TODO profiling is needed here.  We currently protect the completion
      * counter with the COMPLETION critical section, which could be a source of
-     * contention.  It should be possible to peform these updates atomically via
+     * contention.  It should be possible to perform these updates atomically via
      * OPA instead, but the additional complexity should be justified by
      * profiling evidence.  [goodell@ 2010-06-29] */
 #   define MPIDI_CH3_Progress_signal_completion()			\
@@ -1238,7 +1238,7 @@ int MPID_PG_BCast( MPIR_Comm *peercomm_p, MPIR_Comm *comm_p, int root );
 + vc - virtual connection to send the message over
 . pkt - pointer to a MPIDI_CH3_Pkt_t structure containing the substructure to 
   be sent
-- pkt_sz - size of the packet substucture
+- pkt_sz - size of the packet substructure
 
   Output Parameters:
 . sreq_ptr - send request or NULL if the send completed immediately
@@ -1305,7 +1305,7 @@ int MPIDI_CH3_iStartMsgv(MPIDI_VC_t * vc, struct iovec * iov, int iov_n,
 . sreq - pointer to the send request object
 . pkt - pointer to a MPIDI_CH3_Pkt_t structure containing the substructure to 
   be sent
-- pkt_sz - size of the packet substucture
+- pkt_sz - size of the packet substructure
 
   Return value:
   An mpi error code.
@@ -1452,7 +1452,7 @@ int MPIDI_CH3_GetParentPort(char ** parent_port_name);
 
 /*@
    MPIDI_CH3_FreeParentPort - This routine frees the storage associated with
-   a parent port (allocted with MPIDH_CH3_GetParentPort).
+   a parent port (allocated with MPIDH_CH3_GetParentPort).
 
   @*/
 void MPIDI_CH3_FreeParentPort( void );

--- a/src/mpid/ch3/include/mpidpkt.h
+++ b/src/mpid/ch3/include/mpidpkt.h
@@ -654,10 +654,10 @@ typedef struct MPIDI_CH3_Pkt_get {
 typedef struct MPIDI_CH3_Pkt_get_resp {
     MPIDI_CH3_Pkt_type_t type;
     MPI_Request request_handle;
-    /* followings are used to decrement ack_counter at origin */
+    /* following are used to decrement ack_counter at origin */
     int target_rank;
     int pkt_flags;
-    /* Followings are to piggyback IMMED data */
+    /* Following are to piggyback IMMED data */
     struct {
         /* note that we use struct here in order
          * to consistently access data
@@ -699,10 +699,10 @@ typedef struct MPIDI_CH3_Pkt_get_accum {
 typedef struct MPIDI_CH3_Pkt_get_accum_resp {
     MPIDI_CH3_Pkt_type_t type;
     MPI_Request request_handle;
-    /* followings are used to decrement ack_counter at origin */
+    /* following are used to decrement ack_counter at origin */
     int target_rank;
     int pkt_flags;
-    /* Followings are to piggyback IMMED data */
+    /* Following are to piggyback IMMED data */
     struct {
         /* note that we use struct here in order
          * to consistently access data
@@ -731,7 +731,7 @@ typedef struct MPIDI_CH3_Pkt_cas_resp {
          * by "pkt->info.data". */
         MPIDI_CH3_CAS_Immed_u data;
     } info;
-    /* followings are used to decrement ack_counter at orign */
+    /* following are used to decrement ack_counter at origin */
     int target_rank;
     int pkt_flags;
 } MPIDI_CH3_Pkt_cas_resp_t;
@@ -761,7 +761,7 @@ typedef struct MPIDI_CH3_Pkt_fop_resp {
          * by "pkt->info.data". */
         MPIDI_CH3_RMA_Immed_u data;
     } info;
-    /* followings are used to decrement ack_counter at orign */
+    /* following are used to decrement ack_counter at origin */
     int target_rank;
     int pkt_flags;
 } MPIDI_CH3_Pkt_fop_resp_t;

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -219,7 +219,7 @@ MPIDI_CH3I_comm_t;
  * the last op piggybacked with a FLUSH flag to
  * detect remote completion;
  * (4) UNLOCK means origin issues all pending operations
- * incuding the last op piggybacked with an UNLOCK
+ * including the last op piggybacked with an UNLOCK
  * flag to release the lock on target and detect remote
  * completion.
  * Note that FLUSH_LOCAL is a superset of NONE, FLUSH
@@ -727,7 +727,7 @@ int MPID_Win_sync(MPIR_Win *win);
 
 void MPID_Progress_start(MPID_Progress_state * state);
 int MPID_Progress_wait(MPID_Progress_state * state);
-void MPID_Progress_end(MPID_Progress_state * stae);
+void MPID_Progress_end(MPID_Progress_state * state);
 int MPID_Progress_poke(void);
 
 int MPID_Get_processor_name( char *name, int namelen, int *resultlen);

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -181,8 +181,8 @@ typedef struct MPIDI_CH3I_comm
                              * disconnected as a part of
                              * MPI_COMM_DISCONNECT; FALSE otherwise. */
 
-    struct MPIDI_VCRT *vcrt;          /* virtual connecton reference table */
-    struct MPIDI_VCRT *local_vcrt;    /* local virtual connecton reference table */
+    struct MPIDI_VCRT *vcrt;          /* virtual connection reference table */
+    struct MPIDI_VCRT *local_vcrt;    /* local virtual connection reference table */
 
     struct MPIR_Comm *next; /* next pointer for list of communicators */
     struct MPIR_Comm *prev; /* prev pointer for list of communicators */

--- a/src/mpid/ch3/src/ch3u_eager.c
+++ b/src/mpid/ch3/src/ch3u_eager.c
@@ -53,7 +53,7 @@ int MPIDI_CH3_SendNoncontig_iov( MPIDI_VC_t *vc, MPIR_Request *sreq,
     {
 	iov_n += iovcnt;  /* add count of hdr iovs */
 	
-	/* Note this routine is invoked withing a CH3 critical section */
+	/* Note this routine is invoked within a CH3 critical section */
 	/* MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex); */
 	mpi_errno = MPIDI_CH3_iSendv(vc, sreq, iov, iov_n);
 	/* MPID_THREAD_CS_EXIT(POBJ, vc->pobj_mutex); */

--- a/src/mpid/ch3/src/ch3u_handle_recv_pkt.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_pkt.c
@@ -11,7 +11,7 @@
  * This file contains the dispatch routine called by the ch3 progress 
  * engine to process messages.  
  *
- * This file is in transistion
+ * This file is in transition
  *
  * Where possible, the routines that create and send all packets of
  * a particular type are in the same file that contains the implementation 
@@ -427,7 +427,7 @@ int MPIDI_CH3I_Try_acquire_win_lock(MPIR_Win *win_ptr, int requested_lock)
 /* ------------------------------------------------------------------------ */
 /* Here are the functions that implement the packet actions.  They'll be moved
  * to more modular places where it will be easier to replace subsets of the
- * in order to experiement with alternative data transfer methods, such as
+ * in order to experiment with alternative data transfer methods, such as
  * sending some data with a rendezvous request or including data within
  * an eager message.                                                        
  *

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -85,8 +85,8 @@ static int MPIDI_CH3I_Port_connreq_free(MPIDI_CH3I_Port_connreq_t * connreq);
 /*
  * Structure of this file and the connect/accept algorithm:
  *
- * Here are the steps involved in implementating MPI_Comm_connect and
- * MPI_Comm_accept.  These same steps are used withing MPI_Comm_spawn
+ * Here are the steps involved in implementing MPI_Comm_connect and
+ * MPI_Comm_accept.  These same steps are used within MPI_Comm_spawn
  * and MPI_Comm_spawn_multiple.
  *
  * First, the connecting process establishes a connection (not a virtual
@@ -512,7 +512,7 @@ static int MPIDI_CH3I_Initialize_tmp_comm(MPIR_Comm **comm_pptr,
     tmp_comm->recvcontext_id = tmp_comm->context_id;
 
     /* sanity: the INVALID context ID value could potentially conflict with the
-     * dynamic proccess space */
+     * dynamic process space */
     MPIR_Assert(tmp_comm->context_id     != MPIR_INVALID_CONTEXT_ID);
     MPIR_Assert(tmp_comm->recvcontext_id != MPIR_INVALID_CONTEXT_ID);
 

--- a/src/mpid/ch3/src/ch3u_request.c
+++ b/src/mpid/ch3/src/ch3u_request.c
@@ -286,7 +286,7 @@ int MPIDI_CH3U_Request_load_recv_iov(MPIR_Request * const rreq)
 	/* --BEGIN ERROR HANDLING-- */
 	if (rreq->dev.iov_count == 0)
 	{
-	    /* If the data can't be unpacked, the we have a mis-match between
+	    /* If the data can't be unpacked, the we have a mismatch between
 	       the datatype and the amount of data received.  Adjust
 	       the segment info so that the remaining data is received and 
 	       thrown away. */

--- a/src/mpid/ch3/src/ch3u_rma_pkthandler.c
+++ b/src/mpid/ch3/src/ch3u_rma_pkthandler.c
@@ -845,7 +845,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
          * operation are completed when counter reaches zero. */
         win_ptr->at_completion_counter++;
 
-        /* Calculate the length of reponse data, ensure that it fits into immed packet. */
+        /* Calculate the length of response data, ensure that it fits into immed packet. */
         MPIR_Datatype_get_size_macro(get_accum_pkt->datatype, type_size);
         MPIR_Assign_trunc(len, get_accum_pkt->count * type_size, size_t);
 
@@ -1566,7 +1566,7 @@ int MPIDI_CH3_PktHandler_Get_AccumResp(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
         MPIR_Datatype_get_size_macro(basic_type, basic_type_size);
 
         /* Note: here we get the stream_offset from the extended packet header
-         * in the response request, which is set in issue_get_acc_op() funcion.
+         * in the response request, which is set in issue_get_acc_op() function.
          * Note that this extended packet header only contains stream_offset and
          * does not contain datatype info, so here we pass 0 to is_derived_dt
          * flag. */

--- a/src/mpid/ch3/src/ch3u_rma_progress.c
+++ b/src/mpid/ch3/src/ch3u_rma_progress.c
@@ -37,7 +37,7 @@ cvars:
       scope       : MPI_T_SCOPE_ALL_EQ
       description : >-
         Threshold at which the RMA implementation attempts to complete requests
-        while completing RMA operations and while using the lazy synchonization
+        while completing RMA operations and while using the lazy synchronization
         approach.  Change this value if programs fail because they run out of
         requests or other internal resources
 

--- a/src/mpid/ch3/src/ch3u_rma_sync.c
+++ b/src/mpid/ch3/src/ch3u_rma_sync.c
@@ -103,7 +103,7 @@
        following SHM operations will happen after PROC_SYNC and will see the
        latest data on target processes.
 
-       In WIN_COMPLETE, the MEM_SYNC before PROC_SYNC essentailly exposes previous
+       In WIN_COMPLETE, the MEM_SYNC before PROC_SYNC essentially exposes previous
        SHM operations to group of target processes; after PROC_SYNC, target
        processes knows all origin process already exposed their SHM operations;
        in WIN_WAIT/TEST, the MEM_SYNC after PROC_SYNC ensures that following local
@@ -249,7 +249,7 @@ cvars:
         case, the origin process still tries to piggyback LOCK message
         with the first operation; for UNLOCK/FLUSH message, the origin
         process no longer keeps the current last operation but only
-        piggyback UNLOCK/FLUSH if there is an operation avaliable in
+        piggyback UNLOCK/FLUSH if there is an operation available in
         the ending synchronization call.
 
 === END_MPI_T_CVAR_INFO_BLOCK ===

--- a/src/mpid/ch3/src/mpid_cancel_send.c
+++ b/src/mpid/ch3/src/mpid_cancel_send.c
@@ -110,7 +110,7 @@ int MPID_Cancel_send(MPIR_Request * sreq)
                conflict with release of the RTS request if the CTS is received
 	       (see handling of a rendezvous CTS packet in
                MPIDI_CH3U_Handle_recv_pkt()).  
-	       MPID_Request_fetch_and_clear_rts_sreq() is used to gurantee 
+	       MPID_Request_fetch_and_clear_rts_sreq() is used to guarantee 
 	       that atomicity. */
 	    MPIDI_Request_fetch_and_clear_rts_sreq(sreq, &rts_sreq);
 	    if (rts_sreq != NULL) 

--- a/src/mpid/ch3/src/mpid_comm_failure_ack.c
+++ b/src/mpid/ch3/src/mpid_comm_failure_ack.c
@@ -51,7 +51,7 @@ int MPID_Comm_failure_get_acked(MPIR_Comm *comm_ptr, MPIR_Group **group_ptr)
 
     MPIR_Comm_group_impl(comm_ptr, &comm_group);
 
-    /* Get the intersection of all falied processes in this communicator */
+    /* Get the intersection of all failed processes in this communicator */
     MPIR_Group_intersection_impl(failed_group, comm_group, group_ptr);
 
     MPIR_Group_release(comm_group);

--- a/src/mpid/ch3/src/mpid_getpname.c
+++ b/src/mpid/ch3/src/mpid_getpname.c
@@ -44,7 +44,7 @@ int MPID_Get_processor_name(char * name, int namelen, int * resultlen)
 /* Here we define an internal routine to get the processor name, based on 
    which system or facilities are available to us */
 
-/* Additional and alternative implmentations of these routines may be
+/* Additional and alternative implementations of these routines may be
    found in mpich/mpid/ch2/chnodename.c */
 
 /* If we are using sysinfo, we need to make sure that both the 

--- a/src/mpid/ch3/src/mpid_imrecv.c
+++ b/src/mpid/ch3/src/mpid_imrecv.c
@@ -89,7 +89,7 @@ int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
             /* there should never be outstanding completion events for an unexpected
              * recv without also having a "pending recv" */
             MPIR_Assert(recv_pending);
-            /* The data is still being transfered across the net.  We'll
+            /* The data is still being transferred across the net.  We'll
                leave it to the progress engine to handle once the
                entire message has arrived. */
             if (!HANDLE_IS_BUILTIN(datatype))

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -397,7 +397,7 @@ static int init_pg(int *has_parent, int *pg_rank_p, MPIDI_PG_t **pg_p)
        return errors if the routines are in fact used */
     if (usePMI) {
 	/*
-	 * Initialize the process manangement interface (PMI), 
+	 * Initialize the process management interface (PMI), 
 	 * and get rank and size information about our process group
 	 */
 
@@ -409,7 +409,7 @@ static int init_pg(int *has_parent, int *pg_rank_p, MPIDI_PG_t **pg_p)
         pg_size = MPIR_Process.size;
         appnum = MPIR_Process.appnum;
 
-	/* Note that if pmi is not availble, the value of MPI_APPNUM is 
+	/* Note that if pmi is not available, the value of MPI_APPNUM is 
 	   not set */
 	if (appnum != -1) {
 	    MPIR_Process.attrs.appnum = appnum;
@@ -489,7 +489,7 @@ int MPIDI_CH3I_BCInit( char **bc_val_p, int *val_max_sz_p )
                              "**pmi_kvs_get_value_length_max %d", pmi_errno);
     }
 #endif
-    /* This memroy is returned by this routine */
+    /* This memory is returned by this routine */
     *bc_val_p = MPL_malloc(*val_max_sz_p, MPL_MEM_ADDRESS);
     if (*bc_val_p == NULL) {
 	MPIR_ERR_SETANDJUMP1(mpi_errno,MPI_ERR_OTHER, "**nomem","**nomem %d",

--- a/src/mpid/ch3/src/mpid_irecv.c
+++ b/src/mpid/ch3/src/mpid_irecv.c
@@ -42,7 +42,7 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
     {
 	MPIDI_VC_t * vc;
 	
-	/* Message was found in the unexepected queue */
+	/* Message was found in the unexpected queue */
 	MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"request found in unexpected queue");
 
 	/* Release the message queue - we've removed this request from 
@@ -90,7 +90,7 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
                 /* there should never be outstanding completion events for an unexpected
                  * recv without also having a "pending recv" */
                 MPIR_Assert(recv_pending);
-		/* The data is still being transfered across the net.  We'll 
+		/* The data is still being transferred across the net.  We'll 
 		   leave it to the progress engine to handle once the
 		   entire message has arrived. */
 		if (!HANDLE_IS_BUILTIN(datatype))

--- a/src/mpid/ch3/src/mpid_mprobe.c
+++ b/src/mpid/ch3/src/mpid_mprobe.c
@@ -24,7 +24,7 @@ int MPID_Mprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
     if (MPIDI_Anysource_improbe_fn) {
         if (source == MPI_ANY_SOURCE) {
             /* if it's anysource, loop while checking the shm recv
-               queue and improbing the netmod, then do a progress
+               queue and improving the netmod, then do a progress
                test to make some progress. */
             do {
                 MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_MSGQ_MUTEX);

--- a/src/mpid/ch3/src/mpid_recv.c
+++ b/src/mpid/ch3/src/mpid_recv.c
@@ -47,7 +47,7 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
     {
 	MPIDI_VC_t * vc;
 
-	/* Message was found in the unexepected queue */
+	/* Message was found in the unexpected queue */
 	MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"request found in unexpected queue");
 
 	/* Release the message queue - we've removed this request from 
@@ -102,7 +102,7 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
                  * recv without also having a "pending recv" */
                 MPIR_Assert(recv_pending);
 
-		/* The data is still being transfered across the net.  
+		/* The data is still being transferred across the net.  
 		   We'll leave it to the progress engine to handle once the
 		   entire message has arrived. */
 		if (!HANDLE_IS_BUILTIN(datatype))

--- a/src/mpid/ch3/src/mpid_rma.c
+++ b/src/mpid/ch3/src/mpid_rma.c
@@ -32,7 +32,7 @@ cvars:
       description : >-
         Size (in bytes) of available lock data this window can provided. If
         current buffered lock data is more than this value, the process will
-        drop the upcoming operation data. Requires a positive calue.
+        drop the upcoming operation data. Requires a positive value.
 
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */

--- a/src/mpid/ch3/src/mpid_ssend.c
+++ b/src/mpid/ch3/src/mpid_ssend.c
@@ -99,7 +99,7 @@ int MPID_Ssend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
 	mpi_errno = vc->rndvSend_fn( &sreq, buf, count, datatype, dt_contig,
                                      data_sz, dt_true_lb, rank, tag, comm, 
                                      context_offset );
-	/* Note that we don't increase the ref cound on the datatype
+	/* Note that we don't increase the ref count on the datatype
 	   because this is a blocking call, and the calling routine 
 	   must wait until sreq completes */
     }

--- a/src/mpid/ch3/src/mpid_startall.c
+++ b/src/mpid/ch3/src/mpid_startall.c
@@ -264,7 +264,7 @@ int MPID_Bsend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 }
 
 /* 
- * FIXME: The ch3 implmentation of the persistent routines should
+ * FIXME: The ch3 implementation of the persistent routines should
  * be very simple and use common code as much as possible.  All
  * persistent routine should be in the same file, along with 
  * startall.  Consider using function pointers to specify the 

--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -583,7 +583,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
-        /* Extract the context and group sign informatin */
+        /* Extract the context and group sign information */
         *is_low_group     = comm_info[1];
     }
 

--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -36,7 +36,7 @@ cvars:
 
 /* What is the arrangement of VCRT and VCR and VC? 
    
-   Each VC (the virtual connection itself) is refered to by a reference 
+   Each VC (the virtual connection itself) is referred to by a reference 
    (pointer) or VCR.  
    Each communicator has a VCRT, which is nothing more than a 
    structure containing a count (size) and an array of pointers to 
@@ -87,7 +87,7 @@ int MPIDI_VCRT_Create(int size, struct MPIDI_VCRT **vcrt_ptr)
   This is called when a communicator duplicates its group of processes.
   It is used in 'commutil.c' and in routines to create communicators from
   dynamic process operations.  It does not change the state of any of the
-  virtural connections (VCs).
+  virtual connections (VCs).
   @*/
 int MPIDI_VCRT_Add_ref(struct MPIDI_VCRT *vcrt)
 {
@@ -212,7 +212,7 @@ int MPIDI_VCRT_Release(struct MPIDI_VCRT *vcrt, int isDisconnect )
   Notes:
   If the VC is being used for the first time in a VC reference
   table, the reference count is set to two, not one, in order to
-  distinquish between freeing a communicator with 'MPI_Comm_free' and
+  distinguish between freeing a communicator with 'MPI_Comm_free' and
   'MPI_Comm_disconnect', and the reference count on the process group
   is incremented (to indicate that the process group is in use).
   While this has no effect on the process group of 'MPI_COMM_WORLD',
@@ -541,7 +541,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
         }
 #       endif /* HAVE_ERROR_CHECKING */
 
-        /* Make an arbitrary decision about which group of processs is
+        /* Make an arbitrary decision about which group of process is
            the low group.  The LEADERS do this by comparing the
            local process ids of the 0th member of the two groups */
         (*is_low_group) = local_lpids[0] < (*remote_lpids)[0];

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -1046,7 +1046,7 @@ int MPIDI_PG_Dup_vcr( MPIDI_PG_t *pg, int rank, MPIDI_VC_t **vc_p )
     /* Increase the reference count of the vc.  If the reference count 
        increases from 0 to 1, increase the reference count of the 
        process group *and* the reference count of the vc (this
-       allows us to distinquish between Comm_free and Comm_disconnect) */
+       allows us to distinguish between Comm_free and Comm_disconnect) */
     /* FIXME-MT: This should be a fetch and increment for thread-safety */
     if (MPIR_Object_get_ref(vc) == 0) {
 	MPIDI_PG_add_ref(pg);

--- a/src/mpid/ch3/src/mpidi_rma.c
+++ b/src/mpid/ch3/src/mpidi_rma.c
@@ -36,7 +36,7 @@ cvars:
       description : >-
         Size of the Global RMA operations pool (in number of
         operations) that stores information about RMA operations that
-        could not be issued immediatly.  Requires a positive value.
+        could not be issued immediately.  Requires a positive value.
 
     - name        : MPIR_CVAR_CH3_RMA_TARGET_WIN_POOL_SIZE
       category    : CH3
@@ -60,7 +60,7 @@ cvars:
       description : >-
         Size of the Global RMA targets pool (in number of
         targets) that stores information about RMA targets that
-        could not be issued immediatly.  Requires a positive value.
+        could not be issued immediately.  Requires a positive value.
 
     - name        : MPIR_CVAR_CH3_RMA_TARGET_LOCK_ENTRY_WIN_POOL_SIZE
       category    : CH3
@@ -72,7 +72,7 @@ cvars:
       description : >-
         Size of the window-private RMA lock entries pool (in number of
         lock entries) that stores information about RMA lock requests that
-        could not be satisfied immediatly.  Requires a positive value.
+        could not be satisfied immediately.  Requires a positive value.
 
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
@@ -150,7 +150,7 @@ int MPID_Win_free(MPIR_Win ** win_ptr)
      * because for some UNLOCK messages, we do not send ACK back to origin,
      * we must wait until lock is released so that we can free window.
      * 2. We also need to wait until AT completion counter being zero, because
-     * this counter is increment everytime we meet a GET-like operation, it is
+     * this counter is increment every time we meet a GET-like operation, it is
      * possible that when target entering Win_free, passive epoch is not finished
      * yet and there are still GETs doing on this target.
      * 3. We also need to wait until lock queue becomes empty. It is possible

--- a/src/mpid/ch3/util/sock/ch3u_connect_sock.c
+++ b/src/mpid/ch3/util/sock/ch3u_connect_sock.c
@@ -759,7 +759,7 @@ int MPIDI_CH3_Sockconn_handle_conn_event( MPIDI_CH3I_Connection_t * conn )
             /* Neither freed nor updated. This connection is the looser of
                a head-to-head connection. The VC is still in use, but by
                another sochekt connection. The refcount is not incremented
-               By chaning the associated connection. */
+               By changing the associated connection. */
 	    /* MPIR_Assert( conn->vc->ch.conn != conn ); */
 	    /* Set the candidate vc for this connection to NULL (we
 	       are discarding this connection because (I think) we

--- a/src/mpid/ch3/util/sock/ch3u_connect_sock.c
+++ b/src/mpid/ch3/util/sock/ch3u_connect_sock.c
@@ -233,7 +233,7 @@ int MPIDI_CH3I_Connect_to_root_sock(const char * port_name,
     mpi_errno = MPIDI_CH3I_Connection_alloc(&conn);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* conn->pg_id is not used for this conection */
+    /* conn->pg_id is not used for this connection */
 
     /* FIXME: To avoid this global (MPIDI_CH3I_sock_set) which is 
        used only in ch3_progress.c and ch3_progress_connect.c in the channels,
@@ -415,7 +415,7 @@ int MPIDI_CH3U_Get_business_card_sock(int myRank,
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**buscard");
     }
 
-    /* Look up the interface address cooresponding to this host description */
+    /* Look up the interface address corresponding to this host description */
     /* FIXME: We should start switching to getaddrinfo instead of 
        gethostbyname */
     /* FIXME: We don't make use of the ifname in Windows in order to 
@@ -631,7 +631,7 @@ int MPIDI_CH3_Sockconn_handle_close_event( MPIDI_CH3I_Connection_t * conn )
             conn->vc = NULL;
 	}
         else if(conn->state == CONN_STATE_DISCARD) {
-        /* post close, so the socket is closed and memmory leaks are avoided */
+        /* post close, so the socket is closed and memory leaks are avoided */
             MPL_DBG_MSG(MPIDI_CH3_DBG_DISCONNECT,TYPICAL,"CLosing sock (Post_close)");
             conn->state = CONN_STATE_CLOSING;
             mpi_errno = MPIDI_CH3I_Sock_post_close(conn->sock);
@@ -759,7 +759,7 @@ int MPIDI_CH3_Sockconn_handle_conn_event( MPIDI_CH3I_Connection_t * conn )
             /* Neither freed nor updated. This connection is the looser of
                a head-to-head connection. The VC is still in use, but by
                another sochekt connection. The refcount is not incremented
-               By chaning the assosiated connection. */
+               By chaning the associated connection. */
 	    /* MPIR_Assert( conn->vc->ch.conn != conn ); */
 	    /* Set the candidate vc for this connection to NULL (we
 	       are discarding this connection because (I think) we

--- a/src/mpid/ch3/util/sock/errnames.txt
+++ b/src/mpid/ch3/util/sock/errnames.txt
@@ -6,11 +6,11 @@
 **ch3|sock|connrefused:[ch3:sock] connection refused
 **ch3|sock|connrefused %s %d %s:[ch3:sock] failed to connect to process %s:%d (%s)
 **ch3|sock|connterm:[ch3:sock] active connection unexpectedly terminated
-**ch3|sock|connfailed:[ch3:sock] failed to connnect to remote process
+**ch3|sock|connfailed:[ch3:sock] failed to connect to remote process
 **ch3|sock|badsock:[ch3:sock] internal error - bad sock
 **ch3|sock|failure:[ch3:sock] unknown failure
 **ch3|sock|failure %d:[ch3:sock] unknown failure, sock_errno=%d
-**ch3|sock|badpacket:[ch3:sock] received packet of unknow type
+**ch3|sock|badpacket:[ch3:sock] received packet of unknown type
 **ch3|sock|badpacket %d:[ch3:sock] received packet of unknown type (%d)
 **ch3|sock|postread:attempt to post a read operation failed
 **ch3|sock|immedread:immediate read operation failed

--- a/src/mpid/ch3/util/unordered/unordered.c
+++ b/src/mpid/ch3/util/unordered/unordered.c
@@ -105,7 +105,7 @@ int MPIDI_CH3U_Handle_unordered_recv_pkt(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t * pkt,
 		while (pc_cur != NULL)
 		{
 		    /* the current recv seqnum is subtracted from both the 
-		       seqnums prior to comparision so as to remove any wrap
+		       seqnums prior to comparison so as to remove any wrap
 		       around effects. */
 		    if (pc_new->pkt.seqnum - vc->seqnum_recv < 
 			pc_cur->pkt.seqnum - vc->seqnum_recv)

--- a/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
@@ -20,7 +20,7 @@
 #define MPIDIG_PART_REQ_CTS 2   /* Indicating receiver is ready to receive data
                                  * (requests matched and start called) */
 
-/* Status to inactivate at request completion */
+/* Status to deactivate at request completion */
 #define MPIDIG_PART_SREQ_INACTIVE 0     /* Sender need 2 increments to be CTS: start and remote start */
 #define MPIDIG_PART_RREQ_INACTIVE 1     /* Receiver need 1 increments to be CTS: start */
 

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -82,7 +82,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexpected(void *buf, MPI_Aint count,
          */
         if (nbytes > 0) {
             char *addr = (char *) buf + dt_true_lb;
-            assert(addr);       /* to supress gcc-8 warning: -Wnonnull */
+            assert(addr);       /* to suppress gcc-8 warning: -Wnonnull */
             MPIR_Typerep_copy(addr, MPIDIG_REQUEST(rreq, buffer), nbytes);
         }
     }
@@ -101,7 +101,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexpected(void *buf, MPI_Aint count,
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    /* Decrement the refrence counter for the request object (for the reference held by the sending
+    /* Decrement the reference counter for the request object (for the reference held by the sending
      * process). */
     MPID_Request_complete(rreq);
   fn_exit:

--- a/src/mpid/ch4/include/mpid_thread.h
+++ b/src/mpid/ch4/include/mpid_thread.h
@@ -20,7 +20,7 @@ typedef MPIDU_Thread_mutex_t MPID_Thread_mutex_t;
 #define MPID_THREAD_CS_YIELD       MPIDU_THREAD_CS_YIELD
 #define MPID_THREAD_ASSERT_IN_CS   MPIDU_THREAD_ASSERT_IN_CS
 
-/* In limited cases we need use recusive mutex. For example, during establishing anysource
+/* In limited cases we need use recursive mutex. For example, during establishing anysource
  * receive, we need hold shm vci lock while setting up netmod request -- both may be the
  * same vci or different vci. Recursive locking allows us to proceed in both cases.
  * NOTE: use cautiously and comment on the reasoning of its usage.

--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -105,7 +105,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
  * MPIDI_OFI_SYNC_SEND                 The bit to indicate a sync send
  * MPIDI_OFI_SYNC_SEND_ACK             The bit to indicate a sync send ack
  * MPIDI_OFI_DYNPROC_SEND              The bit to indicate a dynamic process send
- * MPIDI_OFI_HUGE_SEND                 The bit to indicate a huge messge
+ * MPIDI_OFI_HUGE_SEND                 The bit to indicate a huge message
  * MPIDI_OFI_CONTEXT_STRUCTS           The number of fi_context structs needed for the provider
  */
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -93,7 +93,7 @@ cvars:
       scope       : MPI_T_SCOPE_LOCAL
       description : >-
         If true, enable virtual addressing for OFI memory regions. This variable is only meaningful
-        for OFI versions 1.5+. It is equivelent to using FI_MR_BASIC in versions of
+        for OFI versions 1.5+. It is equivalent to using FI_MR_BASIC in versions of
         OFI older than 1.5.
 
     - name        : MPIR_CVAR_CH4_OFI_ENABLE_MR_ALLOCATED
@@ -106,7 +106,7 @@ cvars:
       description : >-
         If true, require all OFI memory regions must be backed by physical memory pages
         at the time the registration call is made. This variable is only meaningful
-        for OFI versions 1.5+. It is equivelent to using FI_MR_BASIC in versions of
+        for OFI versions 1.5+. It is equivalent to using FI_MR_BASIC in versions of
         OFI older than 1.5.
 
     - name        : MPIR_CVAR_CH4_OFI_ENABLE_MR_PROV_KEY
@@ -118,7 +118,7 @@ cvars:
       scope       : MPI_T_SCOPE_LOCAL
       description : >-
         If true, enable provider supplied key for OFI memory regions. This variable is only
-        meaningful for OFI versions 1.5+. It is equivelent to using FI_MR_BASIC in versions of OFI
+        meaningful for OFI versions 1.5+. It is equivalent to using FI_MR_BASIC in versions of OFI
         older than 1.5.
 
     - name        : MPIR_CVAR_CH4_OFI_ENABLE_TAGGED
@@ -650,7 +650,7 @@ int MPIDI_OFI_init_local(int *tag_bits)
         num_vnis = MPIDI_OFI_MAX_VNIS;
     }
     /* for best performance, we ensure 1-to-1 vci/vni mapping. ref: MPIDI_OFI_vci_to_vni */
-    /* TODO: allow less num_vnis. Option 1. runtime MOD; 2. overide MPIDI_global.n_vcis */
+    /* TODO: allow less num_vnis. Option 1. runtime MOD; 2. override MPIDI_global.n_vcis */
     MPIR_Assert(num_vnis == MPIDI_global.n_vcis);
 
     /* Multiple vni without using domain require MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS */
@@ -692,7 +692,7 @@ int MPIDI_OFI_init_local(int *tag_bits)
                                               &MPIDI_OFI_global.pack_buf_pool);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* Initalize RMA keys allocator */
+    /* Initialize RMA keys allocator */
     MPIDI_OFI_mr_key_allocator_init();
 
     /* ------------------------------------------------- */
@@ -949,7 +949,7 @@ static int create_vni_context(int vni)
      * the same domain and av, and use a single scalable endpoint. Separate VNI
      * context will have its separate cq and separate tx and rx with the SEP.
      *
-     * To accomodate both configurations, each context structure will have all fields
+     * To accommodate both configurations, each context structure will have all fields
      * including domain, av, cq, ... For "VNI_USE_DOMAIN", they are not shared.
      * When not "VNI_USE_DOMAIN" or "VNI_USE_SEPCTX", domain, av, and ep are shared
      * with the root (or 0th) VNI context.
@@ -1176,7 +1176,7 @@ static int create_vni_domain(struct fid_domain **p_domain, struct fid_av **p_av,
         MPIDI_OFI_CALL(fi_av_open(domain, &av_attr, p_av, NULL), avopen);
     }
 
-    /* ---- other sharable objects ---- */
+    /* ---- other shareable objects ---- */
     struct fi_cntr_attr cntr_attr;
     memset(&cntr_attr, 0, sizeof(cntr_attr));
     cntr_attr.events = FI_CNTR_EVENTS_COMP;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -349,7 +349,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         mpi_errno = MPIDI_OFI_send_lightweight(send_buf, data_sz, cq_data, dst_rank, tag, comm,
                                                context_offset, addr, vni_src, vni_dst);
         if (actual_pack_bytes > 0) {
-            /* Free stage host buf (asigned to send_buf already) after
+            /* Free stage host buf (assigned to send_buf already) after
              * lightweight_send. */
             MPL_gpu_free_host(send_buf);
         }

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -398,7 +398,7 @@ typedef struct MPIDI_OFI_win_acc_hint {
     uint64_t dtypes_max_count[MPIR_DATATYPE_N_PREDEFINED];      /* translate CH4 which_accumulate_ops hints to
                                                                  * atomicity support of all OFI datatypes. A datatype
                                                                  * is supported only when all enabled ops are valid atomic
-                                                                 * provided by the OFI provider (recored in MPIDI_OFI_global.win_op_table).
+                                                                 * provided by the OFI provider (recorded in MPIDI_OFI_global.win_op_table).
                                                                  * Invalid <dtype, op> defined in MPI standard are excluded.
                                                                  * This structure is prepared at window creation time. */
 } MPIDI_OFI_win_acc_hint_t;
@@ -500,7 +500,7 @@ typedef struct MPIDI_OFI_huge_recv {
 } MPIDI_OFI_huge_recv_t;
 
 /* The list of posted huge receives that haven't been matched yet. These need
- * to get matched up when handling the control message that starts transfering
+ * to get matched up when handling the control message that starts transferring
  * data from the remote memory region and we need a way of matching up the
  * control messages with the "real" requests. */
 typedef struct MPIDI_OFI_huge_recv_list {

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -28,7 +28,7 @@ static void load_acc_hint(MPIR_Win * win)
 
     /* TODO: we assume all pes pass the same hint. Allreduce is needed to check
      * the maximal value or the spec must define it as same value on all pes.
-     * Now we assume the spec requries same value on all pes. */
+     * Now we assume the spec requires same value on all pes. */
 
     /* We translate the atomic op hints to max count allowed for all possible atomics with each
      * datatype. We do not need more specific info (e.g., <datatype, op>, because any process may use
@@ -316,7 +316,7 @@ static int win_init_sep(MPIR_Win * win)
             goto fn_fail;
         }
 
-        /* Allocate and initilize tx index array. */
+        /* Allocate and initialize tx index array. */
         utarray_new(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array, &ut_int_icd, MPL_MEM_RMA);
         for (i = 0; i < MPIDI_OFI_global.max_rma_sep_tx_cnt; i++) {
             utarray_push_back(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array, &i, MPL_MEM_RMA);

--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -45,7 +45,7 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
     elif test "x$netmod_args" = "x" || test "$netmod_args" = "runtime"; then
         runtime_capabilities="yes"
         no_providers="yes"
-        AC_MSG_NOTICE([Using runtime capability set due to no selected provider or explicity runtime selection])
+        AC_MSG_NOTICE([Using runtime capability set due to no selected provider or explicitly runtime selection])
     fi
 
     if test "$no_providers" = "no" ; then

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -487,7 +487,7 @@ static void create_dt_map()
     dtsize[FI_LONG_DOUBLE_COMPLEX] = sizeof(long double complex);
 
     /* when atomics are disabled and atomics capability are not
-     * enabled call fo fi_atomic*** may crash */
+     * enabled call of fi_atomic*** may crash */
     MPIR_Assert(MPIDI_OFI_ENABLE_ATOMICS);
 
     memset(MPIDI_OFI_global.win_op_table, 0, sizeof(MPIDI_OFI_global.win_op_table));

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -51,7 +51,7 @@ static void init_num_vnis(void)
     }
 
     /* for best performance, we ensure 1-to-1 vci/vni mapping. ref: MPIDI_OFI_vci_to_vni */
-    /* TODO: allow less num_vnis. Option 1. runtime MOD; 2. overide MPIDI_global.n_vcis */
+    /* TODO: allow less num_vnis. Option 1. runtime MOD; 2. override MPIDI_global.n_vcis */
     MPIR_Assert(num_vnis == MPIDI_global.n_vcis);
 
     MPIDI_UCX_global.num_vnis = num_vnis;

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -313,7 +313,7 @@ int MPIDI_UCX_mpi_finalize_hook(void)
         }
     }
 
-    /* now complete the outstaning requests! Important: call progress inbetween, otherwise we
+    /* now complete the outstaning requests! Important: call progress in between, otherwise we
      * deadlock! */
     int completed = p;
     while (completed != 0) {

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -95,7 +95,7 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
     }
 
     /* We want to skip packing of send buffer is there is no data to be sent . buf == NULL is
-     * not a correct check here because derived datatype can use absolute address for displacment
+     * not a correct check here because derived datatype can use absolute address for displacement
      * which requires buffer address passed as MPI_BOTTOM which is usually NULL. count == 0 is also
      * not reliable because the derived datatype could have zero block size which contains no
      * data. */

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -328,7 +328,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_gather(const void *i
         children = release_gather_info_ptr->reduce_tree.children;
     }
 
-    /* Avoid checking for availabilty of next buffer if it is guaranteed to be available */
+    /* Avoid checking for availability of next buffer if it is guaranteed to be available */
     /* "acquire" makes sure no writes/reads are reordered before this load */
     if ((operation == MPIDI_POSIX_RELEASE_GATHER_OPCODE_BCAST) &&
         (MPL_atomic_acquire_load_uint64(release_gather_info_ptr->gather_flag_addr)) >=

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -937,7 +937,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
      * scan result. for example, to node 3, it will have reduce result
      * of rank 1,2,3,4,5,6 in tempbuf.
      * then we should broadcast this result in the local node, and
-     * reduce it with recvbuf to get final result if nessesary. */
+     * reduce it with recvbuf to get final result if necessary. */
 
     if (comm_ptr->node_comm != NULL) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -478,7 +478,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
 #endif /* HAVE_ERROR_CHECKING */
 
         /*
-         * Make an arbitrary decision about which group of processs is
+         * Make an arbitrary decision about which group of process is
          * the low group.  The LEADERS do this by comparing the
          * local process ids of the 0th member of the two groups
          * LUPID itself is not enough for determine is_low_group because both

--- a/src/mpid/ch4/src/ch4_request.h
+++ b/src/mpid/ch4/src/ch4_request.h
@@ -50,7 +50,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_set_completed(MPIR_Request * req)
    properly.
 
    The CH4I_request functions are even more bare bones.
-   They create request objects that are not useable by the
+   They create request objects that are not usable by the
    lower layers until further initialization takes place.
 
    CH4R_request_xxx functions can be used to create and destroy

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -306,7 +306,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Issend(const void *buf,
     goto fn_exit;
 }
 
-/* Common internal rountine for send_init family */
+/* Common internal routine for send_init family */
 MPL_STATIC_INLINE_PREFIX int MPIDI_psend_init(MPIDI_ptype ptype,
                                               const void *buf,
                                               MPI_Aint count,

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -30,7 +30,7 @@ enum {
  * Flags argument allows to control execution of different parts of progress function,
  * for aims of prioritization of different transports and reentrant-safety of progress call.
  *
- * MPIDI_PROGRESS_HOOKS - enables progress on progress hooks. Hooks may invoke upper-level logic internaly,
+ * MPIDI_PROGRESS_HOOKS - enables progress on progress hooks. Hooks may invoke upper-level logic internally,
  *      that's why MPIDI_Progress_test call with MPIDI_PROGRESS_HOOKS set isn't reentrant safe, and shouldn't be called from netmod's fallback logic.
  * MPIDI_PROGRESS_NM and MPIDI_PROGRESS_SHM enables progress on transports only, and guarantee reentrant-safety.
  */

--- a/src/mpid/ch4/src/ch4i_workq_types.h
+++ b/src/mpid/ch4/src/ch4i_workq_types.h
@@ -59,7 +59,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_dequeue(MPIDI_workq_t * q, void **pp)
 
 typedef enum MPIDI_workq_op MPIDI_workq_op_t;
 
-/* Indentifies the delegated operation */
+/* Identifies the delegated operation */
 enum MPIDI_workq_op { SEND, ISEND, SSEND, ISSEND, RSEND, IRSEND, RECV, IRECV, IMRECV, IPROBE,
     IMPROBE, CSEND, ICSEND, PUT, GET, ACC, CAS, FAO, GACC
 };

--- a/src/mpid/ch4/src/ch4r_proc.c
+++ b/src/mpid/ch4/src/ch4r_proc.c
@@ -167,7 +167,7 @@ static int free_avtid(int avtid)
     /*
      * TODO:
      * If the allowed number of process groups are very large
-     * We need to return unsed pages back to OS.
+     * We need to return unused pages back to OS.
      * madvise(addr, len, MADV_DONTNEED);
      * We need tracking which page can be returned
      */

--- a/src/mpid/ch4/src/ch4r_proc.c
+++ b/src/mpid/ch4/src/ch4r_proc.c
@@ -169,7 +169,7 @@ static int free_avtid(int avtid)
      * If the allowed number of process groups are very large
      * We need to return unsed pages back to OS.
      * madvise(addr, len, MADV_DONTNEED);
-     * We need tracking wich page can be returned
+     * We need tracking which page can be returned
      */
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_FREE_AVTID);
     return 0;

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -412,7 +412,7 @@ esac
 
 #
 # Dependency checks for CH4 MT modes
-# Currently, "handoff" and "runtime" require the followings:
+# Currently, "handoff" and "runtime" require the following:
 # - izem linked in (--with-zm-prefix)
 # - enable-thread-cs=per-vci
 #

--- a/src/mpl/include/mpl_atomic.h
+++ b/src/mpl/include/mpl_atomic.h
@@ -16,7 +16,7 @@ typedef struct MPL_atomic_int64_t MPL_atomic_int64_t;
 typedef struct MPL_atomic_uint64_t MPL_atomic_uint64_t;
 typedef struct MPL_atomic_ptr_t MPL_atomic_ptr_t;
 
-/* By default, we use stronger atomic sematics for load and store. However,
+/* By default, we use stronger atomic semantics for load and store. However,
  * the relaxed semantics still can be used where it deemed approprate.
  */
 #define MPL_atomic_load_int MPL_atomic_acquire_load_int

--- a/src/mpl/include/mpl_dbg.h
+++ b/src/mpl/include/mpl_dbg.h
@@ -71,7 +71,7 @@
         if ((_class & MPL_dbg_active_classes) && MPL_DBG_##_level <= MPL_dbg_max_level) { \
             char _s[MPL_DBG_MAXLINE];                                   \
             int _ret = MPL_snprintf _fmatargs ;                          \
-            /* by checking _ret, we supress -Wformat-trunction in gcc-8 */ \
+            /* by checking _ret, we suppress -Wformat-trunction in gcc-8 */ \
             assert(_ret >= 0);                                          \
             MPL_dbg_outevent(__FILE__, __LINE__, _class, 0, "%s", _s);  \
         }                                                               \

--- a/src/mpl/include/mpl_thread_solaris.h
+++ b/src/mpl/include/mpl_thread_solaris.h
@@ -182,7 +182,7 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
         /*                                                              \
          * FIXME: Solaris threads does not have a key destroy.  We      \
          * need to create equivalent functionality to prevent a         \
-         * callback from occuring when a thread exits after the TLS is  \
+         * callback from occurring when a thread exits after the TLS is  \
          * destroyed.  This is the only way to prevent subsystems that  \
          * have shutdown from continuing to receive callbacks.          \
          */                                                             \

--- a/src/mpl/src/gavl/mpl_gavl.c
+++ b/src/mpl/src/gavl/mpl_gavl.c
@@ -184,7 +184,7 @@ static MPLI_gavl_tree_node_s *gavl_tree_search_internal(MPLI_gavl_tree_s * tree_
 
 /* if avl tree is possibly unbalanced, gavl_tree_rebalance should be called to rebalance
  * it. In unbalanced avl tree, the height difference between left and right child is at
- * most 2; gavl_tree_rebalance takes it as a premise in order to rebalance tree correcly */
+ * most 2; gavl_tree_rebalance takes it as a premise in order to rebalance tree correctly */
 static void gavl_tree_rebalance(MPLI_gavl_tree_s * tree_ptr)
 {
     MPLI_gavl_tree_node_s *cur_node = tree_ptr->cur_node;

--- a/src/mpl/src/gavl/mpl_gavl.c
+++ b/src/mpl/src/gavl/mpl_gavl.c
@@ -495,7 +495,7 @@ static void gavl_tree_remove_nodes(MPLI_gavl_tree_s * tree_ptr, uintptr_t addr, 
         gavl_tree_remove_node_internal(tree_ptr, dnode);
 
         /* we perform rebalance after every internal deletion in order to ensure
-         * lightweight rebalance that rotates left and right childs with at most
+         * lightweight rebalance that rotates left and right children with at most
          * 2 height difference. */
         gavl_tree_rebalance(tree_ptr);
     };

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -205,7 +205,7 @@ int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device)
         .flags = 0,
         .ordinal = 0,   /* We currently support a single memory type */
     };
-    /* Currently ZE ignores this augument and uses an internal alignment
+    /* Currently ZE ignores this argument and uses an internal alignment
      * value. However, this behavior can change in the future. */
     mem_alignment = 1;
     ret = zeMemAllocDevice(global_ze_context, &device_desc, size, mem_alignment, h_device, ptr);
@@ -227,7 +227,7 @@ int MPL_gpu_malloc_host(void **ptr, size_t size)
         .flags = 0,
     };
 
-    /* Currently ZE ignores this augument and uses an internal alignment
+    /* Currently ZE ignores this argument and uses an internal alignment
      * value. However, this behavior can change in the future. */
     mem_alignment = 1;
     ret = zeMemAllocHost(global_ze_context, &host_desc, size, mem_alignment, ptr);

--- a/src/mpl/src/mem/mpl_trmem.c
+++ b/src/mpl/src/mem/mpl_trmem.c
@@ -605,11 +605,11 @@ Input Parameters:
 $   Block [id=%d(%d)] at address %lx is corrupted (probably write past end)
 $   Block allocated in <filename>[<linenumber>]
 
-   if the sentinal at the end of the block has been corrupted, and
+   if the sentinel at the end of the block has been corrupted, and
 
 $   Block at address %lx is corrupted
 
-   if the sentinal at the begining of the block has been corrupted.
+   if the sentinel at the beginning of the block has been corrupted.
 
    The address is the actual address of the block.  The id is the
    value of TRID.

--- a/src/mpl/src/shm/mpl_shm.c
+++ b/src/mpl/src/shm/mpl_shm.c
@@ -43,7 +43,7 @@ int MPL_shm_hnd_deserialize(MPL_shm_hnd_t hnd, const char *str_hnd, size_t str_h
 
 /* Get a serialized handle by reference.
  * Rationale: The user might only want to read the serialized view
- * of the handle & hence not want to allocate a buffer for the ser view
+ * of the handle & hence not want to allocate a buffer for the serialized view
  * of the handle.
  * str_ptr  : Pointer to a string of chars to hold the serialized handle
  *           If the function succeeds, the pointer points to a

--- a/src/mpl/src/sock/mpl_sockaddr.c
+++ b/src/mpl/src/sock/mpl_sockaddr.c
@@ -11,7 +11,7 @@
  */
 
 /** Design considerations:
- *    Either IPv4 or IPv6, globally set as defalt or with command line option, to
+ *    Either IPv4 or IPv6, globally set as default or with command line option, to
  *    simplify logic.
  *    TCP only, no UDP or unix domain sockets.
  *

--- a/src/mpl/src/str/mpl_argstr.c
+++ b/src/mpl/src/str/mpl_argstr.c
@@ -463,7 +463,7 @@ Output Parameters:
     Notes:
     This routine adds a string to a string in such a way that
     MPL_str_get_string can
-    retreive the same string back.  It takes into account spaces and quote
+    retrieve the same string back.  It takes into account spaces and quote
     characters.
     The string pointer is updated to the start of the next string in the
     string and maxlen is updated accordingly.

--- a/src/mpl/src/timer/mpl_timer_clock_gettime.c
+++ b/src/mpl/src/timer/mpl_timer_clock_gettime.c
@@ -96,7 +96,7 @@ int MPL_wtime_init(void)
         goto fn_exit;
 
     /* set a closer time_epoch so MPL_wtime_todouble retain ns resolution */
-    /* time across process are still relavant within 1 hour */
+    /* time across process are still relevant within 1 hour */
     MPL_time_t t;
     MPL_wtime(&t);
     time_epoch = t.tv_sec - t.tv_sec % (3600);

--- a/src/mpl/src/timer/mpl_timer_gethrtime.c
+++ b/src/mpl/src/timer/mpl_timer_gethrtime.c
@@ -17,7 +17,7 @@ static int is_initialized = 0;
  * longlong_t as a structure in some circumstances, making arithmetic
  * with hrtime_t invalid.  FIXME.
  * To fix this, we'll need to test hrtime_t arithmetic in the configure
- * program, and if it fails, check for the Solaris defintions (
+ * program, and if it fails, check for the Solaris definitions (
  * union { double _d; int32_t _l[2]; }.  Alternately, we may decide that
  * if hrtime_t is not supported, then neither is gethrtime.
  *

--- a/src/pm/gforker/mpiexec.c
+++ b/src/pm/gforker/mpiexec.c
@@ -103,7 +103,7 @@ int myspawn(ProcessWorld *, void *);
 /* Set printFailure to 1 to get an explanation of the failure reason
    for each process when a process fails */
 static int printFailure = 0;
-/* Set usePort to 1 if a host:port should be used insted of inheriting
+/* Set usePort to 1 if a host:port should be used instead of inheriting
    an FD to a socketpair.  Meaningful only if code is compilete with
    -DMPIEXEC_ALLOW_PORT */
 static int usePort = 0;

--- a/src/pm/gforker/mpiexec.txt
+++ b/src/pm/gforker/mpiexec.txt
@@ -58,7 +58,7 @@
    processes created by 'mpiexec'.  
 
    Notes:
-   A few additional enviroment variables are defined for the use of
+   A few additional environment variables are defined for the use of
    developers and in debugging.  These are
 
 .  MPIEXEC_DEBUG - If set, 'mpiexec' will write additional information

--- a/src/pm/hydra/hydra-doxygen.cfg.in
+++ b/src/pm/hydra/hydra-doxygen.cfg.in
@@ -278,10 +278,10 @@ TYPEDEF_HIDES_STRUCT   = YES
 # For small to medium size projects (<1000 input files) the default value is
 # probably good enough. For larger projects a too small cache size can cause
 # doxygen to be busy swapping symbols to and from disk most of the time
-# causing a significant performance penality.
+# causing a significant performance penalty.
 # If the system has enough physical memory increasing the cache will improve the
 # performance by keeping more symbols in memory. Note that the value works on
-# a logarithmic scale so increasing the size by one will rougly double the
+# a logarithmic scale so increasing the size by one will roughly double the
 # memory usage. The cache size is given by this formula:
 # 2^(16+SYMBOL_CACHE_SIZE). The valid range is 0..9, the default is 0,
 # corresponding to a cache size of 2^16 = 65536 symbols

--- a/src/pm/hydra/maint/README
+++ b/src/pm/hydra/maint/README
@@ -10,7 +10,7 @@ if the compressed list format is recognized as valid. Otherwise, the test
 returns an error message.
 
 This test can be used to validate nodelist formats for the slurm resource
-manager and to report bugs in the existing code: src/pm/hydra/tools/boostrap/
+manager and to report bugs in the existing code: src/pm/hydra/tools/bootstrap/
 external/slurm_query_node_list.c
 
 Examples:

--- a/src/pm/hydra/pm/pmiserv/hydra_pmi_proxy.txt
+++ b/src/pm/hydra/pm/pmiserv/hydra_pmi_proxy.txt
@@ -1,4 +1,4 @@
-/*D hydra_pmi_proxy - Internal exectuable used by Hydra
+/*D hydra_pmi_proxy - Internal executable used by Hydra
 
    Description:
     This executable is designed to not be run directly by users, but to

--- a/src/pm/hydra/pm/pmiserv/pmiserv_pmi_v1.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_pmi_v1.c
@@ -181,7 +181,7 @@ static HYD_status fn_put(int fd, int pid, int pgid, char *args[])
 
     for (i = 0; i < token_count; i++) {
         status = HYD_pmcd_pmi_add_kvs(tokens[i].key, tokens[i].val, pg_scratch->kvs, &ret);
-        HYDU_ERR_POP(status, "unable to add keypair to kvs\n");
+        HYDU_ERR_POP(status, "unable to add key pair to kvs\n");
     }
 
   fn_exit:
@@ -534,7 +534,7 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
         preput_val = val;
 
         status = HYD_pmcd_pmi_add_kvs(preput_key, preput_val, pg_scratch->kvs, &ret);
-        HYDU_ERR_POP(status, "unable to add keypair to kvs\n");
+        HYDU_ERR_POP(status, "unable to add key pair to kvs\n");
     }
 
     /* Create the proxy list */

--- a/src/pm/hydra/pm/pmiserv/pmiserv_pmi_v2.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_pmi_v2.c
@@ -656,7 +656,7 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
         preput_val = val;
 
         status = HYD_pmcd_pmi_add_kvs(preput_key, preput_val, pg_scratch->kvs, &ret);
-        HYDU_ERR_POP(status, "unable to add keypair to kvs\n");
+        HYDU_ERR_POP(status, "unable to add key pair to kvs\n");
     }
 
     /* Create the proxy list */

--- a/src/pm/hydra/tools/debugger/debugger.h
+++ b/src/pm/hydra/tools/debugger/debugger.h
@@ -48,7 +48,7 @@ extern int MPIR_partial_attach_ok;
  * use of asm(""), recommended by the GCC manual, prevented the
  * inlining of this call.  Rather than place it in a separate file
  * (and still risk whole-program analysis removal), we use a globally
- * visable function pointer. */
+ * visible function pointer. */
 extern int (*MPIR_breakpointFn) (void);
 int MPIR_Breakpoint(void);
 

--- a/src/pm/hydra/ui/mpich/mpiexec.c
+++ b/src/pm/hydra/ui/mpich/mpiexec.c
@@ -242,7 +242,7 @@ int main(int argc, char **argv)
     /* If the number of processes is not given, we allocate all the
      * available nodes to each executable */
     /* NOTE:
-     *   user may accidently give on command line -np 0, or even -np -1,
+     *   user may accidentally give on command line -np 0, or even -np -1,
      *   these cases will all be treated as if it is being ignored.
      */
     HYD_server_info.pg_list.pg_process_count = 0;

--- a/src/pm/hydra/ui/mpich/utils.c
+++ b/src/pm/hydra/ui/mpich/utils.c
@@ -135,7 +135,7 @@ static void help_help_fn(void)
     printf("    -gpus-per-proc                   number of GPUs per process (default: auto)\n");
 
     printf("\n");
-    printf("Please see the intructions provided at\n");
+    printf("Please see the instructions provided at\n");
     printf("http://wiki.mpich.org/mpich/index.php/Using_the_Hydra_Process_Manager\n");
     printf("for further details\n\n");
 }

--- a/src/pm/hydra/utils/signals/signals.c
+++ b/src/pm/hydra/utils/signals/signals.c
@@ -22,7 +22,7 @@ HYD_status HYDU_set_signal(int signum, void (*handler) (int))
 #if defined SA_RESETHAND
     /* Note that if this feature is not supported, there is a race
      * condition in the handling of signals, and the OS is
-     * fundementally flawed */
+     * fundamentally flawed */
     act.sa_flags = act.sa_flags & ~(SA_RESETHAND);
 #endif
     sigaction(signum, &act, (struct sigaction *) NULL);

--- a/src/pm/hydra/utils/sock/sock.c
+++ b/src/pm/hydra/utils/sock/sock.c
@@ -18,7 +18,7 @@ struct fwd_hash {
     struct fwd_hash *next;
 };
 
-/* FIXME: redudant code with PMIServGetPort. Can we call PMIServGetPort here? */
+/* FIXME: redundant code with PMIServGetPort. Can we call PMIServGetPort here? */
 HYD_status HYDU_sock_listen(int *listen_fd, char *port_range, uint16_t * port)
 {
     int ret;

--- a/src/pm/hydra2/configure.ac
+++ b/src/pm/hydra2/configure.ac
@@ -341,7 +341,7 @@ else
 fi
 
 # FIXME: Disable hwloc on Cygwin for now. The hwloc package,
-# atleast as of 1.0.2, does not install correctly on Cygwin
+# at least as of 1.0.2, does not install correctly on Cygwin
 AS_CASE([$host], [*-*-cygwin], [have_hwloc=no])
 
 if test "$have_hwloc" = "yes" ; then

--- a/src/pm/hydra2/hydra-doxygen.cfg.in
+++ b/src/pm/hydra2/hydra-doxygen.cfg.in
@@ -278,10 +278,10 @@ TYPEDEF_HIDES_STRUCT   = YES
 # For small to medium size projects (<1000 input files) the default value is
 # probably good enough. For larger projects a too small cache size can cause
 # doxygen to be busy swapping symbols to and from disk most of the time
-# causing a significant performance penality.
+# causing a significant performance penalty.
 # If the system has enough physical memory increasing the cache will improve the
 # performance by keeping more symbols in memory. Note that the value works on
-# a logarithmic scale so increasing the size by one will rougly double the
+# a logarithmic scale so increasing the size by one will roughly double the
 # memory usage. The cache size is given by this formula:
 # 2^(16+SYMBOL_CACHE_SIZE). The valid range is 0..9, the default is 0,
 # corresponding to a cache size of 2^16 = 65536 symbols

--- a/src/pm/hydra2/libhydra/debugger/hydra_debugger.h
+++ b/src/pm/hydra2/libhydra/debugger/hydra_debugger.h
@@ -52,7 +52,7 @@ extern int MPIR_partial_attach_ok;
  * use of asm(""), recommended by the GCC manual, prevented the
  * inlining of this call.  Rather than place it in a separate file
  * (and still risk whole-program analysis removal), we use a globally
- * visable function pointer. */
+ * visible function pointer. */
 extern int (*MPIR_breakpointFn) (void);
 int MPIR_Breakpoint(void);
 

--- a/src/pm/hydra2/libhydra/signal/hydra_signal.c
+++ b/src/pm/hydra2/libhydra/signal/hydra_signal.c
@@ -23,7 +23,7 @@ HYD_status HYD_signal_set(int signum, void (*handler) (int))
 #if defined SA_RESETHAND
     /* Note that if this feature is not supported, there is a race
      * condition in the handling of signals, and the OS is
-     * fundementally flawed */
+     * fundamentally flawed */
     act.sa_flags = act.sa_flags & ~(SA_RESETHAND);
 #endif
     sigaction(signum, &act, (struct sigaction *) NULL);

--- a/src/pm/hydra2/mpiexec/mpiexec.c
+++ b/src/pm/hydra2/mpiexec/mpiexec.c
@@ -864,7 +864,7 @@ int main(int argc, char **argv)
         goto fn_fail;
     }
 
-    HYD_ERR_POP(status, "error setting up the boostrap proxies\n");
+    HYD_ERR_POP(status, "error setting up the bootstrap proxies\n");
 
     HYD_str_free_list(args);
 

--- a/src/pm/hydra2/mpiexec/mpiexec_params.c
+++ b/src/pm/hydra2/mpiexec/mpiexec_params.c
@@ -102,7 +102,7 @@ static void help_help_fn(void)
     printf("    -usize                           universe size (SYSTEM, INFINITE, <value>)\n");
 
     printf("\n");
-    printf("Please see the intructions provided at\n");
+    printf("Please see the instructions provided at\n");
     printf("http://wiki.mpich.org/mpich/index.php/Using_the_Hydra_Process_Manager\n");
     printf("for further details\n\n");
 }

--- a/src/pm/hydra2/proxy/proxy.c
+++ b/src/pm/hydra2/proxy/proxy.c
@@ -417,7 +417,7 @@ static HYD_status launch_processes(void)
 #define MAPPING_PARSE_ERROR() abort()
 /* advance _c until we find a non whitespace character */
 #define MAPPING_SKIP_SPACE(_c) while (isspace(*(_c))) ++(_c)
-/* return true iff _c points to a character valid as an indentifier, i.e., [-_a-zA-Z0-9] */
+/* return true iff _c points to a character valid as an identifier, i.e., [-_a-zA-Z0-9] */
 #define MAPPING_ISIDENT(_c) (isalnum(_c) || (_c) == '-' || (_c) == '_')
 
 /* give an error iff *_c != _e */

--- a/src/pm/hydra2/proxy/proxy_pmi.c
+++ b/src/pm/hydra2/proxy/proxy_pmi.c
@@ -57,7 +57,7 @@ HYD_status proxy_process_pmi_cb(int fd, HYD_dmx_event_t events, void *userp)
         if (!strncmp(pmi_stash, "cmd=", strlen("cmd="))) {
             if (pmi_stash[count - 1] != '\n') {
                 /* if we reached the end of the buffer we read and did
-                 * not yet get a full comamnd, wait till we get at
+                 * not yet get a full command, wait till we get at
                  * least one more byte */
                 status =
                     HYD_sock_read(fd, pmi_stash + count, 1, &recvd, &closed,
@@ -84,7 +84,7 @@ HYD_status proxy_process_pmi_cb(int fd, HYD_dmx_event_t events, void *userp)
             if (count < (int) strlen("endcmd") ||
                 strncmp(&pmi_stash[count - strlen("endcmd")], "endcmd", strlen("endcmd"))) {
                 /* if we reached the end of the buffer we read and did
-                 * not yet get a full comamnd, wait till we get at
+                 * not yet get a full command, wait till we get at
                  * least one more byte */
                 status =
                     HYD_sock_read(fd, pmi_stash + count, 1, &recvd, &closed,

--- a/src/pm/remshell/mpiexec.c
+++ b/src/pm/remshell/mpiexec.c
@@ -268,7 +268,7 @@ int mypostfork(void *predata, void *data, ProcessState * pState)
         /* Insert into app->args */
         newargs = (const char **) MPL_malloc((app->nArgs + 14 + 1) * sizeof(char *), MPL_MEM_PM);
         if (!pState->hostname) {
-            MPL_error_printf("No hostname avaliable for %s\n", app->exename);
+            MPL_error_printf("No hostname available for %s\n", app->exename);
             exit(1);
         }
 
@@ -378,7 +378,7 @@ int myspawn(ProcessWorld * pWorld, void *data)
  * to the postfork routine; this is called after the fork but before the
  * exec, and it can change the command line by making a copy of the app
  * structure, changing the command line, and setting the pState structure
- * to point to this new app (after the fork, these changes are visable only
+ * to point to this new app (after the fork, these changes are visible only
  * to the forked process).
  *
  * Enhancements:

--- a/src/pm/util/cmnargs.c
+++ b/src/pm/util/cmnargs.c
@@ -234,7 +234,7 @@ int MPIE_Args(int argc, char *argv[], ProcessUniverse * mypUniv,
             MPL_snprintf(envstring, sizeof(envstring), "MPICH_CH3CHANNEL=%s", channame);
             MPIE_Putenv(mypUniv->worlds, envstring);
         }
-/* End of the MPICH mpiexec common extentions */
+/* End of the MPICH mpiexec common extensions */
 
         else if (argv[i][0] != '-') {
             exename = argv[i];
@@ -243,7 +243,7 @@ int MPIE_Args(int argc, char *argv[], ProcessUniverse * mypUniv,
              * directory, convert it to an absolute name.
              * FIXME: Make this optional (MPIEXEC_EXEPATH_ABSOLUTE?) */
             /* We may not want to do this, if the idea is that that
-             * executable should be found in the PATH at the destionation */
+             * executable should be found in the PATH at the destination */
             /* wd = getwd(curdir) */
 
             /* Skip arguments until we hit either the end of the args
@@ -508,7 +508,7 @@ static int getInt(int argnum, int argc, char *argv[])
 
 /* FIXME: Move this routine else where; perhaps a pmutil.c? */
 /*
- * Try to get an integer value from the enviroment.  Return the default
+ * Try to get an integer value from the environment.  Return the default
  * if the value is not available or invalid
  */
 static int GetIntValue(const char name[], int default_val)

--- a/src/pm/util/dbgiface.c
+++ b/src/pm/util/dbgiface.c
@@ -64,7 +64,7 @@ int MPIR_Breakpoint(void);
    Neither the attribute __attribute__((noinline)) nor the use of
    asm(""), recommended by the GCC manual, prevented the inlining of
    this call.  Rather than place it in a separate file (and still
-   risk whole-program analysis removal), we use a globally visable
+   risk whole-program analysis removal), we use a globally visible
    function pointer.
 */
 int (*MPIR_breakpointFn) (void) = MPIR_Breakpoint;

--- a/src/pm/util/ioloop.c
+++ b/src/pm/util/ioloop.c
@@ -8,7 +8,7 @@
  *
  * Each active fd has a handler associated with it.
  */
-/* FIXME: Occassionally, data from stdout has been lost when the job is
+/* FIXME: Occasionally, data from stdout has been lost when the job is
    exiting.  I don't know whether data is being lost because the writer
    is discarding it or the reader (mpiexec) is failing to finish reading from
    all of the sockets before exiting.

--- a/src/pm/util/pmiport.c
+++ b/src/pm/util/pmiport.c
@@ -86,7 +86,7 @@ typedef unsigned int socklen_t;
 int PMIServGetPort(int *fdout, char *portString, int portLen)
 {
     int fd = -1;
-    /* FIXME: delay IPv6 fix (mpl_sockaddr.c) until the redudancy with pm/hydra/utils/sock/sock.c is resolved. */
+    /* FIXME: delay IPv6 fix (mpl_sockaddr.c) until the redundancy with pm/hydra/utils/sock/sock.c is resolved. */
     struct sockaddr_in sa;
     int optval = 1;
     int portnum;

--- a/src/pm/util/pmiserv.c
+++ b/src/pm/util/pmiserv.c
@@ -114,7 +114,7 @@ static PMICmdMap pmiCommands[] = {
     {"spawn", fPMI_Handle_spawn},
     {"get_universe_size", fPMI_Handle_get_universe_size},
     {"get_appnum", fPMI_Handle_get_appnum},
-    {"\0", 0},  /* Sentinal for end of list */
+    {"\0", 0},  /* Sentinel for end of list */
 };
 
 /* ------------------------------------------------------------------------- */
@@ -873,7 +873,7 @@ static int fPMI_Handle_getbyidx(PMIProcess * pentry)
  * set up)
  * After the fork, the child will call
  *      PMISetupInClient(1, &pmiinfo)
- * This adds the PMI_PORT and PMI_ID values to the enviroment
+ * This adds the PMI_PORT and PMI_ID values to the environment
  * The parent also calls
  *      PMISetupFinishInServer(1, &pmiinfo, pState)
  * ? What should this do, since there is no connection yet?

--- a/src/pm/util/pmiserv.c
+++ b/src/pm/util/pmiserv.c
@@ -1129,7 +1129,7 @@ static int fPMI_Handle_spawn(PMIProcess * pentry)
          * separate routine (not yet implemented).
          * simple_pmi.c sends (key,value), so we can keep just the
          * last key and pass the key/value to the registered info
-         * handler, along with tha app structure.  Alternately,
+         * handler, along with the app structure.  Alternately,
          * we could save all info items and let the user's
          * spawner handle it */
         else if (strcmp("info_num", cmdPtr) == 0) {
@@ -1211,7 +1211,7 @@ static int fPMI_Handle_spawn(PMIProcess * pentry)
  *     mpiexec, but possibly a separate pmiserver process)
  * 5. return kvsname; return code
  *    How do we handle soft (no specific return size required).
- *    Also, is part fo the group associated with these processes or
+ *    Also, is part of the group associated with these processes or
  *    another group (the spawner?) of processes?
  *
  * This should be called after receiving the cmd=initack from the client.

--- a/src/pm/util/pmiserv.h
+++ b/src/pm/util/pmiserv.h
@@ -32,7 +32,7 @@ typedef struct PMIProcess {
                                                  * data */
     struct ProcessWorld *spawnWorld;    /* In progress spawn multiple
                                          * new world */
-    struct PMIKVSpace *spawnKVS;        /* In progres KV space for new world */
+    struct PMIKVSpace *spawnKVS;        /* In progress KV space for new world */
 } PMIProcess;
 
 typedef struct PMIGroup {

--- a/src/pm/util/process.c
+++ b/src/pm/util/process.c
@@ -377,7 +377,7 @@ ProcessState *MPIE_FindProcessByPid(pid_t pid)
             pState = app->pState;
             np -= app->nProcess;
             if (np < 0) {
-                /* This is a panic exit, used becaue we may call this
+                /* This is a panic exit, used because we may call this
                  * from within the signal handler */
                 return 0;
             }
@@ -457,7 +457,7 @@ static volatile int skipHandler = 0;
    exit before we've recorded their pids.  This is unlikely, but may
    happen if a process fails to exec (e.g., the fork succeeds but the
    exec immediately fails).  This ensures that we can handle SIGCHLD
-   events without loosing information about the child processes */
+   events without losing information about the child processes */
 #define MAXUNEXPECTEDPIDS 1024
 static struct {
     pid_t pid;
@@ -492,7 +492,7 @@ static void handle_sigchild(int sig)
     DBG_PRINTF(("Entering sigchild handler\n"));
     DBG_EPRINTF((stderr, "Waiting for any child on signal\n"));
 
-    /* Since signals may be coallesced, we process all children that
+    /* Since signals may be coalesced, we process all children that
      * have exited */
     while (1) {
         /* Find out about any children that have exited.  Note that
@@ -574,7 +574,7 @@ void MPIE_ProcessInit(void)
 }
 
 /*
- * Wait upto timeout seconds for all processes to exit.
+ * Wait up to timeout seconds for all processes to exit.
  * Because we are using a SIGCHLD handler to get the exit reason and
  * status from exiting children, this routine waits for those
  * signal handlers to return.  (POSIX requires a SIGCHLD handler, and leaving
@@ -627,7 +627,7 @@ int MPIE_WaitForProcesses(ProcessUniverse * mypUniv, int timeout)
  *
  *
  * Updates the ProcessTable with the new processes, and updates the
- * number of processes.  All processses are added to the end of the
+ * number of processes.  All processes are added to the end of the
  * current array.  Only the "spec" part of the state element is initialized
  *
  * Return value is the number of processes added, or a negative value
@@ -935,7 +935,7 @@ static void MPIE_InstallSigHandler(int sig, void (*handler) (int))
     oldact.sa_handler = (void (*)(int)) handler;
 #ifdef SA_RESETHAND
     /* Note that if this feature is not supported, there is a race
-     * condition in the handling of signals, and the OS is fundementally
+     * condition in the handling of signals, and the OS is fundamentally
      * flawed */
     oldact.sa_flags = oldact.sa_flags & ~(SA_RESETHAND);
 #endif

--- a/src/pm/util/process.h
+++ b/src/pm/util/process.h
@@ -95,7 +95,7 @@ typedef struct ProcessApp {
     const char *arch;           /* Architecture type */
     const char *path;           /* Search path for executables */
     const char *wdir;           /* Working directory */
-    const char *hostname;       /* Default host (can be overridded
+    const char *hostname;       /* Default host (can be overridden
                                  * by each process in an App) */
     const char **args;          /* Pointer into the array of args */
     int nArgs;                  /* Number of args (list is *not* null

--- a/src/pm/util/process.h
+++ b/src/pm/util/process.h
@@ -9,7 +9,7 @@
 #include <sys/types.h>
 
 /*
-Data structures and routines for managing processs
+Data structures and routines for managing processes
 
 The data structures for managing processes following the hierarchy implied
 by MPI-2 design, particularly the ":" syntax of mpiexec and the

--- a/src/pm/util/subconfigure.m4
+++ b/src/pm/util/subconfigure.m4
@@ -189,7 +189,7 @@ if test "$ac_cv_func_select" != yes ; then
     AC_MSG_ERROR([select is required for the process manager utilities])
 else
     # Check that FD_ZERO works.  Under the Darwin xlc (version 6) compiler,
-    # FD_ZERO gets turned into a referece to __builtin_bzero, which is not
+    # FD_ZERO gets turned into a reference to __builtin_bzero, which is not
     # in the xlc libraries.  This is apparently due to xlc pretending that it
     # is GCC within the system header files (the same test that must 
     # succeed within the system header files to cause the declaration to

--- a/src/pmi/errnames.txt
+++ b/src/pmi/errnames.txt
@@ -58,7 +58,7 @@
 **pmi_fullinit: PMI2 init with process manager failed
 **pmi_fullinit %s: PMI2 init with process manager failed: %s
 **pmi_version: PMI2 version mismatch
-**pmi_version %s %s %s %s: PMI2 version mismatch (server version %s.%s, client verison %s.%s)
+**pmi_version %s %s %s %s: PMI2 version mismatch (server version %s.%s, client version %s.%s)
 **pmi_finalize: PMI2 Finalize failed
 **pmi_finalize %s: PMI2 Finalize failed: %s
 **pmi_jobgetid: PMI2 Job_GetID failed

--- a/src/pmi/pmi2/include/pmi2.h
+++ b/src/pmi/pmi2/include/pmi2.h
@@ -300,7 +300,7 @@ D*/
   Input Parameters:
   + jobid - the job id identifying the key-value space in which to look
     for key.  If jobid is NULL, look in the key-value space of this job.
-  . src_pmi_id - the pmi id of the process which put this keypair.  This
+  . src_pmi_id - the pmi id of the process which put this key pair.  This
     is just a hint to the server.  PMI2_ID_NULL should be passed if no
     hint is provided.
   . key - key

--- a/src/pmi/pmi2/simple/README
+++ b/src/pmi/pmi2/simple/README
@@ -9,7 +9,7 @@ implementation yet.  The files have been added to the repository so that they
 can be reviewed by interested parties, particularly 3rd-parties that
 will need to interface to this second-generation interface.
 
-A major issue that PMI verison 2 needs to address is thread-safety and
+A major issue that PMI version 2 needs to address is thread-safety and
 responsiveness.  In particular, no thread that is waiting on a PMI call can
 block other threads, even PMI_Spawn.  The design sketched out here
 addresses these issues as well as providing a relatively simple model

--- a/src/pmi/pmi2/simple/simple2pmi.c
+++ b/src/pmi/pmi2/simple/simple2pmi.c
@@ -1093,7 +1093,7 @@ int PMI2_Nameserv_unpublish(const char service_name[], const PMI2U_Info * info_p
 /* ------------------------------------------------------------------------- */
 
 
-/* frees all of the keyvals pointed to by a keyvalpair* array and the array iteself*/
+/* frees all of the keyvals pointed to by a keyvalpair* array and the array itself*/
 static void freepairs(PMI2_Keyvalpair ** pairs, int npairs)
 {
     int i;
@@ -1832,7 +1832,7 @@ static int PMII_Connect_to_pm(char *hostname, int portnum)
    mpiexec, and PMI2_Init returned as if there was only one process.
 
    Note that PMI routines should not call PMII_singinit; they should
-   call PMIi_InitIfSingleton(), which both connects to the process mangager
+   call PMIi_InitIfSingleton(), which both connects to the process manager
    and sets up the initial KVS connection entry.
 */
 

--- a/src/pmi/simple/simple_pmi.c
+++ b/src/pmi/simple/simple_pmi.c
@@ -69,7 +69,7 @@ static int PMI_rank = 0;
 /* Set PMI_initialized to 1 for singleton init but no process manager
    to help.  Initialized to 2 for normal initialization.  Initialized
    to values higher than 2 when singleton_init by a process manager.
-   All values higher than 1 invlove a PM in some way.
+   All values higher than 1 involve a PM in some way.
 */
 typedef enum { PMI_UNINITIALIZED = 0,
     SINGLETON_INIT_BUT_NO_PM = 1,
@@ -1090,7 +1090,7 @@ static int PMII_Set_from_port(int fd, int id)
    mpiexec, and PMI_Init returned as if there was only one process.
 
    Note that PMI routines should not call PMII_singinit; they should
-   call PMIi_InitIfSingleton(), which both connects to the process mangager
+   call PMIi_InitIfSingleton(), which both connects to the process manager
    and sets up the initial KVS connection entry.
 */
 
@@ -1332,7 +1332,7 @@ static int getPMIFD(int *notset)
         if (p) {
             id = atoi(p);
             /* PMII_Set_from_port sets up the values that are delivered
-             * by enviroment variables when a separate port is not used */
+             * by environment variables when a separate port is not used */
             PMII_Set_from_port(PMI_fd, id);
             *notset = 0;
         }

--- a/src/util/mpir_handlemem.c
+++ b/src/util/mpir_handlemem.c
@@ -42,7 +42,7 @@ cvars:
 
    MPIR_Add_finalize(MPIR_check_handles_on_finalize, objmem, 1);
 
-   as part of the object intialization.
+   as part of the object initialization.
 
    The algorithm follows the following approach:
 

--- a/src/util/mpir_nodemap.h
+++ b/src/util/mpir_nodemap.h
@@ -119,7 +119,7 @@ static inline int MPIR_NODEMAP_publish_node_id(int sz, int myrank)
 #define MPIR_NODEMAP_PARSE_ERROR() MPIR_ERR_INTERNALANDJUMP(mpi_errno, "parse error")
 /* advance _c until we find a non whitespace character */
 #define MPIR_NODEMAP_SKIP_SPACE(_c) while (isspace(*(_c))) ++(_c)
-/* return true iff _c points to a character valid as an indentifier, i.e., [-_a-zA-Z0-9] */
+/* return true iff _c points to a character valid as an identifier, i.e., [-_a-zA-Z0-9] */
 #define MPIR_NODEMAP_ISIDENT(_c) (isalnum(_c) || (_c) == '-' || (_c) == '_')
 
 /* give an error iff *_c != _e */
@@ -325,7 +325,7 @@ static inline int MPIR_NODEMAP_populate_ids_from_mapping(char *mapping,
    processes (g_num_global).  Each process determines maximum node id
    and assigns a node id to each process (g_node_ids[]):
 
-     For each hostname the process seaches the list of unique nodes
+     For each hostname the process searches the list of unique nodes
      names (node_names[]) for a match.  If a match is found, the node id
      is recorded for that matching process.  Otherwise, the hostname is
      added to the list of node names.

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -487,7 +487,7 @@ static int get_ex(int src, const char *key, void *buf, int *p_size, int is_local
 static int optional_bcast_barrier(MPIR_PMI_DOMAIN domain)
 {
 #if defined(USE_PMI1_API)
-    /* unless bcast is skipped alltogether */
+    /* unless bcast is skipped altogether */
     if (domain == MPIR_PMI_DOMAIN_ALL && MPIR_Process.size == 1) {
         return MPI_SUCCESS;
     } else if (domain == MPIR_PMI_DOMAIN_NODE_ROOTS && MPIR_Process.num_nodes == 1) {

--- a/test/commands/README
+++ b/test/commands/README
@@ -6,6 +6,6 @@ options that are part of the common MPICH extensions for mpiexec.
 
 In addition, the program testout.c can be used to check the buffering of
 stdio.  As a quality of implementation issue, users expect programs run
-by mpiexec to preserve their buffering choice (or at least the appearence of
+by mpiexec to preserve their buffering choice (or at least the appearance of
 it).  This program writes several lines of output with delays between each
 line; those delays should be observed when the program is run under mpiexec.

--- a/test/commands/cmdtests.in
+++ b/test/commands/cmdtests.in
@@ -134,7 +134,7 @@ foreach my $key (keys(%EnvSeen)) {
     delete $copyEnv{$key};
 }
 foreach my $key (keys(%copyEnv)) {
-    print "Enviroment variable $key not delivered to target program\n";
+    print "Environment variable $key not delivered to target program\n";
     $errors ++;
 }
 

--- a/test/mpi/ToDo
+++ b/test/mpi/ToDo
@@ -40,7 +40,7 @@ items listed here that are already sufficiently tested.
 		unsigned short, char, unsigned char, float, double,
 		long double, complex (f77), double complex (f77)
 
-	red_scat: differnt alg lengths
+	red_scat: different alg lengths
 
 	reduce: run with non powers of two, both odd and even values
 		run with root in various places, particularly with non

--- a/test/mpi/attr/attrorder.c
+++ b/test/mpi/attr/attrorder.c
@@ -92,7 +92,7 @@ int checkAttrs(MPI_Comm comm, int n, int key[], int attrval[])
             fprintf(stderr, "Attribute for key %d not set\n", i);
         } else if (val_p != &attrval[i]) {
             errs++;
-            fprintf(stderr, "Atribute value for key %d not correct\n", i);
+            fprintf(stderr, "Attribute value for key %d not correct\n", i);
         }
     }
 

--- a/test/mpi/attr/attrordercomm.c
+++ b/test/mpi/attr/attrordercomm.c
@@ -92,7 +92,7 @@ int checkAttrs(MPI_Comm comm, int n, int key[], int attrval[])
             fprintf(stderr, "Attribute for key %d not set\n", i);
         } else if (val_p != &attrval[i]) {
             errs++;
-            fprintf(stderr, "Atribute value for key %d not correct\n", i);
+            fprintf(stderr, "Attribute value for key %d not correct\n", i);
         }
     }
 

--- a/test/mpi/attr/attrordertype.c
+++ b/test/mpi/attr/attrordertype.c
@@ -93,7 +93,7 @@ int checkAttrs(MPI_Datatype type, int n, int key[], int attrval[])
             fprintf(stderr, "Attribute for key %d not set\n", i);
         } else if (val_p != &attrval[i]) {
             errs++;
-            fprintf(stderr, "Atribute value for key %d not correct\n", i);
+            fprintf(stderr, "Attribute value for key %d not correct\n", i);
         }
     }
 

--- a/test/mpi/coll/allred4.c
+++ b/test/mpi/coll/allred4.c
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
 
     MPI_Op_create(matmult, 0, &op);
 
-    /* A single rotation matrix (3x3, stored as 9 consequetive elements) */
+    /* A single rotation matrix (3x3, stored as 9 consecutive elements) */
     MPI_Type_contiguous(9, MPI_INT, &mattype);
     MPI_Type_commit(&mattype);
 

--- a/test/mpi/coll/alltoallw1.c
+++ b/test/mpi/coll/alltoallw1.c
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
 
     /* Create the local matrices.
      * Initialize the input matrix so that the entries are
-     * consequtive integers, by row, starting at 0.
+     * consecutive integers, by row, starting at 0.
      */
     if (rank == size - 1) {
         localA = (float *) malloc(gN * lmlast * sizeof(float));
@@ -223,7 +223,7 @@ int main(int argc, char *argv[])
     Transpose(localA, localB, gM, gN, comm);
 
     /* check the transposed matrix
-     * In the global matrix, the transpose has consequtive integers,
+     * In the global matrix, the transpose has consecutive integers,
      * organized by columns.
      */
     if (rank == size - 1) {

--- a/test/mpi/coll/coll10.c
+++ b/test/mpi/coll/coll10.c
@@ -16,7 +16,7 @@ int assoc(int *, int *, int *, MPI_Datatype *);
     (see 4.9.4).  The order is important.
 
     Note that the computation is in process rank (in the communicator)
-    order, independant of the root.
+    order, independent of the root.
  */
 int assoc(int *invec, int *inoutvec, int *len, MPI_Datatype * dtype)
 {

--- a/test/mpi/coll/gather_big.c
+++ b/test/mpi/coll/gather_big.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
         for (i = 0; i < size; i++) {
             for (j = 0; j < COUNT; j++) {
                 if (recvbuf[i * COUNT + j] != i * VERIFY_CONST + j) {
-                    printf("PE 0: mis-match error");
+                    printf("PE 0: mismatch error");
                     printf("  recbuf[%d * %d + %d] = ", i, COUNT, j);
                     printf("  %ld,", recvbuf[i * COUNT + j]);
                     printf("  should be %ld\n", i * VERIFY_CONST + j);

--- a/test/mpi/coll/nonblocking3.c
+++ b/test/mpi/coll/nonblocking3.c
@@ -122,7 +122,7 @@ static void cleanup_laundry(struct laundry *l)
 }
 
 /* Starts a "random" operation on "comm" corresponding to "rndnum" and returns
- * in (*req) a request handle corresonding to that operation.  This call should
+ * in (*req) a request handle corresponding to that operation.  This call should
  * be considered collective over comm (with a consistent value for "rndnum"),
  * even though the operation may only be a point-to-point request. */
 static void start_random_nonblocking(MPI_Comm comm, unsigned int rndnum, MPI_Request * req,

--- a/test/mpi/coll/opprod.c
+++ b/test/mpi/coll/opprod.c
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
     else
         maxsize = size;
 
-    /* General forumula: If we multiple the values from 1 to n, the
+    /* General formula: If we multiple the values from 1 to n, the
      * product is n!.  This grows very fast, so we'll only use the first
      * five (1! = 1, 2! = 2, 3! = 6, 4! = 24, 5! = 120), with n!
      * stored in the array result[n] */

--- a/test/mpi/coll/red_scat_block2.c
+++ b/test/mpi/coll/red_scat_block2.c
@@ -50,7 +50,7 @@ void right(void *a, void *b, int *count, MPI_Datatype * type)
 }
 
 /* Just performs a simple sum but can be marked as non-commutative to
-   potentially tigger different logic in the implementation. */
+   potentially trigger different logic in the implementation. */
 void nc_sum(void *a, void *b, int *count, MPI_Datatype * type);
 void nc_sum(void *a, void *b, int *count, MPI_Datatype * type)
 {

--- a/test/mpi/coll/redscat2.c
+++ b/test/mpi/coll/redscat2.c
@@ -50,7 +50,7 @@ void right(void *a, void *b, int *count, MPI_Datatype * type)
 }
 
 /* Just performs a simple sum but can be marked as non-commutative to
-   potentially tigger different logic in the implementation. */
+   potentially trigger different logic in the implementation. */
 void nc_sum(void *a, void *b, int *count, MPI_Datatype * type);
 void nc_sum(void *a, void *b, int *count, MPI_Datatype * type)
 {

--- a/test/mpi/coll/scantst.c
+++ b/test/mpi/coll/scantst.c
@@ -24,7 +24,7 @@ void addem(int *invec, int *inoutvec, int *len, MPI_Datatype * dtype)
     (see 4.9.4).  The order is important.
 
     Note that the computation is in process rank (in the communicator)
-    order, independant of the root.
+    order, independent of the root.
  */
 void assoc(int *invec, int *inoutvec, int *len, MPI_Datatype * dtype)
 {

--- a/test/mpi/comm/comm_idup_iallreduce.c
+++ b/test/mpi/comm/comm_idup_iallreduce.c
@@ -12,18 +12,18 @@
 #define ITERS 10
 
 /* This test uses several scenarios to overlap iallreduce and comm_idup
- * 1.)  Use comm_idup  dublicate the COMM_WORLD and do iallreduce
+ * 1.)  Use comm_idup  duplicate the COMM_WORLD and do iallreduce
  *      on the COMM_WORLD
  * 2.)  Do the above test in a loop
- * 3.)  Dublicate  COMM_WORLD, overalp iallreduce on one
+ * 3.)  Duplicate  COMM_WORLD, overalp iallreduce on one
  *      communicator with comm_idup on the nother communicator
  * 4.)  Split MPI_COMM_WORLD, communicate on the split communicator
         while dublicating COMM_WORLD
  *  5.) Duplicate the split communicators with comm_idup
  *      while communicating  onCOMM_WORLD
- *  6.) Ceate an inter-communicator and duplicate it with comm_idup while
+ *  6.) Create an inter-communicator and duplicate it with comm_idup while
  *      communicating on the inter-communicator
- *  7.) Dublicate the inter-communicator whil communicate on COMM_WORLD
+ *  7.) Duplicate the inter-communicator whil communicate on COMM_WORLD
  *  8.) Merge the inter-communicator to an intra-communicator and idup it,
  *      overlapping with communication on MPI_COMM_WORLD
  *  9.) Communicate on the merge communicator, while duplicating COMM_WORLD

--- a/test/mpi/comm/commname.c
+++ b/test/mpi/comm/commname.c
@@ -20,7 +20,7 @@ int main(int argc, char *argv[])
     char name[MPI_MAX_OBJECT_NAME], nameout[MPI_MAX_OBJECT_NAME];
     MTest_Init(&argc, &argv);
 
-    /* Check world and self firt */
+    /* Check world and self first */
     nameout[0] = 0;
     MPI_Comm_get_name(MPI_COMM_WORLD, nameout, &rlen);
     if (strcmp(nameout, "MPI_COMM_WORLD")) {

--- a/test/mpi/comm/dupic.c
+++ b/test/mpi/comm/dupic.c
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
     MPI_Comm comm, dupcomm, dupcomm2;
     MPI_Request rreq[2];
     int count;
-    int indicies[2];
+    int indices[2];
     int r1buf, r2buf, s1buf, s2buf;
     int rank, isLeft;
 
@@ -39,12 +39,12 @@ int main(int argc, char *argv[])
             MPI_Irecv(&r1buf, 1, MPI_INT, 0, 0, dupcomm, &rreq[0]);
             MPI_Irecv(&r2buf, 1, MPI_INT, 0, 0, comm, &rreq[1]);
             MPI_Send(&s2buf, 1, MPI_INT, 0, 0, comm);
-            MPI_Waitsome(2, rreq, &count, indicies, MPI_STATUSES_IGNORE);
-            if (count != 1 || indicies[0] != 1) {
+            MPI_Waitsome(2, rreq, &count, indices, MPI_STATUSES_IGNORE);
+            if (count != 1 || indices[0] != 1) {
                 /* The only valid return is that exactly one message
                  * has been received */
                 errs++;
-                if (count == 1 && indicies[0] != 1) {
+                if (count == 1 && indices[0] != 1) {
                     printf("Error in context values for intercomm\n");
                 } else if (count == 2) {
                     printf("Error: two messages received!\n");
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
                     int i;
                     printf("Error: count = %d", count);
                     for (i = 0; i < count; i++) {
-                        printf(" indicies[%d] = %d", i, indicies[i]);
+                        printf(" indices[%d] = %d", i, indices[i]);
                     }
                     printf("\n");
                 }

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1042,7 +1042,7 @@ dnl EOF
 dnl             # FIXME.  Check for BASECC
 dnl             # Note: This assumes that CC has been set to the C compiler for
 dnl             # MPI Programs, and that either any necessary include paths are 
-dnl             # already set or they are in CPPFLAGS (prefered) or CFLAGS.
+dnl             # already set or they are in CPPFLAGS (preferred) or CFLAGS.
 dnl             if AC_TRY_EVAL(ac_link) && test -s conftest$ac_exeext ; then
 dnl                 if ./conftest$ac_exeext ; then
 dnl                     #success
@@ -1573,7 +1573,7 @@ AC_MSG_RESULT($POINTERINT)
 AC_DEFINE_UNQUOTED(POINTERINT_t,$POINTERINT,[POINTERINT_t is a pointer-sized integer])
 
 # Find perl; used to create some of the tests from template and 
-# defintion files
+# definition files
 AC_PATH_PROG(PERL,perl)
 AC_SUBST(PERL)
 AC_SUBST(otherlangs)

--- a/test/mpi/cxx/datatype/typenamex.cxx
+++ b/test/mpi/cxx/datatype/typenamex.cxx
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
         name[0] = 0;
         mpi_names[i].dtype.Get_name(name, namelen);
         if (strncmp(name, mpi_names[i].name, MPI::MAX_OBJECT_NAME) &&
-            /* LONG_LONG is a synonym of LONG_LONG_INT, thus LONG_LONG_INT is also a vaild name */
+            /* LONG_LONG is a synonym of LONG_LONG_INT, thus LONG_LONG_INT is also a valid name */
             (mpi_names[i].dtype != MPI::LONG_LONG ||
              strncmp(name, "MPI_LONG_LONG_INT", MPI::MAX_OBJECT_NAME))) {
             errs++;
@@ -161,7 +161,7 @@ void InitMPINames(void)
         {MPI::COMPLEX, "MPI::COMPLEX"},
         {MPI::DOUBLE_COMPLEX, "MPI::DOUBLE_COMPLEX"},
         {MPI::LONG_DOUBLE_COMPLEX, "MPI::LONG_DOUBLE_COMPLEX"},
-        {0, (char *) 0},        /* Sentinal used to indicate the last element */
+        {0, (char *) 0},        /* Sentinel used to indicate the last element */
     };
 
     mpi_names = new mpi_names_t[sizeof(lmpi_names) / sizeof(mpi_names_t)];

--- a/test/mpi/cxx/info/infodelx.cxx
+++ b/test/mpi/cxx/info/infodelx.cxx
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
     value = new char[MPI::MAX_INFO_VAL];
 
     info = MPI::Info::Create();
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     for (i = 0; i < NKEYS; i++) {
         info.Set(keys[i], values[i]);

--- a/test/mpi/cxx/info/infodupx.cxx
+++ b/test/mpi/cxx/info/infodupx.cxx
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
     valdup = new char[MPI::MAX_INFO_VAL];
 
     info1 = MPI::Info::Create();
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     info1.Set("host", "myhost.myorg.org");
     info1.Set("file", "runfile.txt");

--- a/test/mpi/cxx/info/infoorderx.cxx
+++ b/test/mpi/cxx/info/infoorderx.cxx
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 
     /* 1,2,3 */
     info = MPI::Info::Create();
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     for (i = 0; i < NKEYS; i++) {
         info.Set(keys1[i], values1[i]);
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
 
     /* 3,2,1 */
     info = MPI::Info::Create();
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     for (i = NKEYS - 1; i >= 0; i--) {
         info.Set(keys1[i], values1[i]);
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 
     /* 1,3,2 */
     info = MPI::Info::Create();
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     info.Set(keys1[0], values1[0]);
     info.Set(keys1[2], values1[2]);
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
 
     /* 2,1,3 */
     info = MPI::Info::Create();
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     info.Set(keys1[1], values1[1]);
     info.Set(keys1[0], values1[0]);
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
 
     /* 2,3,1 */
     info = MPI::Info::Create();
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     info.Set(keys1[1], values1[1]);
     info.Set(keys1[2], values1[2]);
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
 
     /* 3,1,2 */
     info = MPI::Info::Create();
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     info.Set(keys1[2], values1[2]);
     info.Set(keys1[0], values1[0]);

--- a/test/mpi/cxx/info/infovallenx.cxx
+++ b/test/mpi/cxx/info/infovallenx.cxx
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
     value = new char[MPI::MAX_INFO_VAL];
 
     info = MPI::Info::Create();
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     for (i = 0; i < NKEYS; i++) {
         info.Set(keys[i], values[i]);

--- a/test/mpi/cxx/io/Makefile.am
+++ b/test/mpi/cxx/io/Makefile.am
@@ -69,7 +69,7 @@ nodist_writeordbenosx_SOURCES =   writeordbenosx.cxx
 nodist_writeshnosx_SOURCES =      writeshnosx.cxx
 nodist_writeatallbenosx_SOURCES = writeatallbenosx.cxx
 
-# these files are genereated using testmerge (see below)
+# these files are generated using testmerge (see below)
 generated_io_sources =   \
     iwriteatx.cxx        \
     iwritex.cxx          \

--- a/test/mpi/datatype/blockindexed_misc.c
+++ b/test/mpi/datatype/blockindexed_misc.c
@@ -143,7 +143,7 @@ int blockindexed_contig_test(void)
 /* blockindexed_vector_test()
  *
  * Tests behavior with a blockindexed of some vector types;
- * this shouldn't be easily convertable into anything else.
+ * this shouldn't be easily convertible into anything else.
  *
  * Returns the number of errors encountered.
  */

--- a/test/mpi/datatype/hindexed_block.c
+++ b/test/mpi/datatype/hindexed_block.c
@@ -153,7 +153,7 @@ int hindexed_block_contig_test(void)
 /* hindexed_block_vector_test()
  *
  * Tests behavior with a hindexed_block of some vector types;
- * this shouldn't be easily convertable into anything else.
+ * this shouldn't be easily convertible into anything else.
  *
  * Returns the number of errors encountered.
  */

--- a/test/mpi/datatype/hvecblklen.c
+++ b/test/mpi/datatype/hvecblklen.c
@@ -14,7 +14,7 @@
 */
 int main(int argc, char *argv[])
 {
-    MPI_Datatype ot, ot2, newtype;
+    MPI_Datatype dt, dt2, newtype;
     int position, psize, insize, outsize;
     signed char *inbuf = 0, *outbuf = 0, *pbuf = 0, *p;
     int i, j, k;
@@ -25,14 +25,14 @@ int main(int argc, char *argv[])
     /*
      * Create a type with some padding
      */
-    MPI_Type_contiguous(59, MPI_CHAR, &ot);
-    MPI_Type_create_resized(ot, 0, 64, &ot2);
+    MPI_Type_contiguous(59, MPI_CHAR, &dt);
+    MPI_Type_create_resized(dt, 0, 64, &dt2);
     /*
      * Use a vector type with a block size equal to the stride - thus
      * tiling the target memory with copies of old type.  This is not
      * a contiguous copy since oldtype has a gap at the end.
      */
-    MPI_Type_create_hvector(veccount, stride, stride * 64, ot2, &newtype);
+    MPI_Type_create_hvector(veccount, stride, stride * 64, dt2, &newtype);
     MPI_Type_commit(&newtype);
 
     insize = veccount * stride * 64;
@@ -79,8 +79,8 @@ int main(int argc, char *argv[])
     free(inbuf);
     free(outbuf);
 
-    MPI_Type_free(&ot);
-    MPI_Type_free(&ot2);
+    MPI_Type_free(&dt);
+    MPI_Type_free(&dt2);
     MPI_Type_free(&newtype);
     MTest_Finalize(errs);
 

--- a/test/mpi/datatype/large_type.c
+++ b/test/mpi/datatype/large_type.c
@@ -16,7 +16,7 @@ static MPI_Datatype make_largexfer_type_struct(MPI_Offset nbytes)
     int remainder = 0;
     MPI_Datatype memtype, chunktype;
 
-    /* need to cook up a new datatype to accomodate large datatypes */
+    /* need to cook up a new datatype to accommodate large datatypes */
     /* first pass: chunks of 1 MiB plus an additional remainder.  Does require
      * 8 byte MPI_Aint, which should have been checked for earlier */
 
@@ -54,7 +54,7 @@ static MPI_Datatype make_largexfer_type_hindexed(MPI_Offset nbytes)
     MPI_Aint *disp;
     MPI_Datatype memtype;
 
-    /* need to cook up a new datatype to accomodate large datatypes */
+    /* need to cook up a new datatype to accommodate large datatypes */
     /* Does require 8 byte MPI_Aint, which should have been checked for earlier
      */
 

--- a/test/mpi/datatype/lbub_oldapi.c
+++ b/test/mpi/datatype/lbub_oldapi.c
@@ -1137,7 +1137,7 @@ int int_with_negextent_test(void)
             fprintf(stderr, "  MPI_Type_struct of %s failed.\n", typemapstring);
         if (verbose)
             MTestPrintError(err);
-        /* No point in contiuing */
+        /* No point in continuing */
         return errs;
     }
 

--- a/test/mpi/datatype/typename.c
+++ b/test/mpi/datatype/typename.c
@@ -121,7 +121,7 @@ static mpi_names_t mpi_names[] = {
     /* added in MPI 3 */
     {MPI_COUNT, "MPI_COUNT"},
 #endif
-    {0, (char *) 0},    /* Sentinal used to indicate the last element */
+    {0, (char *) 0},    /* Sentinel used to indicate the last element */
 };
 
 int main(int argc, char **argv)
@@ -168,11 +168,11 @@ int main(int argc, char **argv)
         name[0] = 0;
         MPI_Type_get_name(mpi_names[i].dtype, name, &namelen);
 
-        /* LONG_LONG is a synonym of LONG_LONG_INT, thus LONG_LONG_INT is a vaild name */
+        /* LONG_LONG is a synonym of LONG_LONG_INT, thus LONG_LONG_INT is a valid name */
         isSynonymName = (mpi_names[i].dtype == MPI_LONG_LONG &&
                          !strncmp(name, "MPI_LONG_LONG_INT", MPI_MAX_OBJECT_NAME));
 #if MTEST_HAVE_MIN_MPI_VERSION(2,2)
-        /* C_FLOAT_COMPLEX is a synonym of C_COMPLEX, thus C_COMPLEX is a vaild name */
+        /* C_FLOAT_COMPLEX is a synonym of C_COMPLEX, thus C_COMPLEX is a valid name */
         isSynonymName = isSynonymName || (mpi_names[i].dtype == MPI_C_FLOAT_COMPLEX &&
                                           !strncmp(name, "MPI_C_COMPLEX", MPI_MAX_OBJECT_NAME));
 #endif

--- a/test/mpi/datatype/typename_oldapi.c
+++ b/test/mpi/datatype/typename_oldapi.c
@@ -23,7 +23,7 @@ typedef struct mpi_names_t {
 static mpi_names_t mpi_names[] = {
     {MPI_LB, "MPI_LB"},
     {MPI_UB, "MPI_UB"},
-    {0, (char *) 0},    /* Sentinal used to indicate the last element */
+    {0, (char *) 0},    /* Sentinel used to indicate the last element */
 };
 
 int main(int argc, char **argv)

--- a/test/mpi/datatype/vecblklen.c
+++ b/test/mpi/datatype/vecblklen.c
@@ -14,7 +14,7 @@
 */
 int main(int argc, char *argv[])
 {
-    MPI_Datatype ot, ot2, newtype;
+    MPI_Datatype dt, dt2, newtype;
     int position, psize, insize, outsize;
     signed char *inbuf = 0, *outbuf = 0, *pbuf = 0, *p;
     int i, j, k;
@@ -25,14 +25,14 @@ int main(int argc, char *argv[])
     /*
      * Create a type with some padding
      */
-    MPI_Type_contiguous(59, MPI_CHAR, &ot);
-    MPI_Type_create_resized(ot, 0, 64, &ot2);
+    MPI_Type_contiguous(59, MPI_CHAR, &dt);
+    MPI_Type_create_resized(dt, 0, 64, &dt2);
     /*
      * Use a vector type with a block size equal to the stride - thus
      * tiling the target memory with copies of old type.  This is not
      * a contiguous copy since oldtype has a gap at the end.
      */
-    MPI_Type_vector(veccount, stride, stride, ot2, &newtype);
+    MPI_Type_vector(veccount, stride, stride, dt2, &newtype);
     MPI_Type_commit(&newtype);
 
     insize = veccount * stride * 64;
@@ -79,8 +79,8 @@ int main(int argc, char *argv[])
     free(inbuf);
     free(outbuf);
 
-    MPI_Type_free(&ot);
-    MPI_Type_free(&ot2);
+    MPI_Type_free(&dt);
+    MPI_Type_free(&dt2);
     MPI_Type_free(&newtype);
     MTest_Finalize(errs);
 

--- a/test/mpi/errhan/errfatal.c
+++ b/test/mpi/errhan/errfatal.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 
     /* We should not get here, because the default error handler
      * is ERRORS_ARE_FATAL.  This makes sure that the correct error
-     * handler is called and that no failure occured (such as
+     * handler is called and that no failure occurred (such as
      * a SEGV) in Comm_call_errhandler on the default
      * error handler. */
     printf("After the Error Handler Has Been Called\n");

--- a/test/mpi/errhan/errmsg.c
+++ b/test/mpi/errhan/errmsg.c
@@ -11,7 +11,7 @@ void ChkMsg(int, int, const char[]);
 /*
  * This routine is used to check the message associated with an error
  * code.  Currently, it uses MPI_Error_string to get the corresponding
- * message for a code, and prints out the cooresponding class and original
+ * message for a code, and prints out the corresponding class and original
  * message.
  *
  * Eventually, we should also access the generic anc specific messages

--- a/test/mpi/errors/basic/README
+++ b/test/mpi/errors/basic/README
@@ -10,6 +10,6 @@ if a debugger can regain control of an MPI program when such an error, which
 will normally cause an Abort, occurs.
 
 lefthandles: This program allocates several MPI objects that are not freed.
-An MPI implmentation is not required to report this or fail in this case, 
+An MPI implementation is not required to report this or fail in this case, 
 but an MPI implementation that is striving to report storage leaks caused by
 user programs should report allocated and unfreed MPI objects.

--- a/test/mpi/errors/comm/subcomm_abort2.c
+++ b/test/mpi/errors/comm/subcomm_abort2.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     MPI_Comm_rank(split_comm, &local_rank);
 
     /* two processes trying to abort on the same subcomm
-     * should comlete normally, no hanging */
+     * should complete normally, no hanging */
     if (rank == 1) {
         MPI_Abort(split_comm, 8);
     }

--- a/test/mpi/errors/faults/pt2ptf2.c
+++ b/test/mpi/errors/faults/pt2ptf2.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     /* Now, try sending in MPI_COMM_WORLD on dead processes */
     /* There is a race condition here - we don't know for sure that the faulted
      * processes have exited.  However, we can ensure a failure by using
-     * synchronous sends - the sender will wait until the reciever handles
+     * synchronous sends - the sender will wait until the receiver handles
      * receives the message, which will not happen (the process will exit
      * without matching the message, even if it has not yet exited). */
     for (j = 1; j <= wsize / 2; j++) {

--- a/test/mpi/f08/attr/attrlangc.c
+++ b/test/mpi/f08/attr/attrlangc.c
@@ -166,7 +166,7 @@ static int TYPE_DELETE_FN(MPI_Datatype dtype, int keyval, void *outval, void *ex
 {
     if (verbose)
         printf(" In C MPI type delete function, extra = %p\n", extra);
-    /* We reverse the incrment used in copy (checked after free of the type) */
+    /* We reverse the increment used in copy (checked after free of the type) */
     *(int *) outval = *(int *) outval - 1;
     return MPI_SUCCESS;
 }

--- a/test/mpi/f08/attr/attrlangf08.f90
+++ b/test/mpi/f08/attr/attrlangf08.f90
@@ -74,7 +74,7 @@
 !
 ! For X->Y tests:
 !    Using X, store into key created in all three.
-!    Using Y, retrive all attributes.  See above for handling of
+!    Using Y, retrieve all attributes.  See above for handling of
 !     truncated or sign-extended
 !
 ! Use Fortran to drive tests (Fortran main program).  Call C for

--- a/test/mpi/f08/datatype/createf08.f90
+++ b/test/mpi/f08/datatype/createf08.f90
@@ -19,7 +19,7 @@
         errs = 0
         call mtest_init( ierr )
 
-! integers with upto 9 are 4 bytes integers; r of 4 are 2 byte,
+! integers with up to 9 are 4 bytes integers; r of 4 are 2 byte,
 ! and r of 2 is 1 byte
         call mpi_type_create_f90_integer( 9, ntype1, ierr )
 !

--- a/test/mpi/f08/datatype/createf90.f90
+++ b/test/mpi/f08/datatype/createf90.f90
@@ -17,7 +17,7 @@
         errs = 0
         call mtest_init( ierr )
 
-! integers with upto 9 are 4 bytes integers; r of 4 are 2 byte,
+! integers with up to 9 are 4 bytes integers; r of 4 are 2 byte,
 ! and r of 2 is 1 byte
         call mpi_type_create_f90_integer( 9, ntype1, ierr )
 !

--- a/test/mpi/f08/datatype/kinds.f90
+++ b/test/mpi/f08/datatype/kinds.f90
@@ -90,19 +90,19 @@
      endif
      call MPI_RECV( aint, 1, MPI_AINT, 0, 0, MPI_COMM_WORLD, s, ierr )
      if (taint .ne. aint) then
-        print *, "Address-sized int not correctly transfered"
+        print *, "Address-sized int not correctly transferred"
         print *, "Value should be ", taint, " but is ", aint
         errs = errs + 1
      endif
      call MPI_RECV( oint, 1, MPI_OFFSET, 0, 1, MPI_COMM_WORLD, s, ierr )
      if (toint .ne. oint) then
-        print *, "Offset-sized int not correctly transfered"
+        print *, "Offset-sized int not correctly transferred"
         print *, "Value should be ", toint, " but is ", oint
         errs = errs + 1
      endif
      call MPI_RECV( iint, 1, MPI_INTEGER, 0, 2, MPI_COMM_WORLD, s, ierr )
      if (tiint .ne. iint) then
-        print *, "Integer (by kind) not correctly transfered"
+        print *, "Integer (by kind) not correctly transferred"
         print *, "Value should be ", tiint, " but is ", iint
         errs = errs + 1
      endif

--- a/test/mpi/f08/datatype/structf.f90
+++ b/test/mpi/f08/datatype/structf.f90
@@ -61,7 +61,7 @@
           call mpi_type_free(newtype,ierr)
 !         write(*,*) "Sent ",name(1:5),x
       else
-!         Everyone calls barrier incase size > 2
+!         Everyone calls barrier in case size > 2
           call mpi_barrier( MPI_COMM_WORLD, ierr )
           if (me.eq.dest) then
              position=0

--- a/test/mpi/f08/ext/c2f90mult.c
+++ b/test/mpi/f08/ext/c2f90mult.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
         printf("Unable to cancel MPI_Irecv request\n");
     }
     /* Using MPI_Request_free should be ok, but some MPI implementations
-     * object to it imediately after the cancel and that isn't essential to
+     * object to it immediately after the cancel and that isn't essential to
      * this test */
 
     MTest_Finalize(errs);

--- a/test/mpi/f08/info/infotest2f90.f90
+++ b/test/mpi/f08/info/infotest2f90.f90
@@ -16,7 +16,7 @@
 !
       data keys/"Key1", "key2", "KeY3", "A Key With Blanks","See Below", &
       &          "last"/
-      data values/"value 1", "value 2", "VaLue 3", "key=valu:3","false", &
+      data values/"value 1", "value 2", "VaLue 3", "key=value:3","false", &
       &            "no test"/
 !
       errs = 0

--- a/test/mpi/f08/io/Makefile.am
+++ b/test/mpi/f08/io/Makefile.am
@@ -66,7 +66,7 @@ c2f2ciof90_SOURCES = c2f2ciof90.f90 c2f902cio.c
 # ensure that dependent tests will be rebuilt when headers are updated
 
 
-# these files are genereated using testmerge (see below)
+# these files are generated using testmerge (see below)
 generated_io_sources = \
     iwriteatf90.f90        \
     iwriteatallf90.f90     \

--- a/test/mpi/f08/topo/cartcrf90.f90
+++ b/test/mpi/f08/topo/cartcrf90.f90
@@ -22,7 +22,7 @@
       call mtest_init( ierr )
 
 !
-!     For upto 6 dimensions, test with periodicity in 0 through all
+!     For up to 6 dimensions, test with periodicity in 0 through all
 !     dimensions.  The test is computed by both:
 !         get info about the created communicator
 !         apply cart shift

--- a/test/mpi/f08/topo/dgraph_unwgtf90.f90
+++ b/test/mpi/f08/topo/dgraph_unwgtf90.f90
@@ -151,7 +151,7 @@
 
 ! now create one with MPI_WEIGHTS_EMPTY
 ! NOTE that MPI_WEIGHTS_EMPTY was added in MPI-3 and does not
-! appear before then.  Incluing this test means that this test cannot
+! appear before then.  Including this test means that this test cannot
 ! be compiled if the MPI version is less than 3 (see the testlist file)
 
       degs(1) = 0;

--- a/test/mpi/f77/ext/c2fmult.c
+++ b/test/mpi/f77/ext/c2fmult.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
         printf("Unable to cancel MPI_Irecv request\n");
     }
     /* Using MPI_Request_free should be ok, but some MPI implementations
-     * object to it imediately after the cancel and that isn't essential to
+     * object to it immediately after the cancel and that isn't essential to
      * this test */
 
     MTest_Finalize(errs);

--- a/test/mpi/f77/ext/ctypesfromc.c
+++ b/test/mpi/f77/ext/ctypesfromc.c
@@ -66,7 +66,7 @@ static mpi_names_t mpi_names[] = {
     {MPI_LONG_LONG, "MPI_LONG_LONG"},
     {MPI_UNSIGNED_LONG_LONG, "MPI_UNSIGNED_LONG_LONG"},
     {MPI_LONG_DOUBLE_INT, "MPI_LONG_DOUBLE_INT"},
-    {0, (char *) 0},    /* Sentinal used to indicate the last element */
+    {0, (char *) 0},    /* Sentinel used to indicate the last element */
 };
 
 /*
@@ -110,7 +110,7 @@ int f2ctype_(MPI_Fint * fhandle, MPI_Fint * typeidx)
          * if *must* act like it - e.g., the datatype name must be the same */
         MPI_Type_get_name(ctype, mytypename, &mytypenamelen);
         if (strcmp(mytypename, mpi_names[*typeidx].name) != 0 &&
-            /* LONG_LONG is a synonym of LONG_LONG_INT, thus LONG_LONG_INT is also a vaild name */
+            /* LONG_LONG is a synonym of LONG_LONG_INT, thus LONG_LONG_INT is also a valid name */
             (ctype != MPI_LONG_LONG || strcmp(mytypename, "MPI_LONG_LONG_INT") != 0)) {
             errs++;
             printf("C and Fortran types for %s (c name is %s) do not match f=%d, ctof=%d.\n",

--- a/test/mpi/f77/io/Makefile.am
+++ b/test/mpi/f77/io/Makefile.am
@@ -81,7 +81,7 @@ writeordbef.$(OBJEXT): iooffset.h
 writeordf.$(OBJEXT): iooffset.h
 
 
-# these files are genereated using testmerge (see below)
+# these files are generated using testmerge (see below)
 generated_io_sources = \
     iwriteatf.f        \
     iwriteatallf.f     \

--- a/test/mpi/f90/attr/attrlangc.c
+++ b/test/mpi/f90/attr/attrlangc.c
@@ -166,7 +166,7 @@ static int TYPE_DELETE_FN(MPI_Datatype dtype, int keyval, void *outval, void *ex
 {
     if (verbose)
         printf(" In C MPI type delete function, extra = %p\n", extra);
-    /* We reverse the incrment used in copy (checked after free of the type) */
+    /* We reverse the increment used in copy (checked after free of the type) */
     *(int *) outval = *(int *) outval - 1;
     return MPI_SUCCESS;
 }

--- a/test/mpi/f90/attr/attrlangf90.f90
+++ b/test/mpi/f90/attr/attrlangf90.f90
@@ -73,7 +73,7 @@
 !
 ! For X->Y tests:
 !    Using X, store into key created in all three.
-!    Using Y, retrive all attributes.  See above for handling of
+!    Using Y, retrieve all attributes.  See above for handling of
 !     truncated or sign-extended
 !
 ! Use Fortran to drive tests (Fortran main program).  Call C for 

--- a/test/mpi/f90/datatype/createf90.f90
+++ b/test/mpi/f90/datatype/createf90.f90
@@ -17,7 +17,7 @@
         errs = 0
         call mtest_init( ierr )
 
-! integers with upto 9 are 4 bytes integers; r of 4 are 2 byte,
+! integers with up to 9 are 4 bytes integers; r of 4 are 2 byte,
 ! and r of 2 is 1 byte
         call mpi_type_create_f90_integer( 9, ntype1, ierr )
 !

--- a/test/mpi/f90/datatype/kinds.f90
+++ b/test/mpi/f90/datatype/kinds.f90
@@ -90,19 +90,19 @@
      endif
      call MPI_RECV( aint, 1, MPI_AINT, 0, 0, MPI_COMM_WORLD, s, ierr )
      if (taint .ne. aint) then
-        print *, "Address-sized int not correctly transfered"
+        print *, "Address-sized int not correctly transferred"
         print *, "Value should be ", taint, " but is ", aint
         errs = errs + 1
      endif
      call MPI_RECV( oint, 1, MPI_OFFSET, 0, 1, MPI_COMM_WORLD, s, ierr )
      if (toint .ne. oint) then
-        print *, "Offset-sized int not correctly transfered"
+        print *, "Offset-sized int not correctly transferred"
         print *, "Value should be ", toint, " but is ", oint
         errs = errs + 1
      endif
      call MPI_RECV( iint, 1, MPI_INTEGER, 0, 2, MPI_COMM_WORLD, s, ierr )
      if (tiint .ne. iint) then
-        print *, "Integer (by kind) not correctly transfered"
+        print *, "Integer (by kind) not correctly transferred"
         print *, "Value should be ", tiint, " but is ", iint
         errs = errs + 1
      endif

--- a/test/mpi/f90/datatype/structf.f90
+++ b/test/mpi/f90/datatype/structf.f90
@@ -61,7 +61,7 @@
           call mpi_type_free(newtype,ierr)
 !         write(*,*) "Sent ",name(1:5),x
       else 
-!         Everyone calls barrier incase size > 2
+!         Everyone calls barrier in case size > 2
           call mpi_barrier( MPI_COMM_WORLD, ierr )
           if (me.eq.dest) then
              position=0

--- a/test/mpi/f90/f90types/createf90types.c
+++ b/test/mpi/f90/f90types/createf90types.c
@@ -51,17 +51,17 @@ static int checkType(const char str[], int p, int r, int f90kind, int err, MPI_D
             errs++;
             printf("Wrong combiner type (got %d, should be %d) for %s\n", combiner, f90kind, str);
         } else {
-            int parms[2];
+            int ints[2];
             MPI_Datatype outtype;
-            parms[0] = 0;
-            parms[1] = 0;
+            ints[0] = 0;
+            ints[1] = 0;
 
             if (ndtypes != 0) {
                 errs++;
                 printf
                     ("Section 8.6 states that the array_of_datatypes entry is empty for the create_f90 types\n");
             }
-            MPI_Type_get_contents(dtype, 2, 0, 1, parms, 0, &outtype);
+            MPI_Type_get_contents(dtype, 2, 0, 1, ints, 0, &outtype);
             switch (combiner) {
                 case MPI_COMBINER_F90_REAL:
                 case MPI_COMBINER_F90_COMPLEX:
@@ -69,10 +69,10 @@ static int checkType(const char str[], int p, int r, int f90kind, int err, MPI_D
                         errs++;
                         printf("Returned %d integer values, 2 expected for %s\n", nints, str);
                     }
-                    if (parms[0] != p || parms[1] != r) {
+                    if (ints[0] != p || ints[1] != r) {
                         errs++;
                         printf("Returned (p=%d,r=%d); expected (p=%d,r=%d) for %s\n",
-                               parms[0], parms[1], p, r, str);
+                               ints[0], ints[1], p, r, str);
                     }
                     break;
                 case MPI_COMBINER_F90_INTEGER:
@@ -80,9 +80,9 @@ static int checkType(const char str[], int p, int r, int f90kind, int err, MPI_D
                         errs++;
                         printf("Returned %d integer values, 1 expected for %s\n", nints, str);
                     }
-                    if (parms[0] != p) {
+                    if (ints[0] != p) {
                         errs++;
-                        printf("Returned (p=%d); expected (p=%d) for %s\n", parms[0], p, str);
+                        printf("Returned (p=%d); expected (p=%d) for %s\n", ints[0], p, str);
                     }
                     break;
                 default:

--- a/test/mpi/ft/irecvdead.c
+++ b/test/mpi/ft/irecvdead.c
@@ -12,7 +12,7 @@
  * This test attempts MPI_Irecv with the source being a dead process. It should fail
  * and return an error at completion. If we are testing sufficiently new MPICH, we
  * look for the MPIX_ERR_PROC_FAILED error code. These should be converted to look
- * for the standarized error code once it is finalized.
+ * for the standardized error code once it is finalized.
  */
 int main(int argc, char **argv)
 {

--- a/test/mpi/ft/recvdead.c
+++ b/test/mpi/ft/recvdead.c
@@ -12,7 +12,7 @@
  * This test attempts MPI_Recv with the source being a dead process. It should fail
  * and return an error. If we are testing sufficiently new MPICH, we look for the
  * MPIX_ERR_PROC_FAILED error code. These should be converted to look for the
- * standarized error code once it is finalized.
+ * standardized error code once it is finalized.
  */
 int main(int argc, char **argv)
 {

--- a/test/mpi/group/grouptest.c
+++ b/test/mpi/group/grouptest.c
@@ -21,7 +21,7 @@ int main(int argc, char *argv[])
     MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     if (size < 8) {
-        fprintf(stderr, "Test requires 8 processes (16 prefered) only %d provided\n", size);
+        fprintf(stderr, "Test requires 8 processes (16 preferred) only %d provided\n", size);
         errs++;
     }
 

--- a/test/mpi/group/grouptest2.c
+++ b/test/mpi/group/grouptest2.c
@@ -5,7 +5,7 @@
 
 /*
    Test the group routines
-   (some tested elsewere)
+   (some tested elsewhere)
 
 MPI_Group_compare
 MPI_Group_excl

--- a/test/mpi/info/infodel.c
+++ b/test/mpi/info/infodel.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     MTest_Init(&argc, &argv);
 
     MPI_Info_create(&info);
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     for (i = 0; i < NKEYS; i++) {
         MPI_Info_set(info, keys[i], values[i]);

--- a/test/mpi/info/infodup.c
+++ b/test/mpi/info/infodup.c
@@ -23,7 +23,7 @@ int main(int argc, char *argv[])
     MTest_Init(&argc, &argv);
 
     MPI_Info_create(&info1);
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     MPI_Info_set(info1, (char *) "host", (char *) "myhost.myorg.org");
     MPI_Info_set(info1, (char *) "file", (char *) "runfile.txt");

--- a/test/mpi/info/infoorder.c
+++ b/test/mpi/info/infoorder.c
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
 
     /* 1,2,3 */
     MPI_Info_create(&info);
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     for (i = 0; i < NKEYS; i++) {
         MPI_Info_set(info, keys1[i], values1[i]);
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
 
     /* 3,2,1 */
     MPI_Info_create(&info);
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     for (i = NKEYS - 1; i >= 0; i--) {
         MPI_Info_set(info, keys1[i], values1[i]);
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
 
     /* 1,3,2 */
     MPI_Info_create(&info);
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     MPI_Info_set(info, keys1[0], values1[0]);
     MPI_Info_set(info, keys1[2], values1[2]);
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 
     /* 2,1,3 */
     MPI_Info_create(&info);
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     MPI_Info_set(info, keys1[1], values1[1]);
     MPI_Info_set(info, keys1[0], values1[0]);
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
 
     /* 2,3,1 */
     MPI_Info_create(&info);
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     MPI_Info_set(info, keys1[1], values1[1]);
     MPI_Info_set(info, keys1[2], values1[2]);
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
 
     /* 3,1,2 */
     MPI_Info_create(&info);
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     MPI_Info_set(info, keys1[2], values1[2]);
     MPI_Info_set(info, keys1[0], values1[0]);

--- a/test/mpi/info/infovallen.c
+++ b/test/mpi/info/infovallen.c
@@ -23,7 +23,7 @@ int main(int argc, char *argv[])
     MTest_Init(&argc, &argv);
 
     MPI_Info_create(&info);
-    /* Use only named keys incase the info implementation only supports
+    /* Use only named keys in case the info implementation only supports
      * the predefined keys (e.g., IBM) */
     for (i = 0; i < NKEYS; i++) {
         MPI_Info_set(info, keys[i], values[i]);

--- a/test/mpi/init/attrself.c
+++ b/test/mpi/init/attrself.c
@@ -94,7 +94,7 @@ int checkAttrs(MPI_Comm comm, int n, int lkey[], int attrval[])
             fprintf(stderr, "Attribute for key %d not set\n", i);
         } else if (val_p != &attrval[i]) {
             lerrs++;
-            fprintf(stderr, "Atribute value for key %d not correct\n", i);
+            fprintf(stderr, "Attribute value for key %d not correct\n", i);
         }
     }
 

--- a/test/mpi/init/session_psets.c
+++ b/test/mpi/init/session_psets.c
@@ -11,7 +11,7 @@
 /* This is adapted example 10.9 from MPI Standard 4.0
  * This example illustrates the use of Process Set query functions to select a
  * Process Set to use for MPI Group creation. First, the default error handler
- * can be specified when instatiating a Session instance. Second, thre must be
+ * can be specified when instatiating a Session instance. Second, there must be
  * at least two process sets associated with a Session. Third, the example
  * illustrates use of session info object and the one required key: "mpi_size".
  */

--- a/test/mpi/io/hindexed_io.c
+++ b/test/mpi/io/hindexed_io.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
         for (k = 0; k < (DATA_SIZE / sizeof(int)); k++) {
             if (verify[(HEADER + PAD) / sizeof(int) + k + j * (DATA_SIZE / sizeof(int))] != data[k]) {
                 errs++;
-                fprintf(stderr, "expcted %d, read %d\n", data[k],
+                fprintf(stderr, "expected %d, read %d\n", data[k],
                         verify[(HEADER + PAD) / sizeof(int) + k + j * (DATA_SIZE / sizeof(int))]);
             }
             i++;

--- a/test/mpi/io/i_hindexed_io.c
+++ b/test/mpi/io/i_hindexed_io.c
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
             if (verify[(HEADER + PAD) / sizeof(int) + k + j * (DATA_SIZE / sizeof(int))]
                 != data[k]) {
                 errs++;
-                fprintf(stderr, "expcted %d, read %d\n", data[k],
+                fprintf(stderr, "expected %d, read %d\n", data[k],
                         verify[(HEADER + PAD) / sizeof(int) + k + j * (DATA_SIZE / sizeof(int))]);
             }
             i++;

--- a/test/mpi/io/i_noncontig_coll2.c
+++ b/test/mpi/io/i_noncontig_coll2.c
@@ -15,7 +15,7 @@
  *
  * . generalized file writing/reading to handle arbitrary number of processors
  * . provides the "cb_config_list" hint with several permutations of the
- *   avaliable processors.
+ *   available processors.
  *   [ makes use of code copied from ROMIO's ADIO code to collect the names of
  *   the processors ]
  */

--- a/test/mpi/io/simple_collective.c
+++ b/test/mpi/io/simple_collective.c
@@ -5,7 +5,7 @@
 
 
 /* this deceptively simple test uncovered a bug in the way certain file systems
- * dealt with tuning parmeters.  See
+ * dealt with tuning parameters.  See
  * https://github.com/open-mpi/ompi/issues/158 and
  * http://trac.mpich.org/projects/mpich/ticket/2261
  *
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
     sprintf(file, "%s", opt_file);
     MPI_Info_create(&info);
     nr_errors += test_write(file, nprocs, rank, info);
-    /* acutal value does not matter.  test only writes a small amount of data */
+    /* actual value does not matter.  test only writes a small amount of data */
     MPI_Info_set(info, "striping_factor", "50");
     nr_errors += test_write(file, nprocs, rank, info);
     MPI_Info_free(&info);

--- a/test/mpi/maint/f77tof90
+++ b/test/mpi/maint/f77tof90
@@ -470,7 +470,7 @@ sub ConvertTestlist {
 	}
 	elsif (/^c2fmult(\w*)\s+(.*)/) {
 	    # This is a special case for programs that are not Fortran
-	    # programs but are part of the Fortran tests; principly, these
+	    # programs but are part of the Fortran tests; principally, these
 	    # are the tests of MPI handle conversion
 	    # note the \w* instead of \w+; this allows us to match both
 	    # c2fmult.c and c2fmultio.c

--- a/test/mpi/maint/testmerge.in
+++ b/test/mpi/maint/testmerge.in
@@ -132,7 +132,7 @@ sub MergeTemplate {
 	    if (defined($Definitions{$name})) {
 		my $defn = $Definitions{$name};
 		my $newdefn = "";
-		# Add indentation to definition; substitute any defintions
+		# Add indentation to definition; substitute any definitions
 		foreach my $line (split(/\n/,$defn)) {
 		    print "Looking at |$line|\n" if $debug;
 		    $newdefn .= $indent . $line . "\n";

--- a/test/mpi/manual/manyconnect.in
+++ b/test/mpi/manual/manyconnect.in
@@ -16,7 +16,7 @@ rm -f $file
 # Default number of processes to start (the test is for large numbers
 # of processes; use "manyconnect 10" to start with fewer for debugging)
 nconn=100
-# To avoid problems with listner queues, we pause every blockstart
+# To avoid problems with listener queues, we pause every blockstart
 # processes
 blockstart=10
 

--- a/test/mpi/manual/mpi_t/mpit_test.c
+++ b/test/mpi/manual/mpi_t/mpit_test.c
@@ -4,7 +4,7 @@
  */
 
 /* A simple test of the proposed MPI_T_ interface that queries all of
- * the control variables exposed by the MPI implememtation and prints
+ * the control variables exposed by the MPI implementation and prints
  * them to stdout.
  *
  * Author: Dave Goodell <goodell@mcs.anl.gov.

--- a/test/mpi/manual/mpi_t/mpit_test2.c
+++ b/test/mpi/manual/mpi_t/mpit_test2.c
@@ -7,7 +7,7 @@
  * presence of two performance variables: "posted_recvq_length" and
  * "unexpected_recvq_length".  Some information about these variables
  * is printed to stdout and then a few messages are sent/received to
- * show that theses variables are reporting useful information.
+ * show that these variables are reporting useful information.
  *
  * Author: Dave Goodell <goodell@mcs.anl.gov.
  */

--- a/test/mpi/manual/mpi_t/nem_fbox_fallback_to_queue_count.c
+++ b/test/mpi/manual/mpi_t/nem_fbox_fallback_to_queue_count.c
@@ -33,7 +33,7 @@ int err, rank;
 MPI_T_pvar_session session;
 MPI_T_pvar_handle fbox_handle;
 
-/* Check that we can successfuly write to the variable.
+/* Check that we can successfully write to the variable.
  * Question: Do we really want to write pvars other than reset?
  */
 void blank_test()

--- a/test/mpi/manual/testconnect.c
+++ b/test/mpi/manual/testconnect.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
 
     MPI_Init(0, 0);
 
-    /* the existance of the file is used to decide which processes
+    /* the existence of the file is used to decide which processes
      * first do a connect to the root process.  */
     fh = fopen(fname, "rt");
     if (fh == NULL) {

--- a/test/mpi/manual/testconnectserial.c
+++ b/test/mpi/manual/testconnectserial.c
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
          * wait their turn by checking for the correct file to show up */
         actualFname = writePortToFile(portName, "%s.%d", fname, rankToAccept++);
 
-        /* The wrapper script I'm using checks for the existance of "fname", so
+        /* The wrapper script I'm using checks for the existence of "fname", so
          * create that - even though it isn't used  */
         globalFname = writePortToFile(portName, fname);
         installExitHandler(globalFname);

--- a/test/mpi/mpi_t/mpit_vars.c
+++ b/test/mpi/mpi_t/mpit_vars.c
@@ -399,7 +399,7 @@ char *mpit_scopeToStr(int scope)
             p = "SCOPE_ALL_EQ";
             break;
         default:
-            p = "Unrecoginized scope";
+            p = "Unrecognized scope";
             break;
     }
     return p;

--- a/test/mpi/pt2pt/anyall.c
+++ b/test/mpi/pt2pt/anyall.c
@@ -11,7 +11,7 @@
 #define MAX_MSGS 30
 
 /*
-static char MTEST_Descrip[] = "One implementation delivered incorrect data when an MPI recieve uses both ANY_SOURCE and ANY_TAG";
+static char MTEST_Descrip[] = "One implementation delivered incorrect data when an MPI receive uses both ANY_SOURCE and ANY_TAG";
 */
 
 int main(int argc, char *argv[])

--- a/test/mpi/pt2pt/bsendalign.c
+++ b/test/mpi/pt2pt/bsendalign.c
@@ -7,7 +7,7 @@
 #include "mpi.h"
 #include "mpitest.h"
 
-/* Test bsend with a buffer with arbitray alignment */
+/* Test bsend with a buffer with arbitrary alignment */
 #define BUFSIZE 2000*4
 int main(int argc, char *argv[])
 {
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
         if (bptr != buf + align) {
             errs++;
             printf
-                ("Did not recieve the same buffer on detach that was provided on init (%p vs %p)\n",
+                ("Did not receive the same buffer on detach that was provided on init (%p vs %p)\n",
                  bptr, buf);
         }
     }

--- a/test/mpi/rma/acc_ordering.c
+++ b/test/mpi/rma/acc_ordering.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
         data[0].val = 0;
     }
     MPI_Win_fence(0, win);
-    /* 1.b. Large arrary test */
+    /* 1.b. Large array test */
     if (me == nproc - 1) {
         MPI_Accumulate(mine, ARRAY_LEN, MPI_2INT, 0, 0, ARRAY_LEN, MPI_2INT, MPI_REPLACE, win);
         MPI_Accumulate(mine_plus, ARRAY_LEN, MPI_2INT, 0, 0, ARRAY_LEN, MPI_2INT, MPI_REPLACE, win);

--- a/test/mpi/rma/accfence1.c
+++ b/test/mpi/rma/accfence1.c
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
             } else if (rank == target) {
                 MPI_Win_fence(0, win);
                 /* This should have the same effect, in terms of
-                 * transfering data, as a send/recv pair */
+                 * transferring data, as a send/recv pair */
                 MTestCopyContent(targetbuf, targetbuf_h, target_obj.DTP_bufsize, targetmem);
                 err = DTP_obj_buf_check(target_obj, targetbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {

--- a/test/mpi/rma/accpscw1.c
+++ b/test/mpi/rma/accpscw1.c
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
                 MPI_Group_free(&neighbors);
                 MPI_Win_wait(win);
                 /* This should have the same effect, in terms of
-                 * transfering data, as a send/recv pair */
+                 * transferring data, as a send/recv pair */
                 MTestCopyContent(targetbuf, targetbuf_h, maxbufsize, targetmem);
                 err = DTP_obj_buf_check(target_obj, targetbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {

--- a/test/mpi/rma/atomic_rmw_gacc.c
+++ b/test/mpi/rma/atomic_rmw_gacc.c
@@ -6,11 +6,11 @@
 /* This test is going to test the atomicity for "read-modify-write" in GACC
  * operations */
 
-/* This test is similiar with atomic_rmw_fop.c.
+/* This test is similar with atomic_rmw_fop.c.
  * There are three processes involved in this test: P0 (origin_shm), P1 (origin_am),
  * and P2 (dest). P0 and P1 issues multiple GACC with MPI_SUM and OP_COUNT integers
  * (value 1) to P2 via SHM and AM respectively. The correct results should be that the
- * results on P0 and P1 never be the same for intergers on the corresponding index
+ * results on P0 and P1 never be the same for integers on the corresponding index
  * in [0...OP_COUNT-1].
  */
 

--- a/test/mpi/rma/attrorderwin.c
+++ b/test/mpi/rma/attrorderwin.c
@@ -98,7 +98,7 @@ int checkAttrs(MPI_Win win, int n, int key[], int attrval[])
             fprintf(stderr, "Attribute for key %d not set\n", i);
         } else if (val_p != &attrval[i]) {
             errs++;
-            fprintf(stderr, "Atribute value for key %d not correct\n", i);
+            fprintf(stderr, "Attribute value for key %d not correct\n", i);
         }
     }
 

--- a/test/mpi/rma/contention_put.c
+++ b/test/mpi/rma/contention_put.c
@@ -6,7 +6,7 @@
 /** Contended RMA put test -- James Dinan <dinan@mcs.anl.gov>
   *
   * Each process issues COUNT put operations to non-overlapping locations on
-  * every other processs.
+  * every other process.
   */
 
 #include <stdio.h>

--- a/test/mpi/rma/contention_putget.c
+++ b/test/mpi/rma/contention_putget.c
@@ -6,7 +6,7 @@
 /** Contended RMA put/get test -- James Dinan <dinan@mcs.anl.gov>
   *
   * Each process issues COUNT put and get operations to non-overlapping
-  * locations on every other processs.
+  * locations on every other process.
   */
 
 #include <stdio.h>

--- a/test/mpi/rma/fence.c
+++ b/test/mpi/rma/fence.c
@@ -109,7 +109,7 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
         }
 
         /* This should have the same effect, in terms of
-         * transfering data, as a send/recv pair */
+         * transferring data, as a send/recv pair */
 #if defined(USE_GET)
         err =
             MPI_Get(origbuf + orig_obj.DTP_buf_offset, origcount, origtype, target,

--- a/test/mpi/rma/mixedsync.c
+++ b/test/mpi/rma/mixedsync.c
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
         /* Perform several communication operations, mixing synchronization
          * types.  Use multiple communication to avoid the single-operation
          * optimization that may be present. */
-        MTestPrintfMsg(3, "Begining loop %d of mixed sync put/acc operations\n", loop);
+        MTestPrintfMsg(3, "Beginning loop %d of mixed sync put/acc operations\n", loop);
         memset(winbuf, 0, count * sizeof(int));
         MPI_Barrier(comm);
         if (crank == source) {
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
         /* Perform several communication operations, mixing synchronization
          * types.  Use multiple communication to avoid the single-operation
          * optimization that may be present. */
-        MTestPrintfMsg(3, "Begining loop %d of mixed sync put/get/acc operations\n", loop);
+        MTestPrintfMsg(3, "Beginning loop %d of mixed sync put/get/acc operations\n", loop);
         MPI_Barrier(comm);
         if (crank == source) {
             MPI_Win_lock(MPI_LOCK_EXCLUSIVE, dest, 0, win);

--- a/test/mpi/rma/putpscw1.c
+++ b/test/mpi/rma/putpscw1.c
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
                 MPI_Group_free(&neighbors);
                 MPI_Win_wait(win);
                 /* This should have the same effect, in terms of
-                 * transfering data, as a send/recv pair */
+                 * transferring data, as a send/recv pair */
                 MTestCopyContent(targetbuf, targetbuf_h, maxbufsize, targetmem);
                 err = DTP_obj_buf_check(target_obj, targetbuf_h, 0, 1, count);
                 if (err != DTP_SUCCESS) {

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -772,7 +772,7 @@ sub RunMPIProgram {
     # acquire lock if requested
     my ($lockfile, $got_lock);
     if ($test_opt->{lock}) {
-        # explict lock by setting "lock=[shared|name]" on testline directly
+        # explicit lock by setting "lock=[shared|name]" on testline directly
         my $name = $test_opt->{lock};
         $lockfile = "/tmp/runtests-$name.lock";
         if ($name eq "shared") {
@@ -913,7 +913,7 @@ sub AddMPIProgram {
 
     if ($test_opt->{resultTest}) {
         # This test really needs to be run manually, with this test
-        # Eventually, we can update this to include handleing in checktests.
+        # Eventually, we can update this to include handling in checktests.
         print STDERR "Run $curdir/$programname with $np processes and use $test_opt->{resultTest} to check the results\n";
         return;
     }

--- a/test/mpi/threads/mpi_t/mpit_threading.c
+++ b/test/mpi/threads/mpi_t/mpit_threading.c
@@ -350,7 +350,7 @@ char *mpit_scopeToStr(int scope)
             p = "SCOPE_ALL_EQ";
             break;
         default:
-            p = "Unrecoginized scope";
+            p = "Unrecognized scope";
             break;
     }
     return p;

--- a/test/mpi/threads/pt2pt/ibsend.c
+++ b/test/mpi/threads/pt2pt/ibsend.c
@@ -10,7 +10,7 @@
    It starts a single receiver thread that expects
    NUMSENDS from NUMTHREADS sender threads, that
    use [i]bsend/[i]send to send a message of size MSGSIZE
-   to its right neigbour or rank 0 if (my_rank==comm_size-1), i.e.
+   to its right neighbor or rank 0 if (my_rank==comm_size-1), i.e.
    target_rank = (my_rank+1)%size .
 
    After all messages have been received, the

--- a/test/mpi/threads/pt2pt/mt_pt2pt_common.c
+++ b/test/mpi/threads/pt2pt/mt_pt2pt_common.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
         MPI_Abort(MPI_COMM_WORLD, 1);
     }
 
-    /* Setup bufer for bsend */
+    /* Setup buffer for bsend */
 #if defined(BSEND) || defined(IBSEND)
     {
         int n_experiment_grps = 3;

--- a/test/mpi/threads/pt2pt/mt_pt2pt_common.h
+++ b/test/mpi/threads/pt2pt/mt_pt2pt_common.h
@@ -37,7 +37,7 @@
 #define ISEND_FUN MPI_Isend
 #endif
 
-/* Large data tranfer */
+/* Large data transfer */
 #if defined(HUGE_COUNT)
 #define BUFF_ELEMENT_COUNT(iter, count) (count)
 /* Medium data transfer */

--- a/test/mpi/util/dtypes.c
+++ b/test/mpi/util/dtypes.c
@@ -136,7 +136,7 @@ static int basic_only = 0;
   free(myname); \
   counts[cnt]  = 1;  bytesize[cnt] = sizeof(_ctype) * (_count); cnt++; }
 
-/* This defines a structure of two basic members; by chosing things like
+/* This defines a structure of two basic members; by choosing things like
    (char, double), various packing and alignment tests can be made */
 #define SETUPSTRUCT2TYPE(_mpitype1,_ctype1,_mpitype2,_ctype2,_count,_tname) { \
   int i; char *myname;						\

--- a/test/mpi/util/mtest.c
+++ b/test/mpi/util/mtest.c
@@ -560,7 +560,7 @@ int MTestGetIntercomm(MPI_Comm * comm, int *isLeftGroup, int min_size)
                     } else if (rank == size / 2) {
                         rleader = 0;
                     } else {
-                        /* Remote leader is signficant only for the processes
+                        /* Remote leader is significant only for the processes
                          * designated local leaders */
                         rleader = -1;
                     }
@@ -589,7 +589,7 @@ int MTestGetIntercomm(MPI_Comm * comm, int *isLeftGroup, int min_size)
                     } else if (rank == 1) {
                         rleader = 0;
                     } else {
-                        /* Remote leader is signficant only for the processes
+                        /* Remote leader is significant only for the processes
                          * designated local leaders */
                         rleader = -1;
                     }
@@ -619,7 +619,7 @@ int MTestGetIntercomm(MPI_Comm * comm, int *isLeftGroup, int min_size)
                     } else if (rank == 2) {
                         rleader = 0;
                     } else {
-                        /* Remote leader is signficant only for the processes
+                        /* Remote leader is significant only for the processes
                          * designated local leaders */
                         rleader = -1;
                     }
@@ -649,7 +649,7 @@ int MTestGetIntercomm(MPI_Comm * comm, int *isLeftGroup, int min_size)
                     } else if (rank == size / 2) {
                         rleader = 0;
                     } else {
-                        /* Remote leader is signficant only for the processes
+                        /* Remote leader is significant only for the processes
                          * designated local leaders */
                         rleader = -1;
                     }
@@ -689,7 +689,7 @@ int MTestGetIntercomm(MPI_Comm * comm, int *isLeftGroup, int min_size)
                     } else if (rank == size / 2) {
                         rleader = 0;
                     } else {
-                        /* Remote leader is signficant only for the processes
+                        /* Remote leader is significant only for the processes
                          * designated local leaders */
                         rleader = -1;
                     }
@@ -740,7 +740,7 @@ int MTestGetIntercomm(MPI_Comm * comm, int *isLeftGroup, int min_size)
                     } else if (rank == (size / 2)) {
                         rleader = 1;
                     } else {
-                        /* Remote leader is signficant only for the processes
+                        /* Remote leader is significant only for the processes
                          * designated local leaders */
                         rleader = -1;
                     }
@@ -781,7 +781,7 @@ int MTestGetIntercomm(MPI_Comm * comm, int *isLeftGroup, int min_size)
                     } else if (rank == (size / 2)) {
                         rleader = 0;
                     } else {
-                        /* Remote leader is signficant only for the processes
+                        /* Remote leader is significant only for the processes
                          * designated local leaders */
                         rleader = -1;
                     }

--- a/test/mpi/util/mtest_common.c
+++ b/test/mpi/util/mtest_common.c
@@ -8,10 +8,10 @@
 /* ------------------------------------------------------------------------ */
 /* Utilities related to test environment */
 
-/* Some tests would like to test with large buffer, but an arbitary size may fail
+/* Some tests would like to test with large buffer, but an arbitrary size may fail
    on machines that does not have sufficient memory or the OS may not support it.
    This routine provides a portable interface to get that max size.
-   It is taking the simpliest solution here: default to 2GB, unless user set via
+   It is taking the simplest solution here: default to 2GB, unless user set via
    environment variable -- MPITEST_MAXBUFFER
 */
 MPI_Aint MTestDefaultMaxBufferSize()
@@ -236,7 +236,7 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
 
 #ifdef HAVE_ZE
     if (device_id == -1) {
-        /* Initilize ZE driver and device only at first call. */
+        /* Initialize ZE driver and device only at first call. */
         device_id = 0;
         zerr = zeInit(0);
         assert(zerr == ZE_RESULT_SUCCESS);

--- a/test/mpi/util/mtest_common.c
+++ b/test/mpi/util/mtest_common.c
@@ -382,7 +382,7 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
         host_desc.pNext = NULL;
         host_desc.flags = 0;
 
-        /* Currently ZE ignores this augument and uses an internal alignment
+        /* Currently ZE ignores this argument and uses an internal alignment
          * value. However, this behavior can change in the future. */
         mem_alignment = 1;
         zerr = zeMemAllocHost(context, &host_desc, size, mem_alignment, devicebuf);
@@ -399,7 +399,7 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
         device_desc.pNext = NULL;
         device_desc.flags = 0;
         device_desc.ordinal = 0;        /* We currently support a single memory type */
-        /* Currently ZE ignores this augument and uses an internal alignment
+        /* Currently ZE ignores this argument and uses an internal alignment
          * value. However, this behavior can change in the future. */
         mem_alignment = 1;
         zerr =
@@ -430,7 +430,7 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
         host_desc.stype = ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC;
         host_desc.pNext = NULL;
         host_desc.flags = 0;
-        /* Currently ZE ignores this augument and uses an internal alignment
+        /* Currently ZE ignores this argument and uses an internal alignment
          * value. However, this behavior can change in the future. */
         mem_alignment = 1;
         zerr =

--- a/test/mpi/util/mtest_cxx.cxx
+++ b/test/mpi/util/mtest_cxx.cxx
@@ -270,7 +270,7 @@ int MTestGetIntercomm(MPI::Intercomm & comm, int &isLeftGroup, int min_size)
                     } else if (rank == size / 2) {
                         rleader = 0;
                     } else {
-                        /* Remote leader is signficant only for the processes
+                        /* Remote leader is significant only for the processes
                          * designated local leaders */
                         rleader = -1;
                     }
@@ -293,7 +293,7 @@ int MTestGetIntercomm(MPI::Intercomm & comm, int &isLeftGroup, int min_size)
                     } else if (rank == 1) {
                         rleader = 0;
                     } else {
-                        /* Remote leader is signficant only for the processes
+                        /* Remote leader is significant only for the processes
                          * designated local leaders */
                         rleader = -1;
                     }
@@ -317,7 +317,7 @@ int MTestGetIntercomm(MPI::Intercomm & comm, int &isLeftGroup, int min_size)
                     } else if (rank == 2) {
                         rleader = 0;
                     } else {
-                        /* Remote leader is signficant only for the processes
+                        /* Remote leader is significant only for the processes
                          * designated local leaders */
                         rleader = -1;
                     }


### PR DESCRIPTION
## Pull Request Description

Add maint/spellcheck.sh and apply it to the codebase. It uses [codespell](https://github.com/codespell-project/codespell) for spell checking.

Fixes #4982

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
