### PR TITLE
typerep: fix yaksa include check at configure

### DIFF
--- a/src/mpi/datatype/typerep/src/subconfigure.m4
+++ b/src/mpi/datatype/typerep/src/subconfigure.m4
@@ -44,7 +44,7 @@ AC_SUBST([yaksalib])
 
 AM_COND_IF([BUILD_YAKSA_ENGINE], [
 m4_define([yaksa_embedded_dir],[modules/yaksa])
-PAC_CHECK_HEADER_LIB_EXPLICIT([yaksa],[yaksa_config.h],[$YAKSALIBNAME],[yaksa_init])
+PAC_CHECK_HEADER_LIB_EXPLICIT([yaksa],[yaksa.h],[$YAKSALIBNAME],[yaksa_init])
 if test "$with_yaksa" = "embedded" ; then
     PAC_PUSH_ALL_FLAGS()
     PAC_RESET_ALL_FLAGS()


### PR DESCRIPTION
## Pull Request Description
Current configure check for `--with-yaksa` does not work with external yaksa library. It checks `yaksa_config.h` which is  not exposed by yaksa standalone build

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
