### PR TITLE
config: fix hwloc config check and hydra/slurm config check

### DIFF
--- a/confdb/aclocal_libs.m4
+++ b/confdb/aclocal_libs.m4
@@ -83,9 +83,12 @@ dnl prepend the library to WRAPPER_LIBS instead.
 AC_DEFUN([PAC_CHECK_HEADER_LIB],[
     failure=no
     AC_CHECK_HEADER([$1],,failure=yes)
-    PAC_PUSH_FLAG(LIBS)
-    AC_CHECK_LIB($2,$3,,failure=yes)
-    PAC_POP_FLAG(LIBS)
+    dnl Skip lib check if cannot find header
+    if test "$failure" = "no" ; then
+        PAC_PUSH_FLAG(LIBS)
+        AC_CHECK_LIB($2,$3,,failure=yes)
+        PAC_POP_FLAG(LIBS)
+    fi
     if test "$failure" = "no" ; then
        $4
     else

--- a/configure.ac
+++ b/configure.ac
@@ -1111,7 +1111,7 @@ dnl minor difference from e.g. mpl and zm -- we'll prioritize system hwloc by de
 PAC_CHECK_HEADER_LIB_OPTIONAL([hwloc],[hwloc.h],[hwloc],[hwloc_topology_set_pid])
 PAC_CHECK_HEADER_LIB_OPTIONAL([netloc],[netloc.h],[netloc],[netloc_get_all_host_nodes])
 
-if test "$pac_have_hwloc" = "yes" ; then
+if test "$pac_have_hwloc" = "yes" -a "$with_hwloc" != "embedded"; then
     AC_MSG_CHECKING([if hwloc meets minimum version requirement])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <hwloc.h>], [
                        #if HWLOC_API_VERSION < 0x00020000

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -455,10 +455,9 @@ AC_MSG_RESULT([$available_topolibs])
 #########################################################################
 # Slurm hostlist parsing
 #########################################################################
-AC_CHECK_HEADERS(slurm/slurm.h)
-PAC_CHECK_HEADER_LIB_OPTIONAL([libslurm],[slurm/slurm.h],[slurm],[slurm_hostlist_create])
-if test "$pac_have_libslurm" = "yes" ; then
-    AC_DEFINE(HAVE_LIBSLURM,1,[Define if libslurm is available])
+PAC_CHECK_HEADER_LIB_OPTIONAL([slurm],[slurm/slurm.h],[slurm],[slurm_hostlist_create])
+if test "$pac_have_slurm" = "yes" ; then
+    AC_DEFINE(HAVE_SLURM,1,[Define if slurm is available])
 fi
 
 #########################################################################

--- a/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
+++ b/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
@@ -8,7 +8,7 @@
 #include "bscu.h"
 #include "slurm.h"
 
-#if defined(HAVE_SLURM_SLURM_H)
+#if defined(HAVE_SLURM)
 #include <slurm/slurm.h>        /* for slurm_hostlist_create */
 #elif defined(HAVE_POSIX_REGCOMP)
 #include <regex.h>      /* for POSIX regular expressions */
@@ -22,7 +22,7 @@
 static int *tasks_per_node = NULL;
 static struct HYD_node *global_node_list = NULL;
 
-#if defined(HAVE_LIBSLURM)
+#if defined(HAVE_SLURM)
 static HYD_status list_to_nodes(char *str)
 {
     hostlist_t hostlist;


### PR DESCRIPTION
When only libslurm.so is available, slurm code in hydra bootstrap is
still compiled which causes compilation error because type hostlist_t is
undefined. This patch fixes it by compiling the code only when found both
library and header file.

## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
