### PR TITLE
op: MPI_NO_OP and MPI_REPLACE should be non-commutative

### DIFF
--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -131,15 +131,24 @@ extern MPIR_Object_alloc_t MPIR_Op_mem;
 /* Query index of builtin op */
 MPL_STATIC_INLINE_PREFIX int MPIR_Op_builtin_get_index(MPI_Op op)
 {
-    MPIR_Assert(HANDLE_IS_BUILTIN(op));
-    return (0x000000ff & op) - 1;       /* index 1 to 14 in handle. */
+    if (op == MPI_OP_NULL) {
+        return 0;
+    } else {
+        MPIR_Assert(HANDLE_IS_BUILTIN(op));
+        return (0x000000ff & op);
+    }
 }
 
-/* Query builtin op by using index (from 0 to MPIR_OP_N_BUILTIN-1) */
+/* Query builtin op by using index (from 1 to MPIR_OP_N_BUILTIN-1)
+ * Note: index 0 refers to MPI_OP_NULL (0x18000000) */
 MPL_STATIC_INLINE_PREFIX MPI_Op MPIR_Op_builtin_get_op(int index)
 {
-    MPIR_Assert(index >= 0 && index < MPIR_OP_N_BUILTIN);
-    return (MPI_Op) (0x58000000 | (index + 1)); /* index 1 to 14 in handle */
+    if (index == 0) {
+        return MPI_OP_NULL;
+    } else {
+        MPIR_Assert(index > 0 && index < MPIR_OP_N_BUILTIN);
+        return (MPI_Op) (0x58000000 | index);
+    }
 }
 
 MPI_Datatype MPIR_Op_builtin_search_by_shortname(const char *short_name);

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -40,6 +40,8 @@ typedef enum MPIR_Op_kind {
     MPIR_OP_KIND__USER = 33
 } MPIR_Op_kind;
 
+#define MPIR_OP_N_BUILTIN 15
+
 /*S
   MPIR_User_function - Definition of a user function for MPI_Op types.
 
@@ -106,7 +108,6 @@ typedef struct MPIR_Op {
      MPID_DEV_OP_DECL
 #endif
 } MPIR_Op;
-#define MPIR_OP_N_BUILTIN 14
 extern MPIR_Op MPIR_Op_builtin[MPIR_OP_N_BUILTIN];
 extern MPIR_Op MPIR_Op_direct[];
 extern MPIR_Object_alloc_t MPIR_Op_mem;

--- a/src/mpi/coll/op/op_impl.c
+++ b/src/mpi/coll/op/op_impl.c
@@ -103,7 +103,11 @@ int MPIR_Op_is_commutative(MPI_Op op)
     MPIR_Op *op_ptr;
 
     if (HANDLE_IS_BUILTIN(op)) {
-        return TRUE;
+        if (op == MPI_NO_OP || op == MPI_REPLACE) {
+            return FALSE;
+        } else {
+            return TRUE;
+        }
     } else {
         MPIR_Op_get_ptr(op, op_ptr);
         MPIR_Assert(op_ptr != NULL);
@@ -114,19 +118,11 @@ int MPIR_Op_is_commutative(MPI_Op op)
     }
 }
 
-int MPIR_Op_commutative_impl(MPIR_Op * op_ptr, int *commute)
+int MPIR_Op_commutative_impl(MPI_Op op, int *commute)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    /* Built-in op */
-    if (MPIR_OP_KIND__USER_NONCOMMUTE > op_ptr->kind) {
-        *commute = 1;
-    } else {
-        if (op_ptr->kind == MPIR_OP_KIND__USER_NONCOMMUTE)
-            *commute = 0;
-        else
-            *commute = 1;
-    }
+    *commute = MPIR_Op_is_commutative(op);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -349,7 +349,7 @@ typedef enum {
     MPIDIG_ACCU_SAME_OP_NO_OP
 } MPIDIG_win_info_accumulate_ops;
 
-#define MPIDIG_ACCU_NUM_OP (MPIR_OP_N_BUILTIN + 1)      /* builtin reduce op + cswap */
+#define MPIDIG_ACCU_NUM_OP (MPIR_OP_N_BUILTIN)  /* builtin reduce op + cswap */
 
 typedef struct MPIDIG_win_info_args_t {
     int no_locks;

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -1154,26 +1154,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_compute_acc_op(void *source_buf, int source_
     return mpi_errno;
 }
 
+/* NOTE: the slot for MPI_OP_NULL refers to RMA cswap */
 MPL_STATIC_INLINE_PREFIX int MPIDIU_win_acc_op_get_index(MPI_Op op)
 {
-    if (op == MPI_OP_NULL) {
-        /* Builtin index is from 0 to MPIR_OP_N_BUILTIN-1.
-         * Thus use MPIR_OP_N_BUILTIN as index for special OP_NULL as RMA cswap */
-        return MPIR_OP_N_BUILTIN - 1;
-    } else {
-        return MPIR_Op_builtin_get_index(op);
-    }
+    return MPIR_Op_builtin_get_index(op);
 }
 
 MPL_STATIC_INLINE_PREFIX MPI_Op MPIDIU_win_acc_get_op(int index)
 {
-    if (index == MPIR_OP_N_BUILTIN - 1) {
-        /* Builtin index is from 0 to MPIR_OP_N_BUILTIN-1.
-         * Thus use MPIR_OP_N_BUILTIN as index for special OP_NULL as RMA cswap */
-        return MPI_OP_NULL;
-    } else {
-        return MPIR_Op_builtin_get_op(index);
-    }
+    return MPIR_Op_builtin_get_op(index);
 }
 
 /* Determine whether need poll progress for RMA target-side active message.

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -1159,7 +1159,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIU_win_acc_op_get_index(MPI_Op op)
     if (op == MPI_OP_NULL) {
         /* Builtin index is from 0 to MPIR_OP_N_BUILTIN-1.
          * Thus use MPIR_OP_N_BUILTIN as index for special OP_NULL as RMA cswap */
-        return MPIR_OP_N_BUILTIN;
+        return MPIR_OP_N_BUILTIN - 1;
     } else {
         return MPIR_Op_builtin_get_index(op);
     }
@@ -1167,7 +1167,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIU_win_acc_op_get_index(MPI_Op op)
 
 MPL_STATIC_INLINE_PREFIX MPI_Op MPIDIU_win_acc_get_op(int index)
 {
-    if (index == MPIR_OP_N_BUILTIN) {
+    if (index == MPIR_OP_N_BUILTIN - 1) {
         /* Builtin index is from 0 to MPIR_OP_N_BUILTIN-1.
          * Thus use MPIR_OP_N_BUILTIN as index for special OP_NULL as RMA cswap */
         return MPI_OP_NULL;

--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -70,13 +70,11 @@ static void get_info_accu_ops_str(uint32_t val, char *buf, size_t maxlen)
     int c = 0, op_index;
     for (op_index = 0; op_index < MPIDIG_ACCU_NUM_OP; op_index++) {
         if (val & (1 << op_index)) {
-            MPI_Op op = MPIDIU_win_acc_get_op(op_index);
-
             MPIR_Assert(c < maxlen);
-            /* use OP_NULL as special cswap */
-            if (op == MPI_OP_NULL) {
+            if (op_index == 0) {
                 c += snprintf(buf + c, maxlen - c, "%scswap", (c > 0) ? "," : "");
             } else {
+                MPI_Op op = MPIDIU_win_acc_get_op(op_index);
                 const char *short_name = MPIR_Op_builtin_get_shortname(op);
                 c += snprintf(buf + c, maxlen - c, "%s%s", (c > 0) ? "," : "", short_name);
             }

--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -52,9 +52,8 @@ static void parse_info_accu_ops_str(const char *str, uint32_t * ops_ptr)
         } else {
             /* search other reduce op by short name */
             MPI_Op op = MPIR_Op_builtin_search_by_shortname(token);
-            if (op != MPI_OP_NULL) {
-                ops |= (1 << MPIDIU_win_acc_op_get_index(op));
-            }
+            MPIR_Assert(op != MPI_OP_NULL);
+            ops |= (1 << MPIDIU_win_acc_op_get_index(op));
         }
 
         token = (char *) strtok_r(NULL, ",", &savePtr);


### PR DESCRIPTION
## Pull Request Description

MPI_NO_OP and MPI_REPLACE should be non-commutative.

Since it is bad to have two separate code paths, the code is refactored
to all calling MPIR_Op_is_commutative.

Also, fix the wrong MPIR_OP_N_BUILTIN, which was causing an assertion error in `MPIR_Op_get_ptr`.

Fixes #5116

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
