### PR TITLE
coll: cleanup memory in ireduce_scatter_block

### DIFF
--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_halving.c
@@ -43,6 +43,7 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_halving(const void *sendbuf
     }
 
     if (total_count == 0) {
+        MPIR_SCHED_CHKPMEM_REAP(s);
         goto fn_exit;
     }
 


### PR DESCRIPTION
## Pull Request Description
In src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_halving.c
when we determing the total_count is 0, we already allocated the disps
array that needs to be freed. Adding MPIR_SCHED_CHKPMEM_REAP(s) will do.


Fixes #5119 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
