### PR TITLE
comm: use MPIR_Allreduce_impl in contextid routines

### DIFF
--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -472,8 +472,8 @@ int MPIR_Get_contextid_sparse_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr
                                              MPI_INT, MPI_BAND, comm_ptr, group_ptr, coll_tag,
                                              &errflag);
         } else {
-            mpi_errno = MPIR_Allreduce(MPI_IN_PLACE, st.local_mask, MPIR_MAX_CONTEXT_MASK + 1,
-                                       MPI_INT, MPI_BAND, comm_ptr, &errflag);
+            mpi_errno = MPIR_Allreduce_impl(MPI_IN_PLACE, st.local_mask, MPIR_MAX_CONTEXT_MASK + 1,
+                                            MPI_INT, MPI_BAND, comm_ptr, &errflag);
         }
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
@@ -580,8 +580,8 @@ int MPIR_Get_contextid_sparse_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr
                 mpi_errno = MPII_Allreduce_group(MPI_IN_PLACE, &minfree, 1, MPI_INT, MPI_MIN,
                                                  comm_ptr, group_ptr, coll_tag, &errflag);
             } else {
-                mpi_errno = MPIR_Allreduce(MPI_IN_PLACE, &minfree, 1, MPI_INT,
-                                           MPI_MIN, comm_ptr, &errflag);
+                mpi_errno = MPIR_Allreduce_impl(MPI_IN_PLACE, &minfree, 1, MPI_INT,
+                                                MPI_MIN, comm_ptr, &errflag);
             }
 
             if (minfree > 0) {


### PR DESCRIPTION
## Pull Request Description
Let's avoid internally calling device collectives in non-performance-
critical paths. Calling MPIR_Allreduce_impl instead of MPIR_Allreduce
for more stability. The latter may call into MPID collectives.

The shmem collectives in ch4 is routinely causing issues due to the complications raised especially during comm construction. Skip device collective here simplifies it.

Currently there are bugs in the shmem collectives when process bindings are not uniform.


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
