### PR TITLE
comm: add split level "bindset" to HW_UNGUIDED split

### DIFF
--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -211,6 +211,7 @@ int MPIR_Comm_split_type_hw_unguided(MPIR_Comm * comm_ptr, int key, MPIR_Info * 
         "cpu",
         "core",
         "hwthread",
+        "bindset",
     };
 
     for (int i = 0; i < sizeof(topolist) / sizeof(topolist[0]); i++) {

--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -462,6 +462,24 @@ MPIR_hwtopo_gid_t MPIR_hwtopo_get_obj_by_name(const char *name)
             hwtopo_class_e class = get_type_class(non_io_ancestor->type);
             gid = HWTOPO_GET_GID(class, non_io_ancestor->depth, non_io_ancestor->logical_index);
         }
+    } else if (!strcmp(name, "bindset")) {
+        char buf[100];          /* covers up to 800 PUs */
+        memset(buf, 0, 100);
+        int num_pus = hwloc_get_nbobjs_by_type(hwloc_topology, HWLOC_OBJ_PU);
+        int n = MPL_MIN(8 * 100, num_pus);
+        int j = 0;
+        int k = 0;
+        for (int i = 0; i < n; i++) {
+            if (hwloc_bitmap_isset(bindset, i)) {
+                buf[j] |= (1 << k);
+            }
+            k++;
+            if (k >= 8) {
+                j++;
+                k = 0;
+            }
+        }
+        HASH_VALUE(buf, j, gid);
     } else
 #endif
     {


### PR DESCRIPTION
## Pull Request Description

The current supported MPI_Comm_split_type info hints only allow splitting on single levels of hwloc topology. This in practice is only useful when the processes are launched binding to the core or hwthread. However, some applications may need non-uniform splits. For example, an application may wish to have a single process dedicated to GPU computation and the rest of the process spread across rest of the CPU cores. Since there is no single topology instance covering each set, the current hints won't be able to achieve it.

This PR allows a proper split when processes are binded for example:

    mpirun -bind-to user:0+1,2+3,2+3 -n 3 ...

In this case, the processes are clearly grouped to two sets -- 1st set
bound to core 0 and 1, and 2nd set bound to core 2 and 3. There
applications doing such intende different sets run different tasks and
they would need to split the group based on the bindset. The hwloc
topology does not directly support this since neither set identifies a
single instance of hardware resource or they identify at different level
of topology binding. The "bindset" hint will allow user to split
according to the bindset.


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
