### PR TITLE
Hydra: Add parsing of MPIEXEC_PREFIX_DEFAULT

### DIFF
--- a/src/pm/hydra/include/hydra.h
+++ b/src/pm/hydra/include/hydra.h
@@ -528,7 +528,7 @@ HYD_status HYDU_correct_wdir(char **wdir);
 /* args */
 HYD_status HYDU_find_in_path(const char *execname, char **path);
 HYD_status HYDU_parse_array(char ***argv, struct HYD_arg_match_table *match_table);
-HYD_status HYDU_set_str(char *arg, char **var, const char *val);
+HYD_status HYDU_set_str(const char *arg, char **var, const char *val);
 HYD_status HYDU_set_int(char *arg, int *var, int val);
 char *HYDU_getcwd(void);
 HYD_status HYDU_process_mfile_token(char *token, int newline, struct HYD_node **node_list);

--- a/src/pm/hydra/utils/args/args.c
+++ b/src/pm/hydra/utils/args/args.c
@@ -185,7 +185,7 @@ HYD_status HYDU_parse_array(char ***argv, struct HYD_arg_match_table *match_tabl
     goto fn_exit;
 }
 
-HYD_status HYDU_set_str(char *arg, char **var, const char *val)
+HYD_status HYDU_set_str(const char *arg, char **var, const char *val)
 {
     HYD_status status = HYD_SUCCESS;
 


### PR DESCRIPTION
## Pull Request Description
There was no handling of the environment variable MPIEXEC_PREFIX_DEFAULT in the hydra code base. The variable adds the rank as a prefix to stdout in the form [%r] by settings its value to anything greated than zero. A new function, HYD_check_envs, was created to handle this and can be used for the handling of other environment variables in the future. The already existing function, prepend_rank_fn, is used to add the pattern to stdout. This function checks for duplicate settings so using both MPIEXEC_PREFIX_DEFAULT and -prepend-rank will correctly result in an error. These new settings were tested manually and can
confirm that it works as intended.

Fixes #4388 

## TODO
* [x] Confirm user reported issue
* [x] Implement Fix
* [x] Test Fix

## Expected Impact
Users will now be able to user environment variable MPIEXEC_PREFIX_DEFAULT

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
