### PR TITLE
test: fix pingping ignoring recvcnt

### DIFF
--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
                 recvtype = recv_obj.DTP_datatype;
 
                 for (nmsg = 1; nmsg < maxmsg; nmsg++) {
-                    err = DTP_obj_buf_init(recv_obj, recvbuf_h, -1, -1, count[0]);
+                    err = DTP_obj_buf_init(recv_obj, recvbuf_h, -1, -1, count[1]);
                     if (err != DTP_SUCCESS) {
                         errs++;
                         break;
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
                     }
 
                     MTestCopyContent(recvbuf, recvbuf_h, recv_obj.DTP_bufsize, recvmem);
-                    err = DTP_obj_buf_check(recv_obj, recvbuf_h, 0, 1, count[0]);
+                    err = DTP_obj_buf_check(recv_obj, recvbuf_h, 0, 1, count[1]);
                     if (err != DTP_SUCCESS) {
                         if (errs < 10) {
                             char *recv_desc, *send_desc;
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
                             DTP_obj_get_description(send_obj, &send_desc);
                             fprintf(stderr,
                                     "Data in target buffer did not match for destination datatype %s and source datatype %s, count = %ld, message iteration %d of %d\n",
-                                    recv_desc, send_desc, count[0], nmsg, maxmsg);
+                                    recv_desc, send_desc, count[1], nmsg, maxmsg);
                             fflush(stderr);
                             free(recv_desc);
                             free(send_desc);


### PR DESCRIPTION
## Pull Request Description
While it parses the command option, the code ignores the recvcnt,
probably due to typos.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
