### PR TITLE
ch4/ucx: return error for non-supported functions

### DIFF
--- a/src/mpid/ch4/netmod/ucx/errnames.txt
+++ b/src/mpid/ch4/netmod/ucx/errnames.txt
@@ -8,3 +8,4 @@
 **ucx_nm_rq_error %s %d %s %s: returned failed request in UCX netmod(%s %d %s %s)
 **ucx_nm_other:Other UCX error
 **ucx_nm_other %s %d %s %s: Other UCX error (%s %d %s %s)
+**ucx_nm_notsupported:The function is currently not supported with ucx netmod

--- a/src/mpid/ch4/netmod/ucx/ucx_spawn.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_spawn.c
@@ -9,7 +9,9 @@
 int MPIDI_UCX_mpi_open_port(MPIR_Info * info_ptr, char *port_name)
 {
     int mpi_errno = MPI_SUCCESS;
-    port_name[0] = '\0';
+
+    MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**ucx_nm_notsupported");
+
   fn_exit:
     return mpi_errno;
   fn_fail:
@@ -20,6 +22,9 @@ int MPIDI_UCX_mpi_open_port(MPIR_Info * info_ptr, char *port_name)
 int MPIDI_UCX_mpi_close_port(const char *port_name)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**ucx_nm_notsupported");
+
   fn_exit:
     return mpi_errno;
   fn_fail:
@@ -31,6 +36,8 @@ int MPIDI_UCX_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root
                                MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**ucx_nm_notsupported");
 
   fn_exit:
     return mpi_errno;
@@ -63,13 +70,9 @@ int MPIDI_UCX_mpi_comm_accept(const char *port_name, MPIR_Info * info, int root,
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_UCX_MPI_COMM_ACCEPT);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_MPI_COMM_ACCEPT);
-
-
+    MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**ucx_nm_notsupported");
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_UCX_MPI_COMM_ACCEPT);
     return mpi_errno;
   fn_fail:
     goto fn_exit;


### PR DESCRIPTION
## Pull Request Description
Ucx netmod currently does not support MPI_Comm_connect and
MPI_Comm_accept. Return error rather success and fail later
mysteriously.

Refer to https://github.com/pmodels/mpich/pull/5128#issuecomment-795745709

TODO: we probably should return failures for `MPI_Comm_spawn[_multiple]` with ucx as well.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
