### PR TITLE
binding/c: add validation for POLYNUM_PARAM_VALUES

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -377,7 +377,10 @@ def process_func_parameters(func):
             pass
         elif p['param_direction'] == 'out':
             # -- output parameter --
-            validation_list.append({'kind': "ARGNULL", 'name': name})
+            if p['length']:
+                validation_list.append({'kind': "ARGNULL-length", 'name': name, 'length': p['length']})
+            else:
+                validation_list.append({'kind': "ARGNULL", 'name': name})
             if RE.search(r'get_errhandler$', func_name):
                 # we may get the built-in handler, which doesn't have pointer
                 pass
@@ -1696,6 +1699,11 @@ def dump_validation(func, t):
         else:
             G.err_codes['MPI_ERR_ARG'] = 1
             G.out.append("MPIR_ERRTEST_ARGNULL(%s, \"%s\", mpi_errno);" % (name, name))
+    elif RE.match(r'(ARGNULL-length)$', kind):
+        G.err_codes['MPI_ERR_ARG'] = 1
+        dump_if_open("%s > 0" % t['length'])
+        G.out.append("MPIR_ERRTEST_ARGNULL(%s, \"%s\", mpi_errno);" % (name, name))
+        dump_if_close()
     elif RE.match(r'(ARGNEG)$', kind):
         if func['dir'] == 'mpit':
             G.err_codes['MPI_T_ERR_INVALID'] = 1

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -455,7 +455,7 @@ def process_func_parameters(func):
                 validation_list.append({'kind': "COUNT", 'name': name})
         elif RE.match(r'WINDOW_SIZE|WIN_ATTACH_SIZE', kind):
             validation_list.append({'kind': "WIN_SIZE", 'name': name})
-        elif RE.match(r'ALLOC_MEM_NUM_BYTES', kind):
+        elif RE.match(r'(ALLOC_MEM_NUM_BYTES|(POLY)?NUM_PARAM_VALUES)', kind):
             validation_list.append({'kind': "ARGNEG", 'name': name})
         elif RE.match(r'(C_)?BUFFER', kind) and RE.match(r'MPI_Win_(allocate|create|attach)', func_name):
             validation_list.append({'kind': "WINBUFFER", 'name': name})

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1246,7 +1246,9 @@ def dump_body_impl(func, prefix='mpir'):
     elif RE.match(r'mpi_type_', func['name'], re.IGNORECASE):
         p = func['c_parameters'][-1]
         if p['kind'] == "DATATYPE" and p['param_direction'] == 'out':
-            G.out.append("*%s = MPI_DATATYPE_NULL;" % p['name'])
+            # check it is not a datatype array (MPI_Type_get_contents)
+            if not p['length']:
+                G.out.append("*%s = MPI_DATATYPE_NULL;" % p['name'])
 
     impl = func['name']
     if func['_map_type'] == "BIG" and func['_poly_impl'] == "separate":

--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -410,6 +410,7 @@ MPI_Type_hvector:
     newtype: DATATYPE, direction=out, [new datatype]
     .desc: type_hvector
     .replace: removed with MPI_Type_create_hvector
+    .skip: validate-DTYPE_STRIDE_BYTES_SMALL
 
 MPI_Type_indexed:
     .desc: Creates an indexed datatype

--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -243,7 +243,7 @@ MPI_Type_ub:
 
 MPI_Type_get_contents:
     .desc: get type contents
-    .skip: ThreadSafe, validate-POLYNUM_PARAM_VALUES
+    .skip: ThreadSafe
 { -- error_check -- array_of_integers, array_of_addresses, array_of_datatypes
     if (max_integers > 0) {
         MPIR_ERRTEST_ARGNULL(array_of_integers, "array_of_integers", mpi_errno);

--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -244,16 +244,7 @@ MPI_Type_ub:
 MPI_Type_get_contents:
     .desc: get type contents
     .skip: ThreadSafe
-{ -- error_check -- array_of_integers, array_of_addresses, array_of_datatypes
-    if (max_integers > 0) {
-        MPIR_ERRTEST_ARGNULL(array_of_integers, "array_of_integers", mpi_errno);
-    }
-    if (max_addresses > 0) {
-        MPIR_ERRTEST_ARGNULL(array_of_addresses, "array_of_addresses", mpi_errno);
-    }
-    if (max_datatypes > 0) {
-        MPIR_ERRTEST_ARGNULL(array_of_datatypes, "array_of_datatypes", mpi_errno);
-    }
+{ -- error_check --
     if (MPIR_DATATYPE_IS_PREDEFINED(datatype)) {
         mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, MPI_ERR_TYPE, "**contentspredef", 0);
         goto fn_fail;

--- a/src/binding/c/mpit_api.txt
+++ b/src/binding/c/mpit_api.txt
@@ -560,11 +560,12 @@ MPI_T_source_get_num:
 
 MPI_T_source_get_info:
     .desc: Returns additional information on the source identified by the source_index argument
-    .skip: validate-INFO
+    .skip: validate-INFO, validate-SOURCE_INDEX
     .error: MPI_T_ERR_INVALID_INDEX
 
 MPI_T_source_get_timestamp:
     .desc: Returns a current timestamp from the source identified by the source_index argument
+    .skip: validate-SOURCE_INDEX
     .error: MPI_T_ERR_INVALID_INDEX, MPI_T_ERR_NOT_SUPPORTED
 
 MPI_T_event_get_num:
@@ -572,7 +573,7 @@ MPI_T_event_get_num:
 
 MPI_T_event_get_info:
     .desc: Returns additional information about a specific event type
-    .skip: validate-STRING, validate-DATATYPE, validate-DISPLACEMENT_NNI, validate-ARRAY_LENGTH_NNI, validate-INFO
+    .skip: validate-STRING, validate-DATATYPE, validate-DISPLACEMENT_NNI, validate-ARRAY_LENGTH_NNI, validate-INFO, validate-EVENT_INDEX
     .error: MPI_T_ERR_INVALID_INDEX
 
 MPI_T_event_get_index:
@@ -581,7 +582,7 @@ MPI_T_event_get_index:
 
 MPI_T_event_handle_alloc:
     .desc: Creates a registration handle for the event type identified by event_index
-    .skip: validate-TOOL_MPI_OBJ
+    .skip: validate-TOOL_MPI_OBJ, validate-EVENT_INDEX
     .error: MPI_T_ERR_INVALID_INDEX
 
 MPI_T_event_handle_set_info:
@@ -592,18 +593,23 @@ MPI_T_event_handle_get_info:
 
 MPI_T_event_register_callback:
     .desc: Associates a user-defined function with an allocated event-registration handle
+    .skip: validate-CALLBACK_SAFETY, validate-EVENT_CB_FUNCTION
 
 MPI_T_event_callback_set_info:
     .desc: Updates the hints of the callback function registered for the callback safety level specified by cb_safety of the event-registration handle associated with event_registration
+    .skip: validate-CALLBACK_SAFETY
 
 MPI_T_event_callback_get_info:
     .desc: Returns a new info object containing the hints of the callback function registered for the callback safety level specified by cb_safety of the event-registration handle associated with event_registration.
+    .skip: validate-CALLBACK_SAFETY
 
 MPI_T_event_handle_free:
     .desc: Initiates deallocation of the event-registration handle specified by event_registration
+    .skip: validate-EVENT_FREE_CB_FUNCTION
 
 MPI_T_event_set_dropped_handler:
     .desc: Registers a function to be called when event information is dropped for the registration handle specified in event_registration
+    .skip: validate-EVENT_DROP_CB_FUNCTION
 
 MPI_T_event_read:
     .desc: Copy one element of event data to a user-specified buffer

--- a/src/binding/c/part_api.txt
+++ b/src/binding/c/part_api.txt
@@ -51,7 +51,7 @@ MPI_Pready:
 MPI_Pready_range:
     .desc: Indicates that a given range of the send buffer in a partitioned
            communication call is ready to be transferred
-{ -- error_check -- partition
+{ -- error_check -- partition_low, partition_high
     MPIR_ERRTEST_PARTITION(partition_low, request_ptr, mpi_errno);
     MPIR_ERRTEST_PARTITION(partition_high, request_ptr, mpi_errno);
     if (partition_low > partition_high) {

--- a/src/binding/c/topo_api.txt
+++ b/src/binding/c/topo_api.txt
@@ -171,7 +171,7 @@ MPI_Dist_graph_create_adjacent:
 
 MPI_Dist_graph_neighbors:
     .desc: Provides adjacency information for a distributed graph topology
-{ -- error_check -- maxindegree, maxoutdegree
+{ -- error_check -- maxindegree, maxoutdegree, sourceweights, destweights
     MPIR_Topology *topo_ptr = NULL;
     topo_ptr = MPIR_Topology_get(comm_ptr);
     MPIR_ERR_CHKANDJUMP(!topo_ptr || topo_ptr->kind != MPI_DIST_GRAPH, mpi_errno, MPI_ERR_TOPOLOGY, "**notdistgraphtopo");


### PR DESCRIPTION
## Pull Request Description
The max_integers, max_addresses, etc. in MPI_Type_get_contents was not validated. This patch checks them with MPIR_ERRTEST_ARGNEG.

There is a bug in the current python script that treats the output datatype array in MPI_Type_get_contents as if it is creating new datatype handles. this is fixed.

It is a common pattern for output arrays that we only check for ARGNULL when the array length is non-zero. Add this logic to the python script. The old custom error checking can't cover both the normal API and the large count variation. The script logic will handle both.

Fixes #5140

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
