### PR TITLE
dataloop: fix builtin type alignment

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_dataloop_create.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_create.c
@@ -28,7 +28,7 @@ static void update_type_vector(MPI_Aint count, MPI_Aint blocklength, MPI_Aint st
 
         newtype->size = count * blocklength * el_sz;
 
-        newtype->alignsize = el_sz;     /* ??? */
+        newtype->alignsize = MPIR_Datatype_builtintype_alignment(oldtype);
         newtype->n_builtin_elements = count * blocklength;
         newtype->builtin_element_size = el_sz;
         newtype->basic_type = oldtype;
@@ -213,7 +213,7 @@ static void update_type_blockindexed(MPI_Aint count, MPI_Aint blocklength,
 
         newtype->size = count * blocklength * el_sz;
 
-        newtype->alignsize = el_sz;     /* ??? */
+        newtype->alignsize = MPIR_Datatype_builtintype_alignment(oldtype);
         newtype->n_builtin_elements = count * blocklength;
         newtype->builtin_element_size = el_sz;
         newtype->basic_type = oldtype;
@@ -369,7 +369,7 @@ int MPIR_Typerep_create_contig(MPI_Aint count, MPI_Datatype oldtype, MPIR_Dataty
         newtype->ub = newtype->true_ub;
         newtype->extent = newtype->ub - newtype->lb;
 
-        newtype->alignsize = el_sz;
+        newtype->alignsize = MPIR_Datatype_builtintype_alignment(oldtype);
         newtype->n_builtin_elements = count;
         newtype->builtin_element_size = el_sz;
         newtype->basic_type = oldtype;
@@ -586,7 +586,7 @@ int MPIR_Typerep_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint exte
         newtype->true_ub = oldsize;
         newtype->ub = lb + extent;
         newtype->extent = extent;
-        newtype->alignsize = oldsize;   /* FIXME ??? */
+        newtype->alignsize = MPIR_Datatype_builtintype_alignment(oldtype);
         newtype->n_builtin_elements = 1;
         newtype->builtin_element_size = oldsize;
         newtype->is_contig = (extent == oldsize) ? 1 : 0;

--- a/test/mpi/datatype/Makefile.am
+++ b/test/mpi/datatype/Makefile.am
@@ -19,6 +19,7 @@ noinst_PROGRAMS =             \
     contigstruct              \
     cxx_types                 \
     dataalign                 \
+    dataalign2                \
     darray_pack               \
     darray_cyclic             \
     gaddress                  \

--- a/test/mpi/datatype/dataalign2.c
+++ b/test/mpi/datatype/dataalign2.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include "mpitest.h"
+#include <stddef.h>
+#include <stdio.h>
+#include <complex.h>
+#include <stdbool.h>
+#include <inttypes.h>
+
+struct C_BOOL {
+    char a;
+    bool b;
+};
+struct CHAR {
+    char a;
+    char b;
+};
+struct SHORT {
+    char a;
+    short b;
+};
+struct INT {
+    char a;
+    int b;
+};
+struct LONG {
+    char a;
+    long b;
+};
+struct FLOAT {
+    char a;
+    float b;
+};
+struct DOUBLE {
+    char a;
+    double b;
+};
+struct LONG_DOUBLE {
+    char a;
+    long double b;
+};
+struct INT8_T {
+    char a;
+    int8_t b;
+};
+struct INT16_T {
+    char a;
+    int16_t b;
+};
+struct INT32_T {
+    char a;
+    int32_t b;
+};
+struct INT64_T {
+    char a;
+    int64_t b;
+};
+struct AINT {
+    char a;
+    MPI_Aint b;
+};
+struct COUNT {
+    char a;
+    MPI_Count b;
+};
+struct OFFSET {
+    char a;
+    MPI_Offset b;
+};
+struct C_COMPLEX {
+    char a;
+    float complex b;
+};
+struct C_DOUBLE_COMPLEX {
+    char a;
+    double complex b;
+};
+struct C_LONG_DOUBLE_COMPLEX {
+    char a;
+    long double complex b;
+};
+
+/* The resulting struct datatype's extent will round up to the alignment.
+ * It should agree with C's struct size */
+#define TEST_TYPE(T) \
+    do { \
+        displs[1] = offsetof(struct T, b); \
+        MPI_Type_dup(MPI_ ## T, &types[1]); \
+        MPI_Type_create_struct(2, blklens, displs, types, &newtype); \
+        MPI_Type_get_extent(newtype, &lb, &extent); \
+        if (extent != sizeof(struct T)) { \
+            printf("Wrong extent with struct %s, expect %zd, got %lld\n", #T, sizeof(struct T), (long long)extent); \
+            errs++; \
+        } \
+        MPI_Type_free(&types[1]); \
+        MPI_Type_free(&newtype); \
+    } while (0)
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+
+    MTest_Init(&argc, &argv);
+
+    int blklens[2] = { 1, 1 };
+    MPI_Aint displs[2];
+    MPI_Datatype types[2];
+
+    MPI_Datatype newtype;
+    MPI_Aint lb, extent;
+
+    displs[0] = 0;
+    types[0] = MPI_CHAR;
+
+    TEST_TYPE(CHAR);
+    TEST_TYPE(SHORT);
+    TEST_TYPE(INT);
+    TEST_TYPE(LONG);
+    TEST_TYPE(FLOAT);
+    TEST_TYPE(DOUBLE);
+    TEST_TYPE(LONG_DOUBLE);
+    TEST_TYPE(INT8_T);
+    TEST_TYPE(INT16_T);
+    TEST_TYPE(INT32_T);
+    TEST_TYPE(INT64_T);
+    TEST_TYPE(AINT);
+    TEST_TYPE(COUNT);
+    TEST_TYPE(OFFSET);
+    TEST_TYPE(C_BOOL);
+    TEST_TYPE(C_COMPLEX);
+    TEST_TYPE(C_DOUBLE_COMPLEX);
+    TEST_TYPE(C_LONG_DOUBLE_COMPLEX);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/datatype/testlist.in
+++ b/test/mpi/datatype/testlist.in
@@ -61,6 +61,7 @@ vecblklen 1
 hvecblklen 1
 longdouble 1
 dataalign 2
+dataalign2 1
 type_large 1
 @largetest@large_count 1
 cxx_types 1


### PR DESCRIPTION
## Pull Request Description
The old code simply assumes the basic type alignment is the same as the
size. This is not true in principle. In fact, it is not true for complex
datatype and long double on 32-bit system. The fix is to use
MPIR_Datatype_builtintype_alignment (this is created at some to address
the struct alignment issue).

Fixes #3174

Added a test `datatype/dataalign2`, adapted from issue #3174. Before the fix:
```
Wrong extent with struct C_COMPLEX, expect 12, got 16
Wrong extent with struct C_DOUBLE_COMPLEX, expect 24, got 32
Wrong extent with struct C_LONG_DOUBLE_COMPLEX, expect 48, got 64
 Found 3 errors
```

After the fix:
```
 No Errors
```

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
