### PR TITLE
dataloop: Fix builtin alignment for indexed type

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_dataloop_create.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_create.c
@@ -101,7 +101,7 @@ static void update_type_indexed(MPI_Aint count, const MPI_Aint * blocklength_arr
         old_extent = el_sz;
         old_is_contig = 1;
 
-        MPIR_Assign_trunc(newtype->alignsize, el_sz, MPI_Aint);
+        newtype->alignsize = MPIR_Datatype_builtintype_alignment(oldtype);
         newtype->builtin_element_size = el_sz;
         newtype->basic_type = oldtype;
     } else {


### PR DESCRIPTION
## Pull Request Description

[6bed87146bba] missed an instance where aligntype was set incorrectly.

Refs #3174

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
