### PR TITLE
ch4/ofi: remove setting size in dynamic window

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -147,13 +147,20 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
     int rc = 0, allrc = 0;
     MPIDI_OFI_WIN(win).mr = NULL;
     if (base || (win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC && !MPIDI_OFI_ENABLE_MR_ALLOCATED)) {
+        size_t len;
+        if (win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+            len = UINTPTR_MAX - (uintptr_t) base;
+        } else {
+            len = (size_t) win->size;
+        }
+
         /* device buffers are not currently supported */
         if (MPIR_GPU_query_pointer_is_dev(base))
             rc = -1;
         else
             MPIDI_OFI_CALL_RETURN(fi_mr_reg(MPIDI_OFI_global.ctx[vni].domain,   /* In:  Domain Object */
                                             base,       /* In:  Lower memory address */
-                                            win->size,  /* In:  Length              */
+                                            len,        /* In:  Length              */
                                             FI_REMOTE_READ | FI_REMOTE_WRITE,   /* In:  Expose MR for read  */
                                             0ULL,       /* In:  offset(not used)    */
                                             MPIDI_OFI_WIN(win).mr_key,  /* In:  requested key       */
@@ -815,11 +822,6 @@ int MPIDI_OFI_mpi_win_create_dynamic_hook(MPIR_Win * win)
 
     /* This hook is called by CH4 generic call after CH4 initialization */
     if (MPIDI_OFI_ENABLE_RMA) {
-        /* FIXME: should the OFI specific size be stored inside OFI rather
-         * than overwriting CH4 info ? Now we simply followed original
-         * create_dynamic routine.*/
-        win->size = (uintptr_t) UINTPTR_MAX - (uintptr_t) MPI_BOTTOM;
-
         mpi_errno = win_init(win);
         MPIR_ERR_CHECK(mpi_errno);
 


### PR DESCRIPTION
## Pull Request Description
Rather than modifying win->size for the purpose of fi_mr_reg, simply
special treat the case of dynamic window there.

The extra comment is fi_mr_reg is removed, as they are merely repeating
the documentation and creates clutter for reading code.


Fixes #5148 
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
