### PR TITLE
Initial Multi-NIC Awareness

### DIFF
--- a/src/include/mpir_hwtopo.h
+++ b/src/include/mpir_hwtopo.h
@@ -132,4 +132,18 @@ int MPIR_hwtopo_mem_bind(void *baseaddr, size_t len, MPIR_hwtopo_gid_t gid);
  */
 uint64_t MPIR_hwtopo_get_node_mem(void);
 
+/*
+ * Return true if device is close to this process
+ */
+bool MPIR_hwtopo_is_dev_close_by_name(const char *name);
+
+/*
+ * Return true if pci device is close to this process
+ */
+bool MPIR_hwtopo_is_dev_close_by_pci(int domain, int bus, int dev, int func);
+
+/*
+ * Return the global id of the first non-io object above the PCI device
+ */
+MPIR_hwtopo_gid_t MPIR_hwtopo_get_dev_parent_by_pci(int domain, int bus, int dev, int func);
 #endif /* MPIR_HWTOPO_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/Makefile.mk
+++ b/src/mpid/ch4/netmod/ofi/Makefile.mk
@@ -19,6 +19,7 @@ mpi_core_sources   += src/mpid/ch4/netmod/ofi/func_table.c \
                       src/mpid/ch4/netmod/ofi/ofi_progress.c \
                       src/mpid/ch4/netmod/ofi/ofi_am_events.c \
                       src/mpid/ch4/netmod/ofi/ofi_dynproc.c \
+                      src/mpid/ch4/netmod/ofi/ofi_nic.c \
                       src/mpid/ch4/netmod/ofi/globals.c \
                       src/mpid/ch4/netmod/ofi/util.c
 errnames_txt_files += src/mpid/ch4/netmod/ofi/errnames.txt

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -188,7 +188,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
         /* am uses vni 0 */
         int vni_local = 0;
         int vni_remote = 0;
-        MPIDI_OFI_cntr_incr(vni_local);
+        int nic = 0;
+        MPIDI_OFI_cntr_incr(vni_local, nic);
 
         struct iovec iov = {
             .iov_base = (char *) dst + done,
@@ -203,14 +204,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
             .msg_iov = &iov,
             .desc = NULL,
             .iov_count = 1,
-            .addr = MPIDI_OFI_comm_to_phys(comm, src_rank, vni_local, vni_remote),
+            .addr = MPIDI_OFI_comm_to_phys(comm, src_rank, nic, vni_local, vni_remote),
             .rma_iov = &rma_iov,
             .rma_iov_count = 1,
             .context = &am_req->context,
             .data = 0
         };
 
-        MPIDI_OFI_CALL_RETRY_AM(fi_readmsg(MPIDI_OFI_global.ctx[vni_local].tx, &msg, FI_COMPLETION),
+        int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic);
+        MPIDI_OFI_CALL_RETRY_AM(fi_readmsg(MPIDI_OFI_global.ctx[ctx_idx].tx, &msg, FI_COMPLETION),
                                 rdma_readfrom);
 
         done += curr_len;

--- a/src/mpid/ch4/netmod/ofi/ofi_dynproc.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_dynproc.c
@@ -139,7 +139,9 @@ static int dynproc_send_disconnect(int conn_id)
     msg.ignore = DISCONNECT_CONTEXT_ID;
     msg.context = (void *) &req.context;
     msg.data = 0;
-    MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[0].tx, &msg,
+    int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+    MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[ctx_idx].tx, &msg,
                                      FI_COMPLETION | FI_TRANSMIT_COMPLETE | FI_REMOTE_CQ_DATA),
                          0, tsendmsg, FALSE);
     MPIDI_OFI_PROGRESS_WHILE(!req.done, 0);
@@ -173,7 +175,9 @@ static int dynproc_accept_disconnect(int conn_id)
     match_bits = MPIDI_OFI_init_recvtag(&mask_bits, DISCONNECT_CONTEXT_ID, 1);
     match_bits |= MPIDI_OFI_DYNPROC_SEND;
 
-    MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[0].rx,
+    int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+    MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[ctx_idx].rx,
                                   &close_msg, sizeof(int),
                                   NULL, addr, match_bits, mask_bits, &req.context),
                          0, trecv, FALSE);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -112,10 +112,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
         int vni_dst = MPIDI_OFI_get_vni(DST_VCI_FROM_RECVER, c, r, c->rank, rreq->status.MPI_TAG);
         int vni_local = vni_dst;
         int vni_remote = vni_src;
-        MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[vni_local].tx, NULL /* buf */ ,
+        int nic = 0;
+        int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic);
+        MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx, NULL /* buf */ ,
                                             0 /* len */ ,
                                             MPIR_Comm_rank(c),
-                                            MPIDI_OFI_comm_to_phys(c, r, vni_local, vni_remote),
+                                            MPIDI_OFI_comm_to_phys(c, r, nic, vni_local,
+                                                                   vni_remote),
                                             ss_bits), vni_local, tinjectdata, FALSE /* eagain */);
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -23,7 +23,7 @@
 #define MPIDI_OFI_COMM_TO_INDEX(comm,rank) \
     MPIDIU_comm_rank_to_pid(comm, rank, NULL, NULL)
 #define MPIDI_OFI_TO_PHYS(avtid, lpid)                                 \
-    MPIDI_OFI_AV(&MPIDIU_get_av((avtid), (lpid))).dest[0][0]
+    MPIDI_OFI_AV(&MPIDIU_get_av((avtid), (lpid))).dest[0][0][0]
 
 #define MPIDI_OFI_WIN(win)     ((win)->dev.netmod.ofi)
 
@@ -398,17 +398,17 @@ MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_av_to_phys(MPIDI_av_entry_t * av,
 {
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        return fi_rx_addr(MPIDI_OFI_AV(av).dest[vni_local][vni_remote], 0,
+        return fi_rx_addr(MPIDI_OFI_AV(av).dest[0][vni_local][vni_remote], 0,
                           MPIDI_OFI_MAX_ENDPOINTS_BITS);
     } else {
-        return MPIDI_OFI_AV(av).dest[vni_local][vni_remote];
+        return MPIDI_OFI_AV(av).dest[0][vni_local][vni_remote];
     }
 #else /* MPIDI_OFI_VNI_USE_SEPCTX */
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        return fi_rx_addr(MPIDI_OFI_AV(av).dest[0][0], vni_remote, MPIDI_OFI_MAX_ENDPOINTS_BITS);
+        return fi_rx_addr(MPIDI_OFI_AV(av).dest[0][0][0], vni_remote, MPIDI_OFI_MAX_ENDPOINTS_BITS);
     } else {
         MPIR_Assert(vni_remote == 0);
-        return MPIDI_OFI_AV(av).dest[0][0];
+        return MPIDI_OFI_AV(av).dest[0][0][0];
     }
 #endif
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -8,6 +8,7 @@
 #include "mpidu_bc.h"
 #include "ofi_noinline.h"
 #include "ofi_nic.h"
+#include "mpir_hwtopo.h"
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
@@ -1908,6 +1909,12 @@ static void dump_global_settings(void)
     fprintf(stdout, "MPIDI_OFI_CONTEXT_BITS: %d\n", MPIDI_OFI_CONTEXT_BITS);
     fprintf(stdout, "MPIDI_OFI_SOURCE_BITS: %d\n", MPIDI_OFI_SOURCE_BITS);
     fprintf(stdout, "MPIDI_OFI_TAG_BITS: %d\n", MPIDI_OFI_TAG_BITS);
+#ifdef MPIDI_OFI_VNI_USE_DOMAIN
+    fprintf(stdout, "MPIDI_OFI_VNI_USE_DOMAIN: %d\n", 1);
+#endif
+#ifdef MPIDI_OFI_VNI_USE_SEPCTX
+    fprintf(stdout, "MPIDI_OFI_VNI_USE_SEPCTX: %d\n", 1);
+#endif
     fprintf(stdout, "======================================\n");
 
     /* Discover the maximum number of ranks. If the source shift is not

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -391,8 +391,8 @@ cvars:
 
 static int get_ofi_version(void);
 static int open_fabric(void);
-static int create_vni_context(int vni);
-static int destroy_vni_context(int vni);
+static int create_vni_context(int vni, int nic);
+static int destroy_vni_context(int vni, int nic);
 
 static int addr_exchange_root_vni(MPIR_Comm * init_comm);
 static int addr_exchange_all_vnis(void);
@@ -465,6 +465,43 @@ int MPIDI_OFI_init_local(int *tag_bits)
     MPID_Thread_mutex_create(&MPIDI_OFI_THREAD_SPAWN_MUTEX, &err);
     MPIR_Assert(err == 0);
 
+    /* -------------------------------- */
+    /* Create the id to object maps     */
+    /* -------------------------------- */
+    MPIDIU_map_create(&MPIDI_OFI_global.win_map, MPL_MEM_RMA);
+    MPIDIU_map_create(&MPIDI_OFI_global.req_map, MPL_MEM_OTHER);
+
+    /* Create pack buffer pool */
+    mpi_errno =
+        MPIDU_genq_private_pool_create_unsafe(MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE,
+                                              MPIR_CVAR_CH4_OFI_NUM_PACK_BUFFERS_PER_CHUNK,
+                                              MPIR_CVAR_CH4_OFI_MAX_NUM_PACK_BUFFERS,
+                                              host_alloc_registered,
+                                              host_free_registered,
+                                              &MPIDI_OFI_global.pack_buf_pool);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* Initialize RMA keys allocator */
+    MPIDI_OFI_mr_key_allocator_init();
+
+    mpi_errno = MPIDI_OFI_dynproc_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPIR_Comm_register_hint(MPIR_COMM_HINT_EAGAIN, "eagain", NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
+
+    /* index datatypes for RMA atomics */
+    MPIDI_OFI_index_datatypes();
+
+    MPIDI_OFI_global.deferred_am_isend_q = NULL;
+
+    /* -------------------------------- */
+    /* Set up the libfabric provider(s) */
+    /* -------------------------------- */
+
+    /* WB TODO - I assume that after this function is done, there will be an array of providers in
+     * MPIDI_OFI_global.prov_use that will map to the VNI contexts below. We can also use it to
+     * generate the addresses in the business card exchange. */
+    MPIDI_OFI_global.num_nics = 1;
     mpi_errno = open_fabric();
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -501,45 +538,15 @@ int MPIDI_OFI_init_local(int *tag_bits)
 
     MPIDI_OFI_global.num_vnis = num_vnis;
 
-    /* Create MPIDI_OFI_global.ctx[0] first  */
-    mpi_errno = create_vni_context(0);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    /* Creating the additional vni contexts.
+    /* Creating the vni contexts.
      * This code maybe moved to a later stage */
-    for (int i = 1; i < MPIDI_OFI_global.num_vnis; i++) {
-        mpi_errno = create_vni_context(i);
-        MPIR_ERR_CHECK(mpi_errno);
+    for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
+        for (int nic = 0; nic < MPIDI_OFI_global.num_nics; nic++) {
+            mpi_errno = create_vni_context(vni, nic);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
     }
 
-    /* -------------------------------- */
-    /* Create the id to object maps     */
-    /* -------------------------------- */
-    MPIDIU_map_create(&MPIDI_OFI_global.win_map, MPL_MEM_RMA);
-    MPIDIU_map_create(&MPIDI_OFI_global.req_map, MPL_MEM_OTHER);
-
-    /* Create pack buffer pool */
-    mpi_errno =
-        MPIDU_genq_private_pool_create_unsafe(MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE,
-                                              MPIR_CVAR_CH4_OFI_NUM_PACK_BUFFERS_PER_CHUNK,
-                                              MPIR_CVAR_CH4_OFI_MAX_NUM_PACK_BUFFERS,
-                                              host_alloc_registered,
-                                              host_free_registered,
-                                              &MPIDI_OFI_global.pack_buf_pool);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    /* Initialize RMA keys allocator */
-    MPIDI_OFI_mr_key_allocator_init();
-
-    mpi_errno = MPIDI_OFI_dynproc_init();
-    MPIR_ERR_CHECK(mpi_errno);
-
-    MPIR_Comm_register_hint(MPIR_COMM_HINT_EAGAIN, "eagain", NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
-
-    /* index datatypes for RMA atomics */
-    MPIDI_OFI_index_datatypes();
-
-    MPIDI_OFI_global.deferred_am_isend_q = NULL;
 
   fn_exit:
     *tag_bits = MPIDI_OFI_TAG_BITS;
@@ -573,6 +580,8 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     /* Address exchange (essentially activating the vnis)                       */
     /* ------------------------------------------------------------------------ */
 
+    /* If opening a named-AV didn't work, we need to do a full business card exchange for the first
+     * VNI. All other VNIs can copy the address information from this on after the fact. */
     if (!MPIDI_OFI_global.got_named_av) {
         mpi_errno = addr_exchange_root_vni(init_comm);
         MPIR_ERR_CHECK(mpi_errno);
@@ -602,7 +611,9 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
         MPIDI_OFI_global.cq_buffered_static_head = MPIDI_OFI_global.cq_buffered_static_tail = 0;
         optlen = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE;
 
-        MPIDI_OFI_CALL(fi_setopt(&(MPIDI_OFI_global.ctx[0].rx->fid),
+        int nic = 0;
+        int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+        MPIDI_OFI_CALL(fi_setopt(&(MPIDI_OFI_global.ctx[ctx_idx].rx->fid),
                                  FI_OPT_ENDPOINT,
                                  FI_OPT_MIN_MULTI_RECV, &optlen, sizeof(optlen)), setopt);
 
@@ -622,7 +633,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
             MPIDI_OFI_global.am_msg[i].addr = FI_ADDR_UNSPEC;
             MPIDI_OFI_global.am_msg[i].context = &MPIDI_OFI_global.am_reqs[i].context;
             MPIDI_OFI_global.am_msg[i].iov_count = 1;
-            MPIDI_OFI_CALL_RETRY(fi_recvmsg(MPIDI_OFI_global.ctx[0].rx,
+            MPIDI_OFI_CALL_RETRY(fi_recvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx,
                                             &MPIDI_OFI_global.am_msg[i],
                                             FI_MULTI_RECV | FI_COMPLETION), 0, prepost, FALSE);
         }
@@ -647,12 +658,12 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
 #define MPIDI_OFI_FLUSH_TAG        1
 
 /* send a dummy message to flush the send queue */
-static int flush_send(int dst, int vni, MPIDI_OFI_dynamic_process_request_t * req)
+static int flush_send(int dst, int nic, int vni, MPIDI_OFI_dynamic_process_request_t * req)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_Comm *comm = MPIR_Process.comm_world;
-    fi_addr_t addr = MPIDI_OFI_av_to_phys(MPIDIU_comm_rank_to_av(comm, dst), vni, vni);
+    fi_addr_t addr = MPIDI_OFI_av_to_phys(MPIDIU_comm_rank_to_av(comm, dst), nic, vni, vni);
     static int data = 0;
     uint64_t match_bits = MPIDI_OFI_init_sendtag(MPIDI_OFI_FLUSH_CONTEXT_ID,
                                                  MPIDI_OFI_FLUSH_TAG, MPIDI_OFI_DYNPROC_SEND);
@@ -661,8 +672,9 @@ static int flush_send(int dst, int vni, MPIDI_OFI_dynamic_process_request_t * re
     req->done = 0;
     req->event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
 
-    MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[vni].tx, &data, 4, NULL, 0,
-                                      addr, match_bits, &req->context), vni, tsenddata, FALSE);
+    MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vni, nic)].tx,
+                                      &data, 4, NULL, 0, addr, match_bits, &req->context), vni,
+                         tsenddata, FALSE);
 
   fn_exit:
     return mpi_errno;
@@ -671,12 +683,12 @@ static int flush_send(int dst, int vni, MPIDI_OFI_dynamic_process_request_t * re
 }
 
 /* recv the dummy message the other process sent for the purpose flushing send queue */
-static int flush_recv(int src, int vni, MPIDI_OFI_dynamic_process_request_t * req)
+static int flush_recv(int src, int nic, int vni, MPIDI_OFI_dynamic_process_request_t * req)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_Comm *comm = MPIR_Process.comm_world;
-    fi_addr_t addr = MPIDI_OFI_av_to_phys(MPIDIU_comm_rank_to_av(comm, src), vni, vni);
+    fi_addr_t addr = MPIDI_OFI_av_to_phys(MPIDIU_comm_rank_to_av(comm, src), nic, vni, vni);
     uint64_t mask_bits = 0;
     uint64_t match_bits = MPIDI_OFI_init_sendtag(MPIDI_OFI_FLUSH_CONTEXT_ID,
                                                  MPIDI_OFI_FLUSH_TAG, MPIDI_OFI_DYNPROC_SEND);
@@ -687,8 +699,9 @@ static int flush_recv(int src, int vni, MPIDI_OFI_dynamic_process_request_t * re
 
     /* we don't care the data and the tag field is not used */
     void *recvbuf = &(req->tag);
-    MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[vni].rx, recvbuf, 4, NULL,
-                                  addr, match_bits, mask_bits, &req->context), vni, trecv, FALSE);
+    MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vni, nic)].rx,
+                                  recvbuf, 4, NULL, addr, match_bits, mask_bits, &req->context),
+                         vni, trecv, FALSE);
 
   fn_exit:
     return mpi_errno;
@@ -703,6 +716,8 @@ static int flush_send_queue()
     int n = MPIR_Process.size;
     if (n > 1) {
         MPIDI_OFI_dynamic_process_request_t *reqs;
+        /* TODO - Iterate over each NIC in addition to each VNI when multi-NIC within the same
+         * process is implemented. */
         int num_reqs = MPIDI_OFI_global.num_vnis * 2;
         reqs = MPL_malloc(sizeof(MPIDI_OFI_dynamic_process_request_t) * num_reqs, MPL_MEM_OTHER);
 
@@ -711,9 +726,9 @@ static int flush_send_queue()
         int src = (rank - 1 + n) % n;
 
         for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
-            mpi_errno = flush_send(dst, vni, &reqs[vni * 2]);
+            mpi_errno = flush_send(dst, 0, vni, &reqs[vni * 2]);
             MPIR_ERR_CHECK(mpi_errno);
-            mpi_errno = flush_recv(src, vni, &reqs[vni * 2 + 1]);
+            mpi_errno = flush_recv(src, 0, vni, &reqs[vni * 2 + 1]);
             MPIR_ERR_CHECK(mpi_errno);
         }
 
@@ -770,18 +785,19 @@ int MPIDI_OFI_mpi_finalize_hook(void)
         MPIDI_OFI_PROGRESS(0);
     MPIR_Assert(MPL_atomic_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) == 0);
 
-    /* Tearing down endpoints */
-    for (i = 1; i < MPIDI_OFI_global.num_vnis; i++) {
-        mpi_errno = destroy_vni_context(i);
-        MPIR_ERR_CHECK(mpi_errno);
+    /* Tearing down endpoints in reverse order they were created */
+    for (int nic = MPIDI_OFI_global.num_nics - 1; nic >= 0; nic--) {
+        for (int vni = MPIDI_OFI_global.num_vnis - 1; vni >= 0; vni--) {
+            mpi_errno = destroy_vni_context(vni, nic);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
     }
-    /* 0th ctx is special, synonymous to global context */
-    mpi_errno = destroy_vni_context(0);
-    MPIR_ERR_CHECK(mpi_errno);
 
     MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.fabric->fid), fabricclose);
 
-    fi_freeinfo(MPIDI_OFI_global.prov_use);
+    for (i = 0; i < MPIDI_OFI_global.num_nics; i++) {
+        fi_freeinfo(MPIDI_OFI_global.prov_use[i]);
+    }
 
     MPIDIU_map_destroy(MPIDI_OFI_global.win_map);
     MPIDIU_map_destroy(MPIDI_OFI_global.req_map);
@@ -853,22 +869,32 @@ int MPIDI_OFI_mpi_free_mem(void *ptr)
 
 /* ---- static functions for vni contexts ---- */
 static int create_vni_domain(struct fid_domain **p_domain, struct fid_av **p_av,
-                             struct fid_cntr **p_cntr);
+                             struct fid_cntr **p_cntr, int nic);
 static int create_cq(struct fid_domain *domain, struct fid_cq **p_cq);
 static int create_sep_tx(struct fid_ep *ep, int idx, struct fid_ep **p_tx,
-                         struct fid_cq *cq, struct fid_cntr *cntr);
-static int create_sep_rx(struct fid_ep *ep, int idx, struct fid_ep **p_rx, struct fid_cq *cq);
-static int try_open_shared_av(struct fid_domain *domain, struct fid_av **p_av);
+                         struct fid_cq *cq, struct fid_cntr *cntr, int nic);
+static int create_sep_rx(struct fid_ep *ep, int idx, struct fid_ep **p_rx, struct fid_cq *cq,
+                         int nic);
+static int try_open_shared_av(struct fid_domain *domain, struct fid_av **p_av, int nic);
 static int open_local_av(struct fid_domain *p_domain, struct fid_av **p_av);
 
-static int create_vni_context(int vni)
+/* This function creates a vni context which includes all of the OFI-level objects needed to
+ * initialize OFI (e.g. domain, address vector, endpoint, etc.). This function takes two arguments:
+ *
+ * vni - The VNI index within a nic to use when assigning the OFI information being created.
+ * nic - The NIC that should be used when setting up the OFI interfaces.
+ *
+ * Each nic will restart its vni indexing. This allows each VNI to use any nic if desired.
+ */
+static int create_vni_context(int vni, int nic)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_CREATE_VNI_CONTEXT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CREATE_VNI_CONTEXT);
 
-    struct fi_info *prov_use = MPIDI_OFI_global.prov_use;
+    struct fi_info *prov_use = MPIDI_OFI_global.prov_use[nic];
+    int ctx_idx;
 
     /* Each VNI context consists of domain, av, cq, cntr, etc.
      *
@@ -878,7 +904,9 @@ static int create_vni_context(int vni)
      *
      * If MPIDI_OFI_VNI_USE_DOMAIN is false, then all the VNI contexts will share
      * the same domain and av, and use a single scalable endpoint. Separate VNI
-     * context will have its separate cq and separate tx and rx with the SEP.
+     * context will have its separate cq and separate tx and rx with the SEP. VNIs
+     * which are attached to different NICs will have separate scalable endpoints as
+     * they require different fid_domains.
      *
      * To accommodate both configurations, each context structure will have all fields
      * including domain, av, cq, ... For "VNI_USE_DOMAIN", they are not shared.
@@ -895,7 +923,7 @@ static int create_vni_context(int vni)
     struct fid_ep *rx;
 
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
-    mpi_errno = create_vni_domain(&domain, &av, &rma_cmpl_cntr);
+    mpi_errno = create_vni_domain(&domain, &av, &rma_cmpl_cntr, nic);
     MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = create_cq(domain, &cq);
     MPIR_ERR_CHECK(mpi_errno);
@@ -905,9 +933,9 @@ static int create_vni_context(int vni)
         MPIDI_OFI_CALL(fi_scalable_ep_bind(ep, &av->fid, 0), bind);
         MPIDI_OFI_CALL(fi_enable(ep), ep_enable);
 
-        mpi_errno = create_sep_tx(ep, 0, &tx, cq, rma_cmpl_cntr);
+        mpi_errno = create_sep_tx(ep, 0, &tx, cq, rma_cmpl_cntr, nic);
         MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno = create_sep_rx(ep, 0, &rx, cq);
+        mpi_errno = create_sep_rx(ep, 0, &rx, cq, nic);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         MPIDI_OFI_CALL(fi_endpoint(domain, prov_use, &ep, NULL), ep);
@@ -918,27 +946,34 @@ static int create_vni_context(int vni)
         tx = ep;
         rx = ep;
     }
-    MPIDI_OFI_global.ctx[vni].domain = domain;
-    MPIDI_OFI_global.ctx[vni].av = av;
-    MPIDI_OFI_global.ctx[vni].rma_cmpl_cntr = rma_cmpl_cntr;
-    MPIDI_OFI_global.ctx[vni].rma_issued_cntr = 0;
-    MPIDI_OFI_global.ctx[vni].ep = ep;
-    MPIDI_OFI_global.ctx[vni].cq = cq;
-    MPIDI_OFI_global.ctx[vni].tx = tx;
-    MPIDI_OFI_global.ctx[vni].rx = rx;
+    ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+    MPIDI_OFI_global.ctx[ctx_idx].domain = domain;
+    MPIDI_OFI_global.ctx[ctx_idx].av = av;
+    MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr = rma_cmpl_cntr;
+    MPIDI_OFI_global.ctx[ctx_idx].rma_issued_cntr = 0;
+    MPIDI_OFI_global.ctx[ctx_idx].ep = ep;
+    MPIDI_OFI_global.ctx[ctx_idx].cq = cq;
+    MPIDI_OFI_global.ctx[ctx_idx].tx = tx;
+    MPIDI_OFI_global.ctx[ctx_idx].rx = rx;
 
 #else /* MPIDI_OFI_VNI_USE_SEPCTX */
+    /* Endpoints are used to bundle together all VNIs. In addition, we have to duplicate these
+     * endpoints such that each NIC gets its own endpoint. So now we have a endpoint per nic and a
+     * transmit/receive context per vni. */
     if (vni == 0) {
-        mpi_errno = create_vni_domain(&domain, &av, &rma_cmpl_cntr);
+        mpi_errno = create_vni_domain(&domain, &av, &rma_cmpl_cntr, nic);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
-        domain = MPIDI_OFI_global.ctx[0].domain;
-        av = MPIDI_OFI_global.ctx[0].av;
-        rma_cmpl_cntr = MPIDI_OFI_global.ctx[0].rma_cmpl_cntr;
+        ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+        domain = MPIDI_OFI_global.ctx[ctx_idx].domain;
+        av = MPIDI_OFI_global.ctx[ctx_idx].av;
+        rma_cmpl_cntr = MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr;
     }
     mpi_errno = create_cq(domain, &cq);
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* If this is the first vni in the bundle, we need to create the endpoint. Otherwise, just copy
+     * it from the first vni. */
     if (vni == 0) {
         if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
             MPIDI_OFI_CALL(fi_scalable_ep(domain, prov_use, &ep, NULL), ep);
@@ -953,13 +988,14 @@ static int create_vni_context(int vni)
             MPIDI_OFI_CALL(fi_enable(ep), ep_enable);
         }
     } else {
-        ep = MPIDI_OFI_global.ctx[0].ep;
+        ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+        ep = MPIDI_OFI_global.ctx[ctx_idx].ep;
     }
 
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        mpi_errno = create_sep_tx(ep, vni, &tx, cq, rma_cmpl_cntr);
+        mpi_errno = create_sep_tx(ep, vni, &tx, cq, rma_cmpl_cntr, nic);
         MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno = create_sep_rx(ep, vni, &rx, cq);
+        mpi_errno = create_sep_rx(ep, vni, &rx, cq, nic);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         tx = ep;
@@ -967,18 +1003,21 @@ static int create_vni_context(int vni)
     }
 
     if (vni == 0) {
-        MPIDI_OFI_global.ctx[0].domain = domain;
-        MPIDI_OFI_global.ctx[0].av = av;
-        MPIDI_OFI_global.ctx[0].rma_cmpl_cntr = rma_cmpl_cntr;
-        MPIDI_OFI_global.ctx[0].ep = ep;
+        ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+        MPIDI_OFI_global.ctx[ctx_idx].domain = domain;
+        MPIDI_OFI_global.ctx[ctx_idx].av = av;
+        MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr = rma_cmpl_cntr;
+        MPIDI_OFI_global.ctx[ctx_idx].ep = ep;
     } else {
         /* non-zero vni share most fields with vni 0, copy them
          * so we don't have to switch during runtime */
-        MPIDI_OFI_global.ctx[vni] = MPIDI_OFI_global.ctx[0];
+        MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vni, nic)] =
+            MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(0, nic)];
     }
-    MPIDI_OFI_global.ctx[vni].cq = cq;
-    MPIDI_OFI_global.ctx[vni].tx = tx;
-    MPIDI_OFI_global.ctx[vni].rx = rx;
+    ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+    MPIDI_OFI_global.ctx[ctx_idx].cq = cq;
+    MPIDI_OFI_global.ctx[ctx_idx].tx = tx;
+    MPIDI_OFI_global.ctx[ctx_idx].rx = rx;
 #endif
 
   fn_exit:
@@ -1006,60 +1045,61 @@ static struct fi_info *pick_provider_from_list(const char *provname, struct fi_i
 static struct fi_info *pick_provider_by_name(const char *provname, struct fi_info *prov_list);
 static struct fi_info *pick_provider_by_global_settings(struct fi_info *prov_list);
 
-static int destroy_vni_context(int vni)
+static int destroy_vni_context(int vni, int nic)
 {
     int mpi_errno = MPI_SUCCESS;
+    int ctx_num = MPIDI_OFI_get_ctx_index(vni, nic);
 
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[vni].tx), epclose);
-        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[vni].rx), epclose);
-        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[vni].cq), cqclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].tx->fid), epclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].rx->fid), epclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].cq->fid), cqclose);
 
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].ep->fid), epclose);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].av->fid), avclose);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].rma_cmpl_cntr->fid), cntrclose);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].domain->fid), domainclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].ep->fid), epclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].av->fid), avclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].rma_cmpl_cntr->fid), cntrclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].domain->fid), domainclose);
     } else {    /* normal endpoint */
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].ep->fid), epclose);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].cq->fid), cqclose);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].av->fid), avclose);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].rma_cmpl_cntr->fid), cntrclose);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].domain->fid), domainclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].ep->fid), epclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].cq->fid), cqclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].av->fid), avclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].rma_cmpl_cntr->fid), cntrclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].domain->fid), domainclose);
     }
 
 #else /* MPIDI_OFI_VNI_USE_SEPCTX */
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[vni].tx), epclose);
-        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[vni].rx), epclose);
-        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[vni].cq), cqclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].tx->fid), epclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].rx->fid), epclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].cq->fid), cqclose);
         if (vni == 0) {
-            MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].ep->fid), epclose);
-            MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].av->fid), avclose);
-            MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].rma_cmpl_cntr->fid), cntrclose);
-            MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].domain->fid), domainclose);
+            MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].ep->fid), epclose);
+            MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].av->fid), avclose);
+            MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].rma_cmpl_cntr->fid), cntrclose);
+            MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].domain->fid), domainclose);
         }
     } else {    /* normal endpoint */
         MPIR_Assert(vni == 0);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].ep->fid), epclose);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].cq->fid), cqclose);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].av->fid), avclose);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].rma_cmpl_cntr->fid), cntrclose);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].domain->fid), domainclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].ep->fid), epclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].cq->fid), cqclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].av->fid), avclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].rma_cmpl_cntr->fid), cntrclose);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].domain->fid), domainclose);
     }
 #endif
     /* Close RMA scalable EP. */
-    if (MPIDI_OFI_global.ctx[vni].rma_sep) {
+    if (MPIDI_OFI_global.ctx[ctx_num].rma_sep) {
         /* All transmit contexts on RMA must be closed. */
-        MPIR_Assert(utarray_len(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array) ==
+        MPIR_Assert(utarray_len(MPIDI_OFI_global.ctx[ctx_num].rma_sep_idx_array) ==
                     MPIDI_OFI_global.max_rma_sep_tx_cnt);
-        utarray_free(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array);
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].rma_sep->fid), epclose);
+        utarray_free(MPIDI_OFI_global.ctx[ctx_num].rma_sep_idx_array);
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].rma_sep->fid), epclose);
     }
 
     /* Close RMA shared context */
-    if (MPIDI_OFI_global.ctx[vni].rma_stx_ctx != NULL) {
-        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[vni].rma_stx_ctx->fid), stx_ctx_close);
+    if (MPIDI_OFI_global.ctx[ctx_num].rma_stx_ctx != NULL) {
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].rma_stx_ctx->fid), stx_ctx_close);
     }
 
   fn_exit:
@@ -1070,14 +1110,14 @@ static int destroy_vni_context(int vni)
 }
 
 static int create_vni_domain(struct fid_domain **p_domain, struct fid_av **p_av,
-                             struct fid_cntr **p_cntr)
+                             struct fid_cntr **p_cntr, int nic)
 {
     int mpi_errno = MPI_SUCCESS;
 
     /* ---- domain ---- */
     struct fid_domain *domain;
-    MPIDI_OFI_CALL(fi_domain(MPIDI_OFI_global.fabric, MPIDI_OFI_global.prov_use, &domain, NULL),
-                   opendomain);
+    MPIDI_OFI_CALL(fi_domain(MPIDI_OFI_global.fabric, MPIDI_OFI_global.prov_use[nic], &domain,
+                             NULL), opendomain);
     *p_domain = domain;
 
     /* ---- av ---- */
@@ -1087,7 +1127,7 @@ static int create_vni_domain(struct fid_domain **p_domain, struct fid_av **p_av,
      * Otherwise, set MPIDI_OFI_global.got_named_av and
      * copy the map_addr.
      */
-    if (try_open_shared_av(domain, p_av)) {
+    if (try_open_shared_av(domain, p_av, nic)) {
         MPIDI_OFI_global.got_named_av = 1;
     } else {
         mpi_errno = open_local_av(domain, p_av);
@@ -1122,12 +1162,12 @@ static int create_cq(struct fid_domain *domain, struct fid_cq **p_cq)
 }
 
 static int create_sep_tx(struct fid_ep *ep, int idx, struct fid_ep **p_tx,
-                         struct fid_cq *cq, struct fid_cntr *cntr)
+                         struct fid_cq *cq, struct fid_cntr *cntr, int nic)
 {
     int mpi_errno = MPI_SUCCESS;
 
     struct fi_tx_attr tx_attr;
-    tx_attr = *(MPIDI_OFI_global.prov_use->tx_attr);
+    tx_attr = *(MPIDI_OFI_global.prov_use[nic]->tx_attr);
     tx_attr.op_flags = FI_COMPLETION;
     if (MPIDI_OFI_ENABLE_RMA || MPIDI_OFI_ENABLE_ATOMICS)
         tx_attr.op_flags |= FI_DELIVERY_COMPLETE;
@@ -1156,12 +1196,13 @@ static int create_sep_tx(struct fid_ep *ep, int idx, struct fid_ep **p_tx,
     goto fn_exit;
 }
 
-static int create_sep_rx(struct fid_ep *ep, int idx, struct fid_ep **p_rx, struct fid_cq *cq)
+static int create_sep_rx(struct fid_ep *ep, int idx, struct fid_ep **p_rx, struct fid_cq *cq,
+                         int nic)
 {
     int mpi_errno = MPI_SUCCESS;
 
     struct fi_rx_attr rx_attr;
-    rx_attr = *(MPIDI_OFI_global.prov_use->rx_attr);
+    rx_attr = *(MPIDI_OFI_global.prov_use[nic]->rx_attr);
     rx_attr.caps = 0;
 
     if (MPIDI_OFI_ENABLE_TAGGED) {
@@ -1187,12 +1228,14 @@ static int create_sep_rx(struct fid_ep *ep, int idx, struct fid_ep **p_rx, struc
     goto fn_exit;
 }
 
-static int try_open_shared_av(struct fid_domain *domain, struct fid_av **p_av)
+static int try_open_shared_av(struct fid_domain *domain, struct fid_av **p_av, int nic)
 {
-#ifdef MPIDI_OFI_VNI_USE_DOMAIN
-    /* shared/named av table cannot be used when multiple fi_domain is enabled */
-    return 0;
-#else
+    int ret = 0;
+
+    /* It's not possible to use shared address vectors with more than one domain in a single
+     * process. If we're trying to do that (for example if we are using MPIDI_OFI_VNI_USE_DOMAIN or
+     * we have multiple VNIs because of multi-nic), attempt to open up the shared AV in one VNI and
+     * then copy the results to the others later. */
     struct fi_av_attr av_attr;
     memset(&av_attr, 0, sizeof(av_attr));
     if (MPIDI_OFI_ENABLE_AV_TABLE) {
@@ -1215,16 +1258,15 @@ static int try_open_shared_av(struct fid_domain *domain, struct fid_av **p_av)
         /* directly references the mapped fi_addr_t array instead               */
         fi_addr_t *mapped_table = (fi_addr_t *) av_attr.map_addr;
         for (int i = 0; i < MPIR_Process.size; i++) {
-            MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[0][0][0] = mapped_table[i];
+            MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[nic][0][0] = mapped_table[i];
             MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_MAP, VERBOSE,
                             (MPL_DBG_FDEST, " grank mapped to: rank=%d, av=%p, dest=%" PRIu64,
                              i, (void *) &MPIDIU_get_av(0, i), mapped_table[i]));
         }
-        return 1;
-    } else {
-        return 0;
+        ret = 1;
     }
-#endif
+
+    return ret;
 }
 
 static int open_local_av(struct fid_domain *p_domain, struct fid_av **p_av)
@@ -1285,8 +1327,9 @@ static int open_fabric(void)
         update_global_settings(prov, hints);
     }
 
-    MPIDI_OFI_global.prov_use = fi_dupinfo(prov);
-    MPIR_Assert(MPIDI_OFI_global.prov_use);
+    /* WB TODO - This will need to change to account for multiple providers obviously. */
+    MPIDI_OFI_global.prov_use[0] = fi_dupinfo(prov);
+    MPIR_Assert(MPIDI_OFI_global.prov_use[0]);
 
     MPIDI_OFI_global.max_buffered_send = prov->tx_attr->inject_size;
     MPIDI_OFI_global.max_buffered_write = prov->tx_attr->inject_size;
@@ -1812,7 +1855,8 @@ static void init_hints(struct fi_info *hints)
 static void dump_global_settings(void)
 {
     fprintf(stdout, "==== Capability set configuration ====\n");
-    fprintf(stdout, "libfabric provider: %s\n", MPIDI_OFI_global.prov_use->fabric_attr->prov_name);
+    fprintf(stdout, "libfabric provider: %s\n",
+            MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name);
     fprintf(stdout, "MPIDI_OFI_ENABLE_AV_TABLE: %d\n", MPIDI_OFI_ENABLE_AV_TABLE);
     fprintf(stdout, "MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS: %d\n",
             MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS);
@@ -1867,24 +1911,42 @@ static int addr_exchange_root_vni(MPIR_Comm * init_comm)
     int mpi_errno = MPI_SUCCESS;
     int size = MPIR_Process.size;
     int rank = MPIR_Process.rank;
+    int num_nics = MPIDI_OFI_global.num_nics;
+    size_t addrnamelen = MPIDI_OFI_global.addrnamelen = FI_NAME_MAX;
+    MPIR_CHKLMEM_DECL(1);
 
     /* No pre-published address table, need do address exchange. */
-    /* First, each get its own name */
-    MPIDI_OFI_global.addrnamelen = FI_NAME_MAX;
-    MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[0].ep, MPIDI_OFI_global.addrname,
-                              &MPIDI_OFI_global.addrnamelen), getname);
-    MPIR_Assert(MPIDI_OFI_global.addrnamelen <= FI_NAME_MAX);
+    /* First, each process get its own name (for each nic that it will use) */
+    for (int nic = 0; nic < num_nics; nic++) {
+        MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(0, nic)].ep,
+                                  MPIDI_OFI_global.addrname[nic], &addrnamelen), getname);
+        if (nic == 0) {
+            MPIDI_OFI_global.addrnamelen = addrnamelen;
+        } else {
+            MPIR_Assert(MPIDI_OFI_global.addrnamelen == addrnamelen);
+        }
+    }
 
     /* Second, exchange names using PMI */
     /* If MPIR_CVAR_CH4_ROOTS_ONLY_PMI is true, we only collect a table of node-roots.
      * Otherwise, we collect a table of everyone. */
     void *table = NULL;
-    int ret_bc_len;
-    mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map[0],
-                                      &MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
-                                      TRUE, MPIR_CVAR_CH4_ROOTS_ONLY_PMI, &table, &ret_bc_len);
+    int ret_bc_len = 0;
+
+    /* Convert the 2D array to an array of pointers so the memory addresses don't get calculated
+     * incorrectly. */
+    void *addrnames;
+    MPIR_CHKLMEM_MALLOC(addrnames, void *, addrnamelen * num_nics, mpi_errno, "addrnames",
+                        MPL_MEM_ADDRESS);
+    for (int nic = 0; nic < num_nics; nic++) {
+        memcpy(((char *) addrnames) + (addrnamelen * nic), MPIDI_OFI_global.addrname[nic],
+               addrnamelen);
+    }
+
+    mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map[0], addrnames,
+                                      addrnamelen * num_nics, TRUE, MPIR_CVAR_CH4_ROOTS_ONLY_PMI,
+                                      &table, &ret_bc_len);
     MPIR_ERR_CHECK(mpi_errno);
-    /* MPIR_Assert(ret_bc_len = MPIDI_OFI_global.addrnamelen); */
 
     /* Third, each fi_av_insert those addresses */
     if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
@@ -1895,47 +1957,65 @@ static int addr_exchange_root_vni(MPIR_Comm * init_comm)
 
         /* First, insert address of node-roots, init_comm become useful */
         fi_addr_t *mapped_table;
-        mapped_table = (fi_addr_t *) MPL_malloc(num_nodes * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
-        MPIDI_OFI_CALL(fi_av_insert
-                       (MPIDI_OFI_global.ctx[0].av, table, num_nodes, mapped_table, 0ULL, NULL),
-                       avmap);
+        mapped_table = (fi_addr_t *) MPL_malloc(num_nodes * num_nics * sizeof(fi_addr_t),
+                                                MPL_MEM_ADDRESS);
+        for (int i = 0; i < num_nics; i++) {
+            MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(0, i)].av,
+                                        table, num_nodes * num_nics, mapped_table, 0ULL, NULL),
+                           avmap);
+        }
 
         for (int i = 0; i < num_nodes; i++) {
-            MPIR_Assert(mapped_table[i] != FI_ADDR_NOTAVAIL);
-            MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).dest[0][0][0] = mapped_table[i];
+            for (int j = 0; j < num_nics; j++) {
+                fi_addr_t table_entry = mapped_table[(i * num_nics) + j];
+                MPIR_Assert(table_entry != FI_ADDR_NOTAVAIL);
+                MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).dest[j][0][0] = table_entry;
+            }
         }
         MPL_free(mapped_table);
         /* Then, allgather all address names using init_comm */
-        MPIDU_bc_allgather(init_comm, MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
-                           TRUE, &table, &rank_map, &recv_bc_len);
+        MPIDU_bc_allgather(init_comm, addrnames, addrnamelen, TRUE, &table, &rank_map,
+                           &recv_bc_len);
 
         /* Insert the rest of the addresses */
         for (int i = 0; i < MPIR_Process.size; i++) {
-            if (rank_map[i] >= 0) {
-                fi_addr_t addr;
-                char *addrname = (char *) table + recv_bc_len * rank_map[i];
-                MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[0].av,
-                                            addrname, 1, &addr, 0ULL, NULL), avmap);
-                MPIDI_OFI_AV(&MPIDIU_get_av(0, rank)).dest[0][0][0] = addr;
+            for (int nic = 0; nic < num_nics; nic++) {
+                if (rank_map[i] >= 0) {
+                    fi_addr_t addr;
+                    char *addrname = (char *) table + (recv_bc_len * rank_map[i] * nic) +
+                        (nic * rank_map[i]);
+                    MPIDI_OFI_CALL(fi_av_insert
+                                   (MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(0, nic)].av,
+                                    addrname, 1, &addr, 0ULL, NULL), avmap);
+                    MPIDI_OFI_AV(&MPIDIU_get_av(0, rank)).dest[nic][0][0] = addr;
+                }
             }
         }
         MPIDU_bc_table_destroy();
     } else {
         /* not "ROOTS_ONLY", we already have everyone's address name, insert all of them */
         fi_addr_t *mapped_table;
-        mapped_table = (fi_addr_t *) MPL_malloc(size * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
-        MPIDI_OFI_CALL(fi_av_insert
-                       (MPIDI_OFI_global.ctx[0].av, table, size, mapped_table, 0ULL, NULL), avmap);
+        mapped_table = (fi_addr_t *) MPL_malloc(size * num_nics * sizeof(fi_addr_t),
+                                                MPL_MEM_ADDRESS);
+        for (int nic = 0; nic < num_nics; nic++) {
+            MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(0, nic)].av,
+                                        table, size * num_nics, mapped_table, 0ULL, NULL), avmap);
+        }
 
         for (int i = 0; i < size; i++) {
-            MPIR_Assert(mapped_table[i] != FI_ADDR_NOTAVAIL);
-            MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[0][0][0] = mapped_table[i];
+            for (int nic = 0; nic < num_nics; nic++) {
+                MPIR_Assert(mapped_table[i] != FI_ADDR_NOTAVAIL);
+                MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[nic][0][0] =
+                    mapped_table[(i * num_nics) + nic];
+            }
         }
         MPL_free(mapped_table);
         MPIDU_bc_table_destroy();
     }
 
   fn_exit:
+    MPIR_CHKLMEM_FREEALL();
+
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -1949,26 +2029,23 @@ static int addr_exchange_all_vnis(void)
     int size = MPIR_Process.size;
     int rank = MPIR_Process.rank;
     int num_vnis = MPIDI_OFI_global.num_vnis;
+    int num_nics = MPIDI_OFI_global.num_nics;
 
-    /* get addr name length */
-    size_t name_len = 0;
-    int ret = fi_getname((fid_t) MPIDI_OFI_global.ctx[0].ep, NULL, &name_len);
-    MPIR_Assert(ret == -FI_ETOOSMALL);
-    MPIR_Assert(name_len > 0);
-
-    int my_len = num_vnis * name_len;
+    /* Use the maximum name length to simplify the address exchange with multiple NICs */
+    int my_len = num_vnis * num_nics * FI_NAME_MAX;
     char *all_names = MPL_malloc(size * my_len, MPL_MEM_ADDRESS);
     MPIR_Assert(all_names);
-
     char *my_names = all_names + rank * my_len;
 
     /* put in my addrnames */
-    for (int i = 0; i < num_vnis; i++) {
-        size_t actual_name_len = name_len;
-        char *vni_addrname = my_names + i * name_len;
-        MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[i].ep, vni_addrname,
-                                  &actual_name_len), getname);
-        MPIR_Assert(actual_name_len == name_len);
+    for (int nic = 0; nic < num_nics; nic++) {
+        for (int vni = 0; vni < num_vnis; vni++) {
+            size_t actual_name_len = FI_NAME_MAX;
+            char *vni_addrname = my_names + (vni * num_nics * FI_NAME_MAX) + (nic * FI_NAME_MAX);
+            int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+            MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[ctx_idx].ep, vni_addrname,
+                                      &actual_name_len), getname);
+        }
     }
     /* Allgather */
     MPIR_Comm *comm = MPIR_Process.comm_world;
@@ -1977,20 +2054,27 @@ static int addr_exchange_all_vnis(void)
                                             all_names, my_len, MPI_BYTE, comm, &errflag);
     /* insert the addresses */
     fi_addr_t *mapped_table;
-    mapped_table = (fi_addr_t *) MPL_malloc(size * num_vnis * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
-    for (int vni_local = 0; vni_local < num_vnis; vni_local++) {
-        MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[vni_local].av, all_names, size * num_vnis,
-                                    mapped_table, 0ULL, NULL), avmap);
-        for (int r = 0; r < size; r++) {
-            MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(&MPIDIU_get_av(0, r));
-            for (int vni_remote = 0; vni_remote < num_vnis; vni_remote++) {
-                if (vni_local == 0 && vni_remote == 0) {
-                    /* don't overwrite existing addr, or bad things will happen */
-                    continue;
+    mapped_table = (fi_addr_t *) MPL_malloc(size * num_vnis * num_nics * sizeof(fi_addr_t),
+                                            MPL_MEM_ADDRESS);
+    for (int nic = 0; nic < num_nics; nic++) {
+        for (int vni_local = 0; vni_local < num_vnis; vni_local++) {
+            /* Insert each set of addresses into each context so we can send messages from any
+             * vni/nic combination to any other vni/nic combination. */
+            int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic);
+            MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[ctx_idx].av, all_names,
+                                        size * num_vnis * num_nics, mapped_table, 0ULL, NULL),
+                           avmap);
+            for (int r = 0; r < size; r++) {
+                MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(&MPIDIU_get_av(0, r));
+                for (int vni_remote = 0; vni_remote < num_vnis; vni_remote++) {
+                    if (vni_local == 0 && vni_remote == 0) {
+                        /* don't overwrite existing addr, or bad things will happen */
+                        continue;
+                    }
+                    int idx = (r * num_vnis * num_nics) + (vni_remote * num_nics) + nic;
+                    MPIR_Assert(mapped_table[idx] != FI_ADDR_NOTAVAIL);
+                    av->dest[nic][vni_local][vni_remote] = mapped_table[idx];
                 }
-                int idx = r * num_vnis + vni_remote;
-                MPIR_Assert(mapped_table[idx] != FI_ADDR_NOTAVAIL);
-                av->dest[0][vni_local][vni_remote] = mapped_table[idx];
             }
         }
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "ofi_impl.h"
+#include "ofi_nic.h"
+#include "mpir_hwtopo.h"
+
+/* Determine if NIC has already been included in others */
+bool MPIDI_OFI_nic_already_used(const struct fi_info *prov, struct fi_info **others, int nic_count)
+{
+    for (int i = 0; i < nic_count; ++i) {
+        if (prov->nic->bus_attr->bus_type == FI_BUS_PCI &&
+            others[i]->nic->bus_attr->bus_type == FI_BUS_PCI) {
+            struct fi_pci_attr pci = prov->nic->bus_attr->attr.pci;
+            struct fi_pci_attr others_pci = others[i]->nic->bus_attr->attr.pci;
+            if (pci.domain_id == others_pci.domain_id && pci.bus_id == others_pci.bus_id &&
+                pci.device_id == others_pci.device_id && pci.function_id == others_pci.function_id)
+                return true;
+        } else {
+            if (strcmp(prov->domain_attr->name, others[i]->domain_attr->name) == 0)
+                return true;
+        }
+    }
+    return false;
+}
+
+/* Setup the multi-NIC data structures to use the fi_info structure given in prov */
+void MPIDI_OFI_setup_single_nic(struct fi_info *prov)
+{
+    MPIDI_OFI_global.prov_use[0] = fi_dupinfo(prov);
+    MPIR_Assert(MPIDI_OFI_global.prov_use[0]);
+    MPIDI_OFI_global.num_nics = 1;
+}
+
+/* TODO: Now that multiple NICs are detected, sort them based on preferred-ness,
+ * closeness and count of other processes using the NIC. */
+int MPIDI_OFI_setup_multi_nic(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -8,8 +8,57 @@
 #include "ofi_nic.h"
 #include "mpir_hwtopo.h"
 
+/* Return the parent object (typically socket) of the NIC */
+static MPIR_hwtopo_gid_t get_nic_parent(struct fi_info *info)
+{
+    if (info->nic->bus_attr->bus_type == FI_BUS_PCI) {
+        struct fi_pci_attr pci = info->nic->bus_attr->attr.pci;
+        return MPIR_hwtopo_get_dev_parent_by_pci(pci.domain_id, pci.bus_id, pci.device_id,
+                                                 pci.function_id);
+    }
+    return MPIR_hwtopo_get_obj_by_name(info->domain_attr->name);
+}
+
+/* Return true if the NIC is bound to the same socket as calling process */
+static bool is_nic_close(struct fi_info *info)
+{
+    if (info->nic->bus_attr->bus_type == FI_BUS_PCI) {
+        struct fi_pci_attr pci = info->nic->bus_attr->attr.pci;
+        return MPIR_hwtopo_is_dev_close_by_pci(pci.domain_id, pci.bus_id, pci.device_id,
+                                               pci.function_id);
+    }
+    return MPIR_hwtopo_is_dev_close_by_name(info->domain_attr->name);
+}
+
+/* Comparison function for NIC names. Used in qsort() */
+static int compare_nic_names(const void *info1, const void *info2)
+{
+    const struct fi_info **n1 = (const struct fi_info **) info1;
+    const struct fi_info **n2 = (const struct fi_info **) info2;
+    return strcmp((*n1)->domain_attr->name, (*n2)->domain_attr->name);
+}
+
+/* Comparison function for NICs. This function is used in qsort(). */
+static int compare_nics(const void *nic1, const void *nic2)
+{
+    const MPIDI_OFI_nic_info_t *i1 = (const MPIDI_OFI_nic_info_t *) nic1;
+    const MPIDI_OFI_nic_info_t *i2 = (const MPIDI_OFI_nic_info_t *) nic2;
+    if (i1->close && !i2->close)
+        return -1;
+    else if (i2->close && !i1->close)
+        return 1;
+    else if (i1->prefer - i2->prefer)
+        return i1->prefer - i2->prefer;
+    else if (i1->count - i2->count)
+        return i1->count - i2->count;
+    else if (i1->id - i2->id)
+        return i1->id - i2->id;
+    return compare_nic_names(&(i1->nic), &(i2->nic));
+}
+
 /* Determine if NIC has already been included in others */
-bool MPIDI_OFI_nic_already_used(const struct fi_info *prov, struct fi_info **others, int nic_count)
+bool MPIDI_OFI_nic_already_used(const struct fi_info * prov, struct fi_info ** others,
+                                int nic_count)
 {
     for (int i = 0; i < nic_count; ++i) {
         if (prov->nic->bus_attr->bus_type == FI_BUS_PCI &&
@@ -33,14 +82,112 @@ void MPIDI_OFI_setup_single_nic(struct fi_info *prov)
     MPIDI_OFI_global.prov_use[0] = fi_dupinfo(prov);
     MPIR_Assert(MPIDI_OFI_global.prov_use[0]);
     MPIDI_OFI_global.num_nics = 1;
+    MPIDI_OFI_global.num_close_nics = 1;
+    MPIDI_OFI_global.nic_info[0].nic = MPIDI_OFI_global.prov_use[0];
+    MPIDI_OFI_global.nic_info[0].id = 0;
+    MPIDI_OFI_global.nic_info[0].close = 1;
+    MPIDI_OFI_global.nic_info[0].prefer = 0;
+    MPIDI_OFI_global.nic_info[0].count = MPIR_Process.local_size;
+    MPIDI_OFI_global.nic_info[0].num_close_ranks = MPIR_Process.local_size;
 }
 
 /* TODO: Now that multiple NICs are detected, sort them based on preferred-ness,
  * closeness and count of other processes using the NIC. */
 int MPIDI_OFI_setup_multi_nic(void)
 {
+    MPIR_hwtopo_gid_t parents[MPIDI_OFI_MAX_NICS];
+    int num_parents = 0;
     int mpi_errno = MPI_SUCCESS;
+    MPIR_hwtopo_gid_t *close_nic_parents = NULL;
+    int local_rank = MPIR_Process.local_rank;
+    MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;
+
+    /* Initially sort the NICs by name. This way all intranode ranks have a consistent view. */
+    qsort(MPIDI_OFI_global.prov_use, MPIDI_OFI_global.num_nics, sizeof(struct fi_info *),
+          compare_nic_names);
+
+    /* Limit the number of physical NICs depending on the CVAR */
+    if (MPIR_CVAR_CH4_OFI_MAX_NICS > 0 && MPIDI_OFI_global.num_nics > MPIR_CVAR_CH4_OFI_MAX_NICS) {
+        for (int i = MPIR_CVAR_CH4_OFI_MAX_NICS; i < MPIDI_OFI_global.num_nics; ++i) {
+            fi_freeinfo(MPIDI_OFI_global.prov_use[i]);
+        }
+        MPIDI_OFI_global.num_nics = MPIR_CVAR_CH4_OFI_MAX_NICS;
+    }
+
+    /* Now go through every NIC and set initial information
+     * from current process's perspective */
+    for (int i = 0; i < MPIDI_OFI_global.num_nics; ++i) {
+        nics[i].nic = MPIDI_OFI_global.prov_use[i];
+        nics[i].id = i;
+        /* Determine NIC's "closeness" to current process */
+        nics[i].close = is_nic_close(nics[i].nic);
+        if (nics[i].close)
+            MPIDI_OFI_global.num_close_nics++;
+        /* Set the preference of all NICs to least preferable (lower is more preferable) */
+        nics[i].prefer = MPIDI_OFI_global.num_nics + 1;
+        nics[i].count = 0;
+        nics[i].num_close_ranks = 0;
+        /* Determine NIC's first normal parent topology
+         * item (e.g., typically the socket parent) */
+        nics[i].parent = get_nic_parent(nics[i].nic);
+        /* Expand list of close NIC-parent topology items or increment */
+        if (nics[i].close) {
+            int found = 0;
+            for (int j = 0; j < num_parents; ++j) {
+                if (parents[j] == nics[i].parent) {
+                    found = 1;
+                    break;
+                }
+            }
+            if (!found) {
+                parents[num_parents] = nics[i].parent;
+                num_parents++;
+            }
+        }
+    }
+
+    /* If there were zero NICs on my socket, then just consider every NIC close
+     * and share them among all ranks with a similar view */
+    if (MPIDI_OFI_global.num_close_nics == 0) {
+        for (int i = 0; i < MPIDI_OFI_global.num_nics; ++i)
+            nics[i].close = 1;
+        MPIDI_OFI_global.num_close_nics = MPIDI_OFI_global.num_nics;
+    }
+
+    /* Sort the NICs array based on closeness first. This way all the close
+     * NICs are at the beginning of the array */
+    qsort(nics, MPIDI_OFI_global.num_nics, sizeof(nics[0]), compare_nics);
+
+    /* Because we cannot communicate with the other local processes to avoid collisions with the
+     * same NICs, just shift NICs that have multiple close NICs around according to their local
+     * rank. This will likely give the same result as long as processes have been bound properly. */
+    int old_idx = (MPIDI_OFI_global.num_close_nics == 0) ? 0 :
+        local_rank % MPIDI_OFI_global.num_close_nics;
+
+    if (old_idx != 0) {
+        MPIDI_OFI_nic_info_t *old_nics = MPL_malloc(sizeof(MPIDI_OFI_nic_info_t) *
+                                                    MPIDI_OFI_global.num_nics, MPL_MEM_ADDRESS);
+        memcpy(old_nics, nics, sizeof(MPIDI_OFI_nic_info_t) * MPIDI_OFI_global.num_nics);
+
+        /* Rotate the preferred NIC for each process starting at old_idx. */
+        for (int new_idx = 0; new_idx < MPIDI_OFI_global.num_close_nics; new_idx++) {
+            if (new_idx != old_idx)
+                memcpy(&nics[new_idx], &old_nics[old_idx], sizeof(MPIDI_OFI_nic_info_t));
+
+            if (++old_idx >= MPIDI_OFI_global.num_close_nics)
+                old_idx = 0;
+        }
+        MPL_free(old_nics);
+    }
+
+    /* Reorder the prov_use array based on nic_info array */
+    for (int i = 0; i < MPIDI_OFI_global.num_nics; ++i) {
+        MPIDI_OFI_global.prov_use[i] = nics[i].nic;
+    }
+
   fn_exit:
+    if (close_nic_parents)
+        MPIDU_Init_shm_free(close_nic_parents);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef OFI_NIC_H_INCLUDED
+#define OFI_NIC_H_INCLUDED
+
+/* Determine if NIC has already been included in others */
+bool MPIDI_OFI_nic_already_used(const struct fi_info *prov, struct fi_info **others, int nic_count);
+
+/* Setup the multi-NIC data structures to use the fi_info structure given in prov */
+void MPIDI_OFI_setup_single_nic(struct fi_info *prov);
+
+int MPIDI_OFI_setup_multi_nic(void);
+
+#endif /* OFI_NIC_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -240,11 +240,14 @@ typedef struct {
     int progress_counter;
 } MPIDI_OFI_win_t;
 
+/* Maximum number of network interfaces CH4 can support. */
+#define MPIDI_OFI_MAX_NICS 8
+
 typedef struct {
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
-    fi_addr_t dest[MPIDI_CH4_MAX_VCIS][MPIDI_CH4_MAX_VCIS];     /* [local_vni][remote_vni] */
+    fi_addr_t dest[MPIDI_OFI_MAX_NICS][MPIDI_CH4_MAX_VCIS][MPIDI_CH4_MAX_VCIS]; /* [nic][local_vni][remote_vni] */
 #else
-    fi_addr_t dest[1][1];
+    fi_addr_t dest[MPIDI_OFI_MAX_NICS][1][1];
 #endif
 } MPIDI_OFI_addr_t;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -25,6 +25,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
     int ofi_err;
     int vni_local = vni_dst;
     int vni_remote = vni_src;
+    int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vni_dst, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_IPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_IPROBE);
@@ -32,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
     if (unlikely(MPI_ANY_SOURCE == source))
         remote_proc = FI_ADDR_UNSPEC;
     else
-        remote_proc = MPIDI_OFI_av_to_phys(addr, vni_local, vni_remote);
+        remote_proc = MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote);
 
     if (message) {
         rreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__MPROBE, vni_dst);
@@ -55,7 +57,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
     msg.context = (void *) &(MPIDI_OFI_REQUEST(rreq, context));
     msg.data = 0;
 
-    MPIDI_OFI_CALL_RETURN(fi_trecvmsg(MPIDI_OFI_global.ctx[vni_dst].rx, &msg,
+    MPIDI_OFI_CALL_RETURN(fi_trecvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx, &msg,
                                       peek_flags | FI_PEEK | FI_COMPLETION | FI_REMOTE_CQ_DATA),
                           ofi_err);
     if (ofi_err == -FI_ENOMSG) {

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -129,8 +129,9 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
         msg_len = MPL_MIN(origin_iov[origin_cur].iov_len, target_iov[target_cur].iov_len);
 
         int vni = MPIDI_OFI_WIN(win).vni;
+        int nic = 0;
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, vni, vni);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -224,8 +225,9 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         MPIR_ERR_CHKANDSTMT(chunk == NULL, mpi_errno, MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
 
         int vni = MPIDI_OFI_WIN(win).vni;
+        int nic = 0;
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.put.target.addr, vni, vni);
+        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.put.target.addr, nic, vni, vni);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -308,8 +310,9 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         MPIR_ERR_CHKANDSTMT(chunk == NULL, mpi_errno, MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
 
         int vni = MPIDI_OFI_WIN(win).vni;
+        int nic = 0;
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.get.target.addr, vni, vni);
+        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.get.target.addr, nic, vni, vni);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -187,6 +187,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
     MPI_Aint origin_true_lb, target_true_lb;
     struct iovec iov;
     struct fi_rma_iov riov;
+    int nic = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_PUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_PUT);
@@ -230,7 +231,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         MPIDI_OFI_win_cntr_incr(win);
         MPIDI_OFI_CALL_RETRY(fi_inject_write(MPIDI_OFI_WIN(win).ep,
                                              (char *) origin_addr + origin_true_lb, target_bytes,
-                                             MPIDI_OFI_av_to_phys(addr, vni, vni),
+                                             MPIDI_OFI_av_to_phys(addr, nic, vni, vni),
                                              target_mr.addr + target_true_lb,
                                              target_mr.mr_key), 0, rdma_inject_write, FALSE);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
@@ -254,7 +255,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
             flags = FI_DELIVERY_COMPLETE;
         }
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, vni, vni);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -373,6 +374,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
     MPI_Aint target_bytes, target_extent;
     struct fi_rma_iov riov;
     struct iovec iov;
+    int nic = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_GET);
@@ -427,7 +429,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         msg.desc = NULL;
         msg.msg_iov = &iov;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, vni, vni);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni);
         msg.rma_iov = &riov;
         msg.rma_iov_count = 1;
         msg.context = NULL;
@@ -579,6 +581,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     struct fi_ioc comparev;
     struct fi_rma_ioc targetv;
     struct fi_msg_atomic msg;
+    int nic = 0;
 
     int vni = MPIDI_OFI_WIN(win).vni;
 
@@ -649,7 +652,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av, vni, vni);
+    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vni, vni);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;
@@ -669,7 +672,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
   fn_fail:
     goto fn_exit;
   am_fallback:
-    /* Wait for OFI cas to complete for atomicity.
+    /* Wait for OFI case to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
     MPIDI_OFI_win_do_progress(win, vni);
@@ -694,6 +697,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
     int target_contig, origin_contig;
     MPI_Aint target_bytes, origin_bytes, target_extent;
     MPI_Aint origin_true_lb, target_true_lb;
+    int nic = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_ACCUMULATE);
@@ -777,7 +781,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         msg.msg_iov = &originv;
         msg.desc = NULL;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, vni, vni);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni);
         msg.rma_iov = &targetv;
         msg.rma_iov_count = 1;
         msg.datatype = fi_dt;
@@ -838,6 +842,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
     int target_contig, origin_contig, result_contig;
     MPI_Aint target_bytes, target_extent;
     MPI_Aint origin_true_lb, target_true_lb, result_true_lb;
+    int nic = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_GET_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_GET_ACCUMULATE);
@@ -923,7 +928,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         msg.msg_iov = &originv;
         msg.desc = NULL;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, vni, vni);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni);
         msg.rma_iov = &targetv;
         msg.rma_iov_count = 1;
         msg.datatype = fi_dt;
@@ -1091,6 +1096,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_FETCH_AND_OP);
 
     int vni = MPIDI_OFI_WIN(win).vni;
+    int nic = 0;
 
     if (
 #ifndef MPIDI_CH4_DIRECT_NETMOD
@@ -1153,7 +1159,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av, vni, vni);
+    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vni, vni);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -20,15 +20,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     int vni_local = vni_src;
     int vni_remote = vni_dst;
+    int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic);
     uint64_t match_bits;
+
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT);
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, tag, 0);
-    MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[vni_src].tx,
+    MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                         buf,
                                         data_sz,
                                         cq_data,
-                                        MPIDI_OFI_av_to_phys(addr, vni_local, vni_remote),
+                                        MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote),
                                         match_bits),
                          vni_local, tinjectdata, comm->hints[MPIR_COMM_HINT_EAGAIN]);
   fn_exit:
@@ -64,6 +67,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     MPI_Aint num_contig, size;
     int vni_local = vni_src;
     int vni_remote = vni_dst;
+    int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_SEND_IOV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_SEND_IOV);
@@ -99,10 +104,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     msg.ignore = 0ULL;
     msg.context = (void *) &(MPIDI_OFI_REQUEST(sreq, context));
     msg.data = cq_data;
-    msg.addr = MPIDI_OFI_av_to_phys(addr, vni_local, vni_remote);
+    msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote);
 
-    MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[vni_local].tx, &msg, flags), vni_local,
-                         tsendv, FALSE);
+    MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[ctx_idx].tx,
+                                     &msg, flags), vni_local, tsendv, FALSE);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_SEND_IOV);
@@ -133,6 +138,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     bool force_gpu_pack = false;
     int vni_local = vni_src;
     int vni_remote = vni_dst;
+    int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_SEND_NORMAL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_SEND_NORMAL);
@@ -166,11 +173,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIR_cc_incr(sreq->cc_ptr, &c);
         ssend_match = MPIDI_OFI_init_recvtag(&ssend_mask, comm->context_id + context_offset, tag);
         ssend_match |= MPIDI_OFI_SYNC_SEND_ACK;
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[vni_src].rx, /* endpoint    */
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[ctx_idx].rx, /* endpoint    */
                                       NULL,     /* recvbuf     */
                                       0,        /* data sz     */
                                       NULL,     /* memregion descr  */
-                                      MPIDI_OFI_av_to_phys(addr, vni_local, vni_remote),        /* remote proc */
+                                      MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote),   /* remote proc */
                                       ssend_match,      /* match bits  */
                                       0ULL,     /* mask bits   */
                                       (void *) &(ackreq->context)), vni_local, trecvsync, FALSE);
@@ -227,19 +234,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     }
 
     if (data_sz <= MPIDI_OFI_global.max_buffered_send) {
-        MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[vni_src].tx,
+        MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                             send_buf,
                                             data_sz,
                                             cq_data,
-                                            MPIDI_OFI_av_to_phys(addr, vni_local, vni_remote),
+                                            MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote),
                                             match_bits), vni_local, tinjectdata,
                              FALSE /* eagain */);
         MPIDI_OFI_send_event(NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
     } else if (data_sz < MPIDI_OFI_global.max_msg_size) {
-        MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[vni_src].tx,
+        MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           send_buf, data_sz, NULL /* desc */ ,
                                           cq_data,
-                                          MPIDI_OFI_av_to_phys(addr, vni_local, vni_remote),
+                                          MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote),
                                           match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
                              vni_local, tsenddata, FALSE /* eagain */);
@@ -259,7 +266,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
             rma_key = ctrl.rma_key;
         }
 
-        MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.ctx[vni_src].domain,  /* In:  Domain Object */
+        MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.ctx[ctx_idx].domain,  /* In:  Domain Object */
                                  send_buf,      /* In:  Lower memory address */
                                  data_sz,       /* In:  Length              */
                                  FI_REMOTE_READ,        /* In:  Expose MR for read  */
@@ -286,10 +293,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIR_Comm_add_ref(comm);
         MPIDI_OFI_REQUEST(sreq, util_id) = dst_rank;
         match_bits |= MPIDI_OFI_HUGE_SEND;      /* Add the bit for a huge message */
-        MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[vni_src].tx,
+        MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           send_buf, MPIDI_OFI_global.max_msg_size, NULL /* desc */ ,
                                           cq_data,
-                                          MPIDI_OFI_av_to_phys(addr, vni_local, vni_remote),
+                                          MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote),
                                           match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
                              vni_local, tsenddata, FALSE /* eagain */);

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -867,7 +867,7 @@ int MPIDI_OFI_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_
             MPIDI_OFI_VCI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[0].av, new_upids[i],
                                             1, &addr, 0ULL, NULL), 0, avmap);
             MPIR_Assert(addr != FI_ADDR_NOTAVAIL);
-            MPIDI_OFI_AV(&MPIDIU_get_av(avtid, i)).dest[0][0] = addr;
+            MPIDI_OFI_AV(&MPIDIU_get_av(avtid, i)).dest[0][0][0] = addr;
             /* highest bit is marked as 1 to indicate this is a new process */
             (*remote_lupids)[new_avt_procs[i]] = MPIDIU_LUPID_CREATE(avtid, i);
             MPIDIU_LUPID_SET_NEW_AVT_MARK((*remote_lupids)[new_avt_procs[i]]);
@@ -898,7 +898,7 @@ int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char 
     for (i = 0; i < comm->local_size; i++) {
         (*local_upid_size)[i] = MPIDI_OFI_global.addrnamelen;
         MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(MPIDIU_comm_rank_to_av(comm, i));
-        MPIDI_OFI_VCI_CALL(fi_av_lookup(MPIDI_OFI_global.ctx[0].av, av->dest[0][0],
+        MPIDI_OFI_VCI_CALL(fi_av_lookup(MPIDI_OFI_global.ctx[0].av, av->dest[0][0][0],
                                         &temp_buf[i * MPIDI_OFI_global.addrnamelen],
                                         &(*local_upid_size)[i]), 0, avlookup);
         total_size += (*local_upid_size)[i];

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -274,12 +274,24 @@ typedef struct {
     int num_am_buffers;
 } MPIDI_OFI_capabilities_t;
 
+typedef struct {
+    struct fi_info *nic;
+    int id;                     /* Unique NIC ID, consistent across intranode ranks */
+    int close;                  /* Boolean whether nic is close in terms of affinity */
+    int prefer;                 /* Preference to order (lower is more preferred) */
+    int count;                  /* Count of ranks which have this NIC as their preferred NIC */
+    int num_close_ranks;        /* number of ranks which are close to this NIC */
+    MPIR_hwtopo_gid_t parent;   /* Parent topology item of NIC which has affinity mask.
+                                 * This is typically the socket above the NIC */
+} MPIDI_OFI_nic_info_t;
+
 /* Global state data */
 #define MPIDI_KVSAPPSTRLEN 1024
 typedef struct {
     /* OFI objects */
     int avtid;
     struct fi_info *prov_use[MPIDI_OFI_MAX_NICS];
+    MPIDI_OFI_nic_info_t nic_info[MPIDI_OFI_MAX_NICS];
     struct fid_fabric *fabric;
 
     int got_named_av;
@@ -307,6 +319,7 @@ typedef struct {
     MPIDI_OFI_context_t ctx[MPIDI_OFI_MAX_VNIS * MPIDI_OFI_MAX_NICS];
     int num_vnis;
     int num_nics;
+    int num_close_nics;
 
     /* Window/RMA Globals */
     void *win_map;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -279,7 +279,7 @@ typedef struct {
 typedef struct {
     /* OFI objects */
     int avtid;
-    struct fi_info *prov_use;
+    struct fi_info *prov_use[MPIDI_OFI_MAX_NICS];
     struct fid_fabric *fabric;
 
     int got_named_av;
@@ -304,8 +304,9 @@ typedef struct {
 
     /* Mutexes and endpoints */
     MPIDI_OFI_cacheline_mutex_t mutexes[MAX_OFI_MUTEXES];
-    MPIDI_OFI_context_t ctx[MPIDI_OFI_MAX_VNIS];
+    MPIDI_OFI_context_t ctx[MPIDI_OFI_MAX_VNIS * MPIDI_OFI_MAX_NICS];
     int num_vnis;
+    int num_nics;
 
     /* Window/RMA Globals */
     void *win_map;
@@ -339,8 +340,8 @@ typedef struct {
     /* Process management and PMI globals */
     int pname_set;
     int pname_len;
-    char addrname[FI_NAME_MAX];
-    size_t addrnamelen;
+    char addrname[MPIDI_OFI_MAX_NICS][FI_NAME_MAX];
+    size_t addrnamelen;         /* OFI uses the same name length within a provider. */
     char pname[MPI_MAX_PROCESSOR_NAME];
     int port_name_tag_mask[MPIR_MAX_CONTEXT_MASK];
 

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -124,6 +124,7 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_Comm *comm_ptr = win->comm_ptr;
     MPIDI_OFI_win_targetinfo_t *winfo;
+    int nic = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_WIN_ALLGATHER);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_WIN_ALLGATHER);
@@ -136,6 +137,7 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
 
     /* we need register mr on the correct domain for the vni */
     int vni = MPIDI_OFI_get_win_vni(win);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
 
     /* Register the allocated win buffer or MPI_BOTTOM (NULL) for dynamic win.
      * It is clear that we cannot register NULL when FI_MR_ALLOCATED is set, thus
@@ -158,7 +160,7 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
         if (MPIR_GPU_query_pointer_is_dev(base))
             rc = -1;
         else
-            MPIDI_OFI_CALL_RETURN(fi_mr_reg(MPIDI_OFI_global.ctx[vni].domain,   /* In:  Domain Object */
+            MPIDI_OFI_CALL_RETURN(fi_mr_reg(MPIDI_OFI_global.ctx[ctx_idx].domain,       /* In:  Domain Object */
                                             base,       /* In:  Lower memory address */
                                             len,        /* In:  Length              */
                                             FI_REMOTE_READ | FI_REMOTE_WRITE,   /* In:  Expose MR for read  */
@@ -235,6 +237,8 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
 static int win_set_per_win_sync(MPIR_Win * win)
 {
     int ret, mpi_errno = MPI_SUCCESS;
+    int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(MPIDI_OFI_WIN(win).vni, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_WIN_SET_PER_WIN_SYNC);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_WIN_SET_PER_WIN_SYNC);
@@ -243,8 +247,8 @@ static int win_set_per_win_sync(MPIR_Win * win)
     memset(&cntr_attr, 0, sizeof(cntr_attr));
     cntr_attr.events = FI_CNTR_EVENTS_COMP;
     cntr_attr.wait_obj = FI_WAIT_UNSPEC;
-    MPIDI_OFI_CALL_RETURN(fi_cntr_open(MPIDI_OFI_global.ctx[MPIDI_OFI_WIN(win).vni].domain,
-                                       &cntr_attr, &MPIDI_OFI_WIN(win).cmpl_cntr, NULL), ret);
+    MPIDI_OFI_CALL_RETURN(fi_cntr_open(MPIDI_OFI_global.ctx[ctx_idx].domain, &cntr_attr,
+                                       &MPIDI_OFI_WIN(win).cmpl_cntr, NULL), ret);
     if (ret < 0) {
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE, "Failed to open completion counter.\n");
         mpi_errno = MPIDI_OFI_ENAVAIL;
@@ -286,60 +290,63 @@ static int win_init_sep(MPIR_Win * win)
 {
     int i, ret, mpi_errno = MPI_SUCCESS;
     struct fi_info *finfo;
+    int nic = 0;
+    int vni = MPIDI_OFI_WIN(win).vni;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_WIN_INIT_SEP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_WIN_INIT_SEP);
 
-    finfo = fi_dupinfo(MPIDI_OFI_global.prov_use);
+    finfo = fi_dupinfo(MPIDI_OFI_global.prov_use[0]);
     MPIR_Assert(finfo);
 
-    int vni = MPIDI_OFI_WIN(win).vni;
 
     /* Initialize scalable EP when first window is created. */
-    if (MPIDI_OFI_global.ctx[vni].rma_sep == NULL) {
+    if (MPIDI_OFI_global.ctx[ctx_idx].rma_sep == NULL) {
         /* NOTE: if MPIDI_OFI_VNI_USE_SEPCTX, we could share rma_stx_ctx across vnis */
 
         MPIDI_OFI_global.max_rma_sep_tx_cnt =
-            MPL_MIN(MPIDI_OFI_global.prov_use->domain_attr->max_ep_tx_ctx,
+            MPL_MIN(MPIDI_OFI_global.prov_use[0]->domain_attr->max_ep_tx_ctx,
                     MPIR_CVAR_CH4_OFI_MAX_RMA_SEP_CTX);
         finfo->ep_attr->tx_ctx_cnt = MPIDI_OFI_global.max_rma_sep_tx_cnt;
 
-        MPIDI_OFI_CALL_RETURN(fi_scalable_ep(MPIDI_OFI_global.ctx[vni].domain, finfo,
-                                             &MPIDI_OFI_global.ctx[vni].rma_sep, NULL), ret);
+        MPIDI_OFI_CALL_RETURN(fi_scalable_ep(MPIDI_OFI_global.ctx[ctx_idx].domain, finfo,
+                                             &MPIDI_OFI_global.ctx[ctx_idx].rma_sep, NULL), ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE, "Failed to create scalable endpoint.\n");
-            MPIDI_OFI_global.ctx[vni].rma_sep = NULL;
+            MPIDI_OFI_global.ctx[ctx_idx].rma_sep = NULL;
             mpi_errno = MPIDI_OFI_ENAVAIL;
             goto fn_fail;
         }
 
-        MPIDI_OFI_CALL_RETURN(fi_scalable_ep_bind(MPIDI_OFI_global.ctx[vni].rma_sep,
-                                                  &(MPIDI_OFI_global.ctx[vni].av->fid), 0), ret);
+        MPIDI_OFI_CALL_RETURN(fi_scalable_ep_bind(MPIDI_OFI_global.ctx[ctx_idx].rma_sep,
+                                                  &(MPIDI_OFI_global.ctx[ctx_idx].av->fid), 0),
+                              ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         "Failed to bind scalable endpoint to address vector.\n");
-            MPIDI_OFI_global.ctx[vni].rma_sep = NULL;
+            MPIDI_OFI_global.ctx[ctx_idx].rma_sep = NULL;
             mpi_errno = MPIDI_OFI_ENAVAIL;
             goto fn_fail;
         }
 
         /* Allocate and initialize tx index array. */
-        utarray_new(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array, &ut_int_icd, MPL_MEM_RMA);
+        utarray_new(MPIDI_OFI_global.ctx[ctx_idx].rma_sep_idx_array, &ut_int_icd, MPL_MEM_RMA);
         for (i = 0; i < MPIDI_OFI_global.max_rma_sep_tx_cnt; i++) {
-            utarray_push_back(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array, &i, MPL_MEM_RMA);
+            utarray_push_back(MPIDI_OFI_global.ctx[ctx_idx].rma_sep_idx_array, &i, MPL_MEM_RMA);
         }
     }
     /* Set per window transmit attributes. */
     set_rma_fi_info(win, finfo);
     /* Get available transmit context index. */
-    int *idx = (int *) utarray_back(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array);
+    int *idx = (int *) utarray_back(MPIDI_OFI_global.ctx[ctx_idx].rma_sep_idx_array);
     if (idx == NULL) {
         mpi_errno = MPIDI_OFI_ENAVAIL;
         goto fn_fail;
     }
     /* Retrieve transmit context on scalable EP. */
     MPIDI_OFI_CALL_RETURN(fi_tx_context
-                          (MPIDI_OFI_global.ctx[vni].rma_sep, *idx, finfo->tx_attr,
+                          (MPIDI_OFI_global.ctx[ctx_idx].rma_sep, *idx, finfo->tx_attr,
                            &(MPIDI_OFI_WIN(win).ep), NULL), ret);
     if (ret < 0) {
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -350,10 +357,10 @@ static int win_init_sep(MPIR_Win * win)
 
     MPIDI_OFI_WIN(win).sep_tx_idx = *idx;
     /* Pop this index out of reserving array. */
-    utarray_pop_back(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array);
+    utarray_pop_back(MPIDI_OFI_global.ctx[ctx_idx].rma_sep_idx_array);
 
     MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep,
-                                     &MPIDI_OFI_global.ctx[vni].cq->fid,
+                                     &MPIDI_OFI_global.ctx[ctx_idx].cq->fid,
                                      FI_TRANSMIT | FI_SELECTIVE_COMPLETION), ret);
     if (ret < 0) {
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -385,7 +392,7 @@ static int win_init_sep(MPIR_Win * win)
   fn_fail:
     if (MPIDI_OFI_WIN(win).sep_tx_idx != -1) {
         /* Push tx idx back into available pool. */
-        utarray_push_back(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array,
+        utarray_push_back(MPIDI_OFI_global.ctx[ctx_idx].rma_sep_idx_array,
                           &MPIDI_OFI_WIN(win).sep_tx_idx, MPL_MEM_RMA);
         MPIDI_OFI_WIN(win).sep_tx_idx = -1;
     }
@@ -412,17 +419,20 @@ static int win_init_stx(MPIR_Win * win)
     int ret, mpi_errno = MPI_SUCCESS;
     struct fi_info *finfo;
     bool have_per_win_cntr = false;
+    int nic = 0;
+    int vni = MPIDI_OFI_WIN(win).vni;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_WIN_INIT_STX);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_WIN_INIT_STX);
 
-    finfo = fi_dupinfo(MPIDI_OFI_global.prov_use);
+    /* WB TODO - Only setting up nic[0] for RMA right now. */
+    finfo = fi_dupinfo(MPIDI_OFI_global.prov_use[0]);
     MPIR_Assert(finfo);
 
-    int vni = MPIDI_OFI_WIN(win).vni;
 
     /* Initialize rma shared context when first window is created. */
-    if (MPIDI_OFI_global.ctx[vni].rma_stx_ctx == NULL) {
+    if (MPIDI_OFI_global.ctx[ctx_idx].rma_stx_ctx == NULL) {
         /* NOTE: if MPIDI_OFI_VNI_USE_SEPCTX, we could share rma_stx_ctx across vnis */
 
         struct fi_tx_attr tx_attr;
@@ -432,12 +442,13 @@ static int win_init_stx(MPIR_Win * win)
         tx_attr.caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC;
         tx_attr.msg_order = FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
         tx_attr.op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
-        MPIDI_OFI_CALL_RETURN(fi_stx_context(MPIDI_OFI_global.ctx[vni].domain, &tx_attr,
-                                             &MPIDI_OFI_global.ctx[vni].rma_stx_ctx, NULL), ret);
+        MPIDI_OFI_CALL_RETURN(fi_stx_context(MPIDI_OFI_global.ctx[ctx_idx].domain, &tx_attr,
+                                             &MPIDI_OFI_global.ctx[ctx_idx].rma_stx_ctx, NULL),
+                              ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         "Failed to create RMA shared TX context.\n");
-            MPIDI_OFI_global.ctx[vni].rma_stx_ctx = NULL;
+            MPIDI_OFI_global.ctx[ctx_idx].rma_stx_ctx = NULL;
             mpi_errno = MPIDI_OFI_ENAVAIL;
             goto fn_fail;
         }
@@ -450,7 +461,7 @@ static int win_init_stx(MPIR_Win * win)
 
     finfo->ep_attr->tx_ctx_cnt = FI_SHARED_CONTEXT;     /* Request a shared context */
     finfo->ep_attr->rx_ctx_cnt = 0;     /* We don't need RX contexts */
-    MPIDI_OFI_CALL_RETURN(fi_endpoint(MPIDI_OFI_global.ctx[vni].domain,
+    MPIDI_OFI_CALL_RETURN(fi_endpoint(MPIDI_OFI_global.ctx[ctx_idx].domain,
                                       finfo, &MPIDI_OFI_WIN(win).ep, NULL), ret);
     if (ret < 0) {
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -463,7 +474,7 @@ static int win_init_stx(MPIR_Win * win)
     if (win_set_per_win_sync(win) == MPI_SUCCESS) {
         have_per_win_cntr = true;
         MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep,
-                                         &MPIDI_OFI_global.ctx[vni].rma_stx_ctx->fid, 0), ret);
+                                         &MPIDI_OFI_global.ctx[ctx_idx].rma_stx_ctx->fid, 0), ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         "Failed to bind endpoint to shared transmit contxt.\n");
@@ -472,7 +483,7 @@ static int win_init_stx(MPIR_Win * win)
         }
 
         MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep,
-                                         &MPIDI_OFI_global.ctx[vni].cq->fid,
+                                         &MPIDI_OFI_global.ctx[ctx_idx].cq->fid,
                                          FI_TRANSMIT | FI_SELECTIVE_COMPLETION), ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -482,7 +493,8 @@ static int win_init_stx(MPIR_Win * win)
         }
 
         MPIDI_OFI_CALL_RETURN(fi_ep_bind
-                              (MPIDI_OFI_WIN(win).ep, &MPIDI_OFI_global.ctx[vni].av->fid, 0), ret);
+                              (MPIDI_OFI_WIN(win).ep, &MPIDI_OFI_global.ctx[ctx_idx].av->fid, 0),
+                              ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         "Failed to bind endpoint to address vector.\n");
@@ -525,14 +537,18 @@ static int win_init_global(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_WIN_INIT_GLOBAL);
 
     int vni = MPIDI_OFI_WIN(win).vni;
-    MPIDI_OFI_WIN(win).ep = MPIDI_OFI_global.ctx[vni].tx;
+    int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+
+    MPIDI_OFI_WIN(win).ep = MPIDI_OFI_global.ctx[ctx_idx].tx;
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
-    MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_OFI_global.ctx[vni].rma_cmpl_cntr;
-    MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_OFI_global.ctx[vni].rma_issued_cntr;
+    MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr;
+    MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_OFI_global.ctx[ctx_idx].rma_issued_cntr;
 #else
+    ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
     /* NOTE: shared with ctx[0] */
-    MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_OFI_global.ctx[0].rma_cmpl_cntr;
-    MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_OFI_global.ctx[0].rma_issued_cntr;
+    MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr;
+    MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_OFI_global.ctx[ctx_idx].rma_issued_cntr;
 #endif
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_WIN_INIT_GLOBAL);
@@ -881,6 +897,8 @@ int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
     MPIR_Comm *comm_ptr = win->comm_ptr;
     dwin_target_mr_t *target_mrs;
     int mpl_err = MPL_SUCCESS, i;
+    int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(MPIDI_OFI_WIN(win).vni, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_WIN_ATTACH_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_WIN_ATTACH_HOOK);
@@ -900,7 +918,7 @@ int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
     if (MPIR_GPU_query_pointer_is_dev(base))
         rc = -1;
     else
-        MPIDI_OFI_CALL_RETURN(fi_mr_reg(MPIDI_OFI_global.ctx[0].domain, /* In:  Domain Object */
+        MPIDI_OFI_CALL_RETURN(fi_mr_reg(MPIDI_OFI_global.ctx[ctx_idx].domain,   /* In:  Domain Object */
                                         base,   /* In:  Lower memory address */
                                         size,   /* In:  Length              */
                                         FI_REMOTE_READ | FI_REMOTE_WRITE,       /* In:  Expose MR for read  */
@@ -1017,22 +1035,25 @@ int MPIDI_OFI_mpi_win_detach_hook(MPIR_Win * win, const void *base)
 int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
+    int nic = 0;
+
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_WIN_FREE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_WIN_FREE_HOOK);
 
     if (MPIDI_OFI_ENABLE_RMA) {
         int vni = MPIDI_OFI_WIN(win).vni;
+        int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
         MPIDI_OFI_mr_key_free(MPIDI_OFI_COLL_MR_KEY, MPIDI_OFI_WIN(win).win_id);
         MPIDIU_map_erase(MPIDI_OFI_global.win_map, MPIDI_OFI_WIN(win).win_id);
         /* For scalable EP: push transmit context index back into available pool. */
         if (MPIDI_OFI_WIN(win).sep_tx_idx != -1) {
-            utarray_push_back(MPIDI_OFI_global.ctx[vni].rma_sep_idx_array,
+            utarray_push_back(MPIDI_OFI_global.ctx[ctx_idx].rma_sep_idx_array,
                               &(MPIDI_OFI_WIN(win).sep_tx_idx), MPL_MEM_RMA);
         }
-        if (MPIDI_OFI_WIN(win).ep != MPIDI_OFI_global.ctx[vni].tx)
+        if (MPIDI_OFI_WIN(win).ep != MPIDI_OFI_global.ctx[ctx_idx].tx)
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).ep->fid), epclose);
-        /* FIXME: comparing pointer is fragile, ctx[vni].rma_cmpl_cntr may be a dummy */
-        if (MPIDI_OFI_WIN(win).cmpl_cntr != MPIDI_OFI_global.ctx[vni].rma_cmpl_cntr)
+        /* FIXME: comparing pointer is fragile, ctx[ctx_idx].rma_cmpl_cntr may be a dummy */
+        if (MPIDI_OFI_WIN(win).cmpl_cntr != MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr)
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).cmpl_cntr->fid), cntrclose);
         if (MPIDI_OFI_WIN(win).mr)
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).mr->fid), mr_unreg);


### PR DESCRIPTION
## Pull Request Description

### High Level Description

Adds awareness of multiple NICs in the OFI provider. In this PR, the main thing being added is the ability to track and exchange the address information for each NIC.

The processes that share a node will do some work now to ensure that they do not share a NIC if possible. So if there are two processes sharing a node and two NICs attached to that node, process 0 will use one of the NICs and process 1 will use the other NIC. Eventually, there will need to be round-robin assignment when the number of processes exceed the number of NICs.

### What Is Not Here

This PR does not include support for multiple NICs within a single process. There are two optimizations that would fall into this category:

* Striping - Using multiple NICs to send a single, large message.
* Multiplexing - Using multiple NICs to distribute multiple, smaller messages

These optimizations are also implemented, but they'll come in a follow-on PR.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
