### PR TITLE
spawn: fix validation for MPI_Comm_accept/connect

### DIFF
--- a/src/binding/c/spawn_api.txt
+++ b/src/binding/c/spawn_api.txt
@@ -107,9 +107,19 @@ MPI_Close_port:
 
 MPI_Comm_accept:
     .desc: Accept a request to form a new intercommunicator
+{ -- error_check -- port_name
+    if (comm_ptr->rank == root) {
+        MPIR_ERRTEST_ARGNULL(port_name, "port_name", mpi_errno);
+    }
+}
 
 MPI_Comm_connect:
     .desc: Make a request to form a new intercommunicator
+{ -- error_check -- port_name
+    if (comm_ptr->rank == root) {
+        MPIR_ERRTEST_ARGNULL(port_name, "port_name", mpi_errno);
+    }
+}
 
 MPI_Comm_disconnect:
     .desc: Disconnect from a communicator


### PR DESCRIPTION

## Pull Request Description
We should only validate port_name at root.

Fixes #5149 
[skip warnings]
## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
