### PR TITLE
util: add include strings.h to mpir_hwtopo.c

### DIFF
--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -4,6 +4,7 @@
  */
 
 #include "mpiimpl.h"
+#include <strings.h>    /* for strcasecmp */
 
 #ifdef HAVE_HWLOC
 #include "hwloc.h"


### PR DESCRIPTION
## Pull Request Description
The function `strcasecmp` is declared in `strings.h` and need to be included
for its usage.

This should fix the current failure of nightly test on 32-bit freeBSD strict build.


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
