### PR TITLE
maint: add pre-commit script maint/hooks/spellchecker

### DIFF
--- a/maint/hooks/spellchecker
+++ b/maint/hooks/spellchecker
@@ -1,0 +1,54 @@
+#! /usr/bin/env bash
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+# This script is used for CI testing, to use --
+#    git rebase --verbose --exec maint/hooks/spellchecker [base-commit]
+
+# Redirect output to stderr.
+exec 1>&2
+
+MIRROR=/tmp/${USER}/mpich-tmp-mirror
+TMP_FILENAME=/tmp/${USER}/mpich-tmp-file
+
+# Checkout a copy of the current index into MIRROR
+git checkout-index --prefix=$MIRROR/ -af
+
+# Remove files from MIRROR which are no longer present in the index
+git diff-index --cached --name-only --diff-filter=D -z HEAD | \
+    (cd $MIRROR && xargs -0 rm -f --)
+
+# This will check the previous commit again when not amending a commit, but that
+# should be ok if the patches are correct.
+filestring=`git diff --cached --name-only --diff-filter=ACM HEAD~1`
+
+# Everything else happens in the temporary build tree
+pushd $MIRROR > /dev/null
+
+ret=0
+
+# This won't work if we ever have a file with a space in the name
+for file in $filestring
+do
+    if [[ !($file == *.tex) ]] ; then
+        cp ${file} ${TMP_FILENAME}
+        bash maint/spellcheck.sh ${file}
+        git --no-pager diff ${file} ${TMP_FILENAME}
+        if [ $? != 0 ] ; then
+            ret=1
+        fi
+    fi
+done
+
+rm -rf ${MIRROR} ${TMP_FILENAME}
+
+if [ $ret != 0 ] ; then
+    RED='\033[0;31m'
+    NC='\033[0m' # No Color
+    echo -e "${RED}== SPELLCHECKER SCRIPT FAILED ==${NC}"
+    exit $ret
+fi
+
+popd > /dev/null

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -67,7 +67,7 @@ def dump_mpi_c(func, map_type="SMALL"):
     G.out.append("")
 
     # Create the MPI and QMPI wrapper functions that will call the above, "real" version of the
-    # funcion in the MPII prefix
+    # function in the MPII prefix
     dump_qmpi_wrappers(func, func['_map_type'])
 
 def get_func_file_path(func, root_dir):


### PR DESCRIPTION
## Pull Request Description
This script is to be used for CI testing, similar to the one used for
whitespace checker (maint/hooks/pre-commit).

Add jenkins job "spell-checker", triggered by comment "test:mpich/spellcheck". Once this merged, we'll have the test automatically run every time.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
