### PR TITLE
typerep: fix typerep_pack_external and add test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2816,6 +2816,9 @@ AC_CHECK_SIZEOF(wchar_t, 0, [
 ])
 
 AC_CHECK_SIZEOF(__float128, 0)
+if test "$ac_cv_sizeof___float128" = "16" ; then
+    AC_DEFINE(HAVE_FLOAT128, 1, [Define if __float128 is supported])
+fi
 
 AC_CHECK_SIZEOF(float_int, 0, [typedef struct { float a; int b; } float_int; ])
 AC_CHECK_SIZEOF(double_int, 0, [typedef struct { double a; int b; } double_int; ])

--- a/src/mpi/datatype/typerep/Makefile.mk
+++ b/src/mpi/datatype/typerep/Makefile.mk
@@ -5,3 +5,5 @@
 
 include $(top_srcdir)/src/mpi/datatype/typerep/dataloop/Makefile.mk
 include $(top_srcdir)/src/mpi/datatype/typerep/src/Makefile.mk
+
+AM_CPPFLAGS += -I$(top_srcdir)/src/mpi/datatype/typerep/src

--- a/src/mpi/datatype/typerep/Makefile.mk
+++ b/src/mpi/datatype/typerep/Makefile.mk
@@ -3,7 +3,10 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
+if BUILD_DATALOOP_ENGINE
 include $(top_srcdir)/src/mpi/datatype/typerep/dataloop/Makefile.mk
+endif
+
 include $(top_srcdir)/src/mpi/datatype/typerep/src/Makefile.mk
 
 AM_CPPFLAGS += -I$(top_srcdir)/src/mpi/datatype/typerep/src

--- a/src/mpi/datatype/typerep/dataloop/Makefile.mk
+++ b/src/mpi/datatype/typerep/dataloop/Makefile.mk
@@ -14,8 +14,7 @@ mpi_core_sources +=                                    \
     src/mpi/datatype/typerep/dataloop/segment.c                      \
     src/mpi/datatype/typerep/dataloop/segment_count.c                \
     src/mpi/datatype/typerep/dataloop/segment_flatten.c              \
-    src/mpi/datatype/typerep/dataloop/dataloop_debug.c               \
-    src/mpi/datatype/typerep/dataloop/dataloop_ext32.c
+    src/mpi/datatype/typerep/dataloop/dataloop_debug.c
 
 # several headers are included by the rest of MPICH
 AM_CPPFLAGS += -I$(top_srcdir)/src/mpi/datatype/typerep/dataloop

--- a/src/mpi/datatype/typerep/dataloop/dataloop.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop.c
@@ -5,6 +5,7 @@
 
 #include "mpiimpl.h"
 #include "dataloop_internal.h"
+#include "typerep_util.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -522,14 +523,14 @@ void MPIR_Dataloop_create_resized(MPI_Datatype oldtype, MPI_Aint extent, void **
 MPI_Aint MPIR_Dataloop_size_external32(MPI_Datatype type)
 {
     if (HANDLE_IS_BUILTIN(type)) {
-        return MPII_Dataloop_get_basic_size_external32(type);
+        return MPII_Typerep_get_basic_size_external32(type);
     } else {
         MPII_Dataloop *dlp = NULL;
 
         MPIR_DATALOOP_GET_LOOPPTR(type, dlp);
         MPIR_Assert(dlp != NULL);
 
-        return MPII_Dataloop_stream_size(dlp, MPII_Dataloop_get_basic_size_external32);
+        return MPII_Dataloop_stream_size(dlp, MPII_Typerep_get_basic_size_external32);
     }
 }
 

--- a/src/mpi/datatype/typerep/dataloop/dataloop_internal.h
+++ b/src/mpi/datatype/typerep/dataloop/dataloop_internal.h
@@ -199,8 +199,6 @@ void MPII_Dataloop_alloc_and_copy(int kind,
                                   MPI_Aint count,
                                   MPII_Dataloop * old_loop, MPII_Dataloop ** new_loop_p);
 
-MPI_Aint MPII_Dataloop_get_basic_size_external32(MPI_Datatype el_type);
-
 void MPII_Dataloop_segment_flatten(MPIR_Segment * segp,
                                    MPI_Aint first,
                                    MPI_Aint * lastp,

--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -140,7 +140,7 @@ static int external32_basic_convert(char *dest_buf,
             }
         } else if (src_el_size == 8) {
             while (src_ptr != src_end) {
-                BASIC_convert64(src_ptr, dest_ptr);
+                BASIC_convert64(*(const int64_t *) src_ptr, *(int64_t *) dest_ptr);
 
                 src_ptr += src_el_size;
                 dest_ptr += dest_el_size;
@@ -150,7 +150,7 @@ static int external32_basic_convert(char *dest_buf,
         if (src_el_size == 4) {
             while (src_ptr != src_end) {
                 int32_t tmp;
-                BASIC_convert32((*(const int32_t *) src_ptr), (*(int32_t *) dest_ptr));
+                BASIC_convert32((*(const int32_t *) src_ptr), tmp);
                 if (dest_el_size == 8) {
                     /* NOTE: it's wrong if it is unsigned and highest bit is 1, but
                      * at least only happens when number is in the higher half of the

--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -193,22 +193,10 @@ static int external32_float_convert(char *dest_buf,
     MPIR_Assert(dest_buf && src_buf);
 
     if (src_el_size == dest_el_size) {
-        if (src_el_size == 4) {
-            while (src_ptr != src_end) {
-                FLOAT_convert((*(const FOUR_BYTE_FLOAT_TYPE *) src_ptr),
-                              (*(FOUR_BYTE_FLOAT_TYPE *) dest_ptr));
-
-                src_ptr += src_el_size;
-                dest_ptr += dest_el_size;
-            }
-        } else if (src_el_size == 8) {
-            while (src_ptr != src_end) {
-                FLOAT_convert((*(const EIGHT_BYTE_FLOAT_TYPE *) src_ptr),
-                              (*(EIGHT_BYTE_FLOAT_TYPE *) dest_ptr));
-
-                src_ptr += src_el_size;
-                dest_ptr += dest_el_size;
-            }
+        while (src_ptr != src_end) {
+            BASIC_convert(src_ptr, dest_ptr, src_el_size);
+            src_ptr += src_el_size;
+            dest_ptr += dest_el_size;
         }
     } else {
         /* TODO */

--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -747,11 +747,11 @@ static int contig_unpack_external32_to_buf(MPI_Aint * blocks_p,
     } else if (is_float_type(el_type)) {
         external32_float_convert(((char *) bufp) + rel_off,
                                  paramp->u.unpack.unpack_buffer,
-                                 dest_el_size, src_el_size, *blocks_p);
+                                 src_el_size, dest_el_size, *blocks_p);
     } else {
         external32_basic_convert(((char *) bufp) + rel_off,
                                  paramp->u.unpack.unpack_buffer,
-                                 dest_el_size, src_el_size, *blocks_p);
+                                 src_el_size, dest_el_size, *blocks_p);
     }
     paramp->u.unpack.unpack_buffer += (dest_el_size * (*blocks_p));
 

--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -124,16 +124,14 @@ static int external32_basic_convert(char *dest_buf,
     if (src_el_size == dest_el_size) {
         if (src_el_size == 2) {
             while (src_ptr != src_end) {
-                BASIC_convert16((*(const TWO_BYTE_BASIC_TYPE *) src_ptr),
-                                (*(TWO_BYTE_BASIC_TYPE *) dest_ptr));
+                BASIC_convert16(*(const int16_t *) src_ptr, *(int16_t *) dest_ptr);
 
                 src_ptr += src_el_size;
                 dest_ptr += dest_el_size;
             }
         } else if (src_el_size == 4) {
             while (src_ptr != src_end) {
-                BASIC_convert32((*(const FOUR_BYTE_BASIC_TYPE *) src_ptr),
-                                (*(FOUR_BYTE_BASIC_TYPE *) dest_ptr));
+                BASIC_convert32(*(const int32_t *) src_ptr, *(int32_t *) dest_ptr);
 
                 src_ptr += src_el_size;
                 dest_ptr += dest_el_size;

--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -7,7 +7,7 @@
 #include "dataloop_internal.h"
 #include "datatype.h"
 #include "mpir_typerep.h"
-#include "looputil.h"
+#include "typerep_util.h"
 #include "veccpy.h"
 
 #define M2M_TO_USERBUF   0
@@ -651,7 +651,7 @@ static int contig_pack_external32_to_buf(MPI_Aint * blocks_p,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CONTIG_PACK_EXTERNAL32_TO_BUF);
 
     src_el_size = MPIR_Datatype_get_basic_size(el_type);
-    dest_el_size = MPII_Dataloop_get_basic_size_external32(el_type);
+    dest_el_size = MPII_Typerep_get_basic_size_external32(el_type);
     MPIR_Assert(dest_el_size);
 
     /*
@@ -697,7 +697,7 @@ static int contig_unpack_external32_to_buf(MPI_Aint * blocks_p,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CONTIG_UNPACK_EXTERNAL32_TO_BUF);
 
     src_el_size = MPIR_Datatype_get_basic_size(el_type);
-    dest_el_size = MPII_Dataloop_get_basic_size_external32(el_type);
+    dest_el_size = MPII_Typerep_get_basic_size_external32(el_type);
     MPIR_Assert(dest_el_size);
 
     /*
@@ -747,7 +747,7 @@ void MPIR_Segment_pack_external32(struct MPIR_Segment *segp,
     MPII_Segment_manipulate(segp, first, lastp, contig_pack_external32_to_buf, NULL,    /* MPIR_Segment_vector_pack_external32_to_buf, */
                             NULL,       /* blkidx */
                             NULL,       /* MPIR_Segment_index_pack_external32_to_buf, */
-                            MPII_Dataloop_get_basic_size_external32, &pack_params);
+                            MPII_Typerep_get_basic_size_external32, &pack_params);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_SEGMENT_PACK_EXTERNAL32);
     return;
@@ -765,7 +765,7 @@ void MPIR_Segment_unpack_external32(struct MPIR_Segment *segp,
     MPII_Segment_manipulate(segp, first, lastp, contig_unpack_external32_to_buf, NULL,  /* MPIR_Segment_vector_unpack_external32_to_buf, */
                             NULL,       /* blkidx */
                             NULL,       /* MPIR_Segment_index_unpack_external32_to_buf, */
-                            MPII_Dataloop_get_basic_size_external32, &pack_params);
+                            MPII_Typerep_get_basic_size_external32, &pack_params);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_SEGMENT_UNPACK_EXTERNAL32);
     return;

--- a/src/mpi/datatype/typerep/src/Makefile.mk
+++ b/src/mpi/datatype/typerep/src/Makefile.mk
@@ -4,6 +4,7 @@
 ##
 
 mpi_core_sources += \
+   src/mpi/datatype/typerep/src/typerep_ext32.c \
    src/mpi/datatype/typerep/src/typerep_flatten.c
 
 if BUILD_YAKSA_ENGINE

--- a/src/mpi/datatype/typerep/src/typerep_ext32.c
+++ b/src/mpi/datatype/typerep/src/typerep_ext32.c
@@ -5,11 +5,13 @@
 
 #include <mpiimpl.h>
 #include <mpir_typerep.h>
-#include "dataloop_internal.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 
+/* "external32" format defined by MPI specification.
+ * The type is defined to be platform-independent and data is packed in big-endian order.
+ */
 
 typedef struct external32_basic_size {
     MPI_Datatype el_type;
@@ -81,15 +83,15 @@ static external32_basic_size_t external32_basic_size_array[] = {
     {MPI_CXX_LONG_DOUBLE_COMPLEX, 2 * 16}
 };
 
-MPI_Aint MPII_Dataloop_get_basic_size_external32(MPI_Datatype el_type)
+#define COUNT_OF(array) \
+    (sizeof(array) / sizeof(array[0]))
+
+MPI_Aint MPII_Typerep_get_basic_size_external32(MPI_Datatype el_type)
 {
-    MPI_Aint ret = (MPI_Aint) 0;
-    unsigned int i = 0;
-    for (i = 0; i < (sizeof(external32_basic_size_array) / sizeof(external32_basic_size_t)); i++) {
+    for (int i = 0; i < COUNT_OF(external32_basic_size_array); i++) {
         if (external32_basic_size_array[i].el_type == el_type) {
-            ret = external32_basic_size_array[i].el_size;
-            break;
+            return external32_basic_size_array[i].el_size;
         }
     }
-    return ret;
+    return 0;
 }

--- a/src/mpi/datatype/typerep/src/typerep_ext32.c
+++ b/src/mpi/datatype/typerep/src/typerep_ext32.c
@@ -4,7 +4,7 @@
  */
 
 #include <mpiimpl.h>
-#include <mpir_typerep.h>
+#include "typerep_util.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -94,4 +94,47 @@ MPI_Aint MPII_Typerep_get_basic_size_external32(MPI_Datatype el_type)
         }
     }
     return 0;
+}
+
+bool MPII_Typerep_basic_type_is_complex(MPI_Datatype el_type)
+{
+    switch (el_type) {
+        case MPI_C_COMPLEX:
+        case MPI_C_DOUBLE_COMPLEX:
+        case MPI_C_LONG_DOUBLE_COMPLEX:
+#ifdef HAVE_FORTRAN_BINDING
+        case MPI_COMPLEX8:
+        case MPI_COMPLEX16:
+        case MPI_COMPLEX32:
+#endif
+#ifdef HAVE_CXX_BINDING
+        case MPI_CXX_FLOAT_COMPLEX:
+        case MPI_CXX_DOUBLE_COMPLEX:
+        case MPI_CXX_LONG_DOUBLE_COMPLEX:
+#endif
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool MPII_Typerep_basic_type_is_unsigned(MPI_Datatype el_type)
+{
+    switch (el_type) {
+        case MPI_PACKED:
+        case MPI_BYTE:
+        case MPI_WCHAR:
+        case MPI_UNSIGNED_CHAR:
+        case MPI_UNSIGNED_SHORT:
+        case MPI_UNSIGNED:
+        case MPI_UNSIGNED_LONG:
+        case MPI_UNSIGNED_LONG_LONG:
+        case MPI_UINT8_T:
+        case MPI_UINT16_T:
+        case MPI_UINT32_T:
+        case MPI_UINT64_T:
+            return true;
+        default:
+            return false;
+    }
 }

--- a/src/mpi/datatype/typerep/src/typerep_util.h
+++ b/src/mpi/datatype/typerep/src/typerep_util.h
@@ -242,57 +242,6 @@ static inline void BASIC_copyto(const void *src, void *dest, int size)
 
 */
 
-#if (BLENDIAN == 1)
-#define FLOAT_convert(src, dest)              \
-{                                          \
-    register int type_byte_size = sizeof(src);\
-    switch(type_byte_size)                    \
-    {                                         \
-        case 4:                               \
-        {                                     \
-           uint32_t d;                        \
-           BASIC_convert32((uint32_t) src, d); \
-           dest = (float)d;                   \
-        }                                     \
-        break;                                \
-        case 8:                               \
-        {                                     \
-           uint64_t d;                        \
-           BASIC_convert64((uint64_t) src, d); \
-           dest = (double) d;                 \
-        }                                     \
-        break;                                \
-        case 12:                              \
-        {                                     \
-           BASIC_convert96((const char *)&src,\
-                           (char *)&dest);    \
-        }                                     \
-        break;                                \
-        case 16:                              \
-        {                                     \
-           BASIC_convert128((const char *)&src,\
-                            (char *)&dest);   \
-        }                                     \
-        break;                                \
-    }                                         \
-}
-#else
-#define FLOAT_convert(src, dest)              \
-        { dest = src; }
-#endif
-
-#if (SIZEOF_FLOAT == 4)
-#define FOUR_BYTE_FLOAT_TYPE float
-#else
-#error "Cannot detect a float type that is 4 bytes long"
-#endif
-
-#if (SIZEOF_DOUBLE == 8)
-#define EIGHT_BYTE_FLOAT_TYPE double
-#else
-#error "Cannot detect a float type that is 8 bytes long"
-#endif
-
 MPI_Aint MPII_Typerep_get_basic_size_external32(MPI_Datatype el_type);
 bool MPII_Typerep_basic_type_is_complex(MPI_Datatype el_type);
 bool MPII_Typerep_basic_type_is_unsigned(MPI_Datatype el_type);

--- a/src/mpi/datatype/typerep/src/typerep_util.h
+++ b/src/mpi/datatype/typerep/src/typerep_util.h
@@ -417,5 +417,7 @@ static inline void BASIC_convert128(const char *src, char *dest)
 #endif
 
 MPI_Aint MPII_Typerep_get_basic_size_external32(MPI_Datatype el_type);
+bool MPII_Typerep_basic_type_is_complex(MPI_Datatype el_type);
+bool MPII_Typerep_basic_type_is_unsigned(MPI_Datatype el_type);
 
 #endif /* TYPEREP_UTIL_H_INCLUDED */

--- a/src/mpi/datatype/typerep/src/typerep_util.h
+++ b/src/mpi/datatype/typerep/src/typerep_util.h
@@ -147,6 +147,13 @@ static inline void BASIC_convert(const void *src, void *dest, int size)
     }
 }
 
+static inline void BASIC_copyto(const void *src, void *dest, int size)
+{
+    for (int i = 0; i < size; i++) {
+        ((char *) dest)[i] = ((const char *) src)[size - 1 - i];
+    }
+}
+
 #else
 
 /* FIXME: we may need use memcpy to allow no-alignment */
@@ -168,6 +175,11 @@ static inline void BASIC_convert(const void *src, void *dest, int size)
         default:
             MPIR_Assert(0);
     }
+}
+
+static inline void BASIC_copyto(const void *src, void *dest, int size)
+{
+    memcpy(dest, src, (size_t) size);
 }
 
 #endif

--- a/src/mpi/datatype/typerep/src/typerep_util.h
+++ b/src/mpi/datatype/typerep/src/typerep_util.h
@@ -3,8 +3,13 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#ifndef LOOPUTIL_H_INCLUDED
-#define LOOPUTIL_H_INCLUDED
+#ifndef TYPEREP_UTIL_H_INCLUDED
+#define TYPEREP_UTIL_H_INCLUDED
+
+/* This header contains macros and routines to facilitate basic datatype conversions,
+ * e.g. convert integers and real numbers with different sizes and endians. It is mainly
+ * used to support packing and unpacking "external32" datarep.
+ */
 
 #include "mpichconf.h"
 
@@ -411,4 +416,6 @@ static inline void BASIC_convert128(const char *src, char *dest)
 #error "Cannot detect a float type that is 8 bytes long"
 #endif
 
-#endif /* LOOPUTIL_H_INCLUDED */
+MPI_Aint MPII_Typerep_get_basic_size_external32(MPI_Datatype el_type);
+
+#endif /* TYPEREP_UTIL_H_INCLUDED */

--- a/src/mpi/datatype/typerep/src/typerep_util.h
+++ b/src/mpi/datatype/typerep/src/typerep_util.h
@@ -172,7 +172,6 @@ static inline void BASIC_convert128(const char *src, char *dest)
 {
     uint64_t tmp_src[2];
     uint64_t tmp_dest[2];
-    char *ptr = dest;
 
     tmp_src[0] = *((uint64_t *) src);
     tmp_src[1] = *((uint64_t *) ((char *) src + sizeof(uint64_t)));

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
@@ -16,7 +16,7 @@
         for (uintptr_t i = 0; i < max_iov_len; i++) {                   \
             c_type *sbuf = (c_type *) iov[i].iov_base;                  \
             for (size_t j = 0; j < iov[i].iov_len / sizeof(c_type); j++) { \
-                BASIC_convert(sbuf[j], dbuf[idx]);                      \
+                BASIC_convert(&sbuf[j], &dbuf[idx], sizeof(c_type));    \
                 idx++;                                                  \
             }                                                           \
         }                                                               \
@@ -29,7 +29,7 @@
         for (uintptr_t i = 0; i < max_iov_len; i++) {                   \
             c_type *dbuf = (c_type *) iov[i].iov_base;                  \
             for (size_t j = 0; j < iov[i].iov_len / sizeof(c_type); j++) { \
-                BASIC_convert(sbuf[idx], dbuf[j]);                      \
+                BASIC_convert(&sbuf[idx], &dbuf[j], sizeof(c_type));    \
                 idx++;                                                  \
             }                                                           \
         }                                                               \
@@ -44,7 +44,7 @@
             c_type *sbuf = (c_type *) iov[i].iov_base;                  \
             for (size_t j = 0; j < iov[i].iov_len / sizeof(c_type); j++) { \
                 tmp = sbuf[j];                                          \
-                BASIC_convert(tmp, dbuf[idx]);                          \
+                BASIC_convert(&tmp, &dbuf[idx], sizeof(pack_c_type));        \
                 idx++;                                                  \
             }                                                           \
         }                                                               \
@@ -58,7 +58,7 @@
         for (uintptr_t i = 0; i < max_iov_len; i++) {                   \
             c_type *dbuf = (c_type *) iov[i].iov_base;                  \
             for (size_t j = 0; j < iov[i].iov_len / sizeof(c_type); j++) { \
-                BASIC_convert(sbuf[idx], tmp);                          \
+                BASIC_convert(&sbuf[idx], &tmp, sizeof(pack_c_type));        \
                 dbuf[j] = tmp;                                          \
                 idx++;                                                  \
             }                                                           \

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
@@ -6,204 +6,64 @@
 #include "mpiimpl.h"
 #include "yaksa.h"
 #include "typerep_internal.h"
+#include "typerep_util.h"
 #include <assert.h>
 
-/* Define fixed-width equivalents for floating point types */
-#if SIZEOF_FLOAT == 1
-#define typerep_float8_t float
-#elif SIZEOF_DOUBLE == 1
-#define typerep_float8_t double
-#elif SIZEOF_LONG_DOUBLE == 1
-#define typerep_float8_t long double
-#else
-#define typerep_float8_t float
-#endif
-
-#if SIZEOF_FLOAT == 2
-#define typerep_float16_t float
-#elif SIZEOF_DOUBLE == 2
-#define typerep_float16_t double
-#elif SIZEOF_LONG_DOUBLE == 2
-#define typerep_float16_t long double
-#else
-#define typerep_float16_t float
-#endif
-
-#if SIZEOF_FLOAT == 4
-#define typerep_float32_t float
-#elif SIZEOF_DOUBLE == 4
-#define typerep_float32_t double
-#elif SIZEOF_LONG_DOUBLE == 4
-#define typerep_float32_t long double
-#else
-#define typerep_float32_t float
-#endif
-
-#if SIZEOF_FLOAT == 8
-#define typerep_float64_t float
-#elif SIZEOF_DOUBLE == 8
-#define typerep_float64_t double
-#elif SIZEOF_LONG_DOUBLE == 8
-#define typerep_float64_t long double
-#else
-#define typerep_float64_t float
-#endif
-
-#if SIZEOF_FLOAT == 16
-#define typerep_float128_t float
-#elif SIZEOF_DOUBLE == 16
-#define typerep_float128_t double
-#elif SIZEOF_LONG_DOUBLE == 16
-#define typerep_float128_t long double
-#else
-#define typerep_float128_t float
-#endif
-
-#if SIZEOF_FLOAT == 32
-#define typerep_float256_t float
-#elif SIZEOF_DOUBLE == 32
-#define typerep_float256_t double
-#elif SIZEOF_LONG_DOUBLE == 32
-#define typerep_float256_t long double
-#else
-#define typerep_float256_t float
-#endif
-
-#define PACK_EXTERNAL(iov, outbuf, max_iov_len, src_c_type, dest_c_type) \
+#define PACK_EXTERNAL_equal_size(iov, outbuf, max_iov_len, c_type) \
     do {                                                                \
-        dest_c_type *dbuf = (dest_c_type *) outbuf;                     \
+        c_type *dbuf = (c_type *) outbuf;                               \
         uintptr_t idx = 0;                                              \
         for (uintptr_t i = 0; i < max_iov_len; i++) {                   \
-            src_c_type *sbuf = (src_c_type *) iov[i].iov_base;          \
-            for (size_t j = 0; j < iov[i].iov_len / sizeof(src_c_type); j++) { \
-                dbuf[idx++] = (dest_c_type) sbuf[j];                    \
+            c_type *sbuf = (c_type *) iov[i].iov_base;                  \
+            for (size_t j = 0; j < iov[i].iov_len / sizeof(c_type); j++) { \
+                BASIC_convert(sbuf[j], dbuf[idx]);                      \
+                idx++;                                                  \
             }                                                           \
         }                                                               \
     } while (0)
 
-#define PACK_EXTERNAL_INT_MAPPED(inbuf, outbuf, max_iov_len, basic_type_size, dest_c_type) \
+#define UNPACK_EXTERNAL_equal_size(inbuf, iov, max_iov_len, c_type) \
     do {                                                                \
-        switch (basic_type_size) {                                      \
-        case 1:                                                         \
-            PACK_EXTERNAL(inbuf, outbuf, max_iov_len, int8_t, dest_c_type); \
-            break;                                                      \
-                                                                        \
-        case 2:                                                         \
-            PACK_EXTERNAL(inbuf, outbuf, max_iov_len, int16_t, dest_c_type); \
-            break;                                                      \
-                                                                        \
-        case 4:                                                         \
-            PACK_EXTERNAL(inbuf, outbuf, max_iov_len, int32_t, dest_c_type); \
-            break;                                                      \
-                                                                        \
-        case 8:                                                         \
-            PACK_EXTERNAL(inbuf, outbuf, max_iov_len, int64_t, dest_c_type); \
-            break;                                                      \
-                                                                        \
-        default:                                                        \
-            assert(0);                                                  \
-        }                                                               \
-    } while (0)
-
-#define PACK_EXTERNAL_FLOAT_MAPPED(inbuf, outbuf, max_iov_len, basic_type_size, dest_c_type) \
-        do {                                                            \
-            switch (basic_type_size) {                                  \
-            case 1:                                                     \
-                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float8_t, dest_c_type); \
-                break;                                                  \
-                                                                        \
-            case 2:                                                     \
-                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float16_t, dest_c_type); \
-                break;                                                  \
-                                                                        \
-            case 4:                                                     \
-                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float32_t, dest_c_type); \
-                break;                                                  \
-                                                                        \
-            case 8:                                                     \
-                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float64_t, dest_c_type); \
-                break;                                                  \
-                                                                        \
-            case 16:                                                    \
-                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float128_t, dest_c_type); \
-                break;                                                  \
-                                                                        \
-            case 32:                                                    \
-                PACK_EXTERNAL(inbuf, outbuf, max_iov_len, typerep_float256_t, dest_c_type); \
-                break;                                                  \
-                                                                        \
-            default:                                                    \
-                assert(0);                                              \
-            }                                                           \
-        } while (0)
-
-#define UNPACK_EXTERNAL(inbuf, iov, max_iov_len, src_c_type, dest_c_type) \
-    do {                                                                \
-        src_c_type *sbuf = (src_c_type *) inbuf;                        \
+        const c_type *sbuf = inbuf;                                     \
         uintptr_t idx = 0;                                              \
         for (uintptr_t i = 0; i < max_iov_len; i++) {                   \
-            dest_c_type *dbuf = (dest_c_type *) iov[i].iov_base;        \
-            for (size_t j = 0; j < iov[i].iov_len / sizeof(dest_c_type); j++) { \
-                dbuf[j] = (dest_c_type) sbuf[idx++];                    \
+            c_type *dbuf = (c_type *) iov[i].iov_base;                  \
+            for (size_t j = 0; j < iov[i].iov_len / sizeof(c_type); j++) { \
+                BASIC_convert(sbuf[idx], dbuf[j]);                      \
+                idx++;                                                  \
             }                                                           \
         }                                                               \
     } while (0)
 
-#define UNPACK_EXTERNAL_INT_MAPPED(inbuf, outbuf, max_iov_len, basic_type_size, src_c_type) \
+#define PACK_EXTERNAL_unequal_size(iov, outbuf, max_iov_len, c_type, pack_c_type) \
     do {                                                                \
-        switch (basic_type_size) {                                      \
-        case 1:                                                         \
-            UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, src_c_type, int8_t); \
-            break;                                                      \
-                                                                        \
-        case 2:                                                         \
-            UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, src_c_type, int16_t); \
-            break;                                                      \
-                                                                        \
-        case 4:                                                         \
-            UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, src_c_type, int32_t); \
-            break;                                                      \
-                                                                        \
-        case 8:                                                         \
-            UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, src_c_type, int64_t); \
-            break;                                                      \
-                                                                        \
-        default:                                                        \
-            assert(0);                                                  \
+        pack_c_type tmp;                                                \
+        pack_c_type *dbuf = outbuf;                                     \
+        uintptr_t idx = 0;                                              \
+        for (uintptr_t i = 0; i < max_iov_len; i++) {                   \
+            c_type *sbuf = (c_type *) iov[i].iov_base;                  \
+            for (size_t j = 0; j < iov[i].iov_len / sizeof(c_type); j++) { \
+                tmp = sbuf[j];                                          \
+                BASIC_convert(tmp, dbuf[idx]);                          \
+                idx++;                                                  \
+            }                                                           \
         }                                                               \
     } while (0)
 
-#define UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, outbuf, max_iov_len, basic_type_size, src_c_type) \
-        do {                                                            \
-            switch (basic_type_size) {                                  \
-            case 1:                                                     \
-                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, src_c_type, typerep_float8_t); \
-                break;                                                  \
-                                                                        \
-            case 2:                                                     \
-                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, src_c_type, typerep_float16_t); \
-                break;                                                  \
-                                                                        \
-            case 4:                                                     \
-                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, src_c_type, typerep_float32_t); \
-                break;                                                  \
-                                                                        \
-            case 8:                                                     \
-                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, src_c_type, typerep_float64_t); \
-                break;                                                  \
-                                                                        \
-            case 16:                                                    \
-                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, src_c_type, typerep_float128_t); \
-                break;                                                  \
-                                                                        \
-            case 32:                                                    \
-                UNPACK_EXTERNAL(inbuf, outbuf, max_iov_len, src_c_type, typerep_float256_t); \
-                break;                                                  \
-                                                                        \
-            default:                                                    \
-                assert(0);                                              \
+#define UNPACK_EXTERNAL_unequal_size(inbuf, iov, max_iov_len, c_type, pack_c_type) \
+    do {                                                                \
+        pack_c_type tmp;                                                \
+        const pack_c_type *sbuf = inbuf;                                \
+        uintptr_t idx = 0;                                              \
+        for (uintptr_t i = 0; i < max_iov_len; i++) {                   \
+            c_type *dbuf = (c_type *) iov[i].iov_base;                  \
+            for (size_t j = 0; j < iov[i].iov_len / sizeof(c_type); j++) { \
+                BASIC_convert(sbuf[idx], tmp);                          \
+                dbuf[j] = tmp;                                          \
+                idx++;                                                  \
             }                                                           \
-        } while (0)
+        }                                                               \
+    } while (0)
 
 int MPIR_Typerep_pack_external(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                                void *outbuf, MPI_Aint * actual_pack_bytes)
@@ -246,134 +106,51 @@ int MPIR_Typerep_pack_external(const void *inbuf, MPI_Aint incount, MPI_Datatype
         basic_type = typeptr->basic_type;
     }
 
-    MPI_Aint basic_type_size;
+    MPI_Aint basic_type_size, ext_type_size;
     MPIR_Datatype_get_size_macro(basic_type, basic_type_size);
+    ext_type_size = MPII_Typerep_get_basic_size_external32(basic_type);
 
-    /* destination sizes are fixed in external32 packing, so we always
-     * map each type to a fixed type.  See table 13.2 in the MPI-3.1
-     * specification (page 540). */
-    /* we do not need to distinguish between signed and unsigned types
-     * because their bit representations are identical for
-     * pack/unpack. */
-    switch (basic_type) {
-        case MPI_PACKED:
-        case MPI_BYTE:
-        case MPI_INT8_T:
-        case MPI_UINT8_T:
-        case MPI_CHAR:
-        case MPI_UNSIGNED_CHAR:
-        case MPI_SIGNED_CHAR:
-        case MPI_C_BOOL:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_CHARACTER:
-        case MPI_INTEGER1:
-#endif /* HAVE_FORTRAN_BINDING */
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_BOOL:
-#endif /* HAVE_CXX_BINDING */
-            PACK_EXTERNAL_INT_MAPPED(iov, outbuf, max_iov_len, basic_type_size, int8_t);
-            break;
+    if (MPII_Typerep_basic_type_is_complex(basic_type)) {
+        /* treat as float */
+        basic_type_size /= 2;
+        ext_type_size /= 2;
+    }
 
-        case MPI_WCHAR:
-        case MPI_SHORT:
-        case MPI_UNSIGNED_SHORT:
-        case MPI_INT16_T:
-        case MPI_UINT16_T:
-        case MPI_COUNT:
-        case MPI_OFFSET:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_INTEGER2:
-#endif /* HAVE_FORTRAN_BINDING */
-            PACK_EXTERNAL_INT_MAPPED(iov, outbuf, max_iov_len, basic_type_size, int16_t);
-            break;
-
-        case MPI_INT:
-        case MPI_UNSIGNED:
-        case MPI_LONG:
-        case MPI_UNSIGNED_LONG:
-        case MPI_INT32_T:
-        case MPI_UINT32_T:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_LOGICAL:
-        case MPI_INTEGER:
-        case MPI_INTEGER4:
-#endif /* HAVE_FORTRAN_BINDING */
-            PACK_EXTERNAL_INT_MAPPED(iov, outbuf, max_iov_len, basic_type_size, int32_t);
-            break;
-
-        case MPI_LONG_LONG:
-        case MPI_UNSIGNED_LONG_LONG:
-        case MPI_INT64_T:
-        case MPI_UINT64_T:
-        case MPI_AINT:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_INTEGER8:
-#endif /* HAVE_FORTRAN_BINDING */
-            PACK_EXTERNAL_INT_MAPPED(iov, outbuf, max_iov_len, basic_type_size, int64_t);
-            break;
-
-        case MPI_FLOAT:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_REAL:
-        case MPI_REAL4:
-#endif /* HAVE_FORTRAN_BINDING */
-            PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
-                                       typerep_float32_t);
-            break;
-
-        case MPI_DOUBLE:
-        case MPI_C_COMPLEX:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_DOUBLE_PRECISION:
-        case MPI_COMPLEX:
-        case MPI_REAL8:
-        case MPI_COMPLEX8:
-#endif /* HAVE_FORTRAN_BINDING */
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_FLOAT_COMPLEX:
-#endif /* HAVE_CXX_BINDING */
-            PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
-                                       typerep_float64_t);
-            break;
-
-        case MPI_C_DOUBLE_COMPLEX:
-        case MPI_LONG_DOUBLE:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_DOUBLE_COMPLEX:
-        case MPI_COMPLEX16:
-#endif /* HAVE_FORTRAN_BINDING */
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_DOUBLE_COMPLEX:
-#endif /* HAVE_CXX_BINDING */
-            PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
-                                       typerep_float128_t);
-            break;
-
-        case MPI_C_LONG_DOUBLE_COMPLEX:
-#ifdef HAVE_FORTRAN_BINDING
-#endif /* HAVE_FORTRAN_BINDING */
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_LONG_DOUBLE_COMPLEX:
-#endif /* HAVE_CXX_BINDING */
-            PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
-                                       typerep_float256_t);
-            break;
-
-        default:
-            /* some types are handled with if-else branches, instead
-             * of a switch statement because MPICH might define them
-             * as "MPI_DATATYPE_NULL". */
-            if (datatype == MPI_REAL16) {
-                PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
-                                           typerep_float128_t);
-            } else if (datatype == MPI_COMPLEX32) {
-                PACK_EXTERNAL_FLOAT_MAPPED(iov, outbuf, max_iov_len, basic_type_size,
-                                           typerep_float256_t);
+    if (basic_type_size == ext_type_size) {
+        if (basic_type_size == 1) {
+            PACK_EXTERNAL_equal_size(iov, outbuf, max_iov_len, int8_t);
+        } else if (basic_type_size == 2) {
+            PACK_EXTERNAL_equal_size(iov, outbuf, max_iov_len, int16_t);
+        } else if (basic_type_size == 4) {
+            PACK_EXTERNAL_equal_size(iov, outbuf, max_iov_len, int32_t);
+        } else if (basic_type_size == 8) {
+            PACK_EXTERNAL_equal_size(iov, outbuf, max_iov_len, int64_t);
+        } else {
+            MPIR_Assert(0);
+        }
+    } else if (basic_type == MPI_LONG_DOUBLE) {
+        /* FIXME */
+        MPIR_Assert(0);
+    } else {
+        if (basic_type_size == 1) {
+            MPIR_Assert(0);
+        } else if (basic_type_size == 2) {
+            MPIR_Assert(0);
+        } else if (basic_type_size == 4) {
+            MPIR_Assert(0);
+        } else if (basic_type_size == 8) {
+            if (ext_type_size == 4) {
+                if (MPII_Typerep_basic_type_is_unsigned(basic_type)) {
+                    PACK_EXTERNAL_unequal_size(iov, outbuf, max_iov_len, uint64_t, uint32_t);
+                } else {
+                    PACK_EXTERNAL_unequal_size(iov, outbuf, max_iov_len, int64_t, int32_t);
+                }
             } else {
-                /* unsupported, including MPI_INTEGER16 */
-                MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**packextunsupport");
-                goto fn_fail;
+                MPIR_Assert(0);
             }
+        } else {
+            MPIR_Assert(0);
+        }
     }
 
   fn_exit:
@@ -426,135 +203,51 @@ int MPIR_Typerep_unpack_external(const void *inbuf, void *outbuf, MPI_Aint outco
         basic_type = typeptr->basic_type;
     }
 
-    MPI_Aint basic_type_size;
+    MPI_Aint basic_type_size, ext_type_size;
     MPIR_Datatype_get_size_macro(basic_type, basic_type_size);
+    ext_type_size = MPII_Typerep_get_basic_size_external32(basic_type);
 
-    /* destination sizes are fixed in external32 packing, so we always
-     * map each type to a fixed type.  See table 13.2 in the MPI-3.1
-     * specification (page 540). */
-    /* we do not need to distinguish between signed and unsigned types
-     * because their bit representations are identical for
-     * pack/unpack. */
-    switch (basic_type) {
-        case MPI_PACKED:
-        case MPI_BYTE:
-        case MPI_INT8_T:
-        case MPI_UINT8_T:
-        case MPI_CHAR:
-        case MPI_UNSIGNED_CHAR:
-        case MPI_SIGNED_CHAR:
-        case MPI_C_BOOL:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_CHARACTER:
-        case MPI_INTEGER1:
-#endif /* HAVE_FORTRAN_BINDING */
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_BOOL:
-#endif /* HAVE_CXX_BINDING */
-            UNPACK_EXTERNAL_INT_MAPPED(inbuf, iov, max_iov_len, basic_type_size, int8_t);
-            break;
+    if (MPII_Typerep_basic_type_is_complex(basic_type)) {
+        /* treat as float */
+        basic_type_size /= 2;
+        ext_type_size /= 2;
+    }
 
-        case MPI_WCHAR:
-        case MPI_SHORT:
-        case MPI_UNSIGNED_SHORT:
-        case MPI_INT16_T:
-        case MPI_UINT16_T:
-        case MPI_COUNT:
-        case MPI_OFFSET:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_INTEGER2:
-#endif /* HAVE_FORTRAN_BINDING */
-            UNPACK_EXTERNAL_INT_MAPPED(inbuf, iov, max_iov_len, basic_type_size, int16_t);
-            break;
-
-        case MPI_INT:
-        case MPI_UNSIGNED:
-        case MPI_LONG:
-        case MPI_UNSIGNED_LONG:
-        case MPI_INT32_T:
-        case MPI_UINT32_T:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_LOGICAL:
-        case MPI_INTEGER:
-        case MPI_INTEGER4:
-#endif /* HAVE_FORTRAN_BINDING */
-            UNPACK_EXTERNAL_INT_MAPPED(inbuf, iov, max_iov_len, basic_type_size, int32_t);
-            break;
-
-        case MPI_LONG_LONG:
-        case MPI_UNSIGNED_LONG_LONG:
-        case MPI_INT64_T:
-        case MPI_UINT64_T:
-        case MPI_AINT:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_INTEGER8:
-#endif /* HAVE_FORTRAN_BINDING */
-            UNPACK_EXTERNAL_INT_MAPPED(inbuf, iov, max_iov_len, basic_type_size, int64_t);
-            break;
-
-        case MPI_FLOAT:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_REAL:
-        case MPI_REAL4:
-#endif /* HAVE_FORTRAN_BINDING */
-            UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
-                                         typerep_float32_t);
-            break;
-
-        case MPI_DOUBLE:
-        case MPI_C_COMPLEX:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_DOUBLE_PRECISION:
-        case MPI_COMPLEX:
-        case MPI_REAL8:
-        case MPI_COMPLEX8:
-#endif /* HAVE_FORTRAN_BINDING */
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_FLOAT_COMPLEX:
-#endif /* HAVE_CXX_BINDING */
-            UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
-                                         typerep_float64_t);
-            break;
-
-        case MPI_C_DOUBLE_COMPLEX:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_DOUBLE_COMPLEX:
-        case MPI_LONG_DOUBLE:
-        case MPI_COMPLEX16:
-#endif /* HAVE_FORTRAN_BINDING */
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_DOUBLE_COMPLEX:
-#endif /* HAVE_CXX_BINDING */
-            UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
-                                         typerep_float128_t);
-            break;
-
-        case MPI_C_LONG_DOUBLE_COMPLEX:
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_LONG_DOUBLE_COMPLEX:
-#endif /* HAVE_CXX_BINDING */
-            UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
-                                         typerep_float256_t);
-            break;
-
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_INTEGER16:
-#endif /* HAVE_FORTRAN_BINDING */
-        default:
-            /* some types are handled with if-else branches, instead
-             * of a switch statement because MPICH might define them
-             * as "MPI_DATATYPE_NULL". */
-            if (datatype == MPI_REAL16) {
-                UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
-                                             typerep_float128_t);
-            } else if (datatype == MPI_COMPLEX32) {
-                UNPACK_EXTERNAL_FLOAT_MAPPED(inbuf, iov, max_iov_len, basic_type_size,
-                                             typerep_float256_t);
+    if (basic_type_size == ext_type_size) {
+        if (basic_type_size == 1) {
+            UNPACK_EXTERNAL_equal_size(inbuf, iov, max_iov_len, int8_t);
+        } else if (basic_type_size == 2) {
+            UNPACK_EXTERNAL_equal_size(inbuf, iov, max_iov_len, int16_t);
+        } else if (basic_type_size == 4) {
+            UNPACK_EXTERNAL_equal_size(inbuf, iov, max_iov_len, int32_t);
+        } else if (basic_type_size == 8) {
+            UNPACK_EXTERNAL_equal_size(inbuf, iov, max_iov_len, int64_t);
+        } else {
+            MPIR_Assert(0);
+        }
+    } else if (basic_type == MPI_LONG_DOUBLE) {
+        /* FIXME */
+        MPIR_Assert(0);
+    } else {
+        if (basic_type_size == 1) {
+            MPIR_Assert(0);
+        } else if (basic_type_size == 2) {
+            MPIR_Assert(0);
+        } else if (basic_type_size == 4) {
+            MPIR_Assert(0);
+        } else if (basic_type_size == 8) {
+            if (ext_type_size == 4) {
+                if (MPII_Typerep_basic_type_is_unsigned(basic_type)) {
+                    UNPACK_EXTERNAL_unequal_size(inbuf, iov, max_iov_len, uint64_t, uint32_t);
+                } else {
+                    UNPACK_EXTERNAL_unequal_size(inbuf, iov, max_iov_len, int64_t, int32_t);
+                }
             } else {
-                /* unsupported, including MPI_INTEGER16 */
-                MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**packextunsupport");
-                goto fn_fail;
+                MPIR_Assert(0);
             }
+        } else {
+            MPIR_Assert(0);
+        }
     }
 
   fn_exit:
@@ -590,108 +283,7 @@ int MPIR_Typerep_size_external32(MPI_Datatype type)
     MPIR_Datatype_get_size_macro(basic_type, basic_type_size);
 
     size = typeptr->size / basic_type_size;
-
-    switch (basic_type) {
-        case MPI_PACKED:
-        case MPI_BYTE:
-        case MPI_INT8_T:
-        case MPI_UINT8_T:
-        case MPI_CHAR:
-        case MPI_UNSIGNED_CHAR:
-        case MPI_SIGNED_CHAR:
-        case MPI_C_BOOL:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_CHARACTER:
-        case MPI_INTEGER1:
-#endif /* HAVE_FORTRAN_BINDING */
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_BOOL:
-#endif /* HAVE_CXX_BINDING */
-            size *= 1;
-            break;
-
-        case MPI_WCHAR:
-        case MPI_SHORT:
-        case MPI_UNSIGNED_SHORT:
-        case MPI_INT16_T:
-        case MPI_UINT16_T:
-        case MPI_COUNT:
-        case MPI_OFFSET:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_INTEGER2:
-#endif /* HAVE_FORTRAN_BINDING */
-            size *= 2;
-            break;
-
-        case MPI_INT:
-        case MPI_UNSIGNED:
-        case MPI_LONG:
-        case MPI_UNSIGNED_LONG:
-        case MPI_INT32_T:
-        case MPI_UINT32_T:
-        case MPI_FLOAT:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_LOGICAL:
-        case MPI_INTEGER:
-        case MPI_INTEGER4:
-        case MPI_REAL:
-        case MPI_REAL4:
-#endif /* HAVE_FORTRAN_BINDING */
-            size *= 4;
-            break;
-
-        case MPI_LONG_LONG:
-        case MPI_UNSIGNED_LONG_LONG:
-        case MPI_INT64_T:
-        case MPI_UINT64_T:
-        case MPI_AINT:
-        case MPI_INTEGER8:
-        case MPI_DOUBLE:
-        case MPI_C_COMPLEX:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_DOUBLE_PRECISION:
-        case MPI_COMPLEX:
-        case MPI_REAL8:
-        case MPI_COMPLEX8:
-#endif /* HAVE_FORTRAN_BINDING */
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_FLOAT_COMPLEX:
-#endif /* HAVE_CXX_BINDING */
-            size *= 8;
-            break;
-
-        case MPI_C_DOUBLE_COMPLEX:
-        case MPI_LONG_DOUBLE:
-#ifdef HAVE_FORTRAN_BINDING
-        case MPI_DOUBLE_COMPLEX:
-        case MPI_COMPLEX16:
-#endif /* HAVE_FORTRAN_BINDING */
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_DOUBLE_COMPLEX:
-#endif /* HAVE_CXX_BINDING */
-            size *= 16;
-            break;
-
-        case MPI_C_LONG_DOUBLE_COMPLEX:
-#ifdef HAVE_CXX_BINDING
-        case MPI_CXX_LONG_DOUBLE_COMPLEX:
-#endif /* HAVE_CXX_BINDING */
-            size *= 32;
-            break;
-
-        default:
-            /* some types are handled with if-else branches, instead
-             * of a switch statement because MPICH might define them
-             * as "MPI_DATATYPE_NULL". */
-            if (type == MPI_REAL16)
-                size *= 16;
-            else if (type == MPI_COMPLEX32)
-                size *= 32;
-            else if (type == MPI_INTEGER16)
-                size *= 16;
-            else
-                assert(0);
-    }
+    size *= MPII_Typerep_get_basic_size_external32(basic_type);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_SIZE_EXTERNAL32);
     return size;

--- a/test/mpi/datatype/Makefile.am
+++ b/test/mpi/datatype/Makefile.am
@@ -48,6 +48,7 @@ noinst_PROGRAMS =             \
     sendrecvt4                \
     simple_commit             \
     simple_pack               \
+    pack_external             \
     simple_pack_external      \
     simple_pack_external2     \
     simple_resized            \

--- a/test/mpi/datatype/large_type.c
+++ b/test/mpi/datatype/large_type.c
@@ -97,18 +97,19 @@ int testtype(MPI_Datatype type, MPI_Offset expected)
     }
 
     if (size != expected) {
-        printf("reported type size %lld does not match expected %lld\n", size, expected);
+        printf("reported type size %lld does not match expected %lld\n", (long long) size,
+               (long long) expected);
         errs++;
     }
 
     MPI_Type_get_true_extent_x(type, &lb, &extent);
     if (lb != 0) {
-        printf("ERROR: type should have lb of 0, reported %lld\n", lb);
+        printf("ERROR: type should have lb of 0, reported %lld\n", (long long) lb);
         errs++;
     }
 
     if (extent != size) {
-        printf("ERROR: extent should match size, not %lld\n", extent);
+        printf("ERROR: extent should match size, not %lld\n", (long long) extent);
         errs++;
     }
     return errs;

--- a/test/mpi/datatype/pack_external.c
+++ b/test/mpi/datatype/pack_external.c
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "mpi.h"
+#include "mpitest.h"
+
+/* #define TEST_COMPLEX */
+/* #define TEST_LONG_DOUBLE */
+
+#ifdef TEST_COMPLEX
+#include <complex.h>
+#endif
+
+struct dt {
+    MPI_Datatype mpi_type;
+    int length;
+};
+
+static struct dt dt_list[] = {
+    {MPI_PACKED, 1},
+    {MPI_BYTE, 1},
+    {MPI_CHAR, 1},
+    {MPI_UNSIGNED_CHAR, 1},
+    {MPI_SIGNED_CHAR, 1},
+    {MPI_WCHAR, 2},
+    {MPI_SHORT, 2},
+    {MPI_UNSIGNED_SHORT, 2},
+    {MPI_INT, 4},
+    {MPI_UNSIGNED, 4},
+    {MPI_LONG, 4},
+    {MPI_UNSIGNED_LONG, 4},
+    {MPI_LONG_LONG_INT, 8},
+    {MPI_UNSIGNED_LONG_LONG, 8},
+    {MPI_FLOAT, 4},
+    {MPI_DOUBLE, 8},
+    {MPI_LONG_DOUBLE, 16},
+    {MPI_C_BOOL, 1},
+    {MPI_INT8_T, 1},
+    {MPI_INT16_T, 2},
+    {MPI_INT32_T, 4},
+    {MPI_INT64_T, 8},
+    {MPI_UINT8_T, 1},
+    {MPI_UINT16_T, 2},
+    {MPI_UINT32_T, 4},
+    {MPI_UINT64_T, 8},
+    {MPI_AINT, 8},
+    {MPI_COUNT, 8},
+    {MPI_OFFSET, 8},
+    {MPI_C_COMPLEX, 2 * 4},
+    {MPI_C_FLOAT_COMPLEX, 2 * 4},
+    {MPI_C_DOUBLE_COMPLEX, 2 * 8},
+    {MPI_C_LONG_DOUBLE_COMPLEX, 2 * 16},
+    {MPI_CHARACTER, 1},
+    {MPI_LOGICAL, 4},
+    {MPI_INTEGER, 4},
+    {MPI_REAL, 4},
+    {MPI_DOUBLE_PRECISION, 8},
+    {MPI_COMPLEX, 2 * 4},
+    {MPI_DOUBLE_COMPLEX, 2 * 8},
+};
+
+#define N_DT (sizeof(dt_list) / sizeof(struct dt))
+
+#define COUNT 2
+#define OFFSET 0
+
+/* first, input data */
+#define BOOL_DATA {2, 0}
+#define INT_DATA {1, -2}
+#define UINT_DATA {1, 2}
+/* TODO: test NaN */
+#define FLOAT_DATA {1.0, 2.0}
+#define COMPLEX_DATA {1.0, 2.0 + I}
+
+int int_data[COUNT] = INT_DATA;
+char int_pack[8] = { 0, 0, 0, 1, 0xff, 0xff, 0xff, 0xfe };
+
+long long_data[COUNT] = INT_DATA;
+char long_pack[16] = { 0, 0, 0, 1, 0xff, 0xff, 0xff, 0xfe };
+
+long long long_long_data[COUNT] = INT_DATA;
+char long_long_pack[16] =
+    { 0, 0, 0, 0, 0, 0, 0, 1, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe };
+
+float float_data[COUNT] = FLOAT_DATA;
+char float_pack[8] = { 0x3f, 0x80, 0, 0, 0x40, 0, 0, 0 };
+
+long double long_double_data[COUNT] = FLOAT_DATA;
+char long_double_pack[32] = {
+    0x3f, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0x40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+bool bool_data[COUNT] = BOOL_DATA;
+char bool_pack[2] = { 1, 0 };
+
+#ifdef TEST_COMPLEX
+float complex complex_data[COUNT] = COMPLEX_DATA;
+char complex_pack[16] = {
+    0x3f, 0x80, 0, 0, 0, 0, 0, 0,
+    0x40, 0, 0, 0, 0x3f, 0x80, 0, 0
+};
+#endif
+
+static const char *get_mpi_type_name(MPI_Datatype mpi_type)
+{
+    static char type_name[MPI_MAX_OBJECT_NAME];
+    int name_len;
+    MPI_Type_get_name(mpi_type, type_name, &name_len);
+    return type_name;
+}
+
+static bool mpi_type_is_bool(MPI_Datatype mpi_type)
+{
+    return mpi_type == MPI_C_BOOL || mpi_type == MPI_LOGICAL;
+}
+
+static const void *get_in_buffer(struct dt dt)
+{
+    switch (dt.mpi_type) {
+        case MPI_INT:
+            return int_data;
+        case MPI_LONG:
+            return long_data;
+        case MPI_LONG_LONG_INT:
+            return long_long_data;
+        case MPI_FLOAT:
+            return float_data;
+#ifdef TEST_LONG_DOUBLE
+        case MPI_LONG_DOUBLE:
+            return long_double_data;
+#endif
+#ifdef TEST_COMPLEX
+        case MPI_C_COMPLEX:
+            return complex_data;
+#endif
+        case MPI_C_BOOL:
+            return bool_data;
+        default:
+            /* TODO: add more datatypes */
+            return NULL;
+    }
+    return NULL;
+}
+
+static const void *get_pack_buffer(struct dt dt)
+{
+    switch (dt.mpi_type) {
+        case MPI_INT:
+            return int_pack;
+        case MPI_LONG:
+            return long_pack;;
+        case MPI_LONG_LONG_INT:
+            return long_long_pack;
+        case MPI_FLOAT:
+            return float_pack;
+#ifdef TEST_LONG_DOUBLE
+        case MPI_LONG_DOUBLE:
+            return long_double_pack;
+#endif
+#ifdef TEST_COMPLEX
+        case MPI_C_COMPLEX:
+            return complex_pack;
+#endif
+        case MPI_C_BOOL:
+            return bool_pack;
+        default:
+            /* TODO: add more datatypes */
+            return NULL;
+    }
+    return NULL;
+}
+
+static int get_bool_val(const void *buf, int dt_size)
+{
+    const char *p = buf;
+    /* return 1 for any non-zero */
+    for (int i = 0; i < dt_size; i++) {
+        if (p[i]) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void get_elem_dump(const void *buf, int dt_size, char *str_out)
+{
+    const char *p = buf;
+    /* NOTE: assumes str_out has enough space */
+    char *s = str_out;
+    for (int i = 0; i < dt_size; i++) {
+        sprintf(s, "%02x", p[i] & 0xff);
+        s += 2;
+    }
+    *s = '\0';
+}
+
+int main(int argc, char **argv)
+{
+    int errs = 0;
+
+    MTest_Init(&argc, &argv);
+
+    for (int i = 0; i < N_DT; i++) {
+        const void *buf = get_in_buffer(dt_list[i]);
+        if (!buf) {
+            continue;
+        }
+
+        MPI_Aint size;
+        MPI_Pack_external_size("external32", COUNT, dt_list[i].mpi_type, &size);
+        if (size != COUNT * dt_list[i].length) {
+            printf("MPI_Pack_external_size of %s: returns %d, expect %d\n",
+                   get_mpi_type_name(dt_list[i].mpi_type), (int) size, COUNT * dt_list[i].length);
+            errs++;
+        }
+
+        static char pack_buf[COUNT * 32 + OFFSET];
+        MPI_Aint bufsize = COUNT * 32 + OFFSET;
+        MPI_Aint pos = OFFSET;
+
+        assert(size < COUNT * 32);
+        MPI_Pack_external("external32", buf, COUNT, dt_list[i].mpi_type, pack_buf, bufsize, &pos);
+        if (pos != size + OFFSET) {
+            printf("MPI_Pack_external %s: updated pos to %d, expect %d\n",
+                   get_mpi_type_name(dt_list[i].mpi_type), (int) pos, (int) size + OFFSET);
+            errs++;
+        }
+
+        const char *ref = get_pack_buffer(dt_list[i]);
+        if (memcmp(pack_buf + OFFSET, ref, size) != 0) {
+            printf("MPI_Pack_external %s: results mismatch!\n",
+                   get_mpi_type_name(dt_list[i].mpi_type));
+            errs++;
+            const char *p = pack_buf + OFFSET;
+            for (int i = 0; i < size; i++) {
+                if (ref[i] != p[i]) {
+                    printf("    pack_buf[%d] is 0x%02x, expect 0x%02x\n", i, p[i] & 0xff,
+                           ref[i] & 0xff);
+                }
+            }
+        }
+
+        static char unpack_buf[COUNT * 32];
+        pos = OFFSET;
+        MPI_Unpack_external("external32", pack_buf, bufsize, &pos, unpack_buf, COUNT,
+                            dt_list[i].mpi_type);
+        if (pos != size + OFFSET) {
+            printf("MPI_Unpack_external %s: updated pos to %d, expect %d\n",
+                   get_mpi_type_name(dt_list[i].mpi_type), (int) pos, (int) size + OFFSET);
+            errs++;
+        }
+
+        int dt_size;
+        MPI_Type_size(dt_list[i].mpi_type, &dt_size);
+        for (int j = 0; j < COUNT; j++) {
+            const void *p = (const char *) buf + j * dt_size;
+            const void *q = (const char *) unpack_buf + j * dt_size;
+            if (mpi_type_is_bool(dt_list[i].mpi_type)) {
+                if (get_bool_val(p, dt_size) != get_bool_val(q, dt_size)) {
+                    printf("MPI_Unpack_external %s: element %d mismatch, got %d, expect %d\n",
+                           get_mpi_type_name(dt_list[i].mpi_type), j, get_bool_val(q, dt_size),
+                           get_bool_val(p, dt_size));
+                    errs++;
+                }
+            } else if (dt_list[i].mpi_type == MPI_LONG_DOUBLE) {
+                if (*(long double *) p != *(long double *) q) {
+                    printf("MPI_Unpack_external %s: element %d mismatch, got %Lf, expect %Lf\n",
+                           get_mpi_type_name(dt_list[i].mpi_type), j, *(long double *) p,
+                           *(long double *) q);
+                    errs++;
+                }
+            } else {
+                if (memcmp(p, q, dt_size)) {
+                    char p_buf[100], q_buf[100];
+                    get_elem_dump(p, dt_size, p_buf);
+                    get_elem_dump(q, dt_size, q_buf);
+                    printf("MPI_Unpack_external %s: element %d mismatch, got %s, expect %s\n",
+                           get_mpi_type_name(dt_list[i].mpi_type), j, q_buf, p_buf);
+                    errs++;
+                }
+            }
+        }
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/datatype/testlist.in
+++ b/test/mpi/datatype/testlist.in
@@ -3,6 +3,7 @@ gaddress 1
 lbub 1
 lbub_oldapi 1 strict=FALSE
 localpack 1
+pack_external 1
 simple_pack 1
 simple_pack_external 1
 simple_pack_external2 1


### PR DESCRIPTION
## Pull Request Description
The typerep_yaksa_pack_external.c contains bugs resulting packing error
in MPI_LONG. In addition, it appears it is not packing into big-endian
format as required by the specification. This patch adds a test to show
the bugs.

ref: This is discovered by @dalcinl in https://github.com/pmodels/mpich/pull/5161#issuecomment-803579385

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
