### PR TITLE
mpi_t: consistent descriptions for the CVAR error return codes

### DIFF
--- a/doc/mansrc/mpiconsts.txt
+++ b/doc/mansrc/mpiconsts.txt
@@ -532,8 +532,8 @@ Error codes for MPI_T:
 . MPI_T_ERR_OUT_OF_HANDLES    - No more handles available
 . MPI_T_ERR_OUT_OF_SESSIONS   - No more sessions available
 . MPI_T_ERR_INVALID_SESSION   - Session argument is not valid
-. MPI_T_ERR_CVAR_SET_NOT_NOW  - Cvar can''t be set at this moment
-. MPI_T_ERR_CVAR_SET_NEVER    - Cvar can''t be set until end of execution
+. MPI_T_ERR_CVAR_SET_NOT_NOW  - Cvar cannot be set at this moment
+. MPI_T_ERR_CVAR_SET_NEVER    - Cvar cannot be set until end of execution
 . MPI_T_ERR_PVAR_NO_STARTSTOP - Pvar can''t be started or stopped
 . MPI_T_ERR_PVAR_NO_WRITE     - Pvar can''t be written or reset
 . MPI_T_ERR_PVAR_NO_ATOMIC    - Pvar can''t be R/W atomically

--- a/src/env/mpivars.c
+++ b/src/env/mpivars.c
@@ -510,10 +510,10 @@ const char *mpit_errclasscheck(int err)
     const char *p = 0;
     switch (err) {
         case MPI_T_ERR_CVAR_SET_NOT_NOW:
-            p = "MPI_T cvar not set";
+            p = "MPI_T cvar cannot be set at this moment";
             break;
         case MPI_T_ERR_CVAR_SET_NEVER:
-            p = "MPI_T cvar was never set";
+            p = "MPI_T cvar cannot be set until end of execution";
             break;
         case MPI_T_ERR_PVAR_NO_STARTSTOP:
             p = "MPI_T pvar does not support start and stop";


### PR DESCRIPTION
## Pull Request Description
correct the inconsistent descriptions for the CVAR error return codes

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
