### PR TITLE
mpi_t: check the CVAR scope before attempting to write to it

### DIFF
--- a/test/mpi/mpi_t/cvarwrite.c
+++ b/test/mpi/mpi_t/cvarwrite.c
@@ -46,6 +46,9 @@ int main(int argc, char *argv[])
         if (binding != MPI_T_BIND_NO_OBJECT)
             continue;
 
+        if (scope == MPI_T_SCOPE_READONLY || scope == MPI_T_SCOPE_CONSTANT)
+            continue;
+
         MPI_T_cvar_handle_alloc(i, NULL, &chandle, &count);
         if (count == 1 || (datatype == MPI_CHAR && count < sizeof(cin))) {
             if (MPI_INT == datatype) {


### PR DESCRIPTION
mpi_t: check the CVAR scope before attempting to write to it 

fixes #2654

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
