### PR TITLE
ch4: fix accept/connect not ignoring args on non-root ranks

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -846,6 +846,8 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **vc_in_error_state:Connection is in error state
 **tcp_cleanup_fail:Error while cleaning up failed connection
 **tmpvc_connect_fail:Failure during connection protocol
+**comm_connect_fail:Unable to establish connection to process
+**comm_accept_fail:Unable to establish connection from process
 
 **coll_fail:Failure during collective
 **collalgo:User set collective algorithm is not usable for the provided arguments

--- a/src/mpid/ch4/src/ch4_spawn.c
+++ b/src/mpid/ch4/src/ch4_spawn.c
@@ -92,9 +92,8 @@ int MPID_Comm_spawn_multiple(int count, char *commands[], char **argvs[], const 
             MPIR_Bcast(pmi_errcodes, total_num_processes, MPI_INT, root, comm_ptr, &errflag);
         MPIR_ERR_CHECK(mpi_errno);
 
-        /* FIXME: Are we only checking pmi_errcodes[0] and ignoring the rest? */
         for (int i = 0; i < total_num_processes; i++) {
-            errcodes[i] = pmi_errcodes[0];
+            errcodes[i] = pmi_errcodes[i];
             should_accept = should_accept && errcodes[i];
         }
         should_accept = !should_accept;


### PR DESCRIPTION
## Pull Request Description

The port_name parameter in MPI_Comm_connect and MPI_Comm_accept is only needed by root rank and should be ignored by other ranks. The current code assumes the parameter is available for all processes, which is wrong. This PR fixes it by having root process proceed with the connection and then broadcast the results (`errno`) to children.

Fixes #5149
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
