### PR TITLE
mpl/ze: Fix initialization bugs

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -94,6 +94,9 @@ static int gpu_ze_init_driver()
 
         if (NULL != global_ze_driver_handle) {
             break;
+        } else {
+            MPL_free(global_ze_devices_handle);
+            global_ze_devices_handle = NULL;
         }
     }
 

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -16,7 +16,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 ze_driver_handle_t global_ze_driver_handle;
 ze_device_handle_t *global_ze_devices_handle = NULL;
 ze_context_handle_t global_ze_context;
-int global_ze_device_count = 0;
+int global_ze_device_count;
 static int gpu_ze_init_driver(void);
 
 #define ZE_ERR_CHECK(ret) \
@@ -69,6 +69,7 @@ static int gpu_ze_init_driver()
     int i, d;
     /* Find a driver instance with a GPU device */
     for (i = 0; i < driver_count; ++i) {
+        global_ze_device_count = 0;
         ret = zeDeviceGet(all_drivers[i], &global_ze_device_count, NULL);
         ZE_ERR_CHECK(ret);
         global_ze_devices_handle =


### PR DESCRIPTION
## Pull Request Description

Fix some bugs in the MPL ZE initialization code.
1. Make sure to get the correct number of devices.
2. Fix a potential memory leak if a GPU device is not found associated with a driver.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
