### PR TITLE
Bug fixes for VPATH build and VCI typo

### DIFF
--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -59,7 +59,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_vci(int flag, MPIR_Comm * comm_ptr,
 MPL_STATIC_INLINE_PREFIX int MPIDI_get_vci(int flag, MPIR_Comm * comm_ptr,
                                            int src_rank, int dst_rank, int tag)
 {
-    if (flag & 0x1) {
+    if (!(flag & 0x1)) {
         /* src */
         return (tag == MPI_ANY_TAG) ? 0 : ((tag >> 10) & 0x1f);
     } else {

--- a/test/mpi/dtpools/configure.ac
+++ b/test/mpi/dtpools/configure.ac
@@ -50,7 +50,7 @@ AC_CHECK_HEADERS([stdlib.h string.h limits.h stdint.h sys/types.h],,
                  [AC_MSG_ERROR([Cannot find headers.])],)
 
 # Must be able to find mpi.h
-MPI_H_INCLUDE="-I${main_top_builddir}/src/include"
+MPI_H_INCLUDE="-I${main_top_builddir}/src/include -I${main_top_srcdir}/src/include"
 AC_SUBST([MPI_H_INCLUDE])
 
 # check if we need declarations


### PR DESCRIPTION
## Pull Request Description
This PR contains two patches for the following:
* Fix inclusion of mpi_proto.h and mpi.h under VPATH build of the test suite
* Fix the incorrectly marked src and dst in tag based explicit VCI selection routines

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
