### PR TITLE
ch4: add stubs for implicit selection of VCIs

### DIFF
--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -8,6 +8,8 @@
 #include "ch4_comm.h"
 #include "ch4i_comm.h"
 
+static void register_comm_hints(MPIR_Comm * comm);
+
 int MPID_Comm_reenable_anysource(MPIR_Comm * comm, MPIR_Group ** failed_group_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_REENABLE_ANYSOURCE);
@@ -196,6 +198,8 @@ int MPID_Comm_commit_pre_hook(MPIR_Comm * comm)
                 MPIDIU_avt_add_ref(MPIDI_COMM(comm, local_map).avtid);
         }
     }
+
+    register_comm_hints(comm);
 
     mpi_errno = MPIDIG_init_comm(comm);
     MPIR_ERR_CHECK(mpi_errno);
@@ -650,4 +654,9 @@ int MPID_Create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const ui
     return mpi_errno;
   fn_fail:
     goto fn_exit;
+}
+
+/* Register CH4-specific hints */
+static void register_comm_hints(MPIR_Comm * comm)
+{
 }


### PR DESCRIPTION
## Pull Request Description
This PR contains patches to add the following features:
* Enable implicit hashing for VCI selection
* Add hash functions to select VCI based on (comm, rank, tag), but with basic placeholder implementation.

Update: some features features have been moved to the following PRs:

- PR: https://github.com/pmodels/mpich/pull/5481

  * Use of the standard hints: `mpi_assert_no_any_tag`, `mpi_assert_no_any_source`, and `mpi_assert_allow_overtaking` to relax the selection of VCI on sender and receiver side
  * Add non-standard user hints `vci_idx_sender`, and `vci_idx_receiver` to directly select specific VCI for a comm. This feature can be used by threads to directly distribute or isolate traffic across different VCIs.
  * Add non-standard used hint `thread_id` which can control both `vci_idx_sender` and `vci_idx_receiver` at the same time. This hint can be modified at runtime by using a CVAR. Its use can also be extended to control how we assign/offload the reduction operation to different progress threads. This hint can be useful for certain applications, e.g., OneCCL.
  * Add tests cases to evaluate functional correctness of the added comm hints

* PR: https://github.com/pmodels/mpich/pull/5476
  * Bug fixes

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
