### PR TITLE
autogen: fix reflect libtool patch.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -370,14 +370,14 @@ AC_INIT(foo,1.0)
 AC_PROG_LIBTOOL
 AC_OUTPUT
 _EOF
-        AUTORECONF="$autoreconf -I $libtoolm4dir"
+        AUTORECONF="$autoreconf -B $libtoolm4dir"
         if (cd .tmp && $AUTORECONF -ivf >/dev/null 2>&1) ; then
             new_autoreconf_works=yes
         fi
         rm -rf .tmp
     fi
     echo "$new_autoreconf_works"
-    # If autoreconf accepts -I <libtool's m4 dir> correctly, use -I.
+    # If autoreconf accepts -B <libtool's m4 dir> correctly, use -B.
     # If not, run libtoolize before autoreconf (i.e. for autoconf <= 2.63)
     # This test is more general than checking the autoconf version.
     if [ "$new_autoreconf_works" != "yes" ] ; then


### PR DESCRIPTION
## Pull Request Description

autogem.sh is apllyed  libtool,m4 patches in maint/patches/optional/confdb.
But when autoconf and libtool are different install path, autoreconf use libtool's libtool.m4.

This PR change autoreconf -I option to -B, and use confdb/libtool.m4.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
