### PR TITLE
maint: update spellchekcer to preserve file mode

### DIFF
--- a/maint/hooks/spellchecker
+++ b/maint/hooks/spellchecker
@@ -33,7 +33,7 @@ ret=0
 for file in $filestring
 do
     if [[ !($file == *.tex) ]] ; then
-        cp ${file} ${TMP_FILENAME}
+        cp -p ${file} ${TMP_FILENAME}
         bash maint/spellcheck.sh ${file}
         git --no-pager diff ${file} ${TMP_FILENAME}
         if [ $? != 0 ] ; then


### PR DESCRIPTION
## Pull Request Description
When the script, maint/hooks/spellchecker, copies file without preserve
permissions, git diff will report difference in file modes, which is
undesirable in a spell checker. This one fixes it.




## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
