### PR TITLE
 romio: ensure config headers are included first

### DIFF
--- a/src/mpi/romio/adio/ad_lustre/ad_lustre.h
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre.h
@@ -9,6 +9,7 @@
 /* temp*/
 #define HAVE_ASM_TYPES_H 1
 
+#include "adio.h"
 #include <unistd.h>
 #include <linux/types.h>
 
@@ -24,7 +25,6 @@
 
 #include <sys/ioctl.h>
 
-#include "adio.h"
 #include "ad_tuning.h"
 
 #ifdef HAVE_LUSTRE_LUSTRE_USER_H

--- a/src/mpi/romio/adio/ad_panfs/ad_panfs.h
+++ b/src/mpi/romio/adio/ad_panfs/ad_panfs.h
@@ -6,10 +6,10 @@
 #ifndef AD_PANFS_H_INCLUDED
 #define AD_PANFS_H_INCLUDED
 
+#include "adio.h"
 #include <unistd.h>
 #include <sys/types.h>
 #include <fcntl.h>
-#include "adio.h"
 
 #ifndef NO_AIO
 #ifdef AIO_SUN

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io_dtype.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io_dtype.c
@@ -3,8 +3,8 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include <assert.h>
 #include "adio.h"
+#include <assert.h>
 #include "adio_extern.h"
 #include "ad_pvfs2.h"
 #include "ad_pvfs2_io.h"

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io_list.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io_list.c
@@ -3,8 +3,8 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include <assert.h>
 #include "adio.h"
+#include <assert.h>
 #include "adio_extern.h"
 #include "ad_pvfs2.h"
 #include "ad_pvfs2_io.h"

--- a/src/mpi/romio/adio/ad_xfs/ad_xfs.h
+++ b/src/mpi/romio/adio/ad_xfs/ad_xfs.h
@@ -6,10 +6,10 @@
 #ifndef AD_XFS_H_INCLUDED
 #define AD_XFS_H_INCLUDED
 
+#include "adio.h"
 #include <unistd.h>
 #include <sys/types.h>
 #include <fcntl.h>
-#include "adio.h"
 
 #if defined(MPISGI)
 #include "xfs/xfs_fs.h"

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -58,6 +58,7 @@ AH_TOP([/*
  */
 #ifndef ROMIOCONF_H_INCLUDED
 #define ROMIOCONF_H_INCLUDED
+#include <mplconfig.h>
 ])
 AH_BOTTOM([
 /* quash PACKAGE and PACKAGE_* vars, see MPICH top-level configure.ac for

--- a/src/mpi/romio/mpi-io/fortran/deletef.c
+++ b/src/mpi/romio/mpi-io/fortran/deletef.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "adio.h"
 #ifdef _UNICOS
 #include <fortran.h>
 #endif
-#include "adio.h"
 #include "mpio.h"
 
 

--- a/src/mpi/romio/mpi-io/fortran/get_viewf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_viewf.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "adio.h"
 #ifdef _UNICOS
 #include <fortran.h>
 #endif
-#include "adio.h"
 #include "mpio.h"
 
 

--- a/src/mpi/romio/mpi-io/fortran/openf.c
+++ b/src/mpi/romio/mpi-io/fortran/openf.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "adio.h"
 #ifdef _UNICOS
 #include <fortran.h>
 #endif
-#include "adio.h"
 #include "mpio.h"
 
 

--- a/src/mpi/romio/mpi-io/fortran/set_viewf.c
+++ b/src/mpi/romio/mpi-io/fortran/set_viewf.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "adio.h"
 #ifdef _UNICOS
 #include <fortran.h>
 #endif
-#include "adio.h"
 #include "mpio.h"
 
 


### PR DESCRIPTION
There was a problem with romio's use of MPL and the include order sometimes having system files before the config files generated by configure.  So for example at configure time _GNU_SOURCE was used and thus configure concluded that aligned_memory() was already declared, but then later in romio sometimes stdlib.h or similar sys includes were coming before mplconfig.h and maybe even before romioconf.h.

My understanding of the design described by hzhou is that universlaly putting the config files at the top is the best solution to this ordering.

All over the romio code they seem to use adio.h as their top level include, which has romioconf.h as its first include.  So in this PR I'm moved adio.h to the top of a few more files.

And I also made romioconf.h include mplconfig.h as its first include.  Otherwise what we have for romio's use of MPL is

```
adio.h:
  includes romioconf.h  <-- we're relying on _GNU_SOURCE being here too
  includes many things including system files
  includes adioi.h
    includes mpl.h
      includes mplconfig.h with _GNU_SOURCE
```

so having _GNU_SOURCE down in mplconfig.h doesn't really ensure it's in front of the system files unless we can rely on it being there in romioconf.h (Maybe we can? I'm not sure).  Anyway as long as the top level romioconf.h knows it's consuming MPL it can put mplconfig.h at its top and then all the rest of the romio code only needs to follow the rule of putting adio.h first and then both romio and mpl will get their config settings included at the top

Signed-off-by: Mark Allen <markalle@us.ibm.com>