### PR TITLE
Minor autogen fixes

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -603,7 +603,7 @@ echo
 check_submodule_presence modules/hwloc
 
 # external packages that require autogen.sh to be run for each of them
-externals="src/pm/hydra src/pm/hydra2 src/mpi/romio modules/hwloc test/mpi modules/json-c modules/yaksa"
+externals="src/pm/hydra src/pm/hydra2 src/mpi/romio modules/hwloc test/mpi"
 
 if [ "yes" = "$do_izem" ] ; then
     check_submodule_presence modules/izem
@@ -622,10 +622,12 @@ fi
 
 if [ "yes" = "$do_json" ] ; then
     check_submodule_presence "modules/json-c"
+    externals="${externals} modules/json-c"
 fi
 
 if [ "yes" = "$do_yaksa" ] ; then
     check_submodule_presence "modules/yaksa"
+    externals="${externals} modules/yaksa"
 fi
 
 ########################################################################

--- a/autogen.sh
+++ b/autogen.sh
@@ -234,6 +234,10 @@ for arg in "$@" ; do
         do_json=no
         ;;
 
+    -without-yaksa|--without-yaksa)
+        do_yaksa=no
+        ;;
+
 	-help|--help|-usage|--usage)
 	    cat <<EOF
    ./autogen.sh [ --with-autotools=dir ] \\


### PR DESCRIPTION
First commit fixes the behaviour of --without-json.
Even if used, json is built and used instead of the system one.
Also fix the same behaviour for yaksa

Second commit add --without-yaksa option to use a system version instead of the submodule. 