### PR TITLE
test: fix warnings when test is configured under `--enable-strict`

### DIFF
--- a/test/mpi/attr/attr2type.c
+++ b/test/mpi/attr/attr2type.c
@@ -25,7 +25,6 @@ static int copy_called = 0;
 
 int main(int argc, char *argv[])
 {
-    int mpi_errno;
     MPI_Datatype type, duptype;
     int rank;
     int errs = 0;
@@ -36,17 +35,17 @@ int main(int argc, char *argv[])
 
     foo_initialize();
 
-    mpi_errno = MPI_Type_contiguous(2, MPI_INT, &type);
+    MPI_Type_contiguous(2, MPI_INT, &type);
 
-    mpi_errno = MPI_Type_set_attr(type, foo_keyval, NULL);
+    MPI_Type_set_attr(type, foo_keyval, NULL);
 
-    mpi_errno = MPI_Type_dup(type, &duptype);
+    MPI_Type_dup(type, &duptype);
 
     my_func = "Free of type";
-    mpi_errno = MPI_Type_free(&type);
+    MPI_Type_free(&type);
 
     my_func = "free of duptype";
-    mpi_errno = MPI_Type_free(&duptype);
+    MPI_Type_free(&duptype);
 
     foo_finalize();
 
@@ -93,11 +92,8 @@ int foo_delete_attr_function(MPI_Datatype type,
 
 int foo_initialize(void)
 {
-    int mpi_errno;
-
     /* create keyval for use later */
-    mpi_errno = MPI_Type_create_keyval(foo_copy_attr_function,
-                                       foo_delete_attr_function, &foo_keyval, NULL);
+    MPI_Type_create_keyval(foo_copy_attr_function, foo_delete_attr_function, &foo_keyval, NULL);
     if (verbose)
         printf("created keyval\n");
 
@@ -106,10 +102,8 @@ int foo_initialize(void)
 
 void foo_finalize(void)
 {
-    int mpi_errno;
-
     /* remove keyval */
-    mpi_errno = MPI_Type_free_keyval(&foo_keyval);
+    MPI_Type_free_keyval(&foo_keyval);
 
     if (verbose)
         printf("freed keyval\n");

--- a/test/mpi/attr/fkeyvaltype.c
+++ b/test/mpi/attr/fkeyvaltype.c
@@ -45,11 +45,10 @@ int main(int argc, char *argv[])
 {
     int err, errs = 0;
     int attrval;
-    int i, j, key[32], keyval, saveKeyval;
+    int i, key[32], keyval, saveKeyval;
     int seed, testsize;
     int obj_idx;
     MPI_Aint count, maxbufsize;
-    int tnlen;
     MPI_Datatype type, duptype;
     DTP_pool_s dtp;
     DTP_obj_s obj;

--- a/test/mpi/basic/sendrecv.c
+++ b/test/mpi/basic/sendrecv.c
@@ -11,11 +11,12 @@
 #define LARGE_SIZE  100*1024
 #define RNDV_SIZE   256*1024
 
+char big_buffer[RNDV_SIZE] = "big garbage";
+
 int main(int argc, char *argv[])
 {
     int size, rank;
     char buffer[100] = "garbage";
-    char big_buffer[RNDV_SIZE] = "big garbage";
     MPI_Status status;
     int tag = 1;
     int reps = 1;

--- a/test/mpi/coll/allgatherv4.c
+++ b/test/mpi/coll/allgatherv4.c
@@ -27,9 +27,6 @@ char *sbuf, *rbuf;
 int *recvcounts, *displs;
 int errs = 0;
 
-/* #define dprintf printf */
-#define dprintf(...)
-
 typedef enum {
     REGULAR,
     BCAST,
@@ -81,24 +78,24 @@ int main(int argc, char **argv)
     }
 
     if (!comm_rank) {
-        dprintf("Message Range: (%d, %d); System size: %d\n", START_BUF, LARGE_BUF, comm_size);
-        fflush(stdout);
+        MTestPrintfMsg(1, "Message Range: (%d, %d); System size: %d\n", START_BUF, LARGE_BUF,
+                       comm_size);
     }
 
 
     /* COMM_WORLD tests */
     if (!comm_rank) {
-        dprintf("\n\n==========================================================\n");
-        dprintf("                         MPI_COMM_WORLD\n");
-        dprintf("==========================================================\n");
+        MTestPrintfMsg(1, "\n\n==========================================================\n");
+        MTestPrintfMsg(1, "                         MPI_COMM_WORLD\n");
+        MTestPrintfMsg(1, "==========================================================\n");
     }
     comm_tests(MPI_COMM_WORLD);
 
     /* non-COMM_WORLD tests */
     if (!comm_rank) {
-        dprintf("\n\n==========================================================\n");
-        dprintf("                         non-COMM_WORLD\n");
-        dprintf("==========================================================\n");
+        MTestPrintfMsg(1, "\n\n==========================================================\n");
+        MTestPrintfMsg(1, "                         non-COMM_WORLD\n");
+        MTestPrintfMsg(1, "==========================================================\n");
     }
     MPI_Comm_split(MPI_COMM_WORLD, (comm_rank == comm_size - 1) ? 0 : 1, 0, &comm);
     if (comm_rank < comm_size - 1)
@@ -107,9 +104,9 @@ int main(int argc, char **argv)
 
     /* Randomized communicator tests */
     if (!comm_rank) {
-        dprintf("\n\n==========================================================\n");
-        dprintf("                         Randomized Communicator\n");
-        dprintf("==========================================================\n");
+        MTestPrintfMsg(1, "\n\n==========================================================\n");
+        MTestPrintfMsg(1, "                         Randomized Communicator\n");
+        MTestPrintfMsg(1, "==========================================================\n");
     }
     MPI_Comm_split(MPI_COMM_WORLD, 0, rand(), &comm);
     comm_tests(comm);
@@ -137,44 +134,37 @@ void comm_tests(MPI_Comm comm)
 
     for (msg_size = START_BUF; msg_size <= LARGE_BUF; msg_size *= 2) {
         if (!comm_rank) {
-            dprintf("\n====> MSG_SIZE: %d\n", (int) msg_size);
-            fflush(stdout);
+            MTestPrintfMsg(1, "\n====> MSG_SIZE: %d\n", (int) msg_size);
         }
 
         rtime = run_test(msg_size, comm, REGULAR, &max_time);
         if (!comm_rank) {
-            dprintf("REGULAR:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
-            fflush(stdout);
+            MTestPrintfMsg(1, "REGULAR:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
         }
 
         rtime = run_test(msg_size, comm, BCAST, &max_time);
         if (!comm_rank) {
-            dprintf("BCAST:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
-            fflush(stdout);
+            MTestPrintfMsg(1, "BCAST:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
         }
 
         rtime = run_test(msg_size, comm, SPIKE, &max_time);
         if (!comm_rank) {
-            dprintf("SPIKE:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
-            fflush(stdout);
+            MTestPrintfMsg(1, "SPIKE:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
         }
 
         rtime = run_test(msg_size, comm, HALF_FULL, &max_time);
         if (!comm_rank) {
-            dprintf("HALF_FULL:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
-            fflush(stdout);
+            MTestPrintfMsg(1, "HALF_FULL:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
         }
 
         rtime = run_test(msg_size, comm, LINEAR_DECREASE, &max_time);
         if (!comm_rank) {
-            dprintf("LINEAR_DECREASE:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
-            fflush(stdout);
+            MTestPrintfMsg(1, "LINEAR_DECREASE:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
         }
 
         rtime = run_test(msg_size, comm, BELL_CURVE, &max_time);
         if (!comm_rank) {
-            dprintf("BELL_CURVE:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
-            fflush(stdout);
+            MTestPrintfMsg(1, "BELL_CURVE:\tAVG: %.3f\tMAX: %.3f\n", rtime, max_time);
         }
     }
 }

--- a/test/mpi/coll/allred2.c
+++ b/test/mpi/coll/allred2.c
@@ -13,7 +13,7 @@
 static char MTEST_Descrip[] = "Test MPI_Allreduce with MPI_IN_PLACE";
 */
 
-void set_buf(int rank, int count, int *buf)
+static void set_buf(int rank, int count, int *buf)
 {
     int i;
     for (i = 0; i < count; i++) {
@@ -22,7 +22,7 @@ void set_buf(int rank, int count, int *buf)
     }
 }
 
-void check_buf(int size, int count, int *errs, int *buf)
+static void check_buf(int size, int count, int *errs, int *buf)
 {
     int i;
     for (i = 0; i < count; i++) {

--- a/test/mpi/coll/bcast.c
+++ b/test/mpi/coll/bcast.c
@@ -21,9 +21,7 @@ static int bcast_dtp(int seed, int testsize, int count, const char *basic_type,
     int errs = 0, err;
     int rank, size, root;
     int minsize = 2;
-    int i, j;
     MPI_Comm comm;
-    MPI_Datatype type;
     DTP_pool_s dtp;
     struct mtest_obj coll;
     mtest_mem_type_e memtype;
@@ -76,7 +74,7 @@ static int bcast_dtp(int seed, int testsize, int count, const char *basic_type,
         MPI_Comm_set_errhandler(comm, MPI_ERRORS_RETURN);
 
         for (root = 0; root < size; root++) {
-            for (i = 0; i < testsize; i++) {
+            for (int i = 0; i < testsize; i++) {
                 errs += MTest_dtp_create(&coll, true);
 
                 if (rank == root) {
@@ -85,9 +83,8 @@ static int bcast_dtp(int seed, int testsize, int count, const char *basic_type,
                     errs += MTest_dtp_init(&coll, -1, -1, count);
                 }
 
-                err =
-                    MPI_Bcast(coll.buf + coll.dtp_obj.DTP_buf_offset, coll.dtp_obj.DTP_type_count,
-                              coll.dtp_obj.DTP_datatype, root, comm);
+                err = MPI_Bcast((char *) coll.buf + coll.dtp_obj.DTP_buf_offset,
+                                coll.dtp_obj.DTP_type_count, coll.dtp_obj.DTP_datatype, root, comm);
                 if (err) {
                     errs++;
                     MTestPrintError(err);

--- a/test/mpi/coll/coll10.c
+++ b/test/mpi/coll/coll10.c
@@ -9,8 +9,6 @@
 
 #define BAD_ANSWER 100000
 
-int assoc(int *, int *, int *, MPI_Datatype *);
-
 /*
     The operation is inoutvec[i] = invec[i] op inoutvec[i]
     (see 4.9.4).  The order is important.
@@ -18,7 +16,7 @@ int assoc(int *, int *, int *, MPI_Datatype *);
     Note that the computation is in process rank (in the communicator)
     order, independent of the root.
  */
-int assoc(int *invec, int *inoutvec, int *len, MPI_Datatype * dtype)
+static void assoc(int *invec, int *inoutvec, int *len, MPI_Datatype * dtype)
 {
     int i;
     for (i = 0; i < *len; i++) {
@@ -30,7 +28,6 @@ int assoc(int *invec, int *inoutvec, int *len, MPI_Datatype * dtype)
         } else
             inoutvec[i] = invec[i];
     }
-    return (1);
 }
 
 int main(int argc, char **argv)

--- a/test/mpi/coll/coll12.c
+++ b/test/mpi/coll/coll12.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
         int b;
     } in[TABLE_SIZE], out[TABLE_SIZE];
     int i;
-    int errors = 0, toterrors;
+    int errors = 0;
 
     /* Initialize the environment and some variables */
     MTest_Init(&argc, &argv);

--- a/test/mpi/coll/coll13.c
+++ b/test/mpi/coll/coll13.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     int i;
     int *sb;
     int *rb;
-    int status, gstatus;
+    int status;
 
     MTest_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/test/mpi/coll/ibarrier.c
+++ b/test/mpi/coll/ibarrier.c
@@ -6,10 +6,10 @@
 /* Regression test for ticket #1785, contributed by Jed Brown.  The test was
  * hanging indefinitely under a buggy version of ch3:sock. */
 
+#include "mpitest.h"
 #include <mpi.h>
 #include <stdio.h>
 #include <unistd.h>
-#include "mpitest.h"
 
 int main(int argc, char *argv[])
 {

--- a/test/mpi/coll/icbarrier.c
+++ b/test/mpi/coll/icbarrier.c
@@ -22,11 +22,9 @@ int main(int argc, char *argv[])
     int errs = 0, err;
     int leftGroup;
     MPI_Comm comm;
-    MPI_Datatype datatype;
 
     MTest_Init(&argc, &argv);
 
-    datatype = MPI_INT;
     /* Get an intercommunicator */
     while (MTestGetIntercomm(&comm, &leftGroup, 4)) {
         if (comm == MPI_COMM_NULL)

--- a/test/mpi/coll/longuser.c
+++ b/test/mpi/coll/longuser.c
@@ -8,19 +8,17 @@
 #include <stdlib.h>
 #include "mpitest.h"
 
-int add(double *, double *, int *, MPI_Datatype *);
 /*
  * User-defined operation on a long value (tests proper handling of
  * possible pipelining in the implementation of reductions with user-defined
  * operations).
  */
-int add(double *invec, double *inoutvec, int *len, MPI_Datatype * dtype)
+static void add(double *invec, double *inoutvec, int *len, MPI_Datatype * dtype)
 {
     int i, n = *len;
     for (i = 0; i < n; i++) {
         inoutvec[i] = invec[i] + inoutvec[i];
     }
-    return 0;
 }
 
 int main(int argc, char **argv)

--- a/test/mpi/coll/neighb_allgather.c
+++ b/test/mpi/coll/neighb_allgather.c
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
     int periods[1] = { 0 };
     int sendbuf[1];
     int recvbuf[2] = { 0xdeadbeef, 0xdeadbeef };
-    MPI_Comm cart, dgraph, graph;
+    MPI_Comm cart;
 
     MTest_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);

--- a/test/mpi/coll/neighb_allgatherv.c
+++ b/test/mpi/coll/neighb_allgatherv.c
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
     int errs = 0;
     int wrank, wsize;
     int periods[1] = { 0 };
-    MPI_Comm cart, dgraph, graph;
+    MPI_Comm cart;
     int sendbuf[1];
     int recvbuf[2] = { 0xdeadbeef, 0xdeadbeef };
     int recvcounts[2] = { 1, 1 };

--- a/test/mpi/coll/neighb_alltoall.c
+++ b/test/mpi/coll/neighb_alltoall.c
@@ -30,13 +30,14 @@ int main(int argc, char *argv[])
     int errs = 0;
     int wrank, wsize;
     int periods[1] = { 0 };
-    MPI_Comm cart, dgraph, graph;
-    int sendbuf[2] = { -(wrank + 1), wrank + 1 };
-    int recvbuf[2] = { 0xdeadbeef, 0xdeadbeef };
+    MPI_Comm cart;
 
     MTest_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
     MPI_Comm_size(MPI_COMM_WORLD, &wsize);
+
+    int sendbuf[2] = { -(wrank + 1), wrank + 1 };
+    int recvbuf[2] = { 0xdeadbeef, 0xdeadbeef };
 
 #if defined(TEST_NEIGHB_COLL)
     /* (wrap)--> 0 <--> 1 <--> ... <--> p-1 <--(wrap) */

--- a/test/mpi/coll/neighb_alltoallv.c
+++ b/test/mpi/coll/neighb_alltoallv.c
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
     int recvcounts[2] = { 1, 1 };
     int sdispls[2] = { 0, 1 };
     int rdispls[2] = { 1, 0 };
-    MPI_Comm cart, dgraph, graph;
+    MPI_Comm cart;
 
     MTest_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);

--- a/test/mpi/coll/neighb_alltoallw.c
+++ b/test/mpi/coll/neighb_alltoallw.c
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
     int errs = 0;
     int wrank, wsize;
     int periods[1] = { 0 };
-    MPI_Comm cart, dgraph, graph;
+    MPI_Comm cart;
     int sendbuf[2];
     int recvbuf[2] = { 0xdeadbeef, 0xdeadbeef };
     int sendcounts[2] = { 1, 1 };

--- a/test/mpi/coll/nonblocking3.c
+++ b/test/mpi/coll/nonblocking3.c
@@ -12,12 +12,12 @@
  * - post operations on multiple comms from multiple threads
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-#include "mpitest.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/test/mpi/coll/nonblocking3.c
+++ b/test/mpi/coll/nonblocking3.c
@@ -414,12 +414,6 @@ static void check_after_completion(struct laundry *l)
     MPI_Comm comm = l->comm;
     int *buf = l->buf;
     int *recvbuf = l->recvbuf;
-    int *sendcounts = l->sendcounts;
-    int *recvcounts = l->recvcounts;
-    int *sdispls = l->sdispls;
-    int *rdispls = l->rdispls;
-    int *sendtypes = l->sendtypes;
-    int *recvtypes = l->recvtypes;
     char *buf_alias = (char *) buf;
 
     MPI_Comm_rank(comm, &rank);

--- a/test/mpi/coll/op_coll.c
+++ b/test/mpi/coll/op_coll.c
@@ -21,16 +21,6 @@
         }                                                                 \
     } while (0)
 
-static void sum_fn(void *invec, void *inoutvec, int *len, MPI_Datatype * datatype)
-{
-    int i;
-    int *in = invec;
-    int *inout = inoutvec;
-    for (i = 0; i < *len; ++i) {
-        inout[i] = in[i] + inout[i];
-    }
-}
-
 int *buf;
 int *buf_h;
 int *recvbuf;

--- a/test/mpi/coll/opland.c
+++ b/test/mpi/coll/opland.c
@@ -26,8 +26,6 @@ int main(int argc, char *argv[])
     char cinbuf[3], coutbuf[3];
     signed char scinbuf[3], scoutbuf[3];
     unsigned char ucinbuf[3], ucoutbuf[3];
-    float finbuf[3], foutbuf[3];
-    double dinbuf[3], doutbuf[3];
 
     MTest_Init(&argc, &argv);
 

--- a/test/mpi/coll/oplor.c
+++ b/test/mpi/coll/oplor.c
@@ -25,8 +25,6 @@ int main(int argc, char *argv[])
     char cinbuf[3], coutbuf[3];
     signed char scinbuf[3], scoutbuf[3];
     unsigned char ucinbuf[3], ucoutbuf[3];
-    float finbuf[3], foutbuf[3];
-    double dinbuf[3], doutbuf[3];
 
     MTest_Init(&argc, &argv);
 

--- a/test/mpi/coll/p_bcast2.c
+++ b/test/mpi/coll/p_bcast2.c
@@ -24,20 +24,9 @@
         }                                                                 \
     } while (0)
 
-static void sum_fn(void *invec, void *inoutvec, int *len, MPI_Datatype * datatype)
-{
-    int i;
-    int *in = invec;
-    int *inout = inoutvec;
-    for (i = 0; i < *len; ++i) {
-        inout[i] = in[i] + inout[i];
-    }
-}
-
-
 int main(int argc, char **argv)
 {
-    int i, j;
+    int i;
     int errs = 0;
     int rank, size;
     int *buf = NULL;

--- a/test/mpi/coll/reduce.c
+++ b/test/mpi/coll/reduce.c
@@ -46,7 +46,7 @@ static void check_buf(int rank, int size, int count, int *errs, int *buf)
 static int test_reduce(mtest_mem_type_e oddmem, mtest_mem_type_e evenmem)
 {
     int errs = 0;
-    int rank, size, root, i;
+    int rank, size, root;
     void *sendbuf, *recvbuf, *sendbuf_h, *recvbuf_h;
     int minsize = 2, count;
     MPI_Comm comm;
@@ -99,7 +99,6 @@ int main(int argc, char *argv[])
 {
     int errs = 0;
     MTest_Init(&argc, &argv);
-    MTestArgList *head = MTestArgListCreate(argc, argv);
 
     struct dtp_args dtp_args;
     dtp_args_init(&dtp_args, MTEST_COLL_NOCOUNT, argc, argv);

--- a/test/mpi/coll/reduce.c
+++ b/test/mpi/coll/reduce.c
@@ -13,7 +13,7 @@
 static char MTEST_Descrip[] = "A simple test of Reduce with all choices of root process";
 */
 
-void set_send_buf(int count, int *buf)
+static void set_send_buf(int count, int *buf)
 {
     int i;
     for (i = 0; i < count; i++) {
@@ -21,7 +21,7 @@ void set_send_buf(int count, int *buf)
     }
 }
 
-void set_recv_buf(int count, int *buf)
+static void set_recv_buf(int count, int *buf)
 {
     int i;
     for (i = 0; i < count; i++) {
@@ -29,7 +29,7 @@ void set_recv_buf(int count, int *buf)
     }
 }
 
-void check_buf(int rank, int size, int count, int *errs, int *buf)
+static void check_buf(int rank, int size, int count, int *errs, int *buf)
 {
     int i;
     for (i = 0; i < count; i++) {

--- a/test/mpi/coll/ring_neighbor_alltoall.c
+++ b/test/mpi/coll/ring_neighbor_alltoall.c
@@ -12,9 +12,6 @@
 
 int main(int argc, char *argv[])
 {
-    int right, left;
-    int sum, i;
-
     MTest_Init(&argc, &argv);
 
     int size;

--- a/test/mpi/comm/cmsplit_type.c
+++ b/test/mpi/comm/cmsplit_type.c
@@ -254,9 +254,8 @@ int main(int argc, char *argv[])
         MPI_Info_set(info, "network_topo", split_topo_network[i]);
         MPI_Comm_split_type(MPI_COMM_WORLD, MPIX_COMM_TYPE_NEIGHBORHOOD, 0, info, &comm);
         if (comm != MPI_COMM_NULL) {
-            int newsize, world_size;
+            int newsize;
             MPI_Comm_size(comm, &newsize);
-            MPI_Comm_size(MPI_COMM_WORLD, &world_size);
             if (newsize > world_size) {
                 printf("MPIX_COMM_TYPE_NEIGHBORHOOD (network_topo): impossible\n");
                 errs++;

--- a/test/mpi/comm/comm_group_half.c
+++ b/test/mpi/comm/comm_group_half.c
@@ -10,7 +10,7 @@
 
 int main(int argc, char **argv)
 {
-    int rank, size, i;
+    int rank, size;
     MPI_Group full_group, half_group;
     int range[1][3];
     MPI_Comm comm;

--- a/test/mpi/comm/comm_idup_comm.c
+++ b/test/mpi/comm/comm_idup_comm.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
     int ranges[1][3];
     int isLeft, rleader;
     MPI_Group world_group, high_group, even_group;
-    MPI_Comm local_comm, inter_comm, test_comm, outcomm;
+    MPI_Comm local_comm, inter_comm, outcomm;
     MPI_Comm idupcomms[NUM_IDUPS];
     MPI_Request reqs[NUM_IDUPS];
 

--- a/test/mpi/comm/comm_idup_comm2.c
+++ b/test/mpi/comm/comm_idup_comm2.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
     int ranges[1][3];
     int isLeft, rleader;
     MPI_Group dup_group, high_group, even_group;
-    MPI_Comm local_comm, inter_comm, test_comm, outcomm, dupcomm;
+    MPI_Comm local_comm, inter_comm, outcomm, dupcomm;
     MPI_Comm idupcomms[NUM_IDUPS];
     MPI_Request reqs[NUM_IDUPS];
 

--- a/test/mpi/comm/comm_idup_nb.c
+++ b/test/mpi/comm/comm_idup_nb.c
@@ -17,7 +17,7 @@ int main(int argc, char **argv)
     int i, isleft;
     MPI_Comm test_comm, new_comm[ITERS];
     int in[ITERS], out[ITERS], sol;
-    int rank, size, rsize, rrank;
+    int rank, size, rsize;
     MPI_Request sreq[ITERS * 2];
     int root;
 

--- a/test/mpi/comm/comm_idup_overlap.c
+++ b/test/mpi/comm/comm_idup_overlap.c
@@ -9,8 +9,7 @@
 
 int main(int argc, char **argv)
 {
-    int i, rank, size, color;
-    MPI_Group group;
+    int i, rank, size;
     MPI_Comm primary[2], secondary[2], tmp;
     MPI_Request req[2];
 

--- a/test/mpi/comm/comm_info.c
+++ b/test/mpi/comm/comm_info.c
@@ -11,11 +11,10 @@
 
 int main(int argc, char **argv)
 {
-    int i, j, rank;
+    int rank;
     MPI_Info info_in, info_out;
     int errors = 0, errs = 0;
     MPI_Comm comm;
-    void *base;
     char invalid_key[] = "invalid_test_key";
     char buf[MPI_MAX_INFO_VAL];
     int flag;

--- a/test/mpi/comm/comm_info2.c
+++ b/test/mpi/comm/comm_info2.c
@@ -15,14 +15,13 @@
 
 int main(int argc, char **argv)
 {
-    int i, j, rank;
+    int rank;
     MPI_Info info_in, info_out;
-    int errors = 0, errs = 0;
+    int errs = 0;
     MPI_Comm comm;
     char query_key[MPI_MAX_INFO_KEY];
     char val[MPI_MAX_INFO_VAL];
     char new_key[MPI_MAX_INFO_KEY];
-    short hint_mutable;         /* a hint is mutable or immutable based on an MPI implementation */
     MPI_Comm comm_dup2;
     MPI_Comm comm_dup3;
     MPI_Comm comm_dup4;

--- a/test/mpi/comm/dup_with_info.c
+++ b/test/mpi/comm/dup_with_info.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include "mpitest.h"
 
-int run_tests(MPI_Comm comm)
+static int run_tests(MPI_Comm comm)
 {
     int rank, size, wrank, wsize, dest, a, b, errs = 0;
     MPI_Status status;

--- a/test/mpi/comm/ic1.c
+++ b/test/mpi/comm/ic1.c
@@ -14,12 +14,8 @@ int main(int argc, char *argv[])
 {
     MPI_Comm intercomm;
     int remote_rank, rank, size, errs = 0;
-    volatile int trigger;
 
     MTest_Init(&argc, &argv);
-
-    trigger = 1;
-/*    while (trigger) ; */
 
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     if (size < 2) {

--- a/test/mpi/comm/idup_with_info.c
+++ b/test/mpi/comm/idup_with_info.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include "mpitest.h"
 
-int run_tests(MPI_Comm comm)
+static int run_tests(MPI_Comm comm)
 {
     int rank, size, wrank, wsize, dest, a, b, errs = 0;
     MPI_Status status;

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -700,6 +700,8 @@ AC_PROG_RANLIB
 AM_PROG_AR
 
 # Check for --enable-strict
+# NOTE: do this before checking any AC_CHECK_HEADERS, because strict may
+# turn on extension macros
 PAC_ARG_STRICT
 
 # General headers
@@ -707,6 +709,17 @@ AC_HEADER_STDC
 dnl AC_CHECK_HEADERS(stdarg.h unistd.h string.h stdlib.h memory.h stdint.h)
 dnl unistd.h string.h stdlib.h memory.h stdint.h are checked by AC_PROG_CC.
 AC_CHECK_HEADERS(stdarg.h sys/time.h sys/resource.h)
+
+# check if we need declarations
+AC_CHECK_FUNCS(strdup)
+if test "$ac_cv_func_strdup" = "yes" ; then
+   PAC_FUNC_NEEDS_DECL([#include <string.h>],strdup)
+fi
+
+AC_CHECK_FUNCS(usleep)
+if test "$ac_cv_func_usleep" = "yes" ; then
+   PAC_FUNC_NEEDS_DECL([#include <unistd.h>],usleep)
+fi
 
 # Check for fixed width types
 AC_TYPE_INT8_T

--- a/test/mpi/datatype/concurrent_irecv.c
+++ b/test/mpi/datatype/concurrent_irecv.c
@@ -24,7 +24,7 @@ int main(int argc, char *argv[])
     if (nranks != 3)
         MPI_Abort(MPI_COMM_WORLD, 1);
 
-    MPI_Request reqs[nranks - 1];
+    MPI_Request reqs[2];
 
     if (rank == 0) {
         MPI_Datatype type;

--- a/test/mpi/datatype/contents.c
+++ b/test/mpi/datatype/contents.c
@@ -86,9 +86,9 @@ int builtin_float_test(void)
 {
     int nints, nadds, ntypes, combiner;
 
-    int err, errs = 0;
+    int errs = 0;
 
-    err = MPI_Type_get_envelope(MPI_FLOAT, &nints, &nadds, &ntypes, &combiner);
+    MPI_Type_get_envelope(MPI_FLOAT, &nints, &nadds, &ntypes, &combiner);
 
     if (combiner != MPI_COMBINER_NAMED)
         errs++;
@@ -292,13 +292,13 @@ int optimizable_vector_of_basics_test(void)
     MPI_Aint *adds = NULL;
     MPI_Datatype *types;
 
-    int err, errs = 0;
+    int errs = 0;
 
     /* set up type */
-    err = MPI_Type_vector(10, 2, 2, MPI_INT, &parent_type);
+    MPI_Type_vector(10, 2, 2, MPI_INT, &parent_type);
 
     /* decode */
-    err = MPI_Type_get_envelope(parent_type, &nints, &nadds, &ntypes, &combiner);
+    MPI_Type_get_envelope(parent_type, &nints, &nadds, &ntypes, &combiner);
 
     if (nints != 3)
         errs++;
@@ -325,7 +325,7 @@ int optimizable_vector_of_basics_test(void)
         adds = malloc(nadds * sizeof(*adds));
     types = malloc(ntypes * sizeof(*types));
 
-    err = MPI_Type_get_contents(parent_type, nints, nadds, ntypes, ints, adds, types);
+    MPI_Type_get_contents(parent_type, nints, nadds, ntypes, ints, adds, types);
 
     if (ints[0] != 10)
         errs++;
@@ -374,13 +374,13 @@ int indexed_of_basics_test(void)
     MPI_Aint *adds = NULL;
     MPI_Datatype *types;
 
-    int err, errs = 0;
+    int errs = 0;
 
     /* set up type */
-    err = MPI_Type_indexed(s_count, s_blocklengths, s_displacements, MPI_INT, &parent_type);
+    MPI_Type_indexed(s_count, s_blocklengths, s_displacements, MPI_INT, &parent_type);
 
     /* decode */
-    err = MPI_Type_get_envelope(parent_type, &nints, &nadds, &ntypes, &combiner);
+    MPI_Type_get_envelope(parent_type, &nints, &nadds, &ntypes, &combiner);
 
     if (nints != 7)
         errs++;
@@ -407,7 +407,7 @@ int indexed_of_basics_test(void)
         adds = malloc(nadds * sizeof(*adds));
     types = malloc(ntypes * sizeof(*types));
 
-    err = MPI_Type_get_contents(parent_type, nints, nadds, ntypes, ints, adds, types);
+    MPI_Type_get_contents(parent_type, nints, nadds, ntypes, ints, adds, types);
 
     if (ints[0] != s_count)
         errs++;

--- a/test/mpi/datatype/darray_cyclic.c
+++ b/test/mpi/datatype/darray_cyclic.c
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
 int AllocateGrid(int nx, int ny, int **srcArray, int **destArray)
 {
     int *src, *dest;
-    int i, j;
+    int i;
     src = (int *) malloc(nx * ny * sizeof(int));
     dest = (int *) malloc(nx * ny * sizeof(int));
     if (!src || !dest) {

--- a/test/mpi/datatype/large_count.c
+++ b/test/mpi/datatype/large_count.c
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
             MPI_Get_elements(&status, (type_), &elements);        \
             MPI_Get_elements_x(&status, (type_), &elements_x);    \
             MPI_Get_count(&status, (type_), &count);              \
-            check(elements == (elts_));                           \
+            check(elements == (int) (elts_));                     \
             check(elements_x == (elts_));                         \
             check(count == 1);                                    \
         }                                                         \
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
             check(elements == MPI_UNDEFINED);                     \
         }                                                         \
         else {                                                    \
-            check(elements == (elts_));                           \
+            check(elements == (int) (elts_));                           \
         }                                                         \
         check(elements_x == (elts_));                             \
         check(count == 1);                                        \

--- a/test/mpi/datatype/large_type.c
+++ b/test/mpi/datatype/large_type.c
@@ -85,7 +85,7 @@ static MPI_Datatype make_largexfer_type_hindexed(MPI_Offset nbytes)
 }
 
 
-int testtype(MPI_Datatype type, MPI_Offset expected)
+static int testtype(MPI_Datatype type, MPI_Offset expected)
 {
     MPI_Count size, lb, extent;
     int errs = 0;

--- a/test/mpi/datatype/large_vec.c
+++ b/test/mpi/datatype/large_vec.c
@@ -13,7 +13,7 @@
 
 int main(int argc, char *argv[])
 {
-    int ierr, i, size, rank;
+    int i, size, rank;
     int elems = 270000000;
     MPI_Status status;
     MPI_Datatype dtype;
@@ -29,8 +29,8 @@ int main(int argc, char *argv[])
         return MTestReturnValue(errs);
     }
 
-    ierr = MPI_Comm_size(MPI_COMM_WORLD, &size);
-    ierr = MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     if (size != 3) {
         fprintf(stderr, "[%d] usage: mpiexec -n 3 %s\n", rank, argv[0]);
         MPI_Abort(MPI_COMM_WORLD, 1);
@@ -51,14 +51,14 @@ int main(int argc, char *argv[])
         for (i = 0; i < elems; i++)
             cols[i] = i;
         /* printf("[%d] sending...\n",rank); */
-        ierr = MPI_Send(cols, 1, dtype, 1, 0, MPI_COMM_WORLD);
-        ierr = MPI_Send(cols, 1, dtype, 2, 0, MPI_COMM_WORLD);
+        MPI_Send(cols, 1, dtype, 1, 0, MPI_COMM_WORLD);
+        MPI_Send(cols, 1, dtype, 2, 0, MPI_COMM_WORLD);
     } else {
         /* printf("[%d] receiving...\n",rank); */
         for (i = 0; i < elems; i++)
             cols[i] = -1;
-        ierr = MPI_Recv(cols, 1, dtype, 0, 0, MPI_COMM_WORLD, &status);
-        /* ierr = MPI_Get_count(&status,MPI_LONG_LONG_INT,&cnt);
+        MPI_Recv(cols, 1, dtype, 0, 0, MPI_COMM_WORLD, &status);
+        /* MPI_Get_count(&status,MPI_LONG_LONG_INT,&cnt);
          * Get_count still fails because count is not 64 bit */
         for (i = 0; i < elems; i++) {
             if (i % 2)

--- a/test/mpi/datatype/longdouble.c
+++ b/test/mpi/datatype/longdouble.c
@@ -21,7 +21,7 @@
 
 int main(int argc, char *argv[])
 {
-    int rank, size, i, type_size;
+    int rank, size, type_size;
     int errs = 0;
 
     MPI_Init(&argc, &argv);

--- a/test/mpi/datatype/sendrecvt2.c
+++ b/test/mpi/datatype/sendrecvt2.c
@@ -20,8 +20,8 @@ int main(int argc, char **argv)
     void **inbufs, **outbufs;
     int *counts, *bytesize, ntype;
     MPI_Comm comm;
-    int ncomm = 20, rank, np, partner, tag, count;
-    int i, j, k, err, toterr, world_rank, errloc;
+    int rank, np, partner, tag, count;
+    int i, j, k, err, world_rank, errloc;
     MPI_Status status;
     char *obuf;
     char myname[MPI_MAX_OBJECT_NAME];

--- a/test/mpi/datatype/sendrecvt4.c
+++ b/test/mpi/datatype/sendrecvt4.c
@@ -21,8 +21,8 @@ int main(int argc, char **argv)
     void **inbufs, **outbufs;
     int *counts, *bytesize, ntype;
     MPI_Comm comm;
-    int ncomm = 20, rank, np, partner, tag, count;
-    int j, k, err, toterr, world_rank, errloc;
+    int rank, np, partner, tag, count;
+    int j, k, err, world_rank, errloc;
     MPI_Status status;
     char *obuf;
     MPI_Datatype offsettype;

--- a/test/mpi/datatype/simple_pack.c
+++ b/test/mpi/datatype/simple_pack.c
@@ -63,9 +63,9 @@ int builtin_float_test(void)
 {
     int nints, nadds, ntypes, combiner;
 
-    int err, errs = 0;
+    int errs = 0;
 
-    err = MPI_Type_get_envelope(MPI_FLOAT, &nints, &nadds, &ntypes, &combiner);
+    MPI_Type_get_envelope(MPI_FLOAT, &nints, &nadds, &ntypes, &combiner);
 
     if (combiner != MPI_COMBINER_NAMED)
         errs++;
@@ -190,7 +190,7 @@ int optimizable_vector_of_basics_test(void)
     char *buf;
     int i, sizeofint, sizeoftype, position;
 
-    int err, errs = 0;
+    int errs = 0;
 
     MPI_Type_size(MPI_INT, &sizeofint);
 
@@ -201,7 +201,7 @@ int optimizable_vector_of_basics_test(void)
     }
 
     /* set up type */
-    err = MPI_Type_vector(10, 2, 2, MPI_INT, &parent_type);
+    MPI_Type_vector(10, 2, 2, MPI_INT, &parent_type);
 
     MPI_Type_commit(&parent_type);
 
@@ -217,7 +217,7 @@ int optimizable_vector_of_basics_test(void)
     buf = (char *) malloc(sizeoftype);
 
     position = 0;
-    err = MPI_Pack(array, 1, parent_type, buf, sizeoftype, &position, MPI_COMM_WORLD);
+    MPI_Pack(array, 1, parent_type, buf, sizeoftype, &position, MPI_COMM_WORLD);
 
     if (position != sizeoftype) {
         errs++;
@@ -227,7 +227,7 @@ int optimizable_vector_of_basics_test(void)
 
     memset(array, 0, 20 * sizeof(int));
     position = 0;
-    err = MPI_Unpack(buf, sizeoftype, &position, array, 1, parent_type, MPI_COMM_WORLD);
+    MPI_Unpack(buf, sizeoftype, &position, array, 1, parent_type, MPI_COMM_WORLD);
 
     if (position != sizeoftype) {
         errs++;

--- a/test/mpi/datatype/simple_pack_external.c
+++ b/test/mpi/datatype/simple_pack_external.c
@@ -67,9 +67,9 @@ int builtin_float_test(void)
 {
     int nints, nadds, ntypes, combiner;
 
-    int err, errs = 0;
+    int errs = 0;
 
-    err = MPI_Type_get_envelope(MPI_FLOAT, &nints, &nadds, &ntypes, &combiner);
+    MPI_Type_get_envelope(MPI_FLOAT, &nints, &nadds, &ntypes, &combiner);
 
     if (combiner != MPI_COMBINER_NAMED)
         errs++;
@@ -200,7 +200,7 @@ int optimizable_vector_of_basics_test(void)
     int i;
     MPI_Aint sizeofint, sizeoftype, position;
 
-    int err, errs = 0;
+    int errs = 0;
 
     MPI_Pack_external_size((char *) "external32", 1, MPI_INT, &sizeofint);
 
@@ -211,7 +211,7 @@ int optimizable_vector_of_basics_test(void)
     }
 
     /* set up type */
-    err = MPI_Type_vector(10, 2, 2, MPI_INT, &parent_type);
+    MPI_Type_vector(10, 2, 2, MPI_INT, &parent_type);
 
     MPI_Type_commit(&parent_type);
 
@@ -228,8 +228,7 @@ int optimizable_vector_of_basics_test(void)
     buf = (char *) malloc(sizeoftype);
 
     position = 0;
-    err = MPI_Pack_external((char *) "external32",
-                            array, 1, parent_type, buf, sizeoftype, &position);
+    MPI_Pack_external((char *) "external32", array, 1, parent_type, buf, sizeoftype, &position);
 
     if (position != sizeoftype) {
         errs++;
@@ -240,8 +239,7 @@ int optimizable_vector_of_basics_test(void)
 
     memset(array, 0, 20 * sizeof(int));
     position = 0;
-    err = MPI_Unpack_external((char *) "external32",
-                              buf, sizeoftype, &position, array, 1, parent_type);
+    MPI_Unpack_external((char *) "external32", buf, sizeoftype, &position, array, 1, parent_type);
 
     if (position != sizeoftype) {
         errs++;
@@ -283,7 +281,7 @@ int struct_of_basics_test(void)
     MPI_Aint indices[10];
     MPI_Datatype types[10];
 
-    int err, errs = 0;
+    int errs = 0;
 
     MPI_Pack_external_size((char *) "external32", 1, MPI_INT, &sizeofint);
 
@@ -302,7 +300,7 @@ int struct_of_basics_test(void)
     }
 
     /* set up type */
-    err = MPI_Type_create_struct(10, blocks, indices, types, &parent_type);
+    MPI_Type_create_struct(10, blocks, indices, types, &parent_type);
 
     MPI_Type_commit(&parent_type);
 
@@ -318,8 +316,7 @@ int struct_of_basics_test(void)
     buf = (char *) malloc(sizeoftype);
 
     position = 0;
-    err = MPI_Pack_external((char *) "external32",
-                            array, 1, parent_type, buf, sizeoftype, &position);
+    MPI_Pack_external((char *) "external32", array, 1, parent_type, buf, sizeoftype, &position);
 
     if (position != sizeoftype) {
         errs++;
@@ -330,8 +327,7 @@ int struct_of_basics_test(void)
 
     memset(array, 0, 20 * sizeof(int));
     position = 0;
-    err = MPI_Unpack_external((char *) "external32",
-                              buf, sizeoftype, &position, array, 1, parent_type);
+    MPI_Unpack_external((char *) "external32", buf, sizeoftype, &position, array, 1, parent_type);
 
     if (position != sizeoftype) {
         errs++;

--- a/test/mpi/datatype/simple_pack_external2.c
+++ b/test/mpi/datatype/simple_pack_external2.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include "mpitest.h"
 
-char *datarep = "external32";
+const char *datarep = "external32";
 
 #define UINT_COUNT (2)
 #define DBLE_COUNT (24)

--- a/test/mpi/datatype/simple_size_extent.c
+++ b/test/mpi/datatype/simple_size_extent.c
@@ -20,7 +20,7 @@ int parse_args(int argc, char **argv);
 int main(int argc, char **argv)
 {
     int mpi_err, errs = 0, size;
-    MPI_Aint lb, ub, extent;
+    MPI_Aint lb, extent;
     MPI_Datatype type;
 
     struct {

--- a/test/mpi/datatype/structpack2.c
+++ b/test/mpi/datatype/structpack2.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[])
         char c;
     } s[10], s1[10];
     int j;
-    int errs = 0, toterrs;
+    int errs = 0;
     int rank, size, tsize;
     MPI_Aint text, tmp_lb;
     int blens[2];

--- a/test/mpi/datatype/transpose_pack.c
+++ b/test/mpi/datatype/transpose_pack.c
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
     MPI_Datatype row, xpose;
     MPI_Aint sizeofint, tmp_lb;
 
-    int err, errs = 0;
+    int errs = 0;
     int bufsize, position = 0;
     void *buffer;
 
@@ -58,11 +58,11 @@ int main(int argc, char *argv[])
      * change the error handler to errors return */
     MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
 
-    err = MPI_Pack(a, 1, xpose, buffer, bufsize, &position, MPI_COMM_WORLD);
+    MPI_Pack(a, 1, xpose, buffer, bufsize, &position, MPI_COMM_WORLD);
 
     /* Unpack the buffer into b. */
     position = 0;
-    err = MPI_Unpack(buffer, bufsize, &position, b, 100 * 100, MPI_INT, MPI_COMM_WORLD);
+    MPI_Unpack(buffer, bufsize, &position, b, 100 * 100, MPI_INT, MPI_COMM_WORLD);
 
     for (i = 0; i < 100; i++) {
         for (j = 0; j < 100; j++) {

--- a/test/mpi/datatype/transpose_pack_oldapi.c
+++ b/test/mpi/datatype/transpose_pack_oldapi.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
     MPI_Datatype row, xpose;
     MPI_Aint sizeofint;
 
-    int err, errs = 0;
+    int errs = 0;
     int bufsize, position = 0;
     void *buffer;
 
@@ -61,11 +61,11 @@ int main(int argc, char *argv[])
      * change the error handler to errors return */
     MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
 
-    err = MPI_Pack(a, 1, xpose, buffer, bufsize, &position, MPI_COMM_WORLD);
+    MPI_Pack(a, 1, xpose, buffer, bufsize, &position, MPI_COMM_WORLD);
 
     /* Unpack the buffer into b. */
     position = 0;
-    err = MPI_Unpack(buffer, bufsize, &position, b, 100 * 100, MPI_INT, MPI_COMM_WORLD);
+    MPI_Unpack(buffer, bufsize, &position, b, 100 * 100, MPI_INT, MPI_COMM_WORLD);
 
     for (i = 0; i < 100; i++) {
         for (j = 0; j < 100; j++) {

--- a/test/mpi/datatype/type_large.c
+++ b/test/mpi/datatype/type_large.c
@@ -101,7 +101,7 @@ static int testtype(MPI_Datatype type, MPI_Count expected)
 int main(int argc, char **argv)
 {
 
-    int errs = 0, i;
+    int errs = 0;
     int rank, size;
     MTest_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
     types[1] = make_large_indexed_block(expected_sizes[1]);
     types[2] = make_large_hindexed(expected_sizes[2]);
 
-    for (i = 0; i < NR_TYPES; i++) {
+    for (int i = 0; i < NR_TYPES; i++) {
         if (types[i] != MPI_DATATYPE_NULL) {
             errs += testtype(types[i], expected_sizes[i]);
             MPI_Type_free(&(types[i]));

--- a/test/mpi/datatype/type_large.c
+++ b/test/mpi/datatype/type_large.c
@@ -67,7 +67,7 @@ static MPI_Datatype make_large_hindexed(MPI_Count nbytes)
 }
 
 
-int testtype(MPI_Datatype type, MPI_Count expected)
+static int testtype(MPI_Datatype type, MPI_Count expected)
 {
     MPI_Count size, lb, extent;
     int errs = 0;

--- a/test/mpi/errhan/predef_eh.c
+++ b/test/mpi/errhan/predef_eh.c
@@ -13,7 +13,7 @@
  * communicators does not cause a problem at finalize time.  Regression
  * test for ticket #1591 */
 
-void errf(MPI_Comm * comm, int *ec)
+static void errf(MPI_Comm * comm, int *ec)
 {
     /* do nothing */
 }

--- a/test/mpi/errors/coll/reduce_local.c
+++ b/test/mpi/errors/coll/reduce_local.c
@@ -17,11 +17,10 @@
 
 int main(int argc, char *argv[])
 {
-    int err, errs = 0, len, i, errclass;
+    int err, errs = 0, i, errclass;
     int rank = -1, size = -1;
     int *buf;
     int *recvbuf;
-    char msg[MPI_MAX_ERROR_STRING];
 
     MTest_Init(&argc, &argv);
     MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);

--- a/test/mpi/errors/comm/comm_size_nullarg.c
+++ b/test/mpi/errors/comm/comm_size_nullarg.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char *argv[])
 {
-    int rank, size;
+    int rank;
     int errclass, errs = 0, mpi_errno;
 
     MTest_Init(&argc, &argv);

--- a/test/mpi/errors/io/openerr.c
+++ b/test/mpi/errors/io/openerr.c
@@ -24,9 +24,9 @@ int main(int argc, char *argv[])
     char emsg[MPI_MAX_ERROR_STRING];
     int emsglen, err, ec, errs = 0;
     int amode, rank;
-    char *name = 0;
+    const char *name = 0;
     MPI_Status st;
-    int outbuf[BUFLEN], inbuf[BUFLEN];
+    char outbuf[BUFLEN], inbuf[BUFLEN];
 
     MTest_Init(&argc, &argv);
 

--- a/test/mpi/errors/rma/win_sync_complete.c
+++ b/test/mpi/errors/rma/win_sync_complete.c
@@ -10,13 +10,11 @@
 
 int main(int argc, char *argv[])
 {
-    int rank;
     int errors = 0, errs = 0;
     int buf = 0;
     MPI_Win win;
 
     MTest_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     MPI_Win_create(&buf, sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 

--- a/test/mpi/errors/rma/win_sync_free_at.c
+++ b/test/mpi/errors/rma/win_sync_free_at.c
@@ -11,14 +11,13 @@
 
 int main(int argc, char *argv[])
 {
-    int rank, nproc, i;
+    int nproc, i;
     int errors = 0, errs = 0;
     int buf = 0, *my_buf;
     MPI_Win win;
     MPI_Group world_group;
 
     MTest_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);
 
     MPI_Win_create(&buf, sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);

--- a/test/mpi/errors/rma/win_sync_free_pt.c
+++ b/test/mpi/errors/rma/win_sync_free_pt.c
@@ -10,13 +10,11 @@
 
 int main(int argc, char *argv[])
 {
-    int rank;
     int errors = 0, errs = 0;
     int buf = 0;
     MPI_Win win;
 
     MTest_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     MPI_Win_create(&buf, sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 

--- a/test/mpi/errors/rma/win_sync_lock_at.c
+++ b/test/mpi/errors/rma/win_sync_lock_at.c
@@ -11,14 +11,13 @@
 
 int main(int argc, char *argv[])
 {
-    int rank, nproc, i;
+    int nproc, i;
     int errors = 0, errs = 0;
     int buf = 0, *my_buf;
     MPI_Win win;
     MPI_Group world_group;
 
     MTest_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);
 
     MPI_Win_create(&buf, sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);

--- a/test/mpi/errors/rma/win_sync_lock_fence.c
+++ b/test/mpi/errors/rma/win_sync_lock_fence.c
@@ -11,13 +11,12 @@
 
 int main(int argc, char *argv[])
 {
-    int rank, nproc;
+    int nproc;
     int errors = 0, errs = 0;
     int buf = 0, my_buf;
     MPI_Win win;
 
     MTest_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);
 
     MPI_Win_create(&buf, sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);

--- a/test/mpi/errors/rma/win_sync_lock_pt.c
+++ b/test/mpi/errors/rma/win_sync_lock_pt.c
@@ -10,13 +10,11 @@
 
 int main(int argc, char *argv[])
 {
-    int rank;
     int errors = 0, errs = 0;
     int buf = 0;
     MPI_Win win;
 
     MTest_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     MPI_Win_create(&buf, sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 

--- a/test/mpi/errors/rma/win_sync_nested.c
+++ b/test/mpi/errors/rma/win_sync_nested.c
@@ -11,14 +11,13 @@
 
 int main(int argc, char *argv[])
 {
-    int rank, nproc, i;
+    int nproc, i;
     int errors = 0, errs = 0;
     int buf = 0, *my_buf;
     MPI_Win win;
     MPI_Group world_group;
 
     MTest_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);
 
     MPI_Win_create(&buf, sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);

--- a/test/mpi/errors/rma/win_sync_op.c
+++ b/test/mpi/errors/rma/win_sync_op.c
@@ -11,13 +11,12 @@
 
 int main(int argc, char *argv[])
 {
-    int rank, nproc;
+    int nproc;
     int errors = 0, errs = 0;
     int buf = 0, my_buf;
     MPI_Win win;
 
     MTest_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);
 
     MPI_Win_create(&buf, sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);

--- a/test/mpi/errors/rma/win_sync_unlock.c
+++ b/test/mpi/errors/rma/win_sync_unlock.c
@@ -10,13 +10,11 @@
 
 int main(int argc, char *argv[])
 {
-    int rank;
     int errors = 0, errs = 0;
     int buf = 0;
     MPI_Win win;
 
     MTest_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     MPI_Win_create(&buf, sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 

--- a/test/mpi/errors/rma/winerr.c
+++ b/test/mpi/errors/rma/winerr.c
@@ -34,7 +34,6 @@ void weh(MPI_Win * win, int *err, ...)
 
 int main(int argc, char *argv[])
 {
-    int err;
     int buf[2];
     MPI_Win win;
     MPI_Comm comm;
@@ -58,7 +57,7 @@ int main(int argc, char *argv[])
     MPI_Win_set_errhandler(win, newerr);
 
     expected_err_class = MPI_ERR_RANK;
-    err = MPI_Put(buf, 1, MPI_INT, -5, 0, 1, MPI_INT, win);
+    MPI_Put(buf, 1, MPI_INT, -5, 0, 1, MPI_INT, win);
     if (calls != 1) {
         errs++;
         printf("newerr not called\n");

--- a/test/mpi/errors/rma/winerr2.c
+++ b/test/mpi/errors/rma/winerr2.c
@@ -57,7 +57,6 @@ void weh2(MPI_Win * win, int *err, ...)
 
 int main(int argc, char *argv[])
 {
-    int err;
     int buf[2];
     MPI_Win win;
     MPI_Comm comm;
@@ -85,7 +84,7 @@ int main(int argc, char *argv[])
     MPI_Errhandler_free(&newerr1);
 
     expected_err_class = MPI_ERR_RANK;
-    err = MPI_Put(buf, 1, MPI_INT, -5, 0, 1, MPI_INT, win);
+    MPI_Put(buf, 1, MPI_INT, -5, 0, 1, MPI_INT, win);
     if (w1Called != 1) {
         errs++;
         printf("newerr1 not called\n");
@@ -109,7 +108,7 @@ int main(int argc, char *argv[])
     MPI_Errhandler_free(&newerr2);
 
     expected_err_class = MPI_ERR_RANK;
-    err = MPI_Put(buf, 1, MPI_INT, -5, 0, 1, MPI_INT, win);
+    MPI_Put(buf, 1, MPI_INT, -5, 0, 1, MPI_INT, win);
     if (w2Called != 1) {
         errs++;
         printf("newerr2 not called\n");

--- a/test/mpi/errors/spawn/connect_timeout.c
+++ b/test/mpi/errors/spawn/connect_timeout.c
@@ -85,7 +85,6 @@ int test_mismatched_accept(MPI_Comm intra_comm, int gid)
     int mpi_errno = MPI_SUCCESS;
     int errs = 0;
     int intra_rank, intra_nproc;
-    int server_rank = 0, local_server_rank = 0;
 
     MTEST_VG_MEM_INIT(port, MPI_MAX_PORT_NAME * sizeof(char));
 
@@ -143,13 +142,12 @@ int test_mismatched_accept(MPI_Comm intra_comm, int gid)
 
 int test_no_accept(MPI_Comm intra_comm, int gid)
 {
-    char port[MPI_MAX_PORT_NAME], timeout = 0;
+    char port[MPI_MAX_PORT_NAME];
     MPI_Info info = MPI_INFO_NULL;
     MPI_Comm comm = MPI_COMM_NULL;
     int mpi_errno = MPI_SUCCESS;
     int errs = 0;
     int intra_rank, intra_nproc;
-    int server_rank = 0, local_server_rank = 0;
 
     MTEST_VG_MEM_INIT(port, MPI_MAX_PORT_NAME * sizeof(char));
 
@@ -194,8 +192,7 @@ int test_no_accept(MPI_Comm intra_comm, int gid)
 int main(int argc, char *argv[])
 {
     MPI_Comm intra_comm = MPI_COMM_NULL;
-    int sub_rank, sub_nproc;
-    int errs = 0, allerrs = 0;
+    int errs = 0;
 
     if (getenv("MPITEST_VERBOSE")) {
         verbose = 1;

--- a/test/mpi/f77/datatype/bottomc.c
+++ b/test/mpi/f77/datatype/bottomc.c
@@ -30,6 +30,7 @@
 #error 'Unrecognized Fortran name mapping'
 #endif
 
+void c_routine_(MPI_Fint * ftype, int *errs);
 void c_routine_(MPI_Fint * ftype, int *errs)
 {
     int count = 5;

--- a/test/mpi/f90/attr/attrlangc.c
+++ b/test/mpi/f90/attr/attrlangc.c
@@ -81,6 +81,33 @@ void ccompareint2aint_(MPI_Fint * in1, MPI_Aint * in2, MPI_Fint * result);
 void ccompareint2void_(MPI_Fint * in1, void *in2, MPI_Fint * result);
 void ccompareaint2void_(MPI_Aint * in1, void *in2, MPI_Fint * result);
 
+void cgetenvbool_(const char str[], MPI_Fint * val, int d);
+void cattrinit_(MPI_Fint * fverbose);
+void cgetsizes_(MPI_Fint * ptrSize, MPI_Fint * intSize, MPI_Fint * aintSize);
+void ccreatekeys_(MPI_Fint * ccomm1_key, MPI_Fint * ccomm2_key,
+                  MPI_Fint * ctype2_key, MPI_Fint * cwin2_key);
+void cfreekeys_(void);
+void ctoctest_(MPI_Fint * errs);
+int cmpi1read(MPI_Comm comm, int key, void *expected, const char *msg);
+int cmpi2read(MPI_Comm comm, int key, void *expected, const char *msg);
+int cmpi2readtype(MPI_Datatype dtype, int key, void *expected, const char *msg);
+int cmpi2readwin(MPI_Win win, int key, void *expected, const char *msg);
+void cmpif1read_(MPI_Fint * fcomm, MPI_Fint * fkey, MPI_Fint * expected,
+                 MPI_Fint * errs, const char *msg, int msglen);
+void cmpif2read_(MPI_Fint * fcomm, MPI_Fint * fkey, MPI_Aint * expected,
+                 MPI_Fint * errs, const char *msg, int msglen);
+void cmpif2readtype_(MPI_Fint * ftype, MPI_Fint * fkey, MPI_Aint * expected,
+                     MPI_Fint * errs, const char *msg, int msglen);
+void cmpif2readwin_(MPI_Fint * fwin, MPI_Fint * fkey, MPI_Aint * expected,
+                    MPI_Fint * errs, const char *msg, int msglen);
+void csetmpi_(MPI_Fint * fcomm, MPI_Fint * fkey, MPI_Fint * val, MPI_Fint * errs);
+void csetmpi2_(MPI_Fint * fcomm, MPI_Fint * fkey, MPI_Aint * val, MPI_Fint * errs);
+void csetmpitype_(MPI_Fint * ftype, MPI_Fint * fkey, MPI_Aint * val, MPI_Fint * errs);
+void csetmpiwin_(MPI_Fint * fwin, MPI_Fint * fkey, MPI_Aint * val, MPI_Fint * errs);
+void ccompareint2aint_(MPI_Fint * in1, MPI_Aint * in2, MPI_Fint * result);
+void ccompareint2void_(MPI_Fint * in1, void *in2, MPI_Fint * result);
+void ccompareaint2void_(MPI_Aint * in1, void *in2, MPI_Fint * result);
+
 /* ----------------------------------------------------------------------- */
 /* Initialization functions                                                */
 /* ----------------------------------------------------------------------- */
@@ -175,8 +202,6 @@ static int TYPE_DELETE_FN(MPI_Datatype dtype, int keyval, void *outval, void *ex
    win_dup function */
 static int WIN_COPY_FN(MPI_Win win, int keyval, void *extra, void *inval, void *outval, int *flag)
 {
-    int inValue = *(int *) inval;
-
     if (verbose)
         printf("PANIC: In C MPI win copy function (should never happen)\n");
     *flag = 1;

--- a/test/mpi/ft/abort.c
+++ b/test/mpi/ft/abort.c
@@ -8,7 +8,7 @@
 
 int main(int argc, char **argv)
 {
-    int rank, size;
+    int rank;
 
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/test/mpi/ft/anysource.c
+++ b/test/mpi/ft/anysource.c
@@ -14,7 +14,6 @@
 int main(int argc, char **argv)
 {
     int rank, size, err, ec;
-    char buf[10];
     MPI_Request request;
     MPI_Status status;
 

--- a/test/mpi/ft/bcast.c
+++ b/test/mpi/ft/bcast.c
@@ -15,7 +15,7 @@
  */
 int main(int argc, char **argv)
 {
-    int rank, size, rc, errclass, toterrs, errs = 0;
+    int rank, size, rc, errclass, errs = 0;
     int deadprocs[] = { 1 };
     char buf[100000];
     MPI_Group world, newgroup;

--- a/test/mpi/ft/die.c
+++ b/test/mpi/ft/die.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char **argv)
 {
-    int rank, size;
+    int rank;
 
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/test/mpi/ft/isendalive.c
+++ b/test/mpi/ft/isendalive.c
@@ -15,7 +15,7 @@
  */
 int main(int argc, char **argv)
 {
-    int rank, size, err;
+    int rank, size, err = 0;
     char buf[10];
     MPI_Request request;
 

--- a/test/mpi/ft/revoke_shrink.c
+++ b/test/mpi/ft/revoke_shrink.c
@@ -13,7 +13,7 @@
 
 MPI_Comm comm_all;
 
-void error_handler(MPI_Comm * communicator, int *error_code, ...)
+static void error_handler(MPI_Comm * communicator, int *error_code, ...)
 {
     MPI_Comm *new_comm = malloc(sizeof(MPI_Comm));
 

--- a/test/mpi/ft/sendalive.c
+++ b/test/mpi/ft/sendalive.c
@@ -14,7 +14,7 @@
  */
 int main(int argc, char **argv)
 {
-    int rank, err;
+    int rank, err = 0;
     char buf[10];
 
     MPI_Init(&argc, &argv);

--- a/test/mpi/impls/mpich/comm/comm_dup.c
+++ b/test/mpi/impls/mpich/comm/comm_dup.c
@@ -10,7 +10,7 @@
 int main(int argc, char **argv)
 {
     int errs = 0;
-    MPI_Comm dup, dup2;
+    MPI_Comm dup;
     MPI_Info info_in, info_out;
     int flag;
     char val[MPI_MAX_INFO_VAL] = { 0 };
@@ -33,6 +33,7 @@ int main(int argc, char **argv)
     MPI_Info_free(&info_out);
 
 #if MPI_VERSION >= 4
+    MPI_Comm dup2;
     MPI_Comm_dup(dup, &dup2);
     MPI_Comm_get_info(dup, &info_out);
     MPI_Info_get(info_out, "mpi_assert_no_any_tag", MPI_MAX_INFO_VAL, val, &flag);

--- a/test/mpi/impls/mpich/comm/comm_info_hint.c
+++ b/test/mpi/impls/mpich/comm/comm_info_hint.c
@@ -15,7 +15,8 @@
 
 /* Read given info hint key value from the given info object,
  * while expecting the hint value=val */
-int ReadCommInfo(MPI_Info info, const char *key, const char *val, char *buf, const char *test_name)
+static int ReadCommInfo(MPI_Info info, const char *key, const char *val, char *buf,
+                        const char *test_name)
 {
     int flag;
     int errors = 0;
@@ -36,20 +37,20 @@ int ReadCommInfo(MPI_Info info, const char *key, const char *val, char *buf, con
 
 int main(int argc, char **argv)
 {
-    int i, j, rank;
+    int i, rank;
     int errors = 0, errs = 0;
     char query_key[MPI_MAX_INFO_KEY];
     char buf[MPI_MAX_INFO_VAL];
     char val[MPI_MAX_INFO_VAL];
     MPI_Comm comm_dup1;
-    MPI_Comm comm_dup2;
+    /* comm_dup2 not used */
     MPI_Comm comm_dup3;
     MPI_Comm comm_dup4;
     MPI_Comm comm_split5;
     MPI_Info info_in1;
     MPI_Info info_in4;
     MPI_Info info_out1;
-    MPI_Info info_out2;
+    /* info_out2 not used */
     MPI_Info info_out3;
     MPI_Info info_out4;
     MPI_Info info_out5;

--- a/test/mpi/impls/mpich/mpi_t/collparmt.c
+++ b/test/mpi/impls/mpich/mpi_t/collparmt.c
@@ -19,9 +19,8 @@ int main(int argc, char *argv[])
     MPI_Datatype dtype;
     MPI_T_enum enumtype;
     MPI_T_cvar_handle bcastHandle, bcastLongHandle;
-    int bcastCount, bcastScope, bcastCvar = -1;
-    int bcastLongCount, bcastLongScope, bcastLongCvar = -1;
-    int gatherScope, gatherCvar = -1;
+    int bcastCount, bcastScope = -1, bcastCvar = -1;
+    int bcastLongCount, bcastLongScope = -1, bcastLongCvar = -1;
     int newval;
     int errs = 0;
 
@@ -41,10 +40,7 @@ int main(int argc, char *argv[])
         cnameLen = sizeof(cname);
         MPI_T_cvar_get_info(i, cname, &cnameLen, &verbosity, &dtype,
                             &enumtype, NULL, NULL, &binding, &scope);
-        if (strcmp(cname, "MPIR_CVAR_GATHER_VSMALL_MSG_SIZE") == 0) {
-            gatherCvar = i;
-            gatherScope = scope;
-        } else if (strcmp(cname, "MPIR_CVAR_BCAST_SHORT_MSG_SIZE") == 0) {
+        if (strcmp(cname, "MPIR_CVAR_BCAST_SHORT_MSG_SIZE") == 0) {
             bcastCvar = i;
             bcastScope = scope;
             if (binding != MPI_T_BIND_NO_OBJECT && binding != MPI_T_BIND_MPI_COMM) {
@@ -58,7 +54,6 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "Unexpected binding for MPIR_CVAR_BCAST_LONG_MSG\n");
                 errs++;
             }
-        } else if (strcmp(cname, "MPIR_CVAR_BCAST_MIN_PROCS") == 0) {
         }
     }
 

--- a/test/mpi/impls/mpich/mpi_t/recvq_events.c
+++ b/test/mpi/impls/mpich/mpi_t/recvq_events.c
@@ -19,8 +19,8 @@
 
 static int errs = 0;
 
-void uenq_cb_fn(MPI_T_event_instance event_instance, MPI_T_event_registration er,
-                MPI_T_cb_safety cb_safety, void *user_data)
+static void uenq_cb_fn(MPI_T_event_instance event_instance, MPI_T_event_registration er,
+                       MPI_T_cb_safety cb_safety, void *user_data)
 {
     int rank;
     int tag;
@@ -30,8 +30,8 @@ void uenq_cb_fn(MPI_T_event_instance event_instance, MPI_T_event_registration er
         errs = 1;
 }
 
-void udeq_cb_fn(MPI_T_event_instance event_instance, MPI_T_event_registration er,
-                MPI_T_cb_safety cb_safety, void *user_data)
+static void udeq_cb_fn(MPI_T_event_instance event_instance, MPI_T_event_registration er,
+                       MPI_T_cb_safety cb_safety, void *user_data)
 {
     int rank;
     int tag;
@@ -41,8 +41,8 @@ void udeq_cb_fn(MPI_T_event_instance event_instance, MPI_T_event_registration er
         errs = 1;
 }
 
-void recvq_free_cb(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety,
-                   void *user_data)
+static void recvq_free_cb(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety,
+                          void *user_data)
 {
     return;
 }
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
     MPI_Aint *at;
     int num_elements;
     int bind;
-    int provided, maxnamelen, maxdesclen, maxne;
+    int provided, maxnamelen, maxdesclen, maxne = 0;
     MPI_T_enum enumtype;
     MPI_Info info;
     int uenq_idx = -1, udeq_idx = -1;

--- a/test/mpi/include/mpitest.h
+++ b/test/mpi/include/mpitest.h
@@ -13,6 +13,21 @@
 #include "mpithreadtest.h"
 #include "mtest_common.h"
 
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#if defined NEEDS_STRDUP_DECL && !defined strdup
+extern char *strdup(const char *);
+#endif
+
+#if defined NEEDS_USLEEP_DECL && !defined usleep
+extern int usleep(useconds_t);
+#endif
+
 /*
  * Init and finalize test
  */

--- a/test/mpi/include/mpitest.h
+++ b/test/mpi/include/mpitest.h
@@ -116,6 +116,8 @@ static inline int MTestCheckStatus(MPI_Status * p_status, MPI_Datatype el_type,
             printf("Status expect tag %d, got %d\n", exp_tag, p_status->MPI_TAG);
         }
     }
+
+    return errs;
 }
 
 #endif /* MPITEST_H_INCLUDED */

--- a/test/mpi/include/mpitest.h
+++ b/test/mpi/include/mpitest.h
@@ -6,10 +6,9 @@
 #ifndef MPITEST_H_INCLUDED
 #define MPITEST_H_INCLUDED
 
-#include <string.h>
+#include "mpitestconf.h"
 #include <mpi.h>
 #include "mtest_mpix.h"
-#include "mpitestconf.h"
 #include "mpithreadtest.h"
 #include "mtest_common.h"
 

--- a/test/mpi/include/mtest_common.h
+++ b/test/mpi/include/mtest_common.h
@@ -21,7 +21,7 @@ typedef enum {
     MTEST_MEM_TYPE__ALL,
 } mtest_mem_type_e;
 
-MPI_Aint MTestDefaultMaxBufferSize();
+MPI_Aint MTestDefaultMaxBufferSize(void);
 
 typedef void MTestArgList;
 MTestArgList *MTestArgListCreate(int argc, char *argv[]);
@@ -65,5 +65,5 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
                 bool is_calloc, int device);
 void MTestFree(mtest_mem_type_e type, void *hostbuf, void *devicebuf);
 void MTestCopyContent(const void *sbuf, void *dbuf, size_t size, mtest_mem_type_e type);
-void MTest_finalize_gpu();
+void MTest_finalize_gpu(void);
 #endif

--- a/test/mpi/info/infocreateenv.c
+++ b/test/mpi/info/infocreateenv.c
@@ -56,7 +56,7 @@ static int test_info(MPI_Info info1, MPI_Info info2)
 {
     int i, nerrs = 0;
     char value1[MPI_MAX_INFO_VAL], value2[MPI_MAX_INFO_VAL];
-    char *keys[] = { "command", "argv", "maxprocs", "soft", "host", "arch", "wdir", "file",
+    const char *keys[] = { "command", "argv", "maxprocs", "soft", "host", "arch", "wdir", "file",
         "thread_level"
     };
     for (i = 0; i < (int) (sizeof(keys) / sizeof(keys[0])); i++) {

--- a/test/mpi/info/infoenv.c
+++ b/test/mpi/info/infoenv.c
@@ -12,7 +12,7 @@ static int verbose = 0;
 int main(int argc, char *argv[])
 {
     char value[MPI_MAX_INFO_VAL];
-    char *keys[] = { "command", "argv", "maxprocs", "soft", "host", "arch", "wdir", "file",
+    const char *keys[] = { "command", "argv", "maxprocs", "soft", "host", "arch", "wdir", "file",
         "thread_level", 0
     };
     int flag, i;

--- a/test/mpi/init/session_psets.c
+++ b/test/mpi/init/session_psets.c
@@ -19,7 +19,7 @@
 int main(int argc, char *argv[])
 {
     int errs = 0;
-    int n_psets, psetlen, rc, ret;
+    int n_psets, psetlen, rc;
     int valuelen;
     int flag = 0;
     char *info_val = NULL;

--- a/test/mpi/init/session_psets.c
+++ b/test/mpi/init/session_psets.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <assert.h>
-#include "mpitest.h"
 
 /* This is adapted example 10.9 from MPI Standard 4.0
  * This example illustrates the use of Process Set query functions to select a

--- a/test/mpi/io/async.c
+++ b/test/mpi/io/async.c
@@ -20,7 +20,7 @@ static char MTEST_Descrip[] = "Test contig asynchronous I/O";
    reads them back. The file name is taken as a command-line argument,
    and the process rank is appended to it.*/
 
-static void handle_error(int errcode, char *str)
+static void handle_error(int errcode, const char *str)
 {
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;

--- a/test/mpi/io/hindexed_io.c
+++ b/test/mpi/io/hindexed_io.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
     int data_size = DATA_SIZE;
     int i, j, k, errs = 0;
     MPI_Aint disp[BLK_COUNT];
-    char *filename = "unnamed.dat";
+    const char *filename = "unnamed.dat";
 
     MTest_Init(&argc, &argv);
     disp[0] = (MPI_Aint) (PAD);

--- a/test/mpi/io/hindexed_io.c
+++ b/test/mpi/io/hindexed_io.c
@@ -15,7 +15,7 @@
 #define HEADER 144
 #define BLK_COUNT 3
 
-static void handle_error(int errcode, char *str)
+static void handle_error(int errcode, const char *str)
 {
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;

--- a/test/mpi/io/i_aggregation1.c
+++ b/test/mpi/io/i_aggregation1.c
@@ -9,12 +9,12 @@
 
 /* Uses nonblocking collective I/O.*/
 
+#include "mpitest.h"
 #include <unistd.h>
 #include <stdlib.h>
 #include <mpi.h>
 #include <stdio.h>
 #include <string.h>
-#include "mpitest.h"
 
 #define NUM_OBJS 4
 #define OBJ_SIZE 1048576

--- a/test/mpi/io/i_aggregation1.c
+++ b/test/mpi/io/i_aggregation1.c
@@ -83,7 +83,7 @@ static MPI_Offset get_offset(int rank, int num_objs, int obj_size, int which_obj
     return offset;
 }
 
-static void write_file(char *target, int rank, MPI_Info * info)
+static void write_file(const char *target, int rank, MPI_Info * info)
 {
     MPI_File wfh;
     MPI_Request *request;

--- a/test/mpi/io/i_aggregation1.c
+++ b/test/mpi/io/i_aggregation1.c
@@ -137,7 +137,7 @@ static void write_file(const char *target, int rank, MPI_Info * info)
     free(request);
 }
 
-static void read_file(char *target, int rank, MPI_Info * info, int *corrupt_blocks)
+static void read_file(const char *target, int rank, MPI_Info * info, int *corrupt_blocks)
 {
     MPI_File rfh;
     MPI_Offset *offset;
@@ -236,7 +236,7 @@ set_hints(MPI_Info *info, char *hints) {
 int main(int argc, char *argv[])
 {
     int nproc = 1, rank = 0;
-    char *target = NULL;
+    const char *target = NULL;
     int c;
     MPI_Info info;
     int mpi_ret;

--- a/test/mpi/io/i_aggregation2.c
+++ b/test/mpi/io/i_aggregation2.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
     int errcode;
     int i, rank, errs = 0, buffer[BUFSIZE], buf2[BUFSIZE];
     MPI_Request request;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = (argc > 1) ? argv[1] : "testfile";
 

--- a/test/mpi/io/i_coll_test.c
+++ b/test/mpi/io/i_coll_test.c
@@ -36,8 +36,8 @@ int main(int argc, char **argv)
     int array_of_dargs[3], array_of_psizes[3];
     int *readbuf, *writebuf, mynod, *tmpbuf, array_size;
     MPI_Count bufcount;
-    char *filename;
-    int errs = 0, toterrs;
+    char *filename = NULL;
+    int errs = 0;
     MPI_File fh;
     MPI_Status status;
     MPI_Request request;
@@ -113,7 +113,8 @@ int main(int argc, char **argv)
     /* end of initialization */
 
     /* write the array to the file */
-    errcode = MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, info, &fh);
+    errcode = MPI_File_open(MPI_COMM_WORLD, (const char *) filename,
+                            MPI_MODE_CREATE | MPI_MODE_RDWR, info, &fh);
     if (errcode != MPI_SUCCESS)
         handle_error(errcode, "MPI_File_open");
 

--- a/test/mpi/io/i_coll_test.c
+++ b/test/mpi/io/i_coll_test.c
@@ -3,11 +3,11 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include "mpitest.h"
 
 /* A 32^3 array. For other array sizes, change array_of_gsizes below. */
 

--- a/test/mpi/io/i_darray_read.c
+++ b/test/mpi/io/i_darray_read.c
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
     double *ldata, *pdata;
 
     int tsize, nelem;
-    char *filename;
+    const char *filename;
 
     MPI_File dfile;
 

--- a/test/mpi/io/i_hindexed.c
+++ b/test/mpi/io/i_hindexed.c
@@ -59,7 +59,8 @@ char compare_buf[XLEN * 4][YLEN * 4] = {
 int main(int argc, char **argv)
 {
     int i, j, err, rank, np, num_io;
-    char *buf, *filename;
+    char *buf;
+    const char *filename;
     int rank_dim[2], array_of_sizes[2];
     int array_of_subsizes[2];
     int count, *blocklengths, global_array_size;

--- a/test/mpi/io/i_hindexed_io.c
+++ b/test/mpi/io/i_hindexed_io.c
@@ -35,8 +35,7 @@ int main(int argc, char **argv)
     int data_size = DATA_SIZE;
     int i, j, k, errs = 0;
     MPI_Aint disp[BLK_COUNT];
-    int block_lens[BLK_COUNT];
-    char *filename = "unnamed.dat";
+    const char *filename = "unnamed.dat";
     MPI_Status status;
     MPI_Request request;
 
@@ -44,10 +43,6 @@ int main(int argc, char **argv)
     disp[0] = (MPI_Aint) (PAD);
     disp[1] = (MPI_Aint) (data_size * 1 + PAD);
     disp[2] = (MPI_Aint) (data_size * 2 + PAD);
-
-    block_lens[0] = data_size;
-    block_lens[1] = data_size;
-    block_lens[2] = data_size;
 
     data = malloc(data_size);
     verify = malloc(data_size * BLK_COUNT + HEADER + PAD);

--- a/test/mpi/io/i_hindexed_io.c
+++ b/test/mpi/io/i_hindexed_io.c
@@ -15,7 +15,7 @@
 #define HEADER 144
 #define BLK_COUNT 3
 
-static void handle_error(int errcode, char *str)
+static void handle_error(int errcode, const char *str)
 {
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;

--- a/test/mpi/io/i_noncontig_coll.c
+++ b/test/mpi/io/i_noncontig_coll.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     MPI_File fh;
     MPI_Request request;
     MPI_Status status;
-    char *filename;
+    char *filename = NULL;
     MPI_Datatype typevec, typevec2, newtype;
 
     MTest_Init(&argc, &argv);

--- a/test/mpi/io/i_noncontig_coll.c
+++ b/test/mpi/io/i_noncontig_coll.c
@@ -3,11 +3,11 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include "mpitest.h"
 
 /* tests noncontiguous reads/writes using nonblocking collective I/O */
 

--- a/test/mpi/io/i_noncontig_coll2.c
+++ b/test/mpi/io/i_noncontig_coll2.c
@@ -249,8 +249,8 @@ void simple_shuffle_str(int mynod, int len, ADIO_cb_name_array array, char *dest
 
 int main(int argc, char **argv)
 {
-    int i, mynod, nprocs, len, errs = 0, sum_errs = 0, verbose = 0;
-    char *filename;
+    int i, mynod, nprocs, len, errs = 0, verbose = 0;
+    char *filename = NULL;
     char *cb_config_string;
     int cb_config_len;
     ADIO_cb_name_array array;

--- a/test/mpi/io/i_noncontig_coll2.c
+++ b/test/mpi/io/i_noncontig_coll2.c
@@ -23,7 +23,8 @@
 /* we are going to muck with this later to make it evenly divisible by however many compute nodes we have */
 #define STARTING_SIZE 5000
 
-int test_file(char *filename, int mynod, int nprocs, char *cb_hosts, const char *msg, int verbose);
+int test_file(const char *filename, int mynod, int nprocs, char *cb_hosts, const char *msg,
+              int verbose);
 
 #define ADIOI_Free free
 #define ADIOI_Malloc malloc
@@ -331,7 +332,8 @@ int main(int argc, char **argv)
 
 #define SEEDER(x,y,z) ((x)*1000000 + (y) + (x)*(z))
 
-int test_file(char *filename, int mynod, int nprocs, char *cb_hosts, const char *msg, int verbose)
+int test_file(const char *filename, int mynod, int nprocs, char *cb_hosts, const char *msg,
+              int verbose)
 {
     MPI_Datatype typevec, typevec2, newtype;
     int *buf, i, blocklength, errcode, errors = 0;

--- a/test/mpi/io/i_noncontig_coll2.c
+++ b/test/mpi/io/i_noncontig_coll2.c
@@ -3,11 +3,11 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpitest.h"
 #include "mpi.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include "mpitest.h"
 
 /* tests noncontiguous reads/writes using nonblocking collective I/O */
 

--- a/test/mpi/io/i_types_with_zeros.c
+++ b/test/mpi/io/i_types_with_zeros.c
@@ -30,7 +30,7 @@ enum {
     STRUCT
 } testcases;
 
-static int test_indexed_with_zeros(char *filename, int testcase)
+static int test_indexed_with_zeros(const char *filename, int testcase)
 {
     int i, rank, np, buflen, num, err, errs = 0;
     int nelms[MAXLEN], buf[MAXLEN], indices[MAXLEN], blocklen[MAXLEN];

--- a/test/mpi/io/i_types_with_zeros.c
+++ b/test/mpi/io/i_types_with_zeros.c
@@ -141,7 +141,7 @@ static int test_indexed_with_zeros(const char *filename, int testcase)
 int main(int argc, char **argv)
 {
     int errs, rank, np;
-    char *filename;
+    const char *filename = NULL;
 
     filename = (argc > 1) ? argv[1] : "testfile";
 

--- a/test/mpi/io/simple_collective.c
+++ b/test/mpi/io/simple_collective.c
@@ -18,6 +18,7 @@
  * I am surprised src/mpi/romio/test/create_excl.c did not uncover the bug
  */
 
+#include "mpitest.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,7 +31,6 @@
 #include <mpi.h>
 #include <errno.h>
 #include <getopt.h>
-#include "mpitest.h"
 
 static char *opt_file = NULL;
 static int rank = -1;

--- a/test/mpi/io/simple_collective.c
+++ b/test/mpi/io/simple_collective.c
@@ -38,7 +38,7 @@ static int rank = -1;
 static int parse_args(int argc, char **argv);
 static void usage(const char *prog);
 
-int test_write(char *file, int nprocs, int rank, MPI_Info info)
+static int test_write(char *file, int nprocs, int rank, MPI_Info info)
 {
     double stime, etime, wtime, w_elapsed, w_slowest, elapsed, slowest;
     MPI_File fh;

--- a/test/mpi/io/simple_collective.c
+++ b/test/mpi/io/simple_collective.c
@@ -33,9 +33,8 @@
 #include <getopt.h>
 
 static char *opt_file = NULL;
-static int rank = -1;
 
-static int parse_args(int argc, char **argv);
+static int parse_args(int rank, int argc, char **argv);
 static void usage(const char *prog);
 
 static int test_write(char *file, int nprocs, int rank, MPI_Info info)
@@ -90,18 +89,18 @@ static int test_write(char *file, int nprocs, int rank, MPI_Info info)
 
 int main(int argc, char **argv)
 {
+    int rank = -1;
     int nprocs;
     char file[256];
     MPI_Info info;
     int nr_errors = 0;
-
 
     MTest_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
 
     /* parse the command line arguments */
-    parse_args(argc, argv);
+    parse_args(rank, argc, argv);
 
     sprintf(file, "%s", opt_file);
     MPI_Info_create(&info);
@@ -115,7 +114,7 @@ int main(int argc, char **argv)
     return MTestReturnValue(nr_errors);
 }
 
-static int parse_args(int argc, char **argv)
+static int parse_args(int rank, int argc, char **argv)
 {
     int c;
 

--- a/test/mpi/io/zero_count.c
+++ b/test/mpi/io/zero_count.c
@@ -17,7 +17,8 @@ int main(int argc, char **argv)
 {
     int errs = 0;
     int len, rank, get_size;
-    char buf[10], *filename = __FILE__;
+    char buf[10];
+    const char *filename = __FILE__;
     MPI_File fh;
     MPI_Status status;
 

--- a/test/mpi/manual/mpi_t/nem_fbox_fallback_to_queue_count.c
+++ b/test/mpi/manual/mpi_t/nem_fbox_fallback_to_queue_count.c
@@ -36,6 +36,7 @@ MPI_T_pvar_handle fbox_handle;
 /* Check that we can successfully write to the variable.
  * Question: Do we really want to write pvars other than reset?
  */
+void blank_test(void);
 void blank_test()
 {
     uint64_t temp[2] = { -1 };
@@ -56,7 +57,7 @@ void blank_test()
  * Here, the sender posts all sends before the receiver has a chance to
  * acknowledge any of them; this should force the sender to fall_back to the
  * queue every time. */
-void send_first_test()
+static void send_first_test(void)
 {
     uint64_t nem_fbox_fall_back_to_queue_count[2] = { -1 };
 
@@ -116,6 +117,7 @@ void send_first_test()
  *        also uses messages).  May want to 'sleep' between sends as a
  *        workaround.
  */
+void recv_first_test(void);
 void recv_first_test()
 {
     uint64_t nem_fbox_fall_back_to_queue_count[2] = { -1 };

--- a/test/mpi/manual/singjoin.c
+++ b/test/mpi/manual/singjoin.c
@@ -165,7 +165,6 @@ int parse_args(int argc, char **argv)
 {
 #ifndef HAVE_WINDOWS_H
     int c;
-    extern char *optarg;
     while ((c = getopt(argc, argv, "csp:")) != -1) {
         switch (c) {
             case 's':

--- a/test/mpi/manual/tchandlers.c
+++ b/test/mpi/manual/tchandlers.c
@@ -19,7 +19,9 @@
 
 #include "connectstuff.h"
 
-static char sFnameToDelete[PATH_MAX];
+/* FNAME_SIZE is 10 less than PATH_MAX to avoid warnings during snprintf */
+#define FNAME_SIZE PATH_MAX - 10
+static char sFnameToDelete[FNAME_SIZE];
 static int sWatchdogTimeout = -1;
 static size_t sWatchdogStrokeCount = 0;
 
@@ -95,11 +97,11 @@ void installExitHandler(const char *fname)
 {
     /* Install signal handler */
     struct sigaction new_action;
-    if (strlen(fname) > PATH_MAX) {
+    if (strlen(fname) > FNAME_SIZE) {
         msg("Fname: <%s> too long - aborting", fname);
         _exit(12);
     }
-    strncpy(sFnameToDelete, fname, PATH_MAX);
+    strncpy(sFnameToDelete, fname, FNAME_SIZE);
     new_action.sa_handler = term_handler;
     sigemptyset(&new_action.sa_mask);
     new_action.sa_flags = 0;

--- a/test/mpi/manual/testconnect.c
+++ b/test/mpi/manual/testconnect.c
@@ -18,6 +18,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <assert.h>
 
 char *fname;
 int cachedRank = -1;
@@ -85,8 +86,8 @@ int main(int argc, char **argv)
         }
         comm = MPI_COMM_WORLD;
     } else {
-        char *cerr;
-        cerr = fgets(port, MPI_MAX_PORT_NAME, fh);
+        char *s = fgets(port, MPI_MAX_PORT_NAME, fh);
+        assert(s != NULL);
         fclose(fh);
         if (doPrint) {
             printf("[%d] about to connect: Port from %s is: %s\n", myNum, fname, port);

--- a/test/mpi/manual/testconnectserial.c
+++ b/test/mpi/manual/testconnectserial.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
     char *actualFname = NULL;
     char *globalFname = NULL;
     int totalSize, expectedRank, size, cachedRank;
-    char portName[MPI_MAX_PORT_NAME];
+    char portName[MPI_MAX_PORT_NAME + 1];
     int rankToAccept = 1;
 
     /* Debug - print out where we picked up the MPICH build from */

--- a/test/mpi/mpi_t/mpi_t_str.c
+++ b/test/mpi/mpi_t/mpi_t_str.c
@@ -42,14 +42,9 @@ int main(int argc, char **argv)
     int desc_len;
     char desc[STR_SZ + 1] = ""; /* +1 to check for overrun */
     int verb;
-    MPI_Datatype dtype;
-    int count;
     int bind;
     int scope;
     int provided;
-
-    /* Init'ed to a garbage value, to trigger MPI_T bugs easily if there are. */
-    MPI_T_enum enumtype = (MPI_T_enum) 0x31415926;
 
     MTest_Init(&argc, &argv);
     MPI_T_init_thread(MPI_THREAD_SINGLE, &provided);
@@ -63,6 +58,10 @@ int main(int argc, char **argv)
     MPI_T_cvar_get_num(&num_cvars);
     for (i = 0; i < num_cvars; ++i) {
         int full_name_len, full_desc_len;
+        MPI_Datatype dtype;
+        /* Init'ed to a garbage value, to trigger MPI_T bugs easily if there are. */
+        MPI_T_enum enumtype = (MPI_T_enum) 0x31415926;
+
         /* pass NULL string, non-zero lengths; should get full lengths */
         full_name_len = full_desc_len = 1;
         MPI_T_cvar_get_info(i, NULL, &full_name_len, &verb, &dtype,
@@ -112,7 +111,7 @@ int main(int argc, char **argv)
     /* check string handling for performance variables */
     MPI_T_pvar_get_num(&num_pvars);
     for (i = 0; i < num_pvars; ++i) {
-        int varclass, bind, readonly, continuous, atomic;
+        int varclass, readonly, continuous, atomic;
         MPI_Datatype dtype;
         MPI_T_enum enumtype;
 

--- a/test/mpi/mpi_t/mpit_vars.c
+++ b/test/mpi/mpi_t/mpit_vars.c
@@ -9,12 +9,12 @@
    2021-02-17: added sources and events
  */
 
+#include "mpitest.h"
 #include <stdio.h>
 #include <strings.h>
 #include <string.h>     /* For strncpy */
 #include <stdlib.h>
 #include "mpi.h"
-#include "mpitest.h"
 
 char *mpit_scopeToStr(int scope);
 char *mpit_bindingToStr(int binding);

--- a/test/mpi/mpi_t/mpit_vars.c
+++ b/test/mpi/mpi_t/mpit_vars.c
@@ -16,11 +16,12 @@
 #include <stdlib.h>
 #include "mpi.h"
 
-char *mpit_scopeToStr(int scope);
-char *mpit_bindingToStr(int binding);
-char *mpit_validDtypeStr(MPI_Datatype datatype);
-char *mpit_varclassToStr(int varClass);
-char *mpit_verbosityToStr(int verbosity);
+const char *mpit_scopeToStr(int scope);
+const char *mpit_bindingToStr(int binding);
+const char *mpit_validDtypeStr(MPI_Datatype datatype);
+const char *mpit_varclassToStr(int varClass);
+const char *mpit_verbosityToStr(int verbosity);
+const char *mpit_errclassToStr(int err);
 int perfvarReadInt(int pvarIndex, int isContinuous, int *found);
 unsigned int perfvarReadUint(int pvarIndex, int isContinuous, int *found);
 double perfvarReadDouble(int pvarIndex, int isContinuous, int *found);
@@ -334,9 +335,9 @@ int PrintCategories(FILE * fp)
 
 /* --- Support routines --- */
 
-char *mpit_validDtypeStr(MPI_Datatype datatype)
+const char *mpit_validDtypeStr(MPI_Datatype datatype)
 {
-    char *p = 0;
+    const char *p = 0;
     if (datatype == MPI_INT)
         p = "MPI_INT";
     else if (datatype == MPI_UNSIGNED)
@@ -373,9 +374,9 @@ char *mpit_validDtypeStr(MPI_Datatype datatype)
     return p;
 }
 
-char *mpit_scopeToStr(int scope)
+const char *mpit_scopeToStr(int scope)
 {
-    char *p = 0;
+    const char *p = 0;
     switch (scope) {
         case MPI_T_SCOPE_CONSTANT:
             p = "SCOPE_CONSTANT";
@@ -405,9 +406,9 @@ char *mpit_scopeToStr(int scope)
     return p;
 }
 
-char *mpit_bindingToStr(int binding)
+const char *mpit_bindingToStr(int binding)
 {
-    char *p;
+    const char *p;
     switch (binding) {
         case MPI_T_BIND_NO_OBJECT:
             p = "NO_OBJECT";
@@ -448,9 +449,9 @@ char *mpit_bindingToStr(int binding)
     return p;
 }
 
-char *mpit_varclassToStr(int varClass)
+const char *mpit_varclassToStr(int varClass)
 {
-    char *p = 0;
+    const char *p = 0;
     switch (varClass) {
         case MPI_T_PVAR_CLASS_STATE:
             p = "CLASS_STATE";
@@ -489,9 +490,9 @@ char *mpit_varclassToStr(int varClass)
     return p;
 }
 
-char *mpit_verbosityToStr(int verbosity)
+const char *mpit_verbosityToStr(int verbosity)
 {
-    char *p = 0;
+    const char *p = 0;
     switch (verbosity) {
         case MPI_T_VERBOSITY_USER_BASIC:
             p = "VERBOSITY_USER_BASIC";
@@ -527,9 +528,9 @@ char *mpit_verbosityToStr(int verbosity)
     return p;
 }
 
-char *mpit_errclassToStr(int err)
+const char *mpit_errclassToStr(int err)
 {
-    char *p = 0;
+    const char *p = 0;
     switch (err) {
         case MPI_T_ERR_MEMORY:
             p = "ERR_MEMORY";

--- a/test/mpi/mpi_t/qmpi_test.c
+++ b/test/mpi/mpi_t/qmpi_test.c
@@ -16,6 +16,9 @@
 static int test_val = 0;
 static int qmpi_on = 0;
 
+__attribute__ ((constructor))
+void static_register_my_tool(void);
+
 void test_init_function_pointer(int tool_id);
 int Test_Init_Thread(QMPI_Context context, int tool_id, int *argc, char ***argv, int required,
                      int *provided);

--- a/test/mpi/perf/dtpack.c
+++ b/test/mpi/perf/dtpack.c
@@ -433,7 +433,7 @@ int Report(const char *name, const char *packname, double avgTimeMPI, double avg
 /* Finally, here's the main program */
 int main(int argc, char *argv[])
 {
-    int n, stride, err, errs = 0;
+    int n, stride, errs = 0;
     void *dest, *src;
     double avgTimeUser, avgTimeMPI;
 
@@ -449,13 +449,13 @@ int main(int argc, char *argv[])
     memset(src, 0, n * (1 + stride) * sizeof(double));
     memset(dest, 0, n * sizeof(double));
 
-    err = TestVecPackDouble(n, stride, &avgTimeUser, &avgTimeMPI, dest, src);
+    TestVecPackDouble(n, stride, &avgTimeUser, &avgTimeMPI, dest, src);
     errs += Report("VecPackDouble", "Pack", avgTimeMPI, avgTimeUser);
 
-    err = TestVecUnPackDouble(n, stride, &avgTimeUser, &avgTimeMPI, src, dest);
+    TestVecUnPackDouble(n, stride, &avgTimeUser, &avgTimeMPI, src, dest);
     errs += Report("VecUnPackDouble", "Unpack", avgTimeMPI, avgTimeUser);
 
-    err = TestIndexPackDouble(n, stride, &avgTimeUser, &avgTimeMPI, dest, src);
+    TestIndexPackDouble(n, stride, &avgTimeUser, &avgTimeMPI, dest, src);
     errs += Report("VecIndexDouble", "Pack", avgTimeMPI, avgTimeUser);
 
     free(dest);
@@ -465,7 +465,7 @@ int main(int argc, char *argv[])
     src = (void *) malloc((1 + n) * ((1 + stride) * sizeof(double)));
     memset(dest, 0, 2 * n * sizeof(double));
     memset(src, 0, (1 + n) * (1 + stride) * sizeof(double));
-    err = TestVecPack2Double(n, stride, &avgTimeUser, &avgTimeMPI, dest, src);
+    TestVecPack2Double(n, stride, &avgTimeUser, &avgTimeMPI, dest, src);
     errs += Report("VecPack2Double", "Pack", avgTimeMPI, avgTimeUser);
 
     free(dest);

--- a/test/mpi/perf/indexperf.c
+++ b/test/mpi/perf/indexperf.c
@@ -127,7 +127,6 @@ int main(int argc, char **argv)
     for (ntry = 0; ntry < 5; ntry++) {
         const double *ppe = (const double *) inbuf;
         const int *id = (const int *) index_displacement;
-        int k, j;
         t0 = MPI_Wtime();
         position = 0;
         for (i = 0; i < icount; i++) {

--- a/test/mpi/perf/nestvec2.c
+++ b/test/mpi/perf/nestvec2.c
@@ -33,11 +33,10 @@ int main(int argc, char **argv)
 {
     int vcount, vstride;
     int32_t counts[2];
-    int v2stride, typesize, packsize, i, position, errs = 0;
+    int packsize, i, position, errs = 0;
     double *outbuf, *outbuf2;
     double *vsource;
     MPI_Datatype vtype, stype;
-    MPI_Aint lb, extent;
     double t0, t1;
     double tspack, tvpack, tmanual;
     int ntry;

--- a/test/mpi/perf/sendrecvl.c
+++ b/test/mpi/perf/sendrecvl.c
@@ -88,8 +88,6 @@ int main(int argc, char *argv[])
         if (wrank == 0) {
             t1 = t1 / reps;
             if (t1 > 0) {
-                double rate;
-                rate = (len / t1) / 1.e6;
                 t1 = t1 * 1.e6;
                 if (verbose)
                     printf("%d\t%g\t%g\n", len, t1, len / t1);
@@ -133,8 +131,6 @@ int main(int argc, char *argv[])
         if (wrank == 0) {
             t1 = t1 / reps;
             if (t1 > 0) {
-                double rate;
-                rate = (len / t1) / 1.e6;
                 t1 = t1 * 1.e6;
                 if (verbose)
                     printf("%d\t%g\t%g\n", len, t1, len / t1);
@@ -183,8 +179,6 @@ int main(int argc, char *argv[])
         if (wrank == 0) {
             t1 = t1 / reps;
             if (t1 > 0) {
-                double rate;
-                rate = (len / t1) / 1.e6;
                 t1 = t1 * 1.e6;
                 if (verbose)
                     printf("%d\t%g\t%g\n", len, t1, len / t1);

--- a/test/mpi/perf/twovec.c
+++ b/test/mpi/perf/twovec.c
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
     MPI_Datatype column[LOOPS], xpose[LOOPS];
-    double t[NUM_SIZES], ttmp, tmin, tmax, tmean, tdiff;
+    double t[NUM_SIZES], ttmp, tmean;
     double tMeanLower, tMeanHigher;
     int size;
     int i, j, errs = 0, nrows, ncols;

--- a/test/mpi/pt2pt/big_count_status.c
+++ b/test/mpi/pt2pt/big_count_status.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include "mpitest.h"
 
-int test_count(MPI_Count count)
+static int test_count(MPI_Count count)
 {
     MPI_Status stat;
     int cancelled, cancelled2;

--- a/test/mpi/pt2pt/bsendfrag.c
+++ b/test/mpi/pt2pt/bsendfrag.c
@@ -21,11 +21,11 @@ different messages are received in different orders";
  */
 
 #define MSG_SIZE 17000
+int b1[MSG_SIZE], b2[MSG_SIZE], b3[MSG_SIZE], b4[MSG_SIZE];
 
 int main(int argc, char *argv[])
 {
     int errs = 0;
-    int b1[MSG_SIZE], b2[MSG_SIZE], b3[MSG_SIZE], b4[MSG_SIZE];
     int src, dest, size, rank, i;
     MPI_Comm comm;
     MPI_Status status;

--- a/test/mpi/pt2pt/inactivereq.c
+++ b/test/mpi/pt2pt/inactivereq.c
@@ -17,8 +17,7 @@
 
 */
 
-int StatusEmpty(MPI_Status * s);
-int StatusEmpty(MPI_Status * s)
+static int StatusEmpty(MPI_Status * s)
 {
     int errs = 0;
     int count = 10;
@@ -40,7 +39,7 @@ int StatusEmpty(MPI_Status * s)
     return errs ? 0 : 1;
 }
 
-int test_recv_init(int src_rank, const char *test_name)
+static int test_recv_init(int src_rank, const char *test_name)
 {
     MPI_Request r;
     MPI_Status s;
@@ -79,12 +78,10 @@ int test_recv_init(int src_rank, const char *test_name)
     return errs;
 }
 
-void test_proc_null()
+static void test_proc_null()
 {
     MPI_Request r;
     MPI_Status s;
-    int errs = 0;
-    int flag;
     int buf[10];
     int tag = 27;
 

--- a/test/mpi/pt2pt/isendirecv.c
+++ b/test/mpi/pt2pt/isendirecv.c
@@ -12,7 +12,7 @@ int main(int argc, char *argv[])
 {
     int errs = 0;
     int elems = 20;
-    int rank, nproc, dest, i;
+    int rank, nproc, i;
     float *in_buf, *out_buf;
     MPI_Comm comm;
     MPI_Request *reqs;

--- a/test/mpi/pt2pt/large_message.c
+++ b/test/mpi/pt2pt/large_message.c
@@ -13,7 +13,7 @@
 
 int main(int argc, char *argv[])
 {
-    int ierr, i, size, rank;
+    int i, size, rank;
     int cnt = 270000000;
     int stat_cnt = 0;
     MPI_Status status;
@@ -29,8 +29,8 @@ int main(int argc, char *argv[])
         return MTestReturnValue(errs);
     }
 
-    ierr = MPI_Comm_size(MPI_COMM_WORLD, &size);
-    ierr = MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     if (size != 3) {
         fprintf(stderr, "[%d] usage: mpiexec -n 3 %s\n", rank, argv[0]);
         MPI_Abort(MPI_COMM_WORLD, 1);
@@ -48,14 +48,14 @@ int main(int argc, char *argv[])
         for (i = 0; i < cnt; i++)
             cols[i] = i;
         /* printf("[%d] sending...\n",rank); */
-        ierr = MPI_Send(cols, cnt, MPI_LONG_LONG_INT, 1, 0, MPI_COMM_WORLD);
-        ierr = MPI_Send(cols, cnt, MPI_LONG_LONG_INT, 2, 0, MPI_COMM_WORLD);
+        MPI_Send(cols, cnt, MPI_LONG_LONG_INT, 1, 0, MPI_COMM_WORLD);
+        MPI_Send(cols, cnt, MPI_LONG_LONG_INT, 2, 0, MPI_COMM_WORLD);
     } else {
         /* printf("[%d] receiving...\n",rank); */
         for (i = 0; i < cnt; i++)
             cols[i] = -1;
-        ierr = MPI_Recv(cols, cnt, MPI_LONG_LONG_INT, 0, 0, MPI_COMM_WORLD, &status);
-        ierr = MPI_Get_count(&status, MPI_LONG_LONG_INT, &stat_cnt);
+        MPI_Recv(cols, cnt, MPI_LONG_LONG_INT, 0, 0, MPI_COMM_WORLD, &status);
+        MPI_Get_count(&status, MPI_LONG_LONG_INT, &stat_cnt);
         if (cnt != stat_cnt) {
             fprintf(stderr, "Output of MPI_Get_count (%d) does not match expected count (%d).\n",
                     stat_cnt, cnt);

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -27,9 +27,7 @@ static int pingping(int seed, int testsize, int sendcnt, int recvcnt,
     int err;
     int rank, size, source, dest;
     int minsize = 2, nmsg, maxmsg;
-    int i, j, len;
     MPI_Aint sendcount, recvcount;
-    MPI_Aint maxbufsize;
     MPI_Comm comm;
     MPI_Datatype sendtype, recvtype;
     DTP_pool_s dtp;
@@ -86,7 +84,7 @@ static int pingping(int seed, int testsize, int sendcnt, int recvcnt,
          * change the error handler to errors return */
         MPI_Comm_set_errhandler(comm, MPI_ERRORS_RETURN);
 
-        for (i = 0; i < testsize; i++) {
+        for (int i = 0; i < testsize; i++) {
             errs += MTest_dtp_create(&send, rank == source);
             errs += MTest_dtp_create(&recv, rank == dest);
 
@@ -97,9 +95,8 @@ static int pingping(int seed, int testsize, int sendcnt, int recvcnt,
                 sendtype = send.dtp_obj.DTP_datatype;
 
                 for (nmsg = 1; nmsg < maxmsg; nmsg++) {
-                    err =
-                        MPI_Send(send.buf + send.dtp_obj.DTP_buf_offset, sendcount, sendtype, dest,
-                                 0, comm);
+                    err = MPI_Send((const char *) send.buf + send.dtp_obj.DTP_buf_offset,
+                                   sendcount, sendtype, dest, 0, comm);
                     if (err) {
                         errs++;
                         if (errs < 10) {
@@ -115,7 +112,7 @@ static int pingping(int seed, int testsize, int sendcnt, int recvcnt,
                     MTest_dtp_init(&recv, -1, -1, recvcnt);
 
                     MPI_Status status;
-                    err = MPI_Recv(recv.buf + recv.dtp_obj.DTP_buf_offset,
+                    err = MPI_Recv((char *) recv.buf + recv.dtp_obj.DTP_buf_offset,
                                    recvcount, recvtype, source, 0, comm, &status);
                     if (err) {
                         errs++;

--- a/test/mpi/pt2pt/pscancel.c
+++ b/test/mpi/pt2pt/pscancel.c
@@ -15,7 +15,7 @@ static char MTEST_Descrip[] = "Test of various send cancel calls";
 int main(int argc, char *argv[])
 {
     int errs = 0;
-    int rank, size, source, dest;
+    int rank, size, dest;
     MPI_Comm comm;
     MPI_Status status;
     MPI_Request req;
@@ -33,7 +33,6 @@ int main(int argc, char *argv[])
     MPI_Comm_rank(comm, &rank);
     MPI_Comm_size(comm, &size);
 
-    source = 0;
     dest = size - 1;
 
     for (cs = 0; cs < 4; cs++) {

--- a/test/mpi/pt2pt/recv_any.c
+++ b/test/mpi/pt2pt/recv_any.c
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
     int rank = 0, nprocs = 0;
     int i = 0, x = 0, dst = 0, src = 0, tag = 0;
     MPI_Status stat;
-#if TEST_NB
+#ifdef TEST_NB
     MPI_Request req;
 #endif
     int sbuf[BUFSIZE], rbuf[BUFSIZE];
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
     for (x = 0; x < ITER; x++) {
         tag = x;
         if (rank == dst) {
-#if TEST_NB
+#ifdef TEST_NB
             MPI_Irecv(rbuf, sizeof(int) * BUFSIZE, MPI_CHAR, MPI_ANY_SOURCE, tag, MPI_COMM_WORLD,
                       &req);
             MPI_Wait(&req, &stat);

--- a/test/mpi/pt2pt/scancel.c
+++ b/test/mpi/pt2pt/scancel.c
@@ -15,7 +15,7 @@ static char MTEST_Descrip[] = "Test of various send cancel calls";
 int main(int argc, char *argv[])
 {
     int errs = 0;
-    int rank, size, source, dest;
+    int rank, size, dest;
     MPI_Comm comm;
     MPI_Status status;
     MPI_Request req;
@@ -33,7 +33,6 @@ int main(int argc, char *argv[])
     MPI_Comm_rank(comm, &rank);
     MPI_Comm_size(comm, &size);
 
-    source = 0;
     dest = size - 1;
 
     MTestPrintfMsg(1, "Starting scancel test\n");

--- a/test/mpi/pt2pt/scancel_unmatch.c
+++ b/test/mpi/pt2pt/scancel_unmatch.c
@@ -26,9 +26,6 @@ int main(int argc, char *argv[])
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-    int source = 0;
-    int dest = size - 1;
-
     if (rank == 0) {
         a = 10;
         b = 20;

--- a/test/mpi/pt2pt/sendrecv1.c
+++ b/test/mpi/pt2pt/sendrecv1.c
@@ -24,9 +24,7 @@ static int sendrecv1(int seed, int testsize, int sendcnt, int recvcnt, const cha
     int err;
     int rank, size, source, dest;
     int minsize = 2;
-    int i, j, len;
     MPI_Aint sendcount, recvcount;
-    MPI_Aint maxbufsize;
     MPI_Comm comm;
     MPI_Datatype sendtype, recvtype;
     DTP_pool_s dtp;
@@ -74,7 +72,7 @@ static int sendrecv1(int seed, int testsize, int sendcnt, int recvcnt, const cha
          * change the error handler to errors return */
         MPI_Comm_set_errhandler(comm, MPI_ERRORS_RETURN);
 
-        for (i = 0; i < testsize; i++) {
+        for (int i = 0; i < testsize; i++) {
             DTP_pool_update_count(dtp, (rank == source) ? sendcnt : recvcnt);
             errs += MTest_dtp_create(&send, rank == source);
             errs += MTest_dtp_create(&recv, rank == dest);
@@ -85,9 +83,8 @@ static int sendrecv1(int seed, int testsize, int sendcnt, int recvcnt, const cha
                 sendcount = send.dtp_obj.DTP_type_count;
                 sendtype = send.dtp_obj.DTP_datatype;
 
-                err =
-                    MPI_Send(send.buf + send.dtp_obj.DTP_buf_offset, sendcount, sendtype, dest, 0,
-                             comm);
+                err = MPI_Send((const char *) send.buf + send.dtp_obj.DTP_buf_offset,
+                               sendcount, sendtype, dest, 0, comm);
                 if (err) {
                     errs++;
                     if (errs < 10) {
@@ -101,7 +98,7 @@ static int sendrecv1(int seed, int testsize, int sendcnt, int recvcnt, const cha
                 recvtype = recv.dtp_obj.DTP_datatype;
 
                 MPI_Status status;
-                err = MPI_Recv(recv.buf + recv.dtp_obj.DTP_buf_offset,
+                err = MPI_Recv((char *) recv.buf + recv.dtp_obj.DTP_buf_offset,
                                recvcount, recvtype, source, 0, comm, &status);
                 if (err) {
                     errs++;

--- a/test/mpi/pt2pt/sendself.c
+++ b/test/mpi/pt2pt/sendself.c
@@ -20,9 +20,7 @@ static int sendself(int seed, int testsize, int sendcnt, int recvcnt,
 {
     int errs = 0, err;
     int rank, size;
-    int i, j, len;
     MPI_Aint sendcount, recvcount;
-    MPI_Aint maxbufsize;
     MPI_Comm comm;
     MPI_Datatype sendtype, recvtype;
     MPI_Request req;
@@ -55,7 +53,7 @@ static int sendself(int seed, int testsize, int sendcnt, int recvcnt,
      * change the error handler to errors return */
     MPI_Comm_set_errhandler(comm, MPI_ERRORS_RETURN);
 
-    for (i = 0; i < testsize; i++) {
+    for (int i = 0; i < testsize; i++) {
         MPI_Status status;
 
         DTP_pool_update_count(dtp, sendcnt);
@@ -72,9 +70,8 @@ static int sendself(int seed, int testsize, int sendcnt, int recvcnt,
         recvcount = recv.dtp_obj.DTP_type_count;
         recvtype = recv.dtp_obj.DTP_datatype;
 
-        err =
-            MPI_Irecv(recv.buf + recv.dtp_obj.DTP_buf_offset, recvcount, recvtype, rank, 0, comm,
-                      &req);
+        err = MPI_Irecv((char *) recv.buf + recv.dtp_obj.DTP_buf_offset,
+                        recvcount, recvtype, rank, 0, comm, &req);
         if (err) {
             errs++;
             if (errs < 10) {
@@ -82,32 +79,8 @@ static int sendself(int seed, int testsize, int sendcnt, int recvcnt,
             }
         }
 
-        err = MPI_Send(send.buf + send.dtp_obj.DTP_buf_offset, sendcount, sendtype, rank, 0, comm);
-        if (err) {
-            errs++;
-            if (errs < 10) {
-                MTestPrintError(err);
-            }
-        }
-
-        err = MPI_Wait(&req, &status);
-
-        errs += MTestCheckStatus(&status, dtp.DTP_base_type, sendcnt, rank, 0, errs < 10);
-        errs += MTest_dtp_check(&recv, 0, 1, sendcnt, errs < 10);
-
-        MTest_dtp_init(&recv, -1, -1, sendcnt);
-
-        err =
-            MPI_Irecv(recv.buf + recv.dtp_obj.DTP_buf_offset, recvcount, recvtype, rank, 0, comm,
-                      &req);
-        if (err) {
-            errs++;
-            if (errs < 10) {
-                MTestPrintError(err);
-            }
-        }
-
-        err = MPI_Ssend(send.buf + send.dtp_obj.DTP_buf_offset, sendcount, sendtype, rank, 0, comm);
+        err = MPI_Send((const char *) send.buf + send.dtp_obj.DTP_buf_offset,
+                       sendcount, sendtype, rank, 0, comm);
         if (err) {
             errs++;
             if (errs < 10) {
@@ -122,9 +95,8 @@ static int sendself(int seed, int testsize, int sendcnt, int recvcnt,
 
         MTest_dtp_init(&recv, -1, -1, sendcnt);
 
-        err =
-            MPI_Irecv(recv.buf + recv.dtp_obj.DTP_buf_offset, recvcount, recvtype, rank, 0, comm,
-                      &req);
+        err = MPI_Irecv((char *) recv.buf + recv.dtp_obj.DTP_buf_offset,
+                        recvcount, recvtype, rank, 0, comm, &req);
         if (err) {
             errs++;
             if (errs < 10) {
@@ -132,7 +104,33 @@ static int sendself(int seed, int testsize, int sendcnt, int recvcnt,
             }
         }
 
-        err = MPI_Rsend(send.buf + send.dtp_obj.DTP_buf_offset, sendcount, sendtype, rank, 0, comm);
+        err = MPI_Ssend((char *) send.buf + send.dtp_obj.DTP_buf_offset,
+                        sendcount, sendtype, rank, 0, comm);
+        if (err) {
+            errs++;
+            if (errs < 10) {
+                MTestPrintError(err);
+            }
+        }
+
+        err = MPI_Wait(&req, &status);
+
+        errs += MTestCheckStatus(&status, dtp.DTP_base_type, sendcnt, rank, 0, errs < 10);
+        errs += MTest_dtp_check(&recv, 0, 1, sendcnt, errs < 10);
+
+        MTest_dtp_init(&recv, -1, -1, sendcnt);
+
+        err = MPI_Irecv((char *) recv.buf + recv.dtp_obj.DTP_buf_offset,
+                        recvcount, recvtype, rank, 0, comm, &req);
+        if (err) {
+            errs++;
+            if (errs < 10) {
+                MTestPrintError(err);
+            }
+        }
+
+        err = MPI_Rsend((const char *) send.buf + send.dtp_obj.DTP_buf_offset,
+                        sendcount, sendtype, rank, 0, comm);
         if (err) {
             errs++;
             if (errs < 10) {

--- a/test/mpi/rma/acc_ordering.c
+++ b/test/mpi/rma/acc_ordering.c
@@ -25,7 +25,7 @@ typedef struct {
 
 static int errs = 0;
 
-void verify_result(twoint_t * data, int len, twoint_t expected, const char *test_name)
+static void verify_result(twoint_t * data, int len, twoint_t expected, const char *test_name)
 {
     int i;
     for (i = 0; i < len; i++) {
@@ -39,8 +39,8 @@ void verify_result(twoint_t * data, int len, twoint_t expected, const char *test
 
 /* Check non-deterministic result of none ordering.
  * Expected result has two possibilities. */
-void verify_nondeterministic_result(twoint_t * data,
-                                    int len, twoint_t * expected, const char *test_name)
+static void verify_nondeterministic_result(twoint_t * data,
+                                           int len, twoint_t * expected, const char *test_name)
 {
     int i;
     for (i = 0; i < len; i++) {

--- a/test/mpi/rma/acc_ordering.c
+++ b/test/mpi/rma/acc_ordering.c
@@ -58,7 +58,10 @@ static void verify_nondeterministic_result(twoint_t * data,
 int main(int argc, char **argv)
 {
     int me, nproc, i;
-    twoint_t *data, *mine, *mine_plus, *expected;
+    twoint_t *data;
+    twoint_t *mine = NULL;
+    twoint_t *mine_plus = NULL;
+    twoint_t *expected = NULL;
     MPI_Win win;
     MPI_Info info_in;
 

--- a/test/mpi/rma/accfence1.c
+++ b/test/mpi/rma/accfence1.c
@@ -110,7 +110,7 @@ static int accfence_test(int seed, int testsize, int count, const char *basic_ty
                  * as MPI_Put; the only difference is in the
                  * handling of overlapping accumulate operations,
                  * which are not tested here */
-                err = MPI_Accumulate(orig.buf + orig.dtp_obj.DTP_buf_offset, origcount,
+                err = MPI_Accumulate((char *) orig.buf + orig.dtp_obj.DTP_buf_offset, origcount,
                                      origtype, target_rank, target.dtp_obj.DTP_buf_offset / extent,
                                      targetcount, targettype, MPI_REPLACE, win);
                 if (err) {

--- a/test/mpi/rma/accpscw1.c
+++ b/test/mpi/rma/accpscw1.c
@@ -110,7 +110,7 @@ static int accpscw_test(int seed, int testsize, int count, const char *basic_typ
                     }
                 }
                 MPI_Group_free(&neighbors);
-                err = MPI_Accumulate(orig.buf + orig.dtp_obj.DTP_buf_offset, origcount,
+                err = MPI_Accumulate((char *) orig.buf + orig.dtp_obj.DTP_buf_offset, origcount,
                                      origtype, target_rank, target.dtp_obj.DTP_buf_offset / extent,
                                      targetcount, targettype, MPI_REPLACE, win);
                 if (err) {

--- a/test/mpi/rma/aint.c
+++ b/test/mpi/rma/aint.c
@@ -19,9 +19,9 @@ int main(int argc, char **argv)
     int errs = 0;
     int array[1024];
     int val = 0;
-    int target_rank;
+    int target_rank = 0;        /* suppress warnings */
     MPI_Aint bases[2];
-    MPI_Aint disp, offset;
+    MPI_Aint disp, offset = 0;  /* suppress warnings */
     MPI_Win win;
 
     MTest_Init(&argc, &argv);

--- a/test/mpi/rma/at_complete.c
+++ b/test/mpi/rma/at_complete.c
@@ -12,11 +12,12 @@
 #define WIN_SIZE (PUT_SIZE+GET_SIZE)
 #define LOOP 100
 
+int win_buf[WIN_SIZE], orig_get_buf[GET_SIZE], orig_put_buf[PUT_SIZE];
+
 int main(int argc, char **argv)
 {
     MPI_Win win;
     int i, k, rank, nproc;
-    int win_buf[WIN_SIZE], orig_get_buf[GET_SIZE], orig_put_buf[PUT_SIZE];
     int orig_rank = 0, dest_rank = 1;
     int errs = 0;
     MPI_Group comm_group, orig_group, dest_group;

--- a/test/mpi/rma/atomic_rmw_fop.c
+++ b/test/mpi/rma/atomic_rmw_fop.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     int rank, size, i, j, k;
     int errors = 0;
     int origin_shm, origin_am, dest;
-    int my_buf_size;
+    int my_buf_size = 0;        /* to avoid warnings */
     int *orig_buf = NULL, *result_buf = NULL, *target_buf = NULL, *check_buf = NULL;
     MPI_Win win;
     MPI_Status status;

--- a/test/mpi/rma/atomic_rmw_gacc.c
+++ b/test/mpi/rma/atomic_rmw_gacc.c
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
 {
     int i, k;
     int errors = 0;
-    int my_buf_num;
+    int my_buf_num = 0;         /* to suppress warning */
     MPI_Datatype origin_dtp, target_dtp;
 
     MTest_Init(&argc, &argv);

--- a/test/mpi/rma/atomic_rmw_gacc.c
+++ b/test/mpi/rma/atomic_rmw_gacc.c
@@ -31,7 +31,7 @@ int dest, origin_shm, origin_am;
 int *orig_buf = NULL, *result_buf = NULL, *target_buf = NULL, *check_buf = NULL;
 MPI_Win win;
 
-void checkResults(int loop_k, int *errors)
+static void checkResults(int loop_k, int *errors)
 {
     int i, j, m;
     MPI_Status status;

--- a/test/mpi/rma/badrma.c
+++ b/test/mpi/rma/badrma.c
@@ -12,8 +12,8 @@
 MPI_Win win;
 int win_buf[SIZE], origin_buf[SIZE], result_buf[SIZE];
 
-int do_test(int origin_count, MPI_Datatype origin_type, int result_count,
-            MPI_Datatype result_type, int target_count, MPI_Datatype target_type)
+static int do_test(int origin_count, MPI_Datatype origin_type, int result_count,
+                   MPI_Datatype result_type, int target_count, MPI_Datatype target_type)
 {
     int errs = 0, ret, origin_type_size, result_type_size;
 

--- a/test/mpi/rma/epochtest.c
+++ b/test/mpi/rma/epochtest.c
@@ -127,10 +127,9 @@ static int epoch_test(int seed, int testsize, int count, const char *basic_type,
             }
 
             if (rank == orig_rank) {
-                err =
-                    MPI_Put(orig.buf + orig.dtp_obj.DTP_buf_offset, origcount, origtype,
-                            target_rank, target.dtp_obj.DTP_buf_offset / extent, targetcount,
-                            targettype, win);
+                err = MPI_Put((char *) orig.buf + orig.dtp_obj.DTP_buf_offset, origcount, origtype,
+                              target_rank, target.dtp_obj.DTP_buf_offset / extent, targetcount,
+                              targettype, win);
                 if (err) {
                     if (errs++ < MAX_PERR)
                         MTestPrintError(err);
@@ -147,9 +146,9 @@ static int epoch_test(int seed, int testsize, int count, const char *basic_type,
             if (rank == target_rank) {
                 errs += MTest_dtp_check(&target, 0, 1, count, errs < MAX_PERR);
 
-                err =
-                    MPI_Put(orig.buf + orig.dtp_obj.DTP_buf_offset, origcount, origtype, orig_rank,
-                            target.dtp_obj.DTP_buf_offset / extent, targetcount, targettype, win);
+                err = MPI_Put((char *) orig.buf + orig.dtp_obj.DTP_buf_offset,
+                              origcount, origtype, orig_rank,
+                              target.dtp_obj.DTP_buf_offset / extent, targetcount, targettype, win);
                 if (err) {
                     if (errs++ < MAX_PERR)
                         MTestPrintError(err);
@@ -166,19 +165,18 @@ static int epoch_test(int seed, int testsize, int count, const char *basic_type,
             if (rank == orig_rank) {
                 errs += MTest_dtp_check(&target, 0, 1, count, errs < MAX_PERR);
 
-                err =
-                    MPI_Put(orig.buf + orig.dtp_obj.DTP_buf_offset, origcount, origtype,
-                            target_rank, target.dtp_obj.DTP_buf_offset / extent, targetcount,
-                            targettype, win);
+                err = MPI_Put((char *) orig.buf + orig.dtp_obj.DTP_buf_offset, origcount, origtype,
+                              target_rank, target.dtp_obj.DTP_buf_offset / extent, targetcount,
+                              targettype, win);
                 if (err) {
                     if (errs++ < MAX_PERR)
                         MTestPrintError(err);
                 }
             }
             if (rank == target_rank) {
-                err =
-                    MPI_Put(orig.buf + orig.dtp_obj.DTP_buf_offset, origcount, origtype, orig_rank,
-                            target.dtp_obj.DTP_buf_offset / extent, targetcount, targettype, win);
+                err = MPI_Put((char *) orig.buf + orig.dtp_obj.DTP_buf_offset,
+                              origcount, origtype, orig_rank,
+                              target.dtp_obj.DTP_buf_offset / extent, targetcount, targettype, win);
                 if (err) {
                     if (errs++ < MAX_PERR)
                         MTestPrintError(err);

--- a/test/mpi/rma/fence.c
+++ b/test/mpi/rma/fence.c
@@ -76,13 +76,13 @@ static inline int test(MPI_Comm comm, int rank, int orig_rank, int target_rank,
         /* This should have the same effect, in terms of
          * transferring data, as a send/recv pair */
 #if defined(USE_GET)
-        err =
-            MPI_Get(orig.buf + orig.dtp_obj.DTP_buf_offset, origcount, origtype, target_rank,
-                    target.dtp_obj.DTP_buf_offset / extent, targetcount, targettype, win);
+        err = MPI_Get((char *) orig.buf + orig.dtp_obj.DTP_buf_offset,
+                      origcount, origtype, target_rank,
+                      target.dtp_obj.DTP_buf_offset / extent, targetcount, targettype, win);
 #elif defined(USE_PUT)
-        err =
-            MPI_Put(orig.buf + orig.dtp_obj.DTP_buf_offset, origcount, origtype, target_rank,
-                    target.dtp_obj.DTP_buf_offset / extent, targetcount, targettype, win);
+        err = MPI_Put((char *) orig.buf + orig.dtp_obj.DTP_buf_offset,
+                      origcount, origtype, target_rank,
+                      target.dtp_obj.DTP_buf_offset / extent, targetcount, targettype, win);
 #endif
         if (err) {
             errs++;
@@ -118,7 +118,6 @@ static int fence_test(int seed, int testsize, int count, const char *basic_type,
     int rank, size, orig_rank, target_rank;
     int minsize = 2;
     int i;
-    MPI_Aint maxbufsize;
     MPI_Comm comm;
     DTP_pool_s dtp;
     MPI_Aint extent, lb;
@@ -137,8 +136,6 @@ static int fence_test(int seed, int testsize, int count, const char *basic_type,
         MTestPrintfMsg(1, " %s\n", test_desc);
     }
 
-    maxbufsize = MTestDefaultMaxBufferSize();
-
     err = DTP_pool_create(basic_type, count, seed, &dtp);
     if (err != DTP_SUCCESS) {
         fprintf(stderr, "Error while creating orig pool (%s,%d)\n", basic_type, count);
@@ -155,7 +152,7 @@ static int fence_test(int seed, int testsize, int count, const char *basic_type,
 
     int type_size;
     MPI_Type_size(dtp.DTP_base_type, &type_size);
-    if (type_size * count > maxbufsize) {
+    if (type_size * count > MTestDefaultMaxBufferSize()) {
         /* if the type size or count are too large, we do not have too
          * many objects in the pool that we can search for.  in such
          * cases, simply return. */

--- a/test/mpi/rma/fetch_and_op.c
+++ b/test/mpi/rma/fetch_and_op.c
@@ -40,7 +40,7 @@
 
 #define CMP(x, y) ((x - ((TYPE_C) (y))) > 1.0e-9)
 
-void reset_vars(TYPE_C * val_ptr, TYPE_C * res_ptr, MPI_Win win)
+static void reset_vars(TYPE_C * val_ptr, TYPE_C * res_ptr, MPI_Win win)
 {
     int i, rank, nproc;
 

--- a/test/mpi/rma/get_accumulate.c
+++ b/test/mpi/rma/get_accumulate.c
@@ -63,7 +63,7 @@ static void reset_bufs(TYPE_C * win_ptr, TYPE_C * res_ptr, TYPE_C * val_ptr, TYP
 int main(int argc, char **argv)
 {
     int i, rank, nproc;
-    int j, count, errors = 0;
+    int count, errors = 0;
     TYPE_C *win_ptr, *res_ptr, *val_ptr;
     MPI_Win win;
 #if defined (GACC_TYPE_DERIVED)
@@ -75,8 +75,8 @@ int main(int argc, char **argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);
 
-    for (j = 0; j < NUM_COUNT; j++) {
-        count = test_counts[j];
+    for (int k = 0; k < NUM_COUNT; k++) {
+        count = test_counts[k];
         win_ptr = malloc(sizeof(TYPE_C) * nproc * count);
         res_ptr = malloc(sizeof(TYPE_C) * nproc * count);
         val_ptr = malloc(sizeof(TYPE_C) * count);

--- a/test/mpi/rma/linked_list.c
+++ b/test/mpi/rma/linked_list.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
             success = (next_tail_ptr.rank == nil.rank);
 
             if (success) {
-                int i, flag;
+                int flag;
 
                 MPI_Win_lock(MPI_LOCK_EXCLUSIVE, tail_ptr.rank, 0, llist_win);
 
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
 
                 /* For implementations that use pt-to-pt messaging, force progress for other threads'
                  * RMA operations. */
-                for (i = 0; i < NPROBE; i++)
+                for (int j = 0; j < NPROBE; j++)
                     MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &flag,
                                MPI_STATUS_IGNORE);
 

--- a/test/mpi/rma/linked_list.c
+++ b/test/mpi/rma/linked_list.c
@@ -51,7 +51,7 @@ static int my_elems_size = 0;
 static int my_elems_count = 0;
 
 /* Allocate a new shared linked list element */
-MPI_Aint alloc_elem(int value, MPI_Win win)
+static MPI_Aint alloc_elem(int value, MPI_Win win)
 {
     MPI_Aint disp;
     llist_elem_t *elem_ptr;

--- a/test/mpi/rma/linked_list_bench_lock_all.c
+++ b/test/mpi/rma/linked_list_bench_lock_all.c
@@ -53,7 +53,7 @@ static int my_elems_size = 0;
 static int my_elems_count = 0;
 
 /* Allocate a new shared linked list element */
-MPI_Aint alloc_elem(int value, MPI_Win win)
+static MPI_Aint alloc_elem(int value, MPI_Win win)
 {
     MPI_Aint disp;
     llist_elem_t *elem_ptr;

--- a/test/mpi/rma/linked_list_bench_lock_excl.c
+++ b/test/mpi/rma/linked_list_bench_lock_excl.c
@@ -53,7 +53,7 @@ static int my_elems_size = 0;
 static int my_elems_count = 0;
 
 /* Allocate a new shared linked list element */
-MPI_Aint alloc_elem(int value, MPI_Win win)
+static MPI_Aint alloc_elem(int value, MPI_Win win)
 {
     MPI_Aint disp;
     llist_elem_t *elem_ptr;
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
                            (void *) tail_ptr.disp);
 
                 MPI_Win_lock(MPI_LOCK_EXCLUSIVE, tail_ptr.rank, 0, llist_win);
-#if USE_ACC
+#ifdef USE_ACC
                 MPI_Accumulate(&new_elem_ptr, sizeof(llist_ptr_t), MPI_BYTE, tail_ptr.rank,
                                (MPI_Aint) & (((llist_elem_t *) tail_ptr.disp)->next),
                                sizeof(llist_ptr_t), MPI_BYTE, MPI_REPLACE, llist_win);

--- a/test/mpi/rma/linked_list_bench_lock_excl.c
+++ b/test/mpi/rma/linked_list_bench_lock_excl.c
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
                 llist_ptr_t next_tail_ptr;
 
                 MPI_Win_lock(MPI_LOCK_EXCLUSIVE, tail_ptr.rank, 0, llist_win);
-#if USE_ACC
+#ifdef USE_ACC
                 MPI_Get_accumulate(NULL, 0, MPI_DATATYPE_NULL, &next_tail_ptr,
                                    sizeof(llist_ptr_t), MPI_BYTE, tail_ptr.rank,
                                    (MPI_Aint) & (((llist_elem_t *) tail_ptr.disp)->next),

--- a/test/mpi/rma/linked_list_bench_lock_shr.c
+++ b/test/mpi/rma/linked_list_bench_lock_shr.c
@@ -53,7 +53,7 @@ static int my_elems_size = 0;
 static int my_elems_count = 0;
 
 /* Allocate a new shared linked list element */
-MPI_Aint alloc_elem(int value, MPI_Win win)
+static MPI_Aint alloc_elem(int value, MPI_Win win)
 {
     MPI_Aint disp;
     llist_elem_t *elem_ptr;

--- a/test/mpi/rma/linked_list_fop.c
+++ b/test/mpi/rma/linked_list_fop.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
             success = (next_tail_ptr.rank == nil.rank);
 
             if (success) {
-                int i, flag;
+                int flag;
                 MPI_Aint result;
 
                 MPI_Win_lock(MPI_LOCK_SHARED, tail_ptr.rank, MPI_MODE_NOCHECK, llist_win);
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
 
                 /* For implementations that use pt-to-pt messaging, force progress for other threads'
                  * RMA operations. */
-                for (i = 0; i < NPROBE; i++)
+                for (int j = 0; j < NPROBE; j++)
                     MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &flag,
                                MPI_STATUS_IGNORE);
 

--- a/test/mpi/rma/linked_list_fop.c
+++ b/test/mpi/rma/linked_list_fop.c
@@ -51,7 +51,7 @@ static int my_elems_size = 0;
 static int my_elems_count = 0;
 
 /* Allocate a new shared linked list element */
-MPI_Aint alloc_elem(int value, MPI_Win win)
+static MPI_Aint alloc_elem(int value, MPI_Win win)
 {
     MPI_Aint disp;
     llist_elem_t *elem_ptr;

--- a/test/mpi/rma/linked_list_lockall.c
+++ b/test/mpi/rma/linked_list_lockall.c
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
             success = (next_tail_ptr.rank == nil.rank);
 
             if (success) {
-                int i, flag;
+                int flag;
 
                 MPI_Accumulate(&new_elem_ptr.disp, 1, MPI_AINT, tail_ptr.rank,
                                (MPI_Aint) & (((llist_elem_t *) tail_ptr.disp)->next.disp), 1,
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
 
                 /* For implementations that use pt-to-pt messaging, force progress for other threads'
                  * RMA operations. */
-                for (i = 0; i < NPROBE; i++)
+                for (int j = 0; j < NPROBE; j++)
                     MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &flag,
                                MPI_STATUS_IGNORE);
 

--- a/test/mpi/rma/linked_list_lockall.c
+++ b/test/mpi/rma/linked_list_lockall.c
@@ -51,7 +51,7 @@ static int my_elems_size = 0;
 static int my_elems_count = 0;
 
 /* Allocate a new shared linked list element */
-MPI_Aint alloc_elem(int value, MPI_Win win)
+static MPI_Aint alloc_elem(int value, MPI_Win win)
 {
     MPI_Aint disp;
     llist_elem_t *elem_ptr;

--- a/test/mpi/rma/lock_x_dt.c
+++ b/test/mpi/rma/lock_x_dt.c
@@ -45,8 +45,7 @@ static int run_test(MPI_Comm comm, MPI_Win win, int count, enum acc_type acc)
         FLUSH_LOCAL_TYPE__FLUSH_LOCAL,
         FLUSH_LOCAL_TYPE__FLUSH_LOCAL_ALL,
     } flush_local_type;
-    int err, errs = 0;
-
+    int errs = 0;
 
     MPI_Comm_rank(comm, &rank);
     MPI_Comm_size(comm, &size);
@@ -122,7 +121,7 @@ static int run_test(MPI_Comm comm, MPI_Win win, int count, enum acc_type acc)
         int t;
         if (acc == ACC_TYPE__ACC) {
             for (t = target_start_idx; t <= target_end_idx; t++) {
-                MPI_Accumulate(orig.buf + orig.dtp_obj.DTP_buf_offset, origcount,
+                MPI_Accumulate((char *) orig.buf + orig.dtp_obj.DTP_buf_offset, origcount,
                                origtype, t, target.dtp_obj.DTP_buf_offset / base_type_size,
                                targetcount, targettype, MPI_REPLACE, win);
             }
@@ -132,11 +131,11 @@ static int run_test(MPI_Comm comm, MPI_Win win, int count, enum acc_type acc)
 #endif
 
             for (t = target_start_idx; t <= target_end_idx; t++) {
-                MPI_Get_accumulate(orig.buf + orig.dtp_obj.DTP_buf_offset, origcount,
-                                   origtype, result.buf + result.dtp_obj.DTP_buf_offset,
+                MPI_Get_accumulate((char *) orig.buf + orig.dtp_obj.DTP_buf_offset, origcount,
+                                   origtype, (char *) result.buf + result.dtp_obj.DTP_buf_offset,
                                    resultcount, resulttype, t,
-                                   target.dtp_obj.DTP_buf_offset / base_type_size,
-                                   targetcount, targettype, MPI_REPLACE, win);
+                                   target.dtp_obj.DTP_buf_offset / base_type_size, targetcount,
+                                   targettype, MPI_REPLACE, win);
             }
         }
 

--- a/test/mpi/rma/lockcontention3.c
+++ b/test/mpi/rma/lockcontention3.c
@@ -308,24 +308,22 @@ int RMACheck(int i, int *buf, MPI_Aint bufsize)
             break;
         case 3:        /* Datatype single put (strided put) */
         case 6:        /* a few small puts (like strided put, but 1 word at a time) */
-            /* FIXME: The conditional and increment are reversed below.  This looks
-             * like a bug, and currently prevents the following test from running. */
-            for (j = 0; j++; j < veccount) {
-                if (buf[j * stride] != PUT_VAL + j) {
+            for (j = 0; j < veccount; j++) {
+                int pos = j * stride + OFFSET_1;
+                if (buf[pos] != PUT_VAL + j) {
                     errs++;
-                    printf("case %d: value is %d should be %d\n", i, buf[j * stride], PUT_VAL + j);
+                    printf("case %d: buf[%d] is %d should be %d\n", i, pos, buf[pos], PUT_VAL + j);
                 }
             }
             break;
         case 4:        /* Datatype single accumulate (strided acc) */
         case 7:        /* a few small accumulates (like strided acc, but 1 word at a time) */
-            /* FIXME: The conditional and increment are reversed below.  This looks
-             * like a bug, and currently prevents the following test from running. */
-            for (j = 0; j++; j < veccount) {
-                if (buf[j * stride] != ACC_VAL + j + OFFSET_2 + j * stride) {
+            for (j = 0; j < veccount; j++) {
+                int pos = j * stride + OFFSET_2;
+                if (buf[pos] != ACC_VAL + j + OFFSET_2 + j * stride) {
                     errs++;
-                    printf("case %d: value is %d should be %d\n", i,
-                           buf[j * stride], ACC_VAL + j + OFFSET_2 + j * stride);
+                    printf("case %d: buf[%d] is %d should be %d\n", i, pos, buf[pos],
+                           ACC_VAL + j + OFFSET_2 + j * stride);
                 }
             }
             break;

--- a/test/mpi/rma/putpscw1.c
+++ b/test/mpi/rma/putpscw1.c
@@ -110,10 +110,9 @@ static int putpscw_test(int seed, int testsize, int count, const char *basic_typ
                     }
                 }
                 MPI_Group_free(&neighbors);
-                err =
-                    MPI_Put(orig.buf + orig.dtp_obj.DTP_buf_offset, origcount, origtype,
-                            target_rank, target.dtp_obj.DTP_buf_offset / extent, targetcount,
-                            targettype, win);
+                err = MPI_Put((char *) orig.buf + orig.dtp_obj.DTP_buf_offset,
+                              origcount, origtype, target_rank,
+                              target.dtp_obj.DTP_buf_offset / extent, targetcount, targettype, win);
                 if (err) {
                     errs++;
                     MTestPrintError(err);

--- a/test/mpi/rma/req_example.c
+++ b/test/mpi/rma/req_example.c
@@ -25,7 +25,7 @@
  * function. */
 double junk = 0.0;
 
-void compute(int step, double *data)
+static void compute(int step, double *data)
 {
     int i;
 

--- a/test/mpi/rma/rma_contig.c
+++ b/test/mpi/rma/rma_contig.c
@@ -18,7 +18,7 @@
 const int verbose = 0;
 static int rank;
 
-void run_test(int lock_mode, int lock_assert)
+static void run_test(int lock_mode, int lock_assert)
 {
     int nproc, test_iter, target_rank, data_size;
     int *buf, *win_buf;

--- a/test/mpi/rma/win_dynamic_rma_flush_get.c
+++ b/test/mpi/rma/win_dynamic_rma_flush_get.c
@@ -119,7 +119,7 @@ static int check_iteration_data(int x)
 static int run_test(void)
 {
     int errors = 0;
-    int i, x;
+    int x;
     int dst = 0;
     MPI_Aint target_disp = 0;
 

--- a/test/mpi/spawn/spawn_rootargs.c
+++ b/test/mpi/spawn/spawn_rootargs.c
@@ -16,7 +16,7 @@
 
 int main(int argc, char *argv[])
 {
-    char *args[] = { "a", "b", "c", (char *) 0 };
+    char *args[] = { (char *) "a", (char *) "b", (char *) "c", (char *) 0 };
     int rank;
     MPI_Comm parent, child;
 

--- a/test/mpi/spawn/spawninfo1.c
+++ b/test/mpi/spawn/spawninfo1.c
@@ -17,6 +17,7 @@
 /* Needed for getcwd */
 #include <unistd.h>
 #endif
+#include <assert.h>
 
 /*
 static char MTEST_Descrip[] = "A simple test of Comm_spawn with info";
@@ -32,7 +33,6 @@ int main(int argc, char *argv[])
     MPI_Status status;
     MPI_Info spawninfo;
     char curdir[1024], wd[1024], childwd[1024];
-    char *cerr;
     int can_spawn;
 
     MTest_Init(&argc, &argv);
@@ -40,7 +40,8 @@ int main(int argc, char *argv[])
     errs += MTestSpawnPossible(&can_spawn);
 
     if (can_spawn) {
-        cerr = getcwd(curdir, sizeof(curdir));
+        char *s = getcwd(curdir, sizeof(curdir));
+        assert(s != NULL);
 
         MPI_Comm_get_parent(&parentcomm);
 

--- a/test/mpi/spawn/spawnminfo1.c
+++ b/test/mpi/spawn/spawnminfo1.c
@@ -17,6 +17,7 @@
 /* Needed for getcwd */
 #include <unistd.h>
 #endif
+#include <assert.h>
 
 /*
 static char MTEST_Descrip[] = "A simple test of Comm_spawn_multiple with info";
@@ -33,7 +34,6 @@ int main(int argc, char *argv[])
     MPI_Info spawninfos[2];
     char curdir[1024], wd[1024], childwd[1024];
     char *commands[2] = { (char *) "spawnminfo1", (char *) "spawnminfo1" };
-    char *cerr;
     int can_spawn;
 
     MTest_Init(&argc, &argv);
@@ -41,7 +41,8 @@ int main(int argc, char *argv[])
     errs += MTestSpawnPossible(&can_spawn);
 
     if (can_spawn) {
-        cerr = getcwd(curdir, sizeof(curdir));
+        char *s = getcwd(curdir, sizeof(curdir));
+        assert(s != NULL);
 
         MPI_Comm_get_parent(&parentcomm);
 

--- a/test/mpi/threads/coll/allred.c
+++ b/test/mpi/threads/coll/allred.c
@@ -30,9 +30,8 @@
 MPI_Comm comms[NUM_THREADS];
 int rank, size;
 
-MTEST_THREAD_RETURN_TYPE test_iallred(void *arg)
+static MTEST_THREAD_RETURN_TYPE test_iallred(void *arg)
 {
-    MPI_Request req;
     int tid = *(int *) arg;
     int buf[BUF_SIZE];
 

--- a/test/mpi/threads/coll/iallred.c
+++ b/test/mpi/threads/coll/iallred.c
@@ -30,7 +30,7 @@
 MPI_Comm comms[NUM_THREADS];
 int rank, size;
 
-MTEST_THREAD_RETURN_TYPE test_iallred(void *arg)
+static MTEST_THREAD_RETURN_TYPE test_iallred(void *arg)
 {
     MPI_Request req;
     int tid = *(int *) arg;

--- a/test/mpi/threads/comm/comm_create_group_threads.c
+++ b/test/mpi/threads/comm/comm_create_group_threads.c
@@ -24,7 +24,7 @@ MTEST_THREAD_LOCK_TYPE comm_lock;
 int rank, size;
 int verbose = 0;
 
-MTEST_THREAD_RETURN_TYPE test_comm_create_group(void *arg)
+static MTEST_THREAD_RETURN_TYPE test_comm_create_group(void *arg)
 {
     int i;
 

--- a/test/mpi/threads/comm/comm_create_group_threads.c
+++ b/test/mpi/threads/comm/comm_create_group_threads.c
@@ -75,7 +75,7 @@ static MTEST_THREAD_RETURN_TYPE test_comm_create_group(void *arg)
 int main(int argc, char **argv)
 {
     int thread_args[NUM_THREADS];
-    int i, err, provided;
+    int i, provided;
 
     MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 

--- a/test/mpi/threads/comm/comm_create_group_threads2.c
+++ b/test/mpi/threads/comm/comm_create_group_threads2.c
@@ -27,7 +27,7 @@ MPI_Group global_group;
 int rank, size;
 int verbose = 0;
 
-MTEST_THREAD_RETURN_TYPE test_comm_create_group(void *arg)
+static MTEST_THREAD_RETURN_TYPE test_comm_create_group(void *arg)
 {
     int i;
     MPI_Group half_group, full_group;

--- a/test/mpi/threads/comm/comm_create_threads.c
+++ b/test/mpi/threads/comm/comm_create_threads.c
@@ -22,7 +22,7 @@
 MPI_Comm comms[NUM_THREADS];
 int rank, size;
 
-MTEST_THREAD_RETURN_TYPE test_comm_create(void *arg)
+static MTEST_THREAD_RETURN_TYPE test_comm_create(void *arg)
 {
     int i;
 

--- a/test/mpi/threads/comm/comm_create_threads.c
+++ b/test/mpi/threads/comm/comm_create_threads.c
@@ -51,7 +51,7 @@ static MTEST_THREAD_RETURN_TYPE test_comm_create(void *arg)
 int main(int argc, char **argv)
 {
     int thread_args[NUM_THREADS];
-    int i, err, provided;
+    int i, provided;
 
     MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 

--- a/test/mpi/threads/comm/comm_dup_deadlock.c
+++ b/test/mpi/threads/comm/comm_dup_deadlock.c
@@ -24,7 +24,7 @@ MTEST_THREAD_LOCK_TYPE comm_lock;
 int rank, size;
 int verbose = 0;
 
-MTEST_THREAD_RETURN_TYPE test_comm_dup(void *arg)
+static MTEST_THREAD_RETURN_TYPE test_comm_dup(void *arg)
 {
     int rank;
     int i;

--- a/test/mpi/threads/comm/comm_dup_deadlock.c
+++ b/test/mpi/threads/comm/comm_dup_deadlock.c
@@ -21,7 +21,6 @@
 
 MPI_Comm comms[NUM_THREADS];
 MTEST_THREAD_LOCK_TYPE comm_lock;
-int rank, size;
 int verbose = 0;
 
 static MTEST_THREAD_RETURN_TYPE test_comm_dup(void *arg)
@@ -70,9 +69,6 @@ int main(int argc, char **argv)
     MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 
     check(provided == MPI_THREAD_MULTIPLE);
-
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
 
     MTest_thread_lock_create(&comm_lock);
 

--- a/test/mpi/threads/comm/comm_idup.c
+++ b/test/mpi/threads/comm/comm_idup.c
@@ -24,7 +24,7 @@ MTEST_THREAD_LOCK_TYPE comm_lock;
 int rank, size;
 int verbose = 0;
 
-MTEST_THREAD_RETURN_TYPE test_comm_dup(void *arg)
+static MTEST_THREAD_RETURN_TYPE test_comm_dup(void *arg)
 {
     int rank;
     int i;

--- a/test/mpi/threads/comm/comm_idup.c
+++ b/test/mpi/threads/comm/comm_idup.c
@@ -21,7 +21,6 @@
 
 MPI_Comm comms[NUM_THREADS];
 MTEST_THREAD_LOCK_TYPE comm_lock;
-int rank, size;
 int verbose = 0;
 
 static MTEST_THREAD_RETURN_TYPE test_comm_dup(void *arg)
@@ -70,9 +69,6 @@ int main(int argc, char **argv)
     MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 
     check(provided == MPI_THREAD_MULTIPLE);
-
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
 
     MTest_thread_lock_create(&comm_lock);
 

--- a/test/mpi/threads/comm/idup_comm_gen.c
+++ b/test/mpi/threads/comm/idup_comm_gen.c
@@ -21,7 +21,7 @@ int errs[NUM_THREADS] = { 0 };
 
 int verbose = 0;
 
-MTEST_THREAD_RETURN_TYPE test_idup(void *arg)
+static MTEST_THREAD_RETURN_TYPE test_idup(void *arg)
 {
     int i;
     int size, rank;

--- a/test/mpi/threads/comm/idup_deadlock.c
+++ b/test/mpi/threads/comm/idup_deadlock.c
@@ -21,14 +21,13 @@
 
 MPI_Comm comms[NUM_THREADS];
 MTEST_THREAD_LOCK_TYPE comm_lock;
-int rank, size;
+int size;
 int verbose = 0;
 volatile int start_idup[NUM_THREADS];
 
 static MTEST_THREAD_RETURN_TYPE test_comm_dup(void *arg)
 {
     int rank;
-    int i, j;
     int wait;
     int tid = *(int *) arg;
     MPI_Comm_rank(comms[*(int *) arg], &rank);
@@ -38,7 +37,7 @@ static MTEST_THREAD_RETURN_TYPE test_comm_dup(void *arg)
     if (tid % 2 == 0 && rank % 2 == 0) {
         do {
             wait = 0;
-            for (i = 0; i < NUM_THREADS; i++)
+            for (int i = 0; i < NUM_THREADS; i++)
                 wait += start_idup[i];
             MTest_thread_yield();
         } while (wait > NUM_THREADS / 2);
@@ -61,7 +60,6 @@ int main(int argc, char **argv)
 
     check(provided == MPI_THREAD_MULTIPLE);
 
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
     for (i = 0; i < NUM_THREADS; i++) {

--- a/test/mpi/threads/comm/idup_deadlock.c
+++ b/test/mpi/threads/comm/idup_deadlock.c
@@ -25,7 +25,7 @@ int rank, size;
 int verbose = 0;
 volatile int start_idup[NUM_THREADS];
 
-MTEST_THREAD_RETURN_TYPE test_comm_dup(void *arg)
+static MTEST_THREAD_RETURN_TYPE test_comm_dup(void *arg)
 {
     int rank;
     int i, j;

--- a/test/mpi/threads/comm/idup_nb.c
+++ b/test/mpi/threads/comm/idup_nb.c
@@ -42,7 +42,7 @@ int verbose = 0;
    is overlapped with other non-blocking operations on the same communicator or
    on a different communicator.
 */
-MTEST_THREAD_RETURN_TYPE test_intracomm(void *arg)
+static MTEST_THREAD_RETURN_TYPE test_intracomm(void *arg)
 {
     int i, j;
     int root, bcastbuf;
@@ -123,7 +123,7 @@ MTEST_THREAD_RETURN_TYPE test_intracomm(void *arg)
    is overlapped with other non-blocking operations on the same communicator or
    on a different communicator.
 */
-MTEST_THREAD_RETURN_TYPE test_intercomm(void *arg)
+static MTEST_THREAD_RETURN_TYPE test_intercomm(void *arg)
 {
     int rank, rsize, root;
     int i, j;

--- a/test/mpi/threads/comm/idup_nb.c
+++ b/test/mpi/threads/comm/idup_nb.c
@@ -45,7 +45,6 @@ int verbose = 0;
 static MTEST_THREAD_RETURN_TYPE test_intracomm(void *arg)
 {
     int i, j;
-    int root, bcastbuf;
     int rank, size;
     int ans[4], expected[4];
     MPI_Request reqs[NUM_IDUPS1 + NUM_IDUPS2 + 10] = { MPI_REQUEST_NULL };      /* Preallocate enough reqs */
@@ -138,6 +137,9 @@ static MTEST_THREAD_RETURN_TYPE test_intercomm(void *arg)
 
     for (i = 0; i < NUM_ITER; i++) {
         cnt = 0;
+        MPI_Comm_rank(parentcomm, &rank);
+        MPI_Comm_remote_size(parentcomm, &rsize);
+
         if (*(int *) arg == rank)
             MTestSleep(1);
 
@@ -149,8 +151,6 @@ static MTEST_THREAD_RETURN_TYPE test_intercomm(void *arg)
             MPI_Comm_idup(parentcomm, &comms[j], &reqs[cnt++]);
 
         /* Issue an Iallreduce on parentcomm */
-        MPI_Comm_rank(parentcomm, &rank);
-        MPI_Comm_remote_size(parentcomm, &rsize);
         MPI_Iallreduce(&rank, &ans[0], 1, MPI_INT, MPI_SUM, parentcomm, &reqs[cnt++]);
         expected[0] = (rsize - 1) * rsize / 2;
         /* Wait for the first child comm to be ready */

--- a/test/mpi/threads/mpi_t/mpit_threading.c
+++ b/test/mpi/threads/mpi_t/mpit_threading.c
@@ -39,7 +39,7 @@ int PrintControlVars(FILE * fp, int myThreadId);
 int PrintPerfVars(FILE * fp, int myThreadId);
 int PrintCategories(FILE * fp, int myThreadId);
 
-MTEST_THREAD_RETURN_TYPE RunTest(void *p)
+static MTEST_THREAD_RETURN_TYPE RunTest(void *p)
 {
     int myThreadId = (int) (long) p;
 

--- a/test/mpi/threads/mpi_t/mpit_threading.c
+++ b/test/mpi/threads/mpi_t/mpit_threading.c
@@ -27,11 +27,12 @@ const int NTHREADS = 8;
 static int verbose = 0;
 #define DOPRINT (verbose && myThreadId == 0)
 
-char *mpit_scopeToStr(int scope);
-char *mpit_bindingToStr(int binding);
-char *mpit_validDtypeStr(MPI_Datatype datatype);
-char *mpit_varclassToStr(int varClass);
-char *mpit_verbosityToStr(int verbosity);
+const char *mpit_scopeToStr(int scope);
+const char *mpit_bindingToStr(int binding);
+const char *mpit_validDtypeStr(MPI_Datatype datatype);
+const char *mpit_varclassToStr(int varClass);
+const char *mpit_verbosityToStr(int verbosity);
+const char *mpit_errclassToStr(int err);
 int perfvarReadInt(int pvarIndex, int isContinuous, int *found);
 unsigned int perfvarReadUint(int pvarIndex, int isContinuous, int *found);
 double perfvarReadDouble(int pvarIndex, int isContinuous, int *found);
@@ -291,9 +292,9 @@ int PrintCategories(FILE * fp, int myThreadId)
 
 /* --- Support routines --- */
 
-char *mpit_validDtypeStr(MPI_Datatype datatype)
+const char *mpit_validDtypeStr(MPI_Datatype datatype)
 {
-    char *p = 0;
+    const char *p = 0;
     if (datatype == MPI_INT)
         p = "MPI_INT";
     else if (datatype == MPI_UNSIGNED)
@@ -324,9 +325,9 @@ char *mpit_validDtypeStr(MPI_Datatype datatype)
     return p;
 }
 
-char *mpit_scopeToStr(int scope)
+const char *mpit_scopeToStr(int scope)
 {
-    char *p = 0;
+    const char *p = 0;
     switch (scope) {
         case MPI_T_SCOPE_CONSTANT:
             p = "SCOPE_CONSTANT";
@@ -356,9 +357,9 @@ char *mpit_scopeToStr(int scope)
     return p;
 }
 
-char *mpit_bindingToStr(int binding)
+const char *mpit_bindingToStr(int binding)
 {
-    char *p;
+    const char *p;
     switch (binding) {
         case MPI_T_BIND_NO_OBJECT:
             p = "NO_OBJECT";
@@ -399,9 +400,9 @@ char *mpit_bindingToStr(int binding)
     return p;
 }
 
-char *mpit_varclassToStr(int varClass)
+const char *mpit_varclassToStr(int varClass)
 {
-    char *p = 0;
+    const char *p = 0;
     switch (varClass) {
         case MPI_T_PVAR_CLASS_STATE:
             p = "CLASS_STATE";
@@ -440,9 +441,9 @@ char *mpit_varclassToStr(int varClass)
     return p;
 }
 
-char *mpit_verbosityToStr(int verbosity)
+const char *mpit_verbosityToStr(int verbosity)
 {
-    char *p = 0;
+    const char *p = 0;
     switch (verbosity) {
         case MPI_T_VERBOSITY_USER_BASIC:
             p = "VERBOSITY_USER_BASIC";
@@ -478,9 +479,9 @@ char *mpit_verbosityToStr(int verbosity)
     return p;
 }
 
-char *mpit_errclassToStr(int err)
+const char *mpit_errclassToStr(int err)
 {
-    char *p = 0;
+    const char *p = 0;
     switch (err) {
         case MPI_T_ERR_MEMORY:
             p = "ERR_MEMORY";

--- a/test/mpi/threads/perf/mt_pt2pt_msgrate.c
+++ b/test/mpi/threads/perf/mt_pt2pt_msgrate.c
@@ -84,6 +84,7 @@ MTEST_THREAD_RETURN_TYPE thread_fn(void *arg)
     }
 
     free(buf);
+    return 0;
 }
 
 

--- a/test/mpi/threads/pt2pt/alltoall.c
+++ b/test/mpi/threads/pt2pt/alltoall.c
@@ -11,12 +11,6 @@
 #endif
 #include <stdio.h>
 
-#ifdef DO_DEBUG
-#define DEBUG(_a){ _a ;fflush(stdout);}
-#else
-#define DEBUG(_a)
-#endif
-
 #define NUM_ITER 10000
 
 const int REQ_TAG = 111;
@@ -49,7 +43,7 @@ MTEST_THREAD_RETURN_TYPE listener(void *extra)
         /* get request source */
         source = stat.MPI_SOURCE;
 
-        DEBUG(printf("node %d got request %d from %d\n", rank, req, source));
+        MTestPrintfMsg(1, "node %d got request %d from %d\n", rank, req, source);
 
         if (req == -1)
             ++no_fins;  /* one more node finished requesting */
@@ -59,7 +53,7 @@ MTEST_THREAD_RETURN_TYPE listener(void *extra)
             break;
     }
 
-    DEBUG(printf("node %d has stopped listener\n", rank));
+    MTestPrintfMsg(1, "node %d has stopped listener\n", rank);
     return MTEST_THREAD_RETVAL_IGN;
 }
 

--- a/test/mpi/threads/pt2pt/ibsend.c
+++ b/test/mpi/threads/pt2pt/ibsend.c
@@ -33,7 +33,7 @@
 
 int rank, size;
 
-MTEST_THREAD_RETURN_TYPE receiver(void *ptr)
+static MTEST_THREAD_RETURN_TYPE receiver(void *ptr)
 {
     int k;
     char buf[MSGSIZE];
@@ -46,7 +46,7 @@ MTEST_THREAD_RETURN_TYPE receiver(void *ptr)
 }
 
 
-MTEST_THREAD_RETURN_TYPE sender_bsend(void *ptr)
+static MTEST_THREAD_RETURN_TYPE sender_bsend(void *ptr)
 {
     char buffer[MSGSIZE];
     int i;
@@ -57,7 +57,7 @@ MTEST_THREAD_RETURN_TYPE sender_bsend(void *ptr)
     return NULL;
 }
 
-MTEST_THREAD_RETURN_TYPE sender_ibsend(void *ptr)
+static MTEST_THREAD_RETURN_TYPE sender_ibsend(void *ptr)
 {
     char buffer[MSGSIZE];
     int i;
@@ -70,7 +70,7 @@ MTEST_THREAD_RETURN_TYPE sender_ibsend(void *ptr)
     return NULL;
 }
 
-MTEST_THREAD_RETURN_TYPE sender_isend(void *ptr)
+static MTEST_THREAD_RETURN_TYPE sender_isend(void *ptr)
 {
     char buffer[MSGSIZE];
     int i;
@@ -83,7 +83,7 @@ MTEST_THREAD_RETURN_TYPE sender_isend(void *ptr)
     return NULL;
 }
 
-MTEST_THREAD_RETURN_TYPE sender_send(void *ptr)
+static MTEST_THREAD_RETURN_TYPE sender_send(void *ptr)
 {
     char buffer[MSGSIZE];
     int i;

--- a/test/mpi/threads/pt2pt/ibsend.c
+++ b/test/mpi/threads/pt2pt/ibsend.c
@@ -97,11 +97,10 @@ static MTEST_THREAD_RETURN_TYPE sender_send(void *ptr)
 int main(int argc, char *argv[])
 {
 
-    int provided, i[2], k;
+    int provided, k;
     char *buffer, *ptr_dt;
     buffer = (char *) malloc(BUFSIZE * sizeof(char));
     MTEST_VG_MEM_INIT(buffer, BUFSIZE * sizeof(char));
-    MPI_Status status;
     MPI_Comm communicator;
     int bs;
 

--- a/test/mpi/threads/pt2pt/mt_mpicancel.c
+++ b/test/mpi/threads/pt2pt/mt_mpicancel.c
@@ -25,9 +25,9 @@ MTEST_THREAD_RETURN_TYPE run_test(void *arg)
     /* Rank 0 posts MPI_Irecv to receive from rank 1, but cancels them */
     if (rank == 0) {
         int i, flag;
-        int buffer[p->iter];
-        MPI_Request request[p->iter];
-        MPI_Status status[p->iter];
+        int *buffer = malloc(p->iter * sizeof(int));
+        MPI_Request *request = malloc(p->iter * sizeof(MPI_Request));
+        MPI_Status *status = malloc(p->iter * sizeof(MPI_Status));
 
         /* Post irecv requests */
         for (i = 0; i < p->iter; i++)
@@ -44,6 +44,9 @@ MTEST_THREAD_RETURN_TYPE run_test(void *arg)
             if (!flag)
                 p->result++;
         }
+        free(buffer);
+        free(request);
+        free(status);
     }
 
     return (MTEST_THREAD_RETURN_TYPE) NULL;
@@ -52,7 +55,7 @@ MTEST_THREAD_RETURN_TYPE run_test(void *arg)
 /* Launch multiple threads */
 static int cancel_recv_test(int iter)
 {
-    int i, j, errs = 0;
+    int i, errs = 0;
     struct thread_param params[NTHREADS];
     MPI_Comm dup_worlds[NTHREADS];
 
@@ -79,7 +82,7 @@ static int cancel_recv_test(int iter)
 
 int main(int argc, char **argv)
 {
-    int i, pmode, nprocs, rank, errs = 0, err;
+    int pmode, nprocs, errs = 0, err;
 
     MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &pmode);
     if (pmode != MPI_THREAD_MULTIPLE) {

--- a/test/mpi/threads/pt2pt/mt_mpicancel.c
+++ b/test/mpi/threads/pt2pt/mt_mpicancel.c
@@ -50,7 +50,7 @@ MTEST_THREAD_RETURN_TYPE run_test(void *arg)
 }
 
 /* Launch multiple threads */
-int cancel_recv_test(int iter)
+static int cancel_recv_test(int iter)
 {
     int i, j, errs = 0;
     struct thread_param params[NTHREADS];

--- a/test/mpi/threads/pt2pt/mt_pers_sendrecv_impl.c
+++ b/test/mpi/threads/pt2pt/mt_pers_sendrecv_impl.c
@@ -11,9 +11,14 @@
 #define SENDINIT JOIN(SEND_FUN, _init)
 
 int pers_sendrecv_kernel(int id, int rank, int count, int *buff, MPI_Comm comm, int tag,
+                         MPI_Request * r, MPI_Status * s, int verify);
+int test_pers_sendrecv(int id, int iter, int count, int *buff, MPI_Comm comm, int tag, int verify);
+MTEST_THREAD_RETURN_TYPE run_test(void *arg);
+
+int pers_sendrecv_kernel(int id, int rank, int count, int *buff, MPI_Comm comm, int tag,
                          MPI_Request * r, MPI_Status * s, int verify)
 {
-    int errs = 0, err, i;
+    int errs = 0, i;
 
     if (rank == 0) {
         for (i = 0; i < count; i++)
@@ -40,7 +45,7 @@ int pers_sendrecv_kernel(int id, int rank, int count, int *buff, MPI_Comm comm, 
 
 int test_pers_sendrecv(int id, int iter, int count, int *buff, MPI_Comm comm, int tag, int verify)
 {
-    int errs = 0, err, i, rank;
+    int errs = 0, i, rank;
     MPI_Datatype type = MPI_INT;
     MPI_Comm_rank(comm, &rank);
 

--- a/test/mpi/threads/pt2pt/mt_pt2pt_common.c
+++ b/test/mpi/threads/pt2pt/mt_pt2pt_common.c
@@ -95,7 +95,6 @@ int main(int argc, char **argv)
         MTestPrintfMsg(1, "Testing MT Send-Recv with same comm, same tag\n");
 
     for (i = 0; i < NTHREADS; i++) {
-        int err;
         params[i].buff = malloc(sizeof(int) * BUFF_ELEMENT_COUNT(iter, count));
         params[i].id = i;
         params[i].iter = iter;

--- a/test/mpi/threads/pt2pt/mt_sendrecv_impl.c
+++ b/test/mpi/threads/pt2pt/mt_sendrecv_impl.c
@@ -5,9 +5,16 @@
 
 #include "mt_pt2pt_common.h"
 
+int test_sendrecv(int id, int iter, int *buff, MPI_Comm comm, int tag, int verify);
+int test_sendrecv_huge(int id, int iter, int count, int *buff, MPI_Comm comm, int tag, int verify);
+int test_isendirecv(int id, int iter, int *buff, MPI_Comm comm, int tag, int verify);
+int test_isendirecv_huge(int id, int iter, int count, int *buff, MPI_Comm comm, int tag,
+                         int verify);
+MTEST_THREAD_RETURN_TYPE run_test(void *arg);
+
 int test_sendrecv(int id, int iter, int *buff, MPI_Comm comm, int tag, int verify)
 {
-    int errs = 0, err, i, rank;
+    int errs = 0, i, rank;
     MPI_Datatype type = MPI_INT;
 
     MPI_Comm_rank(comm, &rank);
@@ -43,7 +50,7 @@ int test_sendrecv(int id, int iter, int *buff, MPI_Comm comm, int tag, int verif
 
 int test_sendrecv_huge(int id, int iter, int count, int *buff, MPI_Comm comm, int tag, int verify)
 {
-    int errs = 0, err, i, rank;
+    int errs = 0, i, rank;
     MPI_Datatype type = MPI_INT;
 
     MPI_Comm_rank(comm, &rank);
@@ -83,8 +90,8 @@ int test_sendrecv_huge(int id, int iter, int count, int *buff, MPI_Comm comm, in
 
 int test_isendirecv(int id, int iter, int *buff, MPI_Comm comm, int tag, int verify)
 {
-    int errs = 0, err, i, rank;
-    MPI_Request *reqs = alloca(sizeof(MPI_Request) * iter);
+    int errs = 0, i, rank;
+    MPI_Request *reqs = malloc(sizeof(MPI_Request) * iter);
     MPI_Datatype type = MPI_INT;
 
     MPI_Comm_rank(comm, &rank);
@@ -122,12 +129,13 @@ int test_isendirecv(int id, int iter, int *buff, MPI_Comm comm, int tag, int ver
     }
 
   fn_exit:
+    free(reqs);
     return errs;
 }
 
 int test_isendirecv_huge(int id, int iter, int count, int *buff, MPI_Comm comm, int tag, int verify)
 {
-    int errs = 0, err, i, j, rank;
+    int errs = 0, i, j, rank;
     MPI_Request req;
     MPI_Datatype type = MPI_INT;
 

--- a/test/mpi/threads/pt2pt/threads.c
+++ b/test/mpi/threads/pt2pt/threads.c
@@ -43,7 +43,6 @@ MTEST_THREAD_RETURN_TYPE run_test(void *arg)
     MPI_Request req[WINDOW];
     double start, end;
     int err;
-    int local_num_threads = -1;
 
     if (tp[thread_id].use_proc_null)
         peer = MPI_PROC_NULL;
@@ -53,7 +52,6 @@ MTEST_THREAD_RETURN_TYPE run_test(void *arg)
     err = MTest_thread_lock(&num_threads_lock);
     if (err)
         ABORT_MSG("unable to acquire lock, aborting\n");
-    local_num_threads = num_threads;
     err = MTest_thread_unlock(&num_threads_lock);
     if (err)
         ABORT_MSG("unable to release lock, aborting\n");

--- a/test/mpi/threads/rma/multifence.c
+++ b/test/mpi/threads/rma/multifence.c
@@ -15,7 +15,7 @@ MPI_Win win[NUM_THREADS];
 int *win_mem[NUM_THREADS];
 int rank, nprocs;
 int thread_errs[NUM_THREADS];
-MTEST_THREAD_RETURN_TYPE run_test(void *arg)
+static MTEST_THREAD_RETURN_TYPE run_test(void *arg)
 {
     int i;
     int *local_b;

--- a/test/mpi/threads/rma/multiget.c
+++ b/test/mpi/threads/rma/multiget.c
@@ -15,7 +15,7 @@
 
 MPI_Win win;
 
-MTEST_THREAD_RETURN_TYPE run_test(void *arg)
+static MTEST_THREAD_RETURN_TYPE run_test(void *arg)
 {
     int i;
     double *local_b;

--- a/test/mpi/threads/rma/multirma.c
+++ b/test/mpi/threads/rma/multirma.c
@@ -16,7 +16,7 @@
 MPI_Win win;
 int errs = 0, dummy;
 
-MTEST_THREAD_RETURN_TYPE run_test(void *arg)
+static MTEST_THREAD_RETURN_TYPE run_test(void *arg)
 {
     int i;
 

--- a/test/mpi/util/dtypes.c
+++ b/test/mpi/util/dtypes.c
@@ -55,6 +55,8 @@ static int basic_only = 0;
    has been received.
  */
 
+#define MYNAME_SIZE MPI_MAX_OBJECT_NAME + 50
+
 /*
    Add a predefined MPI type to the tests.  _count instances of the
    type will be sent.
@@ -83,9 +85,9 @@ static int basic_only = 0;
   outbufs[cnt] = (void *)malloc(sizeof(_ctype) * (_count));	\
   a = (_ctype *)inbufs[cnt]; for (i=0; i<(_count); i++) a[i] = i;	\
   a = (_ctype *)outbufs[cnt]; for (i=0; i<(_count); i++) a[i] = 0;	\
-  myname = (char *)malloc(100);\
+  myname = (char *)malloc(MYNAME_SIZE);\
   MPI_Type_get_name(_mpitype, _basename, &_basenamelen); \
-  snprintf(myname, 100, "Contig type %s", _basename);	\
+  snprintf(myname, MYNAME_SIZE, "Contig type %s", _basename);	\
   MPI_Type_set_name(types[cnt], myname); \
   free(myname); \
   counts[cnt]  = 1;  bytesize[cnt] = sizeof(_ctype) * (_count); cnt++; }
@@ -104,9 +106,9 @@ static int basic_only = 0;
   outbufs[cnt] = (void *)calloc(sizeof(_ctype) * (_count) * (_stride),1); \
   a = (_ctype *)inbufs[cnt]; for (i=0; i<(_count); i++) a[i*(_stride)] = i; \
   a = (_ctype *)outbufs[cnt]; for (i=0; i<(_count); i++) a[i*(_stride)] = 0; \
-  myname = (char *)malloc(100);\
+  myname = (char *)malloc(MYNAME_SIZE);\
   MPI_Type_get_name(_mpitype, _basename, &_basenamelen); \
-  snprintf(myname, 100, "Vector type %s", _basename);		\
+  snprintf(myname, MYNAME_SIZE, "Vector type %s", _basename);		\
   MPI_Type_set_name(types[cnt], myname); \
   free(myname); \
   counts[cnt]  = 1; bytesize[cnt] = sizeof(_ctype) * (_count) * (_stride) ;\
@@ -129,9 +131,9 @@ static int basic_only = 0;
   outbufs[cnt] = (void *)malloc(sizeof(_ctype) * (_count)); \
   a = (_ctype *)inbufs[cnt]; for (i=0; i<(_count); i++) a[i] = i; \
   a = (_ctype *)outbufs[cnt]; for (i=0; i<(_count); i++) a[i] = 0; \
-  myname = (char *)malloc(100);\
+  myname = (char *)malloc(MYNAME_SIZE);\
   MPI_Type_get_name(_mpitype, _basename, &_basenamelen); \
-  snprintf(myname, 100, "Index type %s", _basename);		\
+  snprintf(myname, MYNAME_SIZE, "Index type %s", _basename);		\
   MPI_Type_set_name(types[cnt], myname); \
   free(myname); \
   counts[cnt]  = 1;  bytesize[cnt] = sizeof(_ctype) * (_count); cnt++; }
@@ -159,8 +161,8 @@ static int basic_only = 0;
       a[i].a2 = i; }							\
   a = (struct name *)outbufs[cnt]; for (i=0; i<(_count); i++) { a[i].a1 = 0; \
       a[i].a2 = 0; }							\
-  myname = (char *)malloc(100);					\
-  snprintf(myname, 100, "Struct type %s", _tname);		\
+  myname = (char *)malloc(MYNAME_SIZE);					\
+  snprintf(myname, MYNAME_SIZE, "Struct type %s", _tname);		\
   MPI_Type_set_name(types[cnt], myname); \
   free(myname); \
   counts[cnt]  = (_count);  bytesize[cnt] = sizeof(struct name) * (_count);cnt++; }
@@ -176,9 +178,9 @@ static int basic_only = 0;
   outbufs[cnt] = (void *)calloc(sizeof(_ctype) * (_count) * (_stride),1);\
   a = (_ctype *)inbufs[cnt]; for (i=0; i<(_count); i++) a[i*(_stride)] = i;  \
   a = (_ctype *)outbufs[cnt]; for (i=0; i<(_count); i++) a[i*(_stride)] = 0; \
-  myname = (char *)malloc(100);					\
+  myname = (char *)malloc(MYNAME_SIZE);					\
   MPI_Type_get_name(_mpitype, _basename, &_basenamelen); \
-  snprintf(myname, 100, "Struct (MPI_UB) type %s", _basename);	\
+  snprintf(myname, MYNAME_SIZE, "Struct (MPI_UB) type %s", _basename);	\
   MPI_Type_set_name(types[cnt], myname); \
   free(myname); \
   counts[cnt]  = (_count);  \
@@ -344,7 +346,7 @@ int MTestDatatype2Check(void *inbuf, void *outbuf, int size_bytes)
 /*
  * This is a version of CheckData that prints error messages
  */
-int MtestDatatype2CheckAndPrint(void *inbuf, void *outbuf, int size_bytes,
+int MTestDatatype2CheckAndPrint(void *inbuf, void *outbuf, int size_bytes,
                                 char *typename, int typenum)
 {
     int errloc, world_rank;

--- a/test/mpi/util/mtest.c
+++ b/test/mpi/util/mtest.c
@@ -45,7 +45,6 @@ static void MTestResourceSummary(FILE *);
    memory testing */
 
 static int dbgflag = 0;         /* Flag used for debugging */
-static int wrank = -1;          /* World rank */
 static int verbose = 0;         /* Message level (0 is none) */
 static int returnWithVal = 1;   /* Allow programs to return with a non-zero
                                  * if there was an error (may cause problems
@@ -97,7 +96,6 @@ void MTest_Init_thread(int *argc, char ***argv, int required, int *provided)
     /* Check for debugging control */
     if (getenv("MPITEST_DEBUG")) {
         dbgflag = 1;
-        MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
     }
 
     /* Check for verbose control */
@@ -1084,11 +1082,10 @@ void MTestPrintErrorMsg(const char msg[], int errcode)
 void MTestPrintfMsg(int level, const char format[], ...)
 {
     va_list list;
-    int n;
 
     if (verbose && level <= verbose) {
         va_start(list, format);
-        n = vprintf(format, list);
+        vprintf(format, list);
         va_end(list);
         fflush(stdout);
     }


### PR DESCRIPTION
## Pull Request Description

There are many warnings in tests under `--enable-strict`.  This PR tries to fix most of them.

This is split from #5067 and it is tested over there.

There are a lot of changes, but most of them are trivial warning fix --
* remove `mpi_errno` return if the test did not check them
* Avoid allocating large arrays on the stack
* remove used variables
* use `MTestPrintfMsg` to avoid unused variable warning due to `#ifdef`
* use `static` to avoid "missing prototype" warnings (unless it is to be linked to fortran, where we declare the prototypes)
* use `assert` to avoid ignoring returns from `getcwd`, `fgets`, and `system`
* ~~Added `AC_USE_SYSTEM_EXTENSIONS` and move `mpitest.h` to the first inclusion order -- mostly due to use of `strdup`~~
* Added configure check for `strdup` and `usleep`

Also included is a fix to add a missing `return` from PR #5000.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
