### PR TITLE
gpu: fix ze info hints

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_internal.h
+++ b/src/mpi/datatype/typerep/src/typerep_internal.h
@@ -29,25 +29,26 @@ static inline yaksa_info_t MPII_yaksa_get_info(MPL_pointer_attr_t * inattr,
     yaksa_info_t info;
     yaksa_info_create(&info);
 #ifdef MPL_HAVE_GPU
-#if MPL_HAVE_GPU == MPL_GPU_TYPE_CUDA
+    /* Note: MPL_GPU_TYPE_CUDA/ZE are enums, can't be used in #if-expression. Use a branch
+     * in stead. The branch should be optimized away. */
     int rc;
-    yaksa_info_keyval_append(info, "yaksa_gpu_driver", "cuda", 5);
-    rc = yaksa_info_keyval_append(info, "yaksa_cuda_inbuf_ptr_attr", &inattr->device_attr,
-                                  sizeof(MPL_gpu_device_attr));
-    MPIR_Assert(rc == 0);
-    rc = yaksa_info_keyval_append(info, "yaksa_cuda_outbuf_ptr_attr", &outattr->device_attr,
-                                  sizeof(MPL_gpu_device_attr));
-    MPIR_Assert(rc == 0);
-#elif MPL_HAVE_GPU == MPL_GPU_TYPE_ZE
-    int rc;
-    yaksa_info_keyval_append(info, "yaksa_gpu_driver", "ze", 3);
-    rc = yaksa_info_keyval_append(info, "yaksa_ze_inbuf_ptr_attr", &inattr->device_attr,
-                                  sizeof(MPL_gpu_device_attr));
-    MPIR_Assert(rc == 0);
-    rc = yaksa_info_keyval_append(info, "yaksa_ze_outbuf_ptr_attr", &outattr->device_attr,
-                                  sizeof(MPL_gpu_device_attr));
-    MPIR_Assert(rc == 0);
-#endif
+    if (MPL_HAVE_GPU == MPL_GPU_TYPE_CUDA) {
+        yaksa_info_keyval_append(info, "yaksa_gpu_driver", "cuda", 5);
+        rc = yaksa_info_keyval_append(info, "yaksa_cuda_inbuf_ptr_attr", &inattr->device_attr,
+                                      sizeof(MPL_gpu_device_attr));
+        MPIR_Assert(rc == 0);
+        rc = yaksa_info_keyval_append(info, "yaksa_cuda_outbuf_ptr_attr", &outattr->device_attr,
+                                      sizeof(MPL_gpu_device_attr));
+        MPIR_Assert(rc == 0);
+    } else if (MPL_HAVE_GPU == MPL_GPU_TYPE_ZE) {
+        yaksa_info_keyval_append(info, "yaksa_gpu_driver", "ze", 3);
+        rc = yaksa_info_keyval_append(info, "yaksa_ze_inbuf_ptr_attr", &inattr->device_attr,
+                                      sizeof(MPL_gpu_device_attr));
+        MPIR_Assert(rc == 0);
+        rc = yaksa_info_keyval_append(info, "yaksa_ze_outbuf_ptr_attr", &outattr->device_attr,
+                                      sizeof(MPL_gpu_device_attr));
+        MPIR_Assert(rc == 0);
+    }
 #endif
     return info;
 }

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -8,9 +8,14 @@
 
 #include "level_zero/ze_api.h"
 
+typedef struct {
+    ze_memory_allocation_properties_t prop;
+    ze_device_handle_t device;
+} ze_alloc_attr_t;
+
 typedef ze_ipc_mem_handle_t MPL_gpu_ipc_mem_handle_t;
 typedef ze_device_handle_t MPL_gpu_device_handle_t;
-typedef ze_memory_allocation_properties_t MPL_gpu_device_attr;
+typedef ze_alloc_attr_t MPL_gpu_device_attr;
 #define MPL_GPU_DEVICE_INVALID NULL
 
 #endif /* ifndef MPL_GPU_ZE_H_INCLUDED */

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -170,12 +170,12 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     ze_result_t ret;
-    ze_device_handle_t device;
-    memset(&attr->device_attr, 0, sizeof(ze_memory_allocation_properties_t));
-    ret = zeMemGetAllocProperties(global_ze_context, ptr, &attr->device_attr, &device);
+    memset(&attr->device_attr.prop, 0, sizeof(ze_memory_allocation_properties_t));
+    ret = zeMemGetAllocProperties(global_ze_context, ptr,
+                                  &attr->device_attr.prop, &attr->device_attr.device);
     ZE_ERR_CHECK(ret);
-    attr->device = device;
-    switch (attr->device_attr.type) {
+    attr->device = attr->device_attr.device;
+    switch (attr->device_attr.prop.type) {
         case ZE_MEMORY_TYPE_UNKNOWN:
             attr->type = MPL_GPU_POINTER_UNREGISTERED_HOST;
             break;

--- a/test/mpi/util/mtest_common.c
+++ b/test/mpi/util/mtest_common.c
@@ -333,7 +333,7 @@ ze_event_pool_handle_t *event_pools = NULL;
 
 /* allocates memory of specified type */
 void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devicebuf,
-                bool is_calloc, int device)
+                bool is_calloc, int device_id)
 {
 #ifdef HAVE_CUDA
     if (ndevices == -1) {
@@ -463,7 +463,7 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
         if (hostbuf)
             *hostbuf = *devicebuf;
     } else if (type == MTEST_MEM_TYPE__DEVICE) {
-        cudaSetDevice(device % ndevices);
+        cudaSetDevice(device_id % ndevices);
         cudaMalloc(devicebuf, size);
         if (hostbuf) {
             cudaMallocHost(hostbuf, size);
@@ -471,7 +471,7 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
                 memset(*hostbuf, 0, size);
         }
     } else if (type == MTEST_MEM_TYPE__SHARED) {
-        cudaSetDevice(device % ndevices);
+        cudaSetDevice(device_id % ndevices);
         cudaMallocManaged(devicebuf, size, cudaMemAttachGlobal);
         if (hostbuf)
             *hostbuf = *devicebuf;
@@ -505,9 +505,8 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
         /* Currently ZE ignores this argument and uses an internal alignment
          * value. However, this behavior can change in the future. */
         mem_alignment = 1;
-        zerr =
-            zeMemAllocDevice(context, &device_desc, size, mem_alignment, device[device % ndevices],
-                             devicebuf);
+        zerr = zeMemAllocDevice(context, &device_desc, size, mem_alignment,
+                                device[device_id % ndevices], devicebuf);
         assert(zerr == ZE_RESULT_SUCCESS);
 
         if (hostbuf) {
@@ -536,7 +535,7 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
         mem_alignment = 1;
         zerr =
             zeMemAllocShared(context, &device_desc, &host_desc, size, mem_alignment,
-                             device[device % ndevices], devicebuf);
+                             device[device_id % ndevices], devicebuf);
         assert(zerr == ZE_RESULT_SUCCESS);
         if (hostbuf)
             *hostbuf = *devicebuf;


### PR DESCRIPTION
## Pull Request Description
The info hints for ze was packed with wrong struct. Yaksa internally use an unexposed struct for that attribute, but it is simple enough to define it in `MPL`. This patch should fix the ze assertion failure (in info hooks).

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
