### PR TITLE
datatype: additonal fix pack/unpack external32

### DIFF
--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -708,9 +708,9 @@ static int contig_unpack_external32_to_buf(MPI_Aint * blocks_p,
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CONTIG_UNPACK_EXTERNAL32_TO_BUF);
 
-    src_el_size = MPIR_Datatype_get_basic_size(el_type);
-    dest_el_size = MPII_Typerep_get_basic_size_external32(el_type);
-    MPIR_Assert(dest_el_size);
+    dest_el_size = MPIR_Datatype_get_basic_size(el_type);
+    src_el_size = MPII_Typerep_get_basic_size_external32(el_type);
+    MPIR_Assert(src_el_size);
 
     /*
      * h  = handle value
@@ -735,13 +735,13 @@ static int contig_unpack_external32_to_buf(MPI_Aint * blocks_p,
     } else if (is_float_type(el_type)) {
         external32_float_convert(((char *) bufp) + rel_off,
                                  paramp->u.unpack.unpack_buffer,
-                                 src_el_size, dest_el_size, *blocks_p);
+                                 dest_el_size, src_el_size, *blocks_p);
     } else {
         external32_basic_convert(((char *) bufp) + rel_off,
                                  paramp->u.unpack.unpack_buffer,
-                                 src_el_size, dest_el_size, *blocks_p);
+                                 dest_el_size, src_el_size, *blocks_p);
     }
-    paramp->u.unpack.unpack_buffer += (dest_el_size * (*blocks_p));
+    paramp->u.unpack.unpack_buffer += (src_el_size * (*blocks_p));
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_CONTIG_UNPACK_EXTERNAL32_TO_BUF);
     return 0;

--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -685,6 +685,11 @@ static int contig_pack_external32_to_buf(MPI_Aint * blocks_p,
     /* TODO: DEAL WITH CASE WHERE ALL DATA DOESN'T FIT! */
     if ((src_el_size == dest_el_size) && (src_el_size == 1)) {
         MPIR_Memcpy(paramp->u.pack.pack_buffer, ((char *) bufp) + rel_off, *blocks_p);
+    } else if (MPII_Typerep_basic_type_is_complex(el_type)) {
+        /* treat as 2x floating point */
+        external32_float_convert(paramp->u.pack.pack_buffer,
+                                 ((char *) bufp) + rel_off,
+                                 dest_el_size / 2, src_el_size / 2, (*blocks_p) * 2);
     } else if (is_float_type(el_type)) {
         external32_float_convert(paramp->u.pack.pack_buffer,
                                  ((char *) bufp) + rel_off, dest_el_size, src_el_size, *blocks_p);
@@ -732,6 +737,11 @@ static int contig_unpack_external32_to_buf(MPI_Aint * blocks_p,
     /* TODO: DEAL WITH CASE WHERE ALL DATA DOESN'T FIT! */
     if ((src_el_size == dest_el_size) && (src_el_size == 1)) {
         MPIR_Memcpy(((char *) bufp) + rel_off, paramp->u.unpack.unpack_buffer, *blocks_p);
+    } else if (MPII_Typerep_basic_type_is_complex(el_type)) {
+        /* treat as 2x floating point */
+        external32_float_convert(((char *) bufp) + rel_off,
+                                 paramp->u.unpack.unpack_buffer,
+                                 dest_el_size / 2, src_el_size / 2, (*blocks_p) * 2);
     } else if (is_float_type(el_type)) {
         external32_float_convert(((char *) bufp) + rel_off,
                                  paramp->u.unpack.unpack_buffer,

--- a/src/mpi/datatype/typerep/src/typerep_util.h
+++ b/src/mpi/datatype/typerep/src/typerep_util.h
@@ -126,6 +126,13 @@ static inline void BASIC_convert128(const char *src, char *dest)
 }
 
 #if (BLENDIAN == 1)
+static inline void BASIC_copyto(const void *src, void *dest, int size)
+{
+    for (int i = 0; i < size; i++) {
+        ((char *) dest)[i] = ((const char *) src)[size - 1 - i];
+    }
+}
+
 /* Note: use `uint` to suppress warnings on left-shift */
 static inline void BASIC_convert(const void *src, void *dest, int size)
 {
@@ -143,18 +150,15 @@ static inline void BASIC_convert(const void *src, void *dest, int size)
             BASIC_convert64(*(uint64_t *) src, *(uint64_t *) dest);
             break;
         default:
-            MPIR_Assert(0);
-    }
-}
-
-static inline void BASIC_copyto(const void *src, void *dest, int size)
-{
-    for (int i = 0; i < size; i++) {
-        ((char *) dest)[i] = ((const char *) src)[size - 1 - i];
+            BASIC_copyto(src, dest, size);
     }
 }
 
 #else
+static inline void BASIC_copyto(const void *src, void *dest, int size)
+{
+    memcpy(dest, src, (size_t) size);
+}
 
 /* FIXME: we may need use memcpy to allow no-alignment */
 static inline void BASIC_convert(const void *src, void *dest, int size)
@@ -173,13 +177,8 @@ static inline void BASIC_convert(const void *src, void *dest, int size)
             *(int64_t *) dest = *(int64_t *) src;
             break;
         default:
-            MPIR_Assert(0);
+            BASIC_copyto(src, dest, size);
     }
-}
-
-static inline void BASIC_copyto(const void *src, void *dest, int size)
-{
-    memcpy(dest, src, (size_t) size);
 }
 
 #endif

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
@@ -9,6 +9,13 @@
 #include "typerep_util.h"
 #include <assert.h>
 
+/* The 16-byte c type is needed to use following macros */
+
+typedef struct {
+    int64_t a;
+    int64_t b;
+} SIXTEEN_BYTE_TYPE;
+
 /* convert equal sizes */
 #define PACK_EXTERNAL_equal_size(iov, outbuf, max_iov_len, c_type) \
     do {                                                                \
@@ -154,7 +161,7 @@ int MPIR_Typerep_pack_external(const void *inbuf, MPI_Aint incount, MPI_Datatype
         ext_type_size /= 2;
     }
 
-    if (basic_type == MPI_LONG_DOUBLE) {
+    if (basic_type == MPI_LONG_DOUBLE || basic_type == MPI_C_LONG_DOUBLE_COMPLEX) {
         /* most c compiler's long double is different from 128-bit floating point */
         PACK_EXTERNAL_long_double(iov, outbuf, max_iov_len);
     } else if (basic_type_size == ext_type_size) {
@@ -166,6 +173,8 @@ int MPIR_Typerep_pack_external(const void *inbuf, MPI_Aint incount, MPI_Datatype
             PACK_EXTERNAL_equal_size(iov, outbuf, max_iov_len, int32_t);
         } else if (basic_type_size == 8) {
             PACK_EXTERNAL_equal_size(iov, outbuf, max_iov_len, int64_t);
+        } else if (basic_type_size == 16) {
+            PACK_EXTERNAL_equal_size(iov, outbuf, max_iov_len, SIXTEEN_BYTE_TYPE);
         } else {
             MPIR_Assert(0);
         }
@@ -251,7 +260,7 @@ int MPIR_Typerep_unpack_external(const void *inbuf, void *outbuf, MPI_Aint outco
         ext_type_size /= 2;
     }
 
-    if (basic_type == MPI_LONG_DOUBLE) {
+    if (basic_type == MPI_LONG_DOUBLE || basic_type == MPI_C_LONG_DOUBLE_COMPLEX) {
         /* most c compiler's long double is different from 128-bit floating point */
         UNPACK_EXTERNAL_long_double(inbuf, iov, max_iov_len);
     } else if (basic_type_size == ext_type_size) {
@@ -263,6 +272,8 @@ int MPIR_Typerep_unpack_external(const void *inbuf, void *outbuf, MPI_Aint outco
             UNPACK_EXTERNAL_equal_size(inbuf, iov, max_iov_len, int32_t);
         } else if (basic_type_size == 8) {
             UNPACK_EXTERNAL_equal_size(inbuf, iov, max_iov_len, int64_t);
+        } else if (basic_type_size == 16) {
+            UNPACK_EXTERNAL_equal_size(inbuf, iov, max_iov_len, SIXTEEN_BYTE_TYPE);
         } else {
             MPIR_Assert(0);
         }

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
@@ -242,7 +242,7 @@ int MPIR_Typerep_unpack_external(const void *inbuf, void *outbuf, MPI_Aint outco
     assert(max_iov_len == actual_iov_len);
     assert(typeptr->basic_type != MPI_DATATYPE_NULL);
 
-    MPI_Aint basic_type;
+    MPI_Datatype basic_type;
     /* FIXME: assumes a single basic_type, won't work with struct */
     if (HANDLE_IS_BUILTIN(datatype)) {
         basic_type = datatype;
@@ -320,7 +320,7 @@ int MPIR_Typerep_size_external32(MPI_Datatype type)
     MPIR_Datatype *typeptr;
     MPIR_Datatype_get_ptr(type, typeptr);
 
-    MPI_Aint basic_type;
+    MPI_Datatype basic_type;
     /* FIXME: assumes a single basic_type, won't work with struct */
     if (HANDLE_IS_BUILTIN(type)) {
         basic_type = type;


### PR DESCRIPTION
## Pull Request Description

There are still issues left in https://github.com/pmodels/mpich/pull/5163#issuecomment-813890204. This PR addresses them.

* In typerep/yaksa, add a case for `MPI_C_LONG_DOUBLE_COMPLEX`, and support direct conversion of `MPI_COMPLEX32`
* in typerep/dataloop, swap names of `src_el_size` and `dest_el_size` to avoid Coverity warning
* in typerep/dataloop, add separate cases for complex conversions

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
