### PR TITLE
ch4/ucx: fix global variable declaration

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -8,7 +8,7 @@
 
 #include "ucx_impl.h"
 
-void *MPIDI_UCX_am_buf;
+extern void *MPIDI_UCX_am_buf;
 void MPIDI_UCX_am_handler(void *request, ucs_status_t status, ucp_tag_recv_info_t * info);
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)


### PR DESCRIPTION
## Pull Request Description
The declaration of extern global variable in `ucx_progress.h` is wrong. Error is reported by gcc-9.3 with default ucx build. Not sure why it runs OK in the jenkins warning jobs.

```
ucx/ucx_progress.h:34: multiple definition of `MPIDI_UCX_am_buf'; 
src/binding/c/attr/.libs/lib_libmpi_la-attr_delete.o:
../ucx/ucx_progress.h:34: first defined here
```
## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
