### PR TITLE
ch4/vci: remove VCI lock when it reads VCI progress count

### DIFF
--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -28,7 +28,9 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_free_hook(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_REQUEST_FREE_HOOK);
 
     int vci = MPIDI_Request_get_vci(req);
-    MPIDI_global.progress_counts[vci]++;
+    /* Increment MPIDI_global.progress_counts[vci]. */
+    int count = MPL_atomic_relaxed_load_int(&MPIDI_global.progress_counts[vci]);
+    MPL_atomic_relaxed_store_int(&MPIDI_global.progress_counts[vci], count + 1);
 
     /* This is tricky. I think the only solution is to expose partner
      * to the upper layer */

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -282,7 +282,11 @@ typedef struct MPIDI_CH4_Global_t {
 
     int n_vcis;
     MPIDI_vci_t vci[MPIDI_CH4_MAX_VCIS];
-    int progress_counts[MPIDI_CH4_MAX_VCIS];
+    /* The progress counts are mostly accessed in a VCI critical section and thus updated in a
+     * relaxed manner.  MPL_atomic_int_t is used here only for MPIDI_set_progress_vci() and
+     * MPIDI_set_progress_vci_n(), which access these progress counts outside a VCI critical
+     * section. */
+    MPL_atomic_int_t progress_counts[MPIDI_CH4_MAX_VCIS];
 
 #if defined(MPIDI_CH4_USE_WORK_QUEUES)
     /* TODO: move into MPIDI_vci to have per-vci workqueue */

--- a/src/mpid/ch4/src/ch4_wait.h
+++ b/src/mpid/ch4/src/ch4_wait.h
@@ -33,10 +33,8 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci(MPIR_Request * req,
     state->progress_made = 0;
 
     int vci = get_vci_wrapper(req);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
-    state->progress_counts[0] = MPIDI_global.progress_counts[vci];
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
 
+    state->progress_counts[0] = MPL_atomic_relaxed_load_int(&MPIDI_global.progress_counts[vci]);
     state->vci_count = 1;
     state->vci[0] = vci;
 }
@@ -69,9 +67,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci_n(int n, MPIR_Request ** re
     state->vci_count = idx;
     for (int i = 0; i < state->vci_count; i++) {
         int vci = state->vci[i];
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
-        state->progress_counts[i] = MPIDI_global.progress_counts[vci];
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        state->progress_counts[i] = MPL_atomic_relaxed_load_int(&MPIDI_global.progress_counts[vci]);
     }
 }
 


### PR DESCRIPTION
## Pull Request Description

This PR removes a VCI lock when it reads a VCI progress count for initialization.  The new progress count will be read by `MPL_atomic_relaxed_load_int()`.  This can remove a lock.  The following explains the reason why we can remove this lock.

This is related to issue #5070 (closes #5070).

### How the progress count works

This is my understanding.  On initialization, the progress count corresponding to each VCI of a wait state is updated to the current VCI progress count.  The wait operation compares the current progress count and this old value to see if there is progress on this VCI.  If so, the communication this wait operation is waiting for has likely completed.

### Why a VCI lock was considered to be needed

Updating the global progress count and reading it can happen at the same time, so I guess a lock was introduced to avoid data race.

### Why this VCI lock can be replaced by relaxed_load?

We need to read an unbroken progress count, but *this progress count itself is not used for synchronization* (if it is the case, we should not unlock this progress count after reading this progress count; otherwise, some other threads might update this after initializing this progress count.)  This is just a hint, and even if this progress count is not the latest one (e.g., another thread update this progress count after this critical section), the current MPI implementation guarantees a regular check (**I guess**).  `relaxed_load()` is enough to get this value "atomically" (= not reading a value that is being written).

### Why relaxed load/store operations are used instead of acquire-release?

1. Acquire-release semantics is unnecessary for this case since we do not synchronize anything based on this global count.
2. Acquire-release load/store operations are slow on some architectures, specifically non-Intel architectures.  On the other hand, relaxed load/store operations are as fast as normal load/store operations on most architectures in my understanding.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
