### PR TITLE
request: introduce MPIR_Request_add_ref_unsafe()

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -440,6 +440,9 @@ static inline MPIR_Request *MPIR_Request_create(MPIR_Request_kind_t kind)
 #define MPIR_Request_add_ref(req_p_) \
     do { MPIR_Object_add_ref(req_p_); } while (0)
 
+#define MPIR_Request_add_ref_unsafe(req_p_) \
+    do { MPIR_Object_add_ref_unsafe(req_p_); } while (0)
+
 #define MPIR_Request_release_ref(req_p_, inuse_) \
     do { MPIR_Object_release_ref(req_p_, inuse_); } while (0)
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -203,7 +203,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_win_vni(MPIR_Win * win)
     do {                                                      \
         (req) = MPIR_Request_create_from_pool(kind, vni);  \
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq"); \
-        MPIR_Request_add_ref((req));                                \
+        MPIR_Request_add_ref_unsafe((req));                         \
     } while (0)
 
 MPL_STATIC_INLINE_PREFIX uintptr_t MPIDI_OFI_winfo_base(MPIR_Win * w, int rank)

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -967,7 +967,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         *sigreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_ERR_CHKANDSTMT((*sigreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
                             "**nomemreq");
-        MPIR_Request_add_ref(*sigreq);
+        MPIR_Request_add_ref_unsafe(*sigreq);
         MPIDIU_request_complete(*sigreq);
     }
     goto fn_exit;

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -35,7 +35,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
         *flag = 1;
         req = (MPIR_Request *) MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__MPROBE, vni_dst);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        MPIR_Request_add_ref(req);
+        MPIR_Request_add_ref_unsafe(req);
         MPIDI_UCX_REQ(req).message_handler = message_h;
 
         if (status != MPI_STATUS_IGNORE) {

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -156,7 +156,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_recv(void *buf,
         if (req == NULL)
             req = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, vni_dst);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        MPIR_Request_add_ref(req);
+        MPIR_Request_add_ref_unsafe(req);
         MPIDI_UCX_REQ(req).ucp_request = ucp_request;
         ucp_request->req = req;
     }

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -75,7 +75,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
         MPIR_Request *req = NULL;
         req = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_ERR_CHKANDSTMT(req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        MPIR_Request_add_ref(req);
+        MPIR_Request_add_ref_unsafe(req);
         ucp_request->req = req;
         *reqptr = req;
 
@@ -170,7 +170,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
         MPIR_Request *req = NULL;
         req = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_ERR_CHKANDSTMT(req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        MPIR_Request_add_ref(req);
+        MPIR_Request_add_ref_unsafe(req);
         ucp_request->req = req;
         *reqptr = req;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -87,7 +87,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
     if (ucp_request) {
         if (req == NULL)
             req = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, vni_src);
-        MPIR_Request_add_ref(req);
+        MPIR_Request_add_ref_unsafe(req);
         ucp_request->req = req;
         MPIDI_UCX_REQ(req).ucp_request = ucp_request;
     } else if (req != NULL) {

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -382,7 +382,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rput(const void *origin_addr,
         sreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_Assert(sreq);
 
-        MPIR_Request_add_ref(sreq);
+        MPIR_Request_add_ref_unsafe(sreq);
         MPID_Request_complete(sreq);
         *request = sreq;
     }
@@ -499,7 +499,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_raccumulate(const void *origin_addr
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_Assert(sreq);
 
-    MPIR_Request_add_ref(sreq);
+    MPIR_Request_add_ref_unsafe(sreq);
     MPID_Request_complete(sreq);
     *request = sreq;
 
@@ -552,7 +552,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget_accumulate(const void *origin_
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_Assert(sreq);
 
-    MPIR_Request_add_ref(sreq);
+    MPIR_Request_add_ref_unsafe(sreq);
     MPID_Request_complete(sreq);
     *request = sreq;
 
@@ -673,7 +673,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget(void *origin_addr,
         sreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_Assert(sreq);
 
-        MPIR_Request_add_ref(sreq);
+        MPIR_Request_add_ref_unsafe(sreq);
         MPID_Request_complete(sreq);
         *request = sreq;
     }

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -25,14 +25,9 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_request_create(MPIR_Request_kind_t
     /* as long as ref_count is a constant, any compiler should be able
      * to unroll the below loop.  when threading is not enabled, the
      * compiler should be able to combine the below individual
-     * increments to a single increment of "ref_count - 1".
-     *
-     * FIXME: when threading is enabled, the ref_count increase is an
-     * atomic operation, so it might be more inefficient.  we should
-     * use a new API to increase the ref_count value instead of the
-     * for loop. */
+     * increments to a single increment of "ref_count - 1". */
     for (i = 0; i < ref_count - 1; i++)
-        MPIR_Request_add_ref(req);
+        MPIR_Request_add_ref_unsafe(req);
 
     MPIDI_NM_am_request_init(req);
 #ifndef MPIDI_CH4_DIRECT_NETMOD


### PR DESCRIPTION
## Pull Request Description

Currently, `MPIR_Request_add_ref()` is used to initialize `ref_count` of a newly created request.  `MPIR_Request_add_ref()` is wasteful since it calls a heavy atomic fetch-add.  This PR introduces `MPIR_Request_add_ref_unsafe()`, which is a fetch-add-free version of `MPIR_Request_add_ref()`.  See 

### About thread safety

After a request is created, no other thread can check `ref_count`, so updating this in a relaxed way does not hurt thread safety.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
