### PR TITLE
ch4: re-enable runtime selection of thread safety model

### DIFF
--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -532,8 +532,8 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
 #if defined HAVE_DECL_MPI_COMBINER_HINDEXED_BLOCK && HAVE_DECL_MPI_COMBINER_HINDEXED_BLOCK
         case MPI_COMBINER_HINDEXED_BLOCK:
             is_hindexed_block = 1;
-            /* fall through */
 #endif
+            /* fall through */
         case MPI_COMBINER_INDEXED_BLOCK:
 #ifdef FLATTEN_DEBUG
             DBG_FPRINTF(stderr, "ADIOI_Flatten:: MPI_COMBINER_INDEXED_BLOCK\n");

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -24,11 +24,6 @@
 #include "ch4_csel_container.h"
 #include "ch4i_workq_types.h"
 
-/* Currently, workq is a configure-time only option and guarded by macro
- * MPIDI_CH4_USE_WORK_QUEUES. If we want to enable runtime option, we will
- * need to switch everywhere from "#ifdef MPIDI_CH4_USE_WORK_QUEUES" into
- * runtime "if - else".
- */
 #ifdef MPIDI_CH4_USE_MT_DIRECT
 #define MPIDI_CH4_MT_MODEL MPIDI_CH4_MT_DIRECT
 #elif defined MPIDI_CH4_USE_MT_HANDOFF


### PR DESCRIPTION
This patch brings back runtime selection of thread safety model.
Currently, only config time selection was available.

The work queues are still disabled. They should be enabled when the
handoff model is brought back.

To utilize the runtime selection, use the config parameter `--enable-ch4-mt=runtime` 
and the runtime cvar MPIR_CVAR_CH4_MT_MODEL to select an intended thread safety
model, e.g., export MPIR_CVAR_CH4_MT_MODEL=direct

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
