### PR TITLE
romio: fix usage error of DBG_FPRINTF

### DIFF
--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -125,11 +125,11 @@ ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype datatype)
 #ifdef FLATTEN_DEBUG
         {
             int i;
-            for (i = 0; i < flat->count; i++)
+            for (i = 0; i < flat->count; i++) {
                 DBG_FPRINTF(stderr,
                             "ADIOI_Flatten_datatype:: i %#X, blocklens %#llX, indices %#llX\n", i,
-                            flat->blocklens[i], flat->indices[i]
-);
+                            flat->blocklens[i], flat->indices[i]);
+            }
         }
 #endif
     }


### PR DESCRIPTION
## Pull Request Description
The macro DBG_FPRINTF contains extra statement cannot be used inside
for-loop without brackets.

This is reported by coverity recently, probably due to their new ability to look inside commonly disabled preprocessor branches.

I really would like to remove all these debugging prints rather than maintaining them.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
