### PR TITLE
ch4: default MPIDI_CH4_MAX_VCIS to 64 when per-vci is on

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -526,8 +526,8 @@ AC_ARG_ENABLE(thread-cs,
 			[Choose the method used for critical sections
                          and other atomic updates when multiple
                          threads are present.  Values may be default, global,
-                         per-object, per-vci, lock-free. By default, CH3 uses global,
-                         while CH4 uses per-vci.]),,enable_thread_cs=default)
+                         per-object, per-vci, lock-free. Default is global.
+                        ]),,enable_thread_cs=default)
 
 AC_ARG_ENABLE(refcount,
 	AC_HELP_STRING([--enable-refcount=type],


### PR DESCRIPTION
## Pull Request Description

Currently, user have to configure with both --with-thread-cs=per-vci and
--with-ch4-max-vcis, as well as set MPIR_CVAR_CH4_NUM_VCIS to enable
mutiple vcis. This is a bit cumbersome to remember and to explain. Let's
default `--with-ch4-max-vcis` to 64 -- the maximum number of request
pools -- to make it more convenient. It only adds 100K or so global
memory, which most applications won't be concerned with.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
