### PR TITLE
comm: fix a potential missing unlock

### DIFF
--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -756,9 +756,9 @@ int MPIR_Comm_create_from_group_impl(MPIR_Group * group_ptr, const char *stringt
         MPL_initlock_lock(&lock);
         if (!MPIR_Process.comm_world->local_group) {
             mpi_errno = comm_create_local_group(MPIR_Process.comm_world);
-            MPIR_ERR_CHECK(mpi_errno);
         }
         MPL_initlock_unlock(&lock);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Comm_create_group_impl(MPIR_Process.comm_world, group_ptr, tag, p_newcom_ptr);
     } else if (group_ptr->pset_name && strcmp(group_ptr->pset_name, "mpi://WORLD") == 0) {
         /* TODO: once we init process is split into local init and world init, we need call


### PR DESCRIPTION
## Pull Request Description
The MPIR_ERR_CHECK has the potential to jump out of lock/unlock window,
and it need be delayed.

This is caught by Coverity.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
