### PR TITLE
mpl: add missing PATH_MAX definition

### DIFF
--- a/src/mpl/include/mpl_str.h
+++ b/src/mpl/include/mpl_str.h
@@ -8,6 +8,14 @@
 
 #include "mplconfig.h"
 
+/* NOTE: PATH_MAX is simply an arbitary convenience size. It only be used
+ * in non-critical paths or where we are certain the file path is very short.
+ * Critical paths should consider using dynamic buffer.
+ */
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 /* *INDENT-ON* */
 #if defined(__cplusplus)
 extern "C" {


### PR DESCRIPTION

## Pull Request Description
PATH_MAX may be missing on some system and breaking the build. Define it
if it's missing.

I encountered this when testing a build on Raspberry pi.
```
src/str/mpl_str.c: In function ‘MPL_create_pathname’:
src/str/mpl_str.c:413:37: error: ‘PATH_MAX’ undeclared (first use in this function)
  413 |         MPL_snprintf(dest_filename, PATH_MAX, "%s/%s.%u.%u%c", dirname, prefix,
      |                                     ^~~~~~~~
src/str/mpl_str.c:413:37: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [Makefile:1077: src/str/mpl_str.lo] Error 1

```

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
