### PR TITLE
ch4/ofi: fix multiple vni/nic init

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -391,6 +391,7 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
+static void dump_dynamic_settings(void);
 static int get_ofi_version(void);
 static int open_fabric(void);
 static int create_vni_context(int vni, int nic);
@@ -646,6 +647,9 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     MPL_atomic_store_int(&MPIDI_OFI_global.am_inflight_inject_emus, 0);
     MPL_atomic_store_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs, 0);
 
+    if (MPIR_CVAR_CH4_OFI_CAPABILITY_SETS_DEBUG && MPIR_Process.rank == 0) {
+        dump_dynamic_settings();
+    }
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_MPI_INIT_HOOK);
     return mpi_errno;
@@ -1915,8 +1919,6 @@ static void dump_global_settings(void)
 #ifdef MPIDI_OFI_VNI_USE_SEPCTX
     fprintf(stdout, "MPIDI_OFI_VNI_USE_SEPCTX: %d\n", 1);
 #endif
-    fprintf(stdout, "======================================\n");
-
     /* Discover the maximum number of ranks. If the source shift is not
      * defined, there are 32 bits in use due to the uint32_t used in
      * ofi_send.h */
@@ -1937,6 +1939,13 @@ static void dump_global_settings(void)
     fprintf(stdout, "rx_iov_limit: %lu\n", MPIDI_OFI_global.rx_iov_limit);
     fprintf(stdout, "rma_iov_limit: %lu\n", MPIDI_OFI_global.rma_iov_limit);
     fprintf(stdout, "max_mr_key_size: %lu\n", MPIDI_OFI_global.max_mr_key_size);
+}
+
+static void dump_dynamic_settings(void)
+{
+    fprintf(stdout, "==== OFI dyanamic settings ====\n");
+    fprintf(stdout, "num_vnis: %d\n", MPIDI_OFI_global.num_vnis);
+    fprintf(stdout, "num_nics: %d\n", MPIDI_OFI_global.num_nics);
     fprintf(stdout, "======================================\n");
 }
 


### PR DESCRIPTION
## Pull Request Description

The last PR (https://github.com/pmodels/mpich/pull/5154) broke the multiple vni initialization. This PR fixes it.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
