### PR TITLE
ch4/ucx: remove unused variable in ucx_progress.h

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -11,8 +11,6 @@
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
 {
     int mpi_errno = MPI_SUCCESS;
-    ucp_tag_recv_info_t info;
-    MPIDI_UCX_ucp_request_t *ucp_request;
 
     int vni = MPIDI_UCX_vci_to_vni(vci);
     if (vni < 0) {


### PR DESCRIPTION
## Pull Request Description
Last PR (#4934) left two unused variables. This PR fixes it.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
