### PR TITLE
ch4/ofi: fix coverity warnings due to multinic code

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1974,12 +1974,10 @@ static int addr_exchange_root_vni(MPIR_Comm * init_comm)
     /* If MPIR_CVAR_CH4_ROOTS_ONLY_PMI is true, we only collect a table of node-roots.
      * Otherwise, we collect a table of everyone. */
     void *table = NULL;
-    int ret_bc_len;
     mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map[0],
                                       &MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
-                                      TRUE, MPIR_CVAR_CH4_ROOTS_ONLY_PMI, &table, &ret_bc_len);
+                                      TRUE, MPIR_CVAR_CH4_ROOTS_ONLY_PMI, &table, NULL);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_Assert(ret_bc_len = MPIDI_OFI_global.addrnamelen);
 
     /* Third, each fi_av_insert those addresses */
     if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -184,8 +184,5 @@ int MPIDI_OFI_setup_multi_nic(void)
         MPIDI_OFI_global.prov_use[i] = nics[i].nic;
     }
 
-  fn_exit:
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -98,7 +98,6 @@ int MPIDI_OFI_setup_multi_nic(void)
     MPIR_hwtopo_gid_t parents[MPIDI_OFI_MAX_NICS];
     int num_parents = 0;
     int mpi_errno = MPI_SUCCESS;
-    MPIR_hwtopo_gid_t *close_nic_parents = NULL;
     int local_rank = MPIR_Process.local_rank;
     MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;
 
@@ -186,8 +185,6 @@ int MPIDI_OFI_setup_multi_nic(void)
     }
 
   fn_exit:
-    if (close_nic_parents)
-        MPIDU_Init_shm_free(close_nic_parents);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -141,6 +141,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
     if (!same_len) {
         /* if business cards can be different length, use the max value length */
         recv_bc_len = MPID_MAX_BC_SIZE;
+        /* Note: ret_bc_len is only touched if !same_len */
         *ret_bc_len = recv_bc_len;
     }
 


### PR DESCRIPTION
## Pull Request Description
There are a few new coverity warnings introduced by the recent multi-nic PR.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
