### PR TITLE
ch4/ofi: Use PRIu64 specifier for printing uint64_t values

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1936,16 +1936,16 @@ static void dump_global_settings(void)
 
     /* Print global thresholds */
     fprintf(stdout, "==== Provider global thresholds ====\n");
-    fprintf(stdout, "max_buffered_send: %lu\n", MPIDI_OFI_global.max_buffered_write);
-    fprintf(stdout, "max_buffered_write: %lu\n", MPIDI_OFI_global.max_buffered_send);
-    fprintf(stdout, "max_msg_size: %lu\n", MPIDI_OFI_global.max_msg_size);
+    fprintf(stdout, "max_buffered_send: %" PRIu64 "\n", MPIDI_OFI_global.max_buffered_write);
+    fprintf(stdout, "max_buffered_write: %" PRIu64 "\n", MPIDI_OFI_global.max_buffered_send);
+    fprintf(stdout, "max_msg_size: %" PRIu64 "\n", MPIDI_OFI_global.max_msg_size);
     fprintf(stdout, "max_order_raw: %lu\n", MPIDI_OFI_global.max_order_raw);
     fprintf(stdout, "max_order_war: %lu\n", MPIDI_OFI_global.max_order_war);
     fprintf(stdout, "max_order_waw: %lu\n", MPIDI_OFI_global.max_order_waw);
     fprintf(stdout, "tx_iov_limit: %lu\n", MPIDI_OFI_global.tx_iov_limit);
     fprintf(stdout, "rx_iov_limit: %lu\n", MPIDI_OFI_global.rx_iov_limit);
     fprintf(stdout, "rma_iov_limit: %lu\n", MPIDI_OFI_global.rma_iov_limit);
-    fprintf(stdout, "max_mr_key_size: %lu\n", MPIDI_OFI_global.max_mr_key_size);
+    fprintf(stdout, "max_mr_key_size: %" PRIu64 "\n", MPIDI_OFI_global.max_mr_key_size);
 }
 
 static void dump_dynamic_settings(void)


### PR DESCRIPTION
Fix -Wformat warning with clang 12.

## Pull Request Description

Fix compiler warning.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
