### PR TITLE
ch4/ucx: Fix temporary buffer allocation in AM path

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -159,7 +159,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
 
     /* send is done. free all resources and complete the request */
     if (ucp_request == NULL) {
-        MPL_gpu_free_host(send_buf);
+        MPIR_gpu_free_host(send_buf);
         MPIDIG_global.origin_cbs[handler_id] (sreq);
         goto fn_exit;
     }
@@ -223,7 +223,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     ucx_hdr.data_sz = data_sz;
 
     if (dt_contig) {
-        send_buf = MPL_malloc(sizeof(ucx_hdr) + am_hdr_sz, MPL_MEM_BUFFER);
+        MPIR_gpu_malloc_host((void **) &send_buf, sizeof(ucx_hdr) + am_hdr_sz);
         MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
         MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
 


### PR DESCRIPTION
## Pull Request Description

1. Use MPIR_gpu_malloc_host for a buffer that will be freed with
   MPIR_gpu_free_host.
2. Convert a missed MPL_gpu_free_host to MPIR_gpu_free_host to align
   with the rest of MPICH.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
