### PR TITLE
ch4/ofi: Multi-NIC Striping

### DIFF
--- a/src/mpid/ch4/netmod/ofi/errnames.txt
+++ b/src/mpid/ch4/netmod/ofi/errnames.txt
@@ -105,3 +105,5 @@
 **ofid_cancel %s %d %s %s:OFI cancel failed (%s:%d:%s:%s)
 **ofi_max_conn:OFI dynamic process reaches maximum connection
 **ofi_max_conn %d:OFI dynamic process reaches maximum connection (%d)
+**ofi_num_nics:OFI has a different number of nics available on different notes
+**ofi_num_nics %d %d:OFI has a different number of nics available on different notes (%d on this node and %d elsewhere)

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -20,6 +20,13 @@ int MPIDI_OFI_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
     /* no connection for non-dynamic or non-root-rank of intercomm */
     MPIDI_OFI_COMM(comm).conn_id = -1;
 
+    /* Use striping if enabled and there are multiple NICs. */
+    if (MPIR_CVAR_CH4_OFI_ENABLE_STRIPING && MPIDI_OFI_global.num_nics > 1) {
+        MPIDI_OFI_COMM(comm).enable_striping = 1;
+    } else {
+        MPIDI_OFI_COMM(comm).enable_striping = 0;
+    }
+
     /* eagain defaults to off */
     if (comm->hints[MPIR_COMM_HINT_EAGAIN] == 0) {
         comm->hints[MPIR_COMM_HINT_EAGAIN] = FALSE;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -855,7 +855,7 @@ int MPIDI_OFI_post_init(void)
         }
     }
 
-    if (MPIDI_OFI_global.num_vnis > 1) {
+    if (MPIDI_OFI_global.num_vnis > 1 || MPIDI_OFI_global.num_nics > 1) {
         mpi_errno = addr_exchange_all_vnis();
     }
   fn_fail:
@@ -1513,7 +1513,7 @@ static int addr_exchange_all_vnis(void)
             for (int r = 0; r < size; r++) {
                 MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(&MPIDIU_get_av(0, r));
                 for (int vni_remote = 0; vni_remote < num_vnis; vni_remote++) {
-                    if (vni_local == 0 && vni_remote == 0) {
+                    if (vni_local == 0 && vni_remote == 0 && nic == 0) {
                         /* don't overwrite existing addr, or bad things will happen */
                         continue;
                     }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -374,6 +374,26 @@ cvars:
         system up to the limit determined by MPIDI_MAX_NICS (in ofi_types.h).
 
 
+    - name        : MPIR_CVAR_CH4_OFI_ENABLE_STRIPING
+      category    : CH4
+      type        : int
+      default     : 1
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        If true, this cvar enables striping of large messages across multiple NICs.
+
+    - name        : MPIR_CVAR_CH4_OFI_STRIPING_THRESHOLD
+      category    : CH4
+      type        : int
+      default     : 1048576
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Striping will happen for message sizes beyond this threshold.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
@@ -1299,6 +1319,7 @@ static int update_global_limits(struct fi_info *prov)
     } else {
         MPIDI_OFI_global.max_msg_size = MPL_MIN(prov->ep_attr->max_msg_size, MPIR_AINT_MAX);
     }
+    MPIDI_OFI_global.stripe_threshold = MPIR_CVAR_CH4_OFI_STRIPING_THRESHOLD;
     MPIDI_OFI_global.max_order_raw = prov->ep_attr->max_order_raw_size;
     MPIDI_OFI_global.max_order_war = prov->ep_attr->max_order_war_size;
     MPIDI_OFI_global.max_order_waw = prov->ep_attr->max_order_waw_size;

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -47,6 +47,7 @@ typedef struct {
     void *huge_recv_counters;
     /* support for connection */
     int conn_id;
+    int enable_striping;        /* Flag to enable striping per communicator. */
 } MPIDI_OFI_comm_t;
 enum {
     MPIDI_AMTYPE_NONE = 0,

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -36,6 +36,7 @@
 #define MPIDI_OFI_AM_HDR_POOL_NUM_CELLS_PER_CHUNK   (1024)
 #define MPIDI_OFI_AM_HDR_POOL_MAX_NUM_CELLS         (257 * 1024)
 #define MPIDI_OFI_NUM_CQ_BUFFERED          (1024)
+#define MPIDI_OFI_STRIPE_CHUNK_SIZE        (2048)       /* First chunk sent through the preferred NIC during striping */
 
 /* The number of bits in the immediate data field allocated to the source rank. */
 #define MPIDI_OFI_IDATA_SRC_BITS (30)
@@ -304,6 +305,7 @@ typedef struct {
     uint64_t max_buffered_send;
     uint64_t max_buffered_write;
     uint64_t max_msg_size;
+    uint64_t stripe_threshold;
     uint64_t max_short_send;
     uint64_t max_mr_key_size;
     uint64_t max_rma_key_bits;
@@ -382,7 +384,7 @@ typedef struct {
     uintptr_t send_buf;
     size_t msgsize;
     int comm_id;
-    uint64_t rma_key;
+    uint64_t rma_keys[MPIDI_OFI_MAX_NICS];
     int tag;
     int vni_src;
     int vni_dst;
@@ -486,6 +488,8 @@ typedef struct MPIDI_OFI_huge_recv {
     bool peek;                  /* Flag to indicate whether this struct has been created to track an uncompleted peek
                                  * operation. */
     size_t cur_offset;
+    size_t stripe_size;
+    int chunks_outstanding;
     MPIR_Comm *comm_ptr;
     MPIR_Request *localreq;
     struct fi_cq_tagged_entry wc;

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -231,7 +231,11 @@ static int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
     }
 
     recv_elem->event_id = MPIDI_OFI_EVENT_GET_HUGE;
-    recv_elem->cur_offset = MPIDI_OFI_global.max_msg_size;
+    if (MPIDI_OFI_COMM(comm_ptr).enable_striping) {
+        recv_elem->cur_offset = MPIDI_OFI_STRIPE_CHUNK_SIZE;
+    } else {
+        recv_elem->cur_offset = MPIDI_OFI_global.max_msg_size;
+    }
     recv_elem->remote_info = *info;
     recv_elem->comm_ptr = comm_ptr;
     recv_elem->next = NULL;


### PR DESCRIPTION
## Pull Request Description

Add support for striping large messages across multiple NICs when they are available.

This uses the existing huge message protocol, but exposes the MRs on all available NICs, rather than just the first one. The receiver does `fi_read` calls on NICs (when messages are larger than the minimum striping size).

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
