### PR TITLE
config: fix typo in PAC_PROG_C_WEAK_SYMBOLS

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -223,7 +223,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
     int Foo(int a) { return a; }
 ]],[[
     return PFoo(1);
-]])],,has_pragma_weak=yes)
+]])],has_pragma_weak=yes)
 #
 # Some systems (Linux ia64 and ecc, for example), support weak symbols
 # only within a single object file!  This tests that case.


### PR DESCRIPTION
## Pull Request Description
Had an extra comma in the last PR (5206).

Nightly tests on clang were broken because of it. Just realized that `clang` doesn't support `pragma_weak` -- actually, it does, but not with additional `extern` declaration as we used in the tests.

`gcc` went ahead used `__attribute((weak))`, thus was still ok.

EDIT: here is my understanding --

`clang` supports `#pragma weak` but only will link to it if it is also declared with `extern`.  But
if it is declared with `extern` it can't call the alias in the same translation unit. Thus in the old tests,
it fails the pragma-weak's same-unit-with-extern test, but the "typo" let it pass the initial test and successfully pass the linking tests next.

But in our actual mpich code, we use `#pragma weak` without separate extern declaration, thus it failed to link programs, e.g. `mpichvar`.

I think we need to remove the `extern` from the test to match the actual usage. 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
