### PR TITLE
maint: add MPIR_CVAR_DEBUG_CVARS

### DIFF
--- a/maint/extractcvars.in
+++ b/maint/extractcvars.in
@@ -253,10 +253,14 @@ print OUTPUT_C <<EOT;
 int ${fn_ns}_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    int rc;
+    int rc, got_rc;
     const char *tmp_str;
     static int initialized = FALSE;
     MPIR_T_cvar_value_t defaultval;
+
+    int debug = 0;
+    rc = MPL_env2bool("MPIR_CVAR_DEBUG_CVARS", &debug);
+    MPIR_ERR_CHKANDJUMP1((-1 == rc),mpi_errno,MPI_ERR_OTHER,"**envvarparse","**envvarparse %s","MPIR_CVAR_DEBUG_CVARS");
 
     /* FIXME any MT issues here? */
     if (initialized)
@@ -331,27 +335,44 @@ foreach my $p (@cvars) {
     push @env_names, "${alt_ns}_" . $p->{name};
     push @env_names, "${uc_ns}_" . $p->{name};
 
+    print OUTPUT_C "    got_rc = 0;\n";
     foreach my $env_name (@env_names) {
         # assumes rc is defined
         if ($p->{type} eq 'range') {
 print OUTPUT_C <<EOT;
     rc = MPL_env2${env_fn}("$env_name", &($var_name.low), &($var_name.high));
     MPIR_ERR_CHKANDJUMP1((-1 == rc),mpi_errno,MPI_ERR_OTHER,"**envvarparse","**envvarparse %s","$env_name");
+    got_rc += rc;
 EOT
         }
         elsif ($p->{type} eq 'string' or $p->{type} eq 'enum') {
 print OUTPUT_C <<EOT;
     rc = MPL_env2${env_fn}("$env_name", &tmp_str);
     MPIR_ERR_CHKANDJUMP1((-1 == rc),mpi_errno,MPI_ERR_OTHER,"**envvarparse","**envvarparse %s","$env_name");
+    got_rc += rc;
 EOT
         }
         else {
 print OUTPUT_C <<EOT;
     rc = MPL_env2${env_fn}("$env_name", &($var_name));
     MPIR_ERR_CHKANDJUMP1((-1 == rc),mpi_errno,MPI_ERR_OTHER,"**envvarparse","**envvarparse %s","$env_name");
+    got_rc += rc;
 EOT
         }
     }
+
+    # debugging
+    print OUTPUT_C "    if (got_rc && debug) {\n";
+    if ($p->{type} eq 'string' or $p->{type} eq 'enum') {
+        print OUTPUT_C "        printf(\"CVAR: $var_name = %s\\n\", tmp_str);\n";
+    } elsif ($p->{type} eq "range") {
+        print OUTPUT_C "        printf(\"CVAR: $var_name = %d-%d\\n\", $var_name.low, $var_name.high);\n";
+    } else {
+        print OUTPUT_C "        printf(\"CVAR: $var_name = %d\\n\", $var_name);\n";
+    }
+    print OUTPUT_C "    }\n";
+
+    # post process
     if ($p->{type} eq 'string') {
 print OUTPUT_C <<EOT;
     if (tmp_str != NULL) {

--- a/src/mpl/src/env/mpl_env.c
+++ b/src/mpl/src/env/mpl_env.c
@@ -32,6 +32,7 @@ int MPL_env2range(const char *envName, int *lowPtr, int *highPtr)
         }
         *lowPtr = low;
         *highPtr = high;
+        return 1;
     }
     return 0;
 }


### PR DESCRIPTION
## Pull Request Description
Sometimes it is useful to show whether certain CVARs are actually being set. This
patch adds MPIR_CVAR_DEBUG_CVARS, when enabled, it will print all CVARs
that are set via environment.



[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
