### PR TITLE
ch4/ofi: move MPIDI_OFI_index_datatypes after ep created

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -257,7 +257,7 @@ int MPIDI_OFI_am_rdma_read_ack_handler(int handler_id, void *am_hdr, void *data,
                                        MPI_Aint in_data_sz, int is_local, int is_async,
                                        MPIR_Request ** req);
 int MPIDI_OFI_control_dispatch(void *buf);
-void MPIDI_OFI_index_datatypes(void);
+void MPIDI_OFI_index_datatypes(struct fid_ep *ep);
 int MPIDI_OFI_mr_key_allocator_init(void);
 uint64_t MPIDI_OFI_mr_key_alloc(int key_type, uint64_t requested_key);
 void MPIDI_OFI_mr_key_free(int key_type, uint64_t index);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -492,9 +492,6 @@ int MPIDI_OFI_init_local(int *tag_bits)
 
     MPIR_Comm_register_hint(MPIR_COMM_HINT_EAGAIN, "eagain", NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
 
-    /* index datatypes for RMA atomics */
-    MPIDI_OFI_index_datatypes();
-
     MPIDI_OFI_global.deferred_am_isend_q = NULL;
 
     /* -------------------------------- */
@@ -545,6 +542,9 @@ int MPIDI_OFI_init_local(int *tag_bits)
      * This code maybe moved to a later stage */
     mpi_errno = create_vni_context(0, 0);
     MPIR_ERR_CHECK(mpi_errno);
+
+    /* index datatypes for RMA atomics. NOTE: we only can query atomics after ep is created */
+    MPIDI_OFI_index_datatypes();
 
   fn_exit:
     *tag_bits = MPIDI_OFI_TAG_BITS;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -543,8 +543,8 @@ int MPIDI_OFI_init_local(int *tag_bits)
     mpi_errno = create_vni_context(0, 0);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* index datatypes for RMA atomics. NOTE: we only can query atomics after ep is created */
-    MPIDI_OFI_index_datatypes();
+    /* index datatypes for RMA atomics. */
+    MPIDI_OFI_index_datatypes(MPIDI_OFI_global.ctx[0].tx);
 
   fn_exit:
     *tag_bits = MPIDI_OFI_TAG_BITS;

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -457,17 +457,13 @@ static int mpi_to_ofi(MPI_Datatype dt, enum fi_datatype *fi_dt, MPI_Op op, enum 
 #define _TBL MPIDI_OFI_global.win_op_table[i][j]
 #define CHECK_ATOMIC(fcn,field1,field2)            \
   atomic_count = 0;                                \
-  ret = fcn(MPIDI_OFI_global.ctx[0].tx,                \
-    fi_dt,                                 \
-    fi_op,                                 \
-            &atomic_count);                        \
-  if (ret == 0 && atomic_count != 0)                \
-    {                                              \
-  _TBL.field1 = 1;                             \
-  _TBL.field2 = atomic_count;                  \
-    }
+  ret = fcn(ep, fi_dt, fi_op, &atomic_count);      \
+  if (ret == 0 && atomic_count != 0) {             \
+    _TBL.field1 = 1;                               \
+    _TBL.field2 = atomic_count;                    \
+  }
 
-static void create_dt_map(void)
+static void create_dt_map(struct fid_ep *ep)
 {
     int i, j;
     size_t dtsize[FI_DATATYPE_LAST];
@@ -529,9 +525,10 @@ static void create_dt_map(void)
     }
 }
 
-void MPIDI_OFI_index_datatypes(void)
+void MPIDI_OFI_index_datatypes(struct fid_ep *ep)
 {
     /* do not generate map when atomics are not enabled */
-    if (MPIDI_OFI_ENABLE_ATOMICS)
-        create_dt_map();
+    if (MPIDI_OFI_ENABLE_ATOMICS) {
+        create_dt_map(ep);
+    }
 }


### PR DESCRIPTION
## Pull Request Description
`MPIDI_OFI_index_datatypes()` is actually querying atomic ability on an `ep`, thus it has to be called after ep is created. Let's add the `ep` parameter explicitly so such confusion should not happen again.

Fixes #5236 . Thanks @ahori 

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
