### PR TITLE
misc: fixes for the 32-bit systems

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1078,7 +1078,7 @@ def dump_function_normal(func, state_name):
     # ----
     G.out.append("/* ... body of routine ... */")
 
-    if func['_map_type'] == "BIG":
+    if func['_map_type'] == "BIG" and 'code-large_count' not in func:
         # BIG but internally is using MPI_Aint
         impl_args_save = copy.copy(func['_impl_arg_list'])
 

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -395,7 +395,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
             break;
         case MPIR_ERR_PROC_FAILED:
             MPIR_TAG_SET_PROC_FAILURE_BIT(sendtag);
-            MPL_FALLTHROUGH;
+            /* fall through */
         default:
             MPIR_TAG_SET_ERROR_BIT(sendtag);
     }

--- a/src/mpi/datatype/typerep/dataloop/dataloop.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop.c
@@ -359,11 +359,11 @@ void MPII_Dataloop_alloc_and_copy(int kind,
             /* need space for dataloop pointers and extents */
             ptr_sz = count * sizeof(MPII_Dataloop *);
             extent_sz = count * sizeof(MPI_Aint);
-            MPL_FALLTHROUGH;
+            /* fall through */
         case MPII_DATALOOP_KIND_INDEXED:
             /* need space for block sizes */
             blk_sz = count * sizeof(MPI_Aint);
-            MPL_FALLTHROUGH;
+            /* fall through */
         case MPII_DATALOOP_KIND_BLOCKINDEXED:
             /* need space for block offsets */
             off_sz = count * sizeof(MPI_Aint);

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_create.c
@@ -35,11 +35,12 @@ static int update_yaksa_type(MPIR_Datatype * newtype, MPI_Datatype oldtype, MPI_
 
     rc = yaksa_type_get_size(dt, (uintptr_t *) & newtype->size);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
-    rc = yaksa_type_get_extent(dt, &newtype->lb, &newtype->extent);
+    rc = yaksa_type_get_extent(dt, (intptr_t *) & newtype->lb, (intptr_t *) & newtype->extent);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
     newtype->ub = newtype->lb + newtype->extent;
     MPI_Aint true_extent;
-    rc = yaksa_type_get_true_extent(dt, &newtype->true_lb, &true_extent);
+    rc = yaksa_type_get_true_extent(dt, (intptr_t *) & newtype->true_lb,
+                                    (intptr_t *) & true_extent);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
     newtype->true_ub = newtype->true_lb + true_extent;

--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -532,8 +532,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
 #if defined HAVE_DECL_MPI_COMBINER_HINDEXED_BLOCK && HAVE_DECL_MPI_COMBINER_HINDEXED_BLOCK
         case MPI_COMBINER_HINDEXED_BLOCK:
             is_hindexed_block = 1;
-            /* deliberate fall-through */
-            MPL_FALLTHROUGH;
+            /* fall through */
 #endif
         case MPI_COMBINER_INDEXED_BLOCK:
 #ifdef FLATTEN_DEBUG

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -447,7 +447,7 @@ typedef struct MPIDI_Request {
     void *ext_hdr_ptr; /* Pointer to extended packet header.
                         * It is allocated in RMA issuing/pkt_handler functions,
                         * and freed when release request. */
-    intptr_t ext_hdr_sz;
+    MPI_Aint ext_hdr_sz;
 
     struct MPIDI_RMA_Target *rma_target_ptr;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1947,12 +1947,12 @@ static void dump_global_settings(void)
     fprintf(stdout, "max_buffered_send: %" PRIu64 "\n", MPIDI_OFI_global.max_buffered_write);
     fprintf(stdout, "max_buffered_write: %" PRIu64 "\n", MPIDI_OFI_global.max_buffered_send);
     fprintf(stdout, "max_msg_size: %" PRIu64 "\n", MPIDI_OFI_global.max_msg_size);
-    fprintf(stdout, "max_order_raw: %lu\n", MPIDI_OFI_global.max_order_raw);
-    fprintf(stdout, "max_order_war: %lu\n", MPIDI_OFI_global.max_order_war);
-    fprintf(stdout, "max_order_waw: %lu\n", MPIDI_OFI_global.max_order_waw);
-    fprintf(stdout, "tx_iov_limit: %lu\n", MPIDI_OFI_global.tx_iov_limit);
-    fprintf(stdout, "rx_iov_limit: %lu\n", MPIDI_OFI_global.rx_iov_limit);
-    fprintf(stdout, "rma_iov_limit: %lu\n", MPIDI_OFI_global.rma_iov_limit);
+    fprintf(stdout, "max_order_raw: %zd\n", MPIDI_OFI_global.max_order_raw);
+    fprintf(stdout, "max_order_war: %zd\n", MPIDI_OFI_global.max_order_war);
+    fprintf(stdout, "max_order_waw: %zd\n", MPIDI_OFI_global.max_order_waw);
+    fprintf(stdout, "tx_iov_limit: %zd\n", MPIDI_OFI_global.tx_iov_limit);
+    fprintf(stdout, "rx_iov_limit: %zd\n", MPIDI_OFI_global.rx_iov_limit);
+    fprintf(stdout, "rma_iov_limit: %zd\n", MPIDI_OFI_global.rma_iov_limit);
     fprintf(stdout, "max_mr_key_size: %" PRIu64 "\n", MPIDI_OFI_global.max_mr_key_size);
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -123,8 +123,8 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
             MPIDI_OFI_load_iov(origin_addr, origin_count, origin_datatype, origin_len,
                                &origin_iov_offset, origin_iov);
         if (j == target_iov_offset)
-            MPIDI_OFI_load_iov((const void *) target_mr.addr, target_count, target_datatype,
-                               target_len, &target_iov_offset, target_iov);
+            MPIDI_OFI_load_iov((const void *) (uintptr_t) target_mr.addr, target_count,
+                               target_datatype, target_len, &target_iov_offset, target_iov);
 
         msg_len = MPL_MIN(origin_iov[origin_cur].iov_len, target_iov[target_cur].iov_len);
 
@@ -396,7 +396,7 @@ int MPIDI_OFI_pack_put(const void *origin_addr, int origin_count,
     req->noncontig.put.origin.total_bytes = origin_bytes;
 
     /* target */
-    req->noncontig.put.target.base = (void *) target_mr.addr;
+    req->noncontig.put.target.base = (void *) (uintptr_t) target_mr.addr;
     req->noncontig.put.target.count = target_count;
     req->noncontig.put.target.datatype = target_datatype;
     MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
@@ -456,7 +456,7 @@ int MPIDI_OFI_pack_get(void *origin_addr, int origin_count,
     req->noncontig.get.origin.total_bytes = origin_bytes;
 
     /* target */
-    req->noncontig.get.target.base = (void *) target_mr.addr;
+    req->noncontig.get.target.base = (void *) (uintptr_t) target_mr.addr;
     req->noncontig.get.target.count = target_count;
     req->noncontig.get.target.datatype = target_datatype;
     MPIR_Datatype_add_ref_if_not_builtin(target_datatype);

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -137,11 +137,12 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_prepare_target_mr(int target_rank,
         /* Special path for dynamic window with per-attach memory registration. */
         offset = target_disp;   /* dynamic win is always with disp_unit=1 */
         void *target_mr_found = NULL;
-        uint64_t target_addr = (uint64_t) MPI_BOTTOM + offset;
+        uint64_t target_addr = (uintptr_t) MPI_BOTTOM + offset;
         /* Return valid node only when [target_addr:target_extent] matches within a
          * single region. If it crosses two regions, NULL is returned. */
         MPL_gavl_tree_search(MPIDI_OFI_WIN(win).dwin_target_mrs[target_rank],
-                             (const void *) target_addr, target_extent, &target_mr_found);
+                             (const void *) (uintptr_t) target_addr, target_extent,
+                             &target_mr_found);
 
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         (MPL_DBG_FDEST, "target_mr found %d addr 0x%" PRIx64 ", extent 0x%lx",

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -964,7 +964,7 @@ int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
             (MPIDI_OFI_target_mr_t *) MPL_malloc(sizeof(MPIDI_OFI_target_mr_t), MPL_MEM_RMA);
         MPIR_Assert(target_mr);
         /* Store addr only for calculating offset when !MPIDI_OFI_ENABLE_MR_VIRT_ADDRESS */
-        target_mr->addr = (uint64_t) target_mrs[i].base;
+        target_mr->addr = (uintptr_t) target_mrs[i].base;
         target_mr->mr_key = target_mrs[i].mr_key;
 
         mpl_err = MPL_gavl_tree_insert(MPIDI_OFI_WIN(win).dwin_target_mrs[i],

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -1084,8 +1084,6 @@ CFLAGS=""
 AX_GCC_VAR_ATTRIBUTE(aligned)
 AX_GCC_VAR_ATTRIBUTE(used)
 
-dnl Check for fallthrough attribute
-AX_GCC_FUNC_ATTRIBUTE(fallthrough)
 PAC_POP_ALL_FLAGS
 
 dnl Final output

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -1075,14 +1075,16 @@ AC_CHECK_FUNCS(inet_ntop getifaddrs)
 
 dnl Check for ATTRIBUTE
 PAC_C_GNU_ATTRIBUTE
-AX_GCC_VAR_ATTRIBUTE(aligned)
-AX_GCC_VAR_ATTRIBUTE(used)
 
-dnl Check for fallthrough attribute
 PAC_PUSH_ALL_FLAGS
 dnl This check requires removing -Wall and -Wextra first or it will fail. Just
 dnl clear them all.
 CFLAGS=""
+
+AX_GCC_VAR_ATTRIBUTE(aligned)
+AX_GCC_VAR_ATTRIBUTE(used)
+
+dnl Check for fallthrough attribute
 AX_GCC_FUNC_ATTRIBUTE(fallthrough)
 PAC_POP_ALL_FLAGS
 

--- a/src/mpl/include/mpl_base.h
+++ b/src/mpl/include/mpl_base.h
@@ -50,12 +50,6 @@
 #define MPL_STATIC_INLINE_SUFFIX
 #endif
 
-#ifdef MPL_HAVE_FUNC_ATTRIBUTE_FALLTHROUGH
-#define MPL_FALLTHROUGH __attribute__((fallthrough))
-#else
-#define MPL_FALLTHROUGH
-#endif
-
 #ifdef MPL_HAVE_VAR_ATTRIBUTE_ALIGNED
 #define MPL_ATTR_ALIGNED(x) __attribute__((aligned(x)))
 #else


### PR DESCRIPTION
## Pull Request Description
When explicit large_count code block is given, it is using the
`MPI_Count` type directly. This currently only affects
MPI_Get_elements_x in the case of `MPI_Count` bigger than `MPI_Aint` (on
32-bit systems). Another function MPI_Win_shared_query also has explicit
larget_count code block, but since it uses MPI_Aint for its disp_unit
output, the generated code was correct although now it is cleaner.

Reference https://github.com/pmodels/mpich/blob/e7b0cb6601e1d675ed409aaf2f21b678060e8311/src/binding/c/datatype_api.txt#L71-L97

* Also included are some warning fixes on the 32-bit systems.
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
