### PR TITLE
config: replace obsolete autoconf macros

### DIFF
--- a/confdb/aclocal_attr_alias.m4
+++ b/confdb/aclocal_attr_alias.m4
@@ -95,9 +95,7 @@ AC_MSG_CHECKING([for multiple __attribute__((alias)) support])
 #Compile the "other" __attribute__ object file.
 AC_COMPILE_IFELSE([
     AC_LANG_SOURCE([
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
 
 struct mpif_cmblk_t_ { int imember; };
 typedef struct mpif_cmblk_t_ mpif_cmblk_t;
@@ -168,9 +166,7 @@ if test "$pac_c_attr_alias_other" = "yes" ; then
 #   Link the "other" __attribute__ object file.
     AC_LINK_IFELSE([
         AC_LANG_PROGRAM([
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
  
 struct mpif_cmblk_t_ { int imember; };
 typedef struct mpif_cmblk_t_ mpif_cmblk_t;

--- a/confdb/aclocal_cache.m4
+++ b/confdb/aclocal_cache.m4
@@ -175,7 +175,7 @@ dnl set here are redundant; the LOAD_CACHE call relies on the way autoconf
 dnl initially processes ARG_ENABLE commands.
 AC_DEFUN([PAC_ARG_CACHING],[
 AC_ARG_ENABLE(cache,
-	AC_HELP_STRING([--enable-cache], [Turn on configure caching]),,
+	AS_HELP_STRING([--enable-cache], [Turn on configure caching]),,
 	[enable_cache="notgiven"])
 ])
 
@@ -328,7 +328,7 @@ dnl cause problems.
 dnl
 AC_DEFUN([PAC_CREATE_BASE_CACHE],[
 AC_ARG_ENABLE(base-cache,
-	AC_HELP_STRING([--enable-base-cache],
+	AS_HELP_STRING([--enable-base-cache],
 		[Enable the use of a simple cache for the subsidiary
                  configure scripts]),,enable_base_cache=default)
 # The default case is controlled by the environment variable CONF_USE_CACHEFILE

--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -359,7 +359,7 @@ AC_DEFUN([PAC_PROG_CC_WORKS],
 [AC_PROG_CC_WORKS
 AC_MSG_CHECKING([whether the C compiler sets its return status correctly])
 AC_LANG_SAVE
-AC_LANG_C
+AC_LANG([C])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([],[[int a = bzzzt;]])],notbroken=no,notbroken=yes)
 AC_MSG_RESULT($notbroken)
 if test "$notbroken" = "no" ; then

--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -641,7 +641,7 @@ dnl
 dnl D*/
 AC_DEFUN([PAC_ARG_STRICT],[
 AC_ARG_ENABLE(strict,
-	AC_HELP_STRING([--enable-strict], [Turn on strict compilation testing]),,enable_strict=no)
+	AS_HELP_STRING([--enable-strict], [Turn on strict compilation testing]),,enable_strict=no)
 PAC_CC_STRICT($enable_strict)
 CFLAGS="$CFLAGS $pac_cc_strict_flags"
 export CFLAGS

--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -131,7 +131,7 @@ AC_DEFUN([PAC_C_OPTIMIZATION],[
 	    break
         fi
     done
-    if test "$ac_cv_prog_gcc" = "yes" ; then
+    if test "$ac_cv_c_compiler_gnu" = "yes" ; then
 	for copt in "-fomit-frame-pointer" "-finline-functions" \
 		 "-funroll-loops" ; do
 	    PAC_C_CHECK_COMPILER_OPTION($copt,found_opt=yes,found_opt=no)
@@ -1242,7 +1242,7 @@ dnl __attribute__((pure)) but generates warnings for __attribute__((format...))
 dnl
 AC_DEFUN([PAC_C_GNU_ATTRIBUTE],[
 AC_REQUIRE([AC_PROG_CC_GNU])
-if test "$ac_cv_prog_gcc" = "yes" ; then
+if test "$ac_cv_c_compiler_gnu" = "yes" ; then
     AC_CACHE_CHECK([whether __attribute__ allowed], pac_cv_gnu_attr_pure,[
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[int foo(int) __attribute__ ((pure));]],[[int a;]])],
             pac_cv_gnu_attr_pure=yes,pac_cv_gnu_attr_pure=no)

--- a/confdb/aclocal_check_visibility.m4
+++ b/confdb/aclocal_check_visibility.m4
@@ -68,7 +68,7 @@ AC_DEFUN([PAC_CHECK_VISIBILITY],[
     # Check if the compiler has support for visibility, like some
     # versions of gcc, icc, Sun Studio cc.
     AC_ARG_ENABLE(visibility,
-        AC_HELP_STRING([--enable-visibility],
+        AS_HELP_STRING([--enable-visibility],
             [enable visibility feature of certain compilers/linkers (default: enabled on platforms that support it)]))
 
     case ${target} in

--- a/confdb/aclocal_coverage.m4
+++ b/confdb/aclocal_coverage.m4
@@ -18,7 +18,7 @@ AC_ARG_VAR([GCOV],[name/path for the gcov utility])
 AC_CHECK_PROGS([GCOV],[gcov])
 
 AC_ARG_ENABLE([coverage],
-              [AC_HELP_STRING([--enable-coverage],
+              [AS_HELP_STRING([--enable-coverage],
                               [Turn on coverage analysis using gcc and gcov])],
               [],[enable_coverage=no])
 

--- a/confdb/aclocal_coverage.m4
+++ b/confdb/aclocal_coverage.m4
@@ -23,7 +23,7 @@ AC_ARG_ENABLE([coverage],
               [],[enable_coverage=no])
 
 if test "$enable_coverage" = "yes" ; then
-    if test "$ac_cv_prog_gcc" = "yes" ; then
+    if test "$ac_cv_c_compiler_gnu" = "yes" ; then
         CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage"
         LIBS="$LIBS -lgcov"
         if test ${WRAPPER_CFLAGS+set} = set ; then

--- a/confdb/aclocal_cxx.m4
+++ b/confdb/aclocal_cxx.m4
@@ -5,7 +5,7 @@ AC_DEFUN([AX_CXX_BOOL],
 [AC_CACHE_CHECK(whether the compiler recognizes bool as a built-in type,
 ac_cv_cxx_bool,
 [AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
+ AC_LANG([C++])
  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     int f(int  x){return 1;}
     int f(char x){return 1;}
@@ -25,7 +25,7 @@ AC_DEFUN([AX_CXX_EXCEPTIONS],
 [AC_CACHE_CHECK(whether the compiler supports exceptions,
 ac_cv_cxx_exceptions,
 [AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
+ AC_LANG([C++])
  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[[try { throw  1; } catch (int i) { return i; }]])],
     ac_cv_cxx_exceptions=yes, ac_cv_cxx_exceptions=no)
  AC_LANG_RESTORE
@@ -41,7 +41,7 @@ AC_DEFUN([AX_CXX_NAMESPACES],
 [AC_CACHE_CHECK(whether the compiler implements namespaces,
 ac_cv_cxx_namespaces,
 [AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
+ AC_LANG([C++])
  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     namespace Outer { namespace Inner { int i = 0; }}
     ]],[[
@@ -64,7 +64,7 @@ ac_cv_cxx_namespace_std,
 [ac_cv_cxx_namespace_std=no
 if test "$ac_cv_cxx_namespaces" = yes ; then 
    AC_LANG_SAVE
-   AC_LANG_CPLUSPLUS
+   AC_LANG([C++])
    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
         #include <iostream>
         using namespace std;

--- a/confdb/aclocal_f77.m4
+++ b/confdb/aclocal_f77.m4
@@ -1116,8 +1116,8 @@ if test "$pac_linkwithf77" != "yes" -a "$pac_linkwithC" != "yes" ; then
         cobjtype="`${FILE} pac_conftest.$OBJEXT | sed -e \"s|pac_conftest\.$OBJEXT||g\"`"
         if test "$fobjtype" != "$cobjtype" ; then
             AC_MSG_ERROR([****  Incompatible Fortran and C Object File Types!  ****
-F77 Object File Type produced by \"${F77} ${FFLAGS}\" is : ${fobjtype}.
- C  Object File Type produced by \"${CC} ${CFLAGS}\" is : ${cobjtype}.])
+F77 Object File Type produced by "${F77} ${FFLAGS}" is : ${fobjtype}.
+ C  Object File Type produced by "${CC} ${CFLAGS}" is : ${cobjtype}.])
         fi
     fi
 fi

--- a/confdb/aclocal_f77.m4
+++ b/confdb/aclocal_f77.m4
@@ -209,7 +209,6 @@ dnl message.  You can use '0' to specify undetermined.
 dnl
 dnl D*/
 AC_DEFUN([PAC_PROG_F77_CHECK_SIZEOF],[
-AC_REQUIRE([AC_HEADER_STDC])
 AC_REQUIRE([AC_F77_LIBRARY_LDFLAGS])
 changequote(<<, >>)dnl
 dnl The name to #define.
@@ -237,9 +236,7 @@ AC_COMPILE_IFELSE([
     AC_LANG_PUSH([C])
     AC_RUN_IFELSE([
         AC_LANG_PROGRAM([
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
 #ifdef F77_NAME_UPPER
 #define cisize_ CISIZE
 #define isize_ ISIZE
@@ -303,7 +300,6 @@ dnl The cache variable name.
 define(<<PAC_CV_NAME>>, translit(pac_cv_f77_sizeof_$1, [ *], [__]))dnl
 changequote([,])dnl
 AC_CACHE_CHECK([for size of Fortran type $1],PAC_CV_NAME,[
-AC_REQUIRE([AC_HEADER_STDC])
 AC_REQUIRE([PAC_PROG_F77_NAME_MANGLE])
 dnl if test "$cross_compiling" = yes ; then
 dnl     ifelse([$2],[],
@@ -313,9 +309,7 @@ dnl fi
 AC_LANG_PUSH([C])
 AC_COMPILE_IFELSE([
     AC_LANG_SOURCE([
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
 #ifdef F77_NAME_UPPER
 #define cisize_ CISIZE
 #define isize_ ISIZE
@@ -654,7 +648,6 @@ dnl Fortran routine MUST be named ftest unless you include code
 dnl to select the appropriate Fortran name.
 dnl 
 AC_DEFUN([PAC_PROG_F77_RUN_PROC_FROM_C],[
-AC_REQUIRE([AC_HEADER_STDC])
 AC_REQUIRE([AC_F77_LIBRARY_LDFLAGS])
 AC_LANG_PUSH([Fortran 77])
 AC_COMPILE_IFELSE([
@@ -668,9 +661,7 @@ AC_COMPILE_IFELSE([
     AC_LANG_PUSH([C])
     AC_RUN_IFELSE([
         AC_LANG_SOURCE([
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
 #ifdef F77_NAME_UPPER
 #define ftest_ FTEST
 #elif defined(F77_NAME_LOWER) || defined(F77_NAME_MIXED)
@@ -708,7 +699,6 @@ dnl by trying to *run* a trivial program.  It only checks for *linking*.
 dnl 
 dnl
 AC_DEFUN([PAC_PROG_F77_IN_C_LIBS],[
-AC_REQUIRE([AC_HEADER_STDC])
 AC_REQUIRE([AC_F77_LIBRARY_LDFLAGS])
 AC_MSG_CHECKING([for which Fortran libraries are needed to link C with Fortran])
 F77_IN_C_LIBS="invalid"
@@ -729,9 +719,7 @@ AC_COMPILE_IFELSE([
     # Create conftest for all link tests.
     AC_LANG_CONFTEST([
         AC_LANG_PROGRAM([
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
         ],[
 #ifdef F77_NAME_UPPER
 #define ftest_ FTEST
@@ -920,7 +908,6 @@ dnl sometimes requires -lSystemStubs.  If another library is needed,
 dnl add it to F77_OTHER_LIBS
 dnl
 AC_DEFUN([PAC_PROG_F77_AND_C_STDIO_LIBS],[
-AC_REQUIRE([AC_HEADER_STDC])
 AC_REQUIRE([PAC_PROG_F77_NAME_MANGLE])
 # To simply the code in the cache_check macro, chose the routine name
 # first, in case we need it
@@ -941,9 +928,7 @@ pac_cv_prog_f77_and_c_stdio_libs=unknown
 AC_LANG_PUSH([C])
 AC_COMPILE_IFELSE([
     AC_LANG_SOURCE([
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
 int $confname(int a) {
     printf( "The answer is %d\n", a ); fflush(stdout); return 0;
 }
@@ -1249,7 +1234,6 @@ dnl
 dnl PAC_F77_INIT_WORKS_WITH_C
 dnl
 AC_DEFUN([PAC_F77_INIT_WORKS_WITH_C],[
-AC_REQUIRE([AC_HEADER_STDC])
 AC_MSG_CHECKING([whether Fortran init will work with C])
 pac_f_init_works_with_c=unknown
 AC_LANG_PUSH([Fortran 77])
@@ -1274,9 +1258,7 @@ AC_COMPILE_IFELSE([
     AC_LANG_PUSH([C])
     AC_LINK_IFELSE([
         AC_LANG_SOURCE([
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
 #ifdef F77_NAME_UPPER
 #define minit_ MINIT
 #elif defined(F77_NAME_LOWER) || defined(F77_NAME_MIXED)
@@ -1326,7 +1308,6 @@ dnl rest of the bits were ignored.  For now, we'll assume that there are
 dnl unique true and false values.
 dnl
 AC_DEFUN([PAC_F77_LOGICALS_IN_C],[
-AC_REQUIRE([AC_HEADER_STDC])
 AC_REQUIRE([PAC_PROG_F77_NAME_MANGLE])
 pac_mpi_fint="$1"
 AC_MSG_CHECKING([for values of Fortran logicals])
@@ -1335,12 +1316,8 @@ pac_cv_prog_f77_true_false_value=""
 AC_LANG_PUSH([C])
 AC_COMPILE_IFELSE([
     AC_LANG_SOURCE([
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
-#if defined(HAVE_STDLIB_H) || defined(STDC_HEADERS)
 #include <stdlib.h>
-#endif
 #ifdef F77_NAME_UPPER
 #define ftest_ FTEST
 #elif defined(F77_NAME_LOWER) || defined(F77_NAME_MIXED)

--- a/confdb/aclocal_f77old.m4
+++ b/confdb/aclocal_f77old.m4
@@ -77,7 +77,7 @@ $fxx_module
 EOF
     found_answer="no"
     if test -z "$ac_fcompilelink" ; then
-        ac_fcompilelink="${F77-f77} -o conftest $FFLAGS $flags conftest.f $LDFLAGS $LIBS 1>&AC_FD_CC"
+        ac_fcompilelink="${F77-f77} -o conftest $FFLAGS $flags conftest.f $LDFLAGS $LIBS 1>&AS_MESSAGE_LOG_FD"
     fi
     AC_MSG_CHECKING([whether ${F77-f77} $flags $libs works with GETARG and IARGC])
     if AC_TRY_EVAL(ac_fcompilelink) && test -x conftest ; then
@@ -124,7 +124,7 @@ EOF
         program main
         end
 EOF
-    ac_fcompilelink_test='${F77-f77} -o conftest $FFLAGS conftest.f $LDFLAGS $libs $LIBS 1>&AC_FD_CC'
+    ac_fcompilelink_test='${F77-f77} -o conftest $FFLAGS conftest.f $LDFLAGS $libs $LIBS 1>&AS_MESSAGE_LOG_FD'
     for libs in $save_trial_LIBS ; do
 	if test "$libs" = "0" ; then
 	    lib_ok="yes"
@@ -211,7 +211,7 @@ EOF
 	    AC_MSG_CHECKING([whether Fortran 77 routine names are case-insensitive $flagval])
 	    dnl we can use double quotes here because all is already
             dnl evaluated
-            ac_fcompilelink_test="${F77-f77} -o conftest $fflag $FFLAGS conftest.f $LDFLAGS $LIBS 1>&AC_FD_CC"
+            ac_fcompilelink_test="${F77-f77} -o conftest $fflag $FFLAGS conftest.f $LDFLAGS $LIBS 1>&AS_MESSAGE_LOG_FD"
 	    if AC_TRY_EVAL(ac_fcompilelink_test) && test -x conftest ; then
 	        AC_MSG_RESULT(yes)
 	    else
@@ -331,7 +331,7 @@ EOF
                 AC_MSG_CHECKING([whether ${F77-f77} $flags $libs works with $MSG])
 		IFS="$save_IFS"
 		dnl We need this here because we've fiddled with IFS
-	        ac_fcompilelink_test="${F77-f77} -o conftest $FFLAGS $flags conftest.f $LDFLAGS $libs $LIBS 1>&AC_FD_CC"
+	        ac_fcompilelink_test="${F77-f77} -o conftest $FFLAGS $flags conftest.f $LDFLAGS $libs $LIBS 1>&AS_MESSAGE_LOG_FD"
 		found_answer="no"
                 if AC_TRY_EVAL(ac_fcompilelink_test) && test -x conftest ; then
 		    if test "$ac_cv_prog_f77_cross" != "yes" -a \	 
@@ -353,8 +353,8 @@ EOF
 		    break
 	        else
                     AC_MSG_RESULT([no])
-		    echo "configure: failed program was:" >&AC_FD_CC
-                    cat conftest.f >&AC_FD_CC
+		    echo "configure: failed program was:" >&AS_MESSAGE_LOG_FD
+                    cat conftest.f >&AS_MESSAGE_LOG_FD
 	        fi
             done
         done

--- a/confdb/aclocal_fc.m4
+++ b/confdb/aclocal_fc.m4
@@ -553,7 +553,6 @@ dnl
 dnl
 dnl
 AC_DEFUN([PAC_PROG_FC_AND_C_STDIO_LIBS],[
-AC_REQUIRE([AC_HEADER_STDC])
 # To simply the code in the cache_check macro, chose the routine name
 # first, in case we need it
 confname=conf1_
@@ -573,9 +572,7 @@ pac_cv_prog_fc_and_c_stdio_libs=unknown
 AC_LANG_PUSH(C)
 AC_COMPILE_IFELSE([
     AC_LANG_SOURCE([
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
 int $confname( int a )
 { printf( "The answer is %d\n", a ); fflush(stdout); return 0; }
     ])

--- a/confdb/aclocal_libs.m4
+++ b/confdb/aclocal_libs.m4
@@ -18,10 +18,10 @@ dnl TODO as written, this macro cannot handle a "with_option" arg that has "-"
 dnl characters in it.  Use AS_TR_SH (and possibly AS_VAR_* macros) to handle
 dnl this case if it ever arises.
 AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
-    AC_ARG_WITH([$1], [AC_HELP_STRING([--with-$1=[[PATH]]],PAC_WITH_LIB_HELP_STRING($1))])
+    AC_ARG_WITH([$1], [AS_HELP_STRING([--with-$1=[[PATH]]],PAC_WITH_LIB_HELP_STRING($1))])
 
     AC_ARG_WITH([$1-include],
-                [AC_HELP_STRING([--with-$1-include=PATH],
+                [AS_HELP_STRING([--with-$1-include=PATH],
                                 [specify path where $1 include directory can be found])],
                 [AS_CASE(["$withval"],
                          [yes|no|''],
@@ -29,7 +29,7 @@ AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
                           with_$1_include=""])],
                 [])
     AC_ARG_WITH([$1-lib],
-                [AC_HELP_STRING([--with-$1-lib=PATH],
+                [AS_HELP_STRING([--with-$1-lib=PATH],
                                 [specify path where $1 lib directory can be found])],
                 [AS_CASE(["$withval"],
                          [yes|no|''],

--- a/confdb/aclocal_romio.m4
+++ b/confdb/aclocal_romio.m4
@@ -541,7 +541,7 @@ if test -z "$ac_f90ext" ; then
     fi
     AC_MSG_CHECKING([for extension for Fortran 90 programs])
     ac_f90ext="f90"
-    ac_f90compile='${FC-f90} -c $FCFLAGS conftest.$ac_f90ext 1>&AC_FD_CC'
+    ac_f90compile='${FC-f90} -c $FCFLAGS conftest.$ac_f90ext 1>&AS_MESSAGE_LOG_FD'
     cat > conftest.$ac_f90ext <<EOF
       program conftest
       end
@@ -630,7 +630,7 @@ define(PAC_GET_XFS_MEMALIGN,
 [AC_MSG_CHECKING([for memory alignment needed for direct I/O])
 rm -f memalignval
 rm -f /tmp/romio_tmp.bin
-AC_TEST_PROGRAM([#include <stdio.h>
+AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -643,7 +643,7 @@ main() {
   fcntl(fd, F_DIOINFO, &st);
   fprintf( f, "%u\n", st.d_mem);
   exit(0);
-}],Pac_CV_NAME=`cat memalignval`,Pac_CV_NAME="")
+}]])],[Pac_CV_NAME=`cat memalignval`],[Pac_CV_NAME=""],[])
 rm -f memalignval
 rm -f /tmp/romio_tmp.bin
 if test -n "$Pac_CV_NAME" -a "$Pac_CV_NAME" != 0 ; then

--- a/confdb/aclocal_shl.m4
+++ b/confdb/aclocal_shl.m4
@@ -57,11 +57,11 @@ dnl D*/
 AC_DEFUN([PAC_ARG_SHAREDLIBS],[
 
 AC_ARG_ENABLE(shared,
-	AC_HELP_STRING([--enable-shared], [Enable shared library builds]),,
+	AS_HELP_STRING([--enable-shared], [Enable shared library builds]),,
 	enable_shared=no)
 
 AC_ARG_ENABLE(rpath,
-	AC_HELP_STRING([--enable-rpath],
+	AS_HELP_STRING([--enable-rpath],
 		[Determine whether the rpath is set when programs are
 		compiled and linked when shared libraries are built.
 		The default is yes; use --disable-rpath to turn this

--- a/confdb/aclocal_shm.m4
+++ b/confdb/aclocal_shm.m4
@@ -21,7 +21,7 @@ AC_DEFUN([PAC_ARG_SHARED_MEMORY],[
 
 # check how to allocate shared memory
 AC_ARG_WITH(shared-memory,
-    AC_HELP_STRING([--with-shared-memory[=auto|sysv|mmap]], [create shared memory using sysv or mmap (default is auto)]),,
+    AS_HELP_STRING([--with-shared-memory[=auto|sysv|mmap]],[create shared memory using sysv or mmap (default is auto)]),,
     with_shared_memory=auto)
 
 if test "$with_shared_memory" = auto -o "$with_shared_memory" = mmap; then

--- a/configure.ac
+++ b/configure.ac
@@ -177,7 +177,7 @@ MPICH_NUMVERSION=`expr $V1$V2$V3$V4$V5 + 0`
 AC_SUBST(MPICH_NUMVERSION)
 
 AC_ARG_WITH(custom-version-string,
-            AC_HELP_STRING([--with-custom-version-string], [Adds a user-specified value to the output of the mpichversion executable]),,with_custom_version_string="")
+            AS_HELP_STRING([--with-custom-version-string], [Adds a user-specified value to the output of the mpichversion executable]),,with_custom_version_string="")
 MPICH_CUSTOM_STRING=$with_custom_version_string
 AC_SUBST(MPICH_CUSTOM_STRING)
 
@@ -325,7 +325,7 @@ m4_include([subsys_include.m4])
 dnl ----------------------------------------------------------------------------
 dnl setup top-level argument handling
 AC_ARG_ENABLE(echo,
-	AC_HELP_STRING([--enable-echo], [Turn on strong echoing. The default is enable=no.]),
+	AS_HELP_STRING([--enable-echo], [Turn on strong echoing. The default is enable=no.]),
 	set -x)
 
 AC_ARG_ENABLE(error-checking,
@@ -413,7 +413,7 @@ AC_ARG_ENABLE([mpit-events],
 dnl We may want to force MPI_Aint to be the same size as MPI_Offset,
 dnl particularly on 32 bit systems with large (64 bit) file systems.
 AC_ARG_WITH(aint-size,
-	AC_HELP_STRING([--with-aint-size], [Override the size of MPI_AINT (in bytes)]),,
+	AS_HELP_STRING([--with-aint-size], [Override the size of MPI_AINT (in bytes)]),,
 	with_aint_size=0)
 
 AC_ARG_ENABLE(fast,
@@ -431,10 +431,10 @@ AC_ARG_ENABLE(fast,
 ],,enable_fast=O2)
 
 AC_ARG_ENABLE(interlib-deps,
-	[AC_HELP_STRING([--enable-interlib-deps - Enable interlibrary dependencies])],,enable_interlib_deps=yes)
+	[AS_HELP_STRING([--enable-interlib-deps - Enable interlibrary dependencies])],,enable_interlib_deps=yes)
 
 AC_ARG_ENABLE(check-compiler-flags,
-	AC_HELP_STRING([--enable-check-compiler-flags], [enable the checks for all compiler
+	AS_HELP_STRING([--enable-check-compiler-flags], [enable the checks for all compiler
                        options, xxxFLAGS, MPICH_xxxFLAGS. Default is on.]),,
 		       enable_check_compiler_flags=yes)
 
@@ -449,28 +449,28 @@ AC_ARG_ENABLE(fortran,
 ],,[enable_fortran=all])
 
 AC_ARG_ENABLE(f77,
-	AC_HELP_STRING([--enable-f77],
+	AS_HELP_STRING([--enable-f77],
 		[DEPRECATED: Use --enable-fortran or --disable-fortran instead]),,[enable_f77=yes])
 
 AC_ARG_ENABLE(fc,
-	AC_HELP_STRING([--enable-fc],
+	AS_HELP_STRING([--enable-fc],
 		[DEPRECATED: Use --enable-fortran or --disable-fortran instead]),,[enable_fc=yes])
 
 AC_ARG_ENABLE(cxx,
-	AC_HELP_STRING([--enable-cxx], [Enable C++ bindings]),,enable_cxx=yes)
+	AS_HELP_STRING([--enable-cxx], [Enable C++ bindings]),,enable_cxx=yes)
 
 AC_ARG_ENABLE(romio,
-	AC_HELP_STRING([--enable-romio], [Enable ROMIO MPI I/O implementation]),,
+	AS_HELP_STRING([--enable-romio], [Enable ROMIO MPI I/O implementation]),,
 	enable_romio=yes)
 
 AC_ARG_ENABLE(debuginfo,
-	AC_HELP_STRING([--enable-debuginfo], [Enable support for debuggers]),,
+	AS_HELP_STRING([--enable-debuginfo], [Enable support for debuggers]),,
 	enable_debuginfo=no)
 
 
 ## Enable creation of libtool-style versioning or no versioning
 AC_ARG_ENABLE(versioning,
-        [AC_HELP_STRING([--enable-versioning],[Enable library versioning])],,
+        [AS_HELP_STRING([--enable-versioning],[Enable library versioning])],,
         [enable_versioning=yes])
 
 if test "$enable_versioning" = "yes" ; then
@@ -489,15 +489,15 @@ dnl load to access the MPICH internal data structures.
 dnl "default" is a special device that allows MPICH to choose one
 dnl based on the environment.
 AC_ARG_WITH(device,
-	AC_HELP_STRING([--with-device=name], [Specify the communication device for MPICH]),,
+	AS_HELP_STRING([--with-device=name], [Specify the communication device for MPICH]),,
 	with_device=ch4)
 
 AC_ARG_WITH(pmi,
-	AC_HELP_STRING([--with-pmi=name], [Specify the pmi interface for MPICH]),,
+	AS_HELP_STRING([--with-pmi=name], [Specify the pmi interface for MPICH]),,
 	with_pmi=default)
 
 AC_ARG_WITH(pm,
-	AC_HELP_STRING([--with-pm=name],
+	AS_HELP_STRING([--with-pm=name],
 		[Specify the process manager for MPICH.  "no" or "none" are
                  valid values.  Multiple process managers may be specified as
                  long as they all use the same pmi interface by separating them
@@ -522,7 +522,7 @@ AC_ARG_ENABLE(threads,
 ],,enable_threads=default)
 
 AC_ARG_ENABLE(thread-cs,
-	AC_HELP_STRING([--enable-thread-cs=type],
+	AS_HELP_STRING([--enable-thread-cs=type],
 			[Choose the method used for critical sections
                          and other atomic updates when multiple
                          threads are present.  Values may be default, global,
@@ -530,7 +530,7 @@ AC_ARG_ENABLE(thread-cs,
                         ]),,enable_thread_cs=default)
 
 AC_ARG_ENABLE(refcount,
-	AC_HELP_STRING([--enable-refcount=type],
+	AS_HELP_STRING([--enable-refcount=type],
 			[Choose the method for ensuring atomic updates
                          to the reference counts for MPI objects.
                          Values may be lock-free or none.  The
@@ -540,7 +540,7 @@ AC_ARG_ENABLE(refcount,
                          enable_refcount=default)
 
 AC_ARG_ENABLE(mutex-timing,
-	AC_HELP_STRING([--enable-mutex-timing], [calculate the time spent waiting on mutexes]),
+	AS_HELP_STRING([--enable-mutex-timing], [calculate the time spent waiting on mutexes]),
 	AC_DEFINE(MPIU_MUTEX_WAIT_TIME,1,[Define to enable timing mutexes]))
 
 AC_ARG_ENABLE([predefined-refcount],
@@ -551,12 +551,12 @@ AC_ARG_ENABLE([predefined-refcount],
               [enable_predefined_refcount=default])
 
 AC_ARG_ENABLE(weak-symbols,
-	AC_HELP_STRING([--enable-weak-symbols],
+	AS_HELP_STRING([--enable-weak-symbols],
 			[Use weak symbols to implement PMPI routines (default)]),,
 		enable_weak_symbols=yes)
 
 AC_ARG_ENABLE(qmpi,
-	AC_HELP_STRING([--enable-qmpi],
+	AS_HELP_STRING([--enable-qmpi],
 			[Enable QMPI support (default)]),,
 		enable_qmpi=no)
 
@@ -582,12 +582,12 @@ AC_ARG_ENABLE([two-level-namespace],
               [enable_two_level_namespace=no])
 
 AC_ARG_ENABLE(multi-aliases,
-	AC_HELP_STRING([--enable-multi-aliases],
+	AS_HELP_STRING([--enable-multi-aliases],
 		[Multiple aliasing to support multiple fortran compilers (default)]),,
 		enable_multi_aliases=yes)
 
 AC_ARG_WITH([wrapper-dl-type],
-            [AC_HELP_STRING([--enable-wrapper-dl-type],
+            [AS_HELP_STRING([--enable-wrapper-dl-type],
                             [Dynamic loading model for alternate MPI
                              libraries, used when programs are linked
                              by mpicc compiler wrappers.  This only
@@ -602,7 +602,7 @@ AC_ARG_WITH([wrapper-dl-type],
 AC_SUBST([with_wrapper_dl_type])
 
 AC_ARG_ENABLE([long-double],
-              [AC_HELP_STRING([--disable-long-double],
+              [AS_HELP_STRING([--disable-long-double],
                               [Pass --disable-long-double to prevent the MPI
                                library from supporting the C "long double" type,
                                even if the C compiler supports it.  "long
@@ -612,7 +612,7 @@ AC_ARG_ENABLE([long-double],
               [enable_long_double=yes])
 
 AC_ARG_WITH(cross,
-	AC_HELP_STRING([--with-cross=file],
+	AS_HELP_STRING([--with-cross=file],
 		[Specify the values of variables that configure cannot
                  determine in a cross-compilation environment]),,
 		 with_cross=$MPID_DEFAULT_CROSS_FILE)
@@ -628,7 +628,7 @@ AC_ARG_WITH(name-publisher,
     [],
     with_namepublisher=$with_name_publisher,)
 
-AC_ARG_ENABLE(nolocal, AC_HELP_STRING([--enable-nolocal], [enables nolocal mode where shared-memory communication is disabled]),
+AC_ARG_ENABLE(nolocal, AS_HELP_STRING([--enable-nolocal], [enables nolocal mode where shared-memory communication is disabled]),
     AC_DEFINE(ENABLE_NO_LOCAL, 1, [Define to disable shared-memory communication]))
 
 AC_CANONICAL_TARGET
@@ -1904,7 +1904,7 @@ information to configure with the FCFLAGS environment variable.])
    #    gfortran
    # Add others as they become known
    AC_ARG_ENABLE(f77characterlen,
-       AC_HELP_STRING([--enable-f77characterlen],
+       AS_HELP_STRING([--enable-f77characterlen],
            [Select between int and size_t for the length of a Fortran CHARACTER, depending on the F77 compiler.  If --enable-f77characterlen=size_t is given, force the use of size_t.  This is used for passing Fortran CHARACTER data between C and Fortran, and is provided for experts.  Note that the documentation provided by compiler vendors on the calling convention may not be accurate.]),,enable_f77characterlen=no)
 
    # Set the default
@@ -4442,7 +4442,7 @@ PAC_C_MACRO_VA_ARGS
 AC_FUNC_ALLOCA
 # We don't use alloca unless USE_ALLOCA is also set.
 AC_ARG_ENABLE(alloca,
-	AC_HELP_STRING([--enable-alloca],
+	AS_HELP_STRING([--enable-alloca],
 		[Use alloca to allocate temporary memory if available]),,enable_alloca=no)
 if test "$enable_alloca" = yes ; then
     AC_DEFINE(USE_ALLOCA,1,[Define if alloca should be used if available])
@@ -4461,12 +4461,12 @@ fi
 # Look for some non-posix, but commonly provided functions
 # ----------------------------------------------------------------------------
 # mkstemp() is a better replacement for mktemp()
-AC_HAVE_FUNCS(mkstemp)
+AC_CHECK_FUNCS(mkstemp)
 if test "$ac_cv_func_mkstemp" = "yes" ; then
     PAC_FUNC_NEEDS_DECL([#include <stdlib.h>],mkstemp)
 fi
 # putenv() sets environment variable
-AC_HAVE_FUNCS(putenv)
+AC_CHECK_FUNCS(putenv)
 if test "$ac_cv_func_putenv" = "yes" ; then
     PAC_FUNC_NEEDS_DECL([#include <stdlib.h>],putenv)
 fi
@@ -4658,7 +4658,7 @@ fi
 
 # Checkpointing
 AC_ARG_ENABLE(checkpointing,
-    [AC_HELP_STRING([--enable-checkpointing], [Enable application checkpointing])],
+    [AS_HELP_STRING([--enable-checkpointing], [Enable application checkpointing])],
     [ if test "$enableval" != "no" ; then
 	PAC_CHECK_HEADER_LIB_FATAL(blcr, libcr.h, cr, cr_init)
         AC_DEFINE(ENABLE_CHECKPOINTING,1,[Application checkpointing enabled])

--- a/configure.ac
+++ b/configure.ac
@@ -2815,7 +2815,6 @@ AC_CHECK_SIZEOF(double)
 AC_CHECK_SIZEOF(long double)
 AC_CHECK_SIZEOF(void *)
 
-AC_HEADER_STDC
 AC_CHECK_HEADERS([stddef.h])
 AC_CHECK_SIZEOF(wchar_t, 0, [
 #ifdef HAVE_STDDEF_H
@@ -4391,8 +4390,6 @@ fi
 PAC_ENABLE_COVERAGE
 
 # -----------------------------------------------------------------------------
-# Look for Standard headers
-AC_HEADER_STDC
 # Check for a specific header
 # Grrr.  OS/X fails the test for sys/uio.h because uio *requires* sys/types.h
 # to compile.  Thus, we'll make that a separate test

--- a/configure.ac
+++ b/configure.ac
@@ -2021,7 +2021,7 @@ if test "$enable_f77" = "yes" ; then
     PAC_COMPILER_SHLIB_FLAGS([F77],[$f77_shlib_conf])
     AC_SUBST_FILE([f77_shlib_conf])
 
-    AC_LANG_FORTRAN77
+    AC_LANG([Fortran 77])
     PAC_PROG_F77_EXCLAIM_COMMENTS(has_exclaim="yes",has_exclaim="no")
     PAC_PROG_F77_HAS_INCDIR(src)
     PAC_PROG_F77_LIBRARY_DIR_FLAG
@@ -2334,7 +2334,7 @@ if test "$enable_cxx" = "yes" ; then
         AC_MSG_WARN([The C++ compiler $CXX cannot compile a program containing the <string> header - this may indicate a problem with the C++ installation.  Consider configuing with --disable-cxx])
     fi
 
-    AC_LANG_CPLUSPLUS
+    AC_LANG([C++])
     AX_CXX_EXCEPTIONS
     AX_CXX_BOOL
     AX_CXX_NAMESPACES
@@ -2456,7 +2456,7 @@ AC_SUBST(bindings)
 # End of the bindings support
 # ----------------------------------------------------------------------------
 
-AC_LANG_C
+AC_LANG([C])
 #
 # ----------------------------------------------------------------------------
 # Done with the basic argument processing and decisions about which
@@ -3331,7 +3331,7 @@ if test "$enable_f77" = yes ; then
     PAC_PROG_F77_CHECK_SIZEOF_EXT(integer,$CROSS_F77_SIZEOF_INTEGER)
     PAC_PROG_F77_CHECK_SIZEOF_EXT(real,$CROSS_F77_SIZEOF_REAL)
     PAC_PROG_F77_CHECK_SIZEOF_EXT(double precision,$CROSS_F77_SIZEOF_DOUBLE_PRECISION)
-    AC_LANG_FORTRAN77
+    AC_LANG([Fortran 77])
     # If we have sizes for real and double, we do not need to call
     # mpir_get_fsize at run time.
     # For the size-defined types (e.g., integer*2), we assume that if the
@@ -3665,7 +3665,7 @@ dnl Removed MPI_2COMPLEX and MPI_2DOUBLE_COMPLEX, leaving comments to explain th
         fi
         eval $fullvar=$value
     done
-    AC_LANG_C
+    AC_LANG([C])
 
     # Now, handle the sized types
     #
@@ -4140,7 +4140,7 @@ dnl Removed MPI_2COMPLEX and MPI_2DOUBLE_COMPLEX, leaving comments to explain th
     AC_SUBST(REQI8)
     #
 
-    AC_LANG_C
+    AC_LANG([C])
 fi
 # ----------------------------------------------------------------------------
 # C++ types
@@ -4158,7 +4158,7 @@ MPI_F77_CXX_FLOAT_COMPLEX=MPI_DATATYPE_NULL
 MPI_F77_CXX_DOUBLE_COMPLEX=MPI_DATATYPE_NULL
 MPI_F77_CXX_LONG_DOUBLE_COMPLEX=MPI_DATATYPE_NULL
 if test "$enable_cxx" = "yes" ; then
-    AC_LANG_CPLUSPLUS
+    AC_LANG([C++])
     AC_CHECK_SIZEOF(bool)
 
     # Find a C type that matches the size of the C++ boolean type
@@ -4251,7 +4251,7 @@ using namespace std;
             esac
         fi
     fi
-    AC_LANG_C
+    AC_LANG([C])
 
     # Make these available to the collective operations and other code
     AC_DEFINE_UNQUOTED(MPIR_CXX_BOOL_VALUE,$MPIR_CXX_BOOL,[Define as the MPI Datatype handle for MPI::BOOL])

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
-AC_PREREQ(2.63)
+AC_PREREQ([2.69])
 
 dnl Process this file with autoconf to produce a configure script.
 dnl
@@ -201,7 +201,7 @@ fi
 echo "Running on system: `uname -a`"
 
 dnl Definitions will be placed in this file rather than in the DEFS variable
-AC_CONFIG_HEADER(src/include/mpichconf.h)
+AC_CONFIG_HEADERS([src/include/mpichconf.h])
 AH_TOP([/*
  * Copyright (C) by Argonne National Laboratory
  *     See COPYRIGHT in top-level directory
@@ -5312,7 +5312,7 @@ fi
 
 dnl This includes an experimental pkgconfig file for ch3 in the src/pkgconfig
 dnl directory
-AC_OUTPUT(Makefile \
+AC_CONFIG_FILES([Makefile \
           examples/Makefile \
           test/Makefile \
           test/commands/Makefile \
@@ -5345,7 +5345,8 @@ AC_OUTPUT(Makefile \
           doc/installguide/Makefile \
           doc/refman/Makefile \
           doc/userguide/Makefile \
-          test/commands/cmdtests)
+          test/commands/cmdtests])
+AC_OUTPUT
 
 if test ${device_name} = "ch4" ; then
 cat <<EOF

--- a/configure.ac
+++ b/configure.ac
@@ -2563,7 +2563,7 @@ if test "$enable_debuginfo" = "yes" ; then
    #    +noobjdebug
    # for C, Fortran, and C++.  We don't have a good test for this yet,
    # so we add a warning
-   if test "$ac_cv_prog_gcc" = "yes" ; then
+   if test "$ac_cv_c_compiler_gnu" = "yes" ; then
        AC_MSG_WARN([Some versions of gcc do not include debugging information
 within the executable.  Totalview requires this information to detect
 an MPICH code.  If you have trouble, try linking with the additional

--- a/maint/fcrosscompile/configure.ac
+++ b/maint/fcrosscompile/configure.ac
@@ -6,7 +6,7 @@
 AC_INIT
 
 AC_ARG_WITH(aint-size,
-    AC_HELP_STRING([--with-aint-size],
+    AS_HELP_STRING([--with-aint-size],
                    [Override the size of MPI_AINT (in bytes)]),,
     with_aint_size=0)
 

--- a/maint/sampleconf.in
+++ b/maint/sampleconf.in
@@ -7,7 +7,7 @@ dnl The file name here refers to a file in the source being configured
 AC_INIT(pick a local file)
 dnl
 dnl Definitions will be placed in this file rather than in the DEFS variable
-AC_CONFIG_HEADER(pick a headef file name)
+AC_CONFIG_HEADERS([pick a headef file name])
 dnl
 dnl Set the directory that contains support scripts such as install-sh and
 dnl config.guess

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -10,21 +10,9 @@
 #include "mpichconf.h"
 
 #include <stdio.h>
-#ifdef STDC_HEADERS
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
-#else
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STDARG_H
-#include <stdarg.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-#endif
 
 #ifdef HAVE_LIMITS_H
 #include <limits.h>

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -456,7 +456,7 @@ fi
 
 PAC_GET_SPECIAL_SYSTEM_INFO
 
-AC_HAVE_FUNCS(memalign)
+AC_CHECK_FUNCS(memalign)
 
 #
 # Question: Should ROMIO under MPICH ignore the Fortran tests, since

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -7,7 +7,7 @@
 # autoconf --localdir=../confdb configure.ac
 # (or wherever the confdb is)
 #
-AC_PREREQ([2.63])
+AC_PREREQ([2.69])
 
 m4_include([version.m4])
 dnl 2nd arg is intentionally underquoted
@@ -51,7 +51,7 @@ if test -n "$CONFIGURE_ARGS" ; then
     AC_MSG_NOTICE([Configuring with args $CONFIGURE_ARGS])
 fi
 
-AC_CONFIG_HEADER(adio/include/romioconf.h)
+AC_CONFIG_HEADERS([adio/include/romioconf.h])
 AH_TOP([/*
  * Copyright (C) by Argonne National Laboratory
  *     See COPYRIGHT in top-level directory

--- a/src/mpid/ch3/subconfigure.m4
+++ b/src/mpid/ch3/subconfigure.m4
@@ -78,14 +78,8 @@ AC_CHECK_HEADERS(assert.h limits.h string.h sys/types.h sys/uio.h uuid/uuid.h \
 # is a prerequisite.
 AC_CHECK_HEADERS([net/if.h], [], [],
 [#include <stdio.h>
-#ifdef STDC_HEADERS
-# include <stdlib.h>
-# include <stddef.h>
-#else
-# ifdef HAVE_STDLIB_H
-#  include <stdlib.h>
-# endif
-#endif
+#include <stdlib.h>
+#include <stddef.h>
 #ifdef HAVE_SYS_SOCKET_H
 # include <sys/socket.h>
 #endif

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -349,7 +349,7 @@ AC_DEFINE_UNQUOTED([MPIDI_CH4_MAX_VCIS], [$with_ch4_max_vcis], [Number of VCIs c
 
 # Check for enable-ch4-vci-method choice
 AC_ARG_ENABLE(ch4-vci-method,
-	AC_HELP_STRING([--enable-ch4-vci-method=type],
+	AS_HELP_STRING([--enable-ch4-vci-method=type],
 			[Choose the method used for vci selection when enable-thread-cs=per-vci is selected.
                           Values may be default, zero, communicator, tag, implicit, explicit]),,enable_ch4_vci_method=default)
 

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -3,7 +3,7 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
-AC_PREREQ(2.63)
+AC_PREREQ(2.69)
 
 AC_INIT([MPL], [0.1])
 
@@ -44,7 +44,7 @@ else
    AC_MSG_ERROR([Version information not found. Configuration aborted.])
 fi
 
-AC_CONFIG_HEADER([include/config.h])
+AC_CONFIG_HEADERS([include/config.h])
 AC_CONFIG_COMMANDS([prefix-config],[perl $srcdir/confdb/cmd_prefix_config_h.pl MPL include/config.h include/mplconfig.h])
 
 # Non-verbose make

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -59,13 +59,13 @@ PAC_C_BUILTIN_EXPECT
 PAC_C_STATIC_ASSERT
 
 AC_ARG_ENABLE(embedded,
-    AC_HELP_STRING([--enable-embedded], [Build MPL in embedded mode (default is no)]),
+    AS_HELP_STRING([--enable-embedded], [Build MPL in embedded mode (default is no)]),
     [embedded=yes],
     [embedded=no])
 AM_CONDITIONAL([MPL_EMBEDDED_MODE],[test "x${embedded}" = "xyes"])
 
 AC_ARG_ENABLE(g,
-    AC_HELP_STRING([--enable-g=option],
+    AS_HELP_STRING([--enable-g=option],
 	[
 		Control the level of debugging support in MPL.
 		"option" is a list of comma separated names.  Default
@@ -943,12 +943,12 @@ fi
 #######################################################################
 
 # mkstemp() is a better replacement for mktemp()
-AC_HAVE_FUNCS(mkstemp)
+AC_CHECK_FUNCS(mkstemp)
 if test "$ac_cv_func_mkstemp" = "yes" ; then
     PAC_FUNC_NEEDS_DECL([#include <stdlib.h>],mkstemp)
 fi
 # fdopen() converts from an fd to a FILE*
-AC_HAVE_FUNCS(fdopen)
+AC_CHECK_FUNCS(fdopen)
 if test "$ac_cv_func_fdopen" = "yes" ; then
     PAC_FUNC_NEEDS_DECL([#include <stdio.h>],fdopen)
 fi
@@ -972,7 +972,7 @@ PAC_ARG_SHARED_MEMORY
 
 ## Enable creation of libtool-style versioning or no versioning
 AC_ARG_ENABLE(versioning,
-        [AC_HELP_STRING([--enable-versioning],[Enable library versioning])],,
+        [AS_HELP_STRING([--enable-versioning],[Enable library versioning])],,
         [enable_versioning=yes])
 
 if test "$enable_versioning" = "yes" ; then

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -27,7 +27,7 @@ AM_INIT_AUTOMAKE([-Wall -Wno-portability-recursive -Werror foreign 1.12.3 subdir
 
 AM_PROG_AR
 
-AC_CONFIG_HEADER(include/hydra_config.h)
+AC_CONFIG_HEADERS([include/hydra_config.h])
 
 # Non-verbose make
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
@@ -659,7 +659,8 @@ if test "$ac_cv_func_gethostname" = "yes" ; then
 fi
 
 # Final output
-AC_OUTPUT(Makefile
+AC_CONFIG_FILES([Makefile
 	tools/bootstrap/src/bsci_init.c
 	hydra-doxygen.cfg
-)
+])
+AC_OUTPUT

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -151,7 +151,6 @@ AC_SUBST(top_srcdir)
 PAC_ENABLE_COVERAGE
 
 # Check if the necessary headers are available
-AC_HEADER_STDC
 AC_CHECK_HEADERS(unistd.h strings.h sys/types.h sys/socket.h sched.h sys/stat.h sys/param.h \
 		 netinet/in.h netinet/tcp.h sys/un.h sys/time.h time.h ifaddrs.h arpa/inet.h \
 		 poll.h fcntl.h netdb.h winsock2.h windows.h)

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -217,7 +217,7 @@ fi
 # Check what bootstrap server we should use
 #########################################################################
 AC_ARG_WITH(hydra-bss,
-	[AC_HELP_STRING([--with-hydra-bss=name],
+	[AS_HELP_STRING([--with-hydra-bss=name],
 		[Bootstrap Server (user,ssh,rsh,fork,slurm,ll,lsf,sge,pbs,cobalt,manual,persist)])],
 	[ hydra_bss=$withval ],
 	[ hydra_bss="user,ssh,rsh,fork,slurm,ll,lsf,sge,pbs,cobalt,manual,persist" ])

--- a/src/pm/hydra/include/hydra.h
+++ b/src/pm/hydra/include/hydra.h
@@ -19,16 +19,12 @@
 extern char *HYD_dbg_prefix;
 
 /* C89 headers can be included without a check */
-#if defined STDC_HEADERS
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
 #include <errno.h>
 #include <signal.h>
-#else
-#error "STDC_HEADERS are assumed in the Hydra code"
-#endif /* STDC_HEADERS */
 
 #if defined NEEDS_POSIX_FOR_SIGACTION
 #define _POSIX_SOURCE

--- a/src/pm/hydra2/configure.ac
+++ b/src/pm/hydra2/configure.ac
@@ -173,7 +173,6 @@ AC_SUBST(top_srcdir)
 PAC_ENABLE_COVERAGE
 
 # Check if the necessary headers are available
-AC_HEADER_STDC
 AC_CHECK_HEADERS(unistd.h strings.h sys/types.h sys/socket.h sched.h sys/stat.h sys/param.h \
 		 netinet/in.h netinet/tcp.h sys/un.h sys/time.h time.h ifaddrs.h arpa/inet.h \
 		 poll.h fcntl.h netdb.h)

--- a/src/pm/hydra2/configure.ac
+++ b/src/pm/hydra2/configure.ac
@@ -39,7 +39,7 @@ AM_INIT_AUTOMAKE([-Wall -Wno-portability-recursive -Werror foreign 1.12.3 subdir
 
 AM_PROG_AR
 
-AC_CONFIG_HEADER(libhydra/include/hydra_config.h)
+AC_CONFIG_HEADERS([libhydra/include/hydra_config.h])
 
 # Non-verbose make
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])

--- a/src/pm/hydra2/configure.ac
+++ b/src/pm/hydra2/configure.ac
@@ -241,7 +241,7 @@ fi
 # Check what RMK we should use
 #########################################################################
 AC_ARG_WITH(hydra-rmk,
-	[AC_HELP_STRING([--with-hydra-rmk=name],
+	[AS_HELP_STRING([--with-hydra-rmk=name],
 		[RMK (slurm,ll,lsf,sge,pbs,cobalt)])],
 	[ hydra_rmk=$withval ],
 	[ hydra_rmk="slurm,ll,lsf,sge,pbs,cobalt" ])
@@ -280,7 +280,7 @@ AC_DEFINE_UNQUOTED(HYDRA_AVAILABLE_RMKS,"${hydra_rmk_names_unquoted}",[Definitio
 # Check what bstrap we should use
 #########################################################################
 AC_ARG_WITH(hydra-bstrap,
-	[AC_HELP_STRING([--with-hydra-bstrap=name],
+	[AS_HELP_STRING([--with-hydra-bstrap=name],
 		[Bstrap Server (ssh,rsh,slurm,ll,lsf,sge,pbs)])],
 	[ hydra_bstrap=$withval ],
 	[ hydra_bstrap="ssh,slurm,rsh,ll,sge" ])

--- a/src/pm/util/subconfigure.m4
+++ b/src/pm/util/subconfigure.m4
@@ -181,7 +181,7 @@ dnl
 # FIXME: need to include the test, at least for any file that
 # might set _POSIX_SOURCE
 # putenv() sets environment variable
-AC_HAVE_FUNCS(putenv)
+AC_CHECK_FUNCS(putenv)
 if test "$ac_cv_func_putenv" = "yes" ; then
     PAC_FUNC_NEEDS_DECL([#include <stdlib.h>],putenv)
 fi

--- a/src/pm/util/subconfigure.m4
+++ b/src/pm/util/subconfigure.m4
@@ -104,8 +104,6 @@ dnl Is there libnsl needed for gethostbyname?
 dnl AC_SEARCH_LIBS(gethostbyname,nsl)
 AC_SEARCH_LIBS(socketpair,socket)
 dnl
-dnl Look for Standard headers
-AC_HEADER_STDC
 dnl Check for a specific header
 AC_CHECK_HEADERS(sys/types.h signal.h sys/ptrace.h sys/uio.h unistd.h)
 if test "$ac_cv_header_sys_uio_h" = "yes" ; then

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -23,7 +23,7 @@ AC_INIT([mpich-testsuite],
         [mpich-testsuite],
         [http://www.mpich.org/])
 
-AC_CONFIG_HEADER(include/mpitestconf.h)
+AC_CONFIG_HEADERS([include/mpitestconf.h])
 AH_TOP([/*
  * Copyright (C) by Argonne National Laboratory
  *     See COPYRIGHT in top-level directory

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -705,7 +705,6 @@ AM_PROG_AR
 PAC_ARG_STRICT
 
 # General headers
-AC_HEADER_STDC
 dnl AC_CHECK_HEADERS(stdarg.h unistd.h string.h stdlib.h memory.h stdint.h)
 dnl unistd.h string.h stdlib.h memory.h stdint.h are checked by AC_PROG_CC.
 AC_CHECK_HEADERS(stdarg.h sys/time.h sys/resource.h)

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -93,7 +93,7 @@ if test "X$main_top_srcdir" = "X" -a "$USE_MAINTAINER_MODE" = "yes" ; then
 fi
 
 AC_ARG_ENABLE(echo,
-	[AC_HELP_STRING([--enable-echo],[Turn on strong echoing. The default is enable=no.])],
+	[AS_HELP_STRING([--enable-echo],[Turn on strong echoing. The default is enable=no.])],
 	[set -x])
 
 AC_ARG_ENABLE(fortran,
@@ -142,7 +142,7 @@ IFS="$save_IFS"
 
 # DTPools switch
 AC_ARG_ENABLE([dtpools],
-              [AC_HELP_STRING([--disable-dtpools],[Disable dtpools tests])],,
+              [AS_HELP_STRING([--disable-dtpools],[Disable dtpools tests])],,
               [enable_dtpools=yes])
 
 if test "x${enable_dtpools}" = "xyes"; then
@@ -154,74 +154,74 @@ fi
 AC_SUBST(DTP_SWITCH)
 
 AC_ARG_ENABLE(cxx,
-	[AC_HELP_STRING([--enable-cxx],[Turn on C++ tests (default)])],,[enable_cxx=yes])
+	[AS_HELP_STRING([--enable-cxx],[Turn on C++ tests (default)])],,[enable_cxx=yes])
 
 AC_ARG_ENABLE(romio,
-	[AC_HELP_STRING([--enable-romio],[Enable ROMIO MPI I/O implementation])],,
+	[AS_HELP_STRING([--enable-romio],[Enable ROMIO MPI I/O implementation])],,
 	[enable_romio=yes])
 
 AC_ARG_ENABLE(spawn,
-	[AC_HELP_STRING([--enable-spawn],
+	[AS_HELP_STRING([--enable-spawn],
 		[Enable tests of the dynamic process parts of MPI-2 (default)])],,
 	[enable_spawn=yes])
 
 AC_ARG_ENABLE(rma,
-	[AC_HELP_STRING([--enable-rma],[Enable tests of the one sided parts of MPI-2 (default)])],,
+	[AS_HELP_STRING([--enable-rma],[Enable tests of the one sided parts of MPI-2 (default)])],,
 	[enable_rma=yes])
 
 AC_ARG_ENABLE(long-double-complex,
-	[AC_HELP_STRING([--enable-long-double-complex],
+	[AS_HELP_STRING([--enable-long-double-complex],
 		[Enable tests involving MPI_LONG_DOUBLE_COMPLEX (default)])],,
 	[enable_long_double_complex=yes])
 AC_ARG_ENABLE(long-double,
-	[AC_HELP_STRING([--enable-long-double-complex],
+	[AS_HELP_STRING([--enable-long-double-complex],
 		[Enable tests involving MPI_LONG_DOUBLE and related types (default)])],,
 	[enable_long_double=yes])
 
 AC_ARG_ENABLE(checkerrors,
-	[AC_HELP_STRING([--enable-checkerrors],
+	[AS_HELP_STRING([--enable-checkerrors],
 		[Add some tests for checking for errors in user programs])],,
 	[enable_checkerrors=yes])
 
 AC_ARG_ENABLE(perftest,
-	[AC_HELP_STRING([--enable-perftest],
+	[AS_HELP_STRING([--enable-perftest],
 		[Include tests for basic performance consistency (default)])],,
 	[enable_perftest=yes])
 
 AC_ARG_ENABLE(large-tests,
-	[AC_HELP_STRING([--enable-large-tests],
+	[AS_HELP_STRING([--enable-large-tests],
 		[Enable tests which require large (>2GB per proc) amount of memory])],,
 	[enable_large_tests=no])
 
 AC_ARG_ENABLE(ft-tests,
-	[AC_HELP_STRING([--enable-ft-tests],
+	[AS_HELP_STRING([--enable-ft-tests],
 		[Include tests for fault tolerance (default no)])],,
 	[enable_ft_tests=no])
 
 AC_ARG_ENABLE(comm-overlap-tests,
-	[AC_HELP_STRING([--enable-comm-overlap-tests],
+	[AS_HELP_STRING([--enable-comm-overlap-tests],
 		[Include tests for communicator overlap (default)])],,
 	[enable_comm_overlap_tests=yes])
 
 AC_ARG_ENABLE(checkfaults,
-	[AC_HELP_STRING([--enable-checkfaults],
+	[AS_HELP_STRING([--enable-checkfaults],
 		[Add some tests for checking on handling of faults in user programs])],,
 	[enable_checkfaults=no])
 
 AC_ARG_ENABLE(checkpointing,
-	[AC_HELP_STRING([--enable-checkpointing],
+	[AS_HELP_STRING([--enable-checkpointing],
 		[Add some tests for checkpointing])],,
 	[enable_checkpointing=no])
 
 AC_ARG_ENABLE(fast,
-	[AC_HELP_STRING([--enable-fast],
+	[AS_HELP_STRING([--enable-fast],
 		[Indicates that the MPI implementation may have been
 		built for fastest operation, such as building without
 		error checking.  Has the effect of
 		--enable-checkerrors=no])],,)
 
 AC_ARG_ENABLE(strictmpi,
-	[AC_HELP_STRING([--enable-strictmpi],
+	[AS_HELP_STRING([--enable-strictmpi],
 		[Only test for operations specifically defined by the
 		MPI standard.  This turns off tests for some common
 		extensions, including for combinations of predefined
@@ -246,18 +246,18 @@ AC_ARG_ENABLE(threads,
 	[enable_threads=default])
 
 AC_ARG_ENABLE(xfail,
-	[AC_HELP_STRING([--enable-xfail],
+	[AS_HELP_STRING([--enable-xfail],
 		[Run tests marked for expected failure])],,
 	[enable_xfail=no])
 
 AC_ARG_ENABLE(gpu-tests-only,
-        [AC_HELP_STRING([--enable-gpu-tests-only],
+        [AS_HELP_STRING([--enable-gpu-tests-only],
                 [Run only GPU tests])],,
         [enable_gpu_tests_only=no])
 
 # DTPools test generation
 AC_ARG_WITH(dtpools-datatypes,
-    [AC_HELP_STRING([--with-dtpools-datatypes=typelist],
+    [AS_HELP_STRING([--with-dtpools-datatypes=typelist],
         [Comma separated list of MPI datatypes to use for DTPools tests
          generation. Typelist can be of the form: 'MPI_INT,MPI_DOUBLE,...',
          for single element types, 'MPI_INT:4+MPI_DOUBLE:8,...', for multiple
@@ -271,12 +271,12 @@ AC_CONFIG_COMMANDS([gentests],[$srcdir/maint/gentests_dtp.sh $dtp_args],[dtp_arg
 AC_CONFIG_COMMANDS([collcvartests],[$srcdir/maint/test_coll_algos.sh])
 
 AC_ARG_WITH(mpi,
-	[AC_HELP_STRING([--with-mpi=dir],
+	[AS_HELP_STRING([--with-mpi=dir],
 		[Use the selected MPI; compilation scripts for mpicc,
 		mpifort and mpicxx should be in dir/bin])],,)
 
 AC_ARG_WITH(pm,
-	AC_HELP_STRING([--with-pm=name],
+	AS_HELP_STRING([--with-pm=name],
 		[Specify the process manager for MPICH.  "no" or "none" are
                  valid values.  Multiple process managers may be specified as
                  long as they all use the same pmi interface by separating them
@@ -320,7 +320,7 @@ else
 fi
 
 AC_ARG_WITH(config-args,
-	[AC_HELP_STRING([--with-config-args=filename],
+	[AS_HELP_STRING([--with-config-args=filename],
 		[Specify configure argument file that contains the
 		values of variables that configure reads,
 		e.g. CC,CFLAGS,F77,FFLAGS,FC,FCFLAGS....  If the

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1061,14 +1061,14 @@ dnl                     ac_cv_sizeof_MPI_Offset=`cat conftestval`
 dnl                 else
 dnl                     # failure
 dnl                     AC_MSG_WARN([Unable to run the program to determine the size of MPI_Offset])
-dnl                     echo "configure: failed program was:" >&AC_FD_CC
-dnl                     cat conftest.c >&AC_FD_CC
+dnl                     echo "configure: failed program was:" >&AS_MESSAGE_LOG_FD
+dnl                     cat conftest.c >&AS_MESSAGE_LOG_FD
 dnl                 fi
 dnl             else
 dnl                 # failure
 dnl                 AC_MSG_WARN([Unable to build the program to determine the size of MPI_Offset])
-dnl                 echo "configure: failed program was:" >&AC_FD_CC
-dnl                 cat conftest.c >&AC_FD_CC
+dnl                 echo "configure: failed program was:" >&AS_MESSAGE_LOG_FD
+dnl                 cat conftest.c >&AS_MESSAGE_LOG_FD
 dnl             fi
 dnl             rm -f conftest*
 dnl         ])

--- a/test/mpi/dtpools/configure.ac
+++ b/test/mpi/dtpools/configure.ac
@@ -3,11 +3,11 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
-AC_PREREQ([2.63])
+AC_PREREQ([2.69])
 AC_INIT([dtpools], [0.0], [discuss@mpich.org])
 AC_CONFIG_SRCDIR([include/dtpools.h])
 
-AC_CONFIG_HEADER(dtpoolsconf.h)
+AC_CONFIG_HEADERS([dtpoolsconf.h])
 AH_TOP([/*
  * Copyright (C) by Argonne National Laboratory
  *     See COPYRIGHT in top-level directory

--- a/test/mpi/util/dtypes.c
+++ b/test/mpi/util/dtypes.c
@@ -7,15 +7,9 @@
 #include "mpitestconf.h"
 #include "mpitest.h"
 #include "dtypes.h"
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
-#if defined(HAVE_STDLIB_H) || defined(STDC_HEADERS)
 #include <stdlib.h>
-#endif
-#if defined(HAVE_STRING_H) || defined(STDC_HEADERS)
 #include <string.h>
-#endif
 #ifdef HAVE_STDARG_H
 #include <stdarg.h>
 #endif

--- a/test/mpi/util/mtest.c
+++ b/test/mpi/util/mtest.c
@@ -4,15 +4,9 @@
  */
 
 #include "mpitest.h"
-#if defined(HAVE_STDIO_H) || defined(STDC_HEADERS)
 #include <stdio.h>
-#endif
-#if defined(HAVE_STDLIB_H) || defined(STDC_HEADERS)
 #include <stdlib.h>
-#endif
-#if defined(HAVE_STRING_H) || defined(STDC_HEADERS)
 #include <string.h>
-#endif
 #ifdef HAVE_STDARG_H
 #include <stdarg.h>
 #endif


### PR DESCRIPTION
## Pull Request Description

Replace more obsolete autoconf macros. This will make autoconf 2.70 less noisy.

Reference issue #5014

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
