### PR TITLE
Fix mpl gavl tree delete bug

### DIFF
--- a/src/mpl/src/gavl/mpl_gavl.c
+++ b/src/mpl/src/gavl/mpl_gavl.c
@@ -388,12 +388,12 @@ static void gavl_tree_remove_node_internal(MPLI_gavl_tree_s * tree_ptr,
         }
 
         /* remove inorder_node from the tree. */
+        if (inorder_node->u.s.right)
+            inorder_node->u.s.right->u.s.parent = inorder_node->u.s.parent;
         if (inorder_node->u.s.parent != dnode) {
-            if (inorder_node->u.s.right)
-                inorder_node->u.s.right->u.s.parent = inorder_node->u.s.parent;
             inorder_node->u.s.parent->u.s.left = inorder_node->u.s.right;
         } else {
-            dnode->u.s.right = NULL;
+            dnode->u.s.right = inorder_node->u.s.right;
         }
 
         /* exchange inorder_node with dnode and then add dnode into remove_list */

--- a/src/mpl/src/gavl/mpl_gavl.c
+++ b/src/mpl/src/gavl/mpl_gavl.c
@@ -286,7 +286,8 @@ int MPL_gavl_tree_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t 
         /* find which side the new node should be inserted */
         if (cmp_ret == MPLI_GAVL_BUFFER_MATCH) {
             /* new node is duplicate, we need to delete new node and exit */
-            tree_ptr->gavl_free_fn((void *) node_ptr->val);
+            if (tree_ptr->gavl_free_fn)
+                tree_ptr->gavl_free_fn((void *) node_ptr->val);
             MPL_free(node_ptr);
             goto fn_exit;
         }


### PR DESCRIPTION
## Pull Request Description
This PR fix the bug in gavl tree implementation.
The bug is caused by the following reason:
When we try to delete a node from a tree, we need to find the next inorder node to replace the deleted node. In this process, if the inorder node does not have a left child, we need to assign the deleted node right child pointer to the inorder node right child instead of `NULL`

The second commit also adds a safety check for `gavl_free_fn` during insert. If `gavl_free_fn` is `NULL`, we shouldn't call `gavl_free_fn`.

Fixes #5243

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
