### PR TITLE
ch4/ofi: skip critical section in dynproc_wait_disconnect

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_dynproc.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_dynproc.c
@@ -195,7 +195,10 @@ static int dynproc_wait_disconnect(int conn_id)
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_conn_t *p_conn = &MPIDI_OFI_global.conn_mgr.conn_table[conn_id];
 
-    MPIDI_OFI_PROGRESS_WHILE(!p_conn->req->done, 0);
+    while (!p_conn->req->done) {
+        mpi_errno = MPIDI_NM_progress(0, 0);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
     p_conn->state = MPIDI_OFI_DYNPROC_DISCONNECTED;
     MPL_free(p_conn->req);
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE, (MPL_DBG_FDEST, "conn_id=%d closed", conn_id));


### PR DESCRIPTION
## Pull Request Description
dynproc_wait_disconnect runs during MPI_Finalize, thus do not need
critical sections.

This is warned by Coverity scan.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
