### PR TITLE
coll: move OPs and their check tables from allreduce to oputil

### DIFF
--- a/src/mpi/coll/allreduce/allreduce.c
+++ b/src/mpi/coll/allreduce/allreduce.c
@@ -77,29 +77,6 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-/* The order of entries in this table must match the definitions in
-   mpi.h.in */
-MPI_User_function *MPIR_Op_table[] = {
-    NULL, MPIR_MAXF,
-    MPIR_MINF, MPIR_SUM,
-    MPIR_PROD, MPIR_LAND,
-    MPIR_BAND, MPIR_LOR, MPIR_BOR,
-    MPIR_LXOR, MPIR_BXOR,
-    MPIR_MINLOC, MPIR_MAXLOC,
-    MPIR_REPLACE, MPIR_NO_OP
-};
-
-MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[] = {
-    NULL, MPIR_MAXF_check_dtype,
-    MPIR_MINF_check_dtype, MPIR_SUM_check_dtype,
-    MPIR_PROD_check_dtype, MPIR_LAND_check_dtype,
-    MPIR_BAND_check_dtype, MPIR_LOR_check_dtype, MPIR_BOR_check_dtype,
-    MPIR_LXOR_check_dtype, MPIR_BXOR_check_dtype,
-    MPIR_MINLOC_check_dtype, MPIR_MAXLOC_check_dtype,
-    MPIR_REPLACE_check_dtype, MPIR_NO_OP_check_dtype
-};
-
-
 int MPIR_Allreduce_allcomm_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
                                 MPIR_Errflag_t * errflag)

--- a/src/mpi/coll/op/oputil.c
+++ b/src/mpi/coll/op/oputil.c
@@ -5,6 +5,44 @@
 
 #include "mpiimpl.h"
 
+/* The order of entries in this table must match the definitions in
+   mpi.h.in */
+MPI_User_function *MPIR_Op_table[] = {
+    NULL,
+    MPIR_MAXF,
+    MPIR_MINF,
+    MPIR_SUM,
+    MPIR_PROD,
+    MPIR_LAND,
+    MPIR_BAND,
+    MPIR_LOR,
+    MPIR_BOR,
+    MPIR_LXOR,
+    MPIR_BXOR,
+    MPIR_MINLOC,
+    MPIR_MAXLOC,
+    MPIR_REPLACE,
+    MPIR_NO_OP
+};
+
+MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[] = {
+    NULL,
+    MPIR_MAXF_check_dtype,
+    MPIR_MINF_check_dtype,
+    MPIR_SUM_check_dtype,
+    MPIR_PROD_check_dtype,
+    MPIR_LAND_check_dtype,
+    MPIR_BAND_check_dtype,
+    MPIR_LOR_check_dtype,
+    MPIR_BOR_check_dtype,
+    MPIR_LXOR_check_dtype,
+    MPIR_BXOR_check_dtype,
+    MPIR_MINLOC_check_dtype,
+    MPIR_MAXLOC_check_dtype,
+    MPIR_REPLACE_check_dtype,
+    MPIR_NO_OP_check_dtype
+};
+
 typedef struct op_name {
     MPI_Op op;
     const char *short_name;     /* used in info */


### PR DESCRIPTION
## Pull Request Description
Move OPs and their check tables from allreduce to oputil.

Operator tables and their type check tables are used by other collectives, not only allreduce. It's better to put them in more general locations such as optuil.c.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
