### PR TITLE
op: fix locking in user op and support large count

### DIFF
--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -37,7 +37,9 @@ typedef enum MPIR_Op_kind {
     MPIR_OP_KIND__REPLACE = 13,
     MPIR_OP_KIND__NO_OP = 14,
     MPIR_OP_KIND__USER_NONCOMMUTE = 32,
-    MPIR_OP_KIND__USER = 33
+    MPIR_OP_KIND__USER = 33,
+    MPIR_OP_KIND__USER_NONCOMMUTE_LARGE = 34,
+    MPIR_OP_KIND__USER_LARGE = 35
 } MPIR_Op_kind;
 
 #define MPIR_OP_N_BUILTIN 15
@@ -79,6 +81,7 @@ typedef enum MPIR_Op_kind {
   S*/
 typedef union MPIR_User_function {
     void (*c_function) (const void *, void *, const int *, const MPI_Datatype *);
+    void (*c_large_function) (const void *, void *, const MPI_Count *, const MPI_Datatype *);
     void (*f77_function) (const void *, void *, const MPI_Fint *, const MPI_Fint *);
 } MPIR_User_function;
 /* FIXME: Should there be "restrict" in the definitions above, e.g.,

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -154,20 +154,20 @@ MPL_STATIC_INLINE_PREFIX MPI_Op MPIR_Op_builtin_get_op(int index)
 MPI_Datatype MPIR_Op_builtin_search_by_shortname(const char *short_name);
 const char *MPIR_Op_builtin_get_shortname(MPI_Op op);
 
-void MPIR_MAXF(void *, void *, int *, MPI_Datatype *);
-void MPIR_MINF(void *, void *, int *, MPI_Datatype *);
-void MPIR_SUM(void *, void *, int *, MPI_Datatype *);
-void MPIR_PROD(void *, void *, int *, MPI_Datatype *);
-void MPIR_LAND(void *, void *, int *, MPI_Datatype *);
-void MPIR_BAND(void *, void *, int *, MPI_Datatype *);
-void MPIR_LOR(void *, void *, int *, MPI_Datatype *);
-void MPIR_BOR(void *, void *, int *, MPI_Datatype *);
-void MPIR_LXOR(void *, void *, int *, MPI_Datatype *);
-void MPIR_BXOR(void *, void *, int *, MPI_Datatype *);
-void MPIR_MAXLOC(void *, void *, int *, MPI_Datatype *);
-void MPIR_MINLOC(void *, void *, int *, MPI_Datatype *);
-void MPIR_REPLACE(void *, void *, int *, MPI_Datatype *);
-void MPIR_NO_OP(void *, void *, int *, MPI_Datatype *);
+void MPIR_MAXF(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_MINF(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_SUM(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_PROD(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_LAND(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_BAND(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_LOR(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_BOR(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_LXOR(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_BXOR(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_MAXLOC(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_MINLOC(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_REPLACE(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_NO_OP(void *, void *, MPI_Aint *, MPI_Datatype *);
 
 int MPIR_MAXF_check_dtype(MPI_Datatype);
 int MPIR_MINF_check_dtype(MPI_Datatype);
@@ -205,7 +205,9 @@ int MPIR_NO_OP_check_dtype(MPI_Datatype);
         }                                                \
     } while (0)                                          \
 
-extern MPI_User_function *MPIR_Op_table[];
+/* internal op function, uses MPI_Aint for count */
+typedef void (MPIR_op_function) (void *, void *, MPI_Aint *, MPI_Datatype *);
+extern MPIR_op_function *MPIR_Op_table[];
 
 typedef int (MPIR_Op_check_dtype_fn) (MPI_Datatype);
 extern MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[];

--- a/src/mpi/coll/op/op_impl.c
+++ b/src/mpi/coll/op/op_impl.c
@@ -78,7 +78,12 @@ int MPIR_Op_create_impl(MPI_User_function * user_fn, int commute, MPIR_Op ** p_o
 
 int MPIR_Op_create_large_impl(MPI_User_function_c * user_fn, int commute, MPIR_Op ** p_op_ptr)
 {
-    return MPIR_Op_create_impl((void *) user_fn, commute, p_op_ptr);
+    int mpi_errno = MPIR_Op_create_impl((void *) user_fn, commute, p_op_ptr);
+    if (mpi_errno == MPI_SUCCESS) {
+        (*p_op_ptr)->kind =
+            commute ? MPIR_OP_KIND__USER_LARGE : MPIR_OP_KIND__USER_NONCOMMUTE_LARGE;
+    }
+    return mpi_errno;
 }
 
 int MPIR_Op_free_impl(MPIR_Op * op_ptr)
@@ -111,10 +116,12 @@ int MPIR_Op_is_commutative(MPI_Op op)
     } else {
         MPIR_Op_get_ptr(op, op_ptr);
         MPIR_Assert(op_ptr != NULL);
-        if (op_ptr->kind == MPIR_OP_KIND__USER_NONCOMMUTE)
+        if (op_ptr->kind == MPIR_OP_KIND__USER_NONCOMMUTE ||
+            op_ptr->kind == MPIR_OP_KIND__USER_NONCOMMUTE_LARGE) {
             return FALSE;
-        else
+        } else {
             return TRUE;
+        }
     }
 }
 

--- a/src/mpi/coll/op/opband.c
+++ b/src/mpi/coll/op/opband.c
@@ -14,9 +14,9 @@
 #define MPIR_LBAND(a,b) ((a)&(b))
 #endif
 
-void MPIR_BAND(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_BAND(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
     switch (*type) {
 #undef MPIR_OP_TYPE_MACRO

--- a/src/mpi/coll/op/opbor.c
+++ b/src/mpi/coll/op/opbor.c
@@ -14,9 +14,9 @@
 #define MPIR_LBOR(a,b) ((a)|(b))
 #endif
 
-void MPIR_BOR(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_BOR(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
     switch (*type) {
 #undef MPIR_OP_TYPE_MACRO

--- a/src/mpi/coll/op/opbxor.c
+++ b/src/mpi/coll/op/opbxor.c
@@ -14,9 +14,9 @@
 #define MPIR_LBXOR(a,b) ((a)^(b))
 #endif
 
-void MPIR_BXOR(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_BXOR(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
     switch (*type) {
 #undef MPIR_OP_TYPE_MACRO

--- a/src/mpi/coll/op/opland.c
+++ b/src/mpi/coll/op/opland.c
@@ -17,9 +17,9 @@
 #define MPIR_LLAND(a,b) ((a)&&(b))
 #endif
 
-void MPIR_LAND(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_LAND(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
     switch (*type) {
 #undef MPIR_OP_TYPE_MACRO

--- a/src/mpi/coll/op/oplor.c
+++ b/src/mpi/coll/op/oplor.c
@@ -17,9 +17,9 @@
 #define MPIR_LLOR(a,b) ((a)||(b))
 #endif
 
-void MPIR_LOR(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_LOR(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
     switch (*type) {
 #undef MPIR_OP_TYPE_MACRO

--- a/src/mpi/coll/op/oplxor.c
+++ b/src/mpi/coll/op/oplxor.c
@@ -17,9 +17,9 @@
 #define MPIR_LLXOR(a,b) (((a)&&(!b))||((!a)&&(b)))
 #endif
 
-void MPIR_LXOR(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_LXOR(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
     switch (*type) {
 #undef MPIR_OP_TYPE_MACRO

--- a/src/mpi/coll/op/opmax.c
+++ b/src/mpi/coll/op/opmax.c
@@ -11,9 +11,9 @@
  * and floating point types (5.9.2 Predefined reduce operations)
  */
 
-void MPIR_MAXF(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_MAXF(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
     switch (*type) {
 #undef MPIR_OP_TYPE_MACRO

--- a/src/mpi/coll/op/opmaxloc.c
+++ b/src/mpi/coll/op/opmaxloc.c
@@ -70,9 +70,9 @@ typedef struct MPIR_longdoubleint_loctype {
     break
 
 
-void MPIR_MAXLOC(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_MAXLOC(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
 #ifdef HAVE_FORTRAN_BINDING
 #ifndef HAVE_NO_FORTRAN_MPI_TYPES_IN_C

--- a/src/mpi/coll/op/opmin.c
+++ b/src/mpi/coll/op/opmin.c
@@ -10,9 +10,9 @@
  * In MPI-2.1, this operation is valid only for C integer, Fortran integer,
  * and floating point types (5.9.2 Predefined reduce operations)
  */
-void MPIR_MINF(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_MINF(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
     switch (*type) {
 #undef MPIR_OP_TYPE_MACRO

--- a/src/mpi/coll/op/opminloc.c
+++ b/src/mpi/coll/op/opminloc.c
@@ -69,9 +69,9 @@ typedef struct MPIR_longdoubleint_loctype {
     }                                                   \
     break
 
-void MPIR_MINLOC(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_MINLOC(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
 #ifdef HAVE_FORTRAN_BINDING
 #ifndef HAVE_NO_FORTRAN_MPI_TYPES_IN_C

--- a/src/mpi/coll/op/opno_op.c
+++ b/src/mpi/coll/op/opno_op.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 
-void MPIR_NO_OP(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_NO_OP(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
     return;
 }

--- a/src/mpi/coll/op/opprod.c
+++ b/src/mpi/coll/op/opprod.c
@@ -12,9 +12,9 @@
  */
 #define MPIR_LPROD(a,b) ((a)*(b))
 
-void MPIR_PROD(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_PROD(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
     switch (*type) {
 #undef MPIR_OP_TYPE_MACRO

--- a/src/mpi/coll/op/opreplace.c
+++ b/src/mpi/coll/op/opreplace.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 
-void MPIR_REPLACE(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_REPLACE(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/op/opsum.c
+++ b/src/mpi/coll/op/opsum.c
@@ -12,9 +12,9 @@
  */
 #define MPIR_LSUM(a,b) ((a)+(b))
 
-void MPIR_SUM(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
+void MPIR_SUM(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    int i, len = *Len;
+    MPI_Aint i, len = *Len;
 
     switch (*type) {
 #undef MPIR_OP_TYPE_MACRO

--- a/src/mpi/coll/op/oputil.c
+++ b/src/mpi/coll/op/oputil.c
@@ -7,7 +7,7 @@
 
 /* The order of entries in this table must match the definitions in
    mpi.h.in */
-MPI_User_function *MPIR_Op_table[] = {
+MPIR_op_function *MPIR_Op_table[] = {
     NULL,
     MPIR_MAXF,
     MPIR_MINF,

--- a/src/mpi/coll/reduce_local/reduce_local.c
+++ b/src/mpi/coll/reduce_local/reduce_local.c
@@ -13,7 +13,6 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Dat
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Op *op_ptr;
-    MPI_User_function *uop;
 #ifdef HAVE_CXX_BINDING
     int is_cxx_uop = 0;
 #endif
@@ -25,6 +24,7 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Dat
         goto fn_exit;
 
     if (HANDLE_IS_BUILTIN(op)) {
+        MPIR_op_function *uop;
         /* --BEGIN ERROR HANDLING-- */
         mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
         if (mpi_errno != MPI_SUCCESS)
@@ -32,11 +32,9 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Dat
         /* --END ERROR HANDLING-- */
         /* get the function by indexing into the op table */
         uop = MPIR_OP_HDL_TO_FN(op);
-        /* TODO: use MPI_Aint count for built-in op */
-        MPIR_Assert(count <= INT_MAX);
-        int icount = (int) count;
-        (*uop) ((void *) inbuf, inoutbuf, &icount, &datatype);
+        (*uop) ((void *) inbuf, inoutbuf, &count, &datatype);
     } else {
+        MPI_User_function *uop;
         MPIR_Op_get_ptr(op, op_ptr);
 
 #ifdef HAVE_CXX_BINDING

--- a/src/mpid/ch3/include/mpid_rma_shm.h
+++ b/src/mpid/ch3/include/mpid_rma_shm.h
@@ -596,10 +596,10 @@ static inline int MPIDI_CH3I_Shm_fop_op(const void *origin_addr, void *result_ad
                                         MPI_Aint target_disp, MPI_Op op, MPIR_Win * win_ptr)
 {
     void *base = NULL, *dest_addr = NULL;
-    MPI_User_function *uop = NULL;
+    MPIR_op_function *uop = NULL;
     int disp_unit;
     MPI_Aint len;
-    int one, shm_locked = 0;
+    int shm_locked = 0;
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3I_SHM_FOP_OP);
 
@@ -628,7 +628,7 @@ static inline int MPIDI_CH3I_Shm_fop_op(const void *origin_addr, void *result_ad
     MPIR_Memcpy(result_addr, dest_addr, len);
 
     uop = MPIR_OP_HDL_TO_FN(op);
-    one = 1;
+    MPI_Aint one = 1;
 
     (*uop) ((void *) origin_addr, dest_addr, &one, &datatype);
 

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -818,7 +818,7 @@ static inline int do_accumulate_op(void *source_buf, int source_count, MPI_Datat
                                    MPIDI_RMA_Acc_srcbuf_kind_t srckind)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_User_function *uop = NULL;
+    MPIR_op_function *uop = NULL;
     MPI_Aint source_dtp_size = 0, source_dtp_extent = 0;
     int is_empty_source = FALSE;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_DO_ACCUMULATE_OP);
@@ -864,12 +864,13 @@ static inline int do_accumulate_op(void *source_buf, int source_count, MPI_Datat
             curr_target_buf = target_buf;
         }
 
-        (*uop) (source_buf, curr_target_buf, &source_count, &source_dtp);
+        MPI_Aint tmp_count = source_count;
+        (*uop) (source_buf, curr_target_buf, &tmp_count, &source_dtp);
     }
     else {
         /* derived datatype */
         struct iovec *typerep_vec;
-        int i, count;
+        int i;
         MPI_Aint vec_len, type_extent, type_size, src_type_stride;
         MPI_Datatype type;
         MPIR_Datatype*dtp;
@@ -922,7 +923,8 @@ static inline int do_accumulate_op(void *source_buf, int source_count, MPI_Datat
                 continue;
             }
 
-            MPIR_Assign_trunc(count, curr_len / type_size, int);
+            MPI_Aint count;
+            MPIR_Assign_trunc(count, curr_len / type_size, MPI_Aint);
 
             (*uop) ((char *) source_buf + src_type_stride * accumulated_count,
                     (char *) target_buf + MPIR_Ptr_to_aint(curr_loc), &count, &type);

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -639,8 +639,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_fetch_and_op(const void *origin_add
          * 0xf is the mask for op index in MPIR_Op_table,
          * and op should start from 1. */
         MPIR_Assert(((op) & 0xf) > 0);
-        MPI_User_function *uop = MPIR_OP_HDL_TO_FN(op);
-        int one = 1;
+        MPIR_op_function *uop = MPIR_OP_HDL_TO_FN(op);
+        MPI_Aint one = 1;
 
         (*uop) ((void *) origin_addr, target_addr, &one, &datatype);
     }

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -1004,7 +1004,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_compute_acc_op(void *source_buf, int source_
                                                    MPI_Op acc_op, int src_kind)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_User_function *uop = NULL;
+    MPIR_op_function *uop = NULL;
     MPI_Aint source_dtp_size = 0, source_dtp_extent = 0;
     int is_empty_source = FALSE;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_COMPUTE_ACC_OP);
@@ -1045,11 +1045,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_compute_acc_op(void *source_buf, int source_
 
     if (is_empty_source == TRUE || HANDLE_IS_BUILTIN(target_dtp)) {
         /* directly apply op if target dtp is predefined dtp OR source buffer is empty */
-        (*uop) (source_buf, target_buf, &source_count, &source_dtp);
+        MPI_Aint tmp_count = source_count;
+        (*uop) (source_buf, target_buf, &tmp_count, &source_dtp);
     } else {
         /* derived datatype */
         struct iovec *typerep_vec;
-        int i, count;
+        int i;
         MPI_Aint vec_len, type_extent, type_size, src_type_stride;
         MPI_Datatype type;
         MPIR_Datatype *dtp;
@@ -1111,7 +1112,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_compute_acc_op(void *source_buf, int source_
                 continue;
             }
 
-            MPIR_Assign_trunc(count, curr_len / type_size, int);
+            MPI_Aint count;
+            MPIR_Assign_trunc(count, curr_len / type_size, MPI_Aint);
 
             if (src_ptr) {
                 MPI_Aint unpacked_size;

--- a/test/mpi/coll/Makefile.am
+++ b/test/mpi/coll/Makefile.am
@@ -101,6 +101,7 @@ noinst_PROGRAMS =      \
     scattern           \
     scatterv           \
     uoplong            \
+    uoplong_large      \
     uop_equal	       \
     nballtoall1        \
     nbredscat          \
@@ -183,3 +184,7 @@ bcast_SOURCES = bcast.c
 
 bcast_comm_world_only_CPPFLAGS = -DBCAST_COMM_WORLD_ONLY $(AM_CPPFLAGS)
 bcast_comm_world_only_SOURCES = bcast.c
+
+uoplong_large_SOURCES = uoplong.c
+uoplong_large_CPPFLAGS = -DOP_LARGE $(AM_CPPFLAGS)
+

--- a/test/mpi/coll/Makefile.am
+++ b/test/mpi/coll/Makefile.am
@@ -101,6 +101,7 @@ noinst_PROGRAMS =      \
     scattern           \
     scatterv           \
     uoplong            \
+    uop_equal	       \
     nballtoall1        \
     nbredscat          \
     nbredscat3	       \

--- a/test/mpi/coll/uop_equal.c
+++ b/test/mpi/coll/uop_equal.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include "mpitest.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+/*
+ * Test user-defined operations that uses MPI_Type_get_envelope and MPI_Type_get_contents.
+ * Catches the case of recursive locking in THREAD_MULTIPLE.
+ * Reference to user reported issue #5259.
+ */
+
+struct string_int {
+    char str[100];
+    int is_equal;
+};
+
+void myop(void *in, void *out, int *count, MPI_Datatype * dtype);
+
+/*
+ * myop takes a datatype that is of struct string_int and compares the string.
+ */
+void myop(void *in, void *out, int *count, MPI_Datatype * dtype)
+{
+    int n_ints, n_aints, n_datatypes, combiner;
+    MPI_Type_get_envelope(*dtype, &n_ints, &n_aints, &n_datatypes, &combiner);
+    assert(combiner == MPI_COMBINER_STRUCT && n_ints == 3 && n_aints == 2 && n_datatypes == 2);
+
+    int ints[3];
+    MPI_Aint aints[2];
+    MPI_Datatype types[2];
+    MPI_Type_get_contents(*dtype, n_ints, n_aints, n_datatypes, ints, aints, types);
+    assert(ints[0] == 2 && types[0] == MPI_CHAR && types[1] == MPI_INT);
+
+    int *p_in_eq = (int *) ((char *) in + aints[1]);
+    int *p_out_eq = (int *) ((char *) out + aints[1]);
+
+    if (*p_in_eq == 0 || *p_out_eq == 0 || strncmp(in, out, ints[1]) != 0) {
+        *p_out_eq = 0;
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    int wsize, wrank;
+    MPI_Datatype eq_type;
+    MPI_Op op;
+
+    MTest_Init(&argc, &argv);
+    MPI_Op_create(myop, 0, &op);
+
+    MPI_Datatype types[2] = { MPI_CHAR, MPI_INT };
+    int blklens[2] = { 100, 1 };
+    MPI_Aint displs[2] = { 0, 100 };
+    MPI_Type_create_struct(2, blklens, displs, types, &eq_type);
+    MPI_Type_commit(&eq_type);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &wsize);
+    MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
+
+    struct string_int data, result;
+    strcpy(data.str, "Testing String.");
+    data.is_equal = 1;
+    MPI_Reduce(&data, &result, 1, eq_type, op, 0, MPI_COMM_WORLD);
+    if (!result.is_equal) {
+        printf("Expect result to be equal, result not equal!\n");
+        errs++;
+    }
+    MPI_Op_free(&op);
+    MPI_Type_free(&eq_type);
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/coll/uoplong.c
+++ b/test/mpi/coll/uoplong.c
@@ -8,6 +8,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef OP_LARGE
+#define COUNT_TYPE MPI_Count
+#define MPI_Op_create MPI_Op_create_c
+#else
+#define COUNT_TYPE int
+#endif
+
 /*
  * Test user-defined operations with a large number of elements.
  * Added because a talk at EuroMPI'12 claimed that these failed with
@@ -17,13 +24,13 @@
 #define MAX_ERRS 10
 #define MAX_COUNT 1200000
 
-void myop(void *cinPtr, void *coutPtr, int *count, MPI_Datatype * dtype);
+void myop(void *cinPtr, void *coutPtr, COUNT_TYPE * count, MPI_Datatype * dtype);
 
 /*
  * myop takes a datatype that is a triple of doubles, and computes
  * the sum, max, min of the respective elements of the triple.
  */
-void myop(void *cinPtr, void *coutPtr, int *count, MPI_Datatype * dtype)
+void myop(void *cinPtr, void *coutPtr, COUNT_TYPE * count, MPI_Datatype * dtype)
 {
     int i, n = *count;
     double const *cin = (double *) cinPtr;


### PR DESCRIPTION
## Pull Request Description
User op function may call MPI functions and thus need take off the global lock to avoid recursive locking.
Fixes #5259 

large count user op function was not properly implemented. This PR adds the implementation.

[skip warnings]
TODO:
* [x] Add test for op function that calls `MPI_Type_get_contents`
* [x] Add test for `MPI_Op_create_c`

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
