### PR TITLE
ch4: Remove per-comm match queues

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_init.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_init.c
@@ -127,10 +127,8 @@ int MPIDIG_am_init(void)
     MPIDI_global.comm_req_lists = (MPIDIG_comm_req_list_t *)
         MPL_calloc(MPIR_MAX_CONTEXT_MASK * MPIR_CONTEXT_INT_BITS,
                    sizeof(MPIDIG_comm_req_list_t), MPL_MEM_OTHER);
-#ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
     MPIDI_global.posted_list = NULL;
     MPIDI_global.unexp_list = NULL;
-#endif
     MPIDI_global.part_posted_list = NULL;
     MPIDI_global.part_unexp_list = NULL;
 

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -137,10 +137,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_DO_IRECV);
 
     root_comm = MPIDIG_context_id_to_comm(context_id);
-    unexp_req = MPIDIG_dequeue_unexp(rank, tag, context_id, &MPIDIG_COMM(root_comm, unexp_list));
+    unexp_req = MPIDIG_dequeue_unexp(rank, tag, context_id, NULL);
 
     if (unexp_req) {
-        MPIR_Comm_release(root_comm);   /* -1 for removing from unexp_list */
         if (MPIDIG_REQUEST(unexp_req, req->status) & MPIDIG_REQ_BUSY) {
             MPIDIG_REQUEST(unexp_req, req->status) |= MPIDIG_REQ_MATCHED;
         } else if (MPIDIG_REQUEST(unexp_req, req->status) & MPIDIG_REQ_RTS) {
@@ -253,7 +252,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
         /* Increment refcnt for comm before posting rreq to posted_list,
          * to make sure comm is alive while holding an entry in the posted_list */
         MPIR_Comm_add_ref(root_comm);
-        MPIDIG_enqueue_posted(rreq, &MPIDIG_COMM(root_comm, posted_list));
+        MPIDIG_enqueue_posted(rreq, NULL);
         /* MPIDI_CS_EXIT(); */
     } else {
         MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = rreq;
@@ -371,9 +370,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_cancel_recv(MPIR_Request * rreq)
         root_comm = MPIDIG_context_id_to_comm(MPIDIG_REQUEST(rreq, context_id));
 
         /* MPIDI_CS_ENTER(); */
-        found =
-            MPIDIG_delete_posted(&MPIDIG_REQUEST(rreq, req->rreq),
-                                 &MPIDIG_COMM(root_comm, posted_list));
+        found = MPIDIG_delete_posted(&MPIDIG_REQUEST(rreq, req->rreq), NULL);
         /* MPIDI_CS_EXIT(); */
 
         if (found) {

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -515,8 +515,6 @@ typedef struct {
 typedef unsigned MPIDI_locality_t;
 
 typedef struct MPIDIG_comm_t {
-    MPIDIG_rreq_t *posted_list;
-    MPIDIG_rreq_t *unexp_list;
     uint32_t window_instance;
 #ifdef HAVE_DEBUGGER_SUPPORT
     MPIDIG_rreq_t **posted_head_ptr;

--- a/src/mpid/ch4/shm/ipc/src/ipc_control.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.c
@@ -48,8 +48,7 @@ int MPIDI_IPCI_send_contig_lmt_rts_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
     if (root_comm) {
         while (TRUE) {
             rreq = MPIDIG_dequeue_posted(slmt_rts_hdr->src_rank, slmt_rts_hdr->tag,
-                                         slmt_rts_hdr->context_id, 1,
-                                         &MPIDIG_COMM(root_comm, posted_list));
+                                         slmt_rts_hdr->context_id, 1, NULL);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
             if (rreq) {
                 int is_cancelled;
@@ -102,13 +101,7 @@ int MPIDI_IPCI_send_contig_lmt_rts_cb(MPIDI_SHMI_ctrl_hdr_t * ctrl_hdr)
         MPIDI_IPCI_REQUEST(rreq, unexp_rreq).src_lrank = slmt_rts_hdr->src_lrank;
         MPIDI_IPCI_REQUEST(rreq, unexp_rreq).sreq_ptr = slmt_rts_hdr->sreq_ptr;
 
-        if (root_comm) {
-            MPIR_Comm_add_ref(root_comm);       /* +1 for unexp_list */
-            MPIDIG_enqueue_unexp(rreq, &MPIDIG_COMM(root_comm, unexp_list));
-        } else {
-            MPIDIG_enqueue_unexp(rreq,
-                                 MPIDIG_context_id_to_uelist(MPIDIG_REQUEST(rreq, context_id)));
-        }
+        MPIDIG_enqueue_unexp(rreq, NULL);
 
         IPC_TRACE("send_contig_lmt_rts_cb: enqueue unexpected, rreq=%p\n", rreq);
     }

--- a/src/mpid/ch4/shm/ipc/src/ipc_recv.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_recv.h
@@ -105,7 +105,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_irecv(void *buf, MPI_Aint count, MPI_
 
     /* Try to match with an unexpected receive request */
     root_comm = MPIDIG_context_id_to_comm(context_id);
-    unexp_req = MPIDIG_dequeue_unexp(rank, tag, context_id, &MPIDIG_COMM(root_comm, unexp_list));
+    unexp_req = MPIDIG_dequeue_unexp(rank, tag, context_id, NULL);
 
     if (unexp_req) {
         *request = unexp_req;
@@ -113,7 +113,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_irecv(void *buf, MPI_Aint count, MPI_
          * rreq once all data arrived;
          * - Mark as IN_PRORESS so that the SHM receive cannot be cancelled. */
         MPIDIG_REQUEST(unexp_req, req->status) |= MPIDIG_REQ_UNEXP_DQUED | MPIDIG_REQ_IN_PROGRESS;
-        MPIR_Comm_release(root_comm);   /* -1 for removing from unexp_list */
 
         /* TODO: create unsafe version of imrecv to avoid extra locking */
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
@@ -131,7 +130,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_irecv(void *buf, MPI_Aint count, MPI_
         MPIDIG_prepare_recv_req(rank, tag, context_id, buf, count, datatype, rreq);
 
         MPIR_Comm_add_ref(root_comm);   /* +1 for queuing into posted_list */
-        MPIDIG_enqueue_posted(rreq, &MPIDIG_COMM(root_comm, posted_list));
+        MPIDIG_enqueue_posted(rreq, NULL);
 
         *request = rreq;
         MPIDI_POSIX_recv_posted_hook(*request, rank, comm);

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -187,13 +187,8 @@ int MPID_Comm_commit_pre_hook(MPIR_Comm * comm)
 #endif
 
 #ifdef HAVE_DEBUGGER_SUPPORT
-#ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
     MPIDIG_COMM(comm, posted_head_ptr) = &(MPIDI_global.posted_list);
     MPIDIG_COMM(comm, unexp_head_ptr) = &(MPIDI_global.unexp_list);
-#else
-    MPIDIG_COMM(comm, posted_head_ptr) = &(MPIDIG_COMM(comm, posted_list));
-    MPIDIG_COMM(comm, unexp_head_ptr) = &(MPIDIG_COMM(comm, unexp_list));
-#endif
 #endif
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_COMM_COMMIT_PRE_HOOK);

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -70,25 +70,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Comm *MPIDIG_context_id_to_comm(uint64_t context_i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX MPIDIG_rreq_t **MPIDIG_context_id_to_uelist(uint64_t context_id)
-{
-    int comm_idx = MPIDIG_get_context_index(context_id);
-    int subcomm_type = MPIR_CONTEXT_READ_FIELD(SUBCOMM, context_id);
-    int is_localcomm = MPIR_CONTEXT_READ_FIELD(IS_LOCALCOMM, context_id);
-    MPIDIG_rreq_t **ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_CONTEXT_ID_TO_UELIST);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_CONTEXT_ID_TO_UELIST);
-
-    MPIR_Assert(subcomm_type <= 3);
-    MPIR_Assert(is_localcomm <= 2);
-
-    ret = &MPIDI_global.comm_req_lists[comm_idx].uelist[is_localcomm][subcomm_type];
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_CONTEXT_ID_TO_UELIST);
-    return ret;
-}
-
 MPL_STATIC_INLINE_PREFIX MPIR_Context_id_t MPIDIG_win_id_to_context(uint64_t win_id)
 {
     MPIR_Context_id_t ret;

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -192,7 +192,6 @@ typedef MPIDIG_acc_ack_msg_t MPIDIG_get_acc_ack_msg_t;
 
 typedef struct MPIDIG_comm_req_list_t {
     MPIR_Comm *comm[2][4];
-    MPIDIG_rreq_t *uelist[2][4];
 } MPIDIG_comm_req_list_t;
 
 typedef struct {
@@ -271,10 +270,8 @@ typedef struct MPIDI_CH4_Global_t {
     MPIR_Commops MPIR_Comm_fns_store;
     MPID_Thread_mutex_t m[MAX_CH4_MUTEXES];
     MPIDIU_map_t *win_map;
-#ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
     MPIDIG_rreq_t *posted_list;
     MPIDIG_rreq_t *unexp_list;
-#endif
     MPIDIG_part_rreq_t *part_posted_list;
     MPIDIG_part_rreq_t *part_unexp_list;
     MPIDIG_req_ext_t *cmpl_list;

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -429,6 +429,9 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
         MPIDIG_REQUEST(rreq, rank) = hdr->src_rank;
         MPIDIG_REQUEST(rreq, tag) = hdr->tag;
         MPIDIG_REQUEST(rreq, context_id) = hdr->context_id;
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+        MPIDI_REQUEST(rreq, is_local) = is_local;
+#endif
 
         rreq->status.MPI_ERROR = hdr->error_bits;
         if (hdr->flags & MPIDIG_AM_SEND_FLAGS_RTS) {

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -312,11 +312,9 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
                     (MPL_DBG_FDEST, "HDR: data_sz=%ld, flags=0x%X", hdr->data_sz, hdr->flags));
     root_comm = MPIDIG_context_id_to_comm(hdr->context_id);
     if (root_comm) {
-      root_comm_retry:
         /* MPIDI_CS_ENTER(); */
         while (TRUE) {
-            rreq = MPIDIG_dequeue_posted(hdr->src_rank, hdr->tag, hdr->context_id,
-                                         is_local, &MPIDIG_COMM(root_comm, posted_list));
+            rreq = MPIDIG_dequeue_posted(hdr->src_rank, hdr->tag, hdr->context_id, is_local, NULL);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
             if (rreq) {
                 int is_cancelled;
@@ -379,32 +377,7 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
         MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
         MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
-        if (root_comm) {
-            MPIR_Comm_add_ref(root_comm);
-            MPIDIG_enqueue_unexp(rreq, &MPIDIG_COMM(root_comm, unexp_list));
-        } else {
-            MPIR_Comm *root_comm_again;
-            /* This branch means that last time we checked, there was no communicator
-             * associated with the arriving message.
-             * In a multi-threaded environment, it is possible that the communicator
-             * has been created since we checked root_comm last time.
-             * If that is the case, the new message must be put into a queue in
-             * the new communicator. Otherwise that message will be lost forever.
-             * Here that strategy is to query root_comm again, and if found,
-             * simply re-execute the per-communicator enqueue logic above. */
-            root_comm_again = MPIDIG_context_id_to_comm(hdr->context_id);
-            if (unlikely(root_comm_again != NULL)) {
-                MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
-                MPIDU_genq_private_pool_free_cell(MPIDI_global.unexp_pack_buf_pool,
-                                                  MPIDIG_REQUEST(rreq, buffer));
-                MPIDI_CH4_REQUEST_FREE(rreq);
-                MPID_Request_complete(rreq);
-                rreq = NULL;
-                root_comm = root_comm_again;
-                goto root_comm_retry;
-            }
-            MPIDIG_enqueue_unexp(rreq, MPIDIG_context_id_to_uelist(hdr->context_id));
-        }
+        MPIDIG_enqueue_unexp(rreq, NULL);
         MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
 
         /* at this point, we have created and enqueued the unexpected request. If the request is

--- a/src/mpid/ch4/src/ch4r_init.c
+++ b/src/mpid/ch4/src/ch4r_init.c
@@ -9,7 +9,6 @@
 int MPIDIG_init_comm(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS, comm_idx, subcomm_type, is_localcomm;
-    MPIDIG_rreq_t **uelist;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_INIT_COMM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_INIT_COMM);
@@ -26,27 +25,7 @@ int MPIDIG_init_comm(MPIR_Comm * comm)
     MPIR_Assert(subcomm_type <= 3);
     MPIR_Assert(is_localcomm <= 1);
 
-    /* There is a potential race between this code (likely called by a user/main thread)
-     * and an MPIDIG callback handler (called by a progress thread, when async progress
-     * is turned on).
-     * Thus we take a lock here to make sure the following operations are atomically done.
-     * (transferring unexpected messages from a global queue to the newly created communicator) */
-    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
     MPIDI_global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type] = comm;
-    MPIDIG_COMM(comm, posted_list) = NULL;
-    MPIDIG_COMM(comm, unexp_list) = NULL;
-
-    uelist = MPIDIG_context_id_to_uelist(comm->context_id);
-    if (*uelist) {
-        MPIDIG_rreq_t *curr, *tmp;
-        DL_FOREACH_SAFE(*uelist, curr, tmp) {
-            DL_DELETE(*uelist, curr);
-            MPIR_Comm_add_ref(comm);    /* +1 for each entry in unexp_list */
-            DL_APPEND(MPIDIG_COMM(comm, unexp_list), curr);
-        }
-        *uelist = NULL;
-    }
-    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
 
     MPIDIG_COMM(comm, window_instance) = 0;
   fn_exit:
@@ -56,32 +35,17 @@ int MPIDIG_init_comm(MPIR_Comm * comm)
 
 int MPIDIG_destroy_comm(MPIR_Comm * comm)
 {
-    int mpi_errno = MPI_SUCCESS, comm_idx, subcomm_type, is_localcomm;
+    int mpi_errno = MPI_SUCCESS, subcomm_type, is_localcomm;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_DESTROY_COMM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_DESTROY_COMM);
 
     if (MPIR_CONTEXT_READ_FIELD(DYNAMIC_PROC, comm->recvcontext_id))
         goto fn_exit;
-    comm_idx = MPIDIG_get_context_index(comm->recvcontext_id);
     subcomm_type = MPIR_CONTEXT_READ_FIELD(SUBCOMM, comm->recvcontext_id);
     is_localcomm = MPIR_CONTEXT_READ_FIELD(IS_LOCALCOMM, comm->recvcontext_id);
 
     MPIR_Assert(subcomm_type <= 3);
     MPIR_Assert(is_localcomm <= 1);
-
-    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
-    MPIR_Assert(MPIDI_global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type] != NULL);
-
-    if (MPIDI_global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type]) {
-        MPIR_Assert(MPIDIG_COMM
-                    (MPIDI_global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type],
-                     posted_list) == NULL);
-        MPIR_Assert(MPIDIG_COMM
-                    (MPIDI_global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type],
-                     unexp_list) == NULL);
-    }
-    MPIDI_global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type] = NULL;
-    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_DESTROY_COMM);

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -311,18 +311,6 @@ AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
 AM_COND_IF([BUILD_CH4],[
 AC_MSG_NOTICE([RUNNING CONFIGURE FOR CH4 DEVICE])
 
-AC_ARG_ENABLE(ch4r-per-comm-msg-queue,
-    [--enable-ch4r-per-comm-msg-queue=option
-       Enable use of per-communicator message queues for posted recvs/unexpected messages
-         yes       - Use per-communicator message queue. (Default)
-         no        - Use global queue for posted recvs/unexpected messages.
-    ],,enable_ch4r_per_comm_msg_queue=yes)
-
-if test "$enable_ch4r_per_comm_msg_queue" = "yes" ; then
-    AC_DEFINE([MPIDI_CH4U_USE_PER_COMM_QUEUE], [1],
-        [Define if CH4U will use per-communicator message queues])
-fi
-
 dnl Note: the maximum of 64 is due to the fact that we use 6 bits in the
 dnl request handle to encode pool index
 AC_ARG_WITH(ch4-max-vcis,


### PR DESCRIPTION
## Pull Request Description

This configuration adds a lot of complexity to MPICH for questionable
benefit. In the long-term, queues will be associated with VCIs as
opposed to communicators, so we remove this as groundwork to support
future extensions.

This commit also removes communicator reference counting for
unexpected messages. This counting is unnecessary, as the user is
required to receive all messages on a communicator before freeing it.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
