### PR TITLE
ch4/ofi: additional tunining of provider selection

### DIFF
--- a/src/mpid/ch4/netmod/ofi/globals.c
+++ b/src/mpid/ch4/netmod/ofi/globals.c
@@ -86,8 +86,8 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
      .context_bits = MPIDI_OFI_CONTEXT_BITS_PSM2,
      .source_bits = MPIDI_OFI_SOURCE_BITS_PSM2,
      .tag_bits = MPIDI_OFI_TAG_BITS_PSM2,
-     .major_version = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
-     .minor_version = MPIDI_OFI_MINOR_VERSION_MINIMAL}
+     .major_version = MPIDI_OFI_MAJOR_VERSION_PSM2,
+     .minor_version = MPIDI_OFI_MINOR_VERSION_PSM2}
     ,
     {   /* sockets */
      .enable_av_table = MPIDI_OFI_ENABLE_AV_TABLE_SOCKETS,
@@ -110,8 +110,8 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
      .context_bits = MPIDI_OFI_CONTEXT_BITS_SOCKETS,
      .source_bits = MPIDI_OFI_SOURCE_BITS_SOCKETS,
      .tag_bits = MPIDI_OFI_TAG_BITS_SOCKETS,
-     .major_version = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
-     .minor_version = MPIDI_OFI_MINOR_VERSION_MINIMAL}
+     .major_version = MPIDI_OFI_MAJOR_VERSION_SOCKETS,
+     .minor_version = MPIDI_OFI_MINOR_VERSION_SOCKETS}
     ,
     {   /* bgq */
      .enable_av_table = MPIDI_OFI_ENABLE_AV_TABLE_BGQ,
@@ -134,8 +134,8 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
      .context_bits = MPIDI_OFI_CONTEXT_BITS_BGQ,
      .source_bits = MPIDI_OFI_SOURCE_BITS_BGQ,
      .tag_bits = MPIDI_OFI_TAG_BITS_BGQ,
-     .major_version = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
-     .minor_version = MPIDI_OFI_MINOR_VERSION_MINIMAL}
+     .major_version = MPIDI_OFI_MAJOR_VERSION_BGQ,
+     .minor_version = MPIDI_OFI_MINOR_VERSION_BGQ}
     ,
     {   /* VERBS_RXM */
      .enable_av_table = MPIDI_OFI_ENABLE_AV_TABLE_VERBS_RXM,
@@ -158,8 +158,8 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
      .context_bits = MPIDI_OFI_CONTEXT_BITS_VERBS_RXM,
      .source_bits = MPIDI_OFI_SOURCE_BITS_VERBS_RXM,
      .tag_bits = MPIDI_OFI_TAG_BITS_VERBS_RXM,
-     .major_version = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
-     .minor_version = MPIDI_OFI_MINOR_VERSION_MINIMAL}
+     .major_version = MPIDI_OFI_MAJOR_VERSION_RXM,
+     .minor_version = MPIDI_OFI_MINOR_VERSION_RXM}
     ,
     {   /* RxM */
      .enable_av_table = MPIDI_OFI_ENABLE_AV_TABLE_RXM,
@@ -182,8 +182,8 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
      .context_bits = MPIDI_OFI_CONTEXT_BITS_RXM,
      .source_bits = MPIDI_OFI_SOURCE_BITS_RXM,
      .tag_bits = MPIDI_OFI_TAG_BITS_RXM,
-     .major_version = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
-     .minor_version = MPIDI_OFI_MINOR_VERSION_MINIMAL}
+     .major_version = MPIDI_OFI_MAJOR_VERSION_RXM,
+     .minor_version = MPIDI_OFI_MINOR_VERSION_RXM}
     ,
     {   /* GNI */
      .enable_av_table = MPIDI_OFI_ENABLE_AV_TABLE_GNI,
@@ -206,6 +206,6 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
      .context_bits = MPIDI_OFI_CONTEXT_BITS_GNI,
      .source_bits = MPIDI_OFI_SOURCE_BITS_GNI,
      .tag_bits = MPIDI_OFI_TAG_BITS_GNI,
-     .major_version = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
-     .minor_version = MPIDI_OFI_MINOR_VERSION_MINIMAL}
+     .major_version = MPIDI_OFI_MAJOR_VERSION_GNI,
+     .minor_version = MPIDI_OFI_MINOR_VERSION_GNI}
 };

--- a/src/mpid/ch4/netmod/ofi/init_provider.c
+++ b/src/mpid/ch4/netmod/ofi/init_provider.c
@@ -113,7 +113,6 @@ static int find_provider(struct fi_info **prov_out)
         MPIDI_OFI_init_hints(hints);
         hints->fabric_attr->prov_name = MPL_strdup(provname);
         hints->caps = prov->caps;
-        hints->addr_format = prov->addr_format;
 
         /* Now we have the hints with best matched provider, get the new prov_list */
         struct fi_info *old_prov_list = prov_list;

--- a/src/mpid/ch4/netmod/ofi/init_provider.c
+++ b/src/mpid/ch4/netmod/ofi/init_provider.c
@@ -63,7 +63,7 @@ int MPIDI_OFI_find_provider(struct fi_info **prov_out)
     goto fn_exit;
 }
 
-static int MPIDI_OFI_get_required_version(void)
+int MPIDI_OFI_get_required_version(void)
 {
     if (MPIDI_OFI_MAJOR_VERSION != -1 && MPIDI_OFI_MINOR_VERSION != -1)
         return FI_VERSION(MPIDI_OFI_MAJOR_VERSION, MPIDI_OFI_MINOR_VERSION);
@@ -106,6 +106,12 @@ static int find_provider(struct fi_info **prov_out)
         provname = prov->fabric_attr->prov_name;
         /* Initialize MPIDI_OFI_global.settings */
         MPIDI_OFI_init_settings(&MPIDI_OFI_global.settings, provname);
+        /* The presets may have non-default minimum version requirement */
+        required_version = MPIDI_OFI_get_required_version();
+        if (MPIR_CVAR_CH4_OFI_CAPABILITY_SETS_DEBUG && MPIR_Process.rank == 0) {
+            printf("Required minimum FI_VERSION: %x, current version: %x\n", required_version,
+                   fi_version());
+        }
         /* NOTE: we fill the hints with optimal settings. In order to work for providers
          * that support halfway between minimal and optimal, we need try-loop to systematically
          * relax settings. The following code does this for the providers that we have tested.
@@ -125,11 +131,8 @@ static int find_provider(struct fi_info **prov_out)
             ret = fi_getinfo(required_version, NULL, NULL, 0ULL, hints, &prov_list);
         }
         if (ret || prov_list == NULL) {
-            if (prov->domain_attr->mr_mode & FI_MR_BASIC) {
-                hints->domain_attr->mr_mode = FI_MR_BASIC;
-            } else if (prov->domain_attr->mr_mode & FI_MR_SCALABLE) {
-                hints->domain_attr->mr_mode = FI_MR_SCALABLE;
-            }
+            /* relax mr_mode */
+            hints->domain_attr->mr_mode = prov->domain_attr->mr_mode;
             ret = fi_getinfo(required_version, NULL, NULL, 0ULL, hints, &prov_list);
         }
         /* free the old one, the new one will be freed in MPIDI_OFI_find_provider_cleanup */

--- a/src/mpid/ch4/netmod/ofi/init_settings.c
+++ b/src/mpid/ch4/netmod/ofi/init_settings.c
@@ -62,7 +62,7 @@ void MPIDI_OFI_init_hints(struct fi_info *hints)
     /* ------------------------------------------------------------------------ */
     hints->mode = FI_CONTEXT | FI_ASYNC_IOV | FI_RX_CQ_DATA;    /* We can handle contexts  */
 
-    if (fi_version() >= FI_VERSION(1, 5)) {
+    if (MPIDI_OFI_get_required_version() >= FI_VERSION(1, 5)) {
 #ifdef FI_CONTEXT2
         hints->mode |= FI_CONTEXT2;
 #endif
@@ -125,7 +125,7 @@ void MPIDI_OFI_init_hints(struct fi_info *hints)
     hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
     hints->domain_attr->av_type = MPIDI_OFI_ENABLE_AV_TABLE ? FI_AV_TABLE : FI_AV_MAP;
 
-    if (fi_version() >= FI_VERSION(1, 5)) {
+    if (MPIDI_OFI_get_required_version() >= FI_VERSION(1, 5)) {
         hints->domain_attr->mr_mode = 0;
 #ifdef FI_RESTRICTED_COMP
         hints->domain_attr->mode = FI_RESTRICTED_COMP;
@@ -154,17 +154,12 @@ void MPIDI_OFI_init_hints(struct fi_info *hints)
          * FI_MR_SCALABLE is equivallent to all bits off in newer versions.
          */
         MPIR_Assert(MPIDI_OFI_ENABLE_MR_VIRT_ADDRESS == MPIDI_OFI_ENABLE_MR_PROV_KEY);
+        MPIR_Assert(MPIDI_OFI_ENABLE_MR_VIRT_ADDRESS == MPIDI_OFI_ENABLE_MR_ALLOCATED);
         if (MPIDI_OFI_ENABLE_MR_VIRT_ADDRESS) {
             hints->domain_attr->mr_mode = FI_MR_BASIC;
         } else {
             hints->domain_attr->mr_mode = FI_MR_SCALABLE;
         }
-    }
-    /* FI_MR_SCALABLE is implied by lack of mr_mode bits in >= v1.5.
-     * But at least sockets provider still need FI_MR_SCALABLE to be set
-     * or it will return FI_MR_BASIC. */
-    if (hints->domain_attr->mr_mode == 0) {
-        hints->domain_attr->mr_mode = FI_MR_SCALABLE;
     }
     hints->tx_attr->op_flags = FI_COMPLETION;
     hints->tx_attr->msg_order = FI_ORDER_SAS;

--- a/src/mpid/ch4/netmod/ofi/init_settings.c
+++ b/src/mpid/ch4/netmod/ofi/init_settings.c
@@ -273,11 +273,6 @@ int MPIDI_OFI_match_provider(struct fi_info *prov,
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE, (MPL_DBG_FDEST, "Provider name: %s",
                                                      prov->fabric_attr->prov_name));
 
-    if (MPIR_CVAR_OFI_SKIP_IPV6) {
-        if (prov->addr_format == FI_SOCKADDR_IN6) {
-            return 0;
-        }
-    }
     CHECK_CAP(enable_scalable_endpoints,
               prov->domain_attr->max_ep_tx_ctx <= 1 ||
               (prov->caps & FI_NAMED_RX_CTX) != FI_NAMED_RX_CTX);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1394,8 +1394,9 @@ static int update_global_limits(struct fi_info *prov)
 static void dump_global_settings(void)
 {
     fprintf(stdout, "==== Capability set configuration ====\n");
-    fprintf(stdout, "libfabric provider: %s\n",
-            MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name);
+    fprintf(stdout, "libfabric provider: %s - %s\n",
+            MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name,
+            MPIDI_OFI_global.prov_use[0]->fabric_attr->name);
     fprintf(stdout, "MPIDI_OFI_ENABLE_AV_TABLE: %d\n", MPIDI_OFI_ENABLE_AV_TABLE);
     fprintf(stdout, "MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS: %d\n",
             MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -6,6 +6,8 @@
 #ifndef OFI_INIT_H_INCLUDED
 #define OFI_INIT_H_INCLUDED
 
+int MPIDI_OFI_get_required_version(void);
+
 int MPIDI_OFI_find_provider(struct fi_info **prov_out);
 void MPIDI_OFI_find_provider_cleanup(void);
 int MPIDI_OFI_init_multi_nic(struct fi_info *prov);


### PR DESCRIPTION
## Pull Request Description

The filtering of IPV6 providers using hints no longer works, thus we need to filter them manually after return from `fi_getinfo`. Fortunately, the nic selection provides a convenient place for such filtering.

The libfabric (at least) `fi_getinfo` behavior is controlled by the *required* minimum version rather than the actual library version. In particular, the "sockets" provider only can be reliably controlled with pre-1.5 behavior. We should use the required version in the capability presets for more precise control.

reference: this commit fixes `sockets` provider at `fi_av_insert` time https://github.com/ofiwg/libfabric/commit/3e7b83822cccffd88780b88bda56f6abd44e4232
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
