### PR TITLE
ofi: fix accumulate ordering size check

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -383,21 +383,20 @@ int MPIDI_OFI_pack_get(void *origin_addr, int origin_count,
 MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_OFI_check_acc_order_size(MPIR_Win * win, MPI_Aint data_size)
 {
     MPI_Aint max_size = data_size;
-    /* Check ordering limit, a value of -1 guarantees ordering for any data size. */
+    /* Check ordering limit:
+     * - A value of -1 guarantees ordering for any data size.
+     * - An order size value of 0 indicates that ordering is not guaranteed.
+     * The check below returns the supported positive max_size, or zero which indicates disabled acc.*/
     if ((MPIDIG_WIN(win, info_args).accumulate_ordering & MPIDIG_ACCU_ORDER_WAR)
         && MPIDI_OFI_global.max_order_war != -1) {
-        /* An order size value of 0 indicates that ordering is not guaranteed. */
-        MPIR_Assert(MPIDI_OFI_global.max_order_war != 0);
         max_size = MPL_MIN(max_size, MPIDI_OFI_global.max_order_war);
     }
     if ((MPIDIG_WIN(win, info_args).accumulate_ordering & MPIDIG_ACCU_ORDER_WAW)
         && MPIDI_OFI_global.max_order_waw != -1) {
-        MPIR_Assert(MPIDI_OFI_global.max_order_waw != 0);
         max_size = MPL_MIN(max_size, MPIDI_OFI_global.max_order_waw);
     }
     if ((MPIDIG_WIN(win, info_args).accumulate_ordering & MPIDIG_ACCU_ORDER_RAW)
         && MPIDI_OFI_global.max_order_raw != -1) {
-        MPIR_Assert(MPIDI_OFI_global.max_order_raw != 0);
         max_size = MPL_MIN(max_size, MPIDI_OFI_global.max_order_raw);
     }
     return max_size;

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -380,8 +380,9 @@ int MPIDI_OFI_pack_get(void *origin_addr, int origin_count,
  * C and C++ components
  */
 /* Set max size based on OFI acc ordering limit. */
-MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_OFI_check_acc_order_size(MPIR_Win * win, MPI_Aint max_size)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_OFI_check_acc_order_size(MPIR_Win * win, MPI_Aint data_size)
 {
+    MPI_Aint max_size = data_size;
     /* Check ordering limit, a value of -1 guarantees ordering for any data size. */
     if ((MPIDIG_WIN(win, info_args).accumulate_ordering & MPIDIG_ACCU_ORDER_WAR)
         && MPIDI_OFI_global.max_order_war != -1) {


### PR DESCRIPTION
## Pull Request Description
When we reach the network atomics accumulate, the current code in `MPIDI_OFI_check_acc_order_size` aborts when any of the ordering limit is zero. This is not needed, as we can safely fallback to AM when ordering is required by user but not supported by OFI.

The assertion failure was observed with gni provider on Theta

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
