### PR TITLE
coll: reimplement persistent bcast

### DIFF
--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -696,8 +696,12 @@ int MPIR_Ibarrier_inter_sched_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /******************************** Ibcast ********************************/
 /* request-based functions */
-int MPIR_Ibcast_allcomm_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Request ** request);
+int MPIR_Ibcast_sched_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
+                           MPIR_Comm * comm_ptr, bool is_persistent,
+                           void **sched_p, enum MPIR_sched_type *sched_type_p);
+int MPIR_Ibcast_allcomm_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
+                                   MPIR_Comm * comm_ptr, bool is_persistent,
+                                   void **sched_p, enum MPIR_sched_type *sched_type_p);
 int MPIR_Ibcast_intra_gentran_tree(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                    MPIR_Comm * comm_ptr, int tree_type, int k, int maxbytes,
                                    MPIR_Request ** request);

--- a/src/include/mpir_nbc.h
+++ b/src/include/mpir_nbc.h
@@ -50,16 +50,21 @@ int MPIR_Sched_next_tag(MPIR_Comm * comm_ptr, int *tag);
 /* the device must provide a typedef for MPIR_Sched_t in mpidpre.h */
 
 /* creates a new opaque schedule object and returns a handle to it in (*sp) */
-int MPIR_Sched_create(MPIR_Sched_t * sp);
+int MPIR_Sched_create(MPIR_Sched_t * sp, enum MPIR_Sched_kind kind);
 /* clones orig and returns a handle to the new schedule in (*cloned) */
 int MPIR_Sched_clone(MPIR_Sched_t orig, MPIR_Sched_t * cloned);
-/* sets (*sp) to MPIR_SCHED_NULL and gives you back a request pointer in (*req).
- * The caller is giving up ownership of the opaque schedule object.
+/* free the handle. The handle should not be used afterwards */
+int MPIR_Sched_free(MPIR_Sched_t s);
+/* reset a completed persistent collective sched so it can be started again */
+int MPIR_Sched_reset(MPIR_Sched_t s);
+/* allocate the state buffer associated with the sched. It will be freed by MPIR_Sched_free */
+void *MPIR_Sched_alloc_state(MPIR_Sched_t s, MPI_Aint size);
+/* starts the sched and gives you back a request pointer in (*req).
  *
  * comm should be the primary (user) communicator with which this collective is
  * associated, even if other hidden communicators are used for a subset of the
  * operations.  It will be used for error handling and similar operations. */
-int MPIR_Sched_start(MPIR_Sched_t * sp, MPIR_Comm * comm, int tag, MPIR_Request ** req);
+int MPIR_Sched_start(MPIR_Sched_t s, MPIR_Comm * comm, int tag, MPIR_Request ** req);
 
 /* send and recv take a comm ptr to enable hierarchical collectives */
 int MPIR_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -208,9 +208,11 @@ struct MPIR_Request {
 #endif                          /* HAVE_DEBUGGER_SUPPORT */
             /* Persistent requests have their own "real" requests */
             struct MPIR_Request *real_request;
+        } persist;              /* kind : MPID_PREQUEST_SEND or MPID_PREQUEST_RECV */
+        struct {
+            struct MPIR_Request *real_request;
             struct MPII_Genutil_sched_t *sched;
-        } persist;              /* kind : MPID_PREQUEST_SEND or MPID_PREQUEST_RECV
-                                 *   and MPIR_REQUEST_KIND__PREQUEST_COLL */
+        } persist_coll;         /* kind : MPIR_REQUEST_KIND__PREQUEST_COLL */
         struct {
             int partitions;     /* Needed for parameter error check */
             MPL_atomic_int_t active_flag;       /* flag indicating whether in a start-complete active period.

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -150,6 +150,13 @@ extern MPIR_Object_alloc_t MPIR_Grequest_class_mem;
 
 #define MPIR_Request_is_complete(req_) (MPIR_cc_is_complete((req_)->cc_ptr))
 
+/* types of sched structure used in persistent collective */
+enum MPIR_sched_type {
+    MPIR_SCHED_INVALID,
+    MPIR_SCHED_NORMAL,
+    MPIR_SCHED_GENTRAN
+};
+
 /*S
   MPIR_Request - Description of the Request data structure
 
@@ -211,7 +218,8 @@ struct MPIR_Request {
         } persist;              /* kind : MPID_PREQUEST_SEND or MPID_PREQUEST_RECV */
         struct {
             struct MPIR_Request *real_request;
-            struct MPII_Genutil_sched_t *sched;
+            enum MPIR_sched_type sched_type;
+            void *sched;
         } persist_coll;         /* kind : MPIR_REQUEST_KIND__PREQUEST_COLL */
         struct {
             int partitions;     /* Needed for parameter error check */

--- a/src/mpi/coll/bcast/bcast_init.c
+++ b/src/mpi/coll/bcast/bcast_init.c
@@ -33,7 +33,7 @@ int MPIR_Bcast_init_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
     MPIR_Request *req = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_COLL);
     MPIR_ERR_CHKANDJUMP(!req, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
-    req->u.persist.real_request = NULL;
+    req->u.persist_coll.real_request = NULL;
 
     /* generate the schedule */
     sched = MPL_malloc(sizeof(MPIR_TSP_sched_t), MPL_MEM_COLL);
@@ -68,7 +68,7 @@ int MPIR_Bcast_init_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
     }
 
     MPIR_ERR_CHECK(mpi_errno);
-    req->u.persist.sched = sched;
+    req->u.persist_coll.sched = sched;
 
     *request = req;
 

--- a/src/mpi/coll/bcast/bcast_init.c
+++ b/src/mpi/coll/bcast/bcast_init.c
@@ -33,6 +33,7 @@ int MPIR_Bcast_init_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
     MPIR_Request *req = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_COLL);
     MPIR_ERR_CHKANDJUMP(!req, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
+    req->u.persist_coll.sched_type = MPIR_SCHED_INVALID;
     req->u.persist_coll.real_request = NULL;
 
     /* generate the schedule */
@@ -68,6 +69,7 @@ int MPIR_Bcast_init_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
     }
 
     MPIR_ERR_CHECK(mpi_errno);
+    req->u.persist_coll.sched_type = MPIR_SCHED_GENTRAN;
     req->u.persist_coll.sched = sched;
 
     *request = req;

--- a/src/mpi/coll/bcast/bcast_init.c
+++ b/src/mpi/coll/bcast/bcast_init.c
@@ -11,66 +11,24 @@
 #include "../ibcast/ibcast_tsp_tree_algos_prototypes.h"
 #include "../ibcast/ibcast_tsp_scatterv_allgatherv_algos_prototypes.h"
 
-static int MPIR_Bcast_sched_intra_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                       int root, MPIR_Comm * comm_ptr, MPIR_TSP_sched_t * sched)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    mpi_errno = MPIR_TSP_Ibcast_sched_intra_tree(buffer, count, datatype, root, comm_ptr,
-                                                 MPIR_Ibcast_tree_type, MPIR_CVAR_IBCAST_TREE_KVAL,
-                                                 MPIR_CVAR_IBCAST_TREE_PIPELINE_CHUNK_SIZE, sched);
-
-    return mpi_errno;
-}
-
 int MPIR_Bcast_init_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                          MPIR_Comm * comm_ptr, MPIR_Info * info_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_TSP_sched_t *sched;
 
     /* create a new request */
     MPIR_Request *req = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_COLL);
     MPIR_ERR_CHKANDJUMP(!req, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
+    MPIR_Comm_add_ref(comm_ptr);
+    req->comm = comm_ptr;
+
     req->u.persist_coll.sched_type = MPIR_SCHED_INVALID;
     req->u.persist_coll.real_request = NULL;
 
-    /* generate the schedule */
-    sched = MPL_malloc(sizeof(MPIR_TSP_sched_t), MPL_MEM_COLL);
-    MPIR_ERR_CHKANDJUMP(!sched, mpi_errno, MPI_ERR_OTHER, "**nomem");
-    MPIR_TSP_sched_create(sched, true);
-
-    switch (MPIR_CVAR_IBCAST_INTRA_ALGORITHM) {
-        case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_gentran_tree:
-            mpi_errno = MPIR_TSP_Ibcast_sched_intra_tree(buffer, count, datatype, root, comm_ptr,
-                                                         MPIR_Ibcast_tree_type,
-                                                         MPIR_CVAR_IBCAST_TREE_KVAL,
-                                                         MPIR_CVAR_IBCAST_TREE_PIPELINE_CHUNK_SIZE,
-                                                         sched);
-            break;
-        case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_gentran_scatterv_recexch_allgatherv:
-            mpi_errno =
-                MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(buffer, count, datatype, root,
-                                                                comm_ptr,
-                                                                MPIR_CVAR_IBCAST_SCATTERV_KVAL,
-                                                                MPIR_CVAR_IBCAST_ALLGATHERV_RECEXCH_KVAL,
-                                                                sched);
-            break;
-        case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_gentran_ring:
-            mpi_errno =
-                MPIR_TSP_Ibcast_sched_intra_tree(buffer, count, datatype, root, comm_ptr,
-                                                 MPIR_TREE_TYPE_KARY, 1,
-                                                 MPIR_CVAR_IBCAST_RING_CHUNK_SIZE, sched);
-            break;
-        default:
-            mpi_errno = MPIR_Bcast_sched_intra_auto(buffer, count, datatype, root, comm_ptr, sched);
-            break;
-    }
-
+    mpi_errno = MPIR_Ibcast_sched_impl(buffer, count, datatype, root, comm_ptr, true,   /* is_persistent */
+                                       &req->u.persist_coll.sched, &req->u.persist_coll.sched_type);
     MPIR_ERR_CHECK(mpi_errno);
-    req->u.persist_coll.sched_type = MPIR_SCHED_GENTRAN;
-    req->u.persist_coll.sched = sched;
 
     *request = req;
 

--- a/src/mpi/coll/ibcast/ibcast.c
+++ b/src/mpi/coll/ibcast/ibcast.c
@@ -5,6 +5,11 @@
 
 #include "mpiimpl.h"
 #include "ibcast.h"
+/* for MPIR_TSP_sched_t */
+#include "tsp_gentran.h"
+#include "gentran_utils.h"
+#include "../ibcast/ibcast_tsp_tree_algos_prototypes.h"
+#include "../ibcast/ibcast_tsp_scatterv_allgatherv_algos_prototypes.h"
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
@@ -125,14 +130,14 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-/* any non-MPI functions go here, especially non-static ones */
-
 /* Provides a "flat" broadcast that doesn't know anything about
  * hierarchy.  It will choose between several different algorithms
  * based on the given parameters. */
 
-int MPIR_Ibcast_allcomm_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Request ** request)
+int MPIR_Ibcast_allcomm_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype,
+                                   int root, MPIR_Comm * comm_ptr,
+                                   bool is_persistent, void **sched_p,
+                                   enum MPIR_sched_type *sched_type_p)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -150,70 +155,79 @@ int MPIR_Ibcast_allcomm_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype
     MPIR_Assert(cnt);
 
     switch (cnt->id) {
+        /* *INDENT-OFF* */
         case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_gentran_tree:
-            mpi_errno =
-                MPIR_Ibcast_intra_gentran_tree(buffer, count, datatype, root, comm_ptr,
-                                               cnt->u.ibcast.intra_gentran_tree.tree_type,
-                                               cnt->u.ibcast.intra_gentran_tree.k,
-                                               cnt->u.ibcast.intra_gentran_tree.chunk_size,
-                                               request);
+            MPII_GENTRAN_CREATE_SCHED_P();
+            mpi_errno = MPIR_TSP_Ibcast_sched_intra_tree(buffer, count, datatype, root, comm_ptr,
+                                 cnt->u.ibcast.intra_gentran_tree.tree_type,
+                                 cnt->u.ibcast.intra_gentran_tree.k,
+                                 cnt->u.ibcast.intra_gentran_tree.chunk_size,
+                                 *sched_p);
             break;
 
         case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_gentran_scatterv_recexch_allgatherv:
-            mpi_errno =
-                MPIR_Ibcast_intra_gentran_scatterv_recexch_allgatherv(buffer, count, datatype, root,
-                                                                      comm_ptr,
-                                                                      cnt->u.
-                                                                      ibcast.intra_gentran_scatterv_recexch_allgatherv.scatterv_k,
-                                                                      cnt->u.
-                                                                      ibcast.intra_gentran_scatterv_recexch_allgatherv.allgatherv_k,
-                                                                      request);
+            MPII_GENTRAN_CREATE_SCHED_P();
+            mpi_errno = MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(buffer, count, datatype,
+                                root, comm_ptr,
+                                cnt->u.ibcast.intra_gentran_scatterv_recexch_allgatherv.scatterv_k,
+                                cnt->u.ibcast.intra_gentran_scatterv_recexch_allgatherv.allgatherv_k,
+                                *sched_p);
             break;
 
         case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_gentran_ring:
-            mpi_errno =
-                MPIR_Ibcast_intra_gentran_ring(buffer, count, datatype, root, comm_ptr,
-                                               cnt->u.ibcast.intra_gentran_ring.chunk_size,
-                                               request);
+            MPII_GENTRAN_CREATE_SCHED_P();
+            mpi_errno = MPIR_TSP_Ibcast_sched_intra_tree(buffer, count, datatype,
+                                root, comm_ptr,
+                                MPIR_TREE_TYPE_KARY, 1,
+                                cnt->u.ibcast.intra_gentran_ring.chunk_size,
+                                *sched_p);
             break;
 
         case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_sched_auto:
-            MPII_SCHED_WRAPPER(MPIR_Ibcast_intra_sched_auto, comm_ptr, request, buffer, count,
-                               datatype, root);
+            MPII_SCHED_CREATE_SCHED_P();
+            mpi_errno = MPIR_Ibcast_intra_sched_auto(buffer, count, datatype, root, comm_ptr, *sched_p);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
 
         case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_sched_binomial:
-            MPII_SCHED_WRAPPER(MPIR_Ibcast_intra_sched_binomial, comm_ptr, request, buffer, count,
-                               datatype, root);
+            MPII_SCHED_CREATE_SCHED_P();
+            mpi_errno = MPIR_Ibcast_intra_sched_binomial(buffer, count, datatype, root, comm_ptr, *sched_p);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
 
         case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather:
-            MPII_SCHED_WRAPPER(MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather,
-                               comm_ptr, request, buffer, count, datatype, root);
+            MPII_SCHED_CREATE_SCHED_P();
+            mpi_errno = MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(buffer, count, datatype, root, comm_ptr, *sched_p);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
 
         case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_sched_scatter_ring_allgather:
-            MPII_SCHED_WRAPPER(MPIR_Ibcast_intra_sched_scatter_ring_allgather, comm_ptr, request,
-                               buffer, count, datatype, root);
+            MPII_SCHED_CREATE_SCHED_P();
+            mpi_errno = MPIR_Ibcast_intra_sched_scatter_ring_allgather(buffer, count, datatype, root, comm_ptr, *sched_p);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
 
         case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_sched_smp:
-            MPII_SCHED_WRAPPER(MPIR_Ibcast_intra_sched_smp, comm_ptr, request, buffer, count,
-                               datatype, root);
+            MPII_SCHED_CREATE_SCHED_P();
+            mpi_errno = MPIR_Ibcast_intra_sched_smp(buffer, count, datatype, root, comm_ptr, *sched_p);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
 
         case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_inter_sched_auto:
-            MPII_SCHED_WRAPPER(MPIR_Ibcast_inter_sched_auto, comm_ptr, request, buffer, count,
-                               datatype, root);
+            MPII_SCHED_CREATE_SCHED_P();
+            mpi_errno = MPIR_Ibcast_inter_sched_auto(buffer, count, datatype, root, comm_ptr, *sched_p);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
 
         case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_inter_sched_flat:
-            MPII_SCHED_WRAPPER(MPIR_Ibcast_inter_sched_flat, comm_ptr, request, buffer, count,
-                               datatype, root);
+            MPII_SCHED_CREATE_SCHED_P();
+            mpi_errno = MPIR_Ibcast_inter_sched_flat(buffer, count, datatype, root, comm_ptr, *sched_p);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
 
         default:
             MPIR_Assert(0);
+        /* *INDENT-ON* */
     }
 
   fn_exit:
@@ -296,71 +310,82 @@ int MPIR_Ibcast_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, 
     return mpi_errno;
 }
 
-int MPIR_Ibcast_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                     MPIR_Comm * comm_ptr, MPIR_Request ** request)
+int MPIR_Ibcast_sched_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
+                           MPIR_Comm * comm_ptr, bool is_persistent,
+                           void **sched_p, enum MPIR_sched_type *sched_type_p)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
      * before going down to the MPIR_Sched-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
      * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
+    /* *INDENT-OFF* */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         switch (MPIR_CVAR_IBCAST_INTRA_ALGORITHM) {
             case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_gentran_tree:
-                mpi_errno =
-                    MPIR_Ibcast_intra_gentran_tree(buffer, count, datatype, root, comm_ptr,
-                                                   MPIR_Ibcast_tree_type,
-                                                   MPIR_CVAR_IBCAST_TREE_KVAL,
-                                                   MPIR_CVAR_IBCAST_TREE_PIPELINE_CHUNK_SIZE,
-                                                   request);
+                MPII_GENTRAN_CREATE_SCHED_P();
+                mpi_errno = MPIR_TSP_Ibcast_sched_intra_tree(buffer, count, datatype,
+                                                    root, comm_ptr,
+                                                    MPIR_Ibcast_tree_type,
+                                                    MPIR_CVAR_IBCAST_TREE_KVAL,
+                                                    MPIR_CVAR_IBCAST_TREE_PIPELINE_CHUNK_SIZE,
+                                                    *sched_p);
                 break;
 
             case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_gentran_scatterv_recexch_allgatherv:
-                mpi_errno =
-                    MPIR_Ibcast_intra_gentran_scatterv_recexch_allgatherv(buffer, count, datatype,
-                                                                          root, comm_ptr,
-                                                                          MPIR_CVAR_IBCAST_SCATTERV_KVAL,
-                                                                          MPIR_CVAR_IBCAST_ALLGATHERV_RECEXCH_KVAL,
-                                                                          request);
+                MPII_GENTRAN_CREATE_SCHED_P();
+                mpi_errno = MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(buffer, count, datatype,
+                                                    root, comm_ptr,
+                                                    MPIR_CVAR_IBCAST_SCATTERV_KVAL,
+                                                    MPIR_CVAR_IBCAST_ALLGATHERV_RECEXCH_KVAL,
+                                                    *sched_p);
                 break;
 
             case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_gentran_ring:
-                mpi_errno =
-                    MPIR_Ibcast_intra_gentran_ring(buffer, count, datatype, root, comm_ptr,
-                                                   MPIR_CVAR_IBCAST_RING_CHUNK_SIZE, request);
+                MPII_GENTRAN_CREATE_SCHED_P();
+                mpi_errno = MPIR_TSP_Ibcast_sched_intra_tree(buffer, count, datatype,
+                                                    root, comm_ptr,
+                                                    MPIR_TREE_TYPE_KARY, 1,
+                                                    MPIR_CVAR_IBCAST_RING_CHUNK_SIZE,
+                                                    *sched_p);
                 break;
 
             case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_sched_binomial:
-                MPII_SCHED_WRAPPER(MPIR_Ibcast_intra_sched_binomial, comm_ptr, request, buffer,
-                                   count, datatype, root);
+                MPII_SCHED_CREATE_SCHED_P();
+                mpi_errno = MPIR_Ibcast_intra_sched_binomial(buffer, count, datatype, root, comm_ptr, *sched_p);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
 
             case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_sched_smp:
-                MPII_SCHED_WRAPPER(MPIR_Ibcast_intra_sched_smp, comm_ptr, request, buffer,
-                                   count, datatype, root);
+                MPII_SCHED_CREATE_SCHED_P();
+                mpi_errno = MPIR_Ibcast_intra_sched_smp(buffer, count, datatype, root, comm_ptr, *sched_p);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
 
             case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_sched_scatter_recursive_doubling_allgather:
-                MPII_SCHED_WRAPPER(MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather,
-                                   comm_ptr, request, buffer, count, datatype, root);
+                MPII_SCHED_CREATE_SCHED_P();
+                mpi_errno = MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(buffer, count, datatype, root, comm_ptr, *sched_p);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
 
             case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_sched_scatter_ring_allgather:
-                MPII_SCHED_WRAPPER(MPIR_Ibcast_intra_sched_scatter_ring_allgather, comm_ptr,
-                                   request, buffer, count, datatype, root);
+                MPII_SCHED_CREATE_SCHED_P();
+                mpi_errno = MPIR_Ibcast_intra_sched_scatter_ring_allgather(buffer, count, datatype, root, comm_ptr, *sched_p);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
 
             case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_sched_auto:
-                MPII_SCHED_WRAPPER(MPIR_Ibcast_intra_sched_auto, comm_ptr, request, buffer, count,
-                                   datatype, root);
+                MPII_SCHED_CREATE_SCHED_P();
+                mpi_errno = MPIR_Ibcast_intra_sched_auto(buffer, count, datatype, root, comm_ptr, *sched_p);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
 
             case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_auto:
-                mpi_errno =
-                    MPIR_Ibcast_allcomm_auto(buffer, count, datatype, root, comm_ptr, request);
+                mpi_errno = MPIR_Ibcast_allcomm_sched_auto(buffer, count, datatype, root, comm_ptr,
+                                                           is_persistent, sched_p, sched_type_p);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
 
             default:
@@ -369,26 +394,49 @@ int MPIR_Ibcast_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, int ro
     } else {
         switch (MPIR_CVAR_IBCAST_INTER_ALGORITHM) {
             case MPIR_CVAR_IBCAST_INTER_ALGORITHM_sched_flat:
-                MPII_SCHED_WRAPPER(MPIR_Ibcast_inter_sched_flat, comm_ptr, request, buffer, count,
-                                   datatype, root);
+                MPII_SCHED_CREATE_SCHED_P();
+                mpi_errno = MPIR_Ibcast_inter_sched_flat(buffer, count, datatype, root, comm_ptr, *sched_p);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
 
             case MPIR_CVAR_IBCAST_INTER_ALGORITHM_sched_auto:
-                MPII_SCHED_WRAPPER(MPIR_Ibcast_inter_sched_auto, comm_ptr, request, buffer, count,
-                                   datatype, root);
+                MPII_SCHED_CREATE_SCHED_P();
+                mpi_errno = MPIR_Ibcast_inter_sched_auto(buffer, count, datatype, root, comm_ptr, *sched_p);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
 
             case MPIR_CVAR_IBCAST_INTER_ALGORITHM_auto:
-                mpi_errno =
-                    MPIR_Ibcast_allcomm_auto(buffer, count, datatype, root, comm_ptr, request);
+                mpi_errno = MPIR_Ibcast_allcomm_sched_auto(buffer, count, datatype, root, comm_ptr,
+                                                           is_persistent, sched_p, sched_type_p);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
 
             default:
                 MPIR_Assert(0);
         }
     }
+    /* *INDENT-ON* */
 
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Ibcast_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
+                     MPIR_Comm * comm_ptr, MPIR_Request ** request)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    *request = NULL;
+
+    enum MPIR_sched_type sched_type;
+    void *sched;
+    mpi_errno = MPIR_Ibcast_sched_impl(buffer, count, datatype, root, comm_ptr,
+                                       false, &sched, &sched_type);
     MPIR_ERR_CHECK(mpi_errno);
+
+    MPII_SCHED_START(sched_type, sched, comm_ptr, request);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
@@ -61,7 +61,6 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
     MPI_Aint true_extent, true_lb;
     void *tmp_buf;
     struct MPII_Ibcast_state *ibcast_state;
-    MPIR_SCHED_CHKPMEM_DECL(2);
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -83,9 +82,19 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
         MPIR_Datatype_is_contig(datatype, &is_contig);
     }
 
-    MPIR_SCHED_CHKPMEM_MALLOC(ibcast_state, struct MPII_Ibcast_state *,
-                              sizeof(struct MPII_Ibcast_state), mpi_errno, "MPI_Status",
-                              MPL_MEM_BUFFER);
+    /* we'll allocate tmp_buf along with ibcast_state.
+     * Alternatively, we can add init callback to allocate the tmp_buf.
+     */
+    MPI_Aint tmp_size = 0;
+    if (!is_contig) {
+        tmp_size = nbytes;
+    }
+
+    ibcast_state = MPIR_Sched_alloc_state(s, sizeof(struct MPII_Ibcast_state) + tmp_size);
+    MPIR_ERR_CHKANDJUMP(!ibcast_state, mpi_errno, MPI_ERR_OTHER, "**nomem");
+    if (!is_contig) {
+        tmp_buf = ibcast_state + 1;
+    }
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
 
@@ -98,8 +107,6 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
 
         tmp_buf = (char *) buffer + true_lb;
     } else {
-        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
-
         if (rank == root) {
             mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
             MPIR_ERR_CHECK(mpi_errno);
@@ -268,10 +275,8 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
         }
     }
 
-    MPIR_SCHED_CHKPMEM_COMMIT(s);
   fn_exit:
     return mpi_errno;
   fn_fail:
-    MPIR_SCHED_CHKPMEM_REAP(s);
     goto fn_exit;
 }

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
@@ -37,7 +37,6 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
     void *tmp_buf = NULL;
 
     struct MPII_Ibcast_state *ibcast_state;
-    MPIR_SCHED_CHKPMEM_DECL(4);
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -52,9 +51,20 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
         MPIR_Datatype_is_contig(datatype, &is_contig);
     }
 
-    MPIR_SCHED_CHKPMEM_MALLOC(ibcast_state, struct MPII_Ibcast_state *,
-                              sizeof(struct MPII_Ibcast_state), mpi_errno, "MPI_Status",
-                              MPL_MEM_BUFFER);
+    /* we'll allocate tmp_buf along with ibcast_state.
+     * Alternatively, we can add init callback to allocate the tmp_buf.
+     */
+    MPI_Aint tmp_size = 0;
+    if (!is_contig) {
+        tmp_size = nbytes;
+    }
+
+    ibcast_state = MPIR_Sched_alloc_state(s, sizeof(struct MPII_Ibcast_state) + tmp_size);
+    MPIR_ERR_CHKANDJUMP(!ibcast_state, mpi_errno, MPI_ERR_OTHER, "**nomem");
+    if (!is_contig) {
+        tmp_buf = ibcast_state + 1;
+    }
+
     MPIR_Datatype_get_size_macro(datatype, type_size);
     nbytes = type_size * count;
     ibcast_state->n_bytes = nbytes;
@@ -65,8 +75,6 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
 
         tmp_buf = (char *) buffer + true_lb;
     } else {
-        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
-
         if (rank == root) {
             mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
             MPIR_ERR_CHECK(mpi_errno);
@@ -133,10 +141,8 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    MPIR_SCHED_CHKPMEM_COMMIT(s);
   fn_exit:
     return mpi_errno;
   fn_fail:
-    MPIR_SCHED_CHKPMEM_REAP(s);
     goto fn_exit;
 }

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_smp.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_smp.c
@@ -31,14 +31,12 @@ int MPIR_Ibcast_intra_sched_smp(void *buffer, MPI_Aint count, MPI_Datatype datat
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint type_size;
     struct MPII_Ibcast_state *ibcast_state;
-    MPIR_SCHED_CHKPMEM_DECL(1);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(MPIR_Comm_is_parent_comm(comm_ptr));
 #endif
-    MPIR_SCHED_CHKPMEM_MALLOC(ibcast_state, struct MPII_Ibcast_state *,
-                              sizeof(struct MPII_Ibcast_state), mpi_errno, "MPI_Status",
-                              MPL_MEM_BUFFER);
+    ibcast_state = MPIR_Sched_alloc_state(s, sizeof(struct MPII_Ibcast_state));
+    MPIR_ERR_CHKANDJUMP(!ibcast_state, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
 
@@ -81,10 +79,8 @@ int MPIR_Ibcast_intra_sched_smp(void *buffer, MPI_Aint count, MPI_Datatype datat
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    MPIR_SCHED_CHKPMEM_COMMIT(s);
   fn_exit:
     return mpi_errno;
   fn_fail:
-    MPIR_SCHED_CHKPMEM_REAP(s);
     goto fn_exit;
 }

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -65,7 +65,7 @@ int MPII_Coll_finalize(void);
         if (mpi_errno)                                                  \
             MPIR_ERR_POP(mpi_errno);                                    \
                                                                         \
-        mpi_errno = MPIR_Sched_create(&s);                              \
+        mpi_errno = MPIR_Sched_create(&s, MPIR_SCHED_KIND_REGULAR);     \
         if (mpi_errno)                                                  \
             MPIR_ERR_POP(mpi_errno);                                    \
                                                                         \
@@ -73,7 +73,7 @@ int MPII_Coll_finalize(void);
         if (mpi_errno)                                                  \
             MPIR_ERR_POP(mpi_errno);                                    \
                                                                         \
-        mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);       \
+        mpi_errno = MPIR_Sched_start(s, comm_ptr, tag, request);        \
         if (mpi_errno)                                                  \
             MPIR_ERR_POP(mpi_errno);                                    \
     } while (0)
@@ -87,7 +87,7 @@ int MPII_Coll_finalize(void);
         if (mpi_errno)                                                  \
             MPIR_ERR_POP(mpi_errno);                                    \
                                                                         \
-        mpi_errno = MPIR_Sched_create(&s);                              \
+        mpi_errno = MPIR_Sched_create(&s, MPIR_SCHED_KIND_REGULAR);     \
         if (mpi_errno)                                                  \
             MPIR_ERR_POP(mpi_errno);                                    \
                                                                         \
@@ -95,9 +95,8 @@ int MPII_Coll_finalize(void);
         if (mpi_errno)                                                  \
             MPIR_ERR_POP(mpi_errno);                                    \
                                                                         \
-        mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);       \
-        if (mpi_errno)                                                  \
-            MPIR_ERR_POP(mpi_errno);                                    \
+        mpi_errno = MPIR_Sched_start(s, comm_ptr, tag, request);        \
+        MPIR_ERR_CHECK(mpi_errno);                                      \
     } while (0)
 
 /* functions for supporting GPU buffers in reduce collectives */

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -99,6 +99,44 @@ int MPII_Coll_finalize(void);
         MPIR_ERR_CHECK(mpi_errno);                                      \
     } while (0)
 
+#define MPII_GENTRAN_CREATE_SCHED_P() \
+    do { \
+        *sched_type_p = MPIR_SCHED_GENTRAN; \
+        *sched_p = MPL_malloc(sizeof(MPIR_TSP_sched_t), MPL_MEM_COLL); \
+        MPIR_ERR_CHKANDJUMP(!*sched_p, mpi_errno, MPI_ERR_OTHER, "**nomem"); \
+        MPIR_TSP_sched_create(*sched_p, is_persistent); \
+    } while (0)
+
+#define MPII_SCHED_CREATE_SCHED_P() \
+    do { \
+        MPIR_Sched_t s = MPIR_SCHED_NULL; \
+        int sched_kind = MPIR_SCHED_KIND_REGULAR; \
+        if (is_persistent) { \
+            sched_kind = MPIR_SCHED_KIND_PERSISTENT; \
+        } \
+        mpi_errno = MPIR_Sched_create(&s, sched_kind); \
+        MPIR_ERR_CHECK(mpi_errno); \
+        *sched_type_p = MPIR_SCHED_NORMAL; \
+        *sched_p = s; \
+    } while (0)
+
+#define MPII_SCHED_START(sched_type, sched, comm_ptr, request) \
+    do { \
+        if (sched_type == MPIR_SCHED_NORMAL) { \
+            int tag = -1; \
+            mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag); \
+            MPIR_ERR_CHECK(mpi_errno); \
+            \
+            mpi_errno = MPIR_Sched_start(sched, comm_ptr, tag, request); \
+            MPIR_ERR_CHECK(mpi_errno); \
+        } else if (sched_type == MPIR_SCHED_GENTRAN) { \
+            mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, request); \
+            MPIR_ERR_CHECK(mpi_errno); \
+        } else { \
+            MPIR_Assert(0); \
+        } \
+    } while (0)
+
 /* functions for supporting GPU buffers in reduce collectives */
 void MPIR_Coll_host_buffer_alloc(const void *sendbuf, const void *recvbuf, MPI_Aint count,
                                  MPI_Datatype datatype, void **host_sendbuf, void **host_recvbuf);

--- a/src/mpi/coll/nbcutil.c
+++ b/src/mpi/coll/nbcutil.c
@@ -19,8 +19,16 @@ int MPIR_Persist_coll_start(MPIR_Request * preq)
     int mpi_errno = MPI_SUCCESS;
 
     if (preq->u.persist_coll.sched_type == MPIR_SCHED_NORMAL) {
-        /* to-be-implemented */
-        MPIR_Assert(0);
+        int tag = -1;
+        mpi_errno = MPIR_Sched_next_tag(preq->comm, &tag);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        mpi_errno = MPIR_Sched_reset(preq->u.persist_coll.sched);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        mpi_errno = MPIR_Sched_start(preq->u.persist_coll.sched,
+                                     preq->comm, tag, &preq->u.persist_coll.real_request);
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (preq->u.persist_coll.sched_type == MPIR_SCHED_GENTRAN) {
         MPIR_TSP_sched_reset(preq->u.persist_coll.sched);
         mpi_errno = MPIR_TSP_sched_start(preq->u.persist_coll.sched,
@@ -58,7 +66,7 @@ void MPIR_Persist_coll_free_cb(MPIR_Request * request)
     }
 
     if (request->u.persist_coll.sched_type == MPIR_SCHED_NORMAL) {
-        MPIR_Assert(0);
+        MPIR_Sched_free(request->u.persist_coll.sched);
     } else if (request->u.persist_coll.sched_type == MPIR_SCHED_GENTRAN) {
         MPII_Genutil_sched_free(request->u.persist_coll.sched);
     } else {

--- a/src/mpi/coll/nbcutil.c
+++ b/src/mpi/coll/nbcutil.c
@@ -18,19 +18,19 @@ int MPIR_Persist_coll_start(MPIR_Request * preq)
 {
     int mpi_errno;
 
-    MPIR_TSP_sched_reset(preq->u.persist.sched);
-    mpi_errno = MPIR_TSP_sched_start(preq->u.persist.sched,
-                                     preq->comm, &preq->u.persist.real_request);
+    MPIR_TSP_sched_reset(preq->u.persist_coll.sched);
+    mpi_errno = MPIR_TSP_sched_start(preq->u.persist_coll.sched,
+                                     preq->comm, &preq->u.persist_coll.real_request);
     if (mpi_errno == MPI_SUCCESS) {
         preq->status.MPI_ERROR = MPI_SUCCESS;
-        preq->cc_ptr = &preq->u.persist.real_request->cc;
+        preq->cc_ptr = &preq->u.persist_coll.real_request->cc;
     } else {
         /* If a failure occurs attempting to start the request, then we
          * assume that partner request was not created, and stuff
          * the error code in the persistent request.  The wait and test
          * routines will look at the error code in the persistent
          * request if a partner request is not present. */
-        preq->u.persist.real_request = NULL;
+        preq->u.persist_coll.real_request = NULL;
         preq->status.MPI_ERROR = mpi_errno;
         preq->cc_ptr = &preq->cc;
         MPIR_cc_set(&preq->cc, 0);
@@ -43,8 +43,8 @@ void MPIR_Persist_coll_free_cb(MPIR_Request * request)
 {
     /* If this is an active persistent request, we must also
      * release the partner request. */
-    if (request->u.persist.real_request != NULL) {
-        MPIR_Request_free(request->u.persist.real_request);
+    if (request->u.persist_coll.real_request != NULL) {
+        MPIR_Request_free(request->u.persist_coll.real_request);
     }
-    MPII_Genutil_sched_free(request->u.persist.sched);
+    MPII_Genutil_sched_free(request->u.persist_coll.sched);
 }

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -426,7 +426,7 @@ int MPIR_Get_contextid_sparse_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr
             /*If we are here, at least one element must be in the list, at least myself */
 
             /* only the first element in the list can own the mask. However, maybe the mask is used
-             * by another thread, which added another allcoation to the list before. So we have to check,
+             * by another thread, which added another allocation to the list before. So we have to check,
              * if the mask is used and mark, if we own it */
             if (mask_in_use || &st != next_gcn) {
                 memset(st.local_mask, 0, MPIR_MAX_CONTEXT_MASK * sizeof(int));
@@ -973,7 +973,7 @@ int MPIR_Get_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcommp, MPIR
     /* now create a schedule */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
     MPIR_ERR_CHECK(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_create(&s, MPIR_SCHED_KIND_GENERALIZED);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* add some entries to it */
@@ -983,7 +983,7 @@ int MPIR_Get_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcommp, MPIR
     MPIR_ERR_CHECK(mpi_errno);
 
     /* finally, kick off the schedule and give the caller a request */
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, req);
+    mpi_errno = MPIR_Sched_start(s, comm_ptr, tag, req);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -1014,7 +1014,7 @@ int MPIR_Get_intercomm_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newc
     /* now create a schedule */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
     MPIR_ERR_CHECK(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_create(&s, MPIR_SCHED_KIND_GENERALIZED);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* add some entries to it */
@@ -1026,7 +1026,7 @@ int MPIR_Get_intercomm_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newc
     MPIR_ERR_CHECK(mpi_errno);
 
     /* finally, kick off the schedule and give the caller a request */
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, req);
+    mpi_errno = MPIR_Sched_start(s, comm_ptr, tag, req);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:

--- a/src/mpi/pt2pt/sendrecv.c
+++ b/src/mpi/pt2pt/sendrecv.c
@@ -197,7 +197,7 @@ int MPIR_Isendrecv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
 
     MPIR_Sched_t s = MPIR_SCHED_NULL;
 
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_create(&s, MPIR_SCHED_KIND_REGULAR);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_pt2pt_send(sendbuf, sendcount, sendtype, sendtag, dest, comm_ptr, s);
@@ -206,7 +206,7 @@ int MPIR_Isendrecv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
     MPIR_ERR_CHECK(mpi_errno);
 
     /* note: we are not using collective tag, so passing in 0 as a dummy */
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, 0, p_req);
+    mpi_errno = MPIR_Sched_start(s, comm_ptr, 0, p_req);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -265,7 +265,7 @@ int MPIR_Isendrecv_replace_impl(void *buf, int count, MPI_Datatype datatype, int
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &sched_tag);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_create(&s, MPIR_SCHED_KIND_REGULAR);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_pt2pt_send(tmpbuf, count, datatype, sendtag, dest, comm_ptr, s);
@@ -278,7 +278,7 @@ int MPIR_Isendrecv_replace_impl(void *buf, int count, MPI_Datatype datatype, int
     mpi_errno = MPIR_Sched_cb(&release_temp_buffer, tmpbuf, s);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, sched_tag, p_req);
+    mpi_errno = MPIR_Sched_start(s, comm_ptr, sched_tag, p_req);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -174,13 +174,13 @@ int MPIR_Request_completion_processing(MPIR_Request * request_ptr, MPI_Status * 
 
         case MPIR_REQUEST_KIND__PREQUEST_COLL:
             {
-                if (request_ptr->u.persist.real_request != NULL) {
-                    MPIR_Request *prequest_ptr = request_ptr->u.persist.real_request;
+                if (request_ptr->u.persist_coll.real_request != NULL) {
+                    MPIR_Request *prequest_ptr = request_ptr->u.persist_coll.real_request;
 
                     /* reset persistent request to inactive state */
                     MPIR_cc_set(&request_ptr->cc, 0);
                     request_ptr->cc_ptr = &request_ptr->cc;
-                    request_ptr->u.persist.real_request = NULL;
+                    request_ptr->u.persist_coll.real_request = NULL;
 
                     MPIR_Request_extract_status(prequest_ptr, status);
                     mpi_errno = prequest_ptr->status.MPI_ERROR;

--- a/src/mpid/ch3/include/mpid_sched.h
+++ b/src/mpid/ch3/include/mpid_sched.h
@@ -12,6 +12,9 @@
 #define MPIR_Sched_next_tag  MPIDU_Sched_next_tag
 #define MPIR_Sched_create MPIDU_Sched_create
 #define MPIR_Sched_clone MPIDU_Sched_clone
+#define MPIR_Sched_free MPIDU_Sched_free
+#define MPIR_Sched_reset MPIDU_Sched_reset
+#define MPIR_Sched_alloc_state MPIDU_Sched_alloc_state
 #define MPIR_Sched_start MPIDU_Sched_start
 #define MPIR_Sched_send MPIDU_Sched_send
 #define MPIR_Sched_pt2pt_send MPIDU_Sched_pt2pt_send

--- a/src/mpid/ch4/include/mpid_sched.h
+++ b/src/mpid/ch4/include/mpid_sched.h
@@ -12,6 +12,9 @@
 #define MPIR_Sched_next_tag  MPIDU_Sched_next_tag
 #define MPIR_Sched_create MPIDU_Sched_create
 #define MPIR_Sched_clone MPIDU_Sched_clone
+#define MPIR_Sched_free MPIDU_Sched_free
+#define MPIR_Sched_reset MPIDU_Sched_reset
+#define MPIR_Sched_alloc_state MPIDU_Sched_alloc_state
 #define MPIR_Sched_start MPIDU_Sched_start
 #define MPIR_Sched_send MPIDU_Sched_send
 #define MPIR_Sched_pt2pt_send MPIDU_Sched_pt2pt_send

--- a/src/mpid/ch4/src/ch4_wait.h
+++ b/src/mpid/ch4/src/ch4_wait.h
@@ -20,6 +20,13 @@ MPL_STATIC_INLINE_PREFIX int get_vci_wrapper(MPIR_Request * req)
             /* TODO: skip it in MPIDI_set_progress_vci_n */
             vci = 0;
         }
+    } else if (req->kind == MPIR_REQUEST_KIND__PREQUEST_COLL) {
+        if (req->u.persist_coll.real_request) {
+            vci = MPIDI_Request_get_vci(req->u.persist_coll.real_request);
+        } else {
+            /* TODO: skip it in MPIDI_set_progress_vci_n */
+            vci = 0;
+        }
     } else {
         vci = MPIDI_Request_get_vci(req);
     }

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -322,8 +322,12 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
             MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "starting CB entry %d\n", (int) idx);
             if (e->u.cb.cb_type == MPIDU_SCHED_CB_TYPE_1) {
                 ret_errno = e->u.cb.u.cb_p(r->comm, s->tag, e->u.cb.cb_state);
-                /* Sched entries list can be reallocated inside callback */
-                e = &s->entries[idx];
+                if (s->kind == MPIR_SCHED_KIND_GENERALIZED) {
+                    /* Sched entries list can be reallocated inside callback */
+                    e = &s->entries[idx];
+                } else {
+                    MPIR_Assert(e == &s->entries[idx]);
+                }
                 if (unlikely(ret_errno)) {
                     if (MPIR_ERR_NONE == r->u.nbc.errflag) {
                         if (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(ret_errno)) {
@@ -338,8 +342,12 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
                 }
             } else if (e->u.cb.cb_type == MPIDU_SCHED_CB_TYPE_2) {
                 ret_errno = e->u.cb.u.cb2_p(r->comm, s->tag, e->u.cb.cb_state, e->u.cb.cb_state2);
-                /* Sched entries list can be reallocated inside callback */
-                e = &s->entries[idx];
+                if (s->kind == MPIR_SCHED_KIND_GENERALIZED) {
+                    /* Sched entries list can be reallocated inside callback */
+                    e = &s->entries[idx];
+                } else {
+                    MPIR_Assert(e == &s->entries[idx]);
+                }
                 if (unlikely(ret_errno)) {
                     if (MPIR_ERR_NONE == r->u.nbc.errflag) {
                         if (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(ret_errno)) {
@@ -416,7 +424,7 @@ static int MPIDU_Sched_continue(struct MPIDU_Sched *s)
 }
 
 /* creates a new opaque schedule object and returns a handle to it in (*sp) */
-int MPIDU_Sched_create(MPIR_Sched_t * sp)
+int MPIDU_Sched_create(MPIR_Sched_t * sp, enum MPIR_Sched_kind kind)
 {
     int mpi_errno = MPI_SUCCESS;
     struct MPIDU_Sched *s;
@@ -437,6 +445,8 @@ int MPIDU_Sched_create(MPIR_Sched_t * sp)
     s->tag = -1;
     s->req = NULL;
     s->entries = NULL;
+    s->kind = kind;
+    s->num_bufs = 0;
     s->next = NULL;     /* only needed for sanity checks */
     s->prev = NULL;     /* only needed for sanity checks */
 
@@ -467,19 +477,53 @@ int MPIDU_Sched_clone(MPIR_Sched_t orig, MPIR_Sched_t * cloned)
     return mpi_errno;
 }
 
-/* sets (*sp) to MPIR_SCHED_NULL and gives you back a request pointer in (*req).
- * The caller is giving up ownership of the opaque schedule object. */
-int MPIDU_Sched_start(MPIR_Sched_t * sp, MPIR_Comm * comm, int tag, MPIR_Request ** req)
+int MPIDU_Sched_free(struct MPIDU_Sched *s)
+{
+    MPL_free(s->entries);
+    for (int i = 0; i < s->num_bufs; i++) {
+        MPL_free(s->bufs[i]);
+    }
+    MPL_free(s);
+    return MPI_SUCCESS;
+}
+
+int MPIDU_Sched_reset(struct MPIDU_Sched *s)
+{
+    MPIR_Assert(s->kind == MPIR_SCHED_KIND_PERSISTENT);
+
+    for (int i = s->idx; i < s->num_entries; ++i) {
+        s->entries[i].status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
+    }
+    s->idx = 0;
+    s->tag = -1;
+    s->req = NULL;
+    s->next = NULL;     /* only needed for sanity checks */
+    s->prev = NULL;     /* only needed for sanity checks */
+    return MPI_SUCCESS;
+}
+
+void *MPIDU_Sched_alloc_state(struct MPIDU_Sched *s, MPI_Aint size)
+{
+    int i = s->num_bufs;
+    if (i >= MPIDU_SCHED_MAXBUF) {
+        return NULL;
+    }
+    s->bufs[i] = MPL_malloc(size, MPL_MEM_OTHER);
+    if (s->bufs[i]) {
+        s->num_bufs++;
+    }
+    return s->bufs[i];
+}
+
+int MPIDU_Sched_start(struct MPIDU_Sched *s, MPIR_Comm * comm, int tag, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *r;
-    struct MPIDU_Sched *s = *sp;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_SCHED_START);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_SCHED_START);
 
     *req = NULL;
-    *sp = MPIR_SCHED_NULL;
 
     /* sanity check the schedule */
     MPIR_Assert(s->num_entries <= s->size);
@@ -951,7 +995,6 @@ int MPIDU_Sched_cb2(MPIR_Sched_cb2_t * cb_p, void *cb_state, void *cb_state2, MP
     goto fn_exit;
 }
 
-
 /* returns TRUE in (*made_progress) if any of the outstanding schedules in state completed */
 static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made_progress)
 {
@@ -1075,9 +1118,11 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
 
             MPIR_Request_complete(s->req);
 
-            s->req = NULL;
-            MPL_free(s->entries);
-            MPL_free(s);
+            if (s->kind != MPIR_SCHED_KIND_PERSISTENT) {
+                MPIDU_Sched_free(s);
+            } else {
+                s->req = NULL;
+            }
 
             if (made_progress)
                 *made_progress = TRUE;

--- a/src/mpid/common/sched/mpidu_sched.h
+++ b/src/mpid/common/sched/mpidu_sched.h
@@ -12,6 +12,7 @@
  *   hold a pointer to the schedule?  This could cause MT issues.
  */
 #include "mpidu_pre.h"
+#include "utarray.h"
 
 enum MPIR_Sched_kind {
     MPIR_SCHED_KIND_REGULAR = 0,
@@ -115,7 +116,6 @@ struct MPIDU_Sched_entry {
     } u;
 };
 
-#define MPIDU_SCHED_MAXBUF 10
 struct MPIDU_Sched {
     size_t size;                /* capacity (in entries) of the entries array */
     size_t idx;                 /* index into entries array of first yet-outstanding entry */
@@ -124,9 +124,7 @@ struct MPIDU_Sched {
     struct MPIR_Request *req;   /* really needed? could cause MT problems... */
     struct MPIDU_Sched_entry *entries;
     enum MPIR_Sched_kind kind;  /* regular, persistent, generalized */
-    int num_bufs;
-    void *bufs[MPIDU_SCHED_MAXBUF];     /* persistent buffers */
-
+    UT_array *buffers;
     struct MPIDU_Sched *next;   /* linked-list next pointer */
     struct MPIDU_Sched *prev;   /* linked-list next pointer */
 };


### PR DESCRIPTION
## Pull Request Description

Extend MPIDU_Sched utilities to support usage in persistent collectives.
Generalize the sched interface with `MPIR_Ibcast_sched_impl`, and extend
persistent bcast to all nonblocking bcast algorithms.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
