### PR TITLE
Add Multi-NIC Multiplexing and Info Hints

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -88,7 +88,7 @@ enum MPIR_COMM_HINT_PREDEFINED_t {
      * Potentially, we can use macros and configure to hide them */
     MPIR_COMM_HINT_EAGER_THRESH,        /* ch3 */
     MPIR_COMM_HINT_EAGAIN,      /* ch4:ofi */
-    MPIR_COMM_HINT_ENABLE_STRIPING,     /* ch4:ofi */
+    MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING,   /* ch4:ofi */
     MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING,    /* ch4:ofi */
     /* dynamic hints starts here */
     MPIR_COMM_HINT_PREDEFINED_COUNT

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -89,6 +89,7 @@ enum MPIR_COMM_HINT_PREDEFINED_t {
     MPIR_COMM_HINT_EAGER_THRESH,        /* ch3 */
     MPIR_COMM_HINT_EAGAIN,      /* ch4:ofi */
     MPIR_COMM_HINT_ENABLE_STRIPING,     /* ch4:ofi */
+    MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING,    /* ch4:ofi */
     /* dynamic hints starts here */
     MPIR_COMM_HINT_PREDEFINED_COUNT
 };

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -88,6 +88,7 @@ enum MPIR_COMM_HINT_PREDEFINED_t {
      * Potentially, we can use macros and configure to hide them */
     MPIR_COMM_HINT_EAGER_THRESH,        /* ch3 */
     MPIR_COMM_HINT_EAGAIN,      /* ch4:ofi */
+    MPIR_COMM_HINT_ENABLE_STRIPING,     /* ch4:ofi */
     /* dynamic hints starts here */
     MPIR_COMM_HINT_PREDEFINED_COUNT
 };

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -306,7 +306,7 @@ int MPIR_Comm_split_filesystem(MPI_Comm comm, int key, const char *dirname, MPI_
 void MPIR_Comm_hint_init(void);
 typedef int (*MPIR_Comm_hint_fn_t) (MPIR_Comm *, int, int);     /* comm, key, val */
 int MPIR_Comm_register_hint(int index, const char *hint_key, MPIR_Comm_hint_fn_t fn,
-                            int type, int attr);
+                            int type, int attr, int default_val);
 
 int MPIR_Comm_accept_impl(const char *port_name, MPIR_Info * info_ptr, int root,
                           MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm_ptr);

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -179,6 +179,8 @@ void MPIR_Comm_hint_init(void)
     /* Used by ch4:ofi, but needs to be initialized early to get the default value. */
     MPIR_Comm_register_hint(MPIR_COMM_HINT_ENABLE_STRIPING, "enable_striping", NULL,
                             MPIR_COMM_HINT_TYPE_BOOL, 0);
+    MPIR_Comm_register_hint(MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING, "enable_multi_nic_hashing",
+                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
 }
 
 /* FIXME :

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -107,6 +107,8 @@ static int get_string_value(char *s, int type, int val)
  */
 int MPII_Comm_set_hints(MPIR_Comm * comm_ptr, MPIR_Info * info)
 {
+    int mpi_errno = MPI_SUCCESS;
+
     MPIR_Info *curr_info;
     LL_FOREACH(info, curr_info) {
         if (curr_info->key == NULL)
@@ -126,8 +128,15 @@ int MPII_Comm_set_hints(MPIR_Comm * comm_ptr, MPIR_Info * info)
             }
         }
     }
+
+    mpi_errno = MPID_Comm_set_hints(comm_ptr, info);
+    MPIR_ERR_CHECK(mpi_errno);
+
     /* FIXME: run collective to ensure hints consistency */
+  fn_exit:
     return MPI_SUCCESS;
+  fn_fail:
+    goto fn_exit;
 }
 
 int MPII_Comm_get_hints(MPIR_Comm * comm_ptr, MPIR_Info * info)

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -178,8 +178,8 @@ void MPIR_Comm_hint_init(void)
     MPIR_Comm_register_hint(MPIR_COMM_HINT_ALLOW_OVERTAKING, "mpi_assert_allow_overtaking",
                             NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, 0);
     /* Used by ch4:ofi, but needs to be initialized early to get the default value. */
-    MPIR_Comm_register_hint(MPIR_COMM_HINT_ENABLE_STRIPING, "enable_striping", NULL,
-                            MPIR_COMM_HINT_TYPE_BOOL, 0, -1);
+    MPIR_Comm_register_hint(MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING, "enable_multi_nic_striping",
+                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, -1);
     MPIR_Comm_register_hint(MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING, "enable_multi_nic_hashing",
                             NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, -1);
 }

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -176,6 +176,9 @@ void MPIR_Comm_hint_init(void)
                             NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
     MPIR_Comm_register_hint(MPIR_COMM_HINT_ALLOW_OVERTAKING, "mpi_assert_allow_overtaking",
                             NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
+    /* Used by ch4:ofi, but needs to be initialized early to get the default value. */
+    MPIR_Comm_register_hint(MPIR_COMM_HINT_ENABLE_STRIPING, "enable_striping", NULL,
+                            MPIR_COMM_HINT_TYPE_BOOL, 0);
 }
 
 /* FIXME :

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -49,12 +49,13 @@ struct MPIR_HINT {
     MPIR_Comm_hint_fn_t fn;
     int type;
     int attr;                   /* e.g. whether this key is local */
+    int default_val;
 };
 static struct MPIR_HINT MPIR_comm_hint_list[MPIR_COMM_HINT_MAX];
 static int next_comm_hint_index = MPIR_COMM_HINT_PREDEFINED_COUNT;
 
 int MPIR_Comm_register_hint(int idx, const char *hint_key, MPIR_Comm_hint_fn_t fn,
-                            int type, int attr)
+                            int type, int attr, int default_val)
 {
     if (idx == 0) {
         idx = next_comm_hint_index;
@@ -64,7 +65,7 @@ int MPIR_Comm_register_hint(int idx, const char *hint_key, MPIR_Comm_hint_fn_t f
         MPIR_Assert(idx > 0 && idx < MPIR_COMM_HINT_PREDEFINED_COUNT);
     }
     MPIR_comm_hint_list[idx] = (struct MPIR_HINT) {
-    hint_key, fn, type, attr};
+    hint_key, fn, type, attr, default_val};
     return idx;
 }
 
@@ -169,18 +170,18 @@ int MPII_Comm_check_hints(MPIR_Comm * comm)
 void MPIR_Comm_hint_init(void)
 {
     MPIR_Comm_register_hint(MPIR_COMM_HINT_NO_ANY_TAG, "mpi_assert_no_any_tag",
-                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
+                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, 0);
     MPIR_Comm_register_hint(MPIR_COMM_HINT_NO_ANY_SOURCE, "mpi_assert_no_any_source",
-                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
+                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, 0);
     MPIR_Comm_register_hint(MPIR_COMM_HINT_EXACT_LENGTH, "mpi_assert_exact_length",
-                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
+                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, 0);
     MPIR_Comm_register_hint(MPIR_COMM_HINT_ALLOW_OVERTAKING, "mpi_assert_allow_overtaking",
-                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
+                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, 0);
     /* Used by ch4:ofi, but needs to be initialized early to get the default value. */
     MPIR_Comm_register_hint(MPIR_COMM_HINT_ENABLE_STRIPING, "enable_striping", NULL,
-                            MPIR_COMM_HINT_TYPE_BOOL, 0);
+                            MPIR_COMM_HINT_TYPE_BOOL, 0, -1);
     MPIR_Comm_register_hint(MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING, "enable_multi_nic_hashing",
-                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
+                            NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, -1);
 }
 
 /* FIXME :
@@ -230,6 +231,11 @@ int MPII_Comm_init(MPIR_Comm * comm_p)
     comm_p->seq = 0;    /* default to 0, to be updated at Comm_commit */
     comm_p->tainted = 0;
     memset(comm_p->hints, 0, sizeof(comm_p->hints));
+    for (int i = 0; i < next_comm_hint_index; i++) {
+        if (MPIR_comm_hint_list[i].key) {
+            comm_p->hints[i] = MPIR_comm_hint_list[i].default_val;
+        }
+    }
 
     comm_p->hierarchy_kind = MPIR_COMM_HIERARCHY_KIND__FLAT;
     comm_p->node_comm = NULL;

--- a/src/mpi/init/local_proc_attrs.c
+++ b/src/mpi/init/local_proc_attrs.c
@@ -71,6 +71,9 @@ int MPII_init_local_proc_attrs(int *p_thread_required)
      * dimsCreate */
     MPIR_Process.dimsCreate = 0;
 
+    /* Init communicator hints */
+    MPIR_Comm_hint_init();
+
     /* "Allocate" from the reserved space for builtin communicators and
      * (partially) initialize predefined communicators.  comm_parent is
      * initially NULL and will be allocated by the device if the process group
@@ -126,9 +129,6 @@ int MPII_init_local_proc_attrs(int *p_thread_required)
 
     /* Set the number of tag bits. The device may override this value. */
     MPIR_Process.tag_bits = MPIR_TAG_BITS_DEFAULT;
-
-    /* Init communicator hints */
-    MPIR_Comm_hint_init();
 
     return mpi_errno;
 }

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -221,6 +221,8 @@ int MPIDI_CH3I_Comm_commit_pre_hook(struct MPIR_Comm *);
 int MPIDI_CH3I_Comm_destroy_hook(struct MPIR_Comm *);
 int MPIDI_CH3I_Comm_commit_post_hook(struct MPIR_Comm *);
 
+int MPIDI_CH3I_Comm_set_hints(MPIR_Comm *, MPIR_Info *info_ptr);
+
 /*
   Device override hooks for asynchronous progress threads
 */

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -163,6 +163,7 @@ typedef union {
 #define MPID_Comm_commit_pre_hook(comm_) MPIDI_CH3I_Comm_commit_pre_hook(comm_)
 #define MPID_Comm_commit_post_hook(comm_) MPIDI_CH3I_Comm_commit_post_hook(comm_)
 #define MPID_Comm_free_hook(comm_) MPIDI_CH3I_Comm_destroy_hook(comm_)
+#define MPID_Comm_set_hints(comm_, info_) MPIDI_CH3I_Comm_set_hints(comm_, info_)
 
 #ifndef HAVE_MPIDI_VCRT
 #define HAVE_MPIDI_VCRT

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -340,6 +340,15 @@ int MPIDI_CH3I_Comm_destroy_hook(MPIR_Comm *comm)
     goto fn_exit;
 }
 
+int MPIDI_CH3I_Comm_set_hints(MPIR_Comm *comm_ptr, MPIR_Info *info_ptr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3I_COMM_SET_HINTS);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3I_COMM_SET_HINTS);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH3I_COMM_SET_HINTS);
+    return mpi_errno;
+}
 
 int MPIDI_CH3U_Comm_register_create_hook(int (*hook_fn)(struct MPIR_Comm *, void *), void *param)
 {

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -270,7 +270,7 @@ int MPID_Init_world(void)
     MPIR_Process.has_parent = has_parent;
 
     MPIR_Comm_register_hint(MPIR_COMM_HINT_EAGER_THRESH, "eager_rendezvous_threshold",
-                            NULL, MPIR_COMM_HINT_TYPE_INT, 0);
+                            NULL, MPIR_COMM_HINT_TYPE_INT, 0, 0);
 
     mpi_errno = MPIDI_RMA_init();
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -25,6 +25,9 @@ Non Native API:
   mpi_comm_disconnect : int
       NM : comm_ptr
      SHM : comm_ptr
+  comm_set_hints : int
+      NM : comm_ptr, info
+     SHM : comm_ptr, info
   mpi_open_port : int
       NM : info, port_name-2
      SHM : info, port_name-2

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -175,6 +175,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *, int, MPIR_Comm *, int, int *, int *
 int MPID_Create_intercomm_from_lpids(MPIR_Comm *, int, const int[]);
 int MPID_Comm_commit_pre_hook(MPIR_Comm *);
 int MPID_Comm_free_hook(MPIR_Comm *);
+int MPID_Comm_set_hints(MPIR_Comm *, MPIR_Info *);
 int MPID_Comm_commit_post_hook(MPIR_Comm *);
 MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -8,6 +8,37 @@
 #include "mpidu_bc.h"
 #include "ofi_noinline.h"
 
+static int update_multi_nic_hints(MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    if (comm) {
+        /* If the user set a multi-nic hint, but num_nics = 1, disable multi-nic optimizations. */
+        if (MPIDI_OFI_global.num_nics > 1) {
+            int was_enabled_striping = MPIDI_OFI_COMM(comm).enable_striping;
+
+            /* Check if we should use striping */
+            if (comm->hints[MPIR_COMM_HINT_ENABLE_STRIPING] != -1)
+                MPIDI_OFI_COMM(comm).enable_striping = comm->hints[MPIR_COMM_HINT_ENABLE_STRIPING];
+            else
+                MPIDI_OFI_COMM(comm).enable_striping = MPIR_CVAR_CH4_OFI_ENABLE_STRIPING;
+
+            /* If striping was on and we disabled it here, decrement the global counter. */
+            if (was_enabled_striping > 0 && MPIDI_OFI_COMM(comm).enable_striping == 0)
+                MPIDI_OFI_global.num_comms_enabled_striping--;
+            /* If striping was off and we enabled it here, increment the global counter. */
+            else if (was_enabled_striping <= 0 && MPIDI_OFI_COMM(comm).enable_striping != 0)
+                MPIDI_OFI_global.num_comms_enabled_striping++;
+
+            if (MPIDI_OFI_COMM(comm).enable_striping) {
+                MPIDI_OFI_global.stripe_threshold = MPIR_CVAR_CH4_OFI_STRIPING_THRESHOLD;
+            }
+        }
+    }
+
+    return mpi_errno;
+}
+
 int MPIDI_OFI_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -20,17 +51,16 @@ int MPIDI_OFI_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
     /* no connection for non-dynamic or non-root-rank of intercomm */
     MPIDI_OFI_COMM(comm).conn_id = -1;
 
-    /* Use striping if enabled and there are multiple NICs. */
-    if (MPIR_CVAR_CH4_OFI_ENABLE_STRIPING && MPIDI_OFI_global.num_nics > 1) {
-        MPIDI_OFI_COMM(comm).enable_striping = 1;
-    } else {
-        MPIDI_OFI_COMM(comm).enable_striping = 0;
-    }
+    /* Initialize the multi-nic optimization values */
+    MPIDI_OFI_global.num_comms_enabled_striping = 0;
+    MPIDI_OFI_COMM(comm).enable_striping = 0;
 
     /* eagain defaults to off */
     if (comm->hints[MPIR_COMM_HINT_EAGAIN] == 0) {
         comm->hints[MPIR_COMM_HINT_EAGAIN] = FALSE;
     }
+
+    update_multi_nic_hints(comm);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_MPI_COMM_COMMIT_PRE_HOOK);
     return mpi_errno;
@@ -53,6 +83,10 @@ int MPIDI_OFI_mpi_comm_free_hook(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_COMM_FREE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_COMM_FREE_HOOK);
 
+    /* If we enabled striping, decrement the counter. */
+    MPIDI_OFI_global.num_comms_enabled_striping -=
+        (MPIDI_OFI_COMM(comm).enable_striping != 0 ? 1 : 0);
+
     MPIDIU_map_destroy(MPIDI_OFI_COMM(comm).huge_send_counters);
     MPIDIU_map_destroy(MPIDI_OFI_COMM(comm).huge_recv_counters);
 
@@ -63,6 +97,8 @@ int MPIDI_OFI_mpi_comm_free_hook(MPIR_Comm * comm)
 int MPIDI_OFI_comm_set_hints(MPIR_Comm * comm, MPIR_Info * info)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    update_multi_nic_hints(comm);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -33,6 +33,31 @@ static int update_multi_nic_hints(MPIR_Comm * comm)
             if (MPIDI_OFI_COMM(comm).enable_striping) {
                 MPIDI_OFI_global.stripe_threshold = MPIR_CVAR_CH4_OFI_STRIPING_THRESHOLD;
             }
+
+            int was_enabled_hashing = MPIDI_OFI_COMM(comm).enable_hashing;
+
+            /* Check if we should use hashing */
+            if (comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING] != -1)
+                MPIDI_OFI_COMM(comm).enable_hashing =
+                    comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING];
+            else        /* If this value is -1, that means the user hasn't set a value. */
+                MPIDI_OFI_COMM(comm).enable_hashing = MPIR_CVAR_CH4_OFI_ENABLE_MULTI_NIC_HASHING;
+
+            /* If the user set the hashing hint, but not no_any_tag/source, disable
+             * hashing because it would introduce a major performance penalty to have to post a
+             * request on each NIC and then cancel it later. */
+            if (MPIDI_OFI_COMM(comm).enable_hashing &&
+                (!comm->hints[MPIR_COMM_HINT_NO_ANY_TAG] ||
+                 !comm->hints[MPIR_COMM_HINT_NO_ANY_SOURCE])) {
+                MPIDI_OFI_COMM(comm).enable_hashing = 0;
+            }
+
+            /* If hashing was on and we disabled it here, decrement the global counter. */
+            if (was_enabled_hashing > 0 && MPIDI_OFI_COMM(comm).enable_hashing == 0)
+                MPIDI_OFI_global.num_comms_enabled_hashing--;
+            /* If hashing was off and we enabled it here, increment the global counter. */
+            else if (was_enabled_hashing <= 0 && MPIDI_OFI_COMM(comm).enable_hashing != 0)
+                MPIDI_OFI_global.num_comms_enabled_hashing++;
         }
     }
 
@@ -53,7 +78,9 @@ int MPIDI_OFI_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
 
     /* Initialize the multi-nic optimization values */
     MPIDI_OFI_global.num_comms_enabled_striping = 0;
+    MPIDI_OFI_global.num_comms_enabled_hashing = 0;
     MPIDI_OFI_COMM(comm).enable_striping = 0;
+    MPIDI_OFI_COMM(comm).enable_hashing = 0;
 
     /* eagain defaults to off */
     if (comm->hints[MPIR_COMM_HINT_EAGAIN] == 0) {
@@ -83,9 +110,11 @@ int MPIDI_OFI_mpi_comm_free_hook(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_COMM_FREE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_COMM_FREE_HOOK);
 
-    /* If we enabled striping, decrement the counter. */
+    /* If we enabled striping or hashing, decrement the counter. */
     MPIDI_OFI_global.num_comms_enabled_striping -=
         (MPIDI_OFI_COMM(comm).enable_striping != 0 ? 1 : 0);
+    MPIDI_OFI_global.num_comms_enabled_hashing -=
+        (MPIDI_OFI_COMM(comm).enable_hashing != 0 ? 1 : 0);
 
     MPIDIU_map_destroy(MPIDI_OFI_COMM(comm).huge_send_counters);
     MPIDIU_map_destroy(MPIDI_OFI_COMM(comm).huge_recv_counters);

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -59,3 +59,10 @@ int MPIDI_OFI_mpi_comm_free_hook(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_MPI_COMM_FREE_HOOK);
     return mpi_errno;
 }
+
+int MPIDI_OFI_comm_set_hints(MPIR_Comm * comm, MPIR_Info * info)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    return mpi_errno;
+}

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -18,10 +18,11 @@ static int update_multi_nic_hints(MPIR_Comm * comm)
             int was_enabled_striping = MPIDI_OFI_COMM(comm).enable_striping;
 
             /* Check if we should use striping */
-            if (comm->hints[MPIR_COMM_HINT_ENABLE_STRIPING] != -1)
-                MPIDI_OFI_COMM(comm).enable_striping = comm->hints[MPIR_COMM_HINT_ENABLE_STRIPING];
+            if (comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING] != -1)
+                MPIDI_OFI_COMM(comm).enable_striping =
+                    comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING];
             else
-                MPIDI_OFI_COMM(comm).enable_striping = MPIR_CVAR_CH4_OFI_ENABLE_STRIPING;
+                MPIDI_OFI_COMM(comm).enable_striping = MPIR_CVAR_CH4_OFI_ENABLE_MULTI_NIC_STRIPING;
 
             /* If striping was on and we disabled it here, decrement the global counter. */
             if (was_enabled_striping > 0 && MPIDI_OFI_COMM(comm).enable_striping == 0)
@@ -31,7 +32,7 @@ static int update_multi_nic_hints(MPIR_Comm * comm)
                 MPIDI_OFI_global.num_comms_enabled_striping++;
 
             if (MPIDI_OFI_COMM(comm).enable_striping) {
-                MPIDI_OFI_global.stripe_threshold = MPIR_CVAR_CH4_OFI_STRIPING_THRESHOLD;
+                MPIDI_OFI_global.stripe_threshold = MPIR_CVAR_CH4_OFI_MULTI_NIC_STRIPING_THRESHOLD;
             }
 
             int was_enabled_hashing = MPIDI_OFI_COMM(comm).enable_hashing;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -821,14 +821,12 @@ int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_entry *wc, MPIR_Request * re
     return mpi_errno;
 }
 
-int MPIDI_OFI_handle_cq_error(int vni_idx, ssize_t ret)
+int MPIDI_OFI_handle_cq_error(int ctx_idx, ssize_t ret)
 {
     int mpi_errno = MPI_SUCCESS;
     struct fi_cq_err_entry e;
     char err_data[MPIDI_OFI_MAX_ERR_DATA_SIZE];
     MPIR_Request *req;
-    int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni_idx, nic);
     ssize_t ret_cqerr;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_HANDLE_CQ_ERROR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_HANDLE_CQ_ERROR);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -15,7 +15,7 @@
 int MPIDI_OFI_rma_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * in_req);
 int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
 int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
-int MPIDI_OFI_handle_cq_error(int vni_idx, ssize_t ret);
+int MPIDI_OFI_handle_cq_error(int ctx_idx, ssize_t ret);
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_cqe_get_source(struct fi_cq_tagged_entry *wc, bool has_err)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -547,4 +547,56 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_OFI_count_iov(int dt_count,       /* numbe
     return total_iov;
 }
 
+/* Calculate the index of the NIC used to send a message from sender_rank to receiver_rank
+ *
+ * comm - The communicator used to send the message.
+ * ctxid_in_effect - The context ID that will be used to send the message.
+ *                   On the sender side, this should be comm->context_id.
+ *                   On the receiver side, this should be comm->recvcontext_id.
+ * receiver_rank - The rank of the receiving process.
+ * tag - The tag of the message being sent.
+ */
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_multx_sender_nic_index(MPIR_Comm * comm,
+                                                              MPIR_Context_id_t ctxid_in_effect,
+                                                              int receiver_rank, int tag)
+{
+    int nic_idx = 0;
+
+    /* TODO - If there is a communicator specific mapping, that should be checked/used here. */
+    /* TODO - We should use the per-communicator value for the maximum number of NICs in this
+     *        calculation once we have a per-communicator value for it. */
+    if (MPIDI_OFI_COMM(comm).enable_hashing) {
+        nic_idx = ((unsigned int) (MPIR_CONTEXT_READ_FIELD(PREFIX, ctxid_in_effect) +
+                                   receiver_rank + tag)) % MPIDI_OFI_global.num_nics;
+    }
+
+    return nic_idx;
+}
+
+/* Calculate the index of the NIC used to receive a message from sender_rank at receiver_rank
+ *
+ * comm - The communicator used to receive the message.
+ * ctxid_in_effect - The context ID that will be used to receive the message.
+ *                   On the sender side, this should be comm->context_id.
+ *                   On the receiver side, this should be comm->recvcontext_id.
+ * sender_rank - The rank of the sending process.
+ * tag - The tag of the message being sent.
+ */
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_multx_receiver_nic_index(MPIR_Comm * comm,
+                                                                MPIR_Context_id_t ctxid_in_effect,
+                                                                int sender_rank, int tag)
+{
+    int nic_idx = 0;
+
+    /* TODO - If there is a communicator specific mapping, that should be checked/used here. */
+    /* TODO - We should use the per-communicator value for the maximum number of NICs in this
+     *        calculation once we have a per-communicator value for it. */
+    if (MPIDI_OFI_COMM(comm).enable_hashing) {
+        nic_idx = ((unsigned int) (MPIR_CONTEXT_READ_FIELD(PREFIX, ctxid_in_effect) +
+                                   sender_rank + tag)) % MPIDI_OFI_global.num_nics;
+    }
+
+    return nic_idx;
+}
+
 #endif /* OFI_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -290,7 +290,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_set(int ctx_idx, int val)
 #define MPIDI_OFI_LOCAL_MR_KEY 0
 #define MPIDI_OFI_COLL_MR_KEY 1
 #define MPIDI_OFI_INVALID_MR_KEY 0xFFFFFFFFFFFFFFFFULL
-int MPIDI_OFI_handle_cq_error_util(int ep_idx, ssize_t ret);
+int MPIDI_OFI_handle_cq_error_util(int ctx_idx, ssize_t ret);
 int MPIDI_OFI_retry_progress(void);
 int MPIDI_OFI_control_handler(int handler_id, void *am_hdr, void *data, MPI_Aint data_sz,
                               int is_local, int is_async, MPIR_Request ** req);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -496,6 +496,7 @@ int MPIDI_OFI_init_local(int *tag_bits)
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Comm_register_hint(MPIR_COMM_HINT_EAGAIN, "eagain", NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
+    MPIDI_OFI_global.num_comms_enabled_striping = 0;
 
     MPIDI_OFI_global.deferred_am_isend_q = NULL;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -372,7 +372,6 @@ cvars:
         shmmod automatically uses an optimal number depending on what is detected on the
         system up to the limit determined by MPIDI_MAX_NICS (in ofi_types.h).
 
-
     - name        : MPIR_CVAR_CH4_OFI_ENABLE_STRIPING
       category    : CH4
       type        : int
@@ -392,6 +391,20 @@ cvars:
       scope       : MPI_T_SCOPE_LOCAL
       description : >-
         Striping will happen for message sizes beyond this threshold.
+
+    - name        : MPIR_CVAR_CH4_OFI_ENABLE_MULTI_NIC_HASHING
+      category    : CH4
+      type        : int
+      default     : 0
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Multi-NIC hashing means to use more than one NIC to send and receive messages above a
+        certain size.  If set to positive number, this feature will be turned on. If set to 0, this
+        feature will be turned off. If the number is -1, MPICH automatically determines whether to
+        use multi-nic hashing depending on what is detected on the system (e.g., number of NICs
+        available, number of processes sharing the NICs).
 
     - name        : MPIR_CVAR_OFI_USE_MIN_NICS
       category    : DEVELOPER
@@ -497,6 +510,7 @@ int MPIDI_OFI_init_local(int *tag_bits)
 
     MPIR_Comm_register_hint(MPIR_COMM_HINT_EAGAIN, "eagain", NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
     MPIDI_OFI_global.num_comms_enabled_striping = 0;
+    MPIDI_OFI_global.num_comms_enabled_hashing = 0;
 
     MPIDI_OFI_global.deferred_am_isend_q = NULL;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -372,7 +372,7 @@ cvars:
         shmmod automatically uses an optimal number depending on what is detected on the
         system up to the limit determined by MPIDI_MAX_NICS (in ofi_types.h).
 
-    - name        : MPIR_CVAR_CH4_OFI_ENABLE_STRIPING
+    - name        : MPIR_CVAR_CH4_OFI_ENABLE_MULTI_NIC_STRIPING
       category    : CH4
       type        : int
       default     : 1
@@ -382,7 +382,7 @@ cvars:
       description : >-
         If true, this cvar enables striping of large messages across multiple NICs.
 
-    - name        : MPIR_CVAR_CH4_OFI_STRIPING_THRESHOLD
+    - name        : MPIR_CVAR_CH4_OFI_MULTI_NIC_STRIPING_THRESHOLD
       category    : CH4
       type        : int
       default     : 1048576
@@ -1375,7 +1375,7 @@ static int update_global_limits(struct fi_info *prov)
     } else {
         MPIDI_OFI_global.max_msg_size = MPL_MIN(prov->ep_attr->max_msg_size, MPIR_AINT_MAX);
     }
-    MPIDI_OFI_global.stripe_threshold = MPIR_CVAR_CH4_OFI_STRIPING_THRESHOLD;
+    MPIDI_OFI_global.stripe_threshold = MPIR_CVAR_CH4_OFI_MULTI_NIC_STRIPING_THRESHOLD;
     if (prov->ep_attr->max_order_raw_size > MPIR_AINT_MAX) {
         MPIDI_OFI_global.max_order_raw = -1;
     } else {

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -508,7 +508,7 @@ int MPIDI_OFI_init_local(int *tag_bits)
     mpi_errno = MPIDI_OFI_dynproc_init();
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_Comm_register_hint(MPIR_COMM_HINT_EAGAIN, "eagain", NULL, MPIR_COMM_HINT_TYPE_BOOL, 0);
+    MPIR_Comm_register_hint(MPIR_COMM_HINT_EAGAIN, "eagain", NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, 0);
     MPIDI_OFI_global.num_comms_enabled_striping = 0;
     MPIDI_OFI_global.num_comms_enabled_hashing = 0;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -48,6 +48,7 @@ typedef struct {
     /* support for connection */
     int conn_id;
     int enable_striping;        /* Flag to enable striping per communicator. */
+    int enable_hashing;         /* Flag to enable hashing per communicator. */
 } MPIDI_OFI_comm_t;
 enum {
     MPIDI_AMTYPE_NONE = 0,

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -174,6 +174,8 @@ typedef struct {
     int event_id;               /* fixed field, do not move */
     MPL_atomic_int_t util_id;
     MPI_Datatype datatype;
+    int nic_num;                /* Store the nic number so we can use it to cancel a request later
+                                 * if needed. */
     union {
         struct {
             void *buf;

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -131,7 +131,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
             else if (ret == -FI_EAGAIN)
                 mpi_errno = MPI_SUCCESS;
             else
-                mpi_errno = MPIDI_OFI_handle_cq_error(vni, ret);
+                mpi_errno = MPIDI_OFI_handle_cq_error(ctx_idx, ret);
         }
 
         if (unlikely(mpi_errno == MPI_SUCCESS && MPIDI_OFI_global.deferred_am_isend_q)) {

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -20,18 +20,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     int vni_local = vni_src;
     int vni_remote = vni_dst;
-    int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic);
+    int sender_nic = 0, receiver_nic = 0;
+    int ctx_idx = 0;
     uint64_t match_bits;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT);
+
+    /* Calculate the correct NICs. */
+    sender_nic = MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, dst_rank, tag);
+    receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, MPIR_Process.rank,
+                                                      tag);
+    ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, sender_nic);
+
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, tag, 0);
     MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                         buf,
                                         data_sz,
                                         cq_data,
-                                        MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote),
+                                        MPIDI_OFI_av_to_phys(addr, receiver_nic, vni_local,
+                                                             vni_remote),
                                         match_bits),
                          vni_local, tinjectdata, comm->hints[MPIR_COMM_HINT_EAGAIN]);
   fn_exit:
@@ -67,8 +75,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     MPI_Aint num_contig, size;
     int vni_local = vni_src;
     int vni_remote = vni_dst;
-    int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic);
+    int sender_nic = 0, receiver_nic = 0;
+    int ctx_idx = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_SEND_IOV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_SEND_IOV);
@@ -79,6 +87,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
                          &num_contig);
     if (num_contig > MPIDI_OFI_global.tx_iov_limit)
         goto pack;
+
+    /* Calculate the correct NICs. */
+    sender_nic = MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, dst_rank,
+                                                  MPIDI_OFI_init_get_tag(match_bits));
+    receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, MPIR_Process.rank,
+                                                      MPIDI_OFI_init_get_tag(match_bits));
+    MPIDI_OFI_REQUEST(sreq, nic_num) = sender_nic;
+    ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, MPIDI_OFI_REQUEST(sreq, nic_num));
 
     /* everything fits in the IOV array */
     flags = FI_COMPLETION | FI_REMOTE_CQ_DATA;
@@ -104,7 +120,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     msg.ignore = 0ULL;
     msg.context = (void *) &(MPIDI_OFI_REQUEST(sreq, context));
     msg.data = cq_data;
-    msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote);
+    msg.addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vni_local, vni_remote);
 
     MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                      &msg, flags), vni_local, tsendv, FALSE);
@@ -137,8 +153,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     bool force_gpu_pack = false;
     int vni_local = vni_src;
     int vni_remote = vni_dst;
-    int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic);
+    int sender_nic = 0, receiver_nic = 0;
+    int ctx_idx = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_SEND_NORMAL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_SEND_NORMAL);
@@ -160,6 +176,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     MPIDI_OFI_REQUEST(sreq, datatype) = datatype;
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
 
+    /* Calculate the correct NICs. */
+    sender_nic = MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, dst_rank, tag);
+    receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, MPIR_Process.rank,
+                                                      tag);
+    MPIDI_OFI_REQUEST(sreq, nic_num) = sender_nic;
+    ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, MPIDI_OFI_REQUEST(sreq, nic_num));
+
     if (type == MPIDI_OFI_SYNC_SEND) {  /* Branch should compile out */
         uint64_t ssend_match, ssend_mask;
         MPIDI_OFI_ssendack_request_t *ackreq;
@@ -171,11 +194,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIR_cc_inc(sreq->cc_ptr);
         ssend_match = MPIDI_OFI_init_recvtag(&ssend_mask, comm->context_id + context_offset, tag);
         ssend_match |= MPIDI_OFI_SYNC_SEND_ACK;
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[ctx_idx].rx, /* endpoint    */
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vni_local, receiver_nic)].rx,        /* endpoint    */
                                       NULL,     /* recvbuf     */
                                       0,        /* data sz     */
                                       NULL,     /* memregion descr  */
-                                      MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote),   /* remote proc */
+                                      MPIDI_OFI_av_to_phys(addr, sender_nic, vni_local, vni_remote),    /* remote proc */
                                       ssend_match,      /* match bits  */
                                       0ULL,     /* mask bits   */
                                       (void *) &(ackreq->context)), vni_local, trecvsync, FALSE);
@@ -239,9 +262,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                             send_buf,
                                             data_sz,
                                             cq_data,
-                                            MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote),
-                                            match_bits), vni_local, tinjectdata,
-                             FALSE /* eagain */);
+                                            MPIDI_OFI_av_to_phys(addr, receiver_nic, vni_local,
+                                                                 vni_remote), match_bits),
+                             vni_local, tinjectdata, FALSE /* eagain */);
         MPIDI_OFI_send_event(NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
     } else if ((data_sz < MPIDI_OFI_global.max_msg_size && !MPIDI_OFI_COMM(comm).enable_striping)
                || (data_sz < MPIDI_OFI_global.stripe_threshold &&
@@ -249,10 +272,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           send_buf, data_sz, NULL /* desc */ ,
                                           cq_data,
-                                          MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote),
-                                          match_bits,
-                                          (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
-                             vni_local, tsenddata, FALSE /* eagain */);
+                                          MPIDI_OFI_av_to_phys(addr, receiver_nic, vni_local,
+                                                               vni_remote), match_bits,
+                                          (void *) &(MPIDI_OFI_REQUEST(sreq, context))), vni_local,
+                             tsenddata, FALSE /* eagain */);
     } else if (unlikely(1)) {
         MPIDI_OFI_send_control_t ctrl;
         int i, num_nics = MPIDI_OFI_global.num_nics;
@@ -315,7 +338,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           send_buf, msg_size, NULL /* desc */ ,
                                           cq_data,
-                                          MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote),
+                                          MPIDI_OFI_av_to_phys(addr, receiver_nic, vni_local,
+                                                               vni_remote),
                                           match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
                              vni_local, tsenddata, FALSE /* eagain */);

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -326,6 +326,7 @@ typedef struct {
     int num_vnis;
     int num_nics;
     int num_close_nics;
+    int num_comms_enabled_striping;     /* Number of active communicators with striping enabled */
 
     /* Window/RMA Globals */
     void *win_map;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -327,6 +327,7 @@ typedef struct {
     int num_nics;
     int num_close_nics;
     int num_comms_enabled_striping;     /* Number of active communicators with striping enabled */
+    int num_comms_enabled_hashing;      /* Number of active communicators with hashingenabled */
 
     /* Window/RMA Globals */
     void *win_map;

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -9,13 +9,13 @@
 
 #define MPIDI_OFI_MR_KEY_PREFIX_SHIFT 63
 
-int MPIDI_OFI_handle_cq_error_util(int vni_idx, ssize_t ret)
+int MPIDI_OFI_handle_cq_error_util(int ctx_idx, ssize_t ret)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_HANDLE_CQ_ERROR_UTIL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_HANDLE_CQ_ERROR_UTIL);
 
-    mpi_errno = MPIDI_OFI_handle_cq_error(vni_idx, ret);
+    mpi_errno = MPIDI_OFI_handle_cq_error(ctx_idx, ret);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_HANDLE_CQ_ERROR_UTIL);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.c
@@ -47,3 +47,10 @@ int MPIDI_UCX_mpi_comm_free_hook(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_UCX_MPI_COMM_FREE_HOOK);
     return mpi_errno;
 }
+
+int MPIDI_UCX_comm_set_hints(MPIR_Comm * comm, MPIR_Info * info)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    return mpi_errno;
+}

--- a/src/mpid/ch4/shm/posix/posix_comm.c
+++ b/src/mpid/ch4/shm/posix/posix_comm.c
@@ -68,3 +68,10 @@ int MPIDI_POSIX_mpi_comm_free_hook(MPIR_Comm * comm)
   fn_fail:
     goto fn_exit;
 }
+
+int MPIDI_POSIX_comm_set_hints(MPIR_Comm * comm, MPIR_Info * info)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    return mpi_errno;
+}

--- a/src/mpid/ch4/shm/src/shm_hooks.c
+++ b/src/mpid/ch4/shm/src/shm_hooks.c
@@ -34,6 +34,15 @@ int MPIDI_SHM_mpi_comm_commit_post_hook(MPIR_Comm * comm)
     return ret;
 }
 
+int MPIDI_SHM_comm_set_hints(MPIR_Comm * comm, MPIR_Info * info)
+{
+    int ret;
+
+    ret = MPIDI_POSIX_comm_set_hints(comm, info);
+
+    return ret;
+}
+
 int MPIDI_SHM_mpi_comm_free_hook(MPIR_Comm * comm)
 {
     int ret;

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -304,6 +304,23 @@ int MPID_Comm_free_hook(MPIR_Comm * comm)
     goto fn_exit;
 }
 
+int MPID_Comm_set_hints(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIDI_NM_comm_set_hints(comm_ptr, info_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    mpi_errno = MPIDI_SHM_comm_set_hints(comm_ptr, info_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_Comm * peer_comm,
                                 int remote_leader, int *remote_size, int **remote_lupids,
                                 int *is_low_group)


### PR DESCRIPTION
## Pull Request Description

Adds multi-NIC multiplexing for any sized message. This means that a message will be hashed by context ID, rank, and tag and sent/received using a different NIC depending on that value.

This is expected to improve performance when the injection bandwidth of a single NIC is lower than rate at which the MPI library can process those messages (either sending or receiving).

This PR also adds info hints to turn multiplexing on and off by communicator. A hint to do the same for striping is also included. Part of this includes adding a device-level callback for changing info-hint values to the device/netmod/shmmod can see when these have changed and adjust behavior accordingly.

Fixes #4440

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
