### PR TITLE
coll: fix uninitialized usage

### DIFF
--- a/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
@@ -34,6 +34,8 @@ int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype 
     }
 
     MPIR_Datatype_is_contig(datatype, &is_contig);
+    MPIR_Datatype_get_size_macro(datatype, type_size);
+    nbytes = type_size * count;
 
     /* we'll allocate tmp_buf along with ibcast_state.
      * Alternatively, we can add init callback to allocate the tmp_buf.
@@ -48,10 +50,6 @@ int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype 
     if (!is_contig) {
         tmp_buf = ibcast_state + 1;
     }
-
-    MPIR_Datatype_get_size_macro(datatype, type_size);
-
-    nbytes = type_size * count;
 
     ibcast_state->n_bytes = nbytes;
 

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
@@ -82,6 +82,9 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
         MPIR_Datatype_is_contig(datatype, &is_contig);
     }
 
+    MPIR_Datatype_get_size_macro(datatype, type_size);
+    nbytes = type_size * count;
+
     /* we'll allocate tmp_buf along with ibcast_state.
      * Alternatively, we can add init callback to allocate the tmp_buf.
      */
@@ -96,9 +99,6 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
         tmp_buf = ibcast_state + 1;
     }
 
-    MPIR_Datatype_get_size_macro(datatype, type_size);
-
-    nbytes = type_size * count;
     ibcast_state->n_bytes = nbytes;
     ibcast_state->curr_bytes = 0;
     if (is_contig) {

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
@@ -51,6 +51,9 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
         MPIR_Datatype_is_contig(datatype, &is_contig);
     }
 
+    MPIR_Datatype_get_size_macro(datatype, type_size);
+    nbytes = type_size * count;
+
     /* we'll allocate tmp_buf along with ibcast_state.
      * Alternatively, we can add init callback to allocate the tmp_buf.
      */
@@ -65,8 +68,6 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
         tmp_buf = ibcast_state + 1;
     }
 
-    MPIR_Datatype_get_size_macro(datatype, type_size);
-    nbytes = type_size * count;
     ibcast_state->n_bytes = nbytes;
     ibcast_state->curr_bytes = 0;
     if (is_contig) {


### PR DESCRIPTION
## Pull Request Description
The `nbytes` was uninitialzed before being used.

This is missed from PR #5266. Thanks Coverity scan for discovering this -- why we didn't catch this in warnings test?

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
