### PR TITLE
request: check persis_coll union field

### DIFF
--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -368,8 +368,11 @@ cvars:
 
 #define MPIR_ERRTEST_STARTREQ_ACTIVE(reqp,err)                        \
     if (((reqp)->kind == MPIR_REQUEST_KIND__PREQUEST_SEND ||          \
-         (reqp)->kind == MPIR_REQUEST_KIND__PREQUEST_RECV ||          \
-         (reqp)->kind == MPIR_REQUEST_KIND__PREQUEST_COLL) && (reqp)->u.persist.real_request != NULL) { \
+         (reqp)->kind == MPIR_REQUEST_KIND__PREQUEST_RECV) && (reqp)->u.persist.real_request != NULL) { \
+        err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, \
+                                   MPI_ERR_REQUEST, "**requestpersistactive", 0); \
+        goto fn_fail;                                                   \
+    } else if ((reqp)->kind == MPIR_REQUEST_KIND__PREQUEST_COLL && (reqp)->u.persist_coll.real_request != NULL) { \
         err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, \
                                    MPI_ERR_REQUEST, "**requestpersistactive", 0); \
         goto fn_fail;                                                   \


### PR DESCRIPTION
## Pull Request Description
We spearated the union field for persistent collective request but
forgot to modify the MPIR_ERRTEST_STARTREQ_ACTIVE macro.

The bug only shows up when we `--enable-debuginfo`, since, without it, the `persist` and `persist_coll` union fields overlap in its `real_request` member.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
