### PR TITLE
Fix `--disable-shared` builds [3.4.x]

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,12 +3,12 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
-ACLOCAL_AMFLAGS = -I confdb
+ACLOCAL_AMFLAGS = -I confdb -I modules/hwloc/config
 
 # automake requires that we initialize variables to something, even just empty,
 # before appending to them with "+="
-AM_CFLAGS = @VISIBILITY_CFLAGS@
-AM_CPPFLAGS =
+AM_CFLAGS = @VISIBILITY_CFLAGS@ @HWLOC_EMBEDDED_CFLAGS@
+AM_CPPFLAGS = @HWLOC_EMBEDDED_CPPFLAGS@
 AM_FFLAGS =
 AM_FCFLAGS =
 include_HEADERS =
@@ -49,7 +49,7 @@ pkgconfigdir = @pkgconfigdir@
 errnames_txt_files = 
 
 external_subdirs = @mplsrcdir@ @zmsrcdir@ @hwlocsrcdir@ @jsonsrcdir@ @yaksasrcdir@
-external_ldflags = @mpllibdir@ @zmlibdir@ @yaksalibdir@
+external_ldflags = @mpllibdir@ @zmlibdir@ @hwloclibdir@ @netloclibdir@ @yaksalibdir@
 external_libs = @WRAPPER_LIBS@
 mpi_convenience_libs =
 pmpi_convenience_libs = @mpllib@ @zmlib@ @hwloclib@ @jsonlib@ @yaksalib@

--- a/configure.ac
+++ b/configure.ac
@@ -1203,54 +1203,118 @@ PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/json-c],[CPPFLAGS])
 PAC_APPEND_FLAG([-I${main_top_builddir}/modules/json-c],[CPPFLAGS])
 
 # ----------------------------------------------------------------------------
-# HWLOC / NETLOC
+# HWLOC
 # ----------------------------------------------------------------------------
+# Allow the user to override the hwloc location (from embedded to user
+# or system path)
+PAC_CHECK_PREFIX(hwloc)
 hwlocsrcdir=""
 AC_SUBST([hwlocsrcdir])
+hwloclibdir=""
+AC_SUBST([hwloclibdir])
 hwloclib=""
 AC_SUBST([hwloclib])
 
-m4_define([hwloc_embedded_dir],[modules/hwloc])
-PAC_CHECK_HEADER_LIB_OPTIONAL([hwloc],[hwloc.h],[hwloc],[hwloc_topology_set_pid])
-PAC_CHECK_HEADER_LIB_OPTIONAL([netloc],[netloc.h],[netloc],[netloc_get_all_host_nodes])
+if test "$with_hwloc_prefix" = "no" ; then
+   have_hwloc=no
+elif test "$with_hwloc_prefix" = "embedded" ; then
+   # Disable visibility when setting up hwloc
+   PAC_PUSH_FLAG([enable_visibility])
+   enable_visibility=no;
+   HWLOC_SETUP_CORE([modules/hwloc],[have_hwloc=yes],[have_hwloc=no],[1])
+   if test "$have_hwloc" = "yes" ; then
+      hwlocsrcdir="modules/hwloc"
+      hwloclib="$HWLOC_EMBEDDED_LDADD"
+      PAC_PREPEND_FLAG([$HWLOC_EMBEDDED_LIBS], [WRAPPER_LIBS])
+      PAC_APPEND_FLAG([$HWLOC_EMBEDDED_LDFLAGS], [WRAPPER_LDFLAGS])
+      # if possible, do not expose hwloc symbols in libmpi.so
+      PAC_PREPEND_FLAG([$VISIBILITY_CFLAGS], [HWLOC_CFLAGS])
+   fi
+   PAC_POP_FLAG([enable_visibility])
+else
+   AC_CHECK_HEADERS([hwloc.h])
+   PAC_PUSH_FLAG([LIBS])
+   AC_CHECK_LIB([hwloc],[hwloc_topology_set_pid])
+   PAC_POP_FLAG([LIBS])
+   AC_MSG_CHECKING([if non-embedded hwloc works])
+   if test "$ac_cv_header_hwloc_h" = "yes" -a "$ac_cv_lib_hwloc_hwloc_topology_set_pid" = "yes" ; then
+      have_hwloc=yes
+      PAC_PREPEND_FLAG([-lhwloc], [WRAPPER_LIBS])
+   else
+      have_hwloc=no
+   fi
+   AC_MSG_RESULT([$have_hwloc])
 
-if test "$pac_have_hwloc" = "yes" -a "$with_hwloc" != "embedded"; then
-    AC_MSG_CHECKING([if hwloc meets minimum version requirement])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <hwloc.h>], [
-                       #if HWLOC_API_VERSION < 0x00020000
-                       #error
-                       #endif
-                       return 0;])],[],[pac_have_hwloc=no])
-    AC_MSG_RESULT([$pac_have_hwloc])
+   if test "$have_hwloc" = "yes" ; then
+       AC_MSG_CHECKING([if hwloc meets minimum version requirement])
+       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <hwloc.h>], [
+                          #if HWLOC_API_VERSION < 0x00020000
+                          #error
+                          #endif
+                          return 0;])],[],[have_hwloc=no])
+       AC_MSG_RESULT([$have_hwloc])
 
-    # if an old hwloc was specified by the user, throw an error
-    if test "$pac_have_hwloc" = "no" -a -n "$with_hwloc" -a "$with_hwloc" != "yes" ; then
-        AC_MSG_ERROR([hwloc installation does not meet minimum version requirement])
+       # if an old hwloc was specified by the user, throw an error
+       if test "$have_hwloc" = "no" ; then
+           AC_MSG_ERROR([hwloc installation does not meet minimum version requirement])
+       fi
+   fi
+
+   # FIXME: Disable hwloc on Cygwin for now. The hwloc package,
+   # atleast as of 1.0.2, does not install correctly on Cygwin
+   AS_CASE([$host], [*-*-cygwin], [have_hwloc=no])
+
+   if test "$have_hwloc" = "yes" ; then
+      if test -d ${with_hwloc_prefix}/lib64 ; then
+         PAC_APPEND_FLAG([-L${with_hwloc_prefix}/lib64],[WRAPPER_LDFLAGS])
+      else
+         PAC_APPEND_FLAG([-L${with_hwloc_prefix}/lib],[WRAPPER_LDFLAGS])
+      fi
+   fi
+fi
+
+if test "$have_hwloc" = "yes" ; then
+   AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
+fi
+
+HWLOC_DO_AM_CONDITIONALS
+
+# ----------------------------------------------------------------------------
+# NETLOC
+# ----------------------------------------------------------------------------
+AC_ARG_WITH([netloc-prefix],
+            [AS_HELP_STRING([[--with-netloc-prefix[=DIR]]],
+                            [use the NETLOC library installed in DIR]) or system to use the system library], [],
+                            [with_netloc_prefix=no])
+
+netloclibdir=""
+AC_SUBST([netloclibdir])
+
+if test "$have_hwloc" = "yes" ; then
+    if test "${with_netloc_prefix}" != "no" ; then
+        if test "${with_netloc_prefix}" != "system"; then
+            # The user specified an already-installed Netloc; just sanity check,
+            # don't subconfigure it
+            AS_IF([test -s "${with_netloc_prefix}/include/netloc.h"],
+              [:],[AC_MSG_ERROR([the Netloc installation in "${with_netloc_prefix}" appears broken])])
+            PAC_APPEND_FLAG([-I${with_netloc_prefix}/include],[CPPFLAGS])
+            PAC_APPEND_FLAG([-I${with_netloc_prefix}/include],[CFLAGS])
+            PAC_PREPEND_FLAG([-lnetloc],[WRAPPER_LIBS])
+            if test -d ${with_netloc_prefix}/lib64 ; then
+                PAC_APPEND_FLAG([-L${with_netloc_prefix}/lib64],[WRAPPER_LDFLAGS])
+                netloclibdir="-L${with_netloc_prefix}/lib64"
+            else
+                PAC_APPEND_FLAG([-L${with_netloc_prefix}/lib],[WRAPPER_LDFLAGS])
+                netloclibdir="-L${with_netloc_prefix}/lib"
+            fi
+       else
+           AC_LINK_IFELSE([AC_LANG_PROGRAM([#include "netloc.h"
+                                   ],
+                                   [])],
+                          [AC_MSG_ERROR([the Netloc installation seems to be added from system path])], [])
+       fi
+       AC_DEFINE(HAVE_NETLOC,1,[Define if netloc is available in either user specified path or in system path])
     fi
-fi
-
-if test "$pac_have_hwloc" = "no" ; then
-    with_hwloc=embedded
-    pac_have_hwloc=yes
-    dnl TODO: check and configure embedded netloc
-fi
-
-if test "$with_hwloc" = "embedded" ; then
-    PAC_PUSH_FLAG([CFLAGS])
-    CFLAGS="$VISIBILITY_CFLAGS"
-    PAC_CONFIG_SUBDIR_ARGS([modules/hwloc], [--enable-embedded-mode --disable-visibility],[], [AC_MSG_ERROR(embedded hwloc configure failed)])
-    PAC_POP_FLAG([CFLAGS])
-    hwlocsrcdir="${main_top_builddir}/modules/hwloc"
-    hwloclib="${main_top_builddir}/modules/hwloc/hwloc/libhwloc_embedded.la"
-    PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/hwloc/include],[CPPFLAGS])
-    PAC_APPEND_FLAG([-I${main_top_builddir}/modules/hwloc/include],[CPPFLAGS])
-fi
-
-if test "$pac_have_hwloc" = "yes" ; then
-    AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
-fi
-if test "$pac_have_netloc" = "yes" ; then
-    AC_DEFINE(HAVE_NETLOC,1,[Define if netloc is available])
 fi
 
 # ----------------------------------------------------------------------------

--- a/src/pm/hydra/Makefile.am
+++ b/src/pm/hydra/Makefile.am
@@ -3,11 +3,11 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
-external_subdirs = @mpl_srcdir@ @hwloc_srcdir@
-external_dist_subdirs = @mpl_dist_srcdir@ @hwloc_srcdir@
-external_includes = @mpl_includedir@ @hwloc_includedir@
-external_ldflags =
-external_libs = @mpl_lib@ @hwloc_lib@ @WRAPPER_LIBS@
+external_subdirs = @mpl_srcdir@
+external_dist_subdirs = @mpl_dist_srcdir@
+external_includes = @mpl_includedir@
+external_ldflags = @mpl_libdir@
+external_libs = @mpl_lib@ @WRAPPER_LIBS@
 
 bin_PROGRAMS =
 noinst_HEADERS =
@@ -16,7 +16,7 @@ EXTRA_DIST =
 SUFFIXES =
 doc1_src_txt =
 
-ACLOCAL_AMFLAGS = -I confdb
+ACLOCAL_AMFLAGS = -I confdb -I tools/topo/hwloc/hwloc/config
 AM_CPPFLAGS = -I$(top_srcdir)/include $(external_includes)
 AM_CFLAGS =
 

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -11,6 +11,9 @@ AC_INIT([Hydra], MPICH_VERSION_m4)
 AC_CONFIG_AUX_DIR(confdb)
 AC_CONFIG_MACRO_DIR(confdb)
 
+# needed by hwloc in embedded mode.  Must come very early to avoid
+# bizarre expansion ordering warnings
+AC_CANONICAL_TARGET
 AC_ARG_PROGRAM
 
 dnl must come before LT_INIT, which AC_REQUIREs AC_PROG_CC
@@ -22,6 +25,15 @@ AM_PROG_CC_C_O
 # also needed by hwloc in embedded mode, must also come early for expansion
 # ordering reasons
 AC_USE_SYSTEM_EXTENSIONS
+
+# Define -D_DARWIN_C_SOURCE on OS/X to ensure that hwloc will build even if we
+# are building under MPICH with --enable-strict that defined _POSIX_C_SOURCE.
+# Some standard Darwin headers don't build correctly under a strict posix
+# environment.
+AS_CASE([$host],
+    [*-*-darwin*], [PAC_APPEND_FLAG([-D_DARWIN_C_SOURCE],[CPPFLAGS])]
+)
+
 
 AM_INIT_AUTOMAKE([-Wall -Wno-portability-recursive -Werror foreign 1.12.3 subdir-objects])
 
@@ -130,17 +142,25 @@ AC_SUBST([mpl_srcdir])
 AC_SUBST(mpl_dist_srcdir)
 mpl_includedir=""
 AC_SUBST([mpl_includedir])
+mpl_libdir=""
+AC_SUBST([mpl_libdir])
 mpl_lib=""
 AC_SUBST([mpl_lib])
-m4_define([mpl_embedded_dir],[mpl])
-PAC_CHECK_HEADER_LIB_EXPLICIT([mpl],[mplconfig.h],[$MPLLIBNAME],[mpl_str_get_int_arg])
-if test "$with_mpl" = "embedded" ; then
+if test "$with_mpl_prefix" = "embedded" ; then
     mpl_srcdir="mpl"
     mpl_dist_srcdir="mpl"
     mpl_lib="mpl/lib${MPLLIBNAME}.la"
     mpl_subdir_args="--disable-versioning --enable-embedded"
     PAC_CONFIG_SUBDIR_ARGS([mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
     mpl_includedir='-I$(top_builddir)/mpl/include -I$(top_srcdir)/mpl/include'
+else
+    # The user specified an already-installed MPL; just sanity check, don't
+    # subconfigure it
+    AS_IF([test -s "${with_mpl_prefix}/include/mplconfig.h"],
+          [:],[AC_MSG_ERROR([the MPL installation in "${with_mpl_prefix}" appears broken])])
+    mpl_includedir="-I${with_mpl_prefix}/include"
+    mpl_libdir="-L${with_mpl_prefix}/lib"
+    mpl_lib="-l${MPLLIBNAME}"
 fi
 
 # Documentation
@@ -383,6 +403,13 @@ AC_MSG_RESULT($hydra_ui)
 AC_SUBST(hydra_ui)
 AM_CONDITIONAL([hydra_ui_mpich], [test $hydra_ui = "mpich"])
 
+
+#########################################################################
+# System hwloc
+#########################################################################
+PAC_CHECK_PREFIX(hwloc)
+
+
 #########################################################################
 # Processor Topology
 #########################################################################
@@ -394,32 +421,33 @@ AC_MSG_RESULT([$hydra_topolib_list])
 
 hydra_topolibs="`echo $hydra_topolib_list | sed -e 's/:/ /g' -e 's/,/ /g'`"
 
-hwloc_srcdir=""
-hwloc_includedir=""
-hwloc_lib=""
-AC_SUBST([hwloc_srcdir])
-AC_SUBST([hwloc_includedir])
-AC_SUBST([hwloc_lib])
-
+have_hwloc=no
 for hydra_topolib in ${hydra_topolibs}; do
     case "$hydra_topolib" in
 	hwloc)
-                m4_define([hwloc_embedded_dir],[tools/topo/hwloc/hwloc])
-                PAC_CHECK_HEADER_LIB_OPTIONAL([hwloc],[hwloc.h],[hwloc],[hwloc_topology_set_pid])
-                if test "$pac_have_hwloc" = "no" ; then
-                    with_hwloc=embedded
-                    pac_have_hwloc=yes
-                fi
-		if test "$with_hwloc" = "embedded" ; then
-                    hydra_use_embedded_hwloc=yes
-                    PAC_CONFIG_SUBDIR_ARGS([tools/topo/hwloc/hwloc], [--enable-embedded-mode --disable-visibility],[], [AC_MSG_ERROR(embedded hwloc configure failed)])
-                    dnl Note that single quote is intentional to pass the variable as is
-                    hwloc_srcdir="tools/topo/hwloc/hwloc"
-                    hwloc_includedir='-I${srcdir}/${hwloc_srcdir}/include -I${builddir}/${hwloc_srcdir}/include'
-                    hwloc_lib='${builddir}/${hwloc_srcdir}/hwloc/libhwloc_embedded.la'
+		if test "$with_hwloc_prefix" = "embedded" ; then
+		   HWLOC_SETUP_CORE([tools/topo/hwloc/hwloc],[have_hwloc=yes],[have_hwloc=no],[1])
+		   # Only build hwloc in embedded mode
+		   if test "$have_hwloc" = "yes" ; then
+		      hydra_use_embedded_hwloc=yes
+		   fi
+                else
+                    AC_CHECK_HEADERS([hwloc.h])
+                    # hwloc_topology_set_pid was added in hwloc-1.0.0, which is our minimum
+                    # required version
+                    AC_CHECK_LIB([hwloc],[hwloc_topology_set_pid])
+                    AC_MSG_CHECKING([if non-embedded hwloc works])
+                    if test "$ac_cv_header_hwloc_h" = "yes" -a "$ac_cv_lib_hwloc_hwloc_topology_set_pid" = "yes" ; then
+                        have_hwloc=yes
+                    fi
+                    AC_MSG_RESULT([$have_hwloc])
                 fi
 
-		if test "$pac_have_hwloc" = "yes" ; then
+                # FIXME: Disable hwloc on Cygwin for now. The hwloc package, atleast as of 1.0.2,
+                # does not install correctly on Cygwin
+                AS_CASE([$host], [*-*-cygwin], [have_hwloc=no])
+
+		if test "$have_hwloc" = "yes" ; then
 		   AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
 		   available_topolibs="$available_topolibs hwloc"
 		fi
@@ -449,7 +477,9 @@ else
    AC_DEFINE(HYDRA_DEFAULT_TOPOLIB,NULL,[Default processor topology library])
 fi
 
-AM_CONDITIONAL([HYDRA_HAVE_HWLOC], [test "${pac_have_hwloc}" = "yes"])
+HWLOC_DO_AM_CONDITIONALS
+AM_CONDITIONAL([HYDRA_HAVE_HWLOC], [test "${have_hwloc}" = "yes"])
+AM_CONDITIONAL([HYDRA_USE_EMBEDDED_HWLOC], [test "${hydra_use_embedded_hwloc}" = "yes"])
 
 AC_MSG_CHECKING([available processor topology libraries])
 AC_MSG_RESULT([$available_topolibs])

--- a/src/pm/hydra/tools/topo/hwloc/Makefile.mk
+++ b/src/pm/hydra/tools/topo/hwloc/Makefile.mk
@@ -6,3 +6,13 @@
 libhydra_la_SOURCES += tools/topo/hwloc/topo_hwloc.c
 
 noinst_HEADERS += tools/topo/hwloc/topo_hwloc.h
+
+if HYDRA_USE_EMBEDDED_HWLOC
+AM_CPPFLAGS += @HWLOC_EMBEDDED_CPPFLAGS@
+AM_CFLAGS += @HWLOC_EMBEDDED_CFLAGS@
+
+# Append hwloc to the external subdirs, so it gets built first
+external_subdirs += tools/topo/hwloc/hwloc
+external_dist_subdirs += tools/topo/hwloc/hwloc
+external_libs += @HWLOC_EMBEDDED_LDADD@ @HWLOC_EMBEDDED_LIBS@
+endif


### PR DESCRIPTION
## Pull Request Description

Reverts 2 commits related to hwloc configuration. The new hwloc config options in main broke static builds, and are a bit more intrusive than I am comfortable with including in a bug-fix release. Take the conservative approach and revert them. This way there is little impact on users upgrading from 3.4.1->3.4.2.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
