### PR TITLE
gpu/ipc: detect ptr is_ipc and pass down to yaksa

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_internal.h
+++ b/src/mpi/datatype/typerep/src/typerep_internal.h
@@ -40,6 +40,15 @@ static inline yaksa_info_t MPII_yaksa_get_info(MPL_pointer_attr_t * inattr,
         rc = yaksa_info_keyval_append(info, "yaksa_cuda_outbuf_ptr_attr", &outattr->device_attr,
                                       sizeof(MPL_gpu_device_attr));
         MPIR_Assert(rc == 0);
+
+        if (inattr->is_ipc) {
+            rc = yaksa_info_keyval_append(info, "yaksa_cuda_inbuf_ptr_is_ipc", NULL, 0);
+            MPIR_Assert(rc == 0);
+        }
+        if (outattr->is_ipc) {
+            rc = yaksa_info_keyval_append(info, "yaksa_cuda_outbuf_ptr_is_ipc", NULL, 0);
+            MPIR_Assert(rc == 0);
+        }
     } else if (MPL_HAVE_GPU == MPL_GPU_TYPE_ZE) {
         yaksa_info_keyval_append(info, "yaksa_gpu_driver", "ze", 3);
         rc = yaksa_info_keyval_append(info, "yaksa_ze_inbuf_ptr_attr", &inattr->device_attr,

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -265,7 +265,7 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle,
         MPL_gpu_device_handle_t map_dev_handle;
         bool insert_successful = false;
         MPL_gpu_get_dev_handle(map_dev_id, &map_dev_handle);
-        mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, map_dev_handle, &pbase);
+        mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, handle.len, map_dev_handle, &pbase);
         MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                             "**gpu_ipc_handle_map");
 

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -56,8 +56,8 @@ int MPL_gpu_query_support(MPL_gpu_type_t * type);
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle);
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
-                           void **ptr);
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, uintptr_t len,
+                           MPL_gpu_device_handle_t dev_handle, void **ptr);
 int MPL_gpu_ipc_handle_unmap(void *ptr);
 
 int MPL_gpu_malloc_host(void **ptr, size_t size);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -43,7 +43,7 @@ typedef enum {
 static inline int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     attr->type = MPL_GPU_POINTER_UNREGISTERED_HOST;
-    attr->device = -1;
+    attr->device = MPL_GPU_DEVICE_INVALID;
 
     return MPL_SUCCESS;
 }

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -28,6 +28,7 @@ typedef enum {
 
 typedef struct {
     MPL_pointer_type_t type;
+    bool is_ipc;
     MPL_gpu_device_handle_t device;
     MPL_gpu_device_attr device_attr;
 } MPL_pointer_attr_t;
@@ -44,6 +45,7 @@ static inline int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t
 {
     attr->type = MPL_GPU_POINTER_UNREGISTERED_HOST;
     attr->device = MPL_GPU_DEVICE_INVALID;
+    attr->is_ipc = false;
 
     return MPL_SUCCESS;
 }

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -41,6 +41,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     cudaError_t ret;
+    attr->is_ipc = false;
     ret = cudaPointerGetAttributes(&attr->device_attr, ptr);
     if (ret == cudaSuccess) {
         switch (attr->device_attr.type) {

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -88,8 +88,8 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
-                           void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, uintptr_t len,
+                           MPL_gpu_device_handle_t dev_handle, void **ptr)
 {
     cudaError_t ret;
     int prev_devid;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -46,7 +46,7 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
         switch (attr->device_attr.type) {
             case cudaMemoryTypeUnregistered:
                 attr->type = MPL_GPU_POINTER_UNREGISTERED_HOST;
-                attr->device = attr->device_attr.device;
+                attr->device = MPL_GPU_DEVICE_INVALID;
                 break;
             case cudaMemoryTypeHost:
                 attr->type = MPL_GPU_POINTER_REGISTERED_HOST;
@@ -63,7 +63,7 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
         }
     } else if (ret == cudaErrorInvalidValue) {
         attr->type = MPL_GPU_POINTER_UNREGISTERED_HOST;
-        attr->device = -1;
+        attr->device = MPL_GPU_DEVICE_INVALID;
     } else {
         goto fn_fail;
     }

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -17,8 +17,8 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
-                           void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, uintptr_t len,
+                           MPL_gpu_device_handle_t dev_handle, void **ptr)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -187,6 +187,7 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     ze_result_t ret;
+    attr->is_ipc = flase;
     memset(&attr->device_attr.prop, 0, sizeof(ze_memory_allocation_properties_t));
     ret = zeMemGetAllocProperties(global_ze_context, ptr,
                                   &attr->device_attr.prop, &attr->device_attr.device);

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -154,8 +154,8 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
-                           void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, uintptr_t len,
+                           MPL_gpu_device_handle_t dev_handle, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -195,6 +195,7 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     switch (attr->device_attr.prop.type) {
         case ZE_MEMORY_TYPE_UNKNOWN:
             attr->type = MPL_GPU_POINTER_UNREGISTERED_HOST;
+            attr->device = MPL_GPU_DEVICE_INVALID;
             break;
         case ZE_MEMORY_TYPE_HOST:
             attr->type = MPL_GPU_POINTER_REGISTERED_HOST;


### PR DESCRIPTION
## Pull Request Description
Yaksa always chooses the stream of the **source** device to issue the copy in a device-to-device copy to benefit from a higher throughput with **DMA write.** However, when one of the buffers is mapped by IPC, [using the stream of the mapping device] v.s., [using the stream of the other device] can introduce about **3us** CUDA runtime overhead, no matter the mapping device is the source or destination. Such an overhead is significant in the fast-path contiguous copy which takes only **8~us** latency.

#### Experiments to justify CUDA IPC behavior:
- P0 allocates buf0 from GPU0 and P1 allocates buf1 from GPU1. Then P0 receives the IPC handle of buf1 and maps it to GPU_map (map=0,1). Then P0 copies between buf0 and buf1
- Varying the issuing stream of cudaMemcpyAsync
- The below numbers obtained on JLSE/GPU_V100_SMX2, with GPU0,GPU1

 case        | stream@GPU0 | stream@GPU1
------------ | ---------- | ----------
1.map=0, buf0->buf1 | 7.33 | 9.89
2.map=0, buf1->buf0 | 7.45 | 10.08
3.map=1, buf0->buf1 | 10.32 | 7.87
4.map=1, buf1->buf0 | 10.46 | 7.84

#### Performance with MPICH/IPC
- In send/recv over IPC, we always map src buffer (buf0) to the src device (GPU0), same as **case-1+stream@GPU0** (good)
- In RMA over IPC, we map every remote winbuf to the remote device at `win_create` because we don't know which device will hold the origin buffer. Then PUT becomes **case-3+stream@GPU0** (bad); GET becomes **case-4+stream@GPU1** (good)

Two fixes are needed to make it right:
1. Yaksa/cuda has to be IPC-aware when choosing the stream for a fast-path copy. See above table. Yaksa cannot rely on the user to understand the performance impact of mapping, and thus map the buffer always onto the source device.
2. The mapping logic in RMA might be improved if we delay the mapping to first operation.

#### Scope of this PR
This PR addresses fix-1. Fix-2 is ongoing.
 
#### Other questions:
- What happens if both buffers are IPC mapped but with different devices? -- such a case does not exist in MPICH

## EDIT -- Hui
I am not sure `is_ipc` would be a clean name. I think a more direct name is `mapped_to_dev` as "which device it was mapped to". 

I find yaksa need to know the mapped-to device not only for performance in the direct memcpy case. If we are going to launch a kernel, it only can be launched on the mapped device or it will receive a memory access error. The `rma/accfence1` test has been failing after #5445 due to this reason.

Ideally, yaksa needs the ability to query the buffer and find out the mapping device. Otherwise, how would it deal with user-mapped memory?

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
