### PR TITLE
romio: implement mpi-4 large count functions

### DIFF
--- a/src/glue/romio/all_romio_symbols
+++ b/src/glue/romio/all_romio_symbols
@@ -156,7 +156,7 @@ while (<FD>) {
 	elsif ($arglist[$x] =~ /MPI_Errhandler/) {
 	    print OUTFD " = MPI_ERRHANDLER_NULL;\n";
 	}
-	elsif ($arglist[$x] =~ /MPI_Offset/) {
+	elsif ($arglist[$x] =~ /MPI_Offset|MPI_Count/) {
 	    print OUTFD " = 0;\n";
 	}
 	elsif ($arglist[$x] =~ /int/) {

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -942,6 +942,10 @@ typedef int (MPI_Datarep_extent_function)(MPI_Datatype datatype, MPI_Aint *,
                       void *);
 #define MPI_CONVERSION_FN_NULL ((MPI_Datarep_conversion_function *)0)
 
+typedef int (MPI_Datarep_conversion_function_c)(void *, MPI_Datatype, MPI_Count,
+             void *, MPI_Offset, void *);
+#define MPI_CONVERSION_FN_NULL_C ((MPI_Datarep_conversion_function_c *)0)
+
 typedef struct {
     void **storage_stack;
 } QMPI_Context;

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -828,6 +828,20 @@ int MPIOI_File_iread_all(MPI_File fh,
                          void *buf,
                          int count, MPI_Datatype datatype, char *myname, MPI_Request * request);
 
+int MPIOI_File_read_ordered(MPI_File fh, void *buf, int count,
+                            MPI_Datatype datatype, MPI_Status * status);
+int MPIOI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype);
+int MPIOI_File_read_shared(MPI_File fh, void *buf, int count,
+                           MPI_Datatype datatype, MPI_Status * status);
+int MPIOI_File_iread_shared(MPI_File fh, void *buf, int count,
+                            MPI_Datatype datatype, MPI_Request * request);
+int MPIOI_File_write_ordered(MPI_File fh, const void *buf, int count,
+                             MPI_Datatype datatype, MPI_Status * status);
+int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype);
+int MPIOI_File_write_shared(MPI_File fh, const void *buf, int count,
+                            MPI_Datatype datatype, MPI_Status * status);
+int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, int count,
+                             MPI_Datatype datatype, MPIO_Request * request);
 
 
 /* Unix-style file locking */

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -95,9 +95,18 @@ struct ADIOI_Hints_struct {
 typedef struct ADIOI_Datarep {
     char *name;
     void *state;
+    int is_large;
     MPI_Datarep_extent_function *extent_fn;
-    MPI_Datarep_conversion_function *read_conv_fn;
-    MPI_Datarep_conversion_function *write_conv_fn;
+    union {
+        struct {
+            MPI_Datarep_conversion_function *read_conv_fn;
+            MPI_Datarep_conversion_function *write_conv_fn;
+        } small;
+        struct {
+            MPI_Datarep_conversion_function_c *read_conv_fn;
+            MPI_Datarep_conversion_function_c *write_conv_fn;
+        } large;
+    } u;
     struct ADIOI_Datarep *next; /* pointer to next datarep */
 } ADIOI_Datarep;
 
@@ -843,6 +852,12 @@ int MPIOI_File_write_shared(MPI_File fh, const void *buf, int count,
 int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, int count,
                              MPI_Datatype datatype, MPIO_Request * request);
 
+typedef void (*MPIOI_VOID_FN) (void *);
+int MPIOI_Register_datarep(const char *datarep,
+                           MPIOI_VOID_FN * read_conversion_fn,
+                           MPIOI_VOID_FN * write_conversion_fn,
+                           MPI_Datarep_extent_function * dtype_file_extent_fn,
+                           void *extra_state, int is_large);
 
 /* Unix-style file locking */
 

--- a/src/mpi/romio/include/mpio.h.in
+++ b/src/mpi/romio/include/mpio.h.in
@@ -54,6 +54,8 @@ typedef struct ADIOI_RequestD *MPIO_Request;
 #define HAVE_MPI_DATAREP_FUNCTIONS
 typedef int (MPI_Datarep_conversion_function)(void *, MPI_Datatype, int, 
              void *, MPI_Offset, void *);
+typedef int (MPI_Datarep_conversion_function_c)(void *, MPI_Datatype, MPI_Count,
+                                                void *, MPI_Offset, void *);
 typedef int (MPI_Datarep_extent_function)(MPI_Datatype datatype, MPI_Aint *,
 					  void *);
 #endif
@@ -265,6 +267,80 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype,
 int MPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype,
                          MPI_Request *request)
     MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+
+/* MPI 4.0 large count functions */
+int MPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype,
+                     MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int MPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void * buf, MPI_Count count,
+                         MPI_Datatype datatype, MPI_Status *status)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int MPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                               MPI_Datatype datatype) MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int MPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                          MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                         MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_write_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                   MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_write_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                       MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_write_all_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+
+int MPI_File_write_at_c(MPI_File fh, MPI_Offset offset, const void * buf, MPI_Count count,
+                      MPI_Datatype datatype, MPI_Status *status)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int MPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                          MPI_Datatype datatype, MPI_Status *status)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int MPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                                MPI_Datatype datatype) MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int MPI_File_write_ordered_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                           MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_write_ordered_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_write_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                          MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPIO_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                        MPI_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype,
+                      MPIO_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                           MPI_Datatype datatype, MPI_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int MPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                          MPIO_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_iwrite_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                    MPIO_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_iwrite_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                         MPI_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                       MPI_Datatype datatype, MPIO_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                            MPI_Datatype datatype, MPI_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int MPI_File_iwrite_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                           MPIO_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+
+int MPI_File_get_type_extent_c(MPI_File fh, MPI_Datatype datatype, MPI_Count *extent) ROMIO_API_PUBLIC;
+
+int MPI_Register_datarep_c(const char *datarep, MPI_Datarep_conversion_function_c *read_conversion_fn,
+			 MPI_Datarep_conversion_function_c *write_conversion_fn,
+			 MPI_Datarep_extent_function *dtype_file_extent_fn, void *extra_state) ROMIO_API_PUBLIC;
+
 /* End Prototypes */
 
 #ifndef HAVE_MPI_DARRAY_SUBARRAY
@@ -494,6 +570,79 @@ int PMPI_File_iread_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype
 int PMPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype,
                           MPI_Request *request)
     MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+
+/* MPI 4.0 large count functions */
+int PMPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype,
+                     MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int PMPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void * buf, MPI_Count count,
+                         MPI_Datatype datatype, MPI_Status *status)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int PMPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                               MPI_Datatype datatype) MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int PMPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                          MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                         MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_write_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                   MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_write_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                       MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_write_all_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+
+int PMPI_File_write_at_c(MPI_File fh, MPI_Offset offset, const void * buf, MPI_Count count,
+                      MPI_Datatype datatype, MPI_Status *status)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int PMPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                          MPI_Datatype datatype, MPI_Status *status)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int PMPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                                MPI_Datatype datatype) MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int PMPI_File_write_ordered_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                           MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_write_ordered_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_write_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                          MPI_Status *status) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPIO_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                        MPI_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype,
+                      MPIO_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int PMPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                           MPI_Datatype datatype, MPI_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int PMPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                          MPIO_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_iwrite_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                    MPIO_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_iwrite_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                         MPI_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+int PMPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                       MPI_Datatype datatype, MPIO_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int PMPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                            MPI_Datatype datatype, MPI_Request *request)
+    MPICH_ATTR_POINTER_WITH_TYPE_TAG(3,5) ROMIO_API_PUBLIC;
+int PMPI_File_iwrite_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                           MPIO_Request *request) MPICH_ATTR_POINTER_WITH_TYPE_TAG(2,4) ROMIO_API_PUBLIC;
+
+int PMPI_File_get_type_extent_c(MPI_File fh, MPI_Datatype datatype, MPI_Count *extent) ROMIO_API_PUBLIC;
+
+int PMPI_Register_datarep_c(const char *datarep, MPI_Datarep_conversion_function_c *read_conversion_fn,
+			 MPI_Datarep_conversion_function_c *write_conversion_fn,
+			 MPI_Datarep_extent_function *dtype_file_extent_fn, void *extra_state) ROMIO_API_PUBLIC;
 
 #ifndef HAVE_MPI_DARRAY_SUBARRAY
 /* Section 4.14.4 */

--- a/src/mpi/romio/mpi-io/get_extent.c
+++ b/src/mpi/romio/mpi-io/get_extent.c
@@ -56,3 +56,56 @@ int MPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype, MPI_Aint * exte
   fn_exit:
     return error_code;
 }
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_get_type_extent_c = PMPI_File_get_type_extent_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_get_type_extent_c MPI_File_get_type_extent_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_get_type_extent_c as PMPI_File_get_type_extent_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_get_type_extent_c(MPI_File fh, MPI_Datatype datatype, MPI_Count * extent)
+    __attribute__ ((weak, alias("PMPI_File_get_type_extent_c")));
+#endif
+
+#endif
+
+/*@
+    MPI_File_get_type_extent_c - Returns the extent of datatype in the file
+
+Input Parameters:
+. fh - file handle (handle)
+. datatype - datatype (handle)
+
+Output Parameters:
+. extent - extent of the datatype (nonnegative integer)
+
+.N fortran
+@*/
+int MPI_File_get_type_extent_c(MPI_File fh, MPI_Datatype datatype, MPI_Count * extent)
+{
+    int error_code;
+    ADIO_File adio_fh;
+    static char myname[] = "MPI_FILE_GET_TYPE_EXTENT";
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
+    /* --END ERROR HANDLING-- */
+
+    /* FIXME: handle other file data representations */
+
+    MPI_Aint extent_i;
+    error_code = PMPI_Type_extent(datatype, &extent_i);
+    *extent = extent_i;
+
+  fn_exit:
+    return error_code;
+}

--- a/src/mpi/romio/mpi-io/get_extent.c
+++ b/src/mpi/romio/mpi-io/get_extent.c
@@ -51,7 +51,8 @@ int MPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype, MPI_Aint * exte
 
     /* FIXME: handle other file data representations */
 
-    error_code = MPI_Type_extent(datatype, extent);
+    MPI_Aint lb;
+    error_code = PMPI_Type_get_extent(datatype, &lb, extent);
 
   fn_exit:
     return error_code;
@@ -102,8 +103,8 @@ int MPI_File_get_type_extent_c(MPI_File fh, MPI_Datatype datatype, MPI_Count * e
 
     /* FIXME: handle other file data representations */
 
-    MPI_Aint extent_i;
-    error_code = PMPI_Type_extent(datatype, &extent_i);
+    MPI_Aint lb_i, extent_i;
+    error_code = PMPI_Type_get_extent(datatype, &lb_i, &extent_i);
     *extent = extent_i;
 
   fn_exit:

--- a/src/mpi/romio/mpi-io/iread.c
+++ b/src/mpi/romio/mpi-io/iread.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -108,6 +110,7 @@ Output Parameters:
 int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
                      MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code = MPI_SUCCESS;
     static char myname[] = "MPI_FILE_IREAD";
 #ifdef MPI_hpux
@@ -137,6 +140,7 @@ int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datat
 int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf, int count,
                      MPI_Datatype datatype, char *myname, MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     MPI_Count datatype_size;
     ADIO_Status status;

--- a/src/mpi/romio/mpi-io/iread.c
+++ b/src/mpi/romio/mpi-io/iread.c
@@ -68,6 +68,70 @@ int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI
     return error_code;
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iread_c = PMPI_File_iread_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iread_c MPI_File_iread_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iread_c as PMPI_File_iread_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                     MPIO_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iread_c")));
+#endif
+
+#endif
+
+#ifdef HAVE_MPI_GREQUEST
+#include "mpiu_greq.h"
+#endif
+
+/*@
+    MPI_File_iread_c - Nonblocking read using individual file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+. request - request object (handle)
+
+.N fortran
+@*/
+int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                     MPI_Request * request)
+{
+    int error_code = MPI_SUCCESS;
+    static char myname[] = "MPI_FILE_IREAD";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEIREAD, TRDTSYSTEM, fh, datatype, count);
+#endif /* MPI_hpux */
+
+
+    error_code = MPIOI_File_iread(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
+                                  buf, count, datatype, myname, request);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        error_code = MPIO_Err_return_file(fh, error_code);
+    /* --END ERROR HANDLING-- */
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    return error_code;
+}
+
 /* prevent multiple definitions of this routine */
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf, int count,

--- a/src/mpi/romio/mpi-io/iread_all.c
+++ b/src/mpi/romio/mpi-io/iread_all.c
@@ -70,6 +70,70 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count,
     return error_code;
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iread_all_c = PMPI_File_iread_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iread_all_c MPI_File_iread_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iread_all_c as PMPI_File_iread_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                         MPI_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iread_all_c")));
+#endif
+
+#endif
+
+#ifdef HAVE_MPI_GREQUEST
+#include "mpiu_greq.h"
+#endif
+
+/*@
+    MPI_File_iread_all_c - Nonblocking collective read using individual file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+. request - request object (handle)
+
+.N fortran
+@*/
+int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count,
+                         MPI_Datatype datatype, MPI_Request * request)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_IREAD_ALL";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADALL, TRDTBLOCK, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    error_code = MPIOI_File_iread_all(fh, (MPI_Offset) 0,
+                                      ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS) {
+        error_code = MPIO_Err_return_file(fh, error_code);
+    }
+    /* --END ERROR HANDLING-- */
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    return error_code;
+}
+
 /* Note: MPIOI_File_iread_all also used by MPI_File_iread_at_all */
 /* prevent multiple definitions of this routine */
 #ifdef MPIO_BUILD_PROFILING

--- a/src/mpi/romio/mpi-io/iread_all.c
+++ b/src/mpi/romio/mpi-io/iread_all.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -110,6 +112,7 @@ Output Parameters:
 int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count,
                          MPI_Datatype datatype, MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_ALL";
 #ifdef MPI_hpux
@@ -143,6 +146,7 @@ int MPIOI_File_iread_all(MPI_File fh,
                          void *buf,
                          int count, MPI_Datatype datatype, char *myname, MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/iread_at.c
+++ b/src/mpi/romio/mpi-io/iread_at.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -112,6 +114,7 @@ Output Parameters:
 int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
                         MPI_Datatype datatype, MPIO_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT";
 

--- a/src/mpi/romio/mpi-io/iread_at.c
+++ b/src/mpi/romio/mpi-io/iread_at.c
@@ -70,3 +70,69 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_
 
     return error_code;
 }
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iread_at_c = PMPI_File_iread_at_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iread_at_c MPI_File_iread_at_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iread_at_c as PMPI_File_iread_at_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                        MPI_Datatype datatype, MPIO_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iread_at_c")));
+#endif
+
+#endif
+
+#ifdef HAVE_MPI_GREQUEST
+#include "mpiu_greq.h"
+#endif
+
+/*@
+    MPI_File_iread_at_c - Nonblocking read using explicit offset
+
+Input Parameters:
+. fh - file handle (handle)
+. offset - file offset (nonnegative integer)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+. request - request object (handle)
+
+.N fortran
+@*/
+int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                        MPI_Datatype datatype, MPIO_Request * request)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_IREAD_AT";
+
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEIREADAT, TRDTSYSTEM, fh, datatype, count);
+#endif /* MPI_hpux */
+
+
+    error_code = MPIOI_File_iread(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
+                                  count, datatype, myname, request);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        error_code = MPIO_Err_return_file(fh, error_code);
+    /* --END ERROR HANDLING-- */
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    return error_code;
+}

--- a/src/mpi/romio/mpi-io/iread_atall.c
+++ b/src/mpi/romio/mpi-io/iread_atall.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -111,6 +113,7 @@ Output Parameters:
 int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
                             MPI_Count count, MPI_Datatype datatype, MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT_ALL";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/iread_atall.c
+++ b/src/mpi/romio/mpi-io/iread_atall.c
@@ -69,3 +69,67 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf,
 
     return error_code;
 }
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iread_at_all_c = PMPI_File_iread_at_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iread_at_all_c MPI_File_iread_at_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iread_at_all_c as PMPI_File_iread_at_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                            MPI_Datatype datatype, MPI_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iread_at_all_c")));
+#endif
+
+#endif
+
+#ifdef HAVE_MPI_GREQUEST
+#include "mpiu_greq.h"
+#endif
+
+/*@
+    MPI_File_iread_at_all_c - Nonblocking collective read using explicit offset
+
+Input Parameters:
+. fh - file handle (handle)
+. offset - file offset (nonnegative integer)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+. request - request object (handle)
+
+.N fortran
+@*/
+int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
+                            MPI_Count count, MPI_Datatype datatype, MPI_Request * request)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_IREAD_AT_ALL";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEIREADATALL, TRDTBLOCK, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    error_code = MPIOI_File_iread_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
+                                      count, datatype, myname, request);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        error_code = MPIO_Err_return_file(fh, error_code);
+    /* --END ERROR HANDLING-- */
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    return error_code;
+}

--- a/src/mpi/romio/mpi-io/iread_sh.c
+++ b/src/mpi/romio/mpi-io/iread_sh.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -85,6 +87,7 @@ Output Parameters:
 int MPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count,
                             MPI_Datatype datatype, MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     return MPIOI_File_iread_shared(fh, buf, count, datatype, request);
 }
 
@@ -92,6 +95,7 @@ int MPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count,
 int MPIOI_File_iread_shared(MPI_File fh, void *buf, int count,
                             MPI_Datatype datatype, MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     ADIO_Offset bufsize;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/iread_sh.c
+++ b/src/mpi/romio/mpi-io/iread_sh.c
@@ -45,6 +45,13 @@ Output Parameters:
 int MPI_File_iread_shared(MPI_File fh, void *buf, int count,
                           MPI_Datatype datatype, MPI_Request * request)
 {
+    return MPIOI_File_iread_shared(fh, buf, count, datatype, request);
+}
+
+#ifdef MPIO_BUILD_PROFILING
+int MPIOI_File_iread_shared(MPI_File fh, void *buf, int count,
+                            MPI_Datatype datatype, MPI_Request * request)
+{
     int error_code, buftype_is_contig, filetype_is_contig;
     ADIO_Offset bufsize;
     ADIO_File adio_fh;
@@ -127,4 +134,5 @@ int MPI_File_iread_shared(MPI_File fh, void *buf, int count,
     ROMIO_THREAD_CS_EXIT();
     return error_code;
 }
+#endif
 #endif

--- a/src/mpi/romio/mpi-io/iread_sh.c
+++ b/src/mpi/romio/mpi-io/iread_sh.c
@@ -27,6 +27,7 @@ int MPI_File_iread_shared(MPI_File fh, void *buf, int count, MPI_Datatype dataty
 
 #ifdef HAVE_MPI_GREQUEST
 #include "mpiu_greq.h"
+#endif
 
 /*@
     MPI_File_iread_shared - Nonblocking read using shared file pointer
@@ -44,6 +45,45 @@ Output Parameters:
 @*/
 int MPI_File_iread_shared(MPI_File fh, void *buf, int count,
                           MPI_Datatype datatype, MPI_Request * request)
+{
+    return MPIOI_File_iread_shared(fh, buf, count, datatype, request);
+}
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iread_shared_c = PMPI_File_iread_shared_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iread_shared_c MPI_File_iread_shared_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iread_shared_c as PMPI_File_iread_shared_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                            MPIO_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iread_shared_c")));
+#endif
+
+#endif
+
+/*@
+    MPI_File_iread_shared_c - Nonblocking read using shared file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+. request - request object (handle)
+
+.N fortran
+@*/
+int MPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count,
+                            MPI_Datatype datatype, MPI_Request * request)
 {
     return MPIOI_File_iread_shared(fh, buf, count, datatype, request);
 }
@@ -134,5 +174,4 @@ int MPIOI_File_iread_shared(MPI_File fh, void *buf, int count,
     ROMIO_THREAD_CS_EXIT();
     return error_code;
 }
-#endif
 #endif

--- a/src/mpi/romio/mpi-io/iwrite.c
+++ b/src/mpi/romio/mpi-io/iwrite.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -108,6 +110,7 @@ Output Parameters:
 int MPI_File_iwrite_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                       MPI_Datatype datatype, MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code = MPI_SUCCESS;
     static char myname[] = "MPI_FILE_IWRITE";
 #ifdef MPI_hpux
@@ -140,6 +143,7 @@ int MPIOI_File_iwrite(MPI_File fh,
                       const void *buf,
                       int count, MPI_Datatype datatype, char *myname, MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     MPI_Count datatype_size;
     ADIO_Status status;

--- a/src/mpi/romio/mpi-io/iwrite_all.c
+++ b/src/mpi/romio/mpi-io/iwrite_all.c
@@ -64,6 +64,64 @@ int MPI_File_iwrite_all(MPI_File fh, ROMIO_CONST void *buf, int count,
     return error_code;
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iwrite_all_c = PMPI_File_iwrite_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_all_c MPI_File_iwrite_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iwrite_all_c as PMPI_File_iwrite_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iwrite_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                          MPI_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iwrite_all_c")));
+#endif
+
+#endif
+
+#ifdef HAVE_MPI_GREQUEST
+#include "mpiu_greq.h"
+#endif
+
+/*@
+    MPI_File_iwrite_all_c - Nonblocking collective write using individual file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. request - request object (handle)
+
+.N fortran
+@*/
+int MPI_File_iwrite_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
+                          MPI_Datatype datatype, MPI_Request * request)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_IWRITE_ALL";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEALL, TRDTBLOCK, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    error_code = MPIOI_File_iwrite_all(fh, (MPI_Offset) 0,
+                                       ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    return error_code;
+}
+
 /* Note: MPIOI_File_iwrite_all also used by MPI_File_iwrite_at_all */
 /* prevent multiple definitions of this routine */
 #ifdef MPIO_BUILD_PROFILING

--- a/src/mpi/romio/mpi-io/iwrite_all.c
+++ b/src/mpi/romio/mpi-io/iwrite_all.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -104,6 +106,7 @@ Output Parameters:
 int MPI_File_iwrite_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                           MPI_Datatype datatype, MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IWRITE_ALL";
 #ifdef MPI_hpux
@@ -131,6 +134,7 @@ int MPIOI_File_iwrite_all(MPI_File fh,
                           const void *buf,
                           int count, MPI_Datatype datatype, char *myname, MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/iwrite_at.c
+++ b/src/mpi/romio/mpi-io/iwrite_at.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -115,6 +117,7 @@ Output Parameters:
 int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                          MPI_Count count, MPI_Datatype datatype, MPIO_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code;
     ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_IWRITE_AT";

--- a/src/mpi/romio/mpi-io/iwrite_at.c
+++ b/src/mpi/romio/mpi-io/iwrite_at.c
@@ -73,3 +73,71 @@ int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
 #endif /* MPI_hpux */
         return error_code;
 }
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iwrite_at_c = PMPI_File_iwrite_at_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_at_c MPI_File_iwrite_at_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iwrite_at_c as PMPI_File_iwrite_at_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                         MPI_Datatype datatype, MPIO_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iwrite_at_c")));
+#endif
+
+#endif
+
+/*@
+    MPI_File_iwrite_at_c - Nonblocking write using explicit offset
+
+Input Parameters:
+. fh - file handle (handle)
+. offset - file offset (nonnegative integer)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. request - request object (handle)
+
+.N fortran
+@*/
+#ifdef HAVE_MPI_GREQUEST
+#include "mpiu_greq.h"
+#endif
+
+int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
+                         MPI_Count count, MPI_Datatype datatype, MPIO_Request * request)
+{
+    int error_code;
+    ADIO_File adio_fh;
+    static char myname[] = "MPI_FILE_IWRITE_AT";
+
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEAT, TRDTSYSTEM, fh, datatype, count);
+#endif /* MPI_hpux */
+
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    error_code = MPIOI_File_iwrite(adio_fh, offset, ADIO_EXPLICIT_OFFSET, buf,
+                                   count, datatype, myname, request);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
+    /* --END ERROR HANDLING-- */
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count)
+#endif /* MPI_hpux */
+        return error_code;
+}

--- a/src/mpi/romio/mpi-io/iwrite_atall.c
+++ b/src/mpi/romio/mpi-io/iwrite_atall.c
@@ -63,3 +63,61 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf
 #endif /* MPI_hpux */
     return error_code;
 }
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iwrite_at_all_c = PMPI_File_iwrite_at_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_at_all_c MPI_File_iwrite_at_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iwrite_at_all_c as PMPI_File_iwrite_at_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                             MPI_Datatype datatype, MPI_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iwrite_at_all_c")));
+#endif
+
+#endif
+
+#ifdef HAVE_MPI_GREQUEST
+#include "mpiu_greq.h"
+#endif
+
+/*@
+    MPI_File_iwrite_at_all_c - Nonblocking collective write using explicit offset
+
+Input Parameters:
+. fh - file handle (handle)
+. offset - file offset (nonnegative integer)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. request - request object (handle)
+
+.N fortran
+@*/
+int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
+                             MPI_Count count, MPI_Datatype datatype, MPI_Request * request)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_IWRITE_AT_ALL";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEATALL, TRDTBLOCK, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    error_code = MPIOI_File_iwrite_all(fh, offset, ADIO_EXPLICIT_OFFSET,
+                                       buf, count, datatype, myname, request);
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+    return error_code;
+}

--- a/src/mpi/romio/mpi-io/iwrite_atall.c
+++ b/src/mpi/romio/mpi-io/iwrite_atall.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -105,6 +107,7 @@ Output Parameters:
 int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                              MPI_Count count, MPI_Datatype datatype, MPI_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IWRITE_AT_ALL";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/iwrite_sh.c
+++ b/src/mpi/romio/mpi-io/iwrite_sh.c
@@ -46,6 +46,13 @@ Output Parameters:
 int MPI_File_iwrite_shared(MPI_File fh, ROMIO_CONST void *buf, int count,
                            MPI_Datatype datatype, MPIO_Request * request)
 {
+    return MPIOI_File_iwrite_shared(fh, buf, count, datatype, request);
+}
+
+#ifdef MPIO_BUILD_PROFILING
+int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, int count,
+                             MPI_Datatype datatype, MPIO_Request * request)
+{
     int error_code, buftype_is_contig, filetype_is_contig;
     ADIO_File adio_fh;
     ADIO_Offset incr, bufsize;
@@ -116,3 +123,4 @@ int MPI_File_iwrite_shared(MPI_File fh, ROMIO_CONST void *buf, int count,
 
     return error_code;
 }
+#endif

--- a/src/mpi/romio/mpi-io/iwrite_sh.c
+++ b/src/mpi/romio/mpi-io/iwrite_sh.c
@@ -49,6 +49,49 @@ int MPI_File_iwrite_shared(MPI_File fh, ROMIO_CONST void *buf, int count,
     return MPIOI_File_iwrite_shared(fh, buf, count, datatype, request);
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iwrite_shared_c = PMPI_File_iwrite_shared_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_shared_c MPI_File_iwrite_shared_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iwrite_shared_c as PMPI_File_iwrite_shared_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iwrite_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                             MPIO_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iwrite_shared_c")));
+#endif
+
+#endif
+
+/*@
+    MPI_File_iwrite_shared_c - Nonblocking write using shared file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. request - request object (handle)
+
+.N fortran
+@*/
+#ifdef HAVE_MPI_GREQUEST
+#include "mpiu_greq.h"
+#endif
+
+int MPI_File_iwrite_shared_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
+                             MPI_Datatype datatype, MPIO_Request * request)
+{
+    return MPIOI_File_iwrite_shared(fh, buf, count, datatype, request);
+}
+
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, int count,
                              MPI_Datatype datatype, MPIO_Request * request)

--- a/src/mpi/romio/mpi-io/iwrite_sh.c
+++ b/src/mpi/romio/mpi-io/iwrite_sh.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -89,6 +91,7 @@ Output Parameters:
 int MPI_File_iwrite_shared_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                              MPI_Datatype datatype, MPIO_Request * request)
 {
+    assert(count <= INT_MAX);
     return MPIOI_File_iwrite_shared(fh, buf, count, datatype, request);
 }
 
@@ -96,6 +99,7 @@ int MPI_File_iwrite_shared_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count
 int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, int count,
                              MPI_Datatype datatype, MPIO_Request * request)
 {
+    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     ADIO_File adio_fh;
     ADIO_Offset incr, bufsize;

--- a/src/mpi/romio/mpi-io/mpioprof.h
+++ b/src/mpi/romio/mpi-io/mpioprof.h
@@ -157,6 +157,67 @@
 #define MPI_File_c2f PMPI_File_c2f
 #endif
 
+#undef MPI_File_read_c
+#define MPI_File_read_c PMPI_File_read_c
+#undef MPI_File_read_all_c
+#define MPI_File_read_all_c PMPI_File_read_all_c
+#undef MPI_File_read_all_begin_c
+#define MPI_File_read_all_begin_c PMPI_File_read_all_begin_c
+#undef MPI_File_read_at_c
+#define MPI_File_read_at_c PMPI_File_read_at_c
+#undef MPI_File_read_at_all_c
+#define MPI_File_read_at_all_c PMPI_File_read_at_all_c
+#undef MPI_File_read_at_all_begin_c
+#define MPI_File_read_at_all_begin_c PMPI_File_read_at_all_begin_c
+#undef MPI_File_read_ordered_c
+#define MPI_File_read_ordered_c PMPI_File_read_ordered_c
+#undef MPI_File_read_ordered_begin_c
+#define MPI_File_read_ordered_begin_c PMPI_File_read_ordered_begin_c
+#undef MPI_File_read_shared_c
+#define MPI_File_read_shared_c PMPI_File_read_shared_c
+#undef MPI_File_write_c
+#define MPI_File_write_c PMPI_File_write_c
+#undef MPI_File_write_all_c
+#define MPI_File_write_all_c PMPI_File_write_all_c
+#undef MPI_File_write_all_begin_c
+#define MPI_File_write_all_begin_c PMPI_File_write_all_begin_c
+#undef MPI_File_write_at_c
+#define MPI_File_write_at_c PMPI_File_write_at_c
+#undef MPI_File_write_at_all_c
+#define MPI_File_write_at_all_c PMPI_File_write_at_all_c
+#undef MPI_File_write_at_all_begin_c
+#define MPI_File_write_at_all_begin_c PMPI_File_write_at_all_begin_c
+#undef MPI_File_write_ordered_c
+#define MPI_File_write_ordered_c PMPI_File_write_ordered_c
+#undef MPI_File_write_ordered_begin_c
+#define MPI_File_write_ordered_begin_c PMPI_File_write_ordered_begin_c
+#undef MPI_File_write_shared_c
+#define MPI_File_write_shared_c PMPI_File_write_shared_c
+#undef MPI_File_iread_c
+#define MPI_File_iread_c PMPI_File_iread_c
+#undef MPI_File_iread_all_c
+#define MPI_File_iread_all_c PMPI_File_iread_all_c
+#undef MPI_File_iread_at_c
+#define MPI_File_iread_at_c PMPI_File_iread_at_c
+#undef MPI_File_iread_at_all_c
+#define MPI_File_iread_at_all_c PMPI_File_iread_at_all_c
+#undef MPI_File_iread_shared_c
+#define MPI_File_iread_shared_c PMPI_File_iread_shared_c
+#undef MPI_File_iwrite_c
+#define MPI_File_iwrite_c PMPI_File_iwrite_c
+#undef MPI_File_iwrite_all_c
+#define MPI_File_iwrite_all_c PMPI_File_iwrite_all_c
+#undef MPI_File_iwrite_at_c
+#define MPI_File_iwrite_at_c PMPI_File_iwrite_at_c
+#undef MPI_File_iwrite_at_all_c
+#define MPI_File_iwrite_at_all_c PMPI_File_iwrite_at_all_c
+#undef MPI_File_iwrite_shared_c
+#define MPI_File_iwrite_shared_c PMPI_File_iwrite_shared_c
+#undef MPI_File_get_type_extent_c
+#define MPI_File_get_type_extent_c PMPI_File_get_type_extent_c
+#undef MPI_Register_datarep_c
+#define MPI_Register_datarep_c PMPI_Register_datarep_c
+
 #undef MPIO_Test
 #undef PMPIO_Test
 #define MPIO_Test PMPIO_Test

--- a/src/mpi/romio/mpi-io/rd_atallb.c
+++ b/src/mpi/romio/mpi-io/rd_atallb.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -87,6 +89,7 @@ Output Parameters:
 int MPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf,
                                  MPI_Count count, MPI_Datatype datatype)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_READ_AT_ALL_BEGIN";
 

--- a/src/mpi/romio/mpi-io/rd_atallb.c
+++ b/src/mpi/romio/mpi-io/rd_atallb.c
@@ -50,3 +50,48 @@ int MPI_File_read_at_all_begin(MPI_File fh, MPI_Offset offset, void *buf,
 
     return error_code;
 }
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_at_all_begin_c = PMPI_File_read_at_all_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_at_all_begin_c MPI_File_read_at_all_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_at_all_begin_c as PMPI_File_read_at_all_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                                 MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_read_at_all_begin_c")));
+#endif
+
+#endif
+
+/*@
+    MPI_File_read_at_all_begin_c - Begin a split collective read using explicit offset
+
+Input Parameters:
+. fh - file handle (handle)
+. offset - file offset (nonnegative integer)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+
+.N fortran
+@*/
+int MPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf,
+                                 MPI_Count count, MPI_Datatype datatype)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_READ_AT_ALL_BEGIN";
+
+    error_code = MPIOI_File_read_all_begin(fh, offset,
+                                           ADIO_EXPLICIT_OFFSET, buf, count, datatype, myname);
+
+    return error_code;
+}

--- a/src/mpi/romio/mpi-io/read.c
+++ b/src/mpi/romio/mpi-io/read.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -101,6 +103,7 @@ Output Parameters:
 int MPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
                     MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_READ";
 #ifdef MPI_hpux
@@ -126,6 +129,7 @@ int MPIOI_File_read(MPI_File fh,
                     int file_ptr_type,
                     void *buf, int count, MPI_Datatype datatype, char *myname, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/read_all.c
+++ b/src/mpi/romio/mpi-io/read_all.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -98,6 +100,7 @@ Output Parameters:
 int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
                         MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_READ_ALL";
 #ifdef MPI_hpux
@@ -125,6 +128,7 @@ int MPIOI_File_read_all(MPI_File fh,
                         void *buf,
                         int count, MPI_Datatype datatype, char *myname, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/read_all.c
+++ b/src/mpi/romio/mpi-io/read_all.c
@@ -60,6 +60,62 @@ int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, 
     return error_code;
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_all_c = PMPI_File_read_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_all_c MPI_File_read_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_all_c as PMPI_File_read_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                        MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_read_all_c")));
+#endif
+
+#endif
+
+/* status object not filled currently */
+
+/*@
+    MPI_File_read_all_c - Collective read using individual file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+. status - status object (Status)
+
+.N fortran
+@*/
+int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                        MPI_Status * status)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_READ_ALL";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADALL, TRDTBLOCK, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    error_code = MPIOI_File_read_all(fh, (MPI_Offset) 0,
+                                     ADIO_INDIVIDUAL, buf, count, datatype, myname, status);
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    return error_code;
+}
+
 /* Note: MPIOI_File_read_all also used by MPI_File_read_at_all */
 /* prevent multiple definitions of this routine */
 #ifdef MPIO_BUILD_PROFILING

--- a/src/mpi/romio/mpi-io/read_allb.c
+++ b/src/mpi/romio/mpi-io/read_allb.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -81,6 +83,7 @@ Output Parameters:
 @*/
 int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_READ_ALL_BEGIN";
 
@@ -97,6 +100,7 @@ int MPIOI_File_read_all_begin(MPI_File fh,
                               int file_ptr_type,
                               void *buf, int count, MPI_Datatype datatype, char *myname)
 {
+    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/read_allb.c
+++ b/src/mpi/romio/mpi-io/read_allb.c
@@ -48,6 +48,48 @@ int MPI_File_read_all_begin(MPI_File fh, void *buf, int count, MPI_Datatype data
     return error_code;
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_all_begin_c = PMPI_File_read_all_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_all_begin_c MPI_File_read_all_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_all_begin_c as PMPI_File_read_all_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_read_all_begin_c")));
+#endif
+
+#endif
+
+/*@
+    MPI_File_read_all_begin_c - Begin a split collective read using individual file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+
+.N fortran
+@*/
+int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_READ_ALL_BEGIN";
+
+    error_code = MPIOI_File_read_all_begin(fh, (MPI_Offset) 0,
+                                           ADIO_INDIVIDUAL, buf, count, datatype, myname);
+
+    return error_code;
+}
+
 /* prevent multiple definitions of this routine */
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_read_all_begin(MPI_File fh,

--- a/src/mpi/romio/mpi-io/read_at.c
+++ b/src/mpi/romio/mpi-io/read_at.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -101,6 +103,7 @@ Output Parameters:
 int MPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf,
                        MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_READ_AT";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/read_at.c
+++ b/src/mpi/romio/mpi-io/read_at.c
@@ -62,3 +62,60 @@ int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf,
 
     return error_code;
 }
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_at_c = PMPI_File_read_at_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_at_c MPI_File_read_at_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_at_c as PMPI_File_read_at_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                       MPI_Datatype datatype, MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_read_at_c")));
+#endif
+
+#endif
+
+
+/*@
+    MPI_File_read_at_c - Read using explicit offset
+
+Input Parameters:
+. fh - file handle (handle)
+. offset - file offset (nonnegative integer)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+. status - status object (Status)
+
+.N fortran
+@*/
+int MPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf,
+                       MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_READ_AT";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADAT, TRDTBLOCK, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    /* ADIOI_File_read() defined in mpi-io/read.c */
+    error_code = MPIOI_File_read(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
+                                 count, datatype, myname, status);
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    return error_code;
+}

--- a/src/mpi/romio/mpi-io/read_atall.c
+++ b/src/mpi/romio/mpi-io/read_atall.c
@@ -62,3 +62,59 @@ int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf,
 
     return error_code;
 }
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_at_all_c = PMPI_File_read_at_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_at_all_c MPI_File_read_at_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_at_all_c as PMPI_File_read_at_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                           MPI_Datatype datatype, MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_read_at_all_c")));
+#endif
+
+#endif
+
+
+/*@
+    MPI_File_read_at_all_c - Collective read using explicit offset
+
+Input Parameters:
+. fh - file handle (handle)
+. offset - file offset (nonnegative integer)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+. status - status object (Status)
+
+.N fortran
+@*/
+int MPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
+                           MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_IREAD_AT";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADATALL, TRDTBLOCK, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    error_code = MPIOI_File_read_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
+                                     count, datatype, myname, status);
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    return error_code;
+}

--- a/src/mpi/romio/mpi-io/read_atall.c
+++ b/src/mpi/romio/mpi-io/read_atall.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -101,6 +103,7 @@ Output Parameters:
 int MPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
                            MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/read_ord.c
+++ b/src/mpi/romio/mpi-io/read_ord.c
@@ -47,6 +47,46 @@ int MPI_File_read_ordered(MPI_File fh, void *buf, int count,
     return MPIOI_File_read_ordered(fh, buf, count, datatype, status);
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_ordered_c = PMPI_File_read_ordered_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_ordered_c MPI_File_read_ordered_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_ordered_c as PMPI_File_read_ordered_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                            MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_read_ordered_c")));
+#endif
+
+#endif
+
+
+/*@
+    MPI_File_read_ordered_c - Collective read using shared file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+. status - status object (Status)
+
+.N fortran
+@*/
+int MPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count,
+                            MPI_Datatype datatype, MPI_Status * status)
+{
+    return MPIOI_File_read_ordered(fh, buf, count, datatype, status);
+}
+
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_read_ordered(MPI_File fh, void *buf, int count,
                             MPI_Datatype datatype, MPI_Status * status)

--- a/src/mpi/romio/mpi-io/read_ord.c
+++ b/src/mpi/romio/mpi-io/read_ord.c
@@ -44,6 +44,13 @@ Output Parameters:
 int MPI_File_read_ordered(MPI_File fh, void *buf, int count,
                           MPI_Datatype datatype, MPI_Status * status)
 {
+    return MPIOI_File_read_ordered(fh, buf, count, datatype, status);
+}
+
+#ifdef MPIO_BUILD_PROFILING
+int MPIOI_File_read_ordered(MPI_File fh, void *buf, int count,
+                            MPI_Datatype datatype, MPI_Status * status)
+{
     int error_code, nprocs, myrank;
     ADIO_Offset incr;
     MPI_Count datatype_size;
@@ -110,3 +117,4 @@ int MPI_File_read_ordered(MPI_File fh, void *buf, int count,
     /* FIXME: Check for error code from ReadStridedColl? */
     return error_code;
 }
+#endif

--- a/src/mpi/romio/mpi-io/read_ord.c
+++ b/src/mpi/romio/mpi-io/read_ord.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -84,6 +86,7 @@ Output Parameters:
 int MPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count,
                             MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     return MPIOI_File_read_ordered(fh, buf, count, datatype, status);
 }
 
@@ -91,6 +94,7 @@ int MPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count,
 int MPIOI_File_read_ordered(MPI_File fh, void *buf, int count,
                             MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code, nprocs, myrank;
     ADIO_Offset incr;
     MPI_Count datatype_size;

--- a/src/mpi/romio/mpi-io/read_ordb.c
+++ b/src/mpi/romio/mpi-io/read_ordb.c
@@ -39,6 +39,12 @@ Output Parameters:
 @*/
 int MPI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype)
 {
+    return MPIOI_File_read_ordered_begin(fh, buf, count, datatype);
+}
+
+#ifdef MPIO_BUILD_PROFILING
+int MPIOI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype)
+{
     int error_code, nprocs, myrank;
     MPI_Count datatype_size;
     int source, dest;
@@ -129,3 +135,4 @@ int MPI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype 
 
     return error_code;
 }
+#endif

--- a/src/mpi/romio/mpi-io/read_ordb.c
+++ b/src/mpi/romio/mpi-io/read_ordb.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -75,6 +77,7 @@ Output Parameters:
 @*/
 int MPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
 {
+    assert(count <= INT_MAX);
     return MPIOI_File_read_ordered_begin(fh, buf, count, datatype);
 }
 

--- a/src/mpi/romio/mpi-io/read_ordb.c
+++ b/src/mpi/romio/mpi-io/read_ordb.c
@@ -42,6 +42,42 @@ int MPI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype 
     return MPIOI_File_read_ordered_begin(fh, buf, count, datatype);
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_ordered_begin_c = PMPI_File_read_ordered_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_ordered_begin_c MPI_File_read_ordered_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_ordered_begin_c as PMPI_File_read_ordered_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_read_ordered_begin_c")));
+#endif
+
+#endif
+
+/*@
+    MPI_File_read_ordered_begin_c - Begin a split collective read using shared file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+
+.N fortran
+@*/
+int MPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
+{
+    return MPIOI_File_read_ordered_begin(fh, buf, count, datatype);
+}
+
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype)
 {

--- a/src/mpi/romio/mpi-io/read_sh.c
+++ b/src/mpi/romio/mpi-io/read_sh.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -84,6 +86,7 @@ Output Parameters:
 int MPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count,
                            MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     return MPIOI_File_read_shared(fh, buf, count, datatype, status);
 }
 
@@ -91,6 +94,7 @@ int MPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count,
 int MPIOI_File_read_shared(MPI_File fh, void *buf, int count,
                            MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     static char myname[] = "MPI_FILE_READ_SHARED";
     MPI_Count datatype_size;

--- a/src/mpi/romio/mpi-io/read_sh.c
+++ b/src/mpi/romio/mpi-io/read_sh.c
@@ -44,6 +44,13 @@ Output Parameters:
 int MPI_File_read_shared(MPI_File fh, void *buf, int count,
                          MPI_Datatype datatype, MPI_Status * status)
 {
+    return MPIOI_File_read_shared(fh, buf, count, datatype, status);
+}
+
+#ifdef MPIO_BUILD_PROFILING
+int MPIOI_File_read_shared(MPI_File fh, void *buf, int count,
+                           MPI_Datatype datatype, MPI_Status * status)
+{
     int error_code, buftype_is_contig, filetype_is_contig;
     static char myname[] = "MPI_FILE_READ_SHARED";
     MPI_Count datatype_size;
@@ -145,3 +152,4 @@ int MPI_File_read_shared(MPI_File fh, void *buf, int count,
 
     return error_code;
 }
+#endif

--- a/src/mpi/romio/mpi-io/read_sh.c
+++ b/src/mpi/romio/mpi-io/read_sh.c
@@ -47,6 +47,46 @@ int MPI_File_read_shared(MPI_File fh, void *buf, int count,
     return MPIOI_File_read_shared(fh, buf, count, datatype, status);
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_shared_c = PMPI_File_read_shared_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_shared_c MPI_File_read_shared_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_shared_c as PMPI_File_read_shared_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                           MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_read_shared_c")));
+#endif
+
+#endif
+
+
+/*@
+    MPI_File_read_shared_c - Read using shared file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+. status - status object (Status)
+
+.N fortran
+@*/
+int MPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count,
+                           MPI_Datatype datatype, MPI_Status * status)
+{
+    return MPIOI_File_read_shared(fh, buf, count, datatype, status);
+}
+
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_read_shared(MPI_File fh, void *buf, int count,
                            MPI_Datatype datatype, MPI_Status * status)

--- a/src/mpi/romio/mpi-io/wr_atallb.c
+++ b/src/mpi/romio/mpi-io/wr_atallb.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -85,6 +87,7 @@ Input Parameters:
 int MPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                                   MPI_Count count, MPI_Datatype datatype)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_AT_ALL_BEGIN";
 

--- a/src/mpi/romio/mpi-io/wr_atallb.c
+++ b/src/mpi/romio/mpi-io/wr_atallb.c
@@ -49,3 +49,47 @@ int MPI_File_write_at_all_begin(MPI_File fh, MPI_Offset offset, ROMIO_CONST void
 
     return error_code;
 }
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_at_all_begin_c = PMPI_File_write_at_all_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_at_all_begin_c MPI_File_write_at_all_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_at_all_begin_c as PMPI_File_write_at_all_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                                  MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_write_at_all_begin_c")));
+#endif
+
+#endif
+
+/*@
+    MPI_File_write_at_all_begin_c - Begin a split collective write using
+    explicit offset
+
+Input Parameters:
+. fh - file handle (handle)
+. offset - file offset (nonnegative integer)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+.N fortran
+@*/
+int MPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
+                                  MPI_Count count, MPI_Datatype datatype)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_WRITE_AT_ALL_BEGIN";
+
+    error_code = MPIOI_File_write_all_begin(fh, offset,
+                                            ADIO_EXPLICIT_OFFSET, buf, count, datatype, myname);
+
+    return error_code;
+}

--- a/src/mpi/romio/mpi-io/write.c
+++ b/src/mpi/romio/mpi-io/write.c
@@ -61,6 +61,60 @@ int MPI_File_write(MPI_File fh, ROMIO_CONST void *buf, int count,
     return error_code;
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_c = PMPI_File_write_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_c MPI_File_write_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_c as PMPI_File_write_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                     MPI_Status * status) __attribute__ ((weak, alias("PMPI_File_write_c")));
+#endif
+
+#endif
+
+
+/*@
+    MPI_File_write_c - Write using individual file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. status - status object (Status)
+
+.N fortran
+@*/
+int MPI_File_write_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
+                     MPI_Datatype datatype, MPI_Status * status)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_WRITE";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITE, TRDTBLOCK, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    error_code = MPIOI_File_write(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf,
+                                  count, datatype, myname, status);
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    return error_code;
+}
+
 /* prevent multiple definitions of this routine */
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write(MPI_File fh,

--- a/src/mpi/romio/mpi-io/write.c
+++ b/src/mpi/romio/mpi-io/write.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -97,6 +99,7 @@ Output Parameters:
 int MPI_File_write_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                      MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE";
 #ifdef MPI_hpux
@@ -123,6 +126,7 @@ int MPIOI_File_write(MPI_File fh,
                      const void *buf,
                      int count, MPI_Datatype datatype, char *myname, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     MPI_Count datatype_size;
     ADIO_Offset off, bufsize;

--- a/src/mpi/romio/mpi-io/write_all.c
+++ b/src/mpi/romio/mpi-io/write_all.c
@@ -61,6 +61,61 @@ int MPI_File_write_all(MPI_File fh, ROMIO_CONST void *buf, int count,
     return error_code;
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_all_c = PMPI_File_write_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_all_c MPI_File_write_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_all_c as PMPI_File_write_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                         MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_write_all_c")));
+#endif
+
+#endif
+
+
+/*@
+    MPI_File_write_all_c - Collective write using individual file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. status - status object (Status)
+
+.N fortran
+@*/
+int MPI_File_write_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
+                         MPI_Datatype datatype, MPI_Status * status)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_WRITE_ALL";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITEALL, TRDTBLOCK, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    error_code = MPIOI_File_write_all(fh, (MPI_Offset) 0,
+                                      ADIO_INDIVIDUAL, buf, count, datatype, myname, status);
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    return error_code;
+}
+
 /* prevent multiple definitions of this routine */
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write_all(MPI_File fh,

--- a/src/mpi/romio/mpi-io/write_all.c
+++ b/src/mpi/romio/mpi-io/write_all.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -98,6 +100,7 @@ Output Parameters:
 int MPI_File_write_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                          MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_ALL";
 #ifdef MPI_hpux
@@ -124,6 +127,7 @@ int MPIOI_File_write_all(MPI_File fh,
                          const void *buf,
                          int count, MPI_Datatype datatype, char *myname, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/write_allb.c
+++ b/src/mpi/romio/mpi-io/write_allb.c
@@ -47,6 +47,48 @@ int MPI_File_write_all_begin(MPI_File fh, ROMIO_CONST void *buf, int count, MPI_
     return error_code;
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_all_begin_c = PMPI_File_write_all_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_all_begin_c MPI_File_write_all_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_all_begin_c as PMPI_File_write_all_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_all_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_write_all_begin_c")));
+#endif
+
+#endif
+
+/*@
+    MPI_File_write_all_begin_c - Begin a split collective write using
+    individual file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+.N fortran
+@*/
+int MPI_File_write_all_begin_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
+                               MPI_Datatype datatype)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_WRITE_ALL_BEGIN";
+
+    error_code = MPIOI_File_write_all_begin(fh, (MPI_Offset) 0,
+                                            ADIO_INDIVIDUAL, buf, count, datatype, myname);
+
+    return error_code;
+}
+
 /* prevent multiple definitions of this routine */
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write_all_begin(MPI_File fh,

--- a/src/mpi/romio/mpi-io/write_allb.c
+++ b/src/mpi/romio/mpi-io/write_allb.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -80,6 +82,7 @@ Input Parameters:
 int MPI_File_write_all_begin_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                                MPI_Datatype datatype)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_ALL_BEGIN";
 
@@ -96,6 +99,7 @@ int MPIOI_File_write_all_begin(MPI_File fh,
                                int file_ptr_type,
                                const void *buf, int count, MPI_Datatype datatype, char *myname)
 {
+    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/write_at.c
+++ b/src/mpi/romio/mpi-io/write_at.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -102,6 +104,7 @@ Output Parameters:
 int MPI_File_write_at_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                         MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_AT";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/write_at.c
+++ b/src/mpi/romio/mpi-io/write_at.c
@@ -63,3 +63,60 @@ int MPI_File_write_at(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
 
     return error_code;
 }
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_at_c = PMPI_File_write_at_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_at_c MPI_File_write_at_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_at_c as PMPI_File_write_at_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                        MPI_Datatype datatype, MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_write_at_c")));
+#endif
+
+#endif
+
+
+/*@
+    MPI_File_write_at_c - Write using explicit offset
+
+Input Parameters:
+. fh - file handle (handle)
+. offset - file offset (nonnegative integer)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. status - status object (Status)
+
+.N fortran
+@*/
+int MPI_File_write_at_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
+                        MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_WRITE_AT";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITEAT, TRDTBLOCK, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    /* MPIOI_File_write() defined in mpi-io/write.c */
+    error_code = MPIOI_File_write(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
+                                  count, datatype, myname, status);
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    return error_code;
+}

--- a/src/mpi/romio/mpi-io/write_atall.c
+++ b/src/mpi/romio/mpi-io/write_atall.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -100,6 +102,7 @@ Output Parameters:
 int MPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                             MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_AT_ALL";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/write_atall.c
+++ b/src/mpi/romio/mpi-io/write_atall.c
@@ -61,3 +61,58 @@ int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
 #endif /* MPI_hpux */
     return error_code;
 }
+
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_at_all_c = PMPI_File_write_at_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_at_all_c MPI_File_write_at_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_at_all_c as PMPI_File_write_at_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                            MPI_Datatype datatype, MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_write_at_all_c")));
+#endif
+
+#endif
+
+
+/*@
+    MPI_File_write_at_all_c - Collective write using explicit offset
+
+Input Parameters:
+. fh - file handle (handle)
+. offset - file offset (nonnegative integer)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. status - status object (Status)
+
+.N fortran
+@*/
+int MPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
+                            MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
+{
+    int error_code;
+    static char myname[] = "MPI_FILE_WRITE_AT_ALL";
+#ifdef MPI_hpux
+    int fl_xmpi;
+
+    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITEATALL, TRDTBLOCK, fh, datatype, count);
+#endif /* MPI_hpux */
+
+    error_code = MPIOI_File_write_all(fh, offset, ADIO_EXPLICIT_OFFSET,
+                                      buf, count, datatype, myname, status);
+
+#ifdef MPI_hpux
+    HPMP_IO_END(fl_xmpi, fh, datatype, count);
+#endif /* MPI_hpux */
+    return error_code;
+}

--- a/src/mpi/romio/mpi-io/write_ord.c
+++ b/src/mpi/romio/mpi-io/write_ord.c
@@ -47,6 +47,46 @@ int MPI_File_write_ordered(MPI_File fh, ROMIO_CONST void *buf, int count,
     return MPIOI_File_write_ordered(fh, buf, count, datatype, status);
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_ordered_c = PMPI_File_write_ordered_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_ordered_c MPI_File_write_ordered_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_ordered_c as PMPI_File_write_ordered_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_ordered_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                             MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_write_ordered_c")));
+#endif
+
+#endif
+
+
+/*@
+    MPI_File_write_ordered_c - Collective write using shared file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. status - status object (Status)
+
+.N fortran
+@*/
+int MPI_File_write_ordered_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
+                             MPI_Datatype datatype, MPI_Status * status)
+{
+    return MPIOI_File_write_ordered(fh, buf, count, datatype, status);
+}
+
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write_ordered(MPI_File fh, const void *buf, int count,
                              MPI_Datatype datatype, MPI_Status * status)

--- a/src/mpi/romio/mpi-io/write_ord.c
+++ b/src/mpi/romio/mpi-io/write_ord.c
@@ -44,6 +44,13 @@ Output Parameters:
 int MPI_File_write_ordered(MPI_File fh, ROMIO_CONST void *buf, int count,
                            MPI_Datatype datatype, MPI_Status * status)
 {
+    return MPIOI_File_write_ordered(fh, buf, count, datatype, status);
+}
+
+#ifdef MPIO_BUILD_PROFILING
+int MPIOI_File_write_ordered(MPI_File fh, const void *buf, int count,
+                             MPI_Datatype datatype, MPI_Status * status)
+{
     int error_code, nprocs, myrank;
     ADIO_Offset incr;
     MPI_Count datatype_size;
@@ -125,3 +132,4 @@ int MPI_File_write_ordered(MPI_File fh, ROMIO_CONST void *buf, int count,
     /* FIXME: Check for error code from WriteStridedColl? */
     return error_code;
 }
+#endif

--- a/src/mpi/romio/mpi-io/write_ord.c
+++ b/src/mpi/romio/mpi-io/write_ord.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -84,6 +86,7 @@ Output Parameters:
 int MPI_File_write_ordered_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                              MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     return MPIOI_File_write_ordered(fh, buf, count, datatype, status);
 }
 
@@ -91,6 +94,7 @@ int MPI_File_write_ordered_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count
 int MPIOI_File_write_ordered(MPI_File fh, const void *buf, int count,
                              MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     int error_code, nprocs, myrank;
     ADIO_Offset incr;
     MPI_Count datatype_size;

--- a/src/mpi/romio/mpi-io/write_ordb.c
+++ b/src/mpi/romio/mpi-io/write_ordb.c
@@ -40,6 +40,12 @@ Output Parameters:
 int MPI_File_write_ordered_begin(MPI_File fh, ROMIO_CONST void *buf, int count,
                                  MPI_Datatype datatype)
 {
+    return MPIOI_File_write_ordered_begin(fh, buf, count, datatype);
+}
+
+#ifdef MPIO_BUILD_PROFILING
+int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype)
+{
     int error_code, nprocs, myrank;
     ADIO_Offset incr;
     MPI_Count datatype_size;
@@ -126,3 +132,4 @@ int MPI_File_write_ordered_begin(MPI_File fh, ROMIO_CONST void *buf, int count,
     /* FIXME: Check for error code from WriteStridedColl? */
     return error_code;
 }
+#endif

--- a/src/mpi/romio/mpi-io/write_ordb.c
+++ b/src/mpi/romio/mpi-io/write_ordb.c
@@ -43,6 +43,44 @@ int MPI_File_write_ordered_begin(MPI_File fh, ROMIO_CONST void *buf, int count,
     return MPIOI_File_write_ordered_begin(fh, buf, count, datatype);
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_ordered_begin_c = PMPI_File_write_ordered_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_ordered_begin_c MPI_File_write_ordered_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_ordered_begin_c as PMPI_File_write_ordered_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_ordered_begin_c(MPI_File fh, const void *buf, MPI_Count count,
+                                   MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_write_ordered_begin_c")));
+#endif
+
+#endif
+
+/*@
+    MPI_File_write_ordered_begin_c - Begin a split collective write using shared file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. buf - initial address of buffer (choice)
+
+.N fortran
+@*/
+int MPI_File_write_ordered_begin_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
+                                   MPI_Datatype datatype)
+{
+    return MPIOI_File_write_ordered_begin(fh, buf, count, datatype);
+}
+
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype)
 {

--- a/src/mpi/romio/mpi-io/write_ordb.c
+++ b/src/mpi/romio/mpi-io/write_ordb.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -78,12 +80,14 @@ Output Parameters:
 int MPI_File_write_ordered_begin_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                                    MPI_Datatype datatype)
 {
+    assert(count <= INT_MAX);
     return MPIOI_File_write_ordered_begin(fh, buf, count, datatype);
 }
 
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype)
 {
+    assert(count <= INT_MAX);
     int error_code, nprocs, myrank;
     ADIO_Offset incr;
     MPI_Count datatype_size;

--- a/src/mpi/romio/mpi-io/write_sh.c
+++ b/src/mpi/romio/mpi-io/write_sh.c
@@ -4,6 +4,8 @@
  */
 
 #include "mpioimpl.h"
+#include <limits.h>
+#include <assert.h>
 
 #ifdef HAVE_WEAK_SYMBOLS
 
@@ -84,6 +86,7 @@ Output Parameters:
 int MPI_File_write_shared_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                             MPI_Datatype datatype, MPI_Status * status)
 {
+    assert(count <= INT_MAX);
     return MPIOI_File_write_shared(fh, buf, count, datatype, status);
 }
 

--- a/src/mpi/romio/mpi-io/write_sh.c
+++ b/src/mpi/romio/mpi-io/write_sh.c
@@ -44,6 +44,13 @@ Output Parameters:
 int MPI_File_write_shared(MPI_File fh, ROMIO_CONST void *buf, int count,
                           MPI_Datatype datatype, MPI_Status * status)
 {
+    return MPIOI_File_write_shared(fh, buf, count, datatype, status);
+}
+
+#ifdef MPIO_BUILD_PROFILING
+int MPIOI_File_write_shared(MPI_File fh, const void *buf, int count,
+                            MPI_Datatype datatype, MPI_Status * status)
+{
     int error_code, buftype_is_contig, filetype_is_contig;
     ADIO_Offset bufsize;
     static char myname[] = "MPI_FILE_READ_SHARED";
@@ -142,3 +149,4 @@ int MPI_File_write_shared(MPI_File fh, ROMIO_CONST void *buf, int count,
     ROMIO_THREAD_CS_EXIT();
     return error_code;
 }
+#endif

--- a/src/mpi/romio/mpi-io/write_sh.c
+++ b/src/mpi/romio/mpi-io/write_sh.c
@@ -47,6 +47,46 @@ int MPI_File_write_shared(MPI_File fh, ROMIO_CONST void *buf, int count,
     return MPIOI_File_write_shared(fh, buf, count, datatype, status);
 }
 
+/* large count function */
+
+#ifdef HAVE_WEAK_SYMBOLS
+
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_shared_c = PMPI_File_write_shared_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_shared_c MPI_File_write_shared_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_shared_c as PMPI_File_write_shared_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                            MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_write_shared_c")));
+#endif
+
+#endif
+
+
+/*@
+    MPI_File_write_shared_c - Write using shared file pointer
+
+Input Parameters:
+. fh - file handle (handle)
+. buf - initial address of buffer (choice)
+. count - number of elements in buffer (nonnegative integer)
+. datatype - datatype of each buffer element (handle)
+
+Output Parameters:
+. status - status object (Status)
+
+.N fortran
+@*/
+int MPI_File_write_shared_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
+                            MPI_Datatype datatype, MPI_Status * status)
+{
+    return MPIOI_File_write_shared(fh, buf, count, datatype, status);
+}
+
 #ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write_shared(MPI_File fh, const void *buf, int count,
                             MPI_Datatype datatype, MPI_Status * status)


### PR DESCRIPTION
## Pull Request Description

Add large count functions:
```
MPI_File_read_c
MPI_File_read_all_c
MPI_File_read_all_begin_c
MPI_File_read_at_c
MPI_File_read_at_all_c
MPI_File_read_at_all_begin_c
MPI_File_read_ordered_c
MPI_File_read_ordered_begin_c
MPI_File_read_shared_c
MPI_File_write_c
MPI_File_write_all_c
MPI_File_write_all_begin_c
MPI_File_write_at_c
MPI_File_write_at_all_c
MPI_File_write_at_all_begin_c
MPI_File_write_ordered_c
MPI_File_write_ordered_begin_c
MPI_File_write_shared_c
MPI_File_iread_c
MPI_File_iread_all_c
MPI_File_iread_at_c
MPI_File_iread_at_all_c
MPI_File_iread_shared_c
MPI_File_iwrite_c
MPI_File_iwrite_all_c
MPI_File_iwrite_at_c
MPI_File_iwrite_at_all_c
MPI_File_iwrite_shared_c
MPI_File_get_type_extent_c
MPI_Register_datarep_c
```

Most of the functions only has one scalar parameters that is `int count` in small function, and `MPI_Count count` in the large function. This PR simply adds an assertion to ensure the large count can fit in the `int` and rely on compiler to do the integer conversion.

TODO in a future PR -- make internal functions to use `MPI_Aint` for `count`.
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
