### PR TITLE
typerep|rma: optimize pack|unpack for RMA IPC

### DIFF
--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -56,8 +56,13 @@ extern const char MPII_Version_F77[] MPICH_API_PUBLIC;
 extern const char MPII_Version_FC[] MPICH_API_PUBLIC;
 extern const char MPII_Version_custom[] MPICH_API_PUBLIC;
 
+#include "typerep_pre.h"        /* needed for MPIR_Typerep_req */
+
 int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype);
+int MPIR_Ilocalcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                    MPIR_Typerep_req * typereq_req);
 
 /*@ MPIR_Add_finalize - Add a routine to be called when MPI_Finalize is invoked
 

--- a/src/include/mpir_typerep.h
+++ b/src/include/mpir_typerep.h
@@ -63,6 +63,15 @@ int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype
 int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize,
                         void *outbuf, MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
                         MPI_Aint * actual_unpack_bytes);
+int MPIR_Typerep_icopy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
+                       MPIR_Typerep_req * typereq_req);
+int MPIR_Typerep_ipack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
+                       MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
+                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typereq_req);
+int MPIR_Typerep_iunpack(const void *inbuf, MPI_Aint insize,
+                         void *outbuf, MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
+                         MPI_Aint * actual_unpack_bytes, MPIR_Typerep_req * typereq_req);
+int MPIR_Typerep_wait(MPIR_Typerep_req typereq_req);
 
 int MPIR_Typerep_size_external32(MPI_Datatype type);
 int MPIR_Typerep_pack_external(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,

--- a/src/include/mpir_typerep.h
+++ b/src/include/mpir_typerep.h
@@ -7,6 +7,7 @@
 #define MPIR_TYPEREP_H_INCLUDED
 
 #include <mpi.h>
+#include "typerep_pre.h"
 
 void MPIR_Typerep_init(void);
 void MPIR_Typerep_finalize(void);

--- a/src/mpi/datatype/typerep/src/Makefile.mk
+++ b/src/mpi/datatype/typerep/src/Makefile.mk
@@ -31,4 +31,5 @@ mpi_core_sources += \
 endif !BUILD_YAKSA_ENGINE
 
 noinst_HEADERS += \
-    src/mpi/datatype/typerep/src/typerep_internal.h
+    src/mpi/datatype/typerep/src/typerep_internal.h   \
+    src/mpi/datatype/typerep/src/typerep_pre.h

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
@@ -5,21 +5,28 @@
 
 #include "mpiimpl.h"
 #include <dataloop.h>
+#include "typerep_pre.h"
 
-int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
+int MPIR_Typerep_icopy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
+                       MPIR_Typerep_req * typereq_req)
 {
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_COPY);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_COPY);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_ICOPY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_ICOPY);
 
     MPIR_Memcpy(outbuf, inbuf, num_bytes);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_COPY);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_ICOPY);
     return MPI_SUCCESS;
 }
 
-int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
-                      MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
-                      MPI_Aint * actual_pack_bytes)
+int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
+{
+    return MPIR_Typerep_icopy(outbuf, inbuf, num_bytes, NULL);
+}
+
+int MPIR_Typerep_ipack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
+                       MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
+                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typereq_req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Segment *segp;
@@ -73,9 +80,18 @@ int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype
     goto fn_exit;
 }
 
-int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize,
-                        void *outbuf, MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
-                        MPI_Aint * actual_unpack_bytes)
+int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
+                      MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
+                      MPI_Aint * actual_pack_bytes)
+{
+    return MPIR_Typerep_ipack(inbuf, incount, datatype, inoffset, outbuf, max_pack_bytes,
+                              actual_pack_bytes, NULL);
+}
+
+
+int MPIR_Typerep_iunpack(const void *inbuf, MPI_Aint insize,
+                         void *outbuf, MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
+                         MPI_Aint * actual_unpack_bytes, MPIR_Typerep_req * typereq_req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Segment *segp;
@@ -129,4 +145,18 @@ int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize,
     return mpi_errno;
   fn_fail:
     goto fn_exit;
+}
+
+int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize,
+                        void *outbuf, MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
+                        MPI_Aint * actual_unpack_bytes)
+{
+    return MPIR_Typerep_iunpack(inbuf, insize, outbuf, outcount, datatype, outoffset,
+                                actual_unpack_bytes, NULL);
+}
+
+int MPIR_Typerep_wait(MPIR_Typerep_req typereq_req)
+{
+    /* All nonblocking operations are actually blocking. Thus, do nothing in wait. */
+    return MPI_SUCCESS;
 }

--- a/src/mpi/datatype/typerep/src/typerep_internal.h
+++ b/src/mpi/datatype/typerep/src/typerep_internal.h
@@ -7,9 +7,7 @@
 #define TYPEREP_INTERNAL_H_INCLUDED
 
 #include "mpiimpl.h"
-
-#define MPICH_DATATYPE_ENGINE_YAKSA    (1)
-#define MPICH_DATATYPE_ENGINE_DATALOOP (2)
+#include "typerep_pre.h"
 
 #if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
 

--- a/src/mpi/datatype/typerep/src/typerep_pre.h
+++ b/src/mpi/datatype/typerep/src/typerep_pre.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef TYPEREP_PRE_H_INCLUDED
+#define TYPEREP_PRE_H_INCLUDED
+
+#define MPICH_DATATYPE_ENGINE_YAKSA    (1)
+#define MPICH_DATATYPE_ENGINE_DATALOOP (2)
+
+#endif /* TYPEREP_PRE_H_INCLUDED */

--- a/src/mpi/datatype/typerep/src/typerep_pre.h
+++ b/src/mpi/datatype/typerep/src/typerep_pre.h
@@ -9,4 +9,13 @@
 #define MPICH_DATATYPE_ENGINE_YAKSA    (1)
 #define MPICH_DATATYPE_ENGINE_DATALOOP (2)
 
+#if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
+#include "yaksa.h"
+typedef yaksa_request_t MPIR_Typerep_req;
+#define MPIR_TYPEREP_REQ_NULL YAKSA_REQUEST__NULL
+#else
+typedef int MPIR_Typerep_req;   /* unused in dataloop */
+#define MPIR_TYPEREP_REQ_NULL 0
+#endif
+
 #endif /* TYPEREP_PRE_H_INCLUDED */

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -52,11 +52,6 @@ int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
     goto fn_exit;
 }
 
-typedef enum {
-    MEMCPY_DIR__PACK,
-    MEMCPY_DIR__UNPACK,
-} memcpy_dir_e;
-
 int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                       MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
                       MPI_Aint * actual_pack_bytes)

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -7,10 +7,10 @@
 #include "yaksa.h"
 #include "typerep_internal.h"
 
-int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
+static int typerep_do_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
 {
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_COPY);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_COPY);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_TYPEREP_DO_COPY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_TYPEREP_DO_COPY);
 
     int mpi_errno = MPI_SUCCESS;
     int rc;
@@ -46,18 +46,18 @@ int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
     }
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_COPY);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_TYPEREP_DO_COPY);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
-                      MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
-                      MPI_Aint * actual_pack_bytes)
+static int typerep_do_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
+                           MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
+                           MPI_Aint * actual_pack_bytes)
 {
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_PACK);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_PACK);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_TYPEREP_DO_PACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_TYPEREP_DO_PACK);
 
     int mpi_errno = MPI_SUCCESS;
     int rc;
@@ -116,17 +116,19 @@ int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype
     *actual_pack_bytes = (MPI_Aint) real_pack_bytes;
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_PACK);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_TYPEREP_DO_PACK);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_Aint outcount,
-                        MPI_Datatype datatype, MPI_Aint outoffset, MPI_Aint * actual_unpack_bytes)
+
+static int typerep_do_unpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_Aint outcount,
+                             MPI_Datatype datatype, MPI_Aint outoffset,
+                             MPI_Aint * actual_unpack_bytes)
 {
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_UNPACK);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_UNPACK);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_TYPEREP_DO_UNPACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_TYPEREP_DO_UNPACK);
 
     int mpi_errno = MPI_SUCCESS;
     int rc;
@@ -185,6 +187,59 @@ int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_Ai
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
 
     *actual_unpack_bytes = (MPI_Aint) real_unpack_bytes;
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_TYPEREP_DO_UNPACK);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_COPY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_COPY);
+
+    int mpi_errno = MPI_SUCCESS;
+    mpi_errno = typerep_do_copy(outbuf, inbuf, num_bytes);
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_COPY);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
+                      MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
+                      MPI_Aint * actual_pack_bytes)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_PACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_PACK);
+
+    int mpi_errno = MPI_SUCCESS;
+    mpi_errno = typerep_do_pack(inbuf, incount, datatype, inoffset, outbuf, max_pack_bytes,
+                                actual_pack_bytes);
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_PACK);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_Aint outcount,
+                        MPI_Datatype datatype, MPI_Aint outoffset, MPI_Aint * actual_unpack_bytes)
+{
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_UNPACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_UNPACK);
+
+    int mpi_errno = MPI_SUCCESS;
+    mpi_errno = typerep_do_unpack(inbuf, insize, outbuf, outcount, datatype, outoffset,
+                                  actual_unpack_bytes);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_UNPACK);

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -9,7 +9,8 @@
 #define COPY_BUFFER_SZ 16384
 
 static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                        void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype)
+                        void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                        MPIR_Typerep_req * typereq_req)
 {
     int mpi_errno = MPI_SUCCESS;
     int sendtype_iscontig, recvtype_iscontig;
@@ -21,6 +22,9 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_DO_LOCALCOPY);
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_DO_LOCALCOPY);
+
+    if (typereq_req)
+        *typereq_req = MPIR_TYPEREP_REQ_NULL;
 
     MPIR_Datatype_get_size_macro(sendtype, sendsize);
     MPIR_Datatype_get_size_macro(recvtype, recvsize);
@@ -50,19 +54,33 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
     MPIR_Type_get_true_extent_impl(sendtype, &sendtype_true_lb, &true_extent);
     MPIR_Type_get_true_extent_impl(recvtype, &recvtype_true_lb, &true_extent);
 
+    /* For single pack/unpack cases, using nonblocking version for better throughput
+     * when typereq_req is expected; otherwise using blocking version to minimize latency */
     if (sendtype_iscontig) {
         MPI_Aint actual_unpack_bytes;
-        MPIR_Typerep_unpack((char *) sendbuf + sendtype_true_lb, copy_sz, recvbuf, recvcount,
-                            recvtype, 0, &actual_unpack_bytes);
+        if (typereq_req) {
+            MPIR_Typerep_iunpack((char *) sendbuf + sendtype_true_lb, copy_sz, recvbuf, recvcount,
+                                 recvtype, 0, &actual_unpack_bytes, typereq_req);
+        } else {
+            MPIR_Typerep_unpack((char *) sendbuf + sendtype_true_lb, copy_sz, recvbuf, recvcount,
+                                recvtype, 0, &actual_unpack_bytes);
+        }
         MPIR_ERR_CHKANDJUMP(actual_unpack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
                             "**dtypemismatch");
     } else if (recvtype_iscontig) {
         MPI_Aint actual_pack_bytes;
-        MPIR_Typerep_pack(sendbuf, sendcount, sendtype, 0, (char *) recvbuf + recvtype_true_lb,
-                          copy_sz, &actual_pack_bytes);
+        if (typereq_req) {
+            MPIR_Typerep_ipack(sendbuf, sendcount, sendtype, 0, (char *) recvbuf + recvtype_true_lb,
+                               copy_sz, &actual_pack_bytes, typereq_req);
+        } else {
+            MPIR_Typerep_pack(sendbuf, sendcount, sendtype, 0, (char *) recvbuf + recvtype_true_lb,
+                              copy_sz, &actual_pack_bytes);
+        }
         MPIR_ERR_CHKANDJUMP(actual_pack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
                             "**dtypemismatch");
     } else {
+        /* For multi-step pack/unpack, using only blocking version for simplicity. */
+
         intptr_t sfirst;
         intptr_t rfirst;
 
@@ -144,7 +162,27 @@ int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtyp
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_LOCALCOPY);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_LOCALCOPY);
 
-    mpi_errno = do_localcopy(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype);
+    mpi_errno = do_localcopy(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, NULL);
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_LOCALCOPY);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Ilocalcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                    MPIR_Typerep_req * typereq_req)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_LOCALCOPY);
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_LOCALCOPY);
+
+    mpi_errno = do_localcopy(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                             recvtype, typereq_req);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -8,8 +8,8 @@
 
 #define COPY_BUFFER_SZ 16384
 
-int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype)
+static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                        void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype)
 {
     int mpi_errno = MPI_SUCCESS;
     int sendtype_iscontig, recvtype_iscontig;
@@ -18,9 +18,9 @@ int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtyp
     char *buf = NULL;
     MPL_pointer_attr_t send_attr, recv_attr;
     MPIR_CHKLMEM_DECL(1);
-    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_LOCALCOPY);
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_DO_LOCALCOPY);
 
-    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_LOCALCOPY);
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_DO_LOCALCOPY);
 
     MPIR_Datatype_get_size_macro(sendtype, sendsize);
     MPIR_Datatype_get_size_macro(recvtype, recvsize);
@@ -123,7 +123,7 @@ int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtyp
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_LOCALCOPY);
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_DO_LOCALCOPY);
     return mpi_errno;
   fn_fail:
     if (buf) {
@@ -133,5 +133,23 @@ int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtyp
             MPL_gpu_free_host(buf);
         }
     }
+    goto fn_exit;
+}
+
+int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_LOCALCOPY);
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_LOCALCOPY);
+
+    mpi_errno = do_localcopy(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype);
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_LOCALCOPY);
+    return mpi_errno;
+  fn_fail:
     goto fn_exit;
 }

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -349,6 +349,11 @@ typedef enum {
 
 #define MPIDIG_ACCU_NUM_OP (MPIR_OP_N_BUILTIN)  /* builtin reduce op + cswap */
 
+typedef enum {
+    MPIDIG_RMA_LAT_PREFERRED = 0,
+    MPIDIG_RMA_MR_PREFERRED,
+} MPIDIG_win_info_perf_preference;
+
 typedef struct MPIDIG_win_info_args_t {
     int no_locks;
     int same_size;
@@ -367,6 +372,9 @@ typedef struct MPIDIG_win_info_args_t {
                                          * TODO: can be set to win_size.*/
     bool disable_shm_accumulate;        /* false by default. */
     bool coll_attach;           /* false by default. Valid only for dynamic window */
+    int perf_preference;        /* Arbitrary combination of MPIDIG_win_info_perf_preference.
+                                 * By default MPICH/CH4 tends to optimize for low latency.
+                                 * MPICH may ignore invalid combination. */
 
     /* alloc_shm: MPICH specific hint (same in CH3).
      * If true, MPICH will try to use shared memory routines for the window.
@@ -483,6 +491,7 @@ typedef enum {
                                          * its internal optimization. */
     MPIDI_WINATTR_NM_DYNAMIC_MR = 32,   /* whether the memory region is registered dynamically. Valid only for
                                          * dynamic window. Set by netmod. */
+    MPIDI_WINATTR_MR_PREFERRED = 64,    /* message rate preferred flag. Default 0, set by user hint. */
     MPIDI_WINATTR_LAST_BIT
 } MPIDI_winattr_bit_t;
 

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -137,8 +137,19 @@ do { \
     MPIDI_POSIX_eager_recv_completed_hook((request)->dev.ch4.am.shm_am.posix.eager_recv_posted_hook_grank); \
 } while (0)
 
+typedef struct MPIDI_POSIX_rma_req {
+    MPIR_Typerep_req typerep_req;
+    struct MPIDI_POSIX_rma_req *next;
+} MPIDI_POSIX_rma_req_t;
+
 typedef struct {
     MPL_proc_mutex_t *shm_mutex_ptr;    /* interprocess mutex for shm atomic RMA */
+
+    /* Linked list to keep track of outstanding RMA issued via shm.
+     * Host-only copy is always blocking, thus this list should contain only
+     * GPU-involved operations. */
+    MPIDI_POSIX_rma_req_t *outstanding_reqs_head;
+    MPIDI_POSIX_rma_req_t *outstanding_reqs_tail;
 } MPIDI_POSIX_win_t;
 
 /*

--- a/src/mpid/ch4/shm/posix/posix_win.h
+++ b/src/mpid/ch4/shm/posix/posix_win.h
@@ -238,7 +238,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_win_lock_all(int assert, MPIR_Win *
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_rma_win_cmpl_hook(MPIR_Win * win ATTRIBUTE((unused)))
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_rma_win_cmpl_hook(MPIR_Win * win)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_RMA_WIN_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_RMA_WIN_CMPL_HOOK);
@@ -246,11 +246,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_rma_win_cmpl_hook(MPIR_Win * win ATTRIB
     /* Always perform barrier to ensure ordering of local load/store. */
     MPL_atomic_read_write_barrier();
 
+    MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;
+    MPIDI_POSIX_rma_outstanding_req_flushall(posix_win);
+
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_RMA_WIN_CMPL_HOOK);
     return MPI_SUCCESS;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_rma_win_local_cmpl_hook(MPIR_Win * win ATTRIBUTE((unused)))
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_rma_win_local_cmpl_hook(MPIR_Win * win)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_RMA_WIN_LOCAL_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_RMA_WIN_LOCAL_CMPL_HOOK);
@@ -258,12 +261,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_rma_win_local_cmpl_hook(MPIR_Win * win 
     /* Always perform barrier to ensure ordering of local load/store. */
     MPL_atomic_read_write_barrier();
 
+    MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;
+    MPIDI_POSIX_rma_outstanding_req_flushall(posix_win);
+
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_RMA_WIN_LOCAL_CMPL_HOOK);
     return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_rma_target_cmpl_hook(int rank ATTRIBUTE((unused)),
-                                                              MPIR_Win * win ATTRIBUTE((unused)))
+                                                              MPIR_Win * win)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_RMA_TARGET_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_RMA_TARGET_CMPL_HOOK);
@@ -271,19 +277,24 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_rma_target_cmpl_hook(int rank ATTRIBUTE
     /* Always perform barrier to ensure ordering of local load/store. */
     MPL_atomic_read_write_barrier();
 
+    MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;
+    MPIDI_POSIX_rma_outstanding_req_flushall(posix_win);
+
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_RMA_TARGET_CMPL_HOOK);
     return MPI_SUCCESS;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_rma_target_local_cmpl_hook(int rank ATTRIBUTE((unused)),
-                                                                    MPIR_Win *
-                                                                    win ATTRIBUTE((unused)))
+                                                                    MPIR_Win * win)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_RMA_TARGET_LOCAL_CMPL_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_RMA_TARGET_LOCAL_CMPL_HOOK);
 
     /* Always perform barrier to ensure ordering of local load/store. */
     MPL_atomic_read_write_barrier();
+
+    MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;
+    MPIDI_POSIX_rma_outstanding_req_flushall(posix_win);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_RMA_TARGET_LOCAL_CMPL_HOOK);
     return MPI_SUCCESS;


### PR DESCRIPTION
## Pull Request Description
This PR optimizes three aspects:
1. Nonblocking typerep pack|unpack: Current Typerep copy|pack|unpack are all blocking. It was fine in the past because all copy operations are blocking CPU copy. But now we add onnode GPU data transfer under the same pack|unpack API. The GPU data transfer can be nonblocking. Separating the copy issuing and completion steps can benefit message-rate-preferred case. In fact, the underlining yaksa already provides nonblocking routines. Thus, we define a set of nonblocking `MPIR_Typerep_icopy|ipack|iunpack`, as well as `MPIR_Ilocalcopy`.
2. To benefit from optimization-1, we add a window hint for user to specify whether the program prefers low-latency or high message-rate. Thus, when issuing an IPC put/get, we choose the blocking v.s. nonblocking copy based on the preference. 
3. Using newly added blocking yaksa_pack|unpack for blocking `MPIR_Typerep_copy|pack|unpack`. It allows yaksa to internally optimize latency for blocking fast-path (depends on [yaksa#184](https://github.com/pmodels/yaksa/pull/184)).

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
