### PR TITLE
ch4: fix partioned communication status check

### DIFF
--- a/src/mpid/ch4/errnames.txt
+++ b/src/mpid/ch4/errnames.txt
@@ -57,5 +57,4 @@
 #
 **ch4|partitionsync: Wrong synchronization of partitioned calls 
 **ch4|partmismatchsize: Partitioned send and receive buﬀers are not identical in size
-**ch4|partmismatchsize %d %d %d %d: Partitioned send and receive buﬀers are not identical in size; \
-%d bytes received but receive buffer size is %d
+**ch4|partmismatchsize %d %d: Partitioned send and receive buﬀers are not identical in size; %d bytes received but receive buffer size is %d

--- a/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
@@ -31,7 +31,8 @@ static int part_send_data_target_cmpl_cb(MPIR_Request * rreq)
     MPID_Request_complete(rreq);
 
     /* Reset part_rreq status to inactive */
-    MPL_atomic_fetch_sub_int(&MPIDIG_PART_REQUEST(part_rreq, status), 1);
+    MPL_atomic_fetch_sub_int(&MPIDIG_PART_REQUEST(part_rreq, status),
+                             MPIDIG_PART_SEND_NUM_CONDS_TO_SUBTRACT);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_PUT_DT_TARGET_CMPL_CB);
     return mpi_errno;
@@ -52,7 +53,8 @@ int MPIDIG_part_send_data_origin_cb(MPIR_Request * sreq)
     MPID_Request_complete(sreq);
 
     /* Reset part_sreq status to inactive */
-    MPL_atomic_fetch_sub_int(&MPIDIG_PART_REQUEST(part_sreq, status), 2);
+    MPL_atomic_fetch_sub_int(&MPIDIG_PART_REQUEST(part_sreq, status),
+                             MPIDIG_PART_RECV_NUM_CONDS_TO_SUBTRACT);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_PART_SEND_DATA_ORIGIN_CB);
     return mpi_errno;

--- a/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
@@ -31,7 +31,7 @@ static int part_send_data_target_cmpl_cb(MPIR_Request * rreq)
     MPID_Request_complete(rreq);
 
     /* Reset part_rreq status to inactive */
-    MPL_atomic_store_int(&MPIDIG_PART_REQUEST(part_rreq, status), MPIDIG_PART_RREQ_INACTIVE);
+    MPL_atomic_fetch_sub_int(&MPIDIG_PART_REQUEST(part_rreq, status), 1);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_PUT_DT_TARGET_CMPL_CB);
     return mpi_errno;
@@ -52,7 +52,7 @@ int MPIDIG_part_send_data_origin_cb(MPIR_Request * sreq)
     MPID_Request_complete(sreq);
 
     /* Reset part_sreq status to inactive */
-    MPL_atomic_store_int(&MPIDIG_PART_REQUEST(part_sreq, status), MPIDIG_PART_SREQ_INACTIVE);
+    MPL_atomic_fetch_sub_int(&MPIDIG_PART_REQUEST(part_sreq, status), 2);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_PART_SEND_DATA_ORIGIN_CB);
     return mpi_errno;

--- a/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
@@ -20,9 +20,14 @@
 #define MPIDIG_PART_REQ_CTS 2   /* Indicating receiver is ready to receive data
                                  * (requests matched and start called) */
 
-/* Status to deactivate at request completion */
-#define MPIDIG_PART_SREQ_INACTIVE 0     /* Sender need 2 increments to be CTS: start and remote start */
-#define MPIDIG_PART_RREQ_INACTIVE 1     /* Receiver need 1 increments to be CTS: start */
+#define MPIDIG_PART_SEND_NUM_CONDS_TO_SUBTRACT 2        /* the number of conditions to subtract
+                                                         * from status on send completion.
+                                                         * One for send start, and one for receiving
+                                                         * CTS from receiver */
+#define MPIDIG_PART_RECV_NUM_CONDS_TO_SUBTRACT 1        /* the number of conditions to subtract
+                                                         * from status on recv completion.
+                                                         * Only one for recv start.
+                                                         */
 
 /* Atomically increase partitioned rreq status and fetch state after increase.
  * Called when receiver matches request, sender receives CTS, or either side calls start. */

--- a/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
@@ -65,8 +65,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_part_match_rreq(MPIR_Request * part_req)
             part_req->status.MPI_ERROR =
                 MPIR_Err_create_code(part_req->status.MPI_ERROR, MPIR_ERR_RECOVERABLE, __FUNCTION__,
                                      __LINE__, MPI_ERR_OTHER, "**ch4|partmismatchsize",
-                                     "**ch4|partmismatchsize %d %d %d %d",
-                                     part_req->status.MPI_SOURCE, part_req->status.MPI_TAG,
+                                     "**ch4|partmismatchsize %d %d",
                                      (int) rdata_size, (int) sdata_size);
         }
     }


### PR DESCRIPTION
## Pull Request Description

There is a possibility the next round of CTS can arrive before the sender side completes. This bug sporadically triggered and happens more often on FreeBSD. This PR fixes it by always using arithmetic rather than resetting the status on completion. (`MPL_atomic_fetch_sub_int` rather than `MPL_atomic_store_int`).

reference current nightly tests https://jenkins-pmrs.cels.anl.gov/job/mpich-main-ch4-freebsd/229/testReport/
```
summary_junit_xml. - ./part/start_pready 2 -spart=1 -rpart=1 -tot_count=64 -range=1 -iteration=5 | 3 min 0 sec | 1
summary_junit_xml. - ./part/parrived_wait 2 -spart=1 -rpart=1 -tot_count=64 -iteration=5 | 3 min 0 sec | 1
```
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
