### PR TITLE
ch3: fix ubsan warning on 32bit

### DIFF
--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_defs.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_defs.h
@@ -29,7 +29,6 @@ extern char MPID_nem_hostname[MAX_HOSTNAME_LEN];
 #define MPID_NEM_POLL_OUT     1
 
 #define MPID_NEM_ASYMM_NULL_VAL    64
-typedef MPI_Aint MPID_nem_addr_t;
 extern  char *MPID_nem_asymm_base_addr;
 
 #define MPID_NEM_REL_NULL (0x0)
@@ -42,13 +41,14 @@ extern  char *MPID_nem_asymm_base_addr;
 
 static inline MPID_nem_cell_ptr_t MPID_NEM_REL_TO_ABS (MPID_nem_cell_rel_ptr_t r)
 {
-    return (MPID_nem_cell_ptr_t)((char*)MPL_atomic_relaxed_load_ptr(&r.p) + (MPID_nem_addr_t)MPID_nem_asymm_base_addr);
+    void *p = MPL_atomic_relaxed_load_ptr(&r.p);
+    return (MPID_nem_cell_ptr_t) (void *) ((uintptr_t) p + (uintptr_t) MPID_nem_asymm_base_addr);
 }
 
 static inline MPID_nem_cell_rel_ptr_t MPID_NEM_ABS_TO_REL (MPID_nem_cell_ptr_t a)
 {
     MPID_nem_cell_rel_ptr_t ret;
-    MPL_atomic_relaxed_store_ptr(&ret.p, (char *)a - (MPID_nem_addr_t)MPID_nem_asymm_base_addr);
+    MPL_atomic_relaxed_store_ptr(&ret.p, (void *) ((uintptr_t) a - (uintptr_t) MPID_nem_asymm_base_addr));
     return ret;
 }
 

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_defs.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_defs.h
@@ -39,6 +39,11 @@ extern  char *MPID_nem_asymm_base_addr;
 
 #ifndef MPID_NEM_SYMMETRIC_QUEUES
 
+/* NOTE: we are casting to uintptr_t and using integer arithmetic here. While it is pedantically
+ * undefined usage, we don't anticipate issues because the REL addresses will not be directly accessed,
+ * and only consistency matters. We can't use pointer arithmetic here because both the address
+ * (p or a) and MPID_nem_asymm_base_addr could overflow `ptrdiff_t`.
+ */
 static inline MPID_nem_cell_ptr_t MPID_NEM_REL_TO_ABS (MPID_nem_cell_rel_ptr_t r)
 {
     void *p = MPL_atomic_relaxed_load_ptr(&r.p);


### PR DESCRIPTION
## Pull Request Description
Casting address to MPI_Aint let ubsan complain about integer overflow.
Use uintptr_t in stead.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
