### PR TITLE
ch4/rma: fix coverity error in win_get_info

### DIFF
--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -114,8 +114,7 @@ static void get_info_perf_preference_str(int val, char *buf, size_t maxlen)
     int c = 0;
 
     if (val & (1 << MPIDIG_RMA_LAT_PREFERRED)) {
-        MPIR_Assert(c < maxlen);
-        c += snprintf(buf + c, maxlen - c, "%slat", (c > 0) ? "," : "");
+        c += snprintf(buf, maxlen, "lat");
     }
     if (val & (1 << MPIDIG_RMA_MR_PREFERRED)) {
         MPIR_Assert(c < maxlen);


### PR DESCRIPTION
It fixes "Execution cannot reach the expression "","" issue at line 118 in function `get_info_perf_preference_str`.

The original code used same code in both branches. But in the first branch the value of `c` is guaranteed to be zero, thus `(c > 0) ? "," : ""` can never reach the `","` part. Coverity reported this issue.

## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
