### PR TITLE
ch4/ofi: reduce av table dimensions

### DIFF
--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -8,6 +8,16 @@
 
 #include "coll_impl.h"
 
+/* During init, not all algorithms are safe to use. For example, the csel
+ * may not have been initialized. We define a set of fallback routines that
+ * are safe to use during init. They are all intra algorithms.
+ */
+#define MPIR_Barrier_fallback    MPIR_Barrier_intra_dissemination
+#define MPIR_Allgather_fallback  MPIR_Allgather_intra_brucks
+#define MPIR_Allgatherv_fallback MPIR_Allgatherv_intra_brucks
+#define MPIR_Allreduce_fallback  MPIR_Allreduce_intra_recursive_doubling
+
+
 /* Internal point-to-point communication for collectives */
 /* These functions are used in the implementation of collective and
    other internal operations. They are wrappers around MPID send/recv

--- a/src/mpid/ch4/netmod/ofi/Makefile.mk
+++ b/src/mpid/ch4/netmod/ofi/Makefile.mk
@@ -23,6 +23,7 @@ mpi_core_sources   += src/mpid/ch4/netmod/ofi/func_table.c \
                       src/mpid/ch4/netmod/ofi/globals.c \
                       src/mpid/ch4/netmod/ofi/init_provider.c \
                       src/mpid/ch4/netmod/ofi/init_settings.c \
+                      src/mpid/ch4/netmod/ofi/init_addrxchg.c \
                       src/mpid/ch4/netmod/ofi/util.c
 errnames_txt_files += src/mpid/ch4/netmod/ofi/errnames.txt
 external_subdirs   += @ofisrcdir@

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -218,8 +218,8 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
     /* Allgather */
     MPIR_Comm *comm = MPIR_Process.comm_world;
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-    mpi_errno = MPIR_Allgather_allcomm_auto(MPI_IN_PLACE, 0, MPI_BYTE,
-                                            all_names, my_len, MPI_BYTE, comm, &errflag);
+    mpi_errno = MPIR_Allgather_fallback(MPI_IN_PLACE, 0, MPI_BYTE,
+                                        all_names, my_len, MPI_BYTE, comm, &errflag);
 
     /* Step 2: insert and store non-root nic/vni on the root context */
     int root_ctx_idx = MPIDI_OFI_get_ctx_index(0, 0);

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -119,7 +119,7 @@ int MPIDI_OFI_addr_exchange_root_ctx(MPIR_Comm * init_comm)
                 char *addrname = (char *) table + recv_bc_len * rank_map[i];
                 MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[0].av,
                                             addrname, 1, &addr, 0ULL, NULL), avmap);
-                MPIDI_OFI_AV(&MPIDIU_get_av(0, rank)).dest[0][0] = addr;
+                MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[0][0] = addr;
             }
         }
         MPIDU_bc_table_destroy();

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "ofi_impl.h"
+#include "ofi_init.h"
+#include "mpidu_bc.h"
+
+/* NOTE on av insertion order:
+ *
+ * Each nic-vni is an endpoint with a unique address, and inside libfabric maintains
+ * one av table. Thus to fully store the address mapping, we'll need a multi-dim table as
+ *     av_table[src_nic][src_vni][dest_rank][dest_nic][dest_vni]
+ * Note, this table is for illustration, and different from MPIDI_OFI_addr_t.
+ *
+ * However, if we insert the address carefully, we can manage to make the av table inside
+ * each endpoint *identical*. Then, we can omit the dimension of [src_nic][src_vni].
+ *
+ * To achieve that, we use the following 3-step process (described with above illustrative av_table).
+ *
+ * Step 1. insert and store       av_table[ 0 ][ 0 ][rank][ 0 ][ 0 ]
+ *
+ * Step 2. insert and store       av_table[ 0 ][ 0 ][rank][nic][vni]
+ *
+ * Step 3. insert (but not store) av_table[nic][vni][rank][nic][vni]
+ *
+ * The step 1 is done in addr_exchange_root_vni. Step 2 and 3 are done in addr_exchange_all_vnis.
+ * Step 3 populates av tables inside libfabric for all non-zero endpoints, but they should be
+ * identical to the table in root endpoint, thus no need to store them in mpich. Thus the table is
+ * reduced to
+ *      av_table[rank] -> dest[nic][vni]
+ *
+ * With single-nic and single-vni, only step 1 is needed.
+ *
+ * We do step 1 during world-init, and step 2 & 3 during post-init. The separation
+ * isolates multi-nic/vni complications from bootstrapping phase.
+ */
+
+/* with MPIDI_OFI_ENABLE_AV_TABLE, we potentially can omit storing av tables.
+ * The following routines ensures we can do that. It is static now, but we can
+ * easily export to global when we need to.
+ */
+static int get_av_table_index(int rank, int nic, int vni)
+{
+    if (nic == 0 && vni == 0) {
+        if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
+            /* check node roots */
+            for (int i = 0; i < MPIR_Process.num_nodes; i++) {
+                if (MPIR_Process.node_root_map[i] == rank) {
+                    return i;
+                }
+            }
+            /* must be non-node-root */
+            int num_later_nodes = MPIR_Process.num_nodes - (MPIR_Process.node_map[rank] + 1);
+            return rank + num_later_nodes;
+        } else {
+            return rank;
+        }
+    } else {
+        int num_vnis = MPIDI_OFI_global.num_vnis;
+        int num_nics = MPIDI_OFI_global.num_nics;
+        int num_later_ranks = MPIR_Process.size - (rank + 1);
+        return rank * num_nics * num_vnis + nic * num_vnis + vni + num_later_ranks;
+    }
+}
+
+/* Step 1: exchange root contexts */
+int MPIDI_OFI_addr_exchange_root_ctx(MPIR_Comm * init_comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int size = MPIR_Process.size;
+    int rank = MPIR_Process.rank;
+
+    /* No pre-published address table, need do address exchange. */
+    /* First, each get its own name */
+    MPIDI_OFI_global.addrnamelen = FI_NAME_MAX;
+    MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[0].ep, MPIDI_OFI_global.addrname,
+                              &MPIDI_OFI_global.addrnamelen), getname);
+    MPIR_Assert(MPIDI_OFI_global.addrnamelen <= FI_NAME_MAX);
+
+    /* Second, exchange names using PMI */
+    /* If MPIR_CVAR_CH4_ROOTS_ONLY_PMI is true, we only collect a table of node-roots.
+     * Otherwise, we collect a table of everyone. */
+    void *table = NULL;
+    mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map[0],
+                                      &MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
+                                      TRUE, MPIR_CVAR_CH4_ROOTS_ONLY_PMI, &table, NULL);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* Third, each fi_av_insert those addresses */
+    if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
+        /* if "ROOTS_ONLY", we do a two stage bootstrapping ... */
+        int num_nodes = MPIR_Process.num_nodes;
+        int *node_roots = MPIR_Process.node_root_map;
+        int *rank_map, recv_bc_len;
+
+        /* First, insert address of node-roots, init_comm become useful */
+        fi_addr_t *mapped_table;
+        mapped_table = (fi_addr_t *) MPL_malloc(num_nodes * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
+        MPIDI_OFI_CALL(fi_av_insert
+                       (MPIDI_OFI_global.ctx[0].av, table, num_nodes, mapped_table, 0ULL, NULL),
+                       avmap);
+
+        for (int i = 0; i < num_nodes; i++) {
+            MPIR_Assert(mapped_table[i] != FI_ADDR_NOTAVAIL);
+            MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).dest[0][0] = mapped_table[i];
+        }
+        MPL_free(mapped_table);
+        /* Then, allgather all address names using init_comm */
+        MPIDU_bc_allgather(init_comm, MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
+                           TRUE, &table, &rank_map, &recv_bc_len);
+
+        /* Insert the rest of the addresses */
+        for (int i = 0; i < MPIR_Process.size; i++) {
+            if (rank_map[i] >= 0) {
+                fi_addr_t addr;
+                char *addrname = (char *) table + recv_bc_len * rank_map[i];
+                MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[0].av,
+                                            addrname, 1, &addr, 0ULL, NULL), avmap);
+                MPIDI_OFI_AV(&MPIDIU_get_av(0, rank)).dest[0][0] = addr;
+            }
+        }
+        MPIDU_bc_table_destroy();
+    } else {
+        /* not "ROOTS_ONLY", we already have everyone's address name, insert all of them */
+        fi_addr_t *mapped_table;
+        mapped_table = (fi_addr_t *) MPL_malloc(size * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
+        MPIDI_OFI_CALL(fi_av_insert
+                       (MPIDI_OFI_global.ctx[0].av, table, size, mapped_table, 0ULL, NULL), avmap);
+
+        for (int i = 0; i < size; i++) {
+            MPIR_Assert(mapped_table[i] != FI_ADDR_NOTAVAIL);
+            MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[0][0] = mapped_table[i];
+        }
+        MPL_free(mapped_table);
+        MPIDU_bc_table_destroy();
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* Step 2 & 3: exchange non-root contexts */
+
+/* Macros to reduce clutter, so we can focus on the ordering logics.
+ * Note: they are not perfectly-wraaped, but tolearable since only used here. */
+#define GET_AV_AND_ADDRNAMES(rank) \
+    MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(&MPIDIU_get_av(0, rank)); \
+    char *r_names = all_names + rank * num_vnis * num_nics * name_len;
+
+#define DO_AV_INSERT(ctx_idx, nic, vni) \
+    fi_addr_t addr; \
+    MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[ctx_idx].av, \
+                                r_names + (vni * num_nics + nic) * name_len, 1, \
+                                &addr, 0ULL, NULL), avmap);
+
+#define SKIP_ROOT(nic, vni) \
+    if (nic == 0 && vni == 0) { \
+        continue; \
+    }
+
+int MPIDI_OFI_addr_exchange_all_ctx(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    int size = MPIR_Process.size;
+    int rank = MPIR_Process.rank;
+    int num_vnis = MPIDI_OFI_global.num_vnis;
+    int num_nics = MPIDI_OFI_global.num_nics;
+    MPIR_CHKLMEM_DECL(2);
+
+#ifndef MPIDI_OFI_VNI_USE_DOMAIN
+    /* with scalable endpoint as context, all vnis share the same address. For the
+     * purpose of address exchange, we hack it as having single vni.
+     */
+    num_vnis = 1;
+#endif
+
+    if (num_nics * num_vnis == 1) {
+        /* root address exchange already done. */
+        goto fn_check;
+    }
+
+    int *is_node_roots = NULL;
+    if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
+        MPIR_CHKLMEM_MALLOC(is_node_roots, int *, size * sizeof(int),
+                            mpi_errno, "is_node_roots", MPL_MEM_ADDRESS);
+        for (int r = 0; r < size; r++) {
+            is_node_roots[r] = 0;
+        }
+        for (int i = 0; i < MPIR_Process.num_nodes; i++) {
+            is_node_roots[MPIR_Process.node_root_map[i]] = 1;
+        }
+    }
+
+    /* libfabric uses uniform name_len within a single provider */
+    int name_len = MPIDI_OFI_global.addrnamelen;
+    int my_len = num_vnis * num_nics * name_len;
+    char *all_names;
+    MPIR_CHKLMEM_MALLOC(all_names, char *, size * my_len, mpi_errno, "all_names", MPL_MEM_ADDRESS);
+    char *my_names = all_names + rank * my_len;
+
+    /* put in my addrnames */
+    for (int nic = 0; nic < num_nics; nic++) {
+        for (int vni = 0; vni < num_vnis; vni++) {
+            size_t actual_name_len = name_len;
+            char *vni_addrname = my_names + (vni * num_nics + nic) * name_len;
+            int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+            MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[ctx_idx].ep, vni_addrname,
+                                      &actual_name_len), getname);
+            MPIR_Assert(actual_name_len == name_len);
+        }
+    }
+    /* Allgather */
+    MPIR_Comm *comm = MPIR_Process.comm_world;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    mpi_errno = MPIR_Allgather_allcomm_auto(MPI_IN_PLACE, 0, MPI_BYTE,
+                                            all_names, my_len, MPI_BYTE, comm, &errflag);
+
+    /* Step 2: insert and store non-root nic/vni on the root context */
+    int root_ctx_idx = MPIDI_OFI_get_ctx_index(0, 0);
+    for (int r = 0; r < size; r++) {
+        GET_AV_AND_ADDRNAMES(r);
+        for (int nic = 0; nic < num_nics; nic++) {
+            for (int vni = 0; vni < num_vnis; vni++) {
+                SKIP_ROOT(nic, vni);
+                DO_AV_INSERT(root_ctx_idx, nic, vni);
+                av->dest[nic][vni] = addr;
+            }
+        }
+    }
+
+    /* Step 3: insert all nic/vni on non-root context, following exact order as step 1 and 2 */
+    for (int nic_local = 0; nic_local < num_nics; nic_local++) {
+        for (int vni_local = 0; vni_local < num_vnis; vni_local++) {
+            SKIP_ROOT(nic_local, vni_local);
+            int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic_local);
+
+            /* -- same order as step 1 -- */
+            if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
+                /* node roots */
+                for (int r = 0; r < size; r++) {
+                    if (is_node_roots[r]) {
+                        GET_AV_AND_ADDRNAMES(r);
+                        DO_AV_INSERT(ctx_idx, 0, 0);
+                        MPIR_Assert(av->dest[0][0] == addr);
+                    }
+                }
+                /* non-node-root */
+                for (int r = 0; r < size; r++) {
+                    if (!is_node_roots[r]) {
+                        GET_AV_AND_ADDRNAMES(r);
+                        DO_AV_INSERT(ctx_idx, 0, 0);
+                        MPIR_Assert(av->dest[0][0] == addr);
+                    }
+                }
+            } else {
+                /* !MPIR_CVAR_CH4_ROOTS_ONLY_PMI */
+                for (int r = 0; r < size; r++) {
+                    GET_AV_AND_ADDRNAMES(r);
+                    DO_AV_INSERT(ctx_idx, 0, 0);
+                    MPIR_Assert(av->dest[0][0] == addr);
+                }
+            }
+
+            /* -- same order as step 2 -- */
+            for (int r = 0; r < size; r++) {
+                GET_AV_AND_ADDRNAMES(r);
+                for (int nic = 0; nic < num_nics; nic++) {
+                    for (int vni = 0; vni < num_vnis; vni++) {
+                        SKIP_ROOT(nic, vni);
+                        DO_AV_INSERT(ctx_idx, nic, vni);
+                        MPIR_Assert(av->dest[nic][vni] == addr);
+                    }
+                }
+            }
+        }
+    }
+
+  fn_check:
+    if (MPIDI_OFI_ENABLE_AV_TABLE) {
+        for (int r = 0; r < size; r++) {
+            MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(&MPIDIU_get_av(0, r));
+            for (int nic = 0; nic < num_nics; nic++) {
+                for (int vni = 0; vni < num_vnis; vni++) {
+                    MPIR_Assert(av->dest[nic][vni] == get_av_table_index(r, nic, vni));
+                }
+            }
+        }
+    }
+  fn_exit:
+    MPIR_CHKLMEM_FREEALL();
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -23,7 +23,7 @@
 #define MPIDI_OFI_COMM_TO_INDEX(comm,rank) \
     MPIDIU_comm_rank_to_pid(comm, rank, NULL, NULL)
 #define MPIDI_OFI_TO_PHYS(avtid, lpid, _nic) \
-    MPIDI_OFI_AV(&MPIDIU_get_av((avtid), (lpid))).dest[_nic][0][0]
+    MPIDI_OFI_AV(&MPIDIU_get_av((avtid), (lpid))).dest[_nic][0]
 
 #define MPIDI_OFI_WIN(win)     ((win)->dev.netmod.ofi)
 
@@ -446,18 +446,16 @@ MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_av_to_phys(MPIDI_av_entry_t * av, i
 {
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        return fi_rx_addr(MPIDI_OFI_AV(av).dest[nic][vni_local][vni_remote], 0,
-                          MPIDI_OFI_MAX_ENDPOINTS_BITS);
+        return fi_rx_addr(MPIDI_OFI_AV(av).dest[nic][vni_remote], 0, MPIDI_OFI_MAX_ENDPOINTS_BITS);
     } else {
-        return MPIDI_OFI_AV(av).dest[nic][vni_local][vni_remote];
+        return MPIDI_OFI_AV(av).dest[nic][vni_remote];
     }
 #else /* MPIDI_OFI_VNI_USE_SEPCTX */
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        return fi_rx_addr(MPIDI_OFI_AV(av).dest[nic][0][0], vni_remote,
-                          MPIDI_OFI_MAX_ENDPOINTS_BITS);
+        return fi_rx_addr(MPIDI_OFI_AV(av).dest[nic][0], vni_remote, MPIDI_OFI_MAX_ENDPOINTS_BITS);
     } else {
         MPIR_Assert(vni_remote == 0);
-        return MPIDI_OFI_AV(av).dest[nic][0][0];
+        return MPIDI_OFI_AV(av).dest[nic][0];
     }
 #endif
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -5,7 +5,6 @@
 
 #include "mpidimpl.h"
 #include "ofi_impl.h"
-#include "mpidu_bc.h"
 #include "ofi_noinline.h"
 #include "mpir_hwtopo.h"
 #include "ofi_init.h"
@@ -414,9 +413,6 @@ static void dump_dynamic_settings(void);
 static int create_vni_context(int vni, int nic);
 static int destroy_vni_context(int vni, int nic);
 
-static int addr_exchange_root_vni(MPIR_Comm * init_comm);
-static int addr_exchange_all_vnis(void);
-
 static void *host_alloc(uintptr_t size);
 static void *host_alloc_registered(uintptr_t size);
 static void host_free(void *ptr);
@@ -608,7 +604,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     /* If opening a named-AV didn't work, we need to do a full business card exchange for the first
      * VNI. All other VNIs can copy the address information from this on after the fact. */
     if (!MPIDI_OFI_global.got_named_av) {
-        mpi_errno = addr_exchange_root_vni(init_comm);
+        mpi_errno = MPIDI_OFI_addr_exchange_root_ctx(init_comm);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -921,7 +917,7 @@ int MPIDI_OFI_post_init(void)
     }
 
     if (MPIDI_OFI_global.num_vnis > 1 || MPIDI_OFI_global.num_nics > 1) {
-        mpi_errno = addr_exchange_all_vnis();
+        mpi_errno = MPIDI_OFI_addr_exchange_all_ctx();
     }
   fn_fail:
     return mpi_errno;
@@ -1464,287 +1460,4 @@ static void dump_dynamic_settings(void)
     fprintf(stdout, "num_vnis: %d\n", MPIDI_OFI_global.num_vnis);
     fprintf(stdout, "num_nics: %d\n", MPIDI_OFI_global.num_nics);
     fprintf(stdout, "======================================\n");
-}
-
-/* static address exchange routines */
-static int addr_exchange_root_vni(MPIR_Comm * init_comm)
-{
-    int mpi_errno = MPI_SUCCESS;
-    int size = MPIR_Process.size;
-    int rank = MPIR_Process.rank;
-
-    /* No pre-published address table, need do address exchange. */
-    /* First, each get its own name */
-    MPIDI_OFI_global.addrnamelen = FI_NAME_MAX;
-    MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[0].ep, MPIDI_OFI_global.addrname,
-                              &MPIDI_OFI_global.addrnamelen), getname);
-    MPIR_Assert(MPIDI_OFI_global.addrnamelen <= FI_NAME_MAX);
-
-    /* Second, exchange names using PMI */
-    /* If MPIR_CVAR_CH4_ROOTS_ONLY_PMI is true, we only collect a table of node-roots.
-     * Otherwise, we collect a table of everyone. */
-    void *table = NULL;
-    mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map[0],
-                                      &MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
-                                      TRUE, MPIR_CVAR_CH4_ROOTS_ONLY_PMI, &table, NULL);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    /* Third, each fi_av_insert those addresses */
-    if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-        /* if "ROOTS_ONLY", we do a two stage bootstrapping ... */
-        int num_nodes = MPIR_Process.num_nodes;
-        int *node_roots = MPIR_Process.node_root_map;
-        int *rank_map, recv_bc_len;
-
-        /* First, insert address of node-roots, init_comm become useful */
-        fi_addr_t *mapped_table;
-        mapped_table = (fi_addr_t *) MPL_malloc(num_nodes * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
-        MPIDI_OFI_CALL(fi_av_insert
-                       (MPIDI_OFI_global.ctx[0].av, table, num_nodes, mapped_table, 0ULL, NULL),
-                       avmap);
-
-        for (int i = 0; i < num_nodes; i++) {
-            MPIR_Assert(mapped_table[i] != FI_ADDR_NOTAVAIL);
-            MPIDI_OFI_AV(&MPIDIU_get_av(0, node_roots[i])).dest[0][0] = mapped_table[i];
-        }
-        MPL_free(mapped_table);
-        /* Then, allgather all address names using init_comm */
-        MPIDU_bc_allgather(init_comm, MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
-                           TRUE, &table, &rank_map, &recv_bc_len);
-
-        /* Insert the rest of the addresses */
-        for (int i = 0; i < MPIR_Process.size; i++) {
-            if (rank_map[i] >= 0) {
-                fi_addr_t addr;
-                char *addrname = (char *) table + recv_bc_len * rank_map[i];
-                MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[0].av,
-                                            addrname, 1, &addr, 0ULL, NULL), avmap);
-                MPIDI_OFI_AV(&MPIDIU_get_av(0, rank)).dest[0][0] = addr;
-            }
-        }
-        MPIDU_bc_table_destroy();
-    } else {
-        /* not "ROOTS_ONLY", we already have everyone's address name, insert all of them */
-        fi_addr_t *mapped_table;
-        mapped_table = (fi_addr_t *) MPL_malloc(size * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
-        MPIDI_OFI_CALL(fi_av_insert
-                       (MPIDI_OFI_global.ctx[0].av, table, size, mapped_table, 0ULL, NULL), avmap);
-
-        for (int i = 0; i < size; i++) {
-            MPIR_Assert(mapped_table[i] != FI_ADDR_NOTAVAIL);
-            MPIDI_OFI_AV(&MPIDIU_get_av(0, i)).dest[0][0] = mapped_table[i];
-        }
-        MPL_free(mapped_table);
-        MPIDU_bc_table_destroy();
-    }
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-/* NOTE on av insertion order:
- * Each nic-vni is an endpoint with a unique address, and inside libfabric maintains
- * one av table. Thus to fully store the address mapping, we'll need a multi-dim table as
- *     av_table[src_nic][src_vni][dest_rank][dest_nic][dest_vni]
- * Note, this table is for illustration, and different from MPIDI_OFI_addr_t.
- *
- * However, if we insert the address carefully, we can manage to make the av table inside
- * each endpoint *identical*. Then, we can omit the dimension of [src_nic][src_vni].
- *
- * To achieve that, we use the following 3-step process (described with above illustrative av_table).
- *
- * 1. insert and store       av_table[ 0 ][ 0 ][rank][ 0 ][ 0 ]
- *
- * 2. insert and store       av_table[ 0 ][ 0 ][rank][nic][vni]
- *
- * 3. insert (but not store) av_table[nic][vni][rank][nic][vni]
- *
- * The step 1 is done in addr_exchange_root_vni. Step 2 and 3 are done in addr_exchange_all_vnis.
- * Step 3 populates av tables inside libfabric for all non-zero endpoints, but they should be
- * identical to the table in root endpoint, thus no need to store them in mpich. Thus the table is
- * reduced to
- *      av_table[rank] -> dest[nic][vni]
- */
-
-/* with MPIDI_OFI_ENABLE_AV_TABLE, we potentially can omit storing av tables.
- * The following routines ensures we can do that. It is static now, but we can
- * easily export to global when we need to.
- */
-static int get_av_table_index(int rank, int nic, int vni)
-{
-    if (nic == 0 && vni == 0) {
-        if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-            /* check node roots */
-            for (int i = 0; i < MPIR_Process.num_nodes; i++) {
-                if (MPIR_Process.node_root_map[i] == rank) {
-                    return i;
-                }
-            }
-            /* must be non-node-root */
-            int num_later_nodes = MPIR_Process.num_nodes - (MPIR_Process.node_map[rank] + 1);
-            return rank + num_later_nodes;
-        } else {
-            return rank;
-        }
-    } else {
-        int num_vnis = MPIDI_OFI_global.num_vnis;
-        int num_nics = MPIDI_OFI_global.num_nics;
-        int num_later_ranks = MPIR_Process.size - (rank + 1);
-        return rank * num_nics * num_vnis + nic * num_vnis + vni + num_later_ranks;
-    }
-}
-
-/* Macros to reduce clutter, so we can focus on the ordering logics.
- * Note: they are not perfectly-wraaped, but tolearable since only used here. */
-#define GET_AV_AND_ADDRNAMES(rank) \
-    MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(&MPIDIU_get_av(0, rank)); \
-    char *r_names = all_names + rank * num_vnis * num_nics * name_len;
-
-#define DO_AV_INSERT(ctx_idx, nic, vni) \
-    fi_addr_t addr; \
-    MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[ctx_idx].av, \
-                                r_names + (vni * num_nics + nic) * name_len, 1, \
-                                &addr, 0ULL, NULL), avmap);
-
-#define SKIP_ROOT(nic, vni) \
-    if (nic == 0 && vni == 0) { \
-        continue; \
-    }
-
-static int addr_exchange_all_vnis(void)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    int size = MPIR_Process.size;
-    int rank = MPIR_Process.rank;
-    int num_vnis = MPIDI_OFI_global.num_vnis;
-    int num_nics = MPIDI_OFI_global.num_nics;
-    MPIR_CHKLMEM_DECL(2);
-
-#ifndef MPIDI_OFI_VNI_USE_DOMAIN
-    /* with scalable endpoint as context, all vnis share the same address. For the
-     * purpose of address exchange, we hack it as having single vni.
-     */
-    num_vnis = 1;
-#endif
-
-    if (num_nics * num_vnis == 1) {
-        /* root address exchange already done. */
-        goto fn_check;
-    }
-
-    int *is_node_roots = NULL;
-    if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-        MPIR_CHKLMEM_MALLOC(is_node_roots, int *, size * sizeof(int),
-                            mpi_errno, "is_node_roots", MPL_MEM_ADDRESS);
-        for (int r = 0; r < size; r++) {
-            is_node_roots[r] = 0;
-        }
-        for (int i = 0; i < MPIR_Process.num_nodes; i++) {
-            is_node_roots[MPIR_Process.node_root_map[i]] = 1;
-        }
-    }
-
-    /* libfabric uses uniform name_len within a single provider */
-    int name_len = MPIDI_OFI_global.addrnamelen;
-    int my_len = num_vnis * num_nics * name_len;
-    char *all_names;
-    MPIR_CHKLMEM_MALLOC(all_names, char *, size * my_len, mpi_errno, "all_names", MPL_MEM_ADDRESS);
-    char *my_names = all_names + rank * my_len;
-
-    /* put in my addrnames */
-    for (int nic = 0; nic < num_nics; nic++) {
-        for (int vni = 0; vni < num_vnis; vni++) {
-            size_t actual_name_len = name_len;
-            char *vni_addrname = my_names + (vni * num_nics + nic) * name_len;
-            int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
-            MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[ctx_idx].ep, vni_addrname,
-                                      &actual_name_len), getname);
-            MPIR_Assert(actual_name_len == name_len);
-        }
-    }
-    /* Allgather */
-    MPIR_Comm *comm = MPIR_Process.comm_world;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-    mpi_errno = MPIR_Allgather_allcomm_auto(MPI_IN_PLACE, 0, MPI_BYTE,
-                                            all_names, my_len, MPI_BYTE, comm, &errflag);
-
-    /* Step 2: insert and store non-root nic/vni on the root context */
-    int root_ctx_idx = MPIDI_OFI_get_ctx_index(0, 0);
-    for (int r = 0; r < size; r++) {
-        GET_AV_AND_ADDRNAMES(r);
-        for (int nic = 0; nic < num_nics; nic++) {
-            for (int vni = 0; vni < num_vnis; vni++) {
-                SKIP_ROOT(nic, vni);
-                DO_AV_INSERT(root_ctx_idx, nic, vni);
-                av->dest[nic][vni] = addr;
-            }
-        }
-    }
-
-    /* Step 3: insert all nic/vni on non-root context, following exact order as step 1 and 2 */
-    for (int nic_local = 0; nic_local < num_nics; nic_local++) {
-        for (int vni_local = 0; vni_local < num_vnis; vni_local++) {
-            SKIP_ROOT(nic_local, vni_local);
-            int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic_local);
-
-            /* -- same order as step 1 -- */
-            if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-                /* node roots */
-                for (int r = 0; r < size; r++) {
-                    if (is_node_roots[r]) {
-                        GET_AV_AND_ADDRNAMES(r);
-                        DO_AV_INSERT(ctx_idx, 0, 0);
-                        MPIR_Assert(av->dest[0][0] == addr);
-                    }
-                }
-                /* non-node-root */
-                for (int r = 0; r < size; r++) {
-                    if (!is_node_roots[r]) {
-                        GET_AV_AND_ADDRNAMES(r);
-                        DO_AV_INSERT(ctx_idx, 0, 0);
-                        MPIR_Assert(av->dest[0][0] == addr);
-                    }
-                }
-            } else {
-                /* !MPIR_CVAR_CH4_ROOTS_ONLY_PMI */
-                for (int r = 0; r < size; r++) {
-                    GET_AV_AND_ADDRNAMES(r);
-                    DO_AV_INSERT(ctx_idx, 0, 0);
-                    MPIR_Assert(av->dest[0][0] == addr);
-                }
-            }
-
-            /* -- same order as step 2 -- */
-            for (int r = 0; r < size; r++) {
-                GET_AV_AND_ADDRNAMES(r);
-                for (int nic = 0; nic < num_nics; nic++) {
-                    for (int vni = 0; vni < num_vnis; vni++) {
-                        SKIP_ROOT(nic, vni);
-                        DO_AV_INSERT(ctx_idx, nic, vni);
-                        MPIR_Assert(av->dest[nic][vni] == addr);
-                    }
-                }
-            }
-        }
-    }
-
-  fn_check:
-    if (MPIDI_OFI_ENABLE_AV_TABLE) {
-        for (int r = 0; r < size; r++) {
-            MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(&MPIDIU_get_av(0, r));
-            for (int nic = 0; nic < num_nics; nic++) {
-                for (int vni = 0; vni < num_vnis; vni++) {
-                    MPIR_Assert(av->dest[nic][vni] == get_av_table_index(r, nic, vni));
-                }
-            }
-        }
-    }
-  fn_exit:
-    MPIR_CHKLMEM_FREEALL();
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1643,14 +1643,17 @@ static int addr_exchange_all_vnis(void)
 
             /* same order as step 1 */
             for (int r = 0; r < size; r++) {
+                MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(&MPIDIU_get_av(0, r));
                 char *r_name = all_names + r * num_vnis * num_nics * name_len;
                 fi_addr_t addr;
                 MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[ctx_idx].av,
                                             r_name, 1, &addr, 0ULL, NULL), avmap);
+                MPIR_Assert(av->dest[0][0] == addr);
             }
 
             /* same order as step 2 */
             for (int r = 0; r < size; r++) {
+                MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(&MPIDIU_get_av(0, r));
                 char *r_names = all_names + r * num_vnis * num_nics * name_len;
                 for (int nic = 0; nic < num_nics; nic++) {
                     for (int vni = 0; vni < num_vnis; vni++) {
@@ -1662,6 +1665,7 @@ static int addr_exchange_all_vnis(void)
                         MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[ctx_idx].av,
                                                     r_names + (vni * num_nics + nic) * name_len, 1,
                                                     &addr, 0ULL, NULL), avmap);
+                        MPIR_Assert(av->dest[nic][vni] == addr);
                     }
                 }
             }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -32,4 +32,7 @@ void MPIDI_OFI_update_global_settings(struct fi_info *prov);
 /* Determine if NIC has already been included in others */
 bool MPIDI_OFI_nic_already_used(const struct fi_info *prov, struct fi_info **others, int nic_count);
 
+int MPIDI_OFI_addr_exchange_root_ctx(MPIR_Comm * init_comm);
+int MPIDI_OFI_addr_exchange_all_ctx(void);
+
 #endif /* OFI_INIT_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -255,9 +255,9 @@ typedef struct {
 
 typedef struct {
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
-    fi_addr_t dest[MPIDI_OFI_MAX_NICS][MPIDI_CH4_MAX_VCIS][MPIDI_CH4_MAX_VCIS]; /* [nic][local_vni][remote_vni] */
+    fi_addr_t dest[MPIDI_OFI_MAX_NICS][MPIDI_CH4_MAX_VCIS];     /* [nic][vni] */
 #else
-    fi_addr_t dest[MPIDI_OFI_MAX_NICS][1][1];
+    fi_addr_t dest[MPIDI_OFI_MAX_NICS][1];
 #endif
 } MPIDI_OFI_addr_t;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -882,7 +882,7 @@ int MPIDI_OFI_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_
             MPIDI_OFI_VCI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[ctx_idx].av, new_upids[i],
                                             1, &addr, 0ULL, NULL), 0, avmap);
             MPIR_Assert(addr != FI_ADDR_NOTAVAIL);
-            MPIDI_OFI_AV(&MPIDIU_get_av(avtid, i)).dest[nic][0][0] = addr;
+            MPIDI_OFI_AV(&MPIDIU_get_av(avtid, i)).dest[nic][0] = addr;
             /* highest bit is marked as 1 to indicate this is a new process */
             (*remote_lupids)[new_avt_procs[i]] = MPIDIU_LUPID_CREATE(avtid, i);
             MPIDIU_LUPID_SET_NEW_AVT_MARK((*remote_lupids)[new_avt_procs[i]]);
@@ -915,7 +915,7 @@ int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char 
     for (i = 0; i < comm->local_size; i++) {
         (*local_upid_size)[i] = MPIDI_OFI_global.addrnamelen;
         MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(MPIDIU_comm_rank_to_av(comm, i));
-        MPIDI_OFI_VCI_CALL(fi_av_lookup(MPIDI_OFI_global.ctx[ctx_idx].av, av->dest[nic][0][0],
+        MPIDI_OFI_VCI_CALL(fi_av_lookup(MPIDI_OFI_global.ctx[ctx_idx].av, av->dest[nic][0],
                                         &temp_buf[i * MPIDI_OFI_global.addrnamelen],
                                         &(*local_upid_size)[i]), 0, avlookup);
         total_size += (*local_upid_size)[i];

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -314,6 +314,7 @@ static int create_init_comm(MPIR_Comm ** comm)
         init_comm->remote_size = node_roots_comm_size;
         init_comm->local_size = node_roots_comm_size;
         init_comm->coll.pof2 = MPL_pof2(node_roots_comm_size);
+        init_comm->seq = 0;
         MPIDI_COMM(init_comm, map).mode = MPIDI_RANK_MAP_LUT_INTRA;
         mpi_errno = MPIDIU_alloc_lut(&lut, node_roots_comm_size);
         MPIR_ERR_CHECK(mpi_errno);
@@ -484,6 +485,8 @@ int MPID_Init_local(int requested, int *provided)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_LOCAL);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT_LOCAL);
+
+    MPIDI_global.is_initialized = 0;
 
     switch (requested) {
         case MPI_THREAD_SINGLE:
@@ -662,8 +665,6 @@ int MPID_Init_world(void)
     destroy_init_comm(&init_comm);
     mpi_errno = init_builtin_comms();
     MPIR_ERR_CHECK(mpi_errno);
-
-    MPIDI_global.is_initialized = 0;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT_WORLD);

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -34,7 +34,7 @@ extern int global_vci_poll_count;
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_do_global_progress(void)
 {
-    if (MPIDI_global.n_vcis == 1) {
+    if (MPIDI_global.n_vcis == 1 || !MPIDI_global.is_initialized) {
         return 0;
     } else {
         global_vci_poll_count++;
@@ -184,11 +184,16 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_progress_state_init(MPID_Progress_state * st
     }
 
     state->progress_made = 0;
-    /* global progress by default */
-    for (int i = 0; i < MPIDI_global.n_vcis; i++) {
-        state->vci[i] = i;
+    if (!MPIDI_global.is_initialized) {
+        state->vci[0] = 0;
+        state->vci_count = 1;
+    } else {
+        /* global progress by default */
+        for (int i = 0; i < MPIDI_global.n_vcis; i++) {
+            state->vci[i] = i;
+        }
+        state->vci_count = MPIDI_global.n_vcis;
     }
-    state->vci_count = MPIDI_global.n_vcis;
 }
 
 /* only wait functions need check progress_counts */

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -106,8 +106,8 @@ int MPIDU_bc_allgather(MPIR_Comm * allgather_comm, void *bc, int bc_len, int sam
     void *recv_buf = segment + local_size * recv_bc_len;
     if (rank == node_root) {
         MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-        MPIR_Allgatherv(segment, local_size * recv_bc_len, MPI_BYTE, recv_buf,
-                        recv_cnts, recv_offs, MPI_BYTE, allgather_comm, &errflag);
+        MPIR_Allgatherv_fallback(segment, local_size * recv_bc_len, MPI_BYTE, recv_buf,
+                                 recv_cnts, recv_offs, MPI_BYTE, allgather_comm, &errflag);
 
     }
 


### PR DESCRIPTION
## Pull Request Description
In principle, we need to store mappings of every remote context in every
local context. However, if we are careful and control the insertion
order, we can result in identical address mapping in each local context.
While this incurs extra code logic and makes code more fragile -- for
example if we ever need to implement a partial world initialization,
it probably will break -- it saves the storage of the local av table as well
as potentially simplifying the av lookup process. For large-scale
scenarios this saving can be significant enough to justify the
additional code complexity.

[skip warnings]

## Background

This idea of enforcing the same mapping order was from PR #5269 and credit to @wesbland 


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
