### PR TITLE
ch4: refactor world init

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -863,6 +863,10 @@ export device_name
 export device_args
 export devicedir
 
+if test "$device_name" = "ch4" ; then
+    AC_DEFINE([ENABLE_LOCAL_SESSION_INIT], 1, [Define to skip initializing builtin world comm during MPI_Session_init])
+fi
+
 # expand all of the prereq macros in the correct order
 m4_map([PAC_SUBCFG_DO_PREREQ], [PAC_SUBCFG_MODULE_LIST])
 

--- a/src/mpi/init/local_proc_attrs.c
+++ b/src/mpi/init/local_proc_attrs.c
@@ -108,16 +108,3 @@ int MPII_init_tag_ub(void)
 
     return MPI_SUCCESS;
 }
-
-int MPII_finalize_local_proc_attrs(void)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    mpi_errno = MPIR_finalize_builtin_comms();
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -48,7 +48,6 @@ void MPII_thread_mutex_create(void);
 void MPII_thread_mutex_destroy(void);
 
 int MPII_init_local_proc_attrs(int *p_thread_required);
-int MPII_finalize_local_proc_attrs(void);
 int MPII_init_tag_ub(void);
 
 void MPII_init_windows(void);

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -316,7 +316,7 @@ int MPII_Finalize(MPIR_Session * session_ptr)
     MPIR_ThreadInfo.isThreaded = 0;
 #endif
 
-    mpi_errno = MPII_finalize_local_proc_attrs();
+    mpi_errno = MPIR_finalize_builtin_comms();
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Call the high-priority callbacks */

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -209,11 +209,17 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     mpi_errno = MPID_Init(required, &MPIR_ThreadInfo.thread_provided);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIR_init_comm_world();
-    MPIR_ERR_CHECK(mpi_errno);
+    bool need_init_builtin_comms = true;
+#ifdef ENABLE_LOCAL_SESSION_INIT
+    need_init_builtin_comms = is_world_model;
+#endif
+    if (need_init_builtin_comms) {
+        mpi_errno = MPIR_init_comm_world();
+        MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIR_init_comm_self();
-    MPIR_ERR_CHECK(mpi_errno);
+        mpi_errno = MPIR_init_comm_self();
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
     /**********************************************************************/
     /* Section 5: contains post device initialization code.  Anything
@@ -244,8 +250,10 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
      * setup. */
     /**********************************************************************/
 
-    mpi_errno = MPID_InitCompleted();
-    MPIR_ERR_CHECK(mpi_errno);
+    if (is_world_model) {
+        mpi_errno = MPID_InitCompleted();
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
     MPL_atomic_store_int(&MPIR_Process.mpich_state, MPICH_MPI_STATE__INITIALIZED);
 

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -532,10 +532,6 @@ typedef struct {
 
 int MPID_Init(int required, int *provided);
 
-int MPID_Init_local(int requested, int *provided);
-
-int MPID_Init_world(void);
-
 int MPID_InitCompleted( void );
 
 int MPID_Finalize(void);

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -62,16 +62,19 @@ static int finalize_failed_procs_group(void *param)
     return mpi_errno;
 }
 
+static int init_local(int requested, int *provided);
+static int init_world(void);
+
 int MPID_Init(int requested, int *provided)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT);
 
-    mpi_errno = MPID_Init_local(requested, provided);
+    mpi_errno = init_local(requested, provided);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPID_Init_world();
+    mpi_errno = init_world();
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -84,7 +87,7 @@ int MPID_Init(int requested, int *provided)
     /* --END ERROR HANDLING-- */
 }
 
-int MPID_Init_local(int requested, int *provided)
+int init_local(int requested, int *provided)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_LOCAL);
@@ -175,7 +178,7 @@ int MPID_Init_local(int requested, int *provided)
     goto fn_exit;
 }
 
-int MPID_Init_world(void)
+int init_world(void)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_WORLD);

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -3,10 +3,10 @@ Non Native API:
       NM : tag_bits
      SHM : tag_bits
   init_world: int
-      NM : init_comm
+      NM : void
      SHM : void
   mpi_init_hook : int
-      NM : rank, size, appnum, tag_bits, init_comm
+      NM : rank, size, appnum, tag_bits
      SHM : rank, size, tag_bits
   mpi_finalize_hook : int
       NM : void
@@ -511,7 +511,6 @@ PARAM:
     idx: int
     info: MPIR_Info *
     info_p: MPIR_Info **
-    init_comm: MPIR_Comm *
     iov_len: size_t
     is_remote: bool
     length: MPI_Aint

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -5,9 +5,6 @@ Non Native API:
   init_world: int
       NM : void
      SHM : void
-  mpi_init_hook : int
-      NM : rank, size, appnum, tag_bits
-     SHM : rank, size, tag_bits
   mpi_finalize_hook : int
       NM : void
      SHM : void

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -13,8 +13,6 @@
  */
 
 int MPID_Init(int, int *);
-int MPID_Init_local(int requested, int *provided);
-int MPID_Init_world(void);
 int MPID_InitCompleted(void);
 MPL_STATIC_INLINE_PREFIX int MPID_Cancel_recv(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Cancel_send(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -369,7 +369,8 @@ extern MPL_dbg_class MPIDI_CH4_DBG_COMM;
 extern MPL_dbg_class MPIDI_CH4_DBG_MEMORY;
 #endif /* MPL_USE_DBG_LOGGING */
 
-
-
+/* routines only used during init */
+int MPIDI_create_init_comm(MPIR_Comm ** comm_ptr);
+void MPIDI_destroy_init_comm(MPIR_Comm ** comm_ptr);
 
 #endif /* MPIDCH4_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -67,11 +67,12 @@ static int get_av_table_index(int rank, int nic, int vni)
 }
 
 /* Step 1: exchange root contexts */
-int MPIDI_OFI_addr_exchange_root_ctx(MPIR_Comm * init_comm)
+int MPIDI_OFI_addr_exchange_root_ctx(void)
 {
     int mpi_errno = MPI_SUCCESS;
     int size = MPIR_Process.size;
     int rank = MPIR_Process.rank;
+    MPIR_Comm *init_comm = NULL;
 
     /* No pre-published address table, need do address exchange. */
     /* First, each get its own name */
@@ -95,6 +96,9 @@ int MPIDI_OFI_addr_exchange_root_ctx(MPIR_Comm * init_comm)
         int num_nodes = MPIR_Process.num_nodes;
         int *node_roots = MPIR_Process.node_root_map;
         int *rank_map, recv_bc_len;
+
+        mpi_errno = MPIDI_create_init_comm(&init_comm);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* First, insert address of node-roots, init_comm become useful */
         fi_addr_t *mapped_table;
@@ -139,6 +143,9 @@ int MPIDI_OFI_addr_exchange_root_ctx(MPIR_Comm * init_comm)
     }
 
   fn_exit:
+    if (init_comm) {
+        MPIDI_destroy_init_comm(&init_comm);
+    }
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -797,9 +797,12 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     MPIDI_OFI_mr_key_allocator_destroy();
 
     if (strcmp("sockets", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0) {
-        /* sockets provider need flush any last lightweight send */
-        mpi_errno = flush_send_queue();
-        MPIR_ERR_CHECK(mpi_errno);
+        /* sockets provider need flush any last lightweight send. Only do it if we initialized
+         * world. Sockets provider can't even send self messages otherwise. */
+        if (MPIDI_global.is_initialized) {
+            mpi_errno = flush_send_queue();
+            MPIR_ERR_CHECK(mpi_errno);
+        }
     } else if (strcmp("verbs;ofi_rxm", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0) {
         /* verbs;ofi_rxm provider need barrier to prevent message loss */
         mpi_errno = MPIR_pmi_barrier();

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -595,20 +595,20 @@ int MPIDI_OFI_init_local(int *tag_bits)
     goto fn_exit;
 }
 
-int MPIDI_OFI_init_world(MPIR_Comm * init_comm)
+int MPIDI_OFI_init_world(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
     int tmp = MPIR_Process.tag_bits;
     mpi_errno = MPIDI_OFI_mpi_init_hook(MPIR_Process.rank, MPIR_Process.size, MPIR_Process.appnum,
-                                        &tmp, init_comm);
+                                        &tmp);
     /* the code updates tag_bits should be moved to MPIDI_xxx_init_local */
     MPIR_Assert(tmp == MPIR_Process.tag_bits);
 
     return mpi_errno;
 }
 
-int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm)
+int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t optlen;
@@ -623,7 +623,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     /* If opening a named-AV didn't work, we need to do a full business card exchange for the first
      * VNI. All other VNIs can copy the address information from this on after the fact. */
     if (!MPIDI_OFI_global.got_named_av) {
-        mpi_errno = MPIDI_OFI_addr_exchange_root_ctx(init_comm);
+        mpi_errno = MPIDI_OFI_addr_exchange_root_ctx();
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -32,7 +32,7 @@ void MPIDI_OFI_update_global_settings(struct fi_info *prov);
 /* Determine if NIC has already been included in others */
 bool MPIDI_OFI_nic_already_used(const struct fi_info *prov, struct fi_info **others, int nic_count);
 
-int MPIDI_OFI_addr_exchange_root_ctx(MPIR_Comm * init_comm);
+int MPIDI_OFI_addr_exchange_root_ctx(void);
 int MPIDI_OFI_addr_exchange_all_ctx(void);
 
 #endif /* OFI_INIT_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -362,6 +362,12 @@ int MPIDI_UCX_post_init(void)
 int MPIDI_UCX_mpi_finalize_hook(void)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    if (!MPIDI_global.is_initialized) {
+        /* Nothing to do */
+        return mpi_errno;
+    }
+
     ucs_status_ptr_t ucp_request;
     ucs_status_ptr_t *pending;
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -64,6 +64,11 @@ static void ipc_handle_free_hook(void *dptr)
     return;
 }
 
+int MPIDI_GPU_init_local(void)
+{
+    return MPI_SUCCESS;
+}
+
 int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
 {
     int mpl_err, mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -69,15 +69,13 @@ int MPIDI_GPU_init_local(void)
     return MPI_SUCCESS;
 }
 
-int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
+int MPIDI_GPU_init_world(void)
 {
     int mpl_err, mpi_errno = MPI_SUCCESS;
     int device_count;
     int my_max_dev_id, node_max_dev_id = -1;
     MPL_gpu_device_handle_t dev_handle;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_MPI_INIT_HOOK);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_MPI_INIT_HOOK);
     MPIR_CHKPMEM_DECL(1);
 
     MPIDI_GPUI_global.initialized = 0;
@@ -230,7 +228,6 @@ int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
     MPIDI_GPUI_global.initialized = 1;
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GPU_MPI_INIT_HOOK);
     return mpi_errno;
   fn_fail:
     MPIR_CHKPMEM_REAP();

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -33,7 +33,7 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle,
                              MPI_Datatype recv_type, void **vaddr);
 int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle);
 int MPIDI_GPU_init_local(void);
-int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits);
+int MPIDI_GPU_init_world(void);
 int MPIDI_GPU_mpi_finalize_hook(void);
 int MPIDI_GPU_ipc_handle_cache_insert(int rank, MPIR_Comm * comm, MPIDI_GPU_ipc_handle_t handle);
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -32,6 +32,7 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle,
                              MPL_gpu_device_handle_t dev_handle,
                              MPI_Datatype recv_type, void **vaddr);
 int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle);
+int MPIDI_GPU_init_local(void);
 int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits);
 int MPIDI_GPU_mpi_finalize_hook(void);
 int MPIDI_GPU_ipc_handle_cache_insert(int rank, MPIR_Comm * comm, MPIDI_GPU_ipc_handle_t handle);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_stub.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_stub.c
@@ -6,7 +6,12 @@
 #include "mpidimpl.h"
 #include "gpu_post.h"
 
-int MPIDI_GPU_mpi_init_hook(int rank, int size, int *tag_bits)
+int MPIDI_GPU_init_local(void)
+{
+    return MPI_SUCCESS;
+}
+
+int MPIDI_GPU_init_world(void)
 {
     return MPI_SUCCESS;
 }

--- a/src/mpid/ch4/shm/ipc/src/ipc_init.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_init.c
@@ -39,22 +39,19 @@ int MPIDI_IPC_init_local(void)
     goto fn_exit;
 }
 
-int MPIDI_IPC_mpi_init_hook(int rank, int size, int *tag_bits)
+int MPIDI_IPC_init_world(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPC_MPI_INIT_HOOK);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPC_MPI_INIT_HOOK);
 
-    mpi_errno = MPIDI_XPMEM_mpi_init_hook(rank, size, tag_bits);
+    mpi_errno = MPIDI_XPMEM_init_world();
     MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIR_CVAR_ENABLE_GPU) {
-        mpi_errno = MPIDI_GPU_mpi_init_hook(rank, size, tag_bits);
+        mpi_errno = MPIDI_GPU_init_world();
         MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPC_MPI_INIT_HOOK);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/shm/ipc/src/ipc_init.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_init.c
@@ -15,11 +15,9 @@ static void register_shm_ctrl_cb(void)
     MPIDI_SHMI_ctrl_reg_cb(MPIDI_IPC_SEND_CONTIG_LMT_FIN, &MPIDI_IPCI_send_contig_lmt_fin_cb);
 }
 
-int MPIDI_IPC_mpi_init_hook(int rank, int size, int *tag_bits)
+int MPIDI_IPC_init_local(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPC_MPI_INIT_HOOK);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPC_MPI_INIT_HOOK);
 
 #ifdef MPL_USE_DBG_LOGGING
     MPIDI_IPCI_DBG_GENERAL = MPL_dbg_class_alloc("SHM_IPC", "shm_ipc");
@@ -28,6 +26,24 @@ int MPIDI_IPC_mpi_init_hook(int rank, int size, int *tag_bits)
     register_shm_ctrl_cb();
 
     MPIDI_IPCI_global.node_group_ptr = NULL;
+
+    mpi_errno = MPIDI_XPMEM_init_local();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIDI_GPU_init_local();
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_IPC_mpi_init_hook(int rank, int size, int *tag_bits)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPC_MPI_INIT_HOOK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPC_MPI_INIT_HOOK);
 
     mpi_errno = MPIDI_XPMEM_mpi_init_hook(rank, size, tag_bits);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/shm/ipc/src/ipc_noinline.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_noinline.h
@@ -10,6 +10,7 @@
 #include "../xpmem/xpmem_post.h"
 #include "../gpu/gpu_post.h"
 
+int MPIDI_IPC_init_local(void);
 int MPIDI_IPC_mpi_init_hook(int rank, int size, int *tag_bits);
 int MPIDI_IPC_mpi_finalize_hook(void);
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_noinline.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_noinline.h
@@ -11,7 +11,7 @@
 #include "../gpu/gpu_post.h"
 
 int MPIDI_IPC_init_local(void);
-int MPIDI_IPC_mpi_init_hook(int rank, int size, int *tag_bits);
+int MPIDI_IPC_init_world(void);
 int MPIDI_IPC_mpi_finalize_hook(void);
 
 int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win);

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
@@ -9,6 +9,11 @@
 #include "xpmem_seg.h"
 #include "shm_control.h"
 
+int MPIDI_XPMEM_init_local(void)
+{
+    return MPI_SUCCESS;
+}
+
 int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *tag_bits)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
@@ -14,7 +14,7 @@ int MPIDI_XPMEM_init_local(void)
     return MPI_SUCCESS;
 }
 
-int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *tag_bits)
+int MPIDI_XPMEM_init_world(void)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
@@ -9,6 +9,8 @@
 #include "xpmem_seg.h"
 #include "shm_control.h"
 
+static int xpmem_initialized = 0;
+
 int MPIDI_XPMEM_init_local(void)
 {
     return MPI_SUCCESS;
@@ -67,6 +69,8 @@ int MPIDI_XPMEM_init_world(void)
     }
     MPIDU_Init_shm_barrier();
 
+    xpmem_initialized = 1;
+
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_MPI_INIT_HOOK);
     return mpi_errno;
@@ -92,7 +96,7 @@ int MPIDI_XPMEM_mpi_finalize_hook(void)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_MPI_FINALIZE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_MPI_FINALIZE_HOOK);
 
-    if (MPIDI_XPMEMI_global.segid == -1) {
+    if (MPIDI_XPMEMI_global.segid == -1 || !xpmem_initialized) {
         /* if XPMEM was disabled at runtime, return */
         goto fn_exit;
     }
@@ -116,6 +120,8 @@ int MPIDI_XPMEM_mpi_finalize_hook(void)
     ret = xpmem_remove(MPIDI_XPMEMI_global.segid);
     /* success(0) or failure(-1) */
     MPIR_ERR_CHKANDJUMP(ret == -1, mpi_errno, MPI_ERR_OTHER, "**xpmem_remove");
+
+    xpmem_initialized = 0;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_MPI_FINALIZE_HOOK);

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
@@ -67,6 +67,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_ipc_attr(const void *vaddr, uintptr
     return MPI_SUCCESS;
 }
 
+int MPIDI_XPMEM_init_local(void);
 int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *tag_bits);
 int MPIDI_XPMEM_mpi_finalize_hook(void);
 int MPIDI_XPMEM_ipc_handle_map(MPIDI_XPMEM_ipc_handle_t mem_handle, void **vaddr);

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
@@ -68,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_ipc_attr(const void *vaddr, uintptr
 }
 
 int MPIDI_XPMEM_init_local(void);
-int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *tag_bits);
+int MPIDI_XPMEM_init_world(void);
 int MPIDI_XPMEM_mpi_finalize_hook(void);
 int MPIDI_XPMEM_ipc_handle_map(MPIDI_XPMEM_ipc_handle_t mem_handle, void **vaddr);
 

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_stub.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_stub.c
@@ -11,7 +11,7 @@ int MPIDI_XPMEM_init_local(void)
     return MPI_SUCCESS;
 }
 
-int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *tag_bits)
+int MPIDI_XPMEM_init_world(void)
 {
     return MPI_SUCCESS;
 }

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_stub.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_stub.c
@@ -6,6 +6,11 @@
 #include "mpidimpl.h"
 #include "xpmem_post.h"
 
+int MPIDI_XPMEM_init_local(void)
+{
+    return MPI_SUCCESS;
+}
+
 int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *tag_bits)
 {
     return MPI_SUCCESS;

--- a/src/mpid/ch4/shm/posix/posix_comm.c
+++ b/src/mpid/ch4/shm/posix/posix_comm.c
@@ -34,9 +34,13 @@ int MPIDI_POSIX_mpi_comm_commit_post_hook(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_MPI_COMM_COMMIT_POST_HOOK);
 
     /* prune selection tree */
-    mpi_errno = MPIR_Csel_prune(MPIDI_global.shm.posix.csel_root, comm,
-                                &MPIDI_POSIX_COMM(comm, csel_comm));
-    MPIR_ERR_CHECK(mpi_errno);
+    if (MPIDI_global.shm.posix.csel_root) {
+        mpi_errno = MPIR_Csel_prune(MPIDI_global.shm.posix.csel_root, comm,
+                                    &MPIDI_POSIX_COMM(comm, csel_comm));
+        MPIR_ERR_CHECK(mpi_errno);
+    } else {
+        MPIDI_POSIX_COMM(comm, csel_comm) = NULL;
+    }
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_COMM_COMMIT_POST_HOOK);

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -140,14 +140,13 @@ int MPIDI_POSIX_init_local(int *tag_bits /* unused */)
     /* Populate these values with transformation information about each rank and its original
      * information in MPI_COMM_WORLD. */
 
-    MPIDI_POSIX_global.local_procs = MPIR_Process.node_local_map;
     MPIDI_POSIX_global.local_ranks = (int *) MPL_malloc(MPIR_Process.size * sizeof(int),
                                                         MPL_MEM_SHM);
     for (i = 0; i < MPIR_Process.size; ++i) {
         MPIDI_POSIX_global.local_ranks[i] = -1;
     }
     for (i = 0; i < MPIR_Process.local_size; i++) {
-        MPIDI_POSIX_global.local_ranks[MPIDI_POSIX_global.local_procs[i]] = i;
+        MPIDI_POSIX_global.local_ranks[MPIR_Process.node_local_map[i]] = i;
     }
     local_rank_0 = MPIR_Process.node_local_map[0];
     MPIDI_POSIX_global.num_local = MPIR_Process.local_size;
@@ -219,7 +218,6 @@ int MPIDI_POSIX_mpi_finalize_hook(void)
     MPL_free(MPIDI_POSIX_global.active_rreq);
 
     MPL_free(MPIDI_POSIX_global.local_ranks);
-    /* MPL_free(MPIDI_POSIX_global.local_procs); */
 
     posix_world_initialized = 0;
 

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -177,12 +177,12 @@ int MPIDI_POSIX_init_local(int *tag_bits /* unused */)
     goto fn_exit;
 }
 
-int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *tag_bits /* unused */)
+int MPIDI_POSIX_init_world(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_INIT_HOOK);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_MPI_INIT_HOOK);
+    int rank = MPIR_Process.rank;
+    int size = MPIR_Process.size;
 
     mpi_errno = MPIDI_POSIX_eager_init(rank, size);
     MPIR_ERR_CHECK(mpi_errno);
@@ -191,7 +191,6 @@ int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *tag_bits /* unused */)
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_INIT_HOOK);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/shm/src/shm_init.c
+++ b/src/mpid/ch4/shm/src/shm_init.c
@@ -10,19 +10,28 @@
 
 int MPIDI_SHM_init_local(int *tag_bits)
 {
+    int mpi_errno = MPI_SUCCESS;
+
     /* There is no restriction on the tag_bits from the posix shmod side */
     *tag_bits = MPIR_TAG_BITS_DEFAULT;
-    return MPI_SUCCESS;
+
+    mpi_errno = MPIDI_POSIX_init_local(NULL);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIDI_IPC_init_local();
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 int MPIDI_SHM_init_world(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    int tmp = MPIR_Process.tag_bits;
-    mpi_errno = MPIDI_SHM_mpi_init_hook(MPIR_Process.rank, MPIR_Process.size, &tmp);
-    /* the code updates tag_bits should be moved to MPIDI_xxx_init_local */
-    MPIR_Assert(tmp == MPIR_Process.tag_bits);
+    mpi_errno = MPIDI_SHM_mpi_init_hook(MPIR_Process.rank, MPIR_Process.size, NULL);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/src/shm_init.c
+++ b/src/mpid/ch4/shm/src/shm_init.c
@@ -31,28 +31,14 @@ int MPIDI_SHM_init_world(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIDI_SHM_mpi_init_hook(MPIR_Process.rank, MPIR_Process.size, NULL);
+    mpi_errno = MPIDI_POSIX_init_world();
+    MPIR_ERR_CHECK(mpi_errno);
 
-    return mpi_errno;
-}
-
-int MPIDI_SHM_mpi_init_hook(int rank, int size, int *tag_bits)
-{
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
-
-
-    ret = MPIDI_POSIX_mpi_init_hook(rank, size, tag_bits);
-    MPIR_ERR_CHECK(ret);
-
-    ret = MPIDI_IPC_mpi_init_hook(rank, size, tag_bits);
-    MPIR_ERR_CHECK(ret);
+    mpi_errno = MPIDI_IPC_init_world();
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
-    return ret;
+    return mpi_errno;
   fn_fail:
     goto fn_exit;
 }

--- a/src/mpid/ch4/src/Makefile.mk
+++ b/src/mpid/ch4/src/Makefile.mk
@@ -34,6 +34,7 @@ noinst_HEADERS += src/mpid/ch4/src/ch4_comm.h     \
 mpi_core_sources += src/mpid/ch4/src/ch4_globals.c        \
                     src/mpid/ch4/src/ch4_impl.c           \
                     src/mpid/ch4/src/ch4_init.c           \
+                    src/mpid/ch4/src/init_comm.c          \
                     src/mpid/ch4/src/ch4_comm.c           \
                     src/mpid/ch4/src/ch4_spawn.c          \
                     src/mpid/ch4/src/ch4_win.c            \

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -139,6 +139,16 @@ int MPID_Comm_commit_pre_hook(MPIR_Comm * comm)
         MPIDI_COMM(comm, map).size = MPIR_Process.size;
         MPIDI_COMM(comm, local_map).mode = MPIDI_RANK_MAP_NONE;
         MPIDIU_avt_add_ref(0);
+
+        mpi_errno = MPIDU_Init_shm_init();
+        MPIR_ERR_CHECK(mpi_errno);
+
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+        mpi_errno = MPIDI_SHM_init_world();
+        MPIR_ERR_CHECK(mpi_errno);
+#endif
+        mpi_errno = MPIDI_NM_init_world();
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (comm == MPIR_Process.comm_self) {
         MPIDI_COMM(comm, map).mode = MPIDI_RANK_MAP_OFFSET_INTRA;
         MPIDI_COMM(comm, map).avtid = 0;
@@ -214,6 +224,13 @@ int MPID_Comm_commit_post_hook(MPIR_Comm * comm)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_COMMIT_POST_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_COMMIT_POST_HOOK);
+
+    if (comm == MPIR_Process.comm_world) {
+        mpi_errno = MPIDI_NM_post_init();
+        MPIR_ERR_CHECK(mpi_errno);
+
+        MPIDI_global.is_initialized = 1;
+    }
 
     mpi_errno = MPIDI_NM_mpi_comm_commit_post_hook(comm);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -186,8 +186,6 @@ static void *create_container(struct json_object *obj)
 }
 
 static int choose_netmod(void);
-static int create_init_comm(MPIR_Comm **);
-static void destroy_init_comm(MPIR_Comm **);
 static void init_av_table(void);
 static void finalize_av_table(void);
 
@@ -290,65 +288,6 @@ static int set_runtime_configurations(void)
   fn_fail:
 #endif
     return mpi_errno;
-}
-
-static int create_init_comm(MPIR_Comm ** comm)
-{
-    int i, mpi_errno = MPI_SUCCESS;
-    int world_rank = MPIR_Process.rank;
-    int node_root_rank = MPIR_Process.node_root_map[MPIR_Process.node_map[world_rank]];
-
-    /* if the process is not a node root, exit */
-    if (node_root_rank == world_rank) {
-        int node_roots_comm_size = MPIR_Process.num_nodes;
-        int node_roots_comm_rank = MPIR_Process.node_map[world_rank];
-        MPIR_Comm *init_comm = NULL;
-        MPIDI_rank_map_lut_t *lut = NULL;
-        MPIR_Comm_create(&init_comm);
-        init_comm->context_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
-        init_comm->recvcontext_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
-        init_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
-        init_comm->rank = node_roots_comm_rank;
-        init_comm->remote_size = node_roots_comm_size;
-        init_comm->local_size = node_roots_comm_size;
-        init_comm->coll.pof2 = MPL_pof2(node_roots_comm_size);
-        init_comm->seq = 0;
-        MPIDI_COMM(init_comm, map).mode = MPIDI_RANK_MAP_LUT_INTRA;
-        mpi_errno = MPIDIU_alloc_lut(&lut, node_roots_comm_size);
-        MPIR_ERR_CHECK(mpi_errno);
-        MPIDI_COMM(init_comm, map).size = node_roots_comm_size;
-        MPIDI_COMM(init_comm, map).avtid = 0;
-        MPIDI_COMM(init_comm, map).irreg.lut.t = lut;
-        MPIDI_COMM(init_comm, map).irreg.lut.lpid = lut->lpid;
-        MPIDI_COMM(init_comm, local_map).mode = MPIDI_RANK_MAP_NONE;
-        for (i = 0; i < node_roots_comm_size; ++i) {
-            lut->lpid[i] = MPIR_Process.node_root_map[i];
-        }
-        mpi_errno = MPIDIG_init_comm(init_comm);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        *comm = init_comm;
-    }
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-static void destroy_init_comm(MPIR_Comm ** comm_ptr)
-{
-    int in_use;
-    MPIR_Comm *comm = NULL;
-    if (*comm_ptr != NULL) {
-        comm = *comm_ptr;
-        MPIDIU_release_lut(MPIDI_COMM(comm, map).irreg.lut.t);
-        MPIDIG_destroy_comm(comm);
-        MPIR_Object_release_ref(comm, &in_use);
-        MPIR_Assert(MPIR_Object_get_ref(comm) == 0);
-        MPII_COMML_FORGET(comm);
-        MPIR_Handle_obj_free(&MPIR_Comm_mem, comm);
-        *comm_ptr = NULL;
-    }
 }
 
 static void init_av_table(void)
@@ -569,15 +508,11 @@ int MPID_Init_local(int requested, int *provided)
 int MPID_Init_world(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Comm *init_comm = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_WORLD);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT_WORLD);
 
     /* setup receive queue statistics */
     mpi_errno = MPIDIG_recvq_init();
-    MPIR_ERR_CHECK(mpi_errno);
-
-    mpi_errno = create_init_comm(&init_comm);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDU_Init_shm_init();
@@ -592,7 +527,7 @@ int MPID_Init_world(void)
         }
 #endif
 
-        mpi_errno = MPIDI_NM_init_world(init_comm);
+        mpi_errno = MPIDI_NM_init_world();
         if (mpi_errno != MPI_SUCCESS) {
             MPIR_ERR_POPFATAL(mpi_errno);
         }

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -498,40 +498,10 @@ int MPID_Init_local(int requested, int *provided)
         /* Use the minimum tag_bits from the netmod and shmod */
         MPIR_Process.tag_bits = MPL_MIN(shm_tag_bits, nm_tag_bits);
     }
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT_LOCAL);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-int MPID_Init_world(void)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_WORLD);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT_WORLD);
 
     /* setup receive queue statistics */
     mpi_errno = MPIDIG_recvq_init();
     MPIR_ERR_CHECK(mpi_errno);
-
-    mpi_errno = MPIDU_Init_shm_init();
-    MPIR_ERR_CHECK(mpi_errno);
-
-    {
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno = MPIDI_SHM_init_world();
-
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POPFATAL(mpi_errno);
-        }
-#endif
-
-        mpi_errno = MPIDI_NM_init_world();
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POPFATAL(mpi_errno);
-        }
-    }
 
     MPIDIG_am_check_init();
 
@@ -552,7 +522,36 @@ int MPID_Init_world(void)
     MPIR_Process.attrs.appnum = MPIR_Process.appnum;
     MPIR_Process.attrs.io = MPI_ANY_SOURCE;
 
-    destroy_init_comm(&init_comm);
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT_LOCAL);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPID_Init_world(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_WORLD);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT_WORLD);
+
+    mpi_errno = MPIDU_Init_shm_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    {
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+        mpi_errno = MPIDI_SHM_init_world();
+
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POPFATAL(mpi_errno);
+        }
+#endif
+
+        mpi_errno = MPIDI_NM_init_world();
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POPFATAL(mpi_errno);
+        }
+    }
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT_WORLD);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -356,25 +356,6 @@ static int generic_init(void)
 int MPID_Init(int requested, int *provided)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT);
-
-    mpi_errno = MPID_Init_local(requested, provided);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    mpi_errno = MPID_Init_world();
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-int MPID_Init_local(int requested, int *provided)
-{
-    int mpi_errno = MPI_SUCCESS;
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_LOCAL);
 
@@ -527,16 +508,6 @@ int MPID_Init_local(int requested, int *provided)
     return mpi_errno;
   fn_fail:
     goto fn_exit;
-}
-
-int MPID_Init_world(void)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_WORLD);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT_WORLD);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT_WORLD);
-    return mpi_errno;
 }
 
 int MPID_InitCompleted(void)

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -535,51 +535,25 @@ int MPID_Init_world(void)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_WORLD);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT_WORLD);
 
-    mpi_errno = MPIDU_Init_shm_init();
-    MPIR_ERR_CHECK(mpi_errno);
-
-    {
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno = MPIDI_SHM_init_world();
-
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POPFATAL(mpi_errno);
-        }
-#endif
-
-        mpi_errno = MPIDI_NM_init_world();
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POPFATAL(mpi_errno);
-        }
-    }
-
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT_WORLD);
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 int MPID_InitCompleted(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    char parent_port[MPI_MAX_PORT_NAME];
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INITCOMPLETED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INITCOMPLETED);
 
-    mpi_errno = MPIDI_NM_post_init();
-    MPIR_ERR_CHECK(mpi_errno);
-
     if (MPIR_Process.has_parent) {
+        char parent_port[MPI_MAX_PORT_NAME];
         mpi_errno = MPIR_pmi_kvs_get(-1, MPIDI_PARENT_PORT_KVSKEY, parent_port, MPI_MAX_PORT_NAME);
         MPIR_ERR_CHECK(mpi_errno);
         MPID_Comm_connect(parent_port, NULL, 0, MPIR_Process.comm_world, &MPIR_Process.comm_parent);
         MPIR_Assert(MPIR_Process.comm_parent != NULL);
         MPL_strncpy(MPIR_Process.comm_parent->name, "MPI_COMM_PARENT", MPI_MAX_OBJECT_NAME);
     }
-
-    MPIDI_global.is_initialized = 1;
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INITCOMPLETED);
 

--- a/src/mpid/ch4/src/init_comm.c
+++ b/src/mpid/ch4/src/init_comm.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+
+/* During init, in particular, when using MPIR_CVAR_CH4_ROOTS_ONLY_PMI=1,
+ * we need create a temporary node_roots only communicator, called init_comm.
+ * They are directly called by netmod init hooks as needed.
+ */
+
+int MPIDI_create_init_comm(MPIR_Comm ** comm)
+{
+    int i, mpi_errno = MPI_SUCCESS;
+    int world_rank = MPIR_Process.rank;
+    int node_root_rank = MPIR_Process.node_root_map[MPIR_Process.node_map[world_rank]];
+
+    /* if the process is not a node root, exit */
+    if (node_root_rank == world_rank) {
+        int node_roots_comm_size = MPIR_Process.num_nodes;
+        int node_roots_comm_rank = MPIR_Process.node_map[world_rank];
+        MPIR_Comm *init_comm = NULL;
+        MPIDI_rank_map_lut_t *lut = NULL;
+        MPIR_Comm_create(&init_comm);
+        init_comm->context_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
+        init_comm->recvcontext_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
+        init_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
+        init_comm->rank = node_roots_comm_rank;
+        init_comm->remote_size = node_roots_comm_size;
+        init_comm->local_size = node_roots_comm_size;
+        init_comm->coll.pof2 = MPL_pof2(node_roots_comm_size);
+        MPIDI_COMM(init_comm, map).mode = MPIDI_RANK_MAP_LUT_INTRA;
+        mpi_errno = MPIDIU_alloc_lut(&lut, node_roots_comm_size);
+        MPIR_ERR_CHECK(mpi_errno);
+        MPIDI_COMM(init_comm, map).size = node_roots_comm_size;
+        MPIDI_COMM(init_comm, map).avtid = 0;
+        MPIDI_COMM(init_comm, map).irreg.lut.t = lut;
+        MPIDI_COMM(init_comm, map).irreg.lut.lpid = lut->lpid;
+        MPIDI_COMM(init_comm, local_map).mode = MPIDI_RANK_MAP_NONE;
+        for (i = 0; i < node_roots_comm_size; ++i) {
+            lut->lpid[i] = MPIR_Process.node_root_map[i];
+        }
+        mpi_errno = MPIDIG_init_comm(init_comm);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        *comm = init_comm;
+    }
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+void MPIDI_destroy_init_comm(MPIR_Comm ** comm_ptr)
+{
+    int in_use;
+    MPIR_Comm *comm = NULL;
+    if (*comm_ptr != NULL) {
+        comm = *comm_ptr;
+        MPIDIU_release_lut(MPIDI_COMM(comm, map).irreg.lut.t);
+        MPIDIG_destroy_comm(comm);
+        MPIR_Object_release_ref(comm, &in_use);
+        MPIR_Assert(MPIR_Object_get_ref(comm) == 0);
+        MPII_COMML_FORGET(comm);
+        MPIR_Handle_obj_free(&MPIR_Comm_mem, comm);
+        *comm_ptr = NULL;
+    }
+}

--- a/test/mpi/init/Makefile.am
+++ b/test/mpi/init/Makefile.am
@@ -19,6 +19,7 @@ noinst_PROGRAMS = \
     session       \
     session_mult_init \
     session_psets \
+    session_self  \
     version       \
     library_version \
     timeout       \

--- a/test/mpi/init/session_self.c
+++ b/test/mpi/init/session_self.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include <assert.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+
+    int ret;
+    MPI_Session session;
+    MPI_Group group;
+    MPI_Comm comm;
+
+    ret = MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &session);
+    if (ret != MPI_SUCCESS) {
+        errs++;
+        goto fn_exit;
+    }
+
+    ret = MPI_Group_from_session_pset(session, "mpi://self", &group);
+    if (ret != MPI_SUCCESS) {
+        errs++;
+    }
+
+    ret = MPI_Comm_create_from_group(group, "tag", MPI_INFO_NULL, MPI_ERRORS_RETURN, &comm);
+    if (ret != MPI_SUCCESS) {
+        errs++;
+    }
+
+    ret = MPI_Group_free(&group);
+    if (ret != MPI_SUCCESS) {
+        errs++;
+    }
+
+    MPI_Request req;
+    int send_data, recv_data;
+    int rank = 0;
+    int tag = 0;
+
+    ret = MPI_Irecv(&recv_data, 1, MPI_INT, rank, tag, comm, &req);
+    if (ret != MPI_SUCCESS) {
+        errs++;
+    }
+    ret = MPI_Send(&send_data, 1, MPI_INT, rank, tag, comm);
+    if (ret != MPI_SUCCESS) {
+        errs++;
+    }
+    ret = MPI_Wait(&req, MPI_STATUS_IGNORE);
+    if (ret != MPI_SUCCESS) {
+        errs++;
+    }
+
+    ret = MPI_Comm_free(&comm);
+    if (ret != MPI_SUCCESS) {
+        errs++;
+    }
+
+    ret = MPI_Session_finalize(&session);
+    if (ret != MPI_SUCCESS) {
+        errs++;
+    }
+
+    if (errs == 0) {
+        printf("No Errors\n");
+    }
+
+  fn_exit:
+    return errs;
+}

--- a/test/mpi/init/testlist
+++ b/test/mpi/init/testlist
@@ -10,3 +10,4 @@ session 4
 session_mult_init 4
 session_mult_init 4 arg=5
 session_psets 1
+session_self 1


### PR DESCRIPTION
## Pull Request Description
Refactor the world init to loosen the assumption that we always initialize the world on `MPI_Init`. The assumption is we only support `comm_world` and `comm_self`, so that we can delay the address exchange and communication dependent part of initialization when the first `comm_world` is being created.

Fixes #4878

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
