### PR TITLE
util: add MPIR_CVAR_CLIQUES_BY_BLOCK

### DIFF
--- a/src/util/mpir_nodemap.h
+++ b/src/util/mpir_nodemap.h
@@ -8,56 +8,6 @@
 
 #include "mpl.h"
 
-/*
-=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
-
-categories:
-    - name        : NODEMAP
-      description : cvars that control behavior of nodemap
-
-cvars:
-    - name        : MPIR_CVAR_NOLOCAL
-      category    : NODEMAP
-      alt-env     : MPIR_CVAR_NO_LOCAL
-      type        : boolean
-      default     : false
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_ALL_EQ
-      description : >-
-        If true, force all processes to operate as though all processes
-        are located on another node.  For example, this disables shared
-        memory communication hierarchical collectives.
-
-    - name        : MPIR_CVAR_ODD_EVEN_CLIQUES
-      category    : NODEMAP
-      alt-env     : MPIR_CVAR_EVEN_ODD_CLIQUES
-      type        : boolean
-      default     : false
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_ALL_EQ
-      description : >-
-        If true, odd procs on a node are seen as local to each other, and even
-        procs on a node are seen as local to each other.  Used for debugging on
-        a single machine. Deprecated in favor of MPIR_CVAR_NUM_CLIQUES.
-
-    - name        : MPIR_CVAR_NUM_CLIQUES
-      category    : NODEMAP
-      alt-env     : MPIR_CVAR_NUM_CLIQUES
-      type        : int
-      default     : 1
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_ALL_EQ
-      description : >-
-        Specify the number of cliques that should be used to partition procs on
-        a local node. Procs with the same clique number are seen as local to
-        each other. Used for debugging on a single machine.
-
-=== END_MPI_T_CVAR_INFO_BLOCK ===
-*/
-
 #if !defined(USE_PMI2_API) && !defined(USE_PMIX_API)
 /* this function is not used in pmi2 or pmix */
 static inline int MPIR_NODEMAP_publish_node_id(int sz, int myrank)

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -7,6 +7,56 @@
 #include <mpiimpl.h>
 #include "mpir_nodemap.h"
 
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+categories:
+    - name        : NODEMAP
+      description : cvars that control behavior of nodemap
+
+cvars:
+    - name        : MPIR_CVAR_NOLOCAL
+      category    : NODEMAP
+      alt-env     : MPIR_CVAR_NO_LOCAL
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If true, force all processes to operate as though all processes
+        are located on another node.  For example, this disables shared
+        memory communication hierarchical collectives.
+
+    - name        : MPIR_CVAR_ODD_EVEN_CLIQUES
+      category    : NODEMAP
+      alt-env     : MPIR_CVAR_EVEN_ODD_CLIQUES
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If true, odd procs on a node are seen as local to each other, and even
+        procs on a node are seen as local to each other.  Used for debugging on
+        a single machine. Deprecated in favor of MPIR_CVAR_NUM_CLIQUES.
+
+    - name        : MPIR_CVAR_NUM_CLIQUES
+      category    : NODEMAP
+      alt-env     : MPIR_CVAR_NUM_CLIQUES
+      type        : int
+      default     : 1
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        Specify the number of cliques that should be used to partition procs on
+        a local node. Procs with the same clique number are seen as local to
+        each other. Used for debugging on a single machine.
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
 static int build_nodemap(int *nodemap, int sz, int *p_max_node_id);
 static int build_locality(void);
 

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -770,7 +770,7 @@ char *MPIR_pmi_get_failed_procs(void)
   fn_exit:
     return failed_procs_string;
   fn_fail:
-    /* FIXME: approprate error messages here? */
+    /* FIXME: appropriate error messages here? */
     MPL_free(failed_procs_string);
     failed_procs_string = NULL;
     goto fn_exit;


### PR DESCRIPTION
## Pull Request Description
The default `MPIR_CVAR_ODD_EVEN_CLIQUES` and `MPIR_CVAR_NUM_CLIQUES` divide processes into nodes in a round-robin fashion. This PR adds an additional car to allow cliques by block. For example, with 5 processes,
the default `MPIR_CVAR_NUM_CLIQUES=2` result in
```
    [0, 2, 4] and [1, 3]
```
If `MPIR_CVAR_CLIQUES_BY_BLOCK=true` is additionally set, it will do the following instead:
```
    [0, 1, 2] and [3, 4]
```

This allows debugging some specific code conditions.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
