### PR TITLE
hydra: add option -output-from

### DIFF
--- a/src/pm/hydra/ui/include/ui.h
+++ b/src/pm/hydra/ui/include/ui.h
@@ -7,6 +7,7 @@
 #define UI_H_INCLUDED
 
 struct HYD_ui_info_s {
+    int output_from;
     char *prepend_pattern;
     char *outfile_pattern;
     char *errfile_pattern;

--- a/src/pm/hydra/ui/mpich/utils.c
+++ b/src/pm/hydra/ui/mpich/utils.c
@@ -440,6 +440,32 @@ static HYD_status profile_fn(char *arg, char ***argv)
     goto fn_exit;
 }
 
+static void output_from_help_fn(void)
+{
+    printf("\n");
+    printf("-output-from: only show the output from this rank\n\n");
+}
+
+static HYD_status output_from_fn(char *arg, char ***argv)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    if (reading_config_file && HYD_ui_info.output_from != -1) {
+        /* global variable already set; ignore */
+        goto fn_exit;
+    }
+
+    status = HYDU_set_int(arg, &HYD_ui_info.output_from, atoi(**argv));
+    HYDU_ERR_POP(status, "error setting output_from\n");
+
+  fn_exit:
+    (*argv)++;
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
 static void prepend_rank_help_fn(void)
 {
     printf("\n");
@@ -1780,6 +1806,7 @@ static struct HYD_arg_match_table match_table[] = {
     {"hostlist", hostlist_fn, hostlist_help_fn},
     {"ppn", ppn_fn, ppn_help_fn},
     {"profile", profile_fn, profile_help_fn},
+    {"output-from", output_from_fn, output_from_help_fn},
     {"prepend-rank", prepend_rank_fn, prepend_rank_help_fn},
     {"l", prepend_rank_fn, prepend_rank_help_fn},
     {"prepend-pattern", prepend_pattern_fn, prepend_pattern_help_fn},

--- a/src/pm/hydra/ui/utils/uiu.c
+++ b/src/pm/hydra/ui/utils/uiu.c
@@ -42,6 +42,7 @@ void HYD_uiu_init_params(void)
     HYD_server_info.num_pmi_calls = 0;
 #endif /* ENABLE_PROFILING */
 
+    HYD_ui_info.output_from = -1;
     HYD_ui_info.prepend_pattern = NULL;
     HYD_ui_info.outfile_pattern = NULL;
     HYD_ui_info.errfile_pattern = NULL;
@@ -251,6 +252,10 @@ static HYD_status stdoe_cb(int _fd, int pgid, int proxy_id, int rank, void *_buf
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
+
+    if (HYD_ui_info.output_from != -1 && rank != HYD_ui_info.output_from) {
+        goto fn_exit;
+    }
 
     pattern = (_fd == STDOUT_FILENO) ? HYD_ui_info.outfile_pattern :
         (_fd == STDERR_FILENO) ? HYD_ui_info.errfile_pattern : NULL;


### PR DESCRIPTION

## Pull Request Description
Sometimes it is convenient to ask hydra to only show output from a given
process rather than having outputs from all ranks mingled together.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
