### PR TITLE
ch4/ucx: switch on is_initialized before flushing vnis

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -421,7 +421,9 @@ int MPIDI_UCX_post_init(void)
     mpi_errno = all_vnis_address_exchange();
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* flush all pending wireup operations or it may interfere with RMA flush_ops count */
+    /* Flush all pending wireup operations or it may interfere with RMA flush_ops count.
+     * Since this require progress in non-zero vnis, we need switch on is_initialized. */
+    MPIDI_global.is_initialized = 1;
     flush_all();
 
   fn_exit:


### PR DESCRIPTION
## Pull Request Description

UCX init need flushing all vnis during post_init, but last commit --
e8e6d863 -- only runs global progress when MPIDI_global.is_initialized
is on, which is set after netmod post_init. This commit turns that flag
on a bit early inside ucx post_init. Unfortunately, this is a bit hacky.
But the flushing of ucx write-up internal messages is a hacky remedy to
begin with.


## Background

This fixes the night ucx vci tests, broken by https://github.com/pmodels/mpich/pull/5287

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
