### PR TITLE
ch4: Remove unnecessary context_id->comm lookups

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_init.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_init.c
@@ -124,9 +124,6 @@ int MPIDIG_am_init(void)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_AM_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_AM_INIT);
 
-    MPIDI_global.comm_req_lists = (MPIDIG_comm_req_list_t *)
-        MPL_calloc(MPIR_MAX_CONTEXT_MASK * MPIR_CONTEXT_INT_BITS,
-                   sizeof(MPIDIG_comm_req_list_t), MPL_MEM_OTHER);
     MPIDI_global.posted_list = NULL;
     MPIDI_global.unexp_list = NULL;
     MPIDI_global.part_posted_list = NULL;
@@ -228,7 +225,6 @@ void MPIDIG_am_finalize(void)
     MPIDIU_map_destroy(MPIDI_global.win_map);
     MPIDU_genq_private_pool_destroy_unsafe(MPIDI_global.request_pool);
     MPIDU_genq_private_pool_destroy_unsafe(MPIDI_global.unexp_pack_buf_pool);
-    MPL_free(MPIDI_global.comm_req_lists);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_AM_FINALIZE);
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -71,9 +71,6 @@ int MPIDI_OFI_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_COMM_COMMIT_PRE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_COMM_COMMIT_PRE_HOOK);
 
-    MPIDIU_map_create(&MPIDI_OFI_COMM(comm).huge_send_counters, MPL_MEM_COMM);
-    MPIDIU_map_create(&MPIDI_OFI_COMM(comm).huge_recv_counters, MPL_MEM_COMM);
-
     /* no connection for non-dynamic or non-root-rank of intercomm */
     MPIDI_OFI_COMM(comm).conn_id = -1;
 
@@ -116,9 +113,6 @@ int MPIDI_OFI_mpi_comm_free_hook(MPIR_Comm * comm)
         (MPIDI_OFI_COMM(comm).enable_striping != 0 ? 1 : 0);
     MPIDI_OFI_global.num_comms_enabled_hashing -=
         (MPIDI_OFI_COMM(comm).enable_hashing != 0 ? 1 : 0);
-
-    MPIDIU_map_destroy(MPIDI_OFI_COMM(comm).huge_send_counters);
-    MPIDIU_map_destroy(MPIDI_OFI_COMM(comm).huge_recv_counters);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_MPI_COMM_FREE_HOOK);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -693,8 +693,14 @@ static int am_read_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_
         }
     }
 
+    MPIR_Comm *comm;
+    if (rreq->kind == MPIR_REQUEST_KIND__RMA) {
+        comm = rreq->u.rma.win->comm_ptr;
+    } else {
+        comm = rreq->comm;
+    }
     mpi_errno = MPIDI_OFI_do_am_rdma_read_ack(MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).src_rank,
-                                              MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).context_id,
+                                              comm,
                                               MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).sreq_ptr);
 
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -492,6 +492,10 @@ int MPIDI_OFI_init_local(int *tag_bits)
     MPIDIU_map_create(&MPIDI_OFI_global.win_map, MPL_MEM_RMA);
     MPIDIU_map_create(&MPIDI_OFI_global.req_map, MPL_MEM_OTHER);
 
+    /* Create huge protocol maps */
+    MPIDIU_map_create(&MPIDI_OFI_global.huge_send_counters, MPL_MEM_COMM);
+    MPIDIU_map_create(&MPIDI_OFI_global.huge_recv_counters, MPL_MEM_COMM);
+
     /* Create pack buffer pool */
     mpi_errno =
         MPIDU_genq_private_pool_create_unsafe(MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE,
@@ -842,6 +846,9 @@ int MPIDI_OFI_mpi_finalize_hook(void)
 
     MPIDIU_map_destroy(MPIDI_OFI_global.win_map);
     MPIDIU_map_destroy(MPIDI_OFI_global.req_map);
+
+    MPIDIU_map_destroy(MPIDI_OFI_global.huge_send_counters);
+    MPIDIU_map_destroy(MPIDI_OFI_global.huge_recv_counters);
 
     if (MPIDI_OFI_ENABLE_AM) {
         while (MPIDI_OFI_global.am_unordered_msgs) {

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -43,8 +43,6 @@ typedef struct {
 } MPIDI_OFI_Global_t;
 
 typedef struct {
-    void *huge_send_counters;
-    void *huge_recv_counters;
     /* support for connection */
     int conn_id;
     int enable_striping;        /* Flag to enable striping per communicator. */

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -42,6 +42,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
     } else {
         rreq = &r;
     }
+    rreq->comm = comm;
+    MPIR_Comm_add_ref(comm);
 
     match_bits = MPIDI_OFI_init_recvtag(&mask_bits, comm->recvcontext_id + context_offset, tag);
 
@@ -98,6 +100,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
     }
 
   fn_exit:
+    if (message == NULL) {
+        MPIR_Comm_release(comm);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DO_IPROBE);
     return mpi_errno;
   fn_fail:
@@ -139,11 +144,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
 
     if (mpi_errno != MPI_SUCCESS)
         goto fn_exit;
-
-    if (*flag && *message) {
-        (*message)->comm = comm;
-        MPIR_Object_add_ref(comm);
-    }
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_IMPROBE);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -317,7 +317,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                      NULL), mr_reg);    /* In:  context             */
         }
         /* Create map to the memory region */
-        MPIDIU_map_set(MPIDI_OFI_COMM(comm).huge_send_counters, sreq->handle, huge_send_mrs,
+        MPIDIU_map_set(MPIDI_OFI_global.huge_send_counters, sreq->handle, huge_send_mrs,
                        MPL_MEM_BUFFER);
         if (MPIDI_OFI_ENABLE_MR_PROV_KEY) {
             /* MR_BASIC */

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -335,6 +335,10 @@ typedef struct {
      * OFI provider at MPI initialization.*/
     MPIDI_OFI_atomic_valid_t win_op_table[MPIR_DATATYPE_N_PREDEFINED][MPIDIG_ACCU_NUM_OP];
 
+    /* huge protocol globals */
+    void *huge_send_counters;
+    void *huge_recv_counters;
+
     /* Active Message Globals */
     struct iovec am_iov[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
     struct fi_msg am_msg[MPIDI_OFI_MAX_NUM_AM_BUFFERS];

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -195,8 +195,7 @@ static int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
                 LL_DELETE(MPIDI_posted_huge_recv_head, MPIDI_posted_huge_recv_tail, list_ptr);
 
                 recv_elem = (MPIDI_OFI_huge_recv_t *)
-                    MPIDIU_map_lookup(MPIDI_OFI_COMM(comm_ptr).huge_recv_counters,
-                                      list_ptr->rreq->handle);
+                    MPIDIU_map_lookup(MPIDI_OFI_global.huge_recv_counters, list_ptr->rreq->handle);
 
                 /* If this is a "peek" element for an MPI_Probe, it shouldn't be matched. Grab the
                  * important information and remove the element from the list. */
@@ -204,7 +203,7 @@ static int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
                     MPIR_STATUS_SET_COUNT(recv_elem->localreq->status, info->msgsize);
                     MPL_atomic_release_store_int(&(MPIDI_OFI_REQUEST(recv_elem->localreq, util_id)),
                                                  MPIDI_OFI_PEEK_FOUND);
-                    MPIDIU_map_erase(MPIDI_OFI_COMM(recv_elem->comm_ptr).huge_recv_counters,
+                    MPIDIU_map_erase(MPIDI_OFI_global.huge_recv_counters,
                                      recv_elem->localreq->handle);
                     MPL_free(recv_elem);
                     recv_elem = NULL;

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -167,13 +167,9 @@ void MPIDI_OFI_mr_key_allocator_destroy(void)
 static int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
 {
     MPIDI_OFI_huge_recv_t *recv_elem = NULL;
-    MPIR_Comm *comm_ptr;
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_GET_HUGE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_GET_HUGE);
-
-    /* Look up the communicator */
-    comm_ptr = MPIDIG_context_id_to_comm(info->comm_id);
 
     /* If there has been a posted receive, search through the list of unmatched
      * receives to find the one that goes with the incoming message. */
@@ -230,13 +226,7 @@ static int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
     }
 
     recv_elem->event_id = MPIDI_OFI_EVENT_GET_HUGE;
-    if (MPIDI_OFI_COMM(comm_ptr).enable_striping) {
-        recv_elem->cur_offset = MPIDI_OFI_STRIPE_CHUNK_SIZE;
-    } else {
-        recv_elem->cur_offset = MPIDI_OFI_global.max_msg_size;
-    }
     recv_elem->remote_info = *info;
-    recv_elem->comm_ptr = comm_ptr;
     recv_elem->next = NULL;
     MPIDI_OFI_get_huge_event(NULL, (MPIR_Request *) recv_elem);
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -157,9 +157,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
     ack_ctrl_hdr.ipc_contig_slmt_fin.ipc_type = ipc_type;
     ack_ctrl_hdr.ipc_contig_slmt_fin.req_ptr = sreq_ptr;
     mpi_errno = MPIDI_SHM_do_ctrl_send(MPIDIG_REQUEST(rreq, rank),
-                                       MPIDIG_context_id_to_comm(MPIDIG_REQUEST
-                                                                 (rreq, context_id)),
-                                       MPIDI_IPC_SEND_CONTIG_LMT_FIN, &ack_ctrl_hdr);
+                                       rreq->comm, MPIDI_IPC_SEND_CONTIG_LMT_FIN, &ack_ctrl_hdr);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -53,24 +53,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_prequest_get_context_offset(MPIR_Request * pr
     return context_offset;
 }
 
-MPL_STATIC_INLINE_PREFIX MPIR_Comm *MPIDIG_context_id_to_comm(uint64_t context_id)
-{
-    int comm_idx = MPIDIG_get_context_index(context_id);
-    int subcomm_type = MPIR_CONTEXT_READ_FIELD(SUBCOMM, context_id);
-    int is_localcomm = MPIR_CONTEXT_READ_FIELD(IS_LOCALCOMM, context_id);
-    MPIR_Comm *ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_CONTEXT_ID_TO_COMM);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_CONTEXT_ID_TO_COMM);
-
-    MPIR_Assert(subcomm_type <= 3);
-    MPIR_Assert(is_localcomm <= 2);
-    ret = MPIDI_global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type];
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_CONTEXT_ID_TO_COMM);
-    return ret;
-}
-
 MPL_STATIC_INLINE_PREFIX MPIR_Context_id_t MPIDIG_win_id_to_context(uint64_t win_id)
 {
     MPIR_Context_id_t ret;

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -190,10 +190,6 @@ typedef struct MPIDIG_acc_ack_msg_t {
 
 typedef MPIDIG_acc_ack_msg_t MPIDIG_get_acc_ack_msg_t;
 
-typedef struct MPIDIG_comm_req_list_t {
-    MPIR_Comm *comm[2][4];
-} MPIDIG_comm_req_list_t;
-
 typedef struct {
     int max_n_avts;
     int n_avts;
@@ -266,7 +262,6 @@ typedef struct MPIDI_CH4_Global_t {
     MPIDIU_avt_manager avt_mgr;
     int is_ch4u_initialized;
     int **node_map, max_node_id;
-    MPIDIG_comm_req_list_t *comm_req_lists;
     MPIR_Commops MPIR_Comm_fns_store;
     MPID_Thread_mutex_t m[MAX_CH4_MUTEXES];
     MPIDIU_map_t *win_map;

--- a/src/mpid/ch4/src/ch4r_init.c
+++ b/src/mpid/ch4/src/ch4r_init.c
@@ -8,7 +8,7 @@
 
 int MPIDIG_init_comm(MPIR_Comm * comm)
 {
-    int mpi_errno = MPI_SUCCESS, comm_idx, subcomm_type, is_localcomm;
+    int mpi_errno = MPI_SUCCESS, subcomm_type, is_localcomm;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_INIT_COMM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_INIT_COMM);
@@ -18,14 +18,11 @@ int MPIDIG_init_comm(MPIR_Comm * comm)
     if (MPIR_CONTEXT_READ_FIELD(DYNAMIC_PROC, comm->recvcontext_id))
         goto fn_exit;
 
-    comm_idx = MPIDIG_get_context_index(comm->recvcontext_id);
     subcomm_type = MPIR_CONTEXT_READ_FIELD(SUBCOMM, comm->recvcontext_id);
     is_localcomm = MPIR_CONTEXT_READ_FIELD(IS_LOCALCOMM, comm->recvcontext_id);
 
     MPIR_Assert(subcomm_type <= 3);
     MPIR_Assert(is_localcomm <= 1);
-
-    MPIDI_global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type] = comm;
 
     MPIDIG_COMM(comm, window_instance) = 0;
   fn_exit:


### PR DESCRIPTION
## Pull Request Description

This PR removes remaining instances of context_id->comm lookups in "native" paths (ipc and ofi). The last commit removes the comm_req_lists data structures and comm lookup API, as they are no longer needed.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
