### PR TITLE
ch4/ofi: fix miss use of NEEDS_STRICT_ALIGNMENT

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -619,7 +619,7 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
         case MPIDI_AMTYPE_RDMA_READ:
             {
                 /* buffer always copied together (there is no payload, just LMT header) */
-#if NEEDS_STRICT_ALIGNMENT
+#ifdef NEEDS_STRICT_ALIGNMENT
                 MPIDI_OFI_lmt_msg_payload_t temp_rdma_lmt_msg;
                 if (!has_alignment_copy) {
                     memcpy(&temp_rdma_lmt_msg,
@@ -651,7 +651,7 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     if ((uo_msg = MPIDI_OFI_am_claim_unordered_msg(fi_src_addr, next_seqno)) != NULL) {
         am_hdr = &uo_msg->am_hdr;
         orig_buf = am_hdr;
-#if NEEDS_STRICT_ALIGNMENT
+#ifdef NEEDS_STRICT_ALIGNMENT
         /* alignment is ensured for this unordered message as it copies to a temporary buffer
          * in MPIDI_OFI_am_enqueue_unordered_msg */
         has_alignment_copy = 1;


### PR DESCRIPTION

## Pull Request Description
We meant #ifdef NEEDS_STRICT_ALIGNMENT, but miss typed as #if
NEEDS_STRICT_ALIGNMENT.



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
