### PR TITLE
Provide Info Hints for NIC preference

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -400,6 +400,7 @@ AC_ARG_ENABLE([mpit-pvars],
         recvq    - All message queue-related
         nem      - All nemesis-related
         rma      - All rma-related
+        multinic - All multinic-related
         all      - All variables above
 ],[],[enable_mpit_pvars=none])
 
@@ -1703,13 +1704,15 @@ for var in $enable_mpit_pvars ; do
             [nem],[enable_pvar_nem=yes],
             [recvq],[enable_pvar_recvq=yes],
             [rma],[enable_pvar_rma=yes],
-	    [dims],[enable_pvar_dims=yes],
+            [dims],[enable_pvar_dims=yes],
+            [multinic],[enable_pvar_multinic=yes],
             [all|yes],
             [enable_pvar_nem=yes
              enable_pvar_recvq=yes
              enable_pvar_rma=yes
-	     enable_pvar_dims=yes
-	     ],
+             enable_pvar_dims=yes
+             enable_pvar_multinic=yes
+             ],
             [no|none],[],
             [IFS=$save_IFS
              AC_MSG_WARN([Unknown value ($option) for enable-mpit-pvars])
@@ -1754,6 +1757,14 @@ AC_DEFINE_UNQUOTED(ENABLE_PVAR_DIMS,$status_dims_pvars,
 if test "$enable_mpit_events" = "yes" ; then
     AC_DEFINE(HAVE_MPIT_EVENTS, [1], [Define if MPI_T Events are enabled])
 fi
+
+if test -n "$enable_pvar_multinic" ; then
+    status_multinic_pvars=1
+else
+    status_multinic_pvars=0
+fi
+AC_DEFINE_UNQUOTED(ENABLE_PVAR_MULTINIC,$status_multinic_pvars,
+          [Define to 1 to enable message count transmitted through multiple NICs MPI_T performance variables])
 
 # ---------------------------------------------------------------------------
 # Support for the language bindings: Fortran 77, Fortran 90, and C++

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -90,6 +90,7 @@ enum MPIR_COMM_HINT_PREDEFINED_t {
     MPIR_COMM_HINT_EAGAIN,      /* ch4:ofi */
     MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING,   /* ch4:ofi */
     MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING,    /* ch4:ofi */
+    MPIR_COMM_HINT_MULTI_NIC_PREF_NIC,  /* ch4:ofi */
     /* dynamic hints starts here */
     MPIR_COMM_HINT_PREDEFINED_COUNT
 };

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -182,6 +182,8 @@ void MPIR_Comm_hint_init(void)
                             NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, -1);
     MPIR_Comm_register_hint(MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING, "enable_multi_nic_hashing",
                             NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, -1);
+    MPIR_Comm_register_hint(MPIR_COMM_HINT_MULTI_NIC_PREF_NIC, "multi_nic_pref_nic", NULL,
+                            MPIR_COMM_HINT_TYPE_INT, 0, -1);
 }
 
 /* FIXME :

--- a/src/mpid/ch4/netmod/ofi/globals.c
+++ b/src/mpid/ch4/netmod/ofi/globals.c
@@ -12,6 +12,9 @@ MPIDI_OFI_huge_recv_t *MPIDI_unexp_huge_recv_tail = NULL;
 MPIDI_OFI_huge_recv_list_t *MPIDI_posted_huge_recv_head = NULL;
 MPIDI_OFI_huge_recv_list_t *MPIDI_posted_huge_recv_tail = NULL;
 
+unsigned long long PVAR_COUNTER_nic_sent_bytes_count[MPIDI_OFI_MAX_NICS] ATTRIBUTE((unused));
+unsigned long long PVAR_COUNTER_nic_recvd_bytes_count[MPIDI_OFI_MAX_NICS] ATTRIBUTE((unused));
+
 MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
 /* Initialize a runtime version of all of the capability sets defined in
  * ofi_capability_sets.h so we can refer to it if we want to preload a

--- a/src/mpid/ch4/netmod/ofi/globals.c
+++ b/src/mpid/ch4/netmod/ofi/globals.c
@@ -18,6 +18,10 @@ unsigned long long PVAR_COUNTER_striped_nic_sent_bytes_count[MPIDI_OFI_MAX_NICS]
 ATTRIBUTE((unused));
 unsigned long long PVAR_COUNTER_striped_nic_recvd_bytes_count[MPIDI_OFI_MAX_NICS]
 ATTRIBUTE((unused));
+unsigned long long PVAR_COUNTER_rma_pref_phy_nic_put_bytes_count[MPIDI_OFI_MAX_NICS]
+ATTRIBUTE((unused));
+unsigned long long PVAR_COUNTER_rma_pref_phy_nic_get_bytes_count[MPIDI_OFI_MAX_NICS]
+ATTRIBUTE((unused));
 
 MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
 /* Initialize a runtime version of all of the capability sets defined in

--- a/src/mpid/ch4/netmod/ofi/globals.c
+++ b/src/mpid/ch4/netmod/ofi/globals.c
@@ -14,6 +14,10 @@ MPIDI_OFI_huge_recv_list_t *MPIDI_posted_huge_recv_tail = NULL;
 
 unsigned long long PVAR_COUNTER_nic_sent_bytes_count[MPIDI_OFI_MAX_NICS] ATTRIBUTE((unused));
 unsigned long long PVAR_COUNTER_nic_recvd_bytes_count[MPIDI_OFI_MAX_NICS] ATTRIBUTE((unused));
+unsigned long long PVAR_COUNTER_striped_nic_sent_bytes_count[MPIDI_OFI_MAX_NICS]
+ATTRIBUTE((unused));
+unsigned long long PVAR_COUNTER_striped_nic_recvd_bytes_count[MPIDI_OFI_MAX_NICS]
+ATTRIBUTE((unused));
 
 MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
 /* Initialize a runtime version of all of the capability sets defined in

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -216,7 +216,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
         for (int vni = 0; vni < num_vnis; vni++) {
             size_t actual_name_len = name_len;
             char *vni_addrname = my_names + (vni * num_nics + nic) * name_len;
-            int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+            int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
             MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[ctx_idx].ep, vni_addrname,
                                       &actual_name_len), getname);
             MPIR_Assert(actual_name_len == name_len);
@@ -229,7 +229,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
                                         all_names, my_len, MPI_BYTE, comm, &errflag);
 
     /* Step 2: insert and store non-root nic/vni on the root context */
-    int root_ctx_idx = MPIDI_OFI_get_ctx_index(0, 0);
+    int root_ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, 0);
     for (int r = 0; r < size; r++) {
         GET_AV_AND_ADDRNAMES(r);
         for (int nic = 0; nic < num_nics; nic++) {
@@ -245,7 +245,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
     for (int nic_local = 0; nic_local < num_nics; nic_local++) {
         for (int vni_local = 0; vni_local < num_vnis; vni_local++) {
             SKIP_ROOT(nic_local, vni_local);
-            int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic_local);
+            int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni_local, nic_local);
 
             /* -- same order as step 1 -- */
             if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -189,7 +189,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
         int vni_local = 0;
         int vni_remote = 0;
         int nic = 0;
-        MPIDI_OFI_cntr_incr(vni_local, nic);
+        MPIDI_OFI_cntr_incr(comm, vni_local, nic);
 
         struct iovec iov = {
             .iov_base = (char *) dst + done,
@@ -211,7 +211,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
             .data = 0
         };
 
-        int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic);
+        int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_local, nic);
         MPIDI_OFI_CALL_RETRY_AM(fi_readmsg(MPIDI_OFI_global.ctx[ctx_idx].tx, &msg, FI_COMPLETION),
                                 rdma_readfrom);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -85,6 +85,16 @@ int MPIDI_OFI_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
         comm->hints[MPIR_COMM_HINT_EAGAIN] = FALSE;
     }
 
+    if (comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING] == -1) {
+        comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING] =
+            MPIR_CVAR_CH4_OFI_ENABLE_MULTI_NIC_STRIPING;
+    }
+
+    if (comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING] == -1) {
+        comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING] =
+            MPIR_CVAR_CH4_OFI_ENABLE_MULTI_NIC_HASHING;
+    }
+
     update_multi_nic_hints(comm);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_MPI_COMM_COMMIT_PRE_HOOK);

--- a/src/mpid/ch4/netmod/ofi/ofi_dynproc.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_dynproc.c
@@ -144,7 +144,7 @@ static int dynproc_send_disconnect(int conn_id)
     msg.context = (void *) &req.context;
     msg.data = 0;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, nic);
     MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[ctx_idx].tx, &msg,
                                      FI_COMPLETION | FI_TRANSMIT_COMPLETE | FI_REMOTE_CQ_DATA),
                          0, tsendmsg, FALSE);
@@ -179,7 +179,7 @@ static int dynproc_post_recv_disconnect(int conn_id)
 
     int vni = 0;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
     MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[ctx_idx].rx,
                                   &p_conn->req->data, sizeof(int), NULL,
                                   addr, match_bits, mask_bits, &p_conn->req->context),

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -404,7 +404,8 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
                                              remote_key,        /* Key */
                                              (void *) &recv_elem->context), nic,        /* Context */
                                      rdma_readfrom, FALSE);
-                MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_recvd_bytes_count[receiver_nic], bytesToGet);
+                MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_recvd_bytes_count[nic], bytesToGet);
+                MPIR_T_PVAR_COUNTER_INC(MULTINIC, striped_nic_recvd_bytes_count[nic], bytesToGet);
                 recv_elem->cur_offset += bytesToGet;
                 recv_elem->chunks_outstanding++;
             }
@@ -422,7 +423,7 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
                                      remote_key,        /* Key          */
                                      (void *) &recv_elem->context), vni_src, rdma_readfrom,     /* Context */
                              FALSE);
-        MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_recvd_bytes_count[receiver_nic], bytesToGet);
+        MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_recvd_bytes_count[nic], bytesToGet);
         recv_elem->cur_offset += bytesToGet;
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -159,6 +159,8 @@ static int recv_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     }
 
     comm_ptr = rreq->comm;
+    MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_recvd_bytes_count[MPIDI_OFI_REQUEST(rreq, nic_num)],
+                            wc->len);
     /* Check to see if the tracker is already in the unexpected list.
      * Otherwise, allocate one. */
     {
@@ -402,6 +404,7 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
                                              remote_key,        /* Key */
                                              (void *) &recv_elem->context), nic,        /* Context */
                                      rdma_readfrom, FALSE);
+                MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_recvd_bytes_count[receiver_nic], bytesToGet);
                 recv_elem->cur_offset += bytesToGet;
                 recv_elem->chunks_outstanding++;
             }
@@ -419,6 +422,7 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
                                      remote_key,        /* Key          */
                                      (void *) &recv_elem->context), vni_src, rdma_readfrom,     /* Context */
                              FALSE);
+        MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_recvd_bytes_count[receiver_nic], bytesToGet);
         recv_elem->cur_offset += bytesToGet;
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -382,10 +382,10 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
     int vni_src = recv_elem->remote_info.vni_src;
     int vni_dst = recv_elem->remote_info.vni_dst;
     if (MPIDI_OFI_COMM(recv_elem->comm_ptr).enable_striping) {  /* if striping enabled */
-        MPIDI_OFI_cntr_incr(vni_src, nic);
+        MPIDI_OFI_cntr_incr(recv_elem->comm_ptr, vni_src, nic);
         if (recv_elem->cur_offset >= MPIDI_OFI_STRIPE_CHUNK_SIZE && bytesLeft > 0) {
             for (nic = 0; nic < MPIDI_OFI_global.num_nics; nic++) {
-                int ctx_idx = MPIDI_OFI_get_ctx_index(vni_dst, nic);
+                int ctx_idx = MPIDI_OFI_get_ctx_index(recv_elem->comm_ptr, vni_dst, nic);
                 remote_key = recv_elem->remote_info.rma_keys[nic];
 
                 bytesLeft = recv_elem->remote_info.msgsize - recv_elem->cur_offset;
@@ -407,9 +407,9 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
             }
         }
     } else {
-        int ctx_idx = MPIDI_OFI_get_ctx_index(vni_src, nic);
+        int ctx_idx = MPIDI_OFI_get_ctx_index(recv_elem->comm_ptr, vni_src, nic);
         remote_key = recv_elem->remote_info.rma_keys[nic];
-        MPIDI_OFI_cntr_incr(vni_src, nic);
+        MPIDI_OFI_cntr_incr(recv_elem->comm_ptr, vni_src, nic);
         MPIDI_OFI_CALL_RETRY(fi_read(MPIDI_OFI_global.ctx[ctx_idx].tx,  /* endpoint     */
                                      (void *) ((char *) recv_buf + recv_elem->cur_offset),      /* local buffer */
                                      bytesToGet,        /* bytes        */

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -115,7 +115,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
         int vni_local = vni_dst;
         int vni_remote = vni_src;
         int nic = 0;
-        int ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, nic);
+        int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni_local, nic);
         MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx, NULL /* buf */ ,
                                             0 /* len */ ,
                                             MPIR_Comm_rank(c),

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -63,9 +63,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
     count = wc->len;
     MPIR_STATUS_SET_COUNT(rreq->status, count);
 
-    MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_recvd_bytes_count[MPIDI_OFI_REQUEST(rreq, nic_num)],
-                            wc->len);
-
+    /* If striping is enabled, this data will be counted elsewhere. */
+    if (MPIDI_OFI_REQUEST(rreq, event_id) != MPIDI_OFI_EVENT_RECV_HUGE ||
+        !MPIDI_OFI_COMM(rreq->comm).enable_striping) {
+        MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_recvd_bytes_count[MPIDI_OFI_REQUEST(rreq, nic_num)],
+                                wc->len);
+    }
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     int is_cancelled;
     MPIDI_anysrc_try_cancel_partner(rreq, &is_cancelled);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -63,6 +63,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
     count = wc->len;
     MPIR_STATUS_SET_COUNT(rreq->status, count);
 
+    MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_recvd_bytes_count[MPIDI_OFI_REQUEST(rreq, nic_num)],
+                            wc->len);
+
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     int is_cancelled;
     MPIDI_anysrc_try_cancel_partner(rreq, &is_cancelled);

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -21,6 +21,11 @@ extern unsigned long long PVAR_COUNTER_striped_nic_sent_bytes_count[MPIDI_OFI_MA
 ATTRIBUTE((unused));
 extern unsigned long long PVAR_COUNTER_striped_nic_recvd_bytes_count[MPIDI_OFI_MAX_NICS]
 ATTRIBUTE((unused));
+extern unsigned long long PVAR_COUNTER_rma_pref_phy_nic_put_bytes_count[MPIDI_OFI_MAX_NICS]
+ATTRIBUTE((unused));
+extern unsigned long long PVAR_COUNTER_rma_pref_phy_nic_get_bytes_count[MPIDI_OFI_MAX_NICS]
+ATTRIBUTE((unused));
+
 
 #define MPIDI_OFI_ENAVAIL   -1  /* OFI resource not available */
 #define MPIDI_OFI_EPERROR   -2  /* OFI endpoint error */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -17,6 +17,10 @@
 extern unsigned long long PVAR_COUNTER_nic_sent_bytes_count[MPIDI_OFI_MAX_NICS] ATTRIBUTE((unused));
 extern unsigned long long PVAR_COUNTER_nic_recvd_bytes_count[MPIDI_OFI_MAX_NICS]
 ATTRIBUTE((unused));
+extern unsigned long long PVAR_COUNTER_striped_nic_sent_bytes_count[MPIDI_OFI_MAX_NICS]
+ATTRIBUTE((unused));
+extern unsigned long long PVAR_COUNTER_striped_nic_recvd_bytes_count[MPIDI_OFI_MAX_NICS]
+ATTRIBUTE((unused));
 
 #define MPIDI_OFI_ENAVAIL   -1  /* OFI resource not available */
 #define MPIDI_OFI_EPERROR   -2  /* OFI endpoint error */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -14,6 +14,10 @@
 #include "mpidig_am.h"
 #include "ch4_impl.h"
 
+extern unsigned long long PVAR_COUNTER_nic_sent_bytes_count[MPIDI_OFI_MAX_NICS] ATTRIBUTE((unused));
+extern unsigned long long PVAR_COUNTER_nic_recvd_bytes_count[MPIDI_OFI_MAX_NICS]
+ATTRIBUTE((unused));
+
 #define MPIDI_OFI_ENAVAIL   -1  /* OFI resource not available */
 #define MPIDI_OFI_EPERROR   -2  /* OFI endpoint error */
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -256,18 +256,22 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_cntr_incr(MPIR_Win * win)
 /* Calculate the OFI context index.
  * The total number of OFI contexts will be the number of nics * number of vcis
  * Each nic will contain num_vcis vnis. Each corresponding to their respective vci index. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_ctx_index(int vni, int nic)
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_ctx_index(MPIR_Comm * comm_ptr, int vni, int nic)
 {
-    return nic * MPIDI_OFI_global.num_vnis + vni;
+    if (comm_ptr == NULL || MPIDI_OFI_COMM(comm_ptr).pref_nic == NULL) {
+        return nic * MPIDI_OFI_global.num_vnis + vni;
+    } else {
+        return MPIDI_OFI_COMM(comm_ptr).pref_nic[comm_ptr->rank] * MPIDI_OFI_global.num_vnis + vni;
+    }
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr(int vni, int nic)
+MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr(MPIR_Comm * comm, int vni, int nic)
 {
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni, nic);
 #else
     /* NOTE: shared with ctx[0] */
-    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, 0, nic);
 #endif
 
 #if defined(MPIDI_CH4_USE_MT_RUNTIME) || defined(MPIDI_CH4_USE_MT_LOCKLESS)

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -474,6 +474,23 @@ static int ofi_pvar_init(void)
                                                MPIR_T_PVAR_FLAG_SUM), "CH4",
                                               "number of striped bytes received through a particular NIC");
 
+    MPIR_T_PVAR_COUNTER_ARRAY_REGISTER_STATIC(MULTINIC,
+                                              MPI_UNSIGNED_LONG_LONG,
+                                              rma_pref_phy_nic_put_bytes_count,
+                                              MPI_T_VERBOSITY_USER_DETAIL,
+                                              MPI_T_BIND_NO_OBJECT,
+                                              (MPIR_T_PVAR_FLAG_READONLY |
+                                               MPIR_T_PVAR_FLAG_SUM), "CH4",
+                                              "number of bytes sent through preferred physical NIC using RMA");
+
+    MPIR_T_PVAR_COUNTER_ARRAY_REGISTER_STATIC(MULTINIC,
+                                              MPI_UNSIGNED_LONG_LONG,
+                                              rma_pref_phy_nic_get_bytes_count,
+                                              MPI_T_VERBOSITY_USER_DETAIL,
+                                              MPI_T_BIND_NO_OBJECT,
+                                              (MPIR_T_PVAR_FLAG_READONLY |
+                                               MPIR_T_PVAR_FLAG_SUM), "CH4",
+                                              "number of bytes received through preferred physical NIC using RMA");
     return mpi_errno;
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -698,7 +698,8 @@ static int flush_send(int dst, int nic, int vni, MPIDI_OFI_dynamic_process_reque
     req->done = 0;
     req->event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
 
-    MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vni, nic)].tx,
+    MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, vni,
+                                                                                   nic)].tx,
                                       &data, 4, NULL, 0, addr, match_bits, &req->context), vni,
                          tsenddata, FALSE);
 
@@ -724,7 +725,7 @@ static int flush_recv(int src, int nic, int vni, MPIDI_OFI_dynamic_process_reque
 
     /* we don't care the data and the tag field is not used */
     void *recvbuf = &(req->tag);
-    MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vni, nic)].rx,
+    MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, vni, nic)].rx,
                                   recvbuf, 4, NULL, addr, match_bits, mask_bits, &req->context),
                          vni, trecv, FALSE);
 
@@ -972,7 +973,7 @@ static int create_vni_context(int vni, int nic)
         tx = ep;
         rx = ep;
     }
-    ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+    ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
     MPIDI_OFI_global.ctx[ctx_idx].domain = domain;
     MPIDI_OFI_global.ctx[ctx_idx].av = av;
     MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr = rma_cmpl_cntr;
@@ -990,7 +991,7 @@ static int create_vni_context(int vni, int nic)
         mpi_errno = create_vni_domain(&domain, &av, &rma_cmpl_cntr, nic);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
-        ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+        ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, nic);
         domain = MPIDI_OFI_global.ctx[ctx_idx].domain;
         av = MPIDI_OFI_global.ctx[ctx_idx].av;
         rma_cmpl_cntr = MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr;
@@ -1014,7 +1015,7 @@ static int create_vni_context(int vni, int nic)
             MPIDI_OFI_CALL(fi_enable(ep), ep_enable);
         }
     } else {
-        ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+        ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, nic);
         ep = MPIDI_OFI_global.ctx[ctx_idx].ep;
     }
 
@@ -1029,7 +1030,7 @@ static int create_vni_context(int vni, int nic)
     }
 
     if (vni == 0) {
-        ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+        ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
         MPIDI_OFI_global.ctx[ctx_idx].domain = domain;
         MPIDI_OFI_global.ctx[ctx_idx].av = av;
         MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr = rma_cmpl_cntr;
@@ -1037,10 +1038,10 @@ static int create_vni_context(int vni, int nic)
     } else {
         /* non-zero vni share most fields with vni 0, copy them
          * so we don't have to switch during runtime */
-        MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vni, nic)] =
-            MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(0, nic)];
+        MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, vni, nic)] =
+            MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, 0, nic)];
     }
-    ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+    ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
     MPIDI_OFI_global.ctx[ctx_idx].cq = cq;
     MPIDI_OFI_global.ctx[ctx_idx].tx = tx;
     MPIDI_OFI_global.ctx[ctx_idx].rx = rx;
@@ -1056,7 +1057,7 @@ static int create_vni_context(int vni, int nic)
 static int destroy_vni_context(int vni, int nic)
 {
     int mpi_errno = MPI_SUCCESS;
-    int ctx_num = MPIDI_OFI_get_ctx_index(vni, nic);
+    int ctx_num = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
@@ -1466,7 +1467,7 @@ int ofi_am_post_recv(int vni, int nic)
     MPIR_Assert(vni == 0 && nic == 0);
 
     if (MPIDI_OFI_ENABLE_AM) {
-        int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+        int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
         size_t optlen = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE;
 
         MPIDI_OFI_CALL(fi_setopt(&(MPIDI_OFI_global.ctx[ctx_idx].rx->fid),

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -455,6 +455,25 @@ static int ofi_pvar_init(void)
                                               (MPIR_T_PVAR_FLAG_READONLY |
                                                MPIR_T_PVAR_FLAG_SUM), "CH4",
                                               "number of bytes received through a particular NIC");
+
+    MPIR_T_PVAR_COUNTER_ARRAY_REGISTER_STATIC(MULTINIC,
+                                              MPI_UNSIGNED_LONG_LONG,
+                                              striped_nic_sent_bytes_count,
+                                              MPI_T_VERBOSITY_USER_DETAIL,
+                                              MPI_T_BIND_NO_OBJECT,
+                                              (MPIR_T_PVAR_FLAG_READONLY |
+                                               MPIR_T_PVAR_FLAG_SUM), "CH4",
+                                              "number of striped bytes sent through a particular NIC");
+
+    MPIR_T_PVAR_COUNTER_ARRAY_REGISTER_STATIC(MULTINIC,
+                                              MPI_UNSIGNED_LONG_LONG,
+                                              striped_nic_recvd_bytes_count,
+                                              MPI_T_VERBOSITY_USER_DETAIL,
+                                              MPI_T_BIND_NO_OBJECT,
+                                              (MPIR_T_PVAR_FLAG_READONLY |
+                                               MPIR_T_PVAR_FLAG_SUM), "CH4",
+                                              "number of striped bytes received through a particular NIC");
+
     return mpi_errno;
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -146,6 +146,14 @@ static int setup_single_nic(void)
     MPIDI_OFI_global.nic_info[0].count = MPIR_Process.local_size;
     MPIDI_OFI_global.nic_info[0].num_close_ranks = MPIR_Process.local_size;
 
+    char nics_str[32];
+    MPIR_Info *info_ptr = NULL;
+    MPIR_Info_get_ptr(MPI_INFO_ENV, info_ptr);
+    snprintf(nics_str, 32, "%d", 1);
+    MPIR_Info_set_impl(info_ptr, "num_nics", nics_str);
+    snprintf(nics_str, 32, "%d", 1);
+    MPIR_Info_set_impl(info_ptr, "num_close_nics", nics_str);
+
     return MPI_SUCCESS;
 }
 
@@ -243,6 +251,15 @@ static int setup_multi_nic(int nic_count)
     for (int i = 0; i < MPIDI_OFI_global.num_nics; ++i) {
         MPIDI_OFI_global.prov_use[i] = nics[i].nic;
     }
+
+    /* Set some info keys on MPI_INFO_ENV to reflect the number of available (close) NICs */
+    char nics_str[32];
+    MPIR_Info *info_ptr = NULL;
+    MPIR_Info_get_ptr(MPI_INFO_ENV, info_ptr);
+    snprintf(nics_str, 32, "%d", MPIDI_OFI_global.num_nics);
+    MPIR_Info_set_impl(info_ptr, "num_nics", nics_str);
+    snprintf(nics_str, 32, "%d", MPIDI_OFI_global.num_close_nics);
+    MPIR_Info_set_impl(info_ptr, "num_close_nics", nics_str);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -47,6 +47,7 @@ typedef struct {
     int conn_id;
     int enable_striping;        /* Flag to enable striping per communicator. */
     int enable_hashing;         /* Flag to enable hashing per communicator. */
+    int *pref_nic;              /* Array to specify the preferred NIC for each rank (if needed) */
 } MPIDI_OFI_comm_t;
 enum {
     MPIDI_AMTYPE_NONE = 0,

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -26,7 +26,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
     int vni_local = vni_dst;
     int vni_remote = vni_src;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni_dst, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_dst, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_IPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_IPROBE);

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -122,7 +122,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
         mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1);
     } else if (likely(1)) {
         for (int nic = 0; nic < MPIDI_OFI_global.num_nics; nic++) {
-            int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+            int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
             ret = fi_cq_read(MPIDI_OFI_global.ctx[ctx_idx].cq, (void *) wc,
                              MPIDI_OFI_NUM_CQ_ENTRIES);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
     receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->recvcontext_id, rank,
                                                       MPIDI_OFI_init_get_tag(match_bits));
     MPIDI_OFI_REQUEST(rreq, nic_num) = receiver_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(vni_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
 
     if (!flags) {
         flags = FI_COMPLETION | FI_REMOTE_CQ_DATA;
@@ -164,7 +164,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
                                                   tag);
     receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->recvcontext_id, rank, tag);
     MPIDI_OFI_REQUEST(rreq, nic_num) = receiver_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(vni_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
 
     match_bits = MPIDI_OFI_init_recvtag(&mask_bits, context_id, tag);
 
@@ -361,7 +361,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_CANCEL_RECV);
 
     int vni = MPIDI_Request_get_vci(rreq);
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni, MPIDI_OFI_REQUEST(rreq, nic_num));
+    int ctx_idx = MPIDI_OFI_get_ctx_index(rreq->comm, vni, MPIDI_OFI_REQUEST(rreq, nic_num));
 
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_cancel_recv(rreq);

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -216,6 +216,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         goto null_op_exit;
     }
 
+    /* determine preferred physical NIC number for the rank */
+    MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;
+    MPIR_T_PVAR_COUNTER_INC(MULTINIC, rma_pref_phy_nic_put_bytes_count[nics[0].id], target_bytes);
+
     /* prepare remote addr and mr key.
      * Continue native path only when all segments are in the same registered memory region */
     bool target_mr_found;
@@ -400,6 +404,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
                                    target_datatype, origin_addr, origin_count, origin_datatype);
         goto null_op_exit;
     }
+
+    /* determine preferred physical NIC number for the rank */
+    MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;
+    MPIR_T_PVAR_COUNTER_INC(MULTINIC, rma_pref_phy_nic_get_bytes_count[nics[0].id], target_bytes);
 
     /* prepare remote addr and mr key.
      * Continue native path only when all segments are in the same registered memory region */

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -42,6 +42,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
                                                              vni_remote),
                                         match_bits),
                          vni_local, tinjectdata, comm->hints[MPIR_COMM_HINT_EAGAIN]);
+    MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT);
     return mpi_errno;
@@ -124,6 +125,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
 
     MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                      &msg, flags), vni_local, tsendv, FALSE);
+    MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_SEND_IOV);
@@ -265,6 +267,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                             MPIDI_OFI_av_to_phys(addr, receiver_nic, vni_local,
                                                                  vni_remote), match_bits),
                              vni_local, tinjectdata, FALSE /* eagain */);
+        MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
         MPIDI_OFI_send_event(NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
     } else if ((data_sz < MPIDI_OFI_global.max_msg_size && !MPIDI_OFI_COMM(comm).enable_striping)
                || (data_sz < MPIDI_OFI_global.stripe_threshold &&
@@ -276,6 +279,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                                                vni_remote), match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))), vni_local,
                              tsenddata, FALSE /* eagain */);
+        MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
     } else if (unlikely(1)) {
         MPIDI_OFI_send_control_t ctrl;
         int i, num_nics = MPIDI_OFI_global.num_nics;
@@ -343,6 +347,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                           match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
                              vni_local, tsenddata, FALSE /* eagain */);
+        MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], msg_size);
         ctrl.type = MPIDI_OFI_CTRL_HUGE;
         ctrl.seqno = 0;
         ctrl.tag = tag;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -31,7 +31,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
     sender_nic = MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, dst_rank, tag);
     receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, MPIR_Process.rank,
                                                       tag);
-    ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, sender_nic);
+    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_local, sender_nic);
 
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, tag, 0);
     MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx,
@@ -94,7 +94,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, MPIR_Process.rank,
                                                       MPIDI_OFI_init_get_tag(match_bits));
     MPIDI_OFI_REQUEST(sreq, nic_num) = sender_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, MPIDI_OFI_REQUEST(sreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_local, MPIDI_OFI_REQUEST(sreq, nic_num));
 
     /* everything fits in the IOV array */
     flags = FI_COMPLETION | FI_REMOTE_CQ_DATA;
@@ -181,7 +181,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, MPIR_Process.rank,
                                                       tag);
     MPIDI_OFI_REQUEST(sreq, nic_num) = sender_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(vni_local, MPIDI_OFI_REQUEST(sreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_local, MPIDI_OFI_REQUEST(sreq, nic_num));
 
     if (type == MPIDI_OFI_SYNC_SEND) {  /* Branch should compile out */
         uint64_t ssend_match, ssend_mask;
@@ -194,7 +194,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIR_cc_inc(sreq->cc_ptr);
         ssend_match = MPIDI_OFI_init_recvtag(&ssend_mask, comm->context_id + context_offset, tag);
         ssend_match |= MPIDI_OFI_SYNC_SEND_ACK;
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vni_local, receiver_nic)].rx,        /* endpoint    */
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(comm, vni_local, receiver_nic)].rx,  /* endpoint    */
                                       NULL,     /* recvbuf     */
                                       0,        /* data sz     */
                                       NULL,     /* memregion descr  */
@@ -306,7 +306,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
             }
         }
         for (i = 0; i < num_nics; i++) {
-            MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vni_local, i)].domain,        /* In:  Domain Object */
+            MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(comm, vni_local, i)].domain,  /* In:  Domain Object */
                                      send_buf,  /* In:  Lower memory address */
                                      data_sz,   /* In:  Length              */
                                      FI_REMOTE_READ,    /* In:  Expose MR for read  */

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -348,6 +348,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
                              vni_local, tsenddata, FALSE /* eagain */);
         MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], msg_size);
+        MPIR_T_PVAR_COUNTER_INC(MULTINIC, striped_nic_sent_bytes_count[sender_nic], msg_size);
         ctrl.type = MPIDI_OFI_CTRL_HUGE;
         ctrl.seqno = 0;
         ctrl.tag = tag;

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -229,7 +229,7 @@ static int dynproc_handshake(int root, int phase, int timeout, int port_id, fi_a
     MPL_time_t time_sta, time_now;
     double time_gap;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm_ptr, 0, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_DYNPROC_HANDSHAKE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_DYNPROC_HANDSHAKE);
@@ -350,7 +350,7 @@ static int dynproc_exchange_map(int root, int phase, int port_id, fi_addr_t * co
     char *local_upids = NULL;
     int *local_node_ids = NULL;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm_ptr, 0, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_DYNPROC_EXCHANGE_MAP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_DYNPROC_EXCHANGE_MAP);
@@ -515,7 +515,7 @@ int MPIDI_OFI_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root
     int rank = comm_ptr->rank;
     fi_addr_t conn;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm_ptr, 0, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_COMM_CONNECT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_COMM_CONNECT);
@@ -709,7 +709,7 @@ int MPIDI_OFI_mpi_comm_accept(const char *port_name, MPIR_Info * info, int root,
     int rank = comm_ptr->rank;
     int port_id;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm_ptr, 0, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_COMM_ACCEPT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_COMM_ACCEPT);
@@ -827,7 +827,7 @@ int MPIDI_OFI_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_
     int max_n_avts;
     char *curr_upid;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, nic);
 
     MPIR_CHKLMEM_DECL(2);
 
@@ -902,7 +902,7 @@ int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char 
     int i, total_size = 0;
     char *temp_buf = NULL, *curr_ptr = NULL;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, 0, nic);
 
     MPIR_CHKPMEM_DECL(2);
     MPIR_CHKLMEM_DECL(1);

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -137,7 +137,7 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
 
     /* we need register mr on the correct domain for the vni */
     int vni = MPIDI_OFI_get_win_vni(win);
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
     /* Register the allocated win buffer or MPI_BOTTOM (NULL) for dynamic win.
      * It is clear that we cannot register NULL when FI_MR_ALLOCATED is set, thus
@@ -242,7 +242,7 @@ static int win_set_per_win_sync(MPIR_Win * win)
 {
     int ret, mpi_errno = MPI_SUCCESS;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(MPIDI_OFI_WIN(win).vni, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, MPIDI_OFI_WIN(win).vni, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_WIN_SET_PER_WIN_SYNC);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_WIN_SET_PER_WIN_SYNC);
@@ -296,7 +296,7 @@ static int win_init_sep(MPIR_Win * win)
     struct fi_info *finfo;
     int nic = 0;
     int vni = MPIDI_OFI_WIN(win).vni;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_WIN_INIT_SEP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_WIN_INIT_SEP);
@@ -425,7 +425,7 @@ static int win_init_stx(MPIR_Win * win)
     bool have_per_win_cntr = false;
     int nic = 0;
     int vni = MPIDI_OFI_WIN(win).vni;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_WIN_INIT_STX);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_WIN_INIT_STX);
@@ -542,14 +542,14 @@ static int win_init_global(MPIR_Win * win)
 
     int vni = MPIDI_OFI_WIN(win).vni;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
     MPIDI_OFI_WIN(win).ep = MPIDI_OFI_global.ctx[ctx_idx].tx;
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
     MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr;
     MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_OFI_global.ctx[ctx_idx].rma_issued_cntr;
 #else
-    ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
+    ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, nic);
     /* NOTE: shared with ctx[0] */
     MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr;
     MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_OFI_global.ctx[ctx_idx].rma_issued_cntr;
@@ -902,7 +902,7 @@ int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
     dwin_target_mr_t *target_mrs;
     int mpl_err = MPL_SUCCESS, i;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(MPIDI_OFI_WIN(win).vni, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, MPIDI_OFI_WIN(win).vni, nic);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_MPI_WIN_ATTACH_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_MPI_WIN_ATTACH_HOOK);
@@ -1046,7 +1046,7 @@ int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win)
 
     if (MPIDI_OFI_ENABLE_RMA) {
         int vni = MPIDI_OFI_WIN(win).vni;
-        int ctx_idx = MPIDI_OFI_get_ctx_index(vni, nic);
+        int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
         MPIDI_OFI_mr_key_free(MPIDI_OFI_COLL_MR_KEY, MPIDI_OFI_WIN(win).win_id);
         MPIDIU_map_erase(MPIDI_OFI_global.win_map, MPIDI_OFI_WIN(win).win_id);
         /* For scalable EP: push transmit context index back into available pool. */

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1226,6 +1226,7 @@
 /mpi_t/cvarwrite
 /mpi_t/getindex
 /mpi_t/mpi_t_str
+/mpi_t/mpit_isendirecv
 /mpi_t/mpit_vars
 /mpi_t/qmpi_test
 /part/multipart

--- a/test/mpi/info/infoenv.c
+++ b/test/mpi/info/infoenv.c
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
 {
     char value[MPI_MAX_INFO_VAL];
     const char *keys[] = { "command", "argv", "maxprocs", "soft", "host", "arch", "wdir", "file",
-        "thread_level", 0
+        "thread_level", "num_nics", "num_close_nics", 0
     };
     int flag, i;
 
@@ -22,7 +22,7 @@ int main(int argc, char *argv[])
     for (i = 0; keys[i]; i++) {
         MPI_Info_get(MPI_INFO_ENV, keys[i], MPI_MAX_INFO_VAL, value, &flag);
         if (flag && verbose)
-            printf("command: %s\n", value);
+            printf("%s: %s\n", keys[i], value);
     }
 
     MTest_Finalize(0);

--- a/test/mpi/mpi_t/Makefile.am
+++ b/test/mpi/mpi_t/Makefile.am
@@ -12,6 +12,7 @@ EXTRA_DIST = testlist
 ## correctly
 noinst_PROGRAMS =     \
     mpi_t_str   \
+    mpit_isendirecv \
     mpit_vars   \
     cvarwrite   \
     getindex    \

--- a/test/mpi/mpi_t/mpit_isendirecv.c
+++ b/test/mpi/mpi_t/mpit_isendirecv.c
@@ -1,0 +1,372 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "mpitest.h"
+
+#define MAX_NICS_SUPPORTED 8
+
+static unsigned long long nic_sent_bytes_count[MAX_NICS_SUPPORTED];
+static unsigned long long nic_recvd_bytes_count[MAX_NICS_SUPPORTED];
+static unsigned long long striped_nic_sent_bytes_count[MAX_NICS_SUPPORTED];
+static unsigned long long striped_nic_recvd_bytes_count[MAX_NICS_SUPPORTED];
+static MPI_T_pvar_handle nsc_handle, nrc_handle, snsc_handle, snrc_handle;
+static MPI_T_pvar_session session;
+static int elems = 1000000;
+static MPI_Request *reqs;
+static int num_nics = 1;
+static int enable_striping = 1;
+static int enable_hashing = 0;
+static int num_nodes = 0;
+static int num_procs = 0;
+static int num_procs_per_node = 0;
+static int num_pairs = 0;
+
+/* removes duplicates in the char array */
+static int remove_duplicates(char nodenames[][MPI_MAX_PROCESSOR_NAME], int size)
+{
+    int i, j, k;
+
+    for (i = 0; i < size; i++) {
+        for (j = i + 1, k = j; j < size; j++) {
+            /* strings do not match */
+            if (strcmp(nodenames[i], nodenames[j])) {
+                snprintf(nodenames[k], sizeof(nodenames[j]), "%s", nodenames[j]);
+                k++;
+            }
+        }
+        size -= j - k;
+    }
+    return size;
+}
+
+static int compare_vars(int rank, int target, int num_nics)
+{
+    int idx;
+    int errs = 0;
+
+    /* expected output */
+    struct ExpectedMapNicTestOutput {
+        unsigned long long nic_sent_bytes_count[MAX_NICS_SUPPORTED];
+        unsigned long long nic_recvd_bytes_count[MAX_NICS_SUPPORTED];
+        unsigned long long striped_nic_sent_bytes_count[MAX_NICS_SUPPORTED];
+        unsigned long long striped_nic_recvd_bytes_count[MAX_NICS_SUPPORTED];
+    };
+
+    unsigned long long total_elems_byte_size = elems * sizeof(float);
+    int init_normal_msg_send_bytes = 2048;
+
+    /* expected byte count numbers based on the number of NICs in use */
+    /* the number of send and recv byte count between each pair must match */
+    struct ExpectedMapNicTestOutput expected_mapping[2] = { 0 };
+    for (idx = 0; idx < num_nics; ++idx) {
+        int bytes_through_each_nic = (num_nics > idx ? total_elems_byte_size : 0);
+        if (enable_hashing && !enable_striping) {
+            expected_mapping[0].nic_sent_bytes_count[idx] += bytes_through_each_nic;
+            expected_mapping[1].nic_recvd_bytes_count[idx] += bytes_through_each_nic;
+        } else if (!enable_hashing && enable_striping) {
+            expected_mapping[1].nic_recvd_bytes_count[idx] +=
+                bytes_through_each_nic - init_normal_msg_send_bytes;
+            expected_mapping[1].striped_nic_recvd_bytes_count[idx] +=
+                bytes_through_each_nic - init_normal_msg_send_bytes;
+        } else if (enable_hashing && enable_striping) {
+            expected_mapping[0].nic_sent_bytes_count[idx] += init_normal_msg_send_bytes;
+            expected_mapping[1].nic_recvd_bytes_count[idx] += bytes_through_each_nic;
+            expected_mapping[0].striped_nic_sent_bytes_count[idx] += init_normal_msg_send_bytes;
+            expected_mapping[1].striped_nic_recvd_bytes_count[idx] +=
+                bytes_through_each_nic - init_normal_msg_send_bytes;
+        } else if (!enable_hashing && !enable_striping) {
+            if (rank < num_pairs) {
+                /* map the ranks such that it falls within the range of number of NICs available */
+                expected_mapping[0].nic_sent_bytes_count[(rank % num_procs_per_node) %
+                                                         num_nics] += bytes_through_each_nic;
+            } else if (rank < num_pairs * 2) {
+                /* map the ranks such that it falls within the range of number of NICs available */
+                expected_mapping[1].nic_recvd_bytes_count[((rank - num_pairs)
+                                                           % num_procs_per_node) %
+                                                          num_nics] += bytes_through_each_nic;
+            }
+        }
+    }
+
+    /* expected initial send message count when striping is enabled
+     * based on rank<->NIC mapping */
+    if (!enable_hashing && enable_striping) {
+        if (rank < num_pairs) {
+            expected_mapping[0].nic_sent_bytes_count[rank] += (2048 * num_nics);
+            expected_mapping[0].striped_nic_sent_bytes_count[rank] += (2048 * num_nics);
+        } else if (rank < num_pairs * 2) {
+            expected_mapping[1].nic_recvd_bytes_count[rank - num_pairs] += (2048 * num_nics);
+        }
+    }
+
+    /* read the pvars from the session */
+    MPI_T_pvar_read(session, nsc_handle, &nic_sent_bytes_count);
+    MPI_T_pvar_read(session, nrc_handle, &nic_recvd_bytes_count);
+    MPI_T_pvar_read(session, snsc_handle, &striped_nic_sent_bytes_count);
+    MPI_T_pvar_read(session, snrc_handle, &striped_nic_recvd_bytes_count);
+
+    for (idx = 0; idx < num_nics; ++idx) {
+        /* if the actual byte count does not match with any of the expected count in the list
+         * return with error */
+        if (rank < num_pairs) {
+            if (expected_mapping[0].nic_sent_bytes_count[idx] != nic_sent_bytes_count[idx]) {
+                printf
+                    ("rank=%d --> target=%d: Actual sent byte count=%ld through NIC %d does not match with the "
+                     "expected sent byte count=%ld\n", rank, target, nic_sent_bytes_count[idx], idx,
+                     expected_mapping[0].nic_sent_bytes_count[idx]);
+                errs++;
+            }
+            if (expected_mapping[0].nic_recvd_bytes_count[idx] != nic_recvd_bytes_count[idx]) {
+                printf
+                    ("rank=%d --> target=%d: Actual received byte count=%ld through NIC %d does not match with the "
+                     "expected received byte count=%ld\n", rank, target, nic_recvd_bytes_count[idx],
+                     idx, expected_mapping[0].nic_recvd_bytes_count[idx]);
+                errs++;
+            }
+            if (expected_mapping[0].striped_nic_sent_bytes_count[idx] !=
+                striped_nic_sent_bytes_count[idx]) {
+                printf
+                    ("rank=%d --> target=%d: Actual striped sent byte count=%ld through NIC %d does not match with the "
+                     "expected striped sent byte count=%ld\n", rank, target,
+                     striped_nic_sent_bytes_count[idx], idx,
+                     expected_mapping[0].striped_nic_sent_bytes_count[idx]);
+                return -1;
+            }
+            if (expected_mapping[0].striped_nic_recvd_bytes_count[idx] !=
+                striped_nic_recvd_bytes_count[idx]) {
+                printf
+                    ("rank=%d --> target=%d: Actual striped received byte count=%ld through NIC %d does not match with the "
+                     "expected striped received byte count=%ld\n", rank, target,
+                     striped_nic_recvd_bytes_count[idx], idx,
+                     expected_mapping[0].striped_nic_recvd_bytes_count[idx]);
+                return -1;
+            }
+        } else if (rank < num_pairs * 2) {
+            if (expected_mapping[1].nic_sent_bytes_count[idx] != nic_sent_bytes_count[idx]) {
+                printf
+                    ("rank=%d --> target=%d: Actual sent byte count=%ld through NIC %d does not match with the "
+                     "expected sent byte count=%ld\n", rank, target, nic_sent_bytes_count[idx], idx,
+                     expected_mapping[1].nic_sent_bytes_count[idx]);
+                errs++;
+            }
+            if (expected_mapping[1].nic_recvd_bytes_count[idx] != nic_recvd_bytes_count[idx]) {
+                printf
+                    ("rank=%d --> target=%d: Actual received byte count=%ld through NIC %d does not match with the "
+                     "expected received byte count=%ld\n", rank, target, nic_recvd_bytes_count[idx],
+                     idx, expected_mapping[1].nic_recvd_bytes_count[idx]);
+                errs++;
+            }
+            if (expected_mapping[1].striped_nic_sent_bytes_count[idx] !=
+                striped_nic_sent_bytes_count[idx]) {
+                printf
+                    ("rank=%d --> target=%d: Actual striped sent byte count=%ld through NIC %d does not match with the "
+                     "expected striped sent byte count=%ld\n", rank, target,
+                     striped_nic_sent_bytes_count[idx], idx,
+                     expected_mapping[1].striped_nic_sent_bytes_count[idx]);
+                return -1;
+            }
+            if (expected_mapping[1].striped_nic_recvd_bytes_count[idx] !=
+                striped_nic_recvd_bytes_count[idx]) {
+                printf
+                    ("rank=%d --> target=%d: Actual striped received byte count=%ld through NIC %d does not match with the "
+                     "expected striped received byte count=%ld\n", rank, target,
+                     striped_nic_recvd_bytes_count[idx], idx,
+                     expected_mapping[1].striped_nic_recvd_bytes_count[idx]);
+                return -1;
+            }
+        }
+    }
+    return errs;
+}
+
+int main(int argc, char *argv[])
+{
+    int num;
+#define STR_SZ (50)
+    int name_len = STR_SZ;
+    char name[STR_SZ] = "";
+    int desc_len = STR_SZ;
+    char desc[STR_SZ] = "";
+    int verb;
+    MPI_Datatype dtype;
+    int count;
+    int bind;
+    int varclass;
+    int readonly, continuous, atomic;
+    MPI_T_enum enumtype;
+    int nsc_idx = -1, nrc_idx = -1, snsc_idx = -1, snrc_idx = -1;
+
+    int required, provided;
+    int errs = 0;
+    int rank, i;
+    float *in_buf, *out_buf;
+    MPI_Comm comm;
+    MPI_Info comm_info;
+    MPI_Info comm_info_out;
+    char query_key[MPI_MAX_INFO_KEY];
+    char buf[MPI_MAX_INFO_VAL];
+    char val[MPI_MAX_INFO_VAL];
+    int flag;
+    int target;
+
+    MTest_Init(&argc, &argv);
+
+    comm = MPI_COMM_WORLD;
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &num_procs);
+
+    if (argc != 3) {
+        if (rank == 0) {
+            fprintf(stderr, "Expected 2 arguments.\n");
+            fprintf(stderr, "    Usage: ./mpit_isendirecv <enable_striping> <enable_hashing>\n");
+        }
+        exit(1);
+    } else {
+        enable_striping = atoi(argv[1]);
+        enable_hashing = atoi(argv[2]);
+    }
+
+    /* compute total number of nodes */
+    char nodenames[num_procs][MPI_MAX_PROCESSOR_NAME];
+    int len;
+    MPI_Get_processor_name(nodenames[rank], &len);
+    MPI_Allgather(MPI_IN_PLACE, 0, 0, &nodenames, MPI_MAX_PROCESSOR_NAME, MPI_CHAR, MPI_COMM_WORLD);
+
+    /* remove duplicate node names */
+    num_nodes = remove_duplicates(nodenames, num_procs);
+
+    /* number of processes per node */
+    num_procs_per_node = num_procs / num_nodes;
+
+    /* number of pairs */
+    num_pairs = num_procs / 2;
+
+    MPI_Info_create(&comm_info);
+    MPI_Info_set(comm_info, "mpi_assert_no_any_source", "true");
+    MPI_Info_set(comm_info, "mpi_assert_no_any_tag", "true");
+    MPI_Info_set(comm_info, "enable_multi_nic_striping", enable_striping ? "true" : "false");
+    MPI_Info_set(comm_info, "enable_multi_nic_hashing", enable_hashing ? "true" : "false");
+    MPI_Comm_set_info(comm, comm_info);
+
+    /* determine the number of nics in use */
+    memset(buf, 0, MPI_MAX_INFO_VAL * sizeof(char));
+    MPI_Info_get(MPI_INFO_ENV, "num_nics", MPI_MAX_INFO_VAL, buf, &flag);
+    if (!flag) {
+        num_nics = 1;
+    } else {
+        num_nics = atoi(buf);
+    }
+
+    required = MPI_THREAD_SINGLE;
+    MPI_T_init_thread(required, &provided);
+    MTest_Init_thread(&argc, &argv, required, &provided);
+    MPI_T_pvar_get_num(&num);
+    for (i = 0; i < num; ++i) {
+        name_len = desc_len = STR_SZ;
+        MPI_T_pvar_get_info(i, name, &name_len, &verb, &varclass, &dtype, &enumtype, desc,
+                            &desc_len, &bind, &readonly, &continuous, &atomic);
+
+        if (0 == strcmp(name, "nic_sent_bytes_count")) {
+            nsc_idx = i;
+        }
+        if (0 == strcmp(name, "nic_recvd_bytes_count")) {
+            nrc_idx = i;
+        }
+        if (0 == strcmp(name, "striped_nic_sent_bytes_count")) {
+            snsc_idx = i;
+        }
+        if (0 == strcmp(name, "striped_nic_recvd_bytes_count")) {
+            snrc_idx = i;
+        }
+    }
+
+    /* execute only when PVARs are enabled */
+    if (nsc_idx != -1 && nrc_idx != -1 && snsc_idx != -1 && snrc_idx != -1) {
+        /* setup a session and handles for the PVAR variables */
+        session = MPI_T_PVAR_SESSION_NULL;
+        MPI_T_pvar_session_create(&session);
+        assert(session != MPI_T_PVAR_SESSION_NULL);
+
+        nsc_handle = MPI_T_PVAR_HANDLE_NULL;
+        MPI_T_pvar_handle_alloc(session, nsc_idx, NULL, &nsc_handle, &count);
+        assert(count = 1);
+        assert(nsc_handle != MPI_T_PVAR_HANDLE_NULL);
+
+        nrc_handle = MPI_T_PVAR_HANDLE_NULL;
+        MPI_T_pvar_handle_alloc(session, nrc_idx, NULL, &nrc_handle, &count);
+        assert(count = 1);
+        assert(nrc_handle != MPI_T_PVAR_HANDLE_NULL);
+
+        snsc_handle = MPI_T_PVAR_HANDLE_NULL;
+        MPI_T_pvar_handle_alloc(session, snsc_idx, NULL, &snsc_handle, &count);
+        assert(count = 1);
+        assert(snsc_handle != MPI_T_PVAR_HANDLE_NULL);
+
+        snrc_handle = MPI_T_PVAR_HANDLE_NULL;
+        MPI_T_pvar_handle_alloc(session, snrc_idx, NULL, &snrc_handle, &count);
+        assert(count = 1);
+        assert(snrc_handle != MPI_T_PVAR_HANDLE_NULL);
+
+        if (!continuous) {
+            MPI_T_pvar_start(session, nsc_handle);
+            MPI_T_pvar_start(session, nrc_handle);
+            MPI_T_pvar_start(session, snsc_handle);
+            MPI_T_pvar_start(session, snrc_handle);
+        }
+    }
+
+    reqs = (MPI_Request *) malloc(num_nics * sizeof(MPI_Request));
+    in_buf = (float *) malloc(elems * num_nics * sizeof(float));
+    out_buf = (float *) malloc(elems * num_nics * sizeof(float));
+    MTEST_VG_MEM_INIT(out_buf, elems * num_nics * sizeof(float));
+
+    if (rank < num_pairs) {
+        target = rank + num_pairs;
+        for (i = 0; i < num_nics; ++i) {
+            MPI_Isend(&out_buf[elems * i], elems, MPI_FLOAT, target, i, comm, &reqs[i]);
+        }
+
+        MPI_Waitall(num_nics, reqs, MPI_STATUSES_IGNORE);
+    } else if (rank < num_pairs * 2) {
+        target = rank - num_pairs;
+        for (i = 0; i < num_nics; ++i) {
+            MPI_Irecv(&in_buf[elems * i], elems, MPI_FLOAT, target, i, comm, &reqs[i]);
+        }
+        MPI_Waitall(num_nics, reqs, MPI_STATUSES_IGNORE);
+    }
+
+    free(reqs);
+    free(in_buf);
+    free(out_buf);
+
+    /* execute only when PVARs are enabled */
+    if (nsc_idx != -1 && nrc_idx != -1 && snsc_idx != -1 && snrc_idx != -1) {
+        if (!continuous) {
+            MPI_T_pvar_stop(session, nrc_handle);
+            MPI_T_pvar_stop(session, nsc_handle);
+            MPI_T_pvar_stop(session, snrc_handle);
+            MPI_T_pvar_stop(session, snsc_handle);
+        }
+
+        /* compare actual the output with the expected output */
+        errs += compare_vars(rank, target, num_nics);
+
+        /* cleanup */
+        MPI_T_pvar_handle_free(session, &nrc_handle);
+        MPI_T_pvar_handle_free(session, &nsc_handle);
+        MPI_T_pvar_handle_free(session, &snrc_handle);
+        MPI_T_pvar_handle_free(session, &snsc_handle);
+        MPI_T_pvar_session_free(&session);
+    }
+    MPI_T_finalize();
+    MPI_Info_free(&comm_info);
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/mpi_t/testlist
+++ b/test/mpi/mpi_t/testlist
@@ -1,4 +1,8 @@
 mpi_t_str 1
+mpit_isendirecv 2 arg=0 arg=0
+mpit_isendirecv 2 arg=0 arg=1
+mpit_isendirecv 2 arg=1 arg=0
+mpit_isendirecv 2 arg=1 arg=1
 mpit_vars 1
 cvarwrite 1
 getindex 1


### PR DESCRIPTION
## Pull Request Description

This PR gives the user a way to specify that all traffic on a communicator uses a specific NIC. The user can set the hint `multi_nic_pref_nic` to an integer value. If the value is greater than the number if NICs, it will be wrapped around (e.g., if there are 2 NICs per node and the user asks for NIC 2, they'll get NIC 0).

This PR also adds some info key/values to `MPI_INFO_ENV` to let the user ask how many NICs and close NICs are available on the node.

Lastly, there are some new PVARs and tests to use those PVARs to prove that all of these features work (along with the striping #5229 and hashing #5269 code merged previously).

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
