### PR TITLE
ch4/am: Remove unnecessary context_id->comm lookups

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -226,6 +226,9 @@ struct MPIR_Request {
             MPL_atomic_int_t active_flag;       /* flag indicating whether in a start-complete active period.
                                                  * Value is 0 or 1. */
         } part;                 /* kind : MPIR_REQUEST_KIND__PART_SEND or MPIR_REQUEST_KIND__PART_RECV */
+        struct {
+            MPIR_Win *win;
+        } rma;                  /* kind : MPIR_REQUEST_KIND__RMA */
     } u;
 
     /* Other, device-specific information */

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -47,11 +47,11 @@ Non Native API:
       NM*: rank, comm, handler_id, am_hdrs, iov_len, data, count, datatype, sreq
      SHM*: rank, comm, handler_id, am_hdrs, iov_len, data, count, datatype, sreq
   am_send_hdr_reply : int
-      NM*: context_id, src_rank, handler_id, am_hdr, am_hdr_sz
-     SHM*: context_id, src_rank, handler_id, am_hdr, am_hdr_sz
+      NM*: comm, src_rank, handler_id, am_hdr, am_hdr_sz
+     SHM*: comm, src_rank, handler_id, am_hdr, am_hdr_sz
   am_isend_reply : int
-      NM*: context_id, src_rank, handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq
-     SHM*: context_id, src_rank, handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq
+      NM*: comm, src_rank, handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq
+     SHM*: comm, src_rank, handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq
   am_recv: int
       NM*: rreq
      SHM*: rreq

--- a/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
@@ -152,6 +152,8 @@ int MPIDIG_part_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data
     /* Setup an AM rreq to receive data */
     MPIR_Request *rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__PART, 1);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    rreq->comm = part_rreq->comm;
+    MPIR_Comm_add_ref(rreq->comm);
 
     MPIDIG_REQUEST(rreq, buffer) = MPIDI_PART_REQUEST(part_rreq, buffer);
     MPIDIG_REQUEST(rreq, datatype) = MPIDI_PART_REQUEST(part_rreq, datatype);

--- a/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
@@ -88,17 +88,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_issue_cts(MPIR_Request * rreq_ptr)
     am_hdr.rreq_ptr = rreq_ptr;
 
     int source = MPIDI_PART_REQUEST(rreq_ptr, rank);
-    MPIR_Context_id_t context_id = MPIDI_PART_REQUEST(rreq_ptr, context_id);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq_ptr, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(context_id, source, MPIDIG_PART_CTS, &am_hdr,
+            MPIDI_SHM_am_send_hdr_reply(rreq_ptr->comm, source, MPIDIG_PART_CTS, &am_hdr,
                                         sizeof(am_hdr));
     else
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(context_id, source, MPIDIG_PART_CTS, &am_hdr,
+            MPIDI_NM_am_send_hdr_reply(rreq_ptr->comm, source, MPIDIG_PART_CTS, &am_hdr,
                                        sizeof(am_hdr));
     }
 

--- a/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
@@ -116,6 +116,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_issue_data(MPIR_Request * part_sreq, in
 
     MPIR_Request *sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__PART, 1);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    sreq->comm = part_sreq->comm;
+    MPIR_Comm_add_ref(sreq->comm);
 
     MPIDIG_part_send_data_msg_t am_hdr;
     am_hdr.rreq_ptr = MPIDIG_PART_REQUEST(part_sreq, peer_req_ptr);

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -140,6 +140,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
         MPIDIG_rreq_dequeue(rank, tag, context_id, &MPIDI_global.unexp_list, MPIDIG_PT2PT_UNEXP);
 
     if (unexp_req) {
+        unexp_req->comm = comm;
+        MPIR_Comm_add_ref(comm);
         if (MPIDIG_REQUEST(unexp_req, req->status) & MPIDIG_REQ_BUSY) {
             MPIDIG_REQUEST(unexp_req, req->status) |= MPIDIG_REQ_MATCHED;
         } else if (MPIDIG_REQUEST(unexp_req, req->status) & MPIDIG_REQ_RTS) {
@@ -236,6 +238,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
     } else if (alloc_req) {
         rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2);
         MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+        rreq->comm = comm;
+        MPIR_Comm_add_ref(comm);
     } else {
         rreq = *request;
         MPIR_Assert(0);

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -29,8 +29,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_prepare_recv_req(int rank, int tag,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexpected(void *buf, MPI_Aint count,
-                                                      MPI_Datatype datatype, MPIR_Comm * comm,
-                                                      int context_offset, MPIR_Request * rreq)
+                                                      MPI_Datatype datatype, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     int dt_contig;
@@ -175,8 +174,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
             if (MPIDIG_REQUEST(unexp_req, recv_ready)) {
                 /* if the unexpected recv is ready, the data is in the unexpected buffer. Just
                  * copy them to complete */
-                mpi_errno = MPIDIG_handle_unexpected(buf, count, datatype, root_comm, context_id,
-                                                     unexp_req);
+                mpi_errno = MPIDIG_handle_unexpected(buf, count, datatype, unexp_req);
                 MPIR_ERR_CHECK(mpi_errno);
                 if (*request == NULL) {
                     /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating

--- a/src/mpid/ch4/generic/am/mpidig_am_send.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_send.h
@@ -46,6 +46,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
     } else {
         MPIDIG_request_init(sreq, MPIR_REQUEST_KIND__SEND);
     }
+    sreq->comm = comm;
+    MPIR_Comm_add_ref(comm);
 
     MPIDIG_hdr_t am_hdr;
     am_hdr.src_rank = comm->rank;

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -98,7 +98,6 @@ typedef struct MPIDIG_part_am_req_t {
 } MPIDIG_part_am_req_t;
 
 typedef struct MPIDIG_put_req_t {
-    MPIR_Win *win_ptr;
     MPIR_Request *preq_ptr;
     void *flattened_dt;
     MPIR_Datatype *dt;
@@ -111,7 +110,6 @@ typedef struct MPIDIG_put_req_t {
 } MPIDIG_put_req_t;
 
 typedef struct MPIDIG_get_req_t {
-    MPIR_Win *win_ptr;
     MPIR_Request *greq_ptr;
     void *addr;
     MPI_Datatype datatype;
@@ -122,7 +120,6 @@ typedef struct MPIDIG_get_req_t {
 } MPIDIG_get_req_t;
 
 typedef struct MPIDIG_cswap_req_t {
-    MPIR_Win *win_ptr;
     MPIR_Request *creq_ptr;
     void *addr;
     MPI_Datatype datatype;
@@ -131,7 +128,6 @@ typedef struct MPIDIG_cswap_req_t {
 } MPIDIG_cswap_req_t;
 
 typedef struct MPIDIG_acc_req_t {
-    MPIR_Win *win_ptr;
     MPIR_Request *req_ptr;
     MPI_Datatype origin_datatype;
     MPI_Datatype target_datatype;

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -157,7 +157,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Comm * comm,
                                                      int src_rank,
                                                      int handler_id,
                                                      const void *am_hdr,
@@ -170,7 +170,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
 
-    mpi_errno = MPIDI_NM_am_isend(src_rank, MPIDIG_context_id_to_comm(context_id), handler_id,
+    mpi_errno = MPIDI_NM_am_isend(src_rank, comm, handler_id,
                                   am_hdr, am_hdr_sz, data, count, datatype, sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
@@ -215,7 +215,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Comm * comm,
                                                         int src_rank,
                                                         int handler_id, const void *am_hdr,
                                                         MPI_Aint am_hdr_sz)
@@ -225,8 +225,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_SEND_HDR_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_SEND_HDR_REPLY);
 
-    mpi_errno = MPIDI_OFI_do_inject(src_rank, MPIDIG_context_id_to_comm(context_id), handler_id,
-                                    am_hdr, am_hdr_sz);
+    mpi_errno = MPIDI_OFI_do_inject(src_rank, comm, handler_id, am_hdr, am_hdr_sz);
 
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -286,8 +286,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_rdma_read_ack(int rank, int context
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_AM_RDMA_READ_ACK);
 
     ack_msg.sreq_ptr = sreq_ptr;
-    mpi_errno = MPIDI_NM_am_send_hdr_reply(context_id, rank, MPIDI_OFI_AM_RDMA_READ_ACK, &ack_msg,
-                                           (MPI_Aint) sizeof(ack_msg));
+    mpi_errno =
+        MPIDI_NM_am_send_hdr_reply(MPIDIG_context_id_to_comm(context_id), rank,
+                                   MPIDI_OFI_AM_RDMA_READ_ACK, &ack_msg,
+                                   (MPI_Aint) sizeof(ack_msg));
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -180,7 +180,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
 }
 
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Comm * comm,
                                                      int src_rank,
                                                      int handler_id,
                                                      const void *am_hdr,
@@ -200,14 +200,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     MPIR_Datatype *dt_ptr;
     int dt_contig;
     MPIDI_UCX_am_header_t ucx_hdr;
-    MPIR_Comm *use_comm;
     ucp_dt_iov_t *iov = sreq->dev.ch4.am.netmod_am.ucx.iov;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
 
-    use_comm = MPIDIG_context_id_to_comm(context_id);
-    ep = MPIDI_UCX_COMM_TO_EP(use_comm, src_rank, 0, 0);
+    ep = MPIDI_UCX_COMM_TO_EP(comm, src_rank, 0, 0);
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
 
@@ -347,7 +345,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Comm * comm,
                                                         int src_rank,
                                                         int handler_id, const void *am_hdr,
                                                         MPI_Aint am_hdr_sz)
@@ -357,13 +355,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     ucp_ep_h ep;
     char *send_buf;
     MPIDI_UCX_am_header_t ucx_hdr;
-    MPIR_Comm *use_comm;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_SEND_HDR_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_SEND_HDR_REPLY);
 
-    use_comm = MPIDIG_context_id_to_comm(context_id);
-    ep = MPIDI_UCX_COMM_TO_EP(use_comm, src_rank, 0, 0);
+    ep = MPIDI_UCX_COMM_TO_EP(comm, src_rank, 0, 0);
 
     /* initialize our portion of the hdr */
     ucx_hdr.handler_id = handler_id;

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -44,6 +44,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
     sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
     MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     *request = sreq;
+    sreq->comm = comm;
+    MPIR_Comm_add_ref(comm);
     MPIDIG_REQUEST(sreq, buffer) = (void *) buf;
     MPIDIG_REQUEST(sreq, datatype) = datatype;
     MPIDIG_REQUEST(sreq, rank) = rank;

--- a/src/mpid/ch4/shm/ipc/src/ipc_recv.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_recv.h
@@ -92,7 +92,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_irecv(void *buf, MPI_Aint count, MPI_
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPC_MPI_IRECV);
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
-    MPIR_Comm *root_comm = NULL;
     MPIR_Request *unexp_req = NULL;
     MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
 
@@ -104,7 +103,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_irecv(void *buf, MPI_Aint count, MPI_
      */
 
     /* Try to match with an unexpected receive request */
-    root_comm = MPIDIG_context_id_to_comm(context_id);
     unexp_req =
         MPIDIG_rreq_dequeue(rank, tag, context_id, &MPIDI_global.unexp_list, MPIDIG_PT2PT_UNEXP);
 
@@ -134,7 +132,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_irecv(void *buf, MPI_Aint count, MPI_
         MPIR_Datatype_add_ref_if_not_builtin(datatype);
         MPIDIG_prepare_recv_req(rank, tag, context_id, buf, count, datatype, rreq);
 
-        MPIR_Comm_add_ref(root_comm);   /* +1 for queuing into posted_list */
         MPIDIG_enqueue_request(rreq, &MPIDI_global.posted_list, MPIDIG_PT2PT_POSTED);
 
         *request = rreq;

--- a/src/mpid/ch4/shm/ipc/src/ipc_recv.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_recv.h
@@ -109,6 +109,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_irecv(void *buf, MPI_Aint count, MPI_
         MPIDIG_rreq_dequeue(rank, tag, context_id, &MPIDI_global.unexp_list, MPIDIG_PT2PT_UNEXP);
 
     if (unexp_req) {
+        unexp_req->comm = comm;
+        MPIR_Comm_add_ref(comm);
         *request = unexp_req;
         /* - Mark as DEQUEUED so that progress engine can complete a matched BUSY
          * rreq once all data arrived;
@@ -126,6 +128,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_irecv(void *buf, MPI_Aint count, MPI_
 
         rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2);
         MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+        rreq->comm = comm;
+        MPIR_Comm_add_ref(comm);
 
         MPIR_Datatype_add_ref_if_not_builtin(datatype);
         MPIDIG_prepare_recv_req(rank, tag, context_id, buf, count, datatype, rreq);

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -154,7 +154,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(MPIR_Comm * comm, int src_rank,
                                                         MPIDI_POSIX_am_header_kind_t kind,
                                                         int handler_id,
                                                         const void *am_hdr,
@@ -168,7 +168,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(MPIR_Context_id_t contex
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_ISEND_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_ISEND_REPLY);
 
-    mpi_errno = MPIDI_POSIX_am_isend(src_rank, MPIDIG_context_id_to_comm(context_id), kind,
+    mpi_errno = MPIDI_POSIX_am_isend(src_rank, comm, kind,
                                      handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_AM_ISEND_REPLY);
@@ -291,7 +291,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_send_hdr(int grank,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr_reply(MPIR_Context_id_t context_id,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr_reply(MPIR_Comm * comm,
                                                            int src_rank,
                                                            MPIDI_POSIX_am_header_kind_t kind,
                                                            int handler_id, const void *am_hdr,
@@ -302,9 +302,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr_reply(MPIR_Context_id_t con
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR_REPLY);
 
-    mpi_errno = MPIDI_POSIX_am_send_hdr(src_rank,
-                                        MPIDIG_context_id_to_comm(context_id),
-                                        kind, handler_id, am_hdr, am_hdr_sz);
+    mpi_errno = MPIDI_POSIX_am_send_hdr(src_rank, comm, kind, handler_id, am_hdr, am_hdr_sz);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR_REPLY);
 

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -60,7 +60,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Comm * comm,
                                                          int src_rank, int handler_id,
                                                          const void *am_hdr, MPI_Aint am_hdr_sz)
 {
@@ -69,14 +69,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t conte
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_SEND_HDR_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_SEND_HDR_REPLY);
 
-    ret = MPIDI_POSIX_am_send_hdr_reply(context_id, src_rank, MPIDI_POSIX_AM_HDR_CH4,
+    ret = MPIDI_POSIX_am_send_hdr_reply(comm, src_rank, MPIDI_POSIX_AM_HDR_CH4,
                                         handler_id, am_hdr, am_hdr_sz);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_SEND_HDR_REPLY);
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Comm * comm,
                                                       int src_rank, int handler_id,
                                                       const void *am_hdr, MPI_Aint am_hdr_sz,
                                                       const void *data, MPI_Aint count,
@@ -87,7 +87,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_ISEND_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_ISEND_REPLY);
 
-    ret = MPIDI_POSIX_am_isend_reply(context_id, src_rank, MPIDI_POSIX_AM_HDR_CH4,
+    ret = MPIDI_POSIX_am_isend_reply(comm, src_rank, MPIDI_POSIX_AM_HDR_CH4,
                                      handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_ISEND_REPLY);

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -23,16 +23,16 @@ int MPIDIG_do_cts(MPIR_Request * rreq)
                     (MPL_DBG_FDEST, "do cts req %p handle=0x%x", rreq, rreq->handle));
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
+    mpi_errno = MPIDI_NM_am_send_hdr_reply(rreq->comm,
                                            MPIDIG_REQUEST(rreq, rank), MPIDIG_SEND_CTS, &am_hdr,
                                            (MPI_Aint) sizeof(am_hdr));
 #else
     if (MPIDI_REQUEST(rreq, is_local)) {
-        mpi_errno = MPIDI_SHM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
+        mpi_errno = MPIDI_SHM_am_send_hdr_reply(rreq->comm,
                                                 MPIDIG_REQUEST(rreq, rank),
                                                 MPIDIG_SEND_CTS, &am_hdr, sizeof(am_hdr));
     } else {
-        mpi_errno = MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
+        mpi_errno = MPIDI_NM_am_send_hdr_reply(rreq->comm,
                                                MPIDIG_REQUEST(rreq, rank),
                                                MPIDIG_SEND_CTS, &am_hdr, (MPI_Aint) sizeof(am_hdr));
     }
@@ -521,7 +521,7 @@ int MPIDIG_send_cts_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(sreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(sreq, req->sreq).context_id,
+            MPIDI_SHM_am_isend_reply(sreq->comm,
                                      MPIDIG_REQUEST(sreq, rank), MPIDIG_SEND_DATA,
                                      &send_hdr, (MPI_Aint) sizeof(send_hdr),
                                      MPIDIG_REQUEST(sreq, req->sreq).src_buf,
@@ -531,7 +531,7 @@ int MPIDIG_send_cts_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_isend_reply(MPIDIG_REQUEST(sreq, req->sreq).context_id,
+            MPIDI_NM_am_isend_reply(sreq->comm,
                                     MPIDIG_REQUEST(sreq, rank), MPIDIG_SEND_DATA,
                                     &send_hdr, (MPI_Aint) sizeof(send_hdr),
                                     MPIDIG_REQUEST(sreq, req->sreq).src_buf,

--- a/src/mpid/ch4/src/ch4r_recv.h
+++ b/src/mpid/ch4/src/ch4r_recv.h
@@ -19,14 +19,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_reply_ssend(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
+            MPIDI_SHM_am_send_hdr_reply(rreq->comm,
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK, &ack_msg,
                                         (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, context_id),
+            MPIDI_NM_am_send_hdr_reply(rreq->comm,
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK, &ack_msg,
                                        (MPI_Aint) sizeof(ack_msg));
     }

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -66,7 +66,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
      * then put needs to free the second ref_count.*/
     sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 2);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIDIG_REQUEST(sreq, req->preq.win_ptr) = win;
+    sreq->u.rma.win = win;
     MPIDIG_REQUEST(sreq, req->preq.target_datatype) = target_datatype;
     MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
@@ -226,7 +226,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
     sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 2);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
-    MPIDIG_REQUEST(sreq, req->greq.win_ptr) = win;
+    sreq->u.rma.win = win;
     MPIDIG_REQUEST(sreq, req->greq.addr) = origin_addr;
     MPIDIG_REQUEST(sreq, req->greq.count) = origin_count;
     MPIDIG_REQUEST(sreq, req->greq.datatype) = origin_datatype;
@@ -356,7 +356,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
      * then acc needs to free the second ref_count.*/
     sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 2);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    MPIDIG_REQUEST(sreq, req->areq.win_ptr) = win;
+    sreq->u.rma.win = win;
     MPIDIG_REQUEST(sreq, req->areq.target_datatype) = target_datatype;
     MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
@@ -539,7 +539,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
     sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 2);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
-    MPIDIG_REQUEST(sreq, req->areq.win_ptr) = win;
+    sreq->u.rma.win = win;
     MPIDIG_REQUEST(sreq, req->areq.result_addr) = result_addr;
     MPIDIG_REQUEST(sreq, req->areq.result_count) = result_count;
     MPIDIG_REQUEST(sreq, req->areq.result_datatype) = result_datatype;
@@ -906,7 +906,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
     sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
-    MPIDIG_REQUEST(sreq, req->creq.win_ptr) = win;
+    sreq->u.rma.win = win;
     MPIDIG_REQUEST(sreq, req->creq.addr) = result_addr;
     MPIDIG_REQUEST(sreq, req->creq.datatype) = datatype;
     MPIDIG_REQUEST(sreq, req->creq.result_addr) = result_addr;

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -231,16 +231,14 @@ static int ack_put(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (rreq->u.rma.win),
+            MPIDI_SHM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_ACK,
                                         &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
-                                       (rreq->u.rma.win),
+            MPIDI_NM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_ACK,
                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
@@ -272,8 +270,7 @@ static int ack_cswap(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context
-                                     (rreq->u.rma.win),
+            MPIDI_SHM_am_isend_reply(rreq->u.rma.win->comm_ptr,
                                      MPIDIG_REQUEST(rreq, rank), MPIDIG_CSWAP_ACK, &ack_msg,
                                      (MPI_Aint) sizeof(ack_msg), result_addr, 1,
                                      MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
@@ -281,8 +278,7 @@ static int ack_cswap(MPIR_Request * rreq)
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_isend_reply(MPIDIG_win_to_context
-                                    (rreq->u.rma.win),
+            MPIDI_NM_am_isend_reply(rreq->u.rma.win->comm_ptr,
                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_CSWAP_ACK, &ack_msg,
                                     (MPI_Aint) sizeof(ack_msg), result_addr, 1,
                                     MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
@@ -308,16 +304,14 @@ static int ack_acc(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (rreq->u.rma.win),
+            MPIDI_SHM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_ACK,
                                         &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
-                                       (rreq->u.rma.win),
+            MPIDI_NM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_ACK,
                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
@@ -344,8 +338,7 @@ static int ack_get_acc(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context
-                                     (rreq->u.rma.win),
+            MPIDI_SHM_am_isend_reply(rreq->u.rma.win->comm_ptr,
                                      MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_ACK,
                                      &ack_msg, (MPI_Aint) sizeof(ack_msg),
                                      MPIDIG_REQUEST(rreq, req->areq.data),
@@ -355,8 +348,7 @@ static int ack_get_acc(MPIR_Request * rreq)
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_isend_reply(MPIDIG_win_to_context
-                                    (rreq->u.rma.win),
+            MPIDI_NM_am_isend_reply(rreq->u.rma.win->comm_ptr,
                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_ACK,
                                     &ack_msg, (MPI_Aint) sizeof(ack_msg),
                                     MPIDIG_REQUEST(rreq, req->areq.data),
@@ -406,13 +398,13 @@ static int win_lock_advance(MPIR_Win * win)
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (MPIDI_rank_is_local(lock->rank, win->comm_ptr))
-            mpi_errno = MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context(win),
+            mpi_errno = MPIDI_SHM_am_send_hdr_reply(win->comm_ptr,
                                                     lock->rank, handler_id,
                                                     &msg, (MPI_Aint) sizeof(msg));
         else
 #endif
         {
-            mpi_errno = MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context(win),
+            mpi_errno = MPIDI_NM_am_send_hdr_reply(win->comm_ptr,
                                                    lock->rank, handler_id,
                                                    &msg, (MPI_Aint) sizeof(msg));
         }
@@ -498,14 +490,14 @@ static void win_unlock_proc(const MPIDIG_win_cntrl_msg_t * info, int is_local, M
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (is_local)
-        mpi_errno = MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context(win),
+        mpi_errno = MPIDI_SHM_am_send_hdr_reply(win->comm_ptr,
                                                 info->origin_rank,
                                                 MPIDIG_WIN_UNLOCK_ACK,
                                                 &msg, (MPI_Aint) sizeof(msg));
     else
 #endif
     {
-        mpi_errno = MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context(win),
+        mpi_errno = MPIDI_NM_am_send_hdr_reply(win->comm_ptr,
                                                info->origin_rank,
                                                MPIDIG_WIN_UNLOCK_ACK, &msg, (MPI_Aint) sizeof(msg));
     }
@@ -737,7 +729,6 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
     int mpi_errno = MPI_SUCCESS;
     MPIDIG_get_ack_msg_t get_ack;
     MPIR_Win *win;
-    MPIR_Context_id_t context_id;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_GET_TARGET_CMPL_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_GET_TARGET_CMPL_CB);
@@ -745,14 +736,13 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
     MPIR_cc_inc(rreq->cc_ptr);
     get_ack.greq_ptr = MPIDIG_REQUEST(rreq, req->greq.greq_ptr);
     win = rreq->u.rma.win;
-    context_id = MPIDIG_win_to_context(win);
 
     if (MPIDIG_REQUEST(rreq, req->greq.flattened_dt) == NULL) {
         MPIDI_Datatype_check_size(MPIDIG_REQUEST(rreq, req->greq.datatype),
                                   MPIDIG_REQUEST(rreq, req->greq.count), get_ack.target_data_sz);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (MPIDI_REQUEST(rreq, is_local))
-            mpi_errno = MPIDI_SHM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
+            mpi_errno = MPIDI_SHM_am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
                                                  MPIDIG_GET_ACK,
                                                  &get_ack, (MPI_Aint) sizeof(get_ack),
                                                  (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
@@ -761,7 +751,7 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
         else
 #endif
         {
-            mpi_errno = MPIDI_NM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
+            mpi_errno = MPIDI_NM_am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
                                                 MPIDIG_GET_ACK,
                                                 &get_ack, (MPI_Aint) sizeof(get_ack),
                                                 (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
@@ -789,7 +779,7 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
-        mpi_errno = MPIDI_SHM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
+        mpi_errno = MPIDI_SHM_am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
                                              MPIDIG_GET_ACK, &get_ack, (MPI_Aint) sizeof(get_ack),
                                              MPIDIG_REQUEST(rreq, req->greq.addr),
                                              MPIDIG_REQUEST(rreq, req->greq.count), dt->handle,
@@ -797,7 +787,7 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
     else
 #endif
     {
-        mpi_errno = MPIDI_NM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
+        mpi_errno = MPIDI_NM_am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
                                             MPIDIG_GET_ACK, &get_ack, (MPI_Aint) sizeof(get_ack),
                                             MPIDIG_REQUEST(rreq, req->greq.addr),
                                             MPIDIG_REQUEST(rreq, req->greq.count), dt->handle,
@@ -852,16 +842,14 @@ static int put_dt_target_cmpl_cb(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (rreq->u.rma.win),
+            MPIDI_SHM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_DT_ACK,
                                         &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
-                                       (rreq->u.rma.win),
+            MPIDI_NM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_DT_ACK,
                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
@@ -889,16 +877,14 @@ static int acc_dt_target_cmpl_cb(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (rreq->u.rma.win),
+            MPIDI_SHM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_DT_ACK,
                                         &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
-                                       (rreq->u.rma.win),
+            MPIDI_NM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_DT_ACK,
                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
@@ -926,16 +912,14 @@ static int get_acc_dt_target_cmpl_cb(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (rreq->u.rma.win),
+            MPIDI_SHM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_DT_ACK,
                                         &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
 #endif
     {
         mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
-                                       (rreq->u.rma.win),
+            MPIDI_NM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_DT_ACK,
                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
@@ -1452,7 +1436,7 @@ int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (is_local)
-        mpi_errno = MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context(win),
+        mpi_errno = MPIDI_SHM_am_isend_reply(win->comm_ptr,
                                              MPIDIG_REQUEST(origin_req, rank),
                                              MPIDIG_PUT_DAT_REQ,
                                              &dat_msg, (MPI_Aint) sizeof(dat_msg),
@@ -1463,7 +1447,7 @@ int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
     else
 #endif
     {
-        mpi_errno = MPIDI_NM_am_isend_reply(MPIDIG_win_to_context(win),
+        mpi_errno = MPIDI_NM_am_isend_reply(win->comm_ptr,
                                             MPIDIG_REQUEST(origin_req, rank),
                                             MPIDIG_PUT_DAT_REQ,
                                             &dat_msg, (MPI_Aint) sizeof(dat_msg),
@@ -1510,7 +1494,7 @@ int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (is_local)
-        mpi_errno = MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context(win),
+        mpi_errno = MPIDI_SHM_am_isend_reply(win->comm_ptr,
                                              MPIDIG_REQUEST(origin_req, rank),
                                              MPIDIG_ACC_DAT_REQ,
                                              &dat_msg, (MPI_Aint) sizeof(dat_msg),
@@ -1521,7 +1505,7 @@ int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
     else
 #endif
     {
-        mpi_errno = MPIDI_NM_am_isend_reply(MPIDIG_win_to_context(win),
+        mpi_errno = MPIDI_NM_am_isend_reply(win->comm_ptr,
                                             MPIDIG_REQUEST(origin_req, rank),
                                             MPIDIG_ACC_DAT_REQ,
                                             &dat_msg, (MPI_Aint) sizeof(dat_msg),
@@ -1569,7 +1553,7 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (is_local)
-        mpi_errno = MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context(win),
+        mpi_errno = MPIDI_SHM_am_isend_reply(win->comm_ptr,
                                              MPIDIG_REQUEST(origin_req, rank),
                                              MPIDIG_GET_ACC_DAT_REQ,
                                              &dat_msg, (MPI_Aint) sizeof(dat_msg),
@@ -1580,7 +1564,7 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data
     else
 #endif
     {
-        mpi_errno = MPIDI_NM_am_isend_reply(MPIDIG_win_to_context(win),
+        mpi_errno = MPIDI_NM_am_isend_reply(win->comm_ptr,
                                             MPIDIG_REQUEST(origin_req, rank),
                                             MPIDIG_GET_ACC_DAT_REQ,
                                             &dat_msg, (MPI_Aint) sizeof(dat_msg),

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -232,7 +232,7 @@ static int ack_put(MPIR_Request * rreq)
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
             MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (MPIDIG_REQUEST(rreq, req->preq.win_ptr)),
+                                        (rreq->u.rma.win),
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_ACK,
                                         &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
@@ -240,7 +240,7 @@ static int ack_put(MPIR_Request * rreq)
     {
         mpi_errno =
             MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
-                                       (MPIDIG_REQUEST(rreq, req->preq.win_ptr)),
+                                       (rreq->u.rma.win),
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_ACK,
                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
@@ -273,7 +273,7 @@ static int ack_cswap(MPIR_Request * rreq)
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
             MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context
-                                     (MPIDIG_REQUEST(rreq, req->creq.win_ptr)),
+                                     (rreq->u.rma.win),
                                      MPIDIG_REQUEST(rreq, rank), MPIDIG_CSWAP_ACK, &ack_msg,
                                      (MPI_Aint) sizeof(ack_msg), result_addr, 1,
                                      MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
@@ -282,7 +282,7 @@ static int ack_cswap(MPIR_Request * rreq)
     {
         mpi_errno =
             MPIDI_NM_am_isend_reply(MPIDIG_win_to_context
-                                    (MPIDIG_REQUEST(rreq, req->creq.win_ptr)),
+                                    (rreq->u.rma.win),
                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_CSWAP_ACK, &ack_msg,
                                     (MPI_Aint) sizeof(ack_msg), result_addr, 1,
                                     MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
@@ -309,7 +309,7 @@ static int ack_acc(MPIR_Request * rreq)
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
             MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
+                                        (rreq->u.rma.win),
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_ACK,
                                         &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
@@ -317,7 +317,7 @@ static int ack_acc(MPIR_Request * rreq)
     {
         mpi_errno =
             MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
-                                       (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
+                                       (rreq->u.rma.win),
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_ACK,
                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
@@ -345,7 +345,7 @@ static int ack_get_acc(MPIR_Request * rreq)
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
             MPIDI_SHM_am_isend_reply(MPIDIG_win_to_context
-                                     (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
+                                     (rreq->u.rma.win),
                                      MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_ACK,
                                      &ack_msg, (MPI_Aint) sizeof(ack_msg),
                                      MPIDIG_REQUEST(rreq, req->areq.data),
@@ -356,7 +356,7 @@ static int ack_get_acc(MPIR_Request * rreq)
     {
         mpi_errno =
             MPIDI_NM_am_isend_reply(MPIDIG_win_to_context
-                                    (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
+                                    (rreq->u.rma.win),
                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_ACK,
                                     &ack_msg, (MPI_Aint) sizeof(ack_msg),
                                     MPIDIG_REQUEST(rreq, req->areq.data),
@@ -564,7 +564,7 @@ static int handle_acc_cmpl(MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     int shm_locked ATTRIBUTE((unused)) = 0;
-    MPIR_Win *win ATTRIBUTE((unused)) = MPIDIG_REQUEST(rreq, req->areq.win_ptr);
+    MPIR_Win *win ATTRIBUTE((unused)) = rreq->u.rma.win;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_HANDLE_ACC_CMPL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_HANDLE_ACC_CMPL);
@@ -627,7 +627,7 @@ static int handle_get_acc_cmpl(MPIR_Request * rreq)
     char *original = NULL;
     MPI_Aint result_data_sz;
     int shm_locked ATTRIBUTE((unused)) = 0;
-    MPIR_Win *win ATTRIBUTE((unused)) = MPIDIG_REQUEST(rreq, req->areq.win_ptr);
+    MPIR_Win *win ATTRIBUTE((unused)) = rreq->u.rma.win;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_HANDLE_GET_ACC_CMPL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_HANDLE_GET_ACC_CMPL);
@@ -744,7 +744,7 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
 
     MPIR_cc_inc(rreq->cc_ptr);
     get_ack.greq_ptr = MPIDIG_REQUEST(rreq, req->greq.greq_ptr);
-    win = MPIDIG_REQUEST(rreq, req->greq.win_ptr);
+    win = rreq->u.rma.win;
     context_id = MPIDIG_win_to_context(win);
 
     if (MPIDIG_REQUEST(rreq, req->greq.flattened_dt) == NULL) {
@@ -853,7 +853,7 @@ static int put_dt_target_cmpl_cb(MPIR_Request * rreq)
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
             MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (MPIDIG_REQUEST(rreq, req->preq.win_ptr)),
+                                        (rreq->u.rma.win),
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_DT_ACK,
                                         &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
@@ -861,7 +861,7 @@ static int put_dt_target_cmpl_cb(MPIR_Request * rreq)
     {
         mpi_errno =
             MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
-                                       (MPIDIG_REQUEST(rreq, req->preq.win_ptr)),
+                                       (rreq->u.rma.win),
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_DT_ACK,
                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
@@ -890,7 +890,7 @@ static int acc_dt_target_cmpl_cb(MPIR_Request * rreq)
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
             MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
+                                        (rreq->u.rma.win),
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_DT_ACK,
                                         &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
@@ -898,7 +898,7 @@ static int acc_dt_target_cmpl_cb(MPIR_Request * rreq)
     {
         mpi_errno =
             MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
-                                       (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
+                                       (rreq->u.rma.win),
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_DT_ACK,
                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
@@ -927,7 +927,7 @@ static int get_acc_dt_target_cmpl_cb(MPIR_Request * rreq)
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
             MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
+                                        (rreq->u.rma.win),
                                         MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_DT_ACK,
                                         &ack_msg, (MPI_Aint) sizeof(ack_msg));
     else
@@ -935,7 +935,7 @@ static int get_acc_dt_target_cmpl_cb(MPIR_Request * rreq)
     {
         mpi_errno =
             MPIDI_NM_am_send_hdr_reply(MPIDIG_win_to_context
-                                       (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
+                                       (rreq->u.rma.win),
                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_DT_ACK,
                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
     }
@@ -969,7 +969,7 @@ static int cswap_target_cmpl_cb(MPIR_Request * rreq)
 
     /* MPIDI_CS_ENTER(); */
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    win = MPIDIG_REQUEST(rreq, req->creq.win_ptr);
+    win = rreq->u.rma.win;
     if (MPIDI_WIN(win, winattr) & MPIDI_WINATTR_SHM_ALLOCATED) {
         mpi_errno = MPIDI_SHM_rma_op_cs_enter_hook(win);
         MPIR_ERR_CHECK(mpi_errno);
@@ -1055,7 +1055,7 @@ static int get_ack_target_cmpl_cb(MPIR_Request * rreq)
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->greq.target_datatype));
 
-    win = MPIDIG_REQUEST(rreq, req->greq.win_ptr);
+    win = rreq->u.rma.win;
     MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
 
     MPIDIG_recv_finish(rreq);
@@ -1077,7 +1077,7 @@ static int get_acc_ack_target_cmpl_cb(MPIR_Request * rreq)
 
     MPIDIG_recv_finish(rreq);
 
-    win = MPIDIG_REQUEST(rreq, req->areq.win_ptr);
+    win = rreq->u.rma.win;
     MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
     MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
 
@@ -1096,7 +1096,7 @@ static int cswap_ack_target_cmpl_cb(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_CSWAP_ACK_TARGET_CMPL_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CSWAP_ACK_TARGET_CMPL_CB);
 
-    win = MPIDIG_REQUEST(rreq, req->creq.win_ptr);
+    win = rreq->u.rma.win;
     MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
     MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
 
@@ -1120,7 +1120,7 @@ int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_A
     MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_put_ack);
 
     preq = (MPIR_Request *) msg_hdr->preq_ptr;
-    win = MPIDIG_REQUEST(preq, req->preq.win_ptr);
+    win = preq->u.rma.win;
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(preq, req->preq.target_datatype));
 
@@ -1150,7 +1150,7 @@ int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_A
     MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_acc_ack);
 
     rreq = (MPIR_Request *) msg_hdr->req_ptr;
-    win = MPIDIG_REQUEST(rreq, req->areq.win_ptr);
+    win = rreq->u.rma.win;
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->areq.target_datatype));
 
@@ -1324,7 +1324,7 @@ int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint 
 
     base = MPIDIG_win_base_at_target(win);
 
-    MPIDIG_REQUEST(rreq, req->preq.win_ptr) = win;
+    rreq->u.rma.win = win;
 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = put_target_cmpl_cb;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
@@ -1396,8 +1396,7 @@ int MPIDIG_put_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Ai
 
     win = (MPIR_Win *) MPIDIU_map_lookup(MPIDI_global.win_map, msg_hdr->win_id);
     MPIR_Assert(win);
-
-    MPIDIG_REQUEST(rreq, req->preq.win_ptr) = win;
+    rreq->u.rma.win = win;
 
     offset = win->disp_unit * msg_hdr->target_disp;
     base = MPIDIG_win_base_at_target(win);
@@ -1449,7 +1448,7 @@ int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
 
     origin_req = (MPIR_Request *) msg_hdr->origin_preq_ptr;
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
-    win = MPIDIG_REQUEST(origin_req, req->preq.win_ptr);
+    win = origin_req->u.rma.win;
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (is_local)
@@ -1507,7 +1506,7 @@ int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
 
     origin_req = (MPIR_Request *) msg_hdr->origin_preq_ptr;
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
-    win = MPIDIG_REQUEST(origin_req, req->areq.win_ptr);
+    win = origin_req->u.rma.win;
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (is_local)
@@ -1566,7 +1565,7 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data
 
     origin_req = (MPIR_Request *) msg_hdr->origin_preq_ptr;
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
-    win = MPIDIG_REQUEST(origin_req, req->areq.win_ptr);
+    win = origin_req->u.rma.win;
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (is_local)
@@ -1744,7 +1743,7 @@ int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Ain
     uintptr_t base = MPIDIG_win_base_at_target(win);
     size_t offset = win->disp_unit * msg_hdr->target_disp;
 
-    MPIDIG_REQUEST(rreq, req->creq.win_ptr) = win;
+    rreq->u.rma.win = win;
     MPIDIG_REQUEST(rreq, req->creq.creq_ptr) = msg_hdr->req_ptr;
     MPIDIG_REQUEST(rreq, req->creq.datatype) = msg_hdr->datatype;
     MPIDIG_REQUEST(rreq, req->creq.addr) = (char *) base + offset;
@@ -1813,7 +1812,7 @@ int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint 
     uintptr_t base = MPIDIG_win_base_at_target(win);
     size_t offset = win->disp_unit * msg_hdr->target_disp;
 
-    MPIDIG_REQUEST(rreq, req->areq.win_ptr) = win;
+    rreq->u.rma.win = win;
     MPIDIG_REQUEST(rreq, req->areq.req_ptr) = msg_hdr->req_ptr;
     MPIDIG_REQUEST(rreq, req->areq.origin_datatype) = msg_hdr->origin_datatype;
     MPIDIG_REQUEST(rreq, req->areq.target_datatype) = msg_hdr->target_datatype;
@@ -1907,7 +1906,7 @@ int MPIDIG_acc_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Ai
     base = MPIDIG_win_base_at_target(win);
     offset = win->disp_unit * msg_hdr->target_disp;
 
-    MPIDIG_REQUEST(rreq, req->areq.win_ptr) = win;
+    rreq->u.rma.win = win;
     MPIDIG_REQUEST(rreq, req->areq.req_ptr) = msg_hdr->req_ptr;
     MPIDIG_REQUEST(rreq, req->areq.origin_datatype) = msg_hdr->origin_datatype;
     MPIDIG_REQUEST(rreq, req->areq.target_datatype) = MPI_DATATYPE_NULL;
@@ -2001,7 +2000,7 @@ int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint 
     uintptr_t base = MPIDIG_win_base_at_target(win);
     size_t offset = win->disp_unit * msg_hdr->target_disp;
 
-    MPIDIG_REQUEST(rreq, req->greq.win_ptr) = win;
+    rreq->u.rma.win = win;
     MPIDIG_REQUEST(rreq, req->greq.count) = msg_hdr->target_count;
     MPIDIG_REQUEST(rreq, req->greq.datatype) = msg_hdr->target_datatype;
     MPIDIG_REQUEST(rreq, req->greq.flattened_dt) = NULL;


### PR DESCRIPTION
## Pull Request Description

There are many instances where the ch4 active message code uses complicated context_id->comm lookups when they are not necessary.

This PR splits just the active message changes from #5298, which will contain just the native ofi and ipc changes after this is merged.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
