### PR TITLE
test/mpi: Add communicator refcount test

### DIFF
--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -183,6 +183,7 @@
 /coll/uoplong
 /coll/uoplong_large
 /comm/cmfree
+/comm/cmfree2
 /comm/cmsplit
 /comm/cmsplit2
 /comm/cmsplit_type

--- a/test/mpi/comm/Makefile.am
+++ b/test/mpi/comm/Makefile.am
@@ -25,6 +25,7 @@ noinst_PROGRAMS =     \
     icsplit           \
     iccreate          \
     cmfree            \
+    cmfree2           \
     icm               \
     cmsplit           \
     cmsplit2          \

--- a/test/mpi/comm/cmfree2.c
+++ b/test/mpi/comm/cmfree2.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdlib.h>
+#include "mpitest.h"
+
+/*
+static char MTEST_Descrip[] = "Test that communicators have reference count semantics";
+*/
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    int rank, size;
+    MPI_Comm comm;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    if (size < 2) {
+        fprintf(stderr, "This test requires at least two processes.");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Comm_dup(MPI_COMM_WORLD, &comm);
+
+    if (rank == 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Ssend(NULL, 0, MPI_INT, 1, 0, comm);
+        MPI_Comm_free(&comm);
+    } else if (rank == 1) {
+        MPI_Request req;
+        /* recv an ssend after the user frees the comm */
+        MPI_Irecv(NULL, 0, MPI_INT, 0, 0, comm, &req);
+        MPI_Comm_free(&comm);
+        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Wait(&req, MPI_STATUS_IGNORE);
+    } else {
+        MPI_Comm_free(&comm);
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/comm/testlist.in
+++ b/test/mpi/comm/testlist.in
@@ -12,6 +12,7 @@ iccreate 8
 ctxalloc 2 timeLimit=300
 ctxsplit 4 timeLimit=300
 cmfree 4
+cmfree2 2
 cmsplit 4
 cmsplit2 12
 probe_intercomm 2


### PR DESCRIPTION
## Pull Request Description

Add a test that receives a synchronous send *after* the user has freed
the comm in the application. MPI is required to keep the communicator
active because of pending communication. In this case it is needed for
the ACK message to the sender. ch4/am code previously did not pass
this test.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
