### PR TITLE
comm: preparation refactoring builtin comm creation

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -373,4 +373,7 @@ int MPII_Comm_set_hints(MPIR_Comm * comm_ptr, MPIR_Info * info);
 int MPII_Comm_get_hints(MPIR_Comm * comm_ptr, MPIR_Info * info);
 int MPII_Comm_check_hints(MPIR_Comm * comm_ptr);
 
+int MPIR_init_comm_self(void);
+int MPIR_init_comm_world(void);
+int MPIR_finalize_builtin_comms(void);
 #endif /* MPIR_COMM_H_INCLUDED */

--- a/src/include/mpir_group.h
+++ b/src/include/mpir_group.h
@@ -60,8 +60,6 @@ struct MPIR_Group {
     MPII_Group_pmap_t *lrank_to_lpid;   /* Array mapping a local rank to local
                                          * process number */
     int is_local_dense_monotonic;       /* see NOTE-G1 */
-    const char *pset_name;      /* set to one of the pre-configured pset names,
-                                 * or NULL if it is not directly from a pset */
 
     /* We may want some additional data for the RMA syncrhonization calls */
     /* Other, device-specific information */

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -56,6 +56,8 @@ extern const char MPII_Version_F77[] MPICH_API_PUBLIC;
 extern const char MPII_Version_FC[] MPICH_API_PUBLIC;
 extern const char MPII_Version_custom[] MPICH_API_PUBLIC;
 
+extern MPL_initlock_t MPIR_init_lock;
+
 #include "typerep_pre.h"        /* needed for MPIR_Typerep_req */
 
 int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,

--- a/src/mpi/comm/Makefile.mk
+++ b/src/mpi/comm/Makefile.mk
@@ -8,6 +8,7 @@ mpi_core_sources += \
     src/mpi/comm/comm_split.c \
     src/mpi/comm/comm_split_type.c \
     src/mpi/comm/comm_split_type_nbhd.c \
+    src/mpi/comm/builtin_comms.c \
     src/mpi/comm/commutil.c \
     src/mpi/comm/contextid.c
 

--- a/src/mpi/comm/builtin_comms.c
+++ b/src/mpi/comm/builtin_comms.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+int MPIR_init_comm_world(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(MPIR_Process.comm_world == NULL);
+
+    MPIR_Process.comm_world = MPIR_Comm_builtin + 0;
+    MPII_Comm_init(MPIR_Process.comm_world);
+
+    MPIR_Process.comm_world->rank = MPIR_Process.rank;
+    MPIR_Process.comm_world->handle = MPI_COMM_WORLD;
+    MPIR_Process.comm_world->context_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
+    MPIR_Process.comm_world->recvcontext_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
+    MPIR_Process.comm_world->comm_kind = MPIR_COMM_KIND__INTRACOMM;
+
+    MPIR_Process.comm_world->rank = MPIR_Process.rank;
+    MPIR_Process.comm_world->remote_size = MPIR_Process.size;
+    MPIR_Process.comm_world->local_size = MPIR_Process.size;
+
+    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_world);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPL_strncpy(MPIR_Process.comm_world->name, "MPI_COMM_WORLD", MPI_MAX_OBJECT_NAME);
+    MPII_COMML_REMEMBER(MPIR_Process.comm_world);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_init_comm_self(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(MPIR_Process.comm_self == NULL);
+
+    MPIR_Process.comm_self = MPIR_Comm_builtin + 1;
+    MPII_Comm_init(MPIR_Process.comm_self);
+    MPIR_Process.comm_self->handle = MPI_COMM_SELF;
+    MPIR_Process.comm_self->context_id = 1 << MPIR_CONTEXT_PREFIX_SHIFT;
+    MPIR_Process.comm_self->recvcontext_id = 1 << MPIR_CONTEXT_PREFIX_SHIFT;
+    MPIR_Process.comm_self->comm_kind = MPIR_COMM_KIND__INTRACOMM;
+
+    MPIR_Process.comm_self->rank = 0;
+    MPIR_Process.comm_self->remote_size = 1;
+    MPIR_Process.comm_self->local_size = 1;
+
+    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_self);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPL_strncpy(MPIR_Process.comm_self->name, "MPI_COMM_SELF", MPI_MAX_OBJECT_NAME);
+    MPII_COMML_REMEMBER(MPIR_Process.comm_self);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int finalize_builtin_comm(MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    /* Note that the attributes need to be removed from the communicators
+     * so that they aren't freed twice.
+     */
+    if (MPIR_Process.attr_free && comm->attributes) {
+        mpi_errno = MPIR_Process.attr_free(comm->handle, &comm->attributes);
+        MPIR_ERR_CHECK(mpi_errno);
+        comm->attributes = 0;
+    }
+
+    if (comm->errhandler && !(HANDLE_IS_BUILTIN(comm->errhandler->handle))) {
+        int in_use;
+        MPIR_Errhandler_release_ref(comm->errhandler, &in_use);
+        if (!in_use) {
+            MPIR_Handle_obj_free(&MPIR_Errhandler_mem, comm->errhandler);
+        }
+        /* always set to NULL to avoid a double-release later in finalize */
+        comm->errhandler = NULL;
+    }
+
+    MPIR_Comm_release_always(comm);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_finalize_builtin_comms(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    /* The standard (MPI-2, section 4.8) says that the attributes on
+     * MPI_COMM_SELF are deleted before almost anything else happens */
+    if (MPIR_Process.comm_self) {
+        mpi_errno = finalize_builtin_comm(MPIR_Process.comm_self);
+        MPIR_ERR_CHECK(mpi_errno);
+        MPIR_Process.comm_self = NULL;
+    }
+
+    if (MPIR_Process.comm_world) {
+        mpi_errno = finalize_builtin_comm(MPIR_Process.comm_world);
+        MPIR_ERR_CHECK(mpi_errno);
+        MPIR_Process.comm_world = NULL;
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -5,11 +5,6 @@
 
 #include "mpiimpl.h"
 
-/* temporary declaration until auto-generated */
-int MPIR_Comm_create_from_group_impl(MPIR_Group * group_ptr, const char *stringtag,
-                                     MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_ptr,
-                                     MPIR_Comm ** newcomm_ptr);
-
 /* used in MPIR_Comm_group_impl and MPIR_Comm_create_group_impl */
 static int comm_create_local_group(MPIR_Comm * comm_ptr)
 {

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -17,7 +17,7 @@ static int comm_create_local_group(MPIR_Comm * comm_ptr)
 
     group_ptr->is_local_dense_monotonic = TRUE;
 
-    int comm_world_size = MPIR_Process.comm_world->local_size;
+    int comm_world_size = MPIR_Process.size;
     for (int i = 0; i < n; i++) {
         int lpid;
         (void) MPID_Comm_get_lpid(comm_ptr, i, &lpid, FALSE);
@@ -237,7 +237,7 @@ int MPII_Comm_create_calculate_mapping(MPIR_Group * group_ptr,
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         int wsize;
         subsetOfWorld = 1;
-        wsize = MPIR_Process.comm_world->local_size;
+        wsize = MPIR_Process.size;
         for (i = 0; i < n; i++) {
             int g_lpid = group_ptr->lrank_to_lpid[i].lpid;
 

--- a/src/mpi/debugger/dbginit.c
+++ b/src/mpi/debugger/dbginit.c
@@ -206,8 +206,8 @@ void MPII_Wait_for_debugger(void)
     init_lock();
 
 #ifdef MPIU_PROCTABLE_NEEDED
-    int rank = MPIR_Process.comm_world->rank;
-    int size = MPIR_Process.comm_world->local_size;
+    int rank = MPIR_Process.rank;
+    int size = MPIR_Process.size;
     int i, maxsize;
 
     /* FIXME: In MPICH, the executables may not have the information

--- a/src/mpi/group/group_impl.c
+++ b/src/mpi/group/group_impl.c
@@ -641,7 +641,6 @@ int MPIR_Group_from_session_pset_impl(MPIR_Session * session_ptr, const char *ps
         }
         group_ptr->lrank_to_lpid[group_ptr->size - 1].next_lpid = -1;
         group_ptr->idx_of_first_lpid = 0;
-        group_ptr->pset_name = "mpi://WORLD";
     } else if (strcmp(pset_name, "mpi://SELF") == 0) {
         mpi_errno = MPIR_Group_create(1, &group_ptr);
         MPIR_ERR_CHECK(mpi_errno);
@@ -652,7 +651,6 @@ int MPIR_Group_from_session_pset_impl(MPIR_Session * session_ptr, const char *ps
         group_ptr->lrank_to_lpid[0].lpid = MPIR_Process.rank;
         group_ptr->lrank_to_lpid[0].next_lpid = -1;
         group_ptr->idx_of_first_lpid = 0;
-        group_ptr->pset_name = "mpi://SELF";
     } else {
         /* TODO: Implement pset struct, locate pset struct ptr */
         MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_ARG, goto fn_fail, "**psetinvalidname");

--- a/src/mpi/group/group_impl.c
+++ b/src/mpi/group/group_impl.c
@@ -628,7 +628,7 @@ int MPIR_Group_from_session_pset_impl(MPIR_Session * session_ptr, const char *ps
     int mpi_errno = MPI_SUCCESS;
     MPIR_Group *group_ptr;
 
-    if (strcmp(pset_name, "mpi://WORLD") == 0) {
+    if (MPL_stricmp(pset_name, "mpi://WORLD") == 0) {
         mpi_errno = MPIR_Group_create(MPIR_Process.size, &group_ptr);
         MPIR_ERR_CHECK(mpi_errno);
 
@@ -641,7 +641,7 @@ int MPIR_Group_from_session_pset_impl(MPIR_Session * session_ptr, const char *ps
         }
         group_ptr->lrank_to_lpid[group_ptr->size - 1].next_lpid = -1;
         group_ptr->idx_of_first_lpid = 0;
-    } else if (strcmp(pset_name, "mpi://SELF") == 0) {
+    } else if (MPL_stricmp(pset_name, "mpi://SELF") == 0) {
         mpi_errno = MPIR_Group_create(1, &group_ptr);
         MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpi/group/group_impl.c
+++ b/src/mpi/group/group_impl.c
@@ -280,7 +280,7 @@ int MPIR_Group_intersection_impl(MPIR_Group * group_ptr1, MPIR_Group * group_ptr
             (*new_group_ptr)->lrank_to_lpid[k].lpid = lpid;
             if (i == group_ptr1->rank)
                 (*new_group_ptr)->rank = k;
-            if (lpid > MPIR_Process.comm_world->local_size ||
+            if (lpid > MPIR_Process.size ||
                 (k > 0 && (*new_group_ptr)->lrank_to_lpid[k - 1].lpid != (lpid - 1))) {
                 (*new_group_ptr)->is_local_dense_monotonic = FALSE;
             }

--- a/src/mpi/group/group_impl.c
+++ b/src/mpi/group/group_impl.c
@@ -6,10 +6,6 @@
 #include "mpiimpl.h"
 #include "group.h"
 
-/* temporary declaration until auto-generated */
-int MPIR_Group_from_session_pset_impl(MPIR_Session * session_ptr, const char *pset_name,
-                                      MPIR_Group ** newgroup_ptr);
-
 int MPIR_Group_compare_impl(MPIR_Group * group_ptr1, MPIR_Group * group_ptr2, int *result)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/group/grouputil.c
+++ b/src/mpi/group/grouputil.c
@@ -89,7 +89,6 @@ int MPIR_Group_create(int nproc, MPIR_Group ** new_group_ptr)
     (*new_group_ptr)->idx_of_first_lpid = -1;
 
     (*new_group_ptr)->is_local_dense_monotonic = FALSE;
-    (*new_group_ptr)->pset_name = NULL;
     return mpi_errno;
 }
 

--- a/src/mpi/init/globals.c
+++ b/src/mpi/init/globals.c
@@ -5,6 +5,10 @@
 
 #include <mpiimpl.h>
 
+/* Lock to protect concurrent init/finalize (include session init/finalize)
+ * and creation of built-in comms in MPIR_Comm_create_from_group_impl */
+MPL_initlock_t MPIR_init_lock = MPL_INITLOCK_INITIALIZER;
+
 MPIR_Process_t MPIR_Process = {
     .mpich_state = MPL_ATOMIC_INT_T_INITIALIZER(MPICH_MPI_STATE__UNINITIALIZED)
 };

--- a/src/mpi/init/init_dbg_logging.c
+++ b/src/mpi/init/init_dbg_logging.c
@@ -35,7 +35,7 @@ void MPII_init_dbg_logging(void)
     /* FIXME: This is a hack to handle the common case of two worlds.
      * If the parent comm is not NULL, we always give the world number
      * as "1" (false). */
-    MPL_dbg_init(MPIR_Process.comm_parent != NULL, MPIR_Process.comm_world->rank);
+    MPL_dbg_init(MPIR_Process.comm_parent != NULL, MPIR_Process.rank);
 
     MPIR_DBG_INIT = MPL_dbg_class_alloc("INIT", "init");
     MPIR_DBG_PT2PT = MPL_dbg_class_alloc("PT2PT", "pt2pt");

--- a/src/mpi/init/local_proc_attrs.c
+++ b/src/mpi/init/local_proc_attrs.c
@@ -74,47 +74,7 @@ int MPII_init_local_proc_attrs(int *p_thread_required)
     /* Init communicator hints */
     MPIR_Comm_hint_init();
 
-    /* "Allocate" from the reserved space for builtin communicators and
-     * (partially) initialize predefined communicators.  comm_parent is
-     * initially NULL and will be allocated by the device if the process group
-     * was started using one of the MPI_Comm_spawn functions. */
-    MPIR_Process.comm_world = MPIR_Comm_builtin + 0;
-    MPII_Comm_init(MPIR_Process.comm_world);
-    MPIR_Process.comm_world->handle = MPI_COMM_WORLD;
-    MPIR_Process.comm_world->context_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
-    MPIR_Process.comm_world->recvcontext_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
-    MPIR_Process.comm_world->comm_kind = MPIR_COMM_KIND__INTRACOMM;
-    /* This initialization of the comm name could be done only when
-     * comm_get_name is called */
-    MPL_strncpy(MPIR_Process.comm_world->name, "MPI_COMM_WORLD", MPI_MAX_OBJECT_NAME);
-
-    MPIR_Process.comm_self = MPIR_Comm_builtin + 1;
-    MPII_Comm_init(MPIR_Process.comm_self);
-    MPIR_Process.comm_self->handle = MPI_COMM_SELF;
-    MPIR_Process.comm_self->context_id = 1 << MPIR_CONTEXT_PREFIX_SHIFT;
-    MPIR_Process.comm_self->recvcontext_id = 1 << MPIR_CONTEXT_PREFIX_SHIFT;
-    MPIR_Process.comm_self->comm_kind = MPIR_COMM_KIND__INTRACOMM;
-    MPL_strncpy(MPIR_Process.comm_self->name, "MPI_COMM_SELF", MPI_MAX_OBJECT_NAME);
-
-#ifdef MPID_NEEDS_ICOMM_WORLD
-    MPIR_Process.icomm_world = MPIR_Comm_builtin + 2;
-    MPII_Comm_init(MPIR_Process.icomm_world);
-    MPIR_Process.icomm_world->handle = MPIR_ICOMM_WORLD;
-    MPIR_Process.icomm_world->context_id = 2 << MPIR_CONTEXT_PREFIX_SHIFT;
-    MPIR_Process.icomm_world->recvcontext_id = 2 << MPIR_CONTEXT_PREFIX_SHIFT;
-    MPIR_Process.icomm_world->comm_kind = MPIR_COMM_KIND__INTRACOMM;
-    MPL_strncpy(MPIR_Process.icomm_world->name, "MPI_ICOMM_WORLD", MPI_MAX_OBJECT_NAME);
-
-    /* Note that these communicators are not ready for use - MPID_Init
-     * will setup self and world, and icomm_world if it desires it. */
-#endif
-
     MPIR_Process.comm_parent = NULL;
-
-    /* Setup the initial communicator list in case we have
-     * enabled the debugger message-queue interface */
-    MPII_COMML_REMEMBER(MPIR_Process.comm_world);
-    MPII_COMML_REMEMBER(MPIR_Process.comm_self);
 
     /* create MPI_INFO_NULL object */
     MPIR_Info *info_ptr;
@@ -153,49 +113,8 @@ int MPII_finalize_local_proc_attrs(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    /* Remove the attributes, executing the attribute delete routine.
-     * Do this only if the attribute functions are defined. */
-    /* The standard (MPI-2, section 4.8) says that the attributes on
-     * MPI_COMM_SELF are deleted before almost anything else happens */
-    /* Note that the attributes need to be removed from the communicators
-     * so that they aren't freed twice. (The communicators are released
-     * in MPID_Finalize) */
-    if (MPIR_Process.attr_free && MPIR_Process.comm_self->attributes) {
-        mpi_errno = MPIR_Process.attr_free(MPI_COMM_SELF, &MPIR_Process.comm_self->attributes);
-        MPIR_ERR_CHECK(mpi_errno);
-        MPIR_Process.comm_self->attributes = 0;
-    }
-    if (MPIR_Process.attr_free && MPIR_Process.comm_world->attributes) {
-        mpi_errno = MPIR_Process.attr_free(MPI_COMM_WORLD, &MPIR_Process.comm_world->attributes);
-        MPIR_ERR_CHECK(mpi_errno);
-        MPIR_Process.comm_world->attributes = 0;
-    }
-
-    /*
-     * Now that we're finalizing, we need to take control of the error handlers
-     * At this point, we will release any user-defined error handlers on
-     * comm self and comm world
-     */
-    if (MPIR_Process.comm_world->errhandler &&
-        !(HANDLE_IS_BUILTIN(MPIR_Process.comm_world->errhandler->handle))) {
-        int in_use;
-        MPIR_Errhandler_release_ref(MPIR_Process.comm_world->errhandler, &in_use);
-        if (!in_use) {
-            MPIR_Handle_obj_free(&MPIR_Errhandler_mem, MPIR_Process.comm_world->errhandler);
-        }
-        /* always set to NULL to avoid a double-release later in finalize */
-        MPIR_Process.comm_world->errhandler = NULL;
-    }
-    if (MPIR_Process.comm_self->errhandler &&
-        !(HANDLE_IS_BUILTIN(MPIR_Process.comm_self->errhandler->handle))) {
-        int in_use;
-        MPIR_Errhandler_release_ref(MPIR_Process.comm_self->errhandler, &in_use);
-        if (!in_use) {
-            MPIR_Handle_obj_free(&MPIR_Errhandler_mem, MPIR_Process.comm_self->errhandler);
-        }
-        /* always set to NULL to avoid a double-release later in finalize */
-        MPIR_Process.comm_self->errhandler = NULL;
-    }
+    mpi_errno = MPIR_finalize_builtin_comms();
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -115,8 +115,7 @@ static inline void MPII_pre_init_memory_tracing(void)
 static inline void MPII_post_init_memory_tracing(void)
 {
 #ifdef USE_MEMORY_TRACING
-    MPL_trconfig(MPIR_Process.comm_world->rank,
-                 MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE);
+    MPL_trconfig(MPIR_Process.rank, MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE);
 #endif
 }
 

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -212,6 +212,11 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     mpi_errno = MPID_Init(required, &MPIR_ThreadInfo.thread_provided);
     MPIR_ERR_CHECK(mpi_errno);
 
+    mpi_errno = MPIR_init_comm_world();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIR_init_comm_self();
+    MPIR_ERR_CHECK(mpi_errno);
 
     /**********************************************************************/
     /* Section 5: contains post device initialization code.  Anything

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -55,12 +55,9 @@ extern const char MPII_Version_device[];
 /* MPIR_world_model_state tracks so we only init and finalize once in world model */
 MPL_atomic_int_t MPIR_world_model_state = MPL_ATOMIC_INT_T_INITIALIZER(0);
 
-/* Use init_lock to protect concurrent init/finalize (include session init/finalize) */
-static MPL_initlock_t init_lock = MPL_INITLOCK_INITIALIZER;
-
 /* Use init_counter to track when we are initializing for the first time or
  * when we are finalize for the last time and need cleanup states */
-/* Note: we are not using atomic variable since it is always accessed under init_lock */
+/* Note: we are not using atomic variable since it is always accessed under MPIR_init_lock */
 static int init_counter;
 
 /* TODO: currently the world model is not distinguished with session model, neither between
@@ -106,7 +103,7 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     bool is_world_model = (p_session_ptr == NULL);
     int err;
 
-    MPL_initlock_lock(&init_lock);
+    MPL_initlock_lock(&MPIR_init_lock);
 
     if (!is_world_model) {
         *p_session_ptr = (MPIR_Session *) MPIR_Handle_obj_alloc(&MPIR_Session_mem);
@@ -273,7 +270,7 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     if (is_world_model) {
         MPII_world_set_initilized();
     }
-    MPL_initlock_unlock(&init_lock);
+    MPL_initlock_unlock(&MPIR_init_lock);
     return mpi_errno;
 
   fn_fail:
@@ -293,7 +290,7 @@ int MPII_Finalize(MPIR_Session * session_ptr)
     int rank = MPIR_Process.rank;
     bool is_world_model = (session_ptr == NULL);
 
-    MPL_initlock_lock(&init_lock);
+    MPL_initlock_lock(&MPIR_init_lock);
 
     if (!is_world_model) {
         /* handle any clean up on session */
@@ -372,7 +369,7 @@ int MPII_Finalize(MPIR_Session * session_ptr)
     if (is_world_model) {
         MPII_world_set_finalized();
     }
-    MPL_initlock_unlock(&init_lock);
+    MPL_initlock_unlock(&MPIR_init_lock);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -285,7 +285,7 @@ int MPIR_Init_thread_impl(int *argc, char ***argv, int user_required, int *provi
 int MPII_Finalize(MPIR_Session * session_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    int rank = MPIR_Process.comm_world->rank;
+    int rank = MPIR_Process.rank;
     bool is_world_model = (session_ptr == NULL);
 
     MPL_initlock_lock(&init_lock);

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
@@ -547,7 +547,7 @@ int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
     str_errno = MPL_str_add_int_arg(&bc, &my_bc_len, "tag", new_vc->port_name_tag);
     MPIR_ERR_CHKANDJUMP(str_errno, mpi_errno, MPI_ERR_OTHER, "**argstr_port_name_tag");
     MPIDI_CH3I_NM_OFI_RC(MPID_nem_ofi_get_business_card
-                         (MPIR_Process.comm_world->rank, &bc, &my_bc_len));
+                         (MPIR_Process.rank, &bc, &my_bc_len));
     my_bc_len = MPIDI_OFI_KVSAPPSTRLEN - my_bc_len;
 
     MPID_nem_ofi_create_req(&sreq, 1);
@@ -557,7 +557,7 @@ int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
     REQ_OFI(sreq)->event_callback = MPID_nem_ofi_connect_to_root_callback;
     REQ_OFI(sreq)->pack_buffer = my_bc;
     if (gl_data.api_set == API_SET_1) {
-        conn_req_send_bits = init_sendtag(0, MPIR_Process.comm_world->rank, 0, MPIDI_OFI_CONN_REQ);
+        conn_req_send_bits = init_sendtag(0, MPIR_Process.rank, 0, MPIDI_OFI_CONN_REQ);
         FI_RC_RETRY(fi_tsend(gl_data.endpoint,
                              REQ_OFI(sreq)->pack_buffer,
                              my_bc_len,
@@ -570,7 +570,7 @@ int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
                                  REQ_OFI(sreq)->pack_buffer,
                                  my_bc_len,
                                  gl_data.mr,
-                                 MPIR_Process.comm_world->rank,
+                                 MPIR_Process.rank,
                                  VC_OFI(new_vc)->direct_addr,
                                  conn_req_send_bits, &(REQ_OFI(sreq)->ofi_context)), tsend);
     }

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
@@ -29,8 +29,7 @@
     match_bits |= (uint64_t)vc->port_name_tag<<                         \
         (MPIDI_OFI_PORT_SHIFT);                                              \
   }else{                                                                \
-      match_bits |= (uint64_t)MPIR_Process.comm_world->rank <<          \
-          (MPIDI_OFI_PSOURCE_SHIFT);                                         \
+      match_bits |= (uint64_t)MPIR_Process.rank << (MPIDI_OFI_PSOURCE_SHIFT); \
   }                                                                     \
   match_bits |= MPIDI_OFI_MSG_RTS;                                           \
 })

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -938,7 +938,7 @@ extern char *MPIDI_DBG_parent_str;
 #if defined(HAVE_MACRO_VA_ARGS)
 #   define MPIDI_err_printf(func, fmt, ...)				\
     {									\
-        MPL_error_printf("[%d] ERROR - %s(): " fmt "\n", MPIR_Process.comm_world->rank, func, __VA_ARGS__);    \
+        MPL_error_printf("[%d] ERROR - %s(): " fmt "\n", MPIR_Process.rank, func, __VA_ARGS__);    \
         fflush(stdout);							\
     }
 #endif

--- a/src/mpid/ch3/src/mpid_abort.c
+++ b/src/mpid/ch3/src/mpid_abort.c
@@ -37,14 +37,7 @@ int MPID_Abort(MPIR_Comm * comm, int mpi_errno, int exit_code,
 	}
 	else
 	{
-	    if (MPIR_Process.comm_world != NULL)
-	    {
-		rank = MPIR_Process.comm_world->rank;
-	    }
-	    else
-	    {
-		rank = -1;
-	    }
+            rank = MPIR_Process.rank;
 	}
 
 	if (mpi_errno != MPI_SUCCESS)

--- a/src/mpid/ch3/src/mpid_finalize.c
+++ b/src/mpid/ch3/src/mpid_finalize.c
@@ -106,17 +106,6 @@ int MPID_Finalize(void)
     if (mpi_errno) { MPIR_ERR_POP(mpi_errno); }
 #endif
 
-#ifdef MPID_NEEDS_ICOMM_WORLD
-    mpi_errno = MPIR_Comm_release_always(MPIR_Process.icomm_world);
-    MPIR_ERR_CHECK(mpi_errno);
-#endif
-
-    mpi_errno = MPIR_Comm_release_always(MPIR_Process.comm_self);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    mpi_errno = MPIR_Comm_release_always(MPIR_Process.comm_world);
-    MPIR_ERR_CHECK(mpi_errno);
-
     /* Note that the CH3I_Progress_finalize call has been removed; the
        CH3_Finalize routine should call it */
     mpi_errno = MPIDI_CH3_Finalize();

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -178,7 +178,6 @@ int MPID_Init_local(int requested, int *provided)
 int MPID_Init_world(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Comm *comm;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT_WORLD);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT_WORLD);
     /*
@@ -187,11 +186,8 @@ int MPID_Init_world(void)
      * the basic information about the job has been extracted from PMI (e.g.,
      * the size and rank of this process, and the process group id)
      */
-    MPIDI_PG_t *pg = MPIDI_Process.my_pg;
     int has_parent = MPIR_Process.has_parent;
-    int pg_rank = MPIR_Process.rank;
-    int pg_size = MPIR_Process.size;
-    mpi_errno = MPIDI_CH3_Init(has_parent, pg, pg_rank);
+    mpi_errno = MPIDI_CH3_Init(has_parent, MPIDI_Process.my_pg, MPIR_Process.rank);
     if (mpi_errno != MPI_SUCCESS) {
 	MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER, "**ch3|ch3_init");
     }
@@ -202,72 +198,6 @@ int MPID_Init_world(void)
 
     /* Ask channel to expose Window packet ordering. */
     MPIDI_CH3_Win_pkt_orderings_init(&MPIDI_CH3U_Win_pkt_orderings);
-
-    /*
-     * Initialize the MPI_COMM_WORLD object
-     */
-    comm = MPIR_Process.comm_world;
-
-    comm->rank        = pg_rank;
-    comm->remote_size = pg_size;
-    comm->local_size  = pg_size;
-    
-    mpi_errno = MPIDI_VCRT_Create(comm->remote_size, &comm->dev.vcrt);
-    if (mpi_errno != MPI_SUCCESS)
-    {
-	MPIR_ERR_SETANDJUMP1(mpi_errno,MPI_ERR_OTHER,"**dev|vcrt_create", 
-			     "**dev|vcrt_create %s", "MPI_COMM_WORLD");
-    }
-
-    /* Initialize the connection table on COMM_WORLD from the process group's
-       connection table */
-    for (int p = 0; p < pg_size; p++)
-    {
-	MPIDI_VCR_Dup(&pg->vct[p], &comm->dev.vcrt->vcr_table[p]);
-    }
-
-    mpi_errno = MPIR_Comm_commit(comm);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    /*
-     * Initialize the MPI_COMM_SELF object
-     */
-    comm = MPIR_Process.comm_self;
-    comm->rank        = 0;
-    comm->remote_size = 1;
-    comm->local_size  = 1;
-    
-    mpi_errno = MPIDI_VCRT_Create(comm->remote_size, &comm->dev.vcrt);
-    if (mpi_errno != MPI_SUCCESS)
-    {
-	MPIR_ERR_SETANDJUMP1(mpi_errno,MPI_ERR_OTHER, "**dev|vcrt_create", 
-			     "**dev|vcrt_create %s", "MPI_COMM_SELF");
-    }
-    
-    MPIDI_VCR_Dup(&pg->vct[pg_rank], &comm->dev.vcrt->vcr_table[0]);
-
-    mpi_errno = MPIR_Comm_commit(comm);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    /* Currently, mpidpre.h always defines MPID_NEEDS_ICOMM_WORLD. */
-#ifdef MPID_NEEDS_ICOMM_WORLD
-    /*
-     * Initialize the MPIR_ICOMM_WORLD object (an internal, private version
-     * of MPI_COMM_WORLD) 
-     */
-    comm = MPIR_Process.icomm_world;
-
-    comm->rank        = pg_rank;
-    comm->remote_size = pg_size;
-    comm->local_size  = pg_size;
-    MPIDI_VCRT_Add_ref( MPIR_Process.comm_world->dev.vcrt );
-    comm->dev.vcrt = MPIR_Process.comm_world->dev.vcrt;
-    
-    mpi_errno = MPIR_Comm_commit(comm);
-    MPIR_ERR_CHECK(mpi_errno);
-#endif
-
-    MPIR_Process.has_parent = has_parent;
 
     MPIR_Comm_register_hint(MPIR_COMM_HINT_EAGER_THRESH, "eager_rendezvous_threshold",
                             NULL, MPIR_COMM_HINT_TYPE_INT, 0, 0);

--- a/src/mpid/ch3/src/mpid_port.c
+++ b/src/mpid/ch3/src/mpid_port.c
@@ -259,7 +259,7 @@ static int MPIDI_Open_port(MPIR_Info *info_ptr, char *port_name)
     int len;
     int port_name_tag = 0; /* this tag is added to the business card,
                               which is then returned as the port name */
-    int myRank = MPIR_Process.comm_world->rank;
+    int myRank = MPIR_Process.rank;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OPEN_PORT);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OPEN_PORT);

--- a/src/mpid/ch3/util/sock/ch3u_connect_sock.c
+++ b/src/mpid/ch3/util/sock/ch3u_connect_sock.c
@@ -551,7 +551,7 @@ int MPIDI_CH3_Sockconn_handle_connect_event( MPIDI_CH3I_Connection_t *conn,
         }
 	MPIDI_Pkt_init(openpkt, MPIDI_CH3I_PKT_SC_OPEN_REQ);
 	openpkt->pg_id_len = (int) strlen(MPIDI_Process.my_pg->id) + 1;
-	openpkt->pg_rank = MPIR_Process.comm_world->rank;
+	openpkt->pg_rank = MPIR_Process.rank;
 	
 	mpi_errno = connection_post_send_pkt_and_pgid(conn);
 	if (mpi_errno) { MPIR_ERR_POP(mpi_errno); }
@@ -857,7 +857,7 @@ int MPIDI_CH3_Sockconn_handle_connopen_event( MPIDI_CH3I_Connection_t * conn )
 	if (pg == MPIDI_Process.my_pg) {
 	    /* the other process is in the same comm_world; just compare the 
 	       ranks */
-	    if (MPIR_Process.comm_world->rank < pg_rank) {
+	    if (MPIR_Process.rank < pg_rank) {
 		MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_CONNECT,TYPICAL,(MPL_DBG_FDEST,
                 "vc=%p,conn=%p:Accept head-to-head connection (my process group), discarding vcch->conn=%p",vc,conn, vcch->conn));
 
@@ -1136,7 +1136,7 @@ int MPIDI_CH3I_Sock_connect( MPIDI_VC_t *vc, const char val[], int vallen )
 	    MPL_DBG_VCCHSTATECHANGE(vc,VC_STATE_FAILED);
 	    vcch->state = MPIDI_CH3I_VC_STATE_FAILED;
 	    mpi_errno = MPIR_Err_create_code(mpi_errno, MPIR_ERR_FATAL, __func__, __LINE__, MPI_ERR_OTHER, "**ch3|sock|postconnect",
-		"**ch3|sock|postconnect %d %d %s", MPIR_Process.comm_world->rank, vc->pg_rank, val);
+		"**ch3|sock|postconnect %d %d %s", MPIR_Process.rank, vc->pg_rank, val);
 	    goto fn_fail;
 	}
 	/* --END ERROR HANDLING-- */

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -36,8 +36,7 @@ MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_fetch_incr_send_seqno(MPIR_Comm *
                      "Generated seqno=%d for dest_rank=%d "
                      "(context_id=0x%08x, src_addr=%" PRIx64 ", dest_addr=%" PRIx64 ")\n",
                      old_seq, dest_rank, comm->context_id,
-                     MPIDI_OFI_comm_to_phys(MPIR_Process.comm_world, MPIR_Process.comm_world->rank,
-                                            nic, 0, 0), addr));
+                     MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, 0, 0), addr));
 
     return old_seq;
 }
@@ -211,8 +210,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
     msg_hdr->payload_sz = 0;    /* LMT info sent as header */
     msg_hdr->am_type = MPIDI_AMTYPE_RDMA_READ;
     msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank);
-    msg_hdr->fi_src_addr
-        = MPIDI_OFI_comm_to_phys(MPIR_Process.comm_world, MPIR_Process.comm_world->rank, nic, 0, 0);
+    msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, 0, 0);
 
     lmt_info = &MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_info);
     lmt_info->context_id = comm->context_id;
@@ -291,8 +289,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm
     msg_hdr->payload_sz = data_sz;
     msg_hdr->am_type = MPIDI_AMTYPE_SHORT;
     msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank);
-    msg_hdr->fi_src_addr
-        = MPIDI_OFI_comm_to_phys(MPIR_Process.comm_world, MPIR_Process.comm_world->rank, nic, 0, 0);
+    msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, 0, 0);
 
     iov = MPIDI_OFI_AMREQUEST_HDR(sreq, iov);
 
@@ -341,8 +338,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
     msg_hdr->payload_sz = seg_sz;
     msg_hdr->am_type = MPIDI_AMTYPE_PIPELINE;
     msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank);
-    msg_hdr->fi_src_addr
-        = MPIDI_OFI_comm_to_phys(MPIR_Process.comm_world, MPIR_Process.comm_world->rank, nic, 0, 0);
+    msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, 0, 0);
 
     iov = send_req->iov;
 
@@ -539,8 +535,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
     msg_hdr.payload_sz = 0;
     msg_hdr.am_type = MPIDI_AMTYPE_SHORT_HDR;
     msg_hdr.seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank);
-    msg_hdr.fi_src_addr
-        = MPIDI_OFI_comm_to_phys(MPIR_Process.comm_world, MPIR_Process.comm_world->rank, nic, 0, 0);
+    msg_hdr.fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, 0, 0);
 
     MPIR_Assert((uint64_t) comm->rank < (1ULL << MPIDI_OFI_AM_RANK_BITS));
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -460,6 +460,13 @@ MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_av_to_phys(MPIDI_av_entry_t * av, i
 #endif
 }
 
+MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_rank_to_phys(int rank, int nic,
+                                                          int vni_local, int vni_remote)
+{
+    MPIDI_av_entry_t *av = &MPIDIU_get_av(0, rank);
+    return MPIDI_OFI_av_to_phys(av, nic, vni_local, vni_remote);
+}
+
 MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int rank, int nic,
                                                           int vni_local, int vni_remote)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -705,8 +705,7 @@ static int flush_send(int dst, int nic, int vni, MPIDI_OFI_dynamic_process_reque
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_Comm *comm = MPIR_Process.comm_world;
-    fi_addr_t addr = MPIDI_OFI_av_to_phys(MPIDIU_comm_rank_to_av(comm, dst), nic, vni, vni);
+    fi_addr_t addr = MPIDI_OFI_AV(&MPIDIU_get_av(0, dst)).dest[nic][vni];
     static int data = 0;
     uint64_t match_bits = MPIDI_OFI_init_sendtag(MPIDI_OFI_FLUSH_CONTEXT_ID,
                                                  MPIDI_OFI_FLUSH_TAG, MPIDI_OFI_DYNPROC_SEND);
@@ -730,8 +729,7 @@ static int flush_recv(int src, int nic, int vni, MPIDI_OFI_dynamic_process_reque
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_Comm *comm = MPIR_Process.comm_world;
-    fi_addr_t addr = MPIDI_OFI_av_to_phys(MPIDIU_comm_rank_to_av(comm, src), nic, vni, vni);
+    fi_addr_t addr = MPIDI_OFI_AV(&MPIDIU_get_av(0, src)).dest[nic][vni];
     uint64_t mask_bits = 0;
     uint64_t match_bits = MPIDI_OFI_init_sendtag(MPIDI_OFI_FLUSH_CONTEXT_ID,
                                                  MPIDI_OFI_FLUSH_TAG, MPIDI_OFI_DYNPROC_SEND);
@@ -819,8 +817,7 @@ int MPIDI_OFI_mpi_finalize_hook(void)
         MPIR_ERR_CHECK(mpi_errno);
     } else if (strcmp("verbs;ofi_rxm", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0) {
         /* verbs;ofi_rxm provider need barrier to prevent message loss */
-        MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-        mpi_errno = MPIR_Barrier_allcomm_auto(MPIR_Process.comm_world, &errflag);
+        mpi_errno = MPIR_pmi_barrier();
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -318,16 +318,14 @@ int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
 int MPIDI_UCX_mpi_finalize_hook(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Comm *comm;
     ucs_status_ptr_t ucp_request;
     ucs_status_ptr_t *pending;
 
-    comm = MPIR_Process.comm_world;
     int n = MPIDI_UCX_global.num_vnis;
-    pending = MPL_malloc(sizeof(ucs_status_ptr_t) * comm->local_size * n * n, MPL_MEM_OTHER);
+    pending = MPL_malloc(sizeof(ucs_status_ptr_t) * MPIR_Process.size * n * n, MPL_MEM_OTHER);
 
     int p = 0;
-    for (int i = 0; i < comm->local_size; i++) {
+    for (int i = 0; i < MPIR_Process.size; i++) {
         MPIDI_UCX_addr_t *av = &MPIDI_UCX_AV(&MPIDIU_get_av(0, i));
         for (int vni_local = 0; vni_local < MPIDI_UCX_global.num_vnis; vni_local++) {
             for (int vni_remote = 0; vni_remote < MPIDI_UCX_global.num_vnis; vni_remote++) {

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -133,8 +133,20 @@ int MPID_Comm_commit_pre_hook(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_COMMIT_PRE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_COMMIT_PRE_HOOK);
 
-    /* comm_world and comm_self are already initialized */
-    if (comm != MPIR_Process.comm_world && comm != MPIR_Process.comm_self) {
+    if (comm == MPIR_Process.comm_world) {
+        MPIDI_COMM(comm, map).mode = MPIDI_RANK_MAP_DIRECT_INTRA;
+        MPIDI_COMM(comm, map).avtid = 0;
+        MPIDI_COMM(comm, map).size = MPIR_Process.size;
+        MPIDI_COMM(comm, local_map).mode = MPIDI_RANK_MAP_NONE;
+        MPIDIU_avt_add_ref(0);
+    } else if (comm == MPIR_Process.comm_self) {
+        MPIDI_COMM(comm, map).mode = MPIDI_RANK_MAP_OFFSET_INTRA;
+        MPIDI_COMM(comm, map).avtid = 0;
+        MPIDI_COMM(comm, map).size = 1;
+        MPIDI_COMM(comm, map).reg.offset = MPIR_Process.rank;
+        MPIDI_COMM(comm, local_map).mode = MPIDI_RANK_MAP_NONE;
+        MPIDIU_avt_add_ref(0);
+    } else {
         MPIDI_comm_create_rank_map(comm);
         /* add ref to avts */
         switch (MPIDI_COMM(comm, map).mode) {

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -89,7 +89,7 @@ int MPID_Abort(MPIR_Comm * comm, int mpi_errno, int exit_code, const char *error
 
     char world_str[MPI_MAX_ERROR_STRING] = "";
     if (MPIR_Process.comm_world) {
-        int rank = MPIR_Process.comm_world->rank;
+        int rank = MPIR_Process.rank;
         snprintf(world_str, sizeof(world_str), " on node %d", rank);
     }
 

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -916,7 +916,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_av_entry_t *MPIDIU_win_rank_to_av(MPIR_Win * win,
 MPL_STATIC_INLINE_PREFIX int MPIDIU_win_comm_rank(MPIR_Win * win, MPIDI_winattr_t winattr)
 {
     if (winattr & MPIDI_WINATTR_DIRECT_INTRA_COMM)
-        return MPIR_Process.comm_world->rank;
+        return MPIR_Process.rank;
     else
         return win->comm_ptr->rank;
 }

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -809,8 +809,7 @@ int MPID_Get_processor_name(char *name, int namelen, int *resultlen)
             MPIDI_global.pname_len = (int) strlen(MPIDI_global.pname);
 
 #else
-        MPL_snprintf(MPIDI_global.pname, MPI_MAX_PROCESSOR_NAME, "%d",
-                     MPIR_Process.comm_world->rank);
+        MPL_snprintf(MPIDI_global.pname, MPI_MAX_PROCESSOR_NAME, "%d", MPIR_Process.rank);
         MPIDI_global.pname_len = (int) strlen(MPIDI_global.pname);
 #endif
         MPIDI_global.pname_set = 1;

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -188,8 +188,6 @@ static void *create_container(struct json_object *obj)
 static int choose_netmod(void);
 static int create_init_comm(MPIR_Comm **);
 static void destroy_init_comm(MPIR_Comm **);
-static int init_builtin_comms(void);
-static void finalize_builtin_comms(void);
 static void init_av_table(void);
 static void finalize_av_table(void);
 
@@ -351,49 +349,6 @@ static void destroy_init_comm(MPIR_Comm ** comm_ptr)
         MPIR_Handle_obj_free(&MPIR_Comm_mem, comm);
         *comm_ptr = NULL;
     }
-}
-
-static int init_builtin_comms(void)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    /* ---------------------------------- */
-    /* Initialize MPI_COMM_SELF           */
-    /* ---------------------------------- */
-    MPIR_Process.comm_self->rank = 0;
-    MPIR_Process.comm_self->remote_size = 1;
-    MPIR_Process.comm_self->local_size = 1;
-
-    /* ---------------------------------- */
-    /* Initialize MPI_COMM_WORLD          */
-    /* ---------------------------------- */
-    MPIR_Process.comm_world->rank = MPIR_Process.rank;
-    MPIR_Process.comm_world->remote_size = MPIR_Process.size;
-    MPIR_Process.comm_world->local_size = MPIR_Process.size;
-
-    /* initialize rank_map */
-    MPIDI_COMM(MPIR_Process.comm_world, map).mode = MPIDI_RANK_MAP_DIRECT_INTRA;
-    MPIDI_COMM(MPIR_Process.comm_world, map).avtid = 0;
-    MPIDI_COMM(MPIR_Process.comm_world, map).size = MPIR_Process.size;
-    MPIDI_COMM(MPIR_Process.comm_world, local_map).mode = MPIDI_RANK_MAP_NONE;
-    MPIDIU_avt_add_ref(0);
-
-    MPIDI_COMM(MPIR_Process.comm_self, map).mode = MPIDI_RANK_MAP_OFFSET_INTRA;
-    MPIDI_COMM(MPIR_Process.comm_self, map).avtid = 0;
-    MPIDI_COMM(MPIR_Process.comm_self, map).size = 1;
-    MPIDI_COMM(MPIR_Process.comm_self, map).reg.offset = MPIR_Process.rank;
-    MPIDI_COMM(MPIR_Process.comm_self, local_map).mode = MPIDI_RANK_MAP_NONE;
-    MPIDIU_avt_add_ref(0);
-
-    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_self);
-    MPIR_ERR_CHECK(mpi_errno);
-    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_world);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 static void init_av_table(void)
@@ -663,8 +618,6 @@ int MPID_Init_world(void)
     MPIR_Process.attrs.io = MPI_ANY_SOURCE;
 
     destroy_init_comm(&init_comm);
-    mpi_errno = init_builtin_comms();
-    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT_WORLD);
@@ -701,13 +654,6 @@ int MPID_InitCompleted(void)
 
   fn_fail:
     goto fn_exit;
-}
-
-static void finalize_builtin_comms(void)
-{
-    /* Release builtin comms */
-    MPIR_Comm_release_always(MPIR_Process.comm_world);
-    MPIR_Comm_release_always(MPIR_Process.comm_self);
 }
 
 static void finalize_av_table(void)
@@ -750,7 +696,6 @@ int MPID_Finalize(void)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    finalize_builtin_comms();
     generic_finalize();
 
     finalize_av_table();

--- a/src/mpl/include/mpl_str.h
+++ b/src/mpl/include/mpl_str.h
@@ -8,7 +8,7 @@
 
 #include "mplconfig.h"
 
-/* NOTE: PATH_MAX is simply an arbitary convenience size. It only be used
+/* NOTE: PATH_MAX is simply an arbitrary convenience size. It only be used
  * in non-critical paths or where we are certain the file path is very short.
  * Critical paths should consider using dynamic buffer.
  */

--- a/src/mpl/include/mpl_str.h
+++ b/src/mpl/include/mpl_str.h
@@ -51,6 +51,8 @@ int MPL_strnapp(char *dest, const char *src, size_t n);
 void MPL_create_pathname(char *dest_filename, const char *dirname,
                          const char *prefix, const int is_dir);
 
+int MPL_stricmp(const char *a, const char *b);
+
 /* *INDENT-ON* */
 #if defined(__cplusplus)
 }

--- a/src/mpl/src/str/mpl_str.c
+++ b/src/mpl/src/str/mpl_str.c
@@ -416,3 +416,37 @@ void MPL_create_pathname(char *dest_filename, const char *dirname,
         MPL_snprintf(dest_filename, PATH_MAX, "%s.%u.%u%c", prefix, rdm, pid, is_dir ? '/' : '\0');
     }
 }
+
+/*@ MPL_stricmp - Case insensitive string comparison
+
+Arguments:
+s1, s2  - The strings to compare
+
+Return:
+  0 - s1 is equal to s2
+  <0 - s1 is less than s2
+  >0 - s1 is greater than s2
+
+Module:
+  Utility
+@*/
+int MPL_stricmp(const char *s1, const char *s2)
+{
+    while (*s1 && *s2) {
+        if (toupper(*s1) < toupper(*s2)) {
+            return -1;
+        } else if (toupper(*s1) > toupper(*s2)) {
+            return 1;
+        }
+        s1++;
+        s2++;
+    }
+    if (*s1 == *s2) {
+        /* both '\0' */
+        return 0;
+    } else if (*s2) {
+        return -1;
+    } else {
+        return 1;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Refactor the builtin comm creation so that both `MPIR_Process.comm_world` and `MPIR_Process_comm_self` are explicitly created rather than being implicitly created during init. This prepares for the next stage that we may optionally skip builtin-comm creations in MPI_Session_init.

This is a split from #5288 and a prerequisite of that PR.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
