### PR TITLE
async: poke progress directly in async thread

### DIFF
--- a/src/mpi/init/init_async.c
+++ b/src/mpi/init/init_async.c
@@ -38,41 +38,21 @@ cvars:
 #if defined(MPICH_IS_THREADED) && MPICH_THREAD_LEVEL == MPI_THREAD_MULTIPLE
 
 static int MPIR_async_thread_initialized = 0;
-
-static MPIR_Comm *progress_comm_ptr;
 static MPID_Thread_id_t progress_thread_id;
-
-/* We can use whatever tag we want; we use a different communicator
- * for communicating with the progress thread. */
-#define WAKE_TAG 100
+static MPL_atomic_int_t async_done = MPL_ATOMIC_INT_T_INITIALIZER(0);
 
 static void progress_fn(void *data)
 {
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *request_ptr = NULL;
-    MPI_Request request;
-    MPI_Status status;
+    MPID_Progress_state state;
 
-    /* Explicitly add CS_ENTER/EXIT since this thread is created from
-     * within an internal function and will call NMPI functions
-     * directly. */
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
 
-    /* FIXME: We assume that waiting on some request forces progress
-     * on all requests. With fine-grained threads, will this still
-     * work as expected? We can imagine an approach where a request on
-     * a non-conflicting communicator would not touch the remaining
-     * requests to avoid locking issues. Once the fine-grained threads
-     * code is fully functional, we need to revisit this and, if
-     * appropriate, either change what we do in this thread, or delete
-     * this comment. */
-
-    mpi_errno = MPID_Irecv(NULL, 0, MPI_CHAR, 0, WAKE_TAG, progress_comm_ptr,
-                           MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
-    MPIR_Assert(!mpi_errno);
-    request = request_ptr->handle;
-    mpi_errno = MPIR_Wait(&request, &status);
-    MPIR_Assert(!mpi_errno);
+    MPID_Progress_start(&state);
+    while (MPL_atomic_load_int(&async_done) == 0) {
+        MPID_Progress_test(&state);
+        MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    }
+    MPID_Progress_end(&state);
 
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
 
@@ -83,18 +63,11 @@ static void progress_fn(void *data)
 int MPIR_Init_async_thread(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Comm *comm_self_ptr;
-    int err = 0;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_INIT_ASYNC_THREAD);
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_INIT_ASYNC_THREAD);
 
-
-    /* Dup comm world for the progress thread */
-    MPIR_Comm_get_ptr(MPI_COMM_SELF, comm_self_ptr);
-    mpi_errno = MPIR_Comm_dup_impl(comm_self_ptr, &progress_comm_ptr);
-    MPIR_ERR_CHECK(mpi_errno);
-
+    int err = 0;
     MPID_Thread_create((MPID_Thread_func_t) progress_fn, NULL, &progress_thread_id, &err);
     MPIR_ERR_CHKANDJUMP1(err, mpi_errno, MPI_ERR_OTHER, "**mutex_create", "**mutex_create %s",
                          strerror(err));
@@ -111,28 +84,12 @@ int MPIR_Init_async_thread(void)
 int MPIR_Finalize_async_thread(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *request_ptr = NULL;
-    MPI_Request request;
-    MPI_Status status;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_FINALIZE_ASYNC_THREAD);
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_FINALIZE_ASYNC_THREAD);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-
-    mpi_errno = MPID_Isend(NULL, 0, MPI_CHAR, 0, WAKE_TAG, progress_comm_ptr,
-                           MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
-    MPIR_Assert(!mpi_errno);
-    request = request_ptr->handle;
-    mpi_errno = MPIR_Wait(&request, &status);
-    MPIR_Assert(!mpi_errno);
-
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-
+    MPL_atomic_store_int(&async_done, 1);
     MPID_Thread_join(progress_thread_id);
-
-    mpi_errno = MPIR_Comm_free_impl(progress_comm_ptr);
-    MPIR_Assert(!mpi_errno);
 
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_FINALIZE_ASYNC_THREAD);
 


### PR DESCRIPTION
## Pull Request Description
Rather than wait for a self message and pokes progress via MPIR_Wait,
which is susceptible to changes in how we route self messages and how we
optimize the progress loop, directly poke MPID_Progress_test instead.

This fixes the recent nightly test failures due to https://github.com/pmodels/mpich/pull/4981 that self comm message no long updates progress counter in ch4.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
