### PR TITLE
romio: fix weak symbol blocks for large count functions

### DIFF
--- a/src/mpi/romio/mpi-io/get_extent.c
+++ b/src/mpi/romio/mpi-io/get_extent.c
@@ -19,6 +19,18 @@ int MPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype, MPI_Aint * exte
     __attribute__ ((weak, alias("PMPI_File_get_type_extent")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_get_type_extent_c = PMPI_File_get_type_extent_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_get_type_extent_c MPI_File_get_type_extent_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_get_type_extent_c as PMPI_File_get_type_extent_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_get_type_extent_c(MPI_File fh, MPI_Datatype datatype, MPI_Count * extent)
+    __attribute__ ((weak, alias("PMPI_File_get_type_extent_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -60,21 +72,6 @@ int MPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype, MPI_Aint * exte
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_get_type_extent_c = PMPI_File_get_type_extent_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_get_type_extent_c MPI_File_get_type_extent_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_get_type_extent_c as PMPI_File_get_type_extent_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_get_type_extent_c(MPI_File fh, MPI_Datatype datatype, MPI_Count * extent)
-    __attribute__ ((weak, alias("PMPI_File_get_type_extent_c")));
-#endif
-
-#endif
 
 /*@
     MPI_File_get_type_extent_c - Returns the extent of datatype in the file

--- a/src/mpi/romio/mpi-io/iread.c
+++ b/src/mpi/romio/mpi-io/iread.c
@@ -21,6 +21,19 @@ int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI
     __attribute__ ((weak, alias("PMPI_File_iread")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iread_c = PMPI_File_iread_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iread_c MPI_File_iread_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iread_c as PMPI_File_iread_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                     MPIO_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iread_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -72,22 +85,6 @@ int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_iread_c = PMPI_File_iread_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_iread_c MPI_File_iread_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_iread_c as PMPI_File_iread_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
-                     MPIO_Request * request)
-    __attribute__ ((weak, alias("PMPI_File_iread_c")));
-#endif
-
-#endif
 
 #ifdef HAVE_MPI_GREQUEST
 #include "mpiu_greq.h"

--- a/src/mpi/romio/mpi-io/iread_all.c
+++ b/src/mpi/romio/mpi-io/iread_all.c
@@ -22,6 +22,19 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype,
     __attribute__ ((weak, alias("PMPI_File_iread_all")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iread_all_c = PMPI_File_iread_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iread_all_c MPI_File_iread_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iread_all_c as PMPI_File_iread_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                         MPI_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iread_all_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -74,22 +87,6 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_iread_all_c = PMPI_File_iread_all_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_iread_all_c MPI_File_iread_all_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_iread_all_c as PMPI_File_iread_all_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
-                         MPI_Request * request)
-    __attribute__ ((weak, alias("PMPI_File_iread_all_c")));
-#endif
-
-#endif
 
 #ifdef HAVE_MPI_GREQUEST
 #include "mpiu_greq.h"

--- a/src/mpi/romio/mpi-io/iread_at.c
+++ b/src/mpi/romio/mpi-io/iread_at.c
@@ -21,6 +21,19 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_
                       MPIO_Request * request) __attribute__ ((weak, alias("PMPI_File_iread_at")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iread_at_c = PMPI_File_iread_at_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iread_at_c MPI_File_iread_at_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iread_at_c as PMPI_File_iread_at_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                        MPI_Datatype datatype, MPIO_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iread_at_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -75,22 +88,6 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_iread_at_c = PMPI_File_iread_at_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_iread_at_c MPI_File_iread_at_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_iread_at_c as PMPI_File_iread_at_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
-                        MPI_Datatype datatype, MPIO_Request * request)
-    __attribute__ ((weak, alias("PMPI_File_iread_at_c")));
-#endif
-
-#endif
 
 #ifdef HAVE_MPI_GREQUEST
 #include "mpiu_greq.h"

--- a/src/mpi/romio/mpi-io/iread_atall.c
+++ b/src/mpi/romio/mpi-io/iread_atall.c
@@ -22,6 +22,19 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count,
     __attribute__ ((weak, alias("PMPI_File_iread_at_all")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iread_at_all_c = PMPI_File_iread_at_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iread_at_all_c MPI_File_iread_at_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iread_at_all_c as PMPI_File_iread_at_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                            MPI_Datatype datatype, MPI_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iread_at_all_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -74,22 +87,6 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_iread_at_all_c = PMPI_File_iread_at_all_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_iread_at_all_c MPI_File_iread_at_all_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_iread_at_all_c as PMPI_File_iread_at_all_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
-                            MPI_Datatype datatype, MPI_Request * request)
-    __attribute__ ((weak, alias("PMPI_File_iread_at_all_c")));
-#endif
-
-#endif
 
 #ifdef HAVE_MPI_GREQUEST
 #include "mpiu_greq.h"

--- a/src/mpi/romio/mpi-io/iread_sh.c
+++ b/src/mpi/romio/mpi-io/iread_sh.c
@@ -22,6 +22,19 @@ int MPI_File_iread_shared(MPI_File fh, void *buf, int count, MPI_Datatype dataty
     __attribute__ ((weak, alias("PMPI_File_iread_shared")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iread_shared_c = PMPI_File_iread_shared_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iread_shared_c MPI_File_iread_shared_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iread_shared_c as PMPI_File_iread_shared_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                            MPIO_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iread_shared_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -53,22 +66,6 @@ int MPI_File_iread_shared(MPI_File fh, void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_iread_shared_c = PMPI_File_iread_shared_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_iread_shared_c MPI_File_iread_shared_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_iread_shared_c as PMPI_File_iread_shared_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
-                            MPIO_Request * request)
-    __attribute__ ((weak, alias("PMPI_File_iread_shared_c")));
-#endif
-
-#endif
 
 /*@
     MPI_File_iread_shared_c - Nonblocking read using shared file pointer

--- a/src/mpi/romio/mpi-io/iwrite.c
+++ b/src/mpi/romio/mpi-io/iwrite.c
@@ -21,6 +21,18 @@ int MPI_File_iwrite(MPI_File fh, const void *buf, int count, MPI_Datatype dataty
                     MPIO_Request * request) __attribute__ ((weak, alias("PMPI_File_iwrite")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iwrite_c = PMPI_File_iwrite_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_c MPI_File_iwrite_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iwrite_c as PMPI_File_iwrite_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iwrite_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                      MPIO_Request * request) __attribute__ ((weak, alias("PMPI_File_iwrite_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -73,21 +85,6 @@ int MPI_File_iwrite(MPI_File fh, ROMIO_CONST void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_iwrite_c = PMPI_File_iwrite_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_c MPI_File_iwrite_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_iwrite_c as PMPI_File_iwrite_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_iwrite_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
-                      MPIO_Request * request) __attribute__ ((weak, alias("PMPI_File_iwrite_c")));
-#endif
-
-#endif
 
 /*@
     MPI_File_iwrite_c - Nonblocking write using individual file pointer

--- a/src/mpi/romio/mpi-io/iwrite_all.c
+++ b/src/mpi/romio/mpi-io/iwrite_all.c
@@ -22,6 +22,19 @@ int MPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype da
     __attribute__ ((weak, alias("PMPI_File_iwrite_all")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iwrite_all_c = PMPI_File_iwrite_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_all_c MPI_File_iwrite_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iwrite_all_c as PMPI_File_iwrite_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iwrite_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                          MPI_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iwrite_all_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -68,22 +81,6 @@ int MPI_File_iwrite_all(MPI_File fh, ROMIO_CONST void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_iwrite_all_c = PMPI_File_iwrite_all_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_all_c MPI_File_iwrite_all_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_iwrite_all_c as PMPI_File_iwrite_all_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_iwrite_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
-                          MPI_Request * request)
-    __attribute__ ((weak, alias("PMPI_File_iwrite_all_c")));
-#endif
-
-#endif
 
 #ifdef HAVE_MPI_GREQUEST
 #include "mpiu_greq.h"

--- a/src/mpi/romio/mpi-io/iwrite_at.c
+++ b/src/mpi/romio/mpi-io/iwrite_at.c
@@ -22,6 +22,19 @@ int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, const void *buf, int coun
     __attribute__ ((weak, alias("PMPI_File_iwrite_at")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iwrite_at_c = PMPI_File_iwrite_at_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_at_c MPI_File_iwrite_at_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iwrite_at_c as PMPI_File_iwrite_at_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                         MPI_Datatype datatype, MPIO_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iwrite_at_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -78,22 +91,6 @@ int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_iwrite_at_c = PMPI_File_iwrite_at_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_at_c MPI_File_iwrite_at_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_iwrite_at_c as PMPI_File_iwrite_at_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
-                         MPI_Datatype datatype, MPIO_Request * request)
-    __attribute__ ((weak, alias("PMPI_File_iwrite_at_c")));
-#endif
-
-#endif
 
 /*@
     MPI_File_iwrite_at_c - Nonblocking write using explicit offset

--- a/src/mpi/romio/mpi-io/iwrite_atall.c
+++ b/src/mpi/romio/mpi-io/iwrite_atall.c
@@ -22,6 +22,19 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int 
     __attribute__ ((weak, alias("PMPI_File_iwrite_at_all")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iwrite_at_all_c = PMPI_File_iwrite_at_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_at_all_c MPI_File_iwrite_at_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iwrite_at_all_c as PMPI_File_iwrite_at_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                             MPI_Datatype datatype, MPI_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iwrite_at_all_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -68,22 +81,6 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_iwrite_at_all_c = PMPI_File_iwrite_at_all_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_at_all_c MPI_File_iwrite_at_all_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_iwrite_at_all_c as PMPI_File_iwrite_at_all_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
-                             MPI_Datatype datatype, MPI_Request * request)
-    __attribute__ ((weak, alias("PMPI_File_iwrite_at_all_c")));
-#endif
-
-#endif
 
 #ifdef HAVE_MPI_GREQUEST
 #include "mpiu_greq.h"

--- a/src/mpi/romio/mpi-io/iwrite_sh.c
+++ b/src/mpi/romio/mpi-io/iwrite_sh.c
@@ -22,6 +22,19 @@ int MPI_File_iwrite_shared(MPI_File fh, const void *buf, int count, MPI_Datatype
     __attribute__ ((weak, alias("PMPI_File_iwrite_shared")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_iwrite_shared_c = PMPI_File_iwrite_shared_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_shared_c MPI_File_iwrite_shared_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_iwrite_shared_c as PMPI_File_iwrite_shared_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_iwrite_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                             MPIO_Request * request)
+    __attribute__ ((weak, alias("PMPI_File_iwrite_shared_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -53,22 +66,6 @@ int MPI_File_iwrite_shared(MPI_File fh, ROMIO_CONST void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_iwrite_shared_c = PMPI_File_iwrite_shared_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_iwrite_shared_c MPI_File_iwrite_shared_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_iwrite_shared_c as PMPI_File_iwrite_shared_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_iwrite_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
-                             MPIO_Request * request)
-    __attribute__ ((weak, alias("PMPI_File_iwrite_shared_c")));
-#endif
-
-#endif
 
 /*@
     MPI_File_iwrite_shared_c - Nonblocking write using shared file pointer

--- a/src/mpi/romio/mpi-io/rd_atallb.c
+++ b/src/mpi/romio/mpi-io/rd_atallb.c
@@ -22,6 +22,19 @@ int MPI_File_read_at_all_begin(MPI_File fh, MPI_Offset offset, void *buf, int co
     __attribute__ ((weak, alias("PMPI_File_read_at_all_begin")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_at_all_begin_c = PMPI_File_read_at_all_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_at_all_begin_c MPI_File_read_at_all_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_at_all_begin_c as PMPI_File_read_at_all_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                                 MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_read_at_all_begin_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -55,22 +68,6 @@ int MPI_File_read_at_all_begin(MPI_File fh, MPI_Offset offset, void *buf,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_read_at_all_begin_c = PMPI_File_read_at_all_begin_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_read_at_all_begin_c MPI_File_read_at_all_begin_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_read_at_all_begin_c as PMPI_File_read_at_all_begin_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
-                                 MPI_Datatype datatype)
-    __attribute__ ((weak, alias("PMPI_File_read_at_all_begin_c")));
-#endif
-
-#endif
 
 /*@
     MPI_File_read_at_all_begin_c - Begin a split collective read using explicit offset

--- a/src/mpi/romio/mpi-io/read.c
+++ b/src/mpi/romio/mpi-io/read.c
@@ -21,6 +21,19 @@ int MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_
     __attribute__ ((weak, alias("PMPI_File_read")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_c = PMPI_File_read_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_c MPI_File_read_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_c as PMPI_File_read_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                    MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_read_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -64,25 +77,6 @@ int MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_read_c = PMPI_File_read_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_read_c MPI_File_read_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_read_c as PMPI_File_read_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
-                    MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_File_read_c")));
-#endif
-
-/* Include mapping from MPI->PMPI */
-#define MPIO_BUILD_PROFILING
-#include "mpioprof.h"
-#endif
 
 /* status object not filled currently */
 

--- a/src/mpi/romio/mpi-io/read_all.c
+++ b/src/mpi/romio/mpi-io/read_all.c
@@ -21,6 +21,19 @@ int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, 
     __attribute__ ((weak, alias("PMPI_File_read_all")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_all_c = PMPI_File_read_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_all_c MPI_File_read_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_all_c as PMPI_File_read_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                        MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_read_all_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -64,22 +77,6 @@ int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, 
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_read_all_c = PMPI_File_read_all_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_read_all_c MPI_File_read_all_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_read_all_c as PMPI_File_read_all_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
-                        MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_File_read_all_c")));
-#endif
-
-#endif
 
 /* status object not filled currently */
 

--- a/src/mpi/romio/mpi-io/read_allb.c
+++ b/src/mpi/romio/mpi-io/read_allb.c
@@ -21,6 +21,18 @@ int MPI_File_read_all_begin(MPI_File fh, void *buf, int count, MPI_Datatype data
     __attribute__ ((weak, alias("PMPI_File_read_all_begin")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_all_begin_c = PMPI_File_read_all_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_all_begin_c MPI_File_read_all_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_all_begin_c as PMPI_File_read_all_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_read_all_begin_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -52,21 +64,6 @@ int MPI_File_read_all_begin(MPI_File fh, void *buf, int count, MPI_Datatype data
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_read_all_begin_c = PMPI_File_read_all_begin_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_read_all_begin_c MPI_File_read_all_begin_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_read_all_begin_c as PMPI_File_read_all_begin_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
-    __attribute__ ((weak, alias("PMPI_File_read_all_begin_c")));
-#endif
-
-#endif
 
 /*@
     MPI_File_read_all_begin_c - Begin a split collective read using individual file pointer

--- a/src/mpi/romio/mpi-io/read_at.c
+++ b/src/mpi/romio/mpi-io/read_at.c
@@ -21,6 +21,19 @@ int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_D
                      MPI_Status * status) __attribute__ ((weak, alias("PMPI_File_read_at")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_at_c = PMPI_File_read_at_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_at_c MPI_File_read_at_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_at_c as PMPI_File_read_at_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                       MPI_Datatype datatype, MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_read_at_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -67,22 +80,6 @@ int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_read_at_c = PMPI_File_read_at_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_read_at_c MPI_File_read_at_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_read_at_c as PMPI_File_read_at_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
-                       MPI_Datatype datatype, MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_File_read_at_c")));
-#endif
-
-#endif
 
 
 /*@

--- a/src/mpi/romio/mpi-io/read_atall.c
+++ b/src/mpi/romio/mpi-io/read_atall.c
@@ -22,6 +22,19 @@ int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count,
     __attribute__ ((weak, alias("PMPI_File_read_at_all")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_at_all_c = PMPI_File_read_at_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_at_all_c MPI_File_read_at_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_at_all_c as PMPI_File_read_at_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
+                           MPI_Datatype datatype, MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_read_at_all_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -67,22 +80,6 @@ int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_read_at_all_c = PMPI_File_read_at_all_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_read_at_all_c MPI_File_read_at_all_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_read_at_all_c as PMPI_File_read_at_all_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
-                           MPI_Datatype datatype, MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_File_read_at_all_c")));
-#endif
-
-#endif
 
 
 /*@

--- a/src/mpi/romio/mpi-io/read_ord.c
+++ b/src/mpi/romio/mpi-io/read_ord.c
@@ -22,6 +22,19 @@ int MPI_File_read_ordered(MPI_File fh, void *buf, int count, MPI_Datatype dataty
     __attribute__ ((weak, alias("PMPI_File_read_ordered")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_ordered_c = PMPI_File_read_ordered_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_ordered_c MPI_File_read_ordered_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_ordered_c as PMPI_File_read_ordered_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                            MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_read_ordered_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -51,22 +64,6 @@ int MPI_File_read_ordered(MPI_File fh, void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_read_ordered_c = PMPI_File_read_ordered_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_read_ordered_c MPI_File_read_ordered_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_read_ordered_c as PMPI_File_read_ordered_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
-                            MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_File_read_ordered_c")));
-#endif
-
-#endif
 
 
 /*@

--- a/src/mpi/romio/mpi-io/read_ordb.c
+++ b/src/mpi/romio/mpi-io/read_ordb.c
@@ -21,6 +21,18 @@ int MPI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype 
     __attribute__ ((weak, alias("PMPI_File_read_ordered_begin")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_ordered_begin_c = PMPI_File_read_ordered_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_ordered_begin_c MPI_File_read_ordered_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_ordered_begin_c as PMPI_File_read_ordered_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_read_ordered_begin_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -46,21 +58,6 @@ int MPI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype 
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_read_ordered_begin_c = PMPI_File_read_ordered_begin_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_read_ordered_begin_c MPI_File_read_ordered_begin_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_read_ordered_begin_c as PMPI_File_read_ordered_begin_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
-    __attribute__ ((weak, alias("PMPI_File_read_ordered_begin_c")));
-#endif
-
-#endif
 
 /*@
     MPI_File_read_ordered_begin_c - Begin a split collective read using shared file pointer

--- a/src/mpi/romio/mpi-io/read_sh.c
+++ b/src/mpi/romio/mpi-io/read_sh.c
@@ -22,6 +22,19 @@ int MPI_File_read_shared(MPI_File fh, void *buf, int count, MPI_Datatype datatyp
     __attribute__ ((weak, alias("PMPI_File_read_shared")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_read_shared_c = PMPI_File_read_shared_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_read_shared_c MPI_File_read_shared_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_read_shared_c as PMPI_File_read_shared_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
+                           MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_read_shared_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -51,22 +64,6 @@ int MPI_File_read_shared(MPI_File fh, void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_read_shared_c = PMPI_File_read_shared_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_read_shared_c MPI_File_read_shared_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_read_shared_c as PMPI_File_read_shared_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
-                           MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_File_read_shared_c")));
-#endif
-
-#endif
 
 
 /*@

--- a/src/mpi/romio/mpi-io/register_datarep.c
+++ b/src/mpi/romio/mpi-io/register_datarep.c
@@ -22,6 +22,21 @@ int MPI_Register_datarep(const char *datarep, MPI_Datarep_conversion_function * 
     __attribute__ ((weak, alias("PMPI_Register_datarep")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_Register_datarep_c = PMPI_Register_datarep_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_Register_datarep_c MPI_Register_datarep_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_Register_datarep_c as PMPI_Register_datarep_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_Register_datarep_c(const char *datarep,
+                           MPI_Datarep_conversion_function_c * read_conversion_fn,
+                           MPI_Datarep_conversion_function_c * write_conversion_fn,
+                           MPI_Datarep_extent_function * dtype_file_extent_fn, void *extra_state)
+    __attribute__ ((weak, alias("PMPI_Register_datarep_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -66,24 +81,6 @@ int MPI_Register_datarep(ROMIO_CONST char *datarep,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_Register_datarep_c = PMPI_Register_datarep_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_Register_datarep_c MPI_Register_datarep_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_Register_datarep_c as PMPI_Register_datarep_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_Register_datarep_c(const char *datarep,
-                           MPI_Datarep_conversion_function_c * read_conversion_fn,
-                           MPI_Datarep_conversion_function_c * write_conversion_fn,
-                           MPI_Datarep_extent_function * dtype_file_extent_fn, void *extra_state)
-    __attribute__ ((weak, alias("PMPI_Register_datarep_c")));
-#endif
-
-#endif
 
 /*@
   MPI_Register_datarep_c - Register functions for user-defined data

--- a/src/mpi/romio/mpi-io/wr_atallb.c
+++ b/src/mpi/romio/mpi-io/wr_atallb.c
@@ -22,6 +22,19 @@ int MPI_File_write_at_all_begin(MPI_File fh, MPI_Offset offset, const void *buf,
     __attribute__ ((weak, alias("PMPI_File_write_at_all_begin")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_at_all_begin_c = PMPI_File_write_at_all_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_at_all_begin_c MPI_File_write_at_all_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_at_all_begin_c as PMPI_File_write_at_all_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                                  MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_write_at_all_begin_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -54,22 +67,6 @@ int MPI_File_write_at_all_begin(MPI_File fh, MPI_Offset offset, ROMIO_CONST void
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_write_at_all_begin_c = PMPI_File_write_at_all_begin_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_write_at_all_begin_c MPI_File_write_at_all_begin_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_write_at_all_begin_c as PMPI_File_write_at_all_begin_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
-                                  MPI_Datatype datatype)
-    __attribute__ ((weak, alias("PMPI_File_write_at_all_begin_c")));
-#endif
-
-#endif
 
 /*@
     MPI_File_write_at_all_begin_c - Begin a split collective write using

--- a/src/mpi/romio/mpi-io/write.c
+++ b/src/mpi/romio/mpi-io/write.c
@@ -21,6 +21,18 @@ int MPI_File_write(MPI_File fh, const void *buf, int count, MPI_Datatype datatyp
                    MPI_Status * status) __attribute__ ((weak, alias("PMPI_File_write")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_c = PMPI_File_write_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_c MPI_File_write_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_c as PMPI_File_write_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                     MPI_Status * status) __attribute__ ((weak, alias("PMPI_File_write_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -65,21 +77,6 @@ int MPI_File_write(MPI_File fh, ROMIO_CONST void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_write_c = PMPI_File_write_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_write_c MPI_File_write_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_write_c as PMPI_File_write_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_write_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
-                     MPI_Status * status) __attribute__ ((weak, alias("PMPI_File_write_c")));
-#endif
-
-#endif
 
 
 /*@

--- a/src/mpi/romio/mpi-io/write_all.c
+++ b/src/mpi/romio/mpi-io/write_all.c
@@ -21,6 +21,19 @@ int MPI_File_write_all(MPI_File fh, const void *buf, int count, MPI_Datatype dat
                        MPI_Status * status) __attribute__ ((weak, alias("PMPI_File_write_all")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_all_c = PMPI_File_write_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_all_c MPI_File_write_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_all_c as PMPI_File_write_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                         MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_write_all_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -65,22 +78,6 @@ int MPI_File_write_all(MPI_File fh, ROMIO_CONST void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_write_all_c = PMPI_File_write_all_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_write_all_c MPI_File_write_all_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_write_all_c as PMPI_File_write_all_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_write_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
-                         MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_File_write_all_c")));
-#endif
-
-#endif
 
 
 /*@

--- a/src/mpi/romio/mpi-io/write_allb.c
+++ b/src/mpi/romio/mpi-io/write_allb.c
@@ -21,6 +21,18 @@ int MPI_File_write_all_begin(MPI_File fh, const void *buf, int count, MPI_Dataty
     __attribute__ ((weak, alias("PMPI_File_write_all_begin")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_all_begin_c = PMPI_File_write_all_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_all_begin_c MPI_File_write_all_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_all_begin_c as PMPI_File_write_all_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_all_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_write_all_begin_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -51,21 +63,6 @@ int MPI_File_write_all_begin(MPI_File fh, ROMIO_CONST void *buf, int count, MPI_
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_write_all_begin_c = PMPI_File_write_all_begin_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_write_all_begin_c MPI_File_write_all_begin_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_write_all_begin_c as PMPI_File_write_all_begin_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_write_all_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype)
-    __attribute__ ((weak, alias("PMPI_File_write_all_begin_c")));
-#endif
-
-#endif
 
 /*@
     MPI_File_write_all_begin_c - Begin a split collective write using

--- a/src/mpi/romio/mpi-io/write_at.c
+++ b/src/mpi/romio/mpi-io/write_at.c
@@ -22,6 +22,19 @@ int MPI_File_write_at(MPI_File fh, MPI_Offset offset, const void *buf, int count
     __attribute__ ((weak, alias("PMPI_File_write_at")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_at_c = PMPI_File_write_at_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_at_c MPI_File_write_at_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_at_c as PMPI_File_write_at_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                        MPI_Datatype datatype, MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_write_at_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -68,22 +81,6 @@ int MPI_File_write_at(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_write_at_c = PMPI_File_write_at_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_write_at_c MPI_File_write_at_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_write_at_c as PMPI_File_write_at_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_write_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
-                        MPI_Datatype datatype, MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_File_write_at_c")));
-#endif
-
-#endif
 
 
 /*@

--- a/src/mpi/romio/mpi-io/write_atall.c
+++ b/src/mpi/romio/mpi-io/write_atall.c
@@ -22,6 +22,19 @@ int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int c
     __attribute__ ((weak, alias("PMPI_File_write_at_all")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_at_all_c = PMPI_File_write_at_all_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_at_all_c MPI_File_write_at_all_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_at_all_c as PMPI_File_write_at_all_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
+                            MPI_Datatype datatype, MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_write_at_all_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -66,22 +79,6 @@ int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_write_at_all_c = PMPI_File_write_at_all_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_write_at_all_c MPI_File_write_at_all_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_write_at_all_c as PMPI_File_write_at_all_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count,
-                            MPI_Datatype datatype, MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_File_write_at_all_c")));
-#endif
-
-#endif
 
 
 /*@

--- a/src/mpi/romio/mpi-io/write_ord.c
+++ b/src/mpi/romio/mpi-io/write_ord.c
@@ -22,6 +22,19 @@ int MPI_File_write_ordered(MPI_File fh, const void *buf, int count, MPI_Datatype
     __attribute__ ((weak, alias("PMPI_File_write_ordered")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_ordered_c = PMPI_File_write_ordered_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_ordered_c MPI_File_write_ordered_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_ordered_c as PMPI_File_write_ordered_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_ordered_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                             MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_write_ordered_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -51,22 +64,6 @@ int MPI_File_write_ordered(MPI_File fh, ROMIO_CONST void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_write_ordered_c = PMPI_File_write_ordered_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_write_ordered_c MPI_File_write_ordered_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_write_ordered_c as PMPI_File_write_ordered_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_write_ordered_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
-                             MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_File_write_ordered_c")));
-#endif
-
-#endif
 
 
 /*@

--- a/src/mpi/romio/mpi-io/write_ordb.c
+++ b/src/mpi/romio/mpi-io/write_ordb.c
@@ -21,6 +21,19 @@ int MPI_File_write_ordered_begin(MPI_File fh, const void *buf, int count, MPI_Da
     __attribute__ ((weak, alias("PMPI_File_write_ordered_begin")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_ordered_begin_c = PMPI_File_write_ordered_begin_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_ordered_begin_c MPI_File_write_ordered_begin_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_ordered_begin_c as PMPI_File_write_ordered_begin_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_ordered_begin_c(MPI_File fh, const void *buf, MPI_Count count,
+                                   MPI_Datatype datatype)
+    __attribute__ ((weak, alias("PMPI_File_write_ordered_begin_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -47,22 +60,6 @@ int MPI_File_write_ordered_begin(MPI_File fh, ROMIO_CONST void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_write_ordered_begin_c = PMPI_File_write_ordered_begin_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_write_ordered_begin_c MPI_File_write_ordered_begin_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_write_ordered_begin_c as PMPI_File_write_ordered_begin_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_write_ordered_begin_c(MPI_File fh, const void *buf, MPI_Count count,
-                                   MPI_Datatype datatype)
-    __attribute__ ((weak, alias("PMPI_File_write_ordered_begin_c")));
-#endif
-
-#endif
 
 /*@
     MPI_File_write_ordered_begin_c - Begin a split collective write using shared file pointer

--- a/src/mpi/romio/mpi-io/write_sh.c
+++ b/src/mpi/romio/mpi-io/write_sh.c
@@ -22,6 +22,19 @@ int MPI_File_write_shared(MPI_File fh, const void *buf, int count, MPI_Datatype 
     __attribute__ ((weak, alias("PMPI_File_write_shared")));
 #endif
 
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_File_write_shared_c = PMPI_File_write_shared_c
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_File_write_shared_c MPI_File_write_shared_c
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_File_write_shared_c as PMPI_File_write_shared_c
+/* end of weak pragmas */
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_File_write_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
+                            MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_File_write_shared_c")));
+#endif
+
 /* Include mapping from MPI->PMPI */
 #define MPIO_BUILD_PROFILING
 #include "mpioprof.h"
@@ -51,22 +64,6 @@ int MPI_File_write_shared(MPI_File fh, ROMIO_CONST void *buf, int count,
 
 /* large count function */
 
-#ifdef HAVE_WEAK_SYMBOLS
-
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_File_write_shared_c = PMPI_File_write_shared_c
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_File_write_shared_c MPI_File_write_shared_c
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_File_write_shared_c as PMPI_File_write_shared_c
-/* end of weak pragmas */
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_File_write_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype,
-                            MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_File_write_shared_c")));
-#endif
-
-#endif
 
 
 /*@


### PR DESCRIPTION
## Pull Request Description

The weak symbol block has to be placed before inclusion of mpioprof.h.

The fixes the clang build errors introduced by https://github.com/pmodels/mpich/pull/5278


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
