### PR TITLE
Add cvar to dump a corefile on abort

### DIFF
--- a/src/mpi/init/init_impl.c
+++ b/src/mpi/init/init_impl.c
@@ -19,6 +19,15 @@ cvars:
       scope       : MPI_T_SCOPE_ALL_EQ
       description : Disable printing of abort error message.
 
+    - name        : MPIR_CVAR_COREDUMP_ON_ABORT
+      category    : ERROR_HANDLING
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : Call libc abort() to generate a corefile
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 

--- a/src/mpid/ch3/src/mpid_abort.c
+++ b/src/mpid/ch3/src/mpid_abort.c
@@ -67,6 +67,10 @@ int MPID_Abort(MPIR_Comm * comm, int mpi_errno, int exit_code,
     MPL_error_printf("%s\n", error_msg);
     fflush(stderr);
 
+    if (MPIR_CVAR_COREDUMP_ON_ABORT) {
+        abort();
+    }
+
     /* FIXME: What is the scope for PMI_Abort?  Shouldn't it be one or more
        process groups?  Shouldn't abort of a communicator abort either the
        process groups of the communicator or only the current process?

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -121,6 +121,11 @@ int MPID_Abort(MPIR_Comm * comm, int mpi_errno, int exit_code, const char *error
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_ABORT);
     fflush(stderr);
     fflush(stdout);
+
+    if (MPIR_CVAR_COREDUMP_ON_ABORT) {
+        abort();
+    }
+
     if (NULL == comm || (MPIR_Comm_size(comm) == 1 && comm->comm_kind == MPIR_COMM_KIND__INTRACOMM))
         MPL_exit(exit_code);
 


### PR DESCRIPTION
## Pull Request Description

By default, MPICH either exits or calls PMI when aborting. Add a cvar
to allow the user to force MPICH to call abort() and generate a
corefile, which is useful for development/debugging. This patch adds
the abort() call inside MPID_Abort, since that is what MPICH calls
internally when an error is detected.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
