### PR TITLE
mpi: add MPI_ERR_PROC_ABORTED

### DIFF
--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -910,12 +910,13 @@ typedef int (MPIX_Grequest_wait_function)(int, void **, double, MPI_Status *);
 #define MPI_T_ERR_INVALID           74  /* Generic error code for MPI_T added in MPI-3.1 */
 
 #define MPI_ERR_SESSION            75  /* Invalid session handle */
+#define MPI_ERR_PROC_ABORTED       76  /* Trying to communicate with aborted processes */
 
-#define MPI_T_ERR_NOT_SUPPORTED    76  /* Requested functionality not supported */
+#define MPI_T_ERR_NOT_SUPPORTED    77  /* Requested functionality not supported */
 
 #define MPI_ERR_LASTCODE    0x3fffffff  /* Last valid error code for a 
 					   predefined error class */
-#define MPICH_ERR_LAST_CLASS 76     /* It is also helpful to know the
+#define MPICH_ERR_LAST_CLASS 77     /* It is also helpful to know the
 				       last valid class */
 
 #define MPICH_ERR_FIRST_MPIX 100 /* Define a gap here because sock is


### PR DESCRIPTION
## Pull Request Description
MPI-4 adds constant MPI_ERR_PROC_ABORTED. It is optional for
implementation to actually return this error.

Note: the symbol is added with MPIX_ prefix and need be updated when
PR #5316 merges.

Fixes #4890 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
