### PR TITLE
comm: create and release MPIR_Process.icomm_world

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -375,5 +375,8 @@ int MPII_Comm_check_hints(MPIR_Comm * comm_ptr);
 
 int MPIR_init_comm_self(void);
 int MPIR_init_comm_world(void);
+#ifdef MPID_NEEDS_ICOMM_WORLD
+int MPIR_init_icomm_world(void);
+#endif
 int MPIR_finalize_builtin_comms(void);
 #endif /* MPIR_COMM_H_INCLUDED */

--- a/src/mpi/comm/builtin_comms.c
+++ b/src/mpi/comm/builtin_comms.c
@@ -7,6 +7,9 @@
 
 #define COMM_WORLD_CTXID (0 << MPIR_CONTEXT_PREFIX_SHIFT)
 #define COMM_SELF_CTXID  (1 << MPIR_CONTEXT_PREFIX_SHIFT)
+#ifdef MPID_NEEDS_ICOMM_WORLD
+#define ICOMM_WORLD_CTXID (2 << MPIR_CONTEXT_PREFIX_SHIFT)
+#endif
 
 int MPIR_init_comm_world(void)
 {
@@ -68,6 +71,39 @@ int MPIR_init_comm_self(void)
     goto fn_exit;
 }
 
+#ifdef MPID_NEEDS_ICOMM_WORLD
+int MPIR_init_icomm_world(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(MPIR_Process.icomm_world == NULL);
+
+    MPIR_Process.icomm_world = MPIR_Comm_builtin + 2;
+    MPII_Comm_init(MPIR_Process.icomm_world);
+
+    MPIR_Process.icomm_world->rank = MPIR_Process.rank;
+    MPIR_Process.icomm_world->handle = MPIR_ICOMM_WORLD;
+    MPIR_Process.icomm_world->context_id = ICOMM_WORLD_CTXID;
+    MPIR_Process.icomm_world->recvcontext_id = MPIR_Process.icomm_world->context_id;
+    MPIR_Process.icomm_world->comm_kind = MPIR_COMM_KIND__INTRACOMM;
+
+    MPIR_Process.icomm_world->rank = MPIR_Process.rank;
+    MPIR_Process.icomm_world->remote_size = MPIR_Process.size;
+    MPIR_Process.icomm_world->local_size = MPIR_Process.size;
+
+    mpi_errno = MPIR_Comm_commit(MPIR_Process.icomm_world);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPL_strncpy(MPIR_Process.icomm_world->name, "MPI_ICOMM_WORLD", MPI_MAX_OBJECT_NAME);
+    MPII_COMML_REMEMBER(MPIR_Process.icomm_world);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+#endif
+
 static int finalize_builtin_comm(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -120,6 +156,16 @@ int MPIR_finalize_builtin_comms(void)
     } else {
         MPIR_Free_contextid(COMM_WORLD_CTXID);
     }
+
+#ifdef MPID_NEEDS_ICOMM_WORLD
+    if (MPIR_Process.icomm_world) {
+        mpi_errno = finalize_builtin_comm(MPIR_Process.icomm_world);
+        MPIR_ERR_CHECK(mpi_errno);
+        MPIR_Process.icomm_world = NULL;
+    } else {
+        MPIR_Free_contextid(ICOMM_WORLD_CTXID);
+    }
+#endif
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -219,6 +219,11 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
 
         mpi_errno = MPIR_init_comm_self();
         MPIR_ERR_CHECK(mpi_errno);
+
+#ifdef MPID_NEEDS_ICOMM_WORLD
+        mpi_errno = MPIR_init_icomm_world();
+        MPIR_ERR_CHECK(mpi_errno);
+#endif
     }
 
     /**********************************************************************/


### PR DESCRIPTION
## Pull Request Description

We neglected to create and release MPIR_Process.icomm_world when we
refactor the builtin comm creations.

This PR fixes current nightly test failures with `ch3-debug` , e.g.
```
## Test output (expected 'No Errors'):
##  No Errors
## leaked context IDs detected: mask=0x7f0276dc05c0 mask[0]=0xfffffffb
```


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
