### PR TITLE
mpi/init: increase MAX_FINALIZE_FUNC to 256

### DIFF
--- a/src/mpi/init/init_util.c
+++ b/src/mpi/init/init_util.c
@@ -20,7 +20,7 @@ typedef struct Finalize_func_t {
 } Finalize_func_t;
 /* When full debugging is enabled, each MPI handle type has a finalize handler
    installed to detect unfreed handles.  */
-#define MAX_FINALIZE_FUNC 64
+#define MAX_FINALIZE_FUNC 256
 static MPL_initlock_t fstack_lock = MPL_INITLOCK_INITIALIZER;
 static Finalize_func_t fstack[MAX_FINALIZE_FUNC];
 static int fstack_sp = 0;


### PR DESCRIPTION

## Pull Request Description

This PR fixes #5323.

(# of VCIs * 2) finalize functions are registered while # of VCIs is currently set to 64, so in total 128 finalize functions can be registered for VCIs. Current `MAX_FINALIZE_FUNC` is 64, so it causes an overflow in finalize stack.  To avoid this overflow, this PR increases `MAX_FINALIZE_FUNC` to 256.

Note that increase of the memory footprint is negligible since it is less than 10KB or so (`sizeof(Finalize_func_t) * (256 - 64)`).
https://github.com/pmodels/mpich/blob/main/src/mpi/init/init_util.c#L25

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
