### PR TITLE
f08: add missing functions that need skip large interface

### DIFF
--- a/maint/gen_binding_f08.py
+++ b/maint/gen_binding_f08.py
@@ -27,7 +27,7 @@ def main():
     skip_large_list = []
     # skip large variations because MPI_ADDRESS_KIND == MPI_COUNT_KIND
     if 'aint-is-int' not in G.opts:
-        skip_large_list.extend(["MPI_Op_create", "MPI_Register_datarep", "MPI_Type_create_resized", "MPI_Type_get_extent", "MPI_Type_get_true_extent", "MPI_File_get_type_extent"])
+        skip_large_list.extend(["MPI_Op_create", "MPI_Register_datarep", "MPI_Type_create_resized", "MPI_Type_get_extent", "MPI_Type_get_true_extent", "MPI_File_get_type_extent", "MPI_Win_allocate", "MPI_Win_allocate_shared", "MPI_Win_create", "MPI_Win_shared_query"])
     # skip File large count functions because it is not implemented yet
     for func in func_list:
         if func['name'].startswith('MPI_File_') or func['name'] == 'MPI_Register_datarep':


### PR DESCRIPTION
## Pull Request Description
Add missing functions that share the same signature between small and
large count variations on 32-bit systems.

This one should fix the failures on freebsd32. 

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
