### PR TITLE
ch4/ofi: duplicate MPIR_CVAR_OFI_USE_PROVIDER in ch4:ofi

### DIFF
--- a/maint/extractcvars.in
+++ b/maint/extractcvars.in
@@ -26,6 +26,7 @@ $Text::Wrap::unexpand = 0; # disable hard tabs in output
 # set true to enable debug output
 my $debug = 0;
 my @cvars = ();
+my %cvars; # used for duplication detection
 my @categories=();
 my $yaml = YAML::Tiny->new();
 my @dirs = ();
@@ -689,7 +690,17 @@ sub ProcessFile {
                 die "ERROR: cvar $cvar->{name} has no class in $cfile\n" unless exists $cvar->{class};
                 die "ERROR: cvar $cvar->{name} has no description in $cfile\n" unless exists $cvar->{description};
             }
-            push (@cvars, @{$info->{cvars}});
+            foreach my $cvar (@{$info->{cvars}}) {
+                if (!$cvars{$cvar->{name}}) {
+                    $cvars{$cvar->{name}} = $cvar;
+                    push (@cvars, $cvar);
+                } else {
+                    my $prev = $cvars{$cvar->{name}};
+                    if (cvar_cmp($prev, $cvar) != 0) {
+                        die "ERROR: duplicate CVAR definition, $cvar->{name}, and they are not the same\n";
+                    }
+                }
+            }
         }
 
         if (exists $info->{categories}) {
@@ -730,4 +741,30 @@ sub ExpandDir {
     foreach $dir (@subdirs) {
         ExpandDir($dir);
     }
+}
+
+# Compare two cvar, return 0 if they are duplicate and compatible. Other wise, return non-zero.
+# This is useful so we can have duplicated cvar definition is separate modules, e.g. ch3:ofi and ch4:ofi.
+sub cvar_cmp {
+    my ($a, $b) = @_;
+    if ($a->{category} ne $b->{category}) {
+        return 1;
+    }
+    if ($a->{type} ne $b->{type}) {
+        return 1;
+    }
+    if ($a->{default} ne $b->{default}) {
+        return 1;
+    }
+    if ($a->{scope} ne $b->{scope}) {
+        return 1;
+    }
+    if ($a->{class} ne $b->{class}) {
+        return 1;
+    }
+    if ($a->{verbosity} ne $b->{verbosity}) {
+        return 1;
+    }
+    # they are the same
+    return 0;
 }

--- a/src/mpid/ch4/netmod/ofi/init_provider.c
+++ b/src/mpid/ch4/netmod/ofi/init_provider.c
@@ -7,6 +7,25 @@
 #include "ofi_impl.h"
 #include "ofi_init.h"
 
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_OFI_USE_PROVIDER
+      category    : DEVELOPER
+      type        : string
+      default     : NULL
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_MPIDEV_DETAIL
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        If non-null, choose an OFI provider by name. If using with the CH4
+        device and using an older libfabric installation than the recommended
+        version to accompany this MPICH version, unexpected results may occur.
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
 /* There are two configurations: with or without RUNTIME_CHECKS.
  *
  * 1. With RUNTIME_CHECKS.


### PR DESCRIPTION
## Pull Request Description
MPIR_CVAR_OFI_USE_PROVIDER is currently defined in
src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c. This can cause
confusion as it is also used in ch4:ofi but the definition can't be
found there. In addition, if we ever decide to remove ch3:ofi, it will
break ch4:ofi, and it is undesirable.

Fixes #2482

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
