### PR TITLE
config: fix PAC_APPEND_FLAG and PAC_PREPEND_FLAG

### DIFF
--- a/confdb/aclocal_util.m4
+++ b/confdb/aclocal_util.m4
@@ -64,7 +64,7 @@ dnl argument is already present in the variable
 AC_DEFUN([PAC_APPEND_FLAG],[
 	AC_REQUIRE([AC_PROG_FGREP])
 	AS_IF(
-		[echo "$$2" | $FGREP -e "\<$1\>" >/dev/null 2>&1],
+		[echo "$$2" | $FGREP -e "$1" >/dev/null 2>&1],
 		[echo "$2(='$$2') contains '$1', not appending" >&AS_MESSAGE_LOG_FD],
 		[echo "$2(='$$2') does not contain '$1', appending" >&AS_MESSAGE_LOG_FD
 		$2="$$2 $1"]
@@ -80,7 +80,7 @@ dnl should be added in reverse order.
 AC_DEFUN([PAC_PREPEND_FLAG],[
         AC_REQUIRE([AC_PROG_FGREP])
         AS_IF(
-                [echo "$$2" | $FGREP -e "\<$1\>" >/dev/null 2>&1],
+                [echo "$$2" | $FGREP -e "$1" >/dev/null 2>&1],
                 [echo "$2(='$$2') contains '$1', not prepending" >&AS_MESSAGE_LOG_FD],
                 [echo "$2(='$$2') does not contain '$1', prepending" >&AS_MESSAGE_LOG_FD
                 $2="$1 $$2"]


### PR DESCRIPTION
## Pull Request Description
The usage `$FGREP -e "\<$1\>"` is wrong because fgrep doesn't accept
regex. This commit replace it with `$FGREP -e "$1"`. It has the risk of
false positive of matching partial string. We can be hopeful that such
case never occur with our usages. If it does occur, it can be locally
worked around by either swapping appending order or simply replace with
```
    $FLAG="$FLAG $1"
```

Fixes #2304 

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
