### PR TITLE
binding/f08: Clean existing cdesc.h before generating [3.4.x]

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -802,6 +802,8 @@ if [ $do_bindings = "yes" ] ; then
 	( cd src/binding/fortran/use_mpi_f08 && chmod a+x ./buildiface && ./buildiface )
         # Delete the old Makefile.mk
         ( rm -f src/binding/fortran/use_mpi_f08/wrappers_c/Makefile.mk )
+        # Delete the old cdesc.h
+        ( rm -f src/binding/fortran/use_mpi_f08/wrappers_c/cdesc.h )
         # Execute once for mpi.h.in ...
 	( cd src/binding/fortran/use_mpi_f08/wrappers_c && chmod a+x ./buildiface && ./buildiface ../../../../include/mpi.h.in )
         # ... and once for mpio.h.in


### PR DESCRIPTION
## Pull Request Description

Make sure to clear out any existing cdesc.h file in the F08 bindings
before generating it. This avoids possible duplicate symbols when
autogen.sh is run more than once.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
