### PR TITLE
doc: add INFO_HINT_BLOCK

### DIFF
--- a/maint/gen_binding_c.py
+++ b/maint/gen_binding_c.py
@@ -7,6 +7,7 @@ from local_python import MPI_API_Global as G
 from local_python.mpi_api import *
 from local_python.binding_c import *
 from local_python import RE
+from local_python.info_hints import collect_info_hint_blocks
 import glob
 
 def main():
@@ -33,7 +34,11 @@ def main():
         mapping = G.MAPS['SMALL_C_KIND_MAP']
         G.mpi_declares.append(get_declare_function(func, False, "proto"))
 
-    G.check_write_path(c_dir + '/mansrc/')
+    if 'output-mansrc' in G.opts:
+        G.check_write_path(c_dir + '/mansrc/')
+        G.hints = collect_info_hint_blocks("src")
+    else:
+        G.hints = None
 
     # -- Generating code --
     G.out = []

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -848,6 +848,26 @@ def dump_profiling(func):
     G.out.append("")
 
 def dump_manpage(func, out):
+    def dump_description(s):
+        words = s.split()
+        n = len(words)
+        i0 = 0
+        i = 0
+        l = 0
+        for w in words:
+            if l == 0:
+                l += len(w)
+            else:
+                l += len(w) + 1
+                if l > 80:
+                    out.append('  ' + ' '.join(words[i0:i]))
+                    i0 = i
+                    l = len(w)
+            i += 1
+            continue
+        if l > 0:
+            out.append('  ' + ' '.join(words[i0:]))
+    # ----
     out.append("/*D")
     out.append("   %s - %s" % (get_function_name(func, False), func['desc']))
     out.append("")
@@ -904,6 +924,15 @@ def dump_manpage(func, out):
 
         if RE.search(r'with\s+(\w+)', func['replace']):
             out.append("   The replacement for this routine is '%s'." % RE.m.group(1))
+        out.append("")
+
+    # document info keys
+    if G.hints and func['name'] in G.hints:
+        print("Got info hints in %s" % func['name'])
+        out.append("Info hints:")
+        for a in G.hints[func['name']]:
+            out.append(". %s - %s, default = %s." % (a['name'], a['type'], a['default']))
+            dump_description(a['description'])
         out.append("")
 
     for note in func['_docnotes']:

--- a/maint/local_python/info_hints.py
+++ b/maint/local_python/info_hints.py
@@ -1,0 +1,46 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+from local_python import RE
+import subprocess
+
+def collect_info_hint_blocks(root_dir):
+    """Collect INFO_HINT_BLOCKS from source files and return a function-name-keyed dictionary"""
+    infos_by_funcname = {}
+
+    files = subprocess.check_output("find %s -name '*.[ch]' |xargs grep -l BEGIN_INFO_HINT_BLOCK" % root_dir, shell=True).splitlines()
+    for f in files:
+        infos = parse_info_block(f)
+        for info in infos:
+            for funcname in info['functions'].replace(' ', '').split(','):
+                if funcname not in infos_by_funcname:
+                    infos_by_funcname[funcname] = []
+                infos_by_funcname[funcname].append(info)
+    return infos_by_funcname
+
+def parse_info_block(f):
+    """Parse a source file with INFO_HINT_BLOCKs, and return a list of info hints"""
+    hints = []
+    info = None # loop variable
+    stage = 0
+    with open(f) as In:
+        for line in In:
+            if line.startswith("=== BEGIN_INFO_HINT_BLOCK ==="):
+                stage = 1
+            elif line.startswith("=== END_INFO_HINT_BLOCK ==="):
+                stage = 0
+            elif stage:
+                if RE.match(r'\s*-\s*name\s*:\s*(\w+)', line):
+                    info = {"name":RE.m.group(1)}
+                    hints.append(info)
+                elif RE.match(r'\s*(functions|type|default)\s*:\s*(.*)', line):
+                    info[RE.m.group(1)] = RE.m.group(2)
+                elif RE.match(r'\s*description\s*:\s*>-', line):
+                    info['description'] = ""
+                elif RE.match(r'\s+(\S.+)', line):
+                    info['description'] += RE.m.group(1) + ' '
+                else:
+                    info = None
+    return hints

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -170,6 +170,52 @@ int MPII_Comm_check_hints(MPIR_Comm * comm)
     return MPI_SUCCESS;
 }
 
+/*
+=== BEGIN_INFO_HINT_BLOCK ===
+hints:
+    - name        : mpi_assert_no_any_tag
+      functions   : MPI_Comm_dup_with_info, MPI_Comm_idup_with_info, MPI_Comm_set_info
+      type        : boolean
+      default     : false
+      description : >-
+        If set to true, user promises that MPI_ANY_TAG will not be used with
+        the communicator. This potentially allows MPICH to treat messages with
+        different tags independent and seek to improve performance, e.g. by
+        employ multiple network context.
+
+    - name        : mpi_assert_no_any_source
+      functions   : MPI_Comm_dup_with_info, MPI_Comm_idup_with_info, MPI_Comm_set_info
+      type        : boolean
+      default     : false
+      description : >-
+        If set to true, user promises that MPI_ANY_SOURCE will not be used with
+        the communicator. This potentially allows MPICH to treat messages send
+        to different ranks or receive from different ranks independent and
+        seek to improve performance, e.g. by employ multiple network context.
+
+    - name        : mpi_assert_exact_length
+      functions   : MPI_Comm_dup_with_info, MPI_Comm_idup_with_info, MPI_Comm_set_info
+      type        : boolean
+      default     : false
+      description : >-
+        If set to true, user promises that the lengths of messages received
+        by the process will always equal to the size of the corresponding
+        receive buffers.
+
+    - name        : mpi_assert_allow_overtaking
+      functions   : MPI_Comm_dup_with_info, MPI_Comm_idup_with_info, MPI_Comm_set_info
+      type        : boolean
+      default     : false
+      description : >-
+        If set to true, user asserts that send operations are not required
+        to be matched at the receiver in the order in which the send operations
+        were performed by the sender, and receive operations are not required
+        to be matched in the order in which they were performed by the
+        receivers.
+
+=== END_INFO_HINT_BLOCK ===
+*/
+
 void MPIR_Comm_hint_init(void)
 {
     MPIR_Comm_register_hint(MPIR_COMM_HINT_NO_ANY_TAG, "mpi_assert_no_any_tag",


### PR DESCRIPTION
## Pull Request Description

Add INFO_HINT_BLOCK in-code documentation for info hints.

Example: https://github.com/pmodels/mpich/blob/f5f7781db99b6eb3eae1e22d738adbbc4ea820f4/src/mpi/comm/commutil.c#L170-L214

The binding generation script will parse these info blocks and insert them into man pages.

TODO:
* [ ] Document additional info hints

Fixes #2795

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
