### PR TITLE
init: only run async progress in world models

### DIFF
--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -122,7 +122,6 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
 
     init_counter++;
     if (init_counter > 1) {
-        *provided = MPIR_ThreadInfo.thread_provided;
         goto fn_exit;
     }
     /**********************************************************************/
@@ -273,21 +272,22 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     MPIR_ThreadInfo.isThreaded = (MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE);
 #endif
 
-    mpi_errno = MPII_init_async();
-    MPIR_ERR_CHECK(mpi_errno);
-
-    if (provided)
-        *provided = MPIR_ThreadInfo.thread_provided;
-
   fn_exit:
     if (is_world_model) {
         MPII_world_set_initilized();
+
+        mpi_errno = MPII_init_async();
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+    if (provided) {
+        *provided = MPIR_ThreadInfo.thread_provided;
     }
     MPL_initlock_unlock(&MPIR_init_lock);
     return mpi_errno;
 
   fn_fail:
-    goto fn_exit;
+    MPL_initlock_unlock(&MPIR_init_lock);
+    return mpi_errno;
 }
 
 int MPIR_Init_thread_impl(int *argc, char ***argv, int user_required, int *provided)


### PR DESCRIPTION
## Pull Request Description
MPI_Session_init is local, so we can't run async progress in init.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
