### PR TITLE
env: add recursive checks in compiler scripts

### DIFF
--- a/src/env/mpicc.bash.in
+++ b/src/env/mpicc.bash.in
@@ -60,6 +60,17 @@ Show=
 #
 # End of initialization of variables
 #---------------------------------------------------------------------
+
+# Check recursive situaltions
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_CC does not refer to mpicc."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
+
 # Environment Variables.
 # The environment variables MPICH_CC may be used to override the 
 # default choices.

--- a/src/env/mpicc.sh.in
+++ b/src/env/mpicc.sh.in
@@ -60,6 +60,17 @@ Show=eval
 #
 # End of initialization of variables
 #---------------------------------------------------------------------
+
+# Check recursive situaltions
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_CC does not refer to mpicc."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
+
 # Environment Variables.
 # The environment variables MPICH_CC may be used to override the 
 # default choices.

--- a/src/env/mpicxx.bash.in
+++ b/src/env/mpicxx.bash.in
@@ -57,6 +57,17 @@ Show=
 #
 # End of initialization of variables
 #---------------------------------------------------------------------
+
+# Check recursive situaltions
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_CXX does not refer to mpicxx."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
+
 # Environment Variables.
 # The environment variables MPICH_CXX may be used to override the 
 # default choices.

--- a/src/env/mpicxx.sh.in
+++ b/src/env/mpicxx.sh.in
@@ -57,6 +57,17 @@ Show=eval
 #
 # End of initialization of variables
 #---------------------------------------------------------------------
+
+# Check recursive situaltions
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_CXX does not refer to mpicxx."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
+
 # Environment Variables.
 # The environment variables MPICH_CXX may be used to override the 
 # default choices.

--- a/src/env/mpif77.bash.in
+++ b/src/env/mpif77.bash.in
@@ -63,6 +63,17 @@ Show=
 #
 # End of initialization of variables
 #---------------------------------------------------------------------
+
+# Check recursive situaltions
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_F77 does not refer to mpif77."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
+
 # Environment Variables.
 # The environment variables MPICH_F77 may be used to override the 
 # default choices.

--- a/src/env/mpif77.sh.in
+++ b/src/env/mpif77.sh.in
@@ -63,6 +63,17 @@ Show=eval
 #
 # End of initialization of variables
 #---------------------------------------------------------------------
+
+# Check recursive situaltions
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_F77 does not refer to mpif77."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
+
 # Environment Variables.
 # The environment variables MPICH_F77 may be used to override the 
 # default choices.

--- a/src/env/mpifort.bash.in
+++ b/src/env/mpifort.bash.in
@@ -76,6 +76,17 @@ Show=
 #
 # End of initialization of variables
 #---------------------------------------------------------------------
+
+# Check recursive situaltions
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_FC does not refer to mpifort."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
+
 # Environment Variables.
 # The environment variables MPICH_FC may be used to override the
 # default choices.

--- a/src/env/mpifort.sh.in
+++ b/src/env/mpifort.sh.in
@@ -76,6 +76,17 @@ Show=eval
 #
 # End of initialization of variables
 #---------------------------------------------------------------------
+
+# Check recursive situaltions
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_FC does not refer to mpifort."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
+
 # Environment Variables.
 # The environment variables MPICH_FC may be used to override the
 # default choices.


### PR DESCRIPTION
## Pull Request Description

Some time wrong setting could result in compiler scripts such as mpicc
to keep calling itself. This patch adds a simple recursive checking to
prevent such situation.

Fixes #5343 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
