### PR TITLE
ch4/part: Replace request status with send/recv epoch counters

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_part.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part.c
@@ -52,7 +52,8 @@ static int part_req_create(void *buf, int partitions, MPI_Aint count,
 static void part_req_am_init(MPIR_Request * part_req)
 {
     MPIDIG_PART_REQUEST(part_req, peer_req_ptr) = NULL;
-    MPL_atomic_store_int(&MPIDIG_PART_REQUEST(part_req, status), MPIDIG_PART_REQ_UNSET);
+    MPIDIG_PART_REQUEST(part_req, send_epoch) = 0;
+    MPIDIG_PART_REQUEST(part_req, recv_epoch) = 0;
 }
 
 int MPIDIG_mpi_psend_init(void *buf, int partitions, MPI_Aint count,
@@ -136,7 +137,6 @@ int MPIDIG_mpi_precv_init(void *buf, int partitions, int count,
         MPIDI_CH4_REQUEST_FREE(unexp_req);
 
         MPIDIG_part_match_rreq(*request);
-        MPIDIG_PART_REQ_INC_FETCH_STATUS(*request);
     } else {
         MPIDIG_enqueue_request(*request, &MPIDI_global.part_posted_list, MPIDIG_PART);
     }

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -233,7 +233,8 @@ typedef struct MPIDIG_part_rreq {
 } MPIDIG_part_rreq_t;
 
 typedef struct MPIDIG_part_request {
-    MPL_atomic_int_t status;    /* see MPIDIG_PART_REQ_INC_FETCH_STATUS */
+    uint8_t send_epoch;
+    uint8_t recv_epoch;
     MPIR_Request *peer_req_ptr;
     union {
         MPIDIG_part_sreq_t send;


### PR DESCRIPTION
## Pull Request Description

Use counters to track to the send and recv epochs of a partitioned
communication operation. These counters are incremented for each
MPI_START. If the send and recv epochs are the same, then the sender
is clear to send data to the receiver.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
