### PR TITLE
coll: fix persistent collectives

### DIFF
--- a/src/include/mpir_nbc.h
+++ b/src/include/mpir_nbc.h
@@ -46,6 +46,7 @@
  * separate potentially allows more parallelism in the future, but it also
  * pushes more work onto the clients of this interface. */
 int MPIR_Sched_next_tag(MPIR_Comm * comm_ptr, int *tag);
+void MPIR_Sched_set_tag(MPIR_Sched_t s, int tag);
 
 /* the device must provide a typedef for MPIR_Sched_t in mpidpre.h */
 
@@ -64,7 +65,7 @@ void *MPIR_Sched_alloc_state(MPIR_Sched_t s, MPI_Aint size);
  * comm should be the primary (user) communicator with which this collective is
  * associated, even if other hidden communicators are used for a subset of the
  * operations.  It will be used for error handling and similar operations. */
-int MPIR_Sched_start(MPIR_Sched_t s, MPIR_Comm * comm, int tag, MPIR_Request ** req);
+int MPIR_Sched_start(MPIR_Sched_t s, MPIR_Comm * comm, MPIR_Request ** req);
 
 /* send and recv take a comm ptr to enable hierarchical collectives */
 int MPIR_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -73,6 +73,10 @@ int MPII_Coll_finalize(void);
         } \
         mpi_errno = MPIR_Sched_create(&s, sched_kind); \
         MPIR_ERR_CHECK(mpi_errno); \
+        int tag = -1; \
+        mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag); \
+        MPIR_ERR_CHECK(mpi_errno); \
+        MPIR_Sched_set_tag(s, tag); \
         *sched_type_p = MPIR_SCHED_NORMAL; \
         *sched_p = s; \
     } while (0)
@@ -80,11 +84,7 @@ int MPII_Coll_finalize(void);
 #define MPII_SCHED_START(sched_type, sched, comm_ptr, request) \
     do { \
         if (sched_type == MPIR_SCHED_NORMAL) { \
-            int tag = -1; \
-            mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag); \
-            MPIR_ERR_CHECK(mpi_errno); \
-            \
-            mpi_errno = MPIR_Sched_start(sched, comm_ptr, tag, request); \
+            mpi_errno = MPIR_Sched_start(sched, comm_ptr, request); \
             MPIR_ERR_CHECK(mpi_errno); \
         } else if (sched_type == MPIR_SCHED_GENTRAN) { \
             mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, request); \

--- a/src/mpi/coll/nbcutil.c
+++ b/src/mpi/coll/nbcutil.c
@@ -19,15 +19,11 @@ int MPIR_Persist_coll_start(MPIR_Request * preq)
     int mpi_errno = MPI_SUCCESS;
 
     if (preq->u.persist_coll.sched_type == MPIR_SCHED_NORMAL) {
-        int tag = -1;
-        mpi_errno = MPIR_Sched_next_tag(preq->comm, &tag);
-        MPIR_ERR_CHECK(mpi_errno);
-
         mpi_errno = MPIR_Sched_reset(preq->u.persist_coll.sched);
         MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Sched_start(preq->u.persist_coll.sched,
-                                     preq->comm, tag, &preq->u.persist_coll.real_request);
+                                     preq->comm, &preq->u.persist_coll.real_request);
         MPIR_ERR_CHECK(mpi_errno);
     } else if (preq->u.persist_coll.sched_type == MPIR_SCHED_GENTRAN) {
         MPIR_TSP_sched_reset(preq->u.persist_coll.sched);

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -975,6 +975,7 @@ int MPIR_Get_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcommp, MPIR
     MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s, MPIR_SCHED_KIND_GENERALIZED);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Sched_set_tag(s, tag);
 
     /* add some entries to it */
     mpi_errno =
@@ -983,7 +984,7 @@ int MPIR_Get_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcommp, MPIR
     MPIR_ERR_CHECK(mpi_errno);
 
     /* finally, kick off the schedule and give the caller a request */
-    mpi_errno = MPIR_Sched_start(s, comm_ptr, tag, req);
+    mpi_errno = MPIR_Sched_start(s, comm_ptr, req);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -1016,6 +1017,7 @@ int MPIR_Get_intercomm_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newc
     MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s, MPIR_SCHED_KIND_GENERALIZED);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Sched_set_tag(s, tag);
 
     /* add some entries to it */
 
@@ -1026,7 +1028,7 @@ int MPIR_Get_intercomm_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newc
     MPIR_ERR_CHECK(mpi_errno);
 
     /* finally, kick off the schedule and give the caller a request */
-    mpi_errno = MPIR_Sched_start(s, comm_ptr, tag, req);
+    mpi_errno = MPIR_Sched_start(s, comm_ptr, req);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:

--- a/src/mpi/pt2pt/sendrecv.c
+++ b/src/mpi/pt2pt/sendrecv.c
@@ -205,8 +205,8 @@ int MPIR_Isendrecv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
     mpi_errno = MPIR_Sched_pt2pt_recv(recvbuf, recvcount, recvtype, recvtag, source, comm_ptr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* note: we are not using collective tag, so passing in 0 as a dummy */
-    mpi_errno = MPIR_Sched_start(s, comm_ptr, 0, p_req);
+    /* note: we are not using collective tag */
+    mpi_errno = MPIR_Sched_start(s, comm_ptr, p_req);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -260,10 +260,6 @@ int MPIR_Isendrecv_replace_impl(void *buf, int count, MPI_Datatype datatype, int
     }
 
     MPIR_Sched_t s = MPIR_SCHED_NULL;
-    int sched_tag;
-
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &sched_tag);
-    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_create(&s, MPIR_SCHED_KIND_REGULAR);
     MPIR_ERR_CHECK(mpi_errno);
@@ -278,7 +274,8 @@ int MPIR_Isendrecv_replace_impl(void *buf, int count, MPI_Datatype datatype, int
     mpi_errno = MPIR_Sched_cb(&release_temp_buffer, tmpbuf, s);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(s, comm_ptr, sched_tag, p_req);
+    /* note: we are not using collective tag */
+    mpi_errno = MPIR_Sched_start(s, comm_ptr, p_req);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch3/include/mpid_sched.h
+++ b/src/mpid/ch3/include/mpid_sched.h
@@ -10,6 +10,7 @@
 #define MPIR_Sched_cb MPIDU_Sched_cb
 #define MPIR_Sched_cb2 MPIDU_Sched_cb2
 #define MPIR_Sched_next_tag  MPIDU_Sched_next_tag
+#define MPIR_Sched_set_tag  MPIDU_Sched_set_tag
 #define MPIR_Sched_create MPIDU_Sched_create
 #define MPIR_Sched_clone MPIDU_Sched_clone
 #define MPIR_Sched_free MPIDU_Sched_free

--- a/src/mpid/ch4/include/mpid_sched.h
+++ b/src/mpid/ch4/include/mpid_sched.h
@@ -10,6 +10,7 @@
 #define MPIR_Sched_cb MPIDU_Sched_cb
 #define MPIR_Sched_cb2 MPIDU_Sched_cb2
 #define MPIR_Sched_next_tag  MPIDU_Sched_next_tag
+#define MPIR_Sched_set_tag  MPIDU_Sched_set_tag
 #define MPIR_Sched_create MPIDU_Sched_create
 #define MPIR_Sched_clone MPIDU_Sched_clone
 #define MPIR_Sched_free MPIDU_Sched_free

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -199,6 +199,11 @@ int MPIDU_Sched_next_tag(MPIR_Comm * comm_ptr, int *tag)
     return mpi_errno;
 }
 
+void MPIDU_Sched_set_tag(struct MPIDU_Sched *s, int tag)
+{
+    s->tag = tag;
+}
+
 /* initiates the schedule entry "e" in the NBC described by "s", where
  * "e" is at "idx" in "s".  This means posting nonblocking sends/recvs,
  * performing reductions, calling callbacks, etc. */
@@ -512,7 +517,7 @@ int MPIDU_Sched_reset(struct MPIDU_Sched *s)
         s->entries[i].status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
     }
     s->idx = 0;
-    s->tag = -1;
+    /* do not reset tag */
     s->req = NULL;
     s->next = NULL;     /* only needed for sanity checks */
     s->prev = NULL;     /* only needed for sanity checks */
@@ -542,7 +547,7 @@ static void sched_add_ref(struct MPIDU_Sched *s, int handle)
     utarray_push_back(s->handles, &handle, MPL_MEM_OTHER);
 }
 
-int MPIDU_Sched_start(struct MPIDU_Sched *s, MPIR_Comm * comm, int tag, MPIR_Request ** req)
+int MPIDU_Sched_start(struct MPIDU_Sched *s, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *r;
@@ -574,7 +579,6 @@ int MPIDU_Sched_start(struct MPIDU_Sched *s, MPIR_Comm * comm, int tag, MPIR_Req
     *req = r;
     /* cc is 1, which is fine b/c we only use it as a signal, rather than
      * incr/decr on every constituent operation */
-    s->tag = tag;
 
     /* Now kick off any initial operations.  Do this before we tell the progress
      * engine about this req+sched, otherwise we have more MT issues to worry

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -1192,8 +1192,6 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
 
             if (s->kind != MPIR_SCHED_KIND_PERSISTENT) {
                 MPIDU_Sched_free(s);
-            } else {
-                s->req = NULL;
             }
 
             if (made_progress)

--- a/src/mpid/common/sched/mpidu_sched.h
+++ b/src/mpid/common/sched/mpidu_sched.h
@@ -134,12 +134,13 @@ struct MPIDU_Sched {
 int MPIDU_Sched_progress(int *made_progress);
 int MPIDU_Sched_are_pending(void);
 int MPIDU_Sched_next_tag(struct MPIR_Comm *comm_ptr, int *tag);
+void MPIDU_Sched_set_tag(MPIR_Sched_t s, int tag);
 int MPIDU_Sched_create(MPIR_Sched_t * sp, enum MPIR_Sched_kind kind);
 int MPIDU_Sched_clone(MPIR_Sched_t orig, MPIR_Sched_t * cloned);
 int MPIDU_Sched_free(MPIR_Sched_t s);
 int MPIDU_Sched_reset(MPIR_Sched_t s);
 void *MPIDU_Sched_alloc_state(MPIR_Sched_t s, MPI_Aint size);
-int MPIDU_Sched_start(MPIR_Sched_t sp, struct MPIR_Comm *comm, int tag, struct MPIR_Request **req);
+int MPIDU_Sched_start(MPIR_Sched_t sp, struct MPIR_Comm *comm, struct MPIR_Request **req);
 int MPIDU_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
                      struct MPIR_Comm *comm, MPIR_Sched_t s);
 int MPIDU_Sched_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -145,6 +145,7 @@
 /coll/p_allgatherv
 /coll/p_alltoallv
 /coll/p_alltoallw
+/coll/p_order
 /coll/red3
 /coll/red4
 /coll/red_scat_block

--- a/test/mpi/coll/Makefile.am
+++ b/test/mpi/coll/Makefile.am
@@ -104,6 +104,7 @@ noinst_PROGRAMS =      \
     p_neighb_alltoall  \
     p_neighb_alltoallv \
     p_neighb_alltoallw \
+    p_order            \
     red3               \
     red4               \
     red_scat_block     \

--- a/test/mpi/coll/p_order.c
+++ b/test/mpi/coll/p_order.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include "mpitest.h"
+
+/*
+static char MTEST_Descrip[] = "Test that persistent collectives can be started out of matching order";
+*/
+
+int main(int argc, char **argv)
+{
+    int errs = 0;
+
+    MTest_Init(&argc, &argv);
+
+    int size, rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (size < 2) {
+        fprintf(stderr, "This test requires at least two processes.");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    int a = -1;
+    MPI_Request requests[2];
+    MPI_Bcast_init(&a, 1, MPI_INT, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &requests[0]);
+    MPI_Barrier_init(MPI_COMM_WORLD, MPI_INFO_NULL, &requests[1]);
+
+    if (rank == 0) {
+        a = 42;
+        MPI_Start(&requests[0]);
+        MPI_Start(&requests[1]);
+    } else {
+        MPI_Start(&requests[1]);
+        MPI_Start(&requests[0]);
+    }
+
+    MPI_Waitall(2, requests, MPI_STATUSES_IGNORE);
+
+    if (a != 42) {
+        errs++;
+    }
+
+    MPI_Request_free(&requests[0]);
+    MPI_Request_free(&requests[1]);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/coll/testlist.in
+++ b/test/mpi/coll/testlist.in
@@ -197,3 +197,4 @@ p_neighb_allgatherv 4 strict=false
 p_neighb_alltoall 4 strict=false
 p_neighb_alltoallv 4 strict=false
 p_neighb_alltoallw 4 strict=false
+p_order 2 strict=false


### PR DESCRIPTION
## Pull Request Description
With per-vci critical section, there is a race condition between
MPIDU_Sched_reset and MPIDU_Sched_progress_state. Thus we need to protect
MPIDU_Sched_reset.

The second commit fixes the extra locking in ch4 MPIDIG_mpi_fetch_and_op.
This was a trivial error. The reason we only detect it with `async+vci` is because
otherwise `MPI_Fetch_and_op` was only tested in thread single where locking is disabled.
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
