### PR TITLE
test/mpi: Add persistent collective ordering test

### DIFF
--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -145,6 +145,7 @@
 /coll/p_allgatherv
 /coll/p_alltoallv
 /coll/p_alltoallw
+/coll/p_order
 /coll/red3
 /coll/red4
 /coll/red_scat_block

--- a/test/mpi/coll/Makefile.am
+++ b/test/mpi/coll/Makefile.am
@@ -104,6 +104,7 @@ noinst_PROGRAMS =      \
     p_neighb_alltoall  \
     p_neighb_alltoallv \
     p_neighb_alltoallw \
+    p_order            \
     red3               \
     red4               \
     red_scat_block     \

--- a/test/mpi/coll/p_order.c
+++ b/test/mpi/coll/p_order.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include "mpitest.h"
+
+/*
+static char MTEST_Descrip[] = "Test that persistent collectives can be started out of matching order";
+*/
+
+int main(int argc, char **argv)
+{
+    int errs = 0;
+
+    MTest_Init(&argc, &argv);
+
+    int size, rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (size < 2) {
+        fprintf(stderr, "This test requires at least two processes.");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    int a = -1;
+    MPI_Request requests[2];
+    MPI_Bcast_init(&a, 1, MPI_INT, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &requests[0]);
+    MPI_Barrier_init(MPI_COMM_WORLD, MPI_INFO_NULL, &requests[1]);
+
+    if (rank == 0) {
+        a = 42;
+        MPI_Start(&requests[0]);
+        MPI_Start(&requests[1]);
+    } else {
+        MPI_Start(&requests[1]);
+        MPI_Start(&requests[0]);
+    }
+
+    MPI_Waitall(2, requests, MPI_STATUSES_IGNORE);
+
+    if (a != 42) {
+        errs++;
+    }
+
+    MPI_Request_free(&requests[0]);
+    MPI_Request_free(&requests[1]);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/coll/testlist.in
+++ b/test/mpi/coll/testlist.in
@@ -197,3 +197,4 @@ p_neighb_allgatherv 4 strict=false
 p_neighb_alltoall 4 strict=false
 p_neighb_alltoallv 4 strict=false
 p_neighb_alltoallw 4 strict=false
+p_order 2 strict=false


### PR DESCRIPTION
## Pull Request Description

MPI-4.0 states that persistent collective operations may be started
out-of-order, as the matching requirements are satisfied during
initialization. Add a simple test to verify this capability.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
