### PR TITLE
Fix huge message striping

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -85,6 +85,16 @@ int MPIDI_OFI_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
         comm->hints[MPIR_COMM_HINT_EAGAIN] = FALSE;
     }
 
+    if (comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING] == -1) {
+        comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING] =
+            MPIR_CVAR_CH4_OFI_ENABLE_MULTI_NIC_STRIPING;
+    }
+
+    if (comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING] == -1) {
+        comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING] =
+            MPIR_CVAR_CH4_OFI_ENABLE_MULTI_NIC_HASHING;
+    }
+
     update_multi_nic_hints(comm);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_MPI_COMM_COMMIT_PRE_HOOK);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -321,9 +321,9 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_GET_HUGE_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_GET_HUGE_EVENT);
 
-    if (recv_elem->localreq && recv_elem->cur_offset != 0) {    /* If this is true, then the message has a posted
-                                                                 * receive already and we'll be able to find the
-                                                                 * struct describing the transfer. */
+    /* If this is true, then the message has a posted receive already and we'll be able to find the
+     * struct describing the transfer. */
+    if (recv_elem->localreq && recv_elem->cur_offset != 0 && recv_elem->remote_info.msgsize != 0) {
         if (MPIDI_OFI_COMM(recv_elem->comm_ptr).enable_striping) {
             /* Subtract one stripe_chunk_size because we send the first chunk via a regular message
              * instead of the memory region */


### PR DESCRIPTION
## Pull Request Description

90a02540728c broke huge message striping because it started filling in the current offset earlier than was previously expected. This meant that the control message describing the message hadn't yet arrived.

Change the huge message receive protocol to use both the current offset and the message size to make sure the message has arrived.

Also, the initialization for the communicator hints failed to take into account the CVARs that the user can set to apply to the entire job.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
