### PR TITLE
config: save USER_ flags after merging MPICHLIB_ flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,10 +254,6 @@ AC_CONFIG_MACRO_DIR([confdb])
 FROM_MPICH=yes
 export FROM_MPICH
 
-# Save a copy of precious flags as USER_* before any of these flags
-# are being modified by configure tests.
-PAC_PREFIX_ALL_FLAGS(USER)
-
 # WRAPPER_xFLAGS are used by mpicc and friends.
 #
 # WRAPPER_CFLAGS and other compile flags are used for compile options
@@ -313,6 +309,10 @@ CPPFLAGS="$CPPFLAGS $MPICHLIB_CPPFLAGS"
 CXXFLAGS="$CXXFLAGS $MPICHLIB_CXXFLAGS"
 FFLAGS="$FFLAGS $MPICHLIB_FFLAGS"
 FCFLAGS="$FCFLAGS $MPICHLIB_FCFLAGS"
+
+# Save a copy of precious flags as USER_* before any of these flags
+# are being modified by configure tests.
+PAC_PREFIX_ALL_FLAGS(USER)
 
 dnl include all subsystem m4 fragments now that the core autoconf functionality
 dnl has been setup.  No fragment should do anything except define


### PR DESCRIPTION
## Pull Request Description

MPICHLIB_ flags, e.g. MPICHLIB_CFLAGS, are user supplied flags used
during building MPICH. PAC_RESET_ALL_FLAGS, used during configuring
submodules will reset to USER_ flags, which should include MPICHLIB_
flags. Thus, we need set USER_ flags after merging MPICHLIB_ flags.

Fixes #5360
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
