### PR TITLE
test: proper integer cast in redscatbkinter.c and redscatinter.c

### DIFF
--- a/test/mpi/coll/redscatbkinter.c
+++ b/test/mpi/coll/redscatbkinter.c
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
         }
 
         for (i = 0; i < sendcount; i++) {
-            sendbuf[i] = (long long) (rank * sendcount + i);
+            sendbuf[i] = (long long) rank *sendcount + i;
         }
         recvbuf = (long long *) malloc(recvcount * sizeof(long long));
         if (!recvbuf) {

--- a/test/mpi/coll/redscatinter.c
+++ b/test/mpi/coll/redscatinter.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
         }
 
         for (i = 0; i < sendcount; i++) {
-            sendbuf[i] = (long long) (rank * sendcount + i);
+            sendbuf[i] = (long long) rank *sendcount + i;
         }
         recvbuf = (long long *) malloc(recvcount * sizeof(long long));
         if (!recvbuf) {


### PR DESCRIPTION
## Pull Request Description

When cast to larger integer types, we need make sure to prevent
intermediate overflows.

Thanks github user brminich.

Fixes #5330.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
