### PR TITLE
typerep: cleanup endian definitions

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_util.h
+++ b/src/mpi/datatype/typerep/src/typerep_util.h
@@ -25,15 +25,6 @@
 
 /* Relying on the common predefined macros */
 
-/* Some platforms, like AIX, use BYTE_ORDER instead of __BYTE_ORDER */
-#ifndef __BYTE_ORDER
-#if defined(BYTE_ORDER) /* e.g. AIX */
-#define __BYTE_ORDER BYTE_ORDER
-#elif defined(__BYTE_ORDER__)   /* e.g. clang */
-#define __BYTE_ORDER __BYTE_ORDER__
-#endif
-#endif /* __BYTE_ORDER */
-
 #if defined(WORDS_BIGENDIAN)
 #define BLENDIAN 0
 
@@ -42,19 +33,27 @@
 
 #else
 
+#ifndef __BYTE_ORDER
+#if defined(BYTE_ORDER) /* e.g. AIX */
+#define __BYTE_ORDER BYTE_ORDER
+#elif defined(__BYTE_ORDER__)   /* e.g. clang */
+#define __BYTE_ORDER __BYTE_ORDER__
+#endif
+#endif /* __BYTE_ORDER */
+
 #ifndef __BIG_ENDIAN
 #if defined(_BIG_ENDIAN)
 #define __BIG_ENDIAN _BIG_ENDIAN
 #elif define(__BIG_ENDIAN__)
 #define __BIG_ENDIAN __BIG_ENDIAN__
 #endif
+#endif /* __BIG_ENDIAN */
 
 #if !defined(__BYTE_ORDER) || !defined(__BIG_ENDIAN)
 #error This code assumes that __BYTE_ORDER and __BIG_ENDIAN are defined
 #endif
-/* FIXME: I don't understand this. Whether ntohl being a macro or defined seems have
- * nothing to do with the logic. */
-#if ((defined(_BIG_ENDIAN) && !defined(ntohl)) || (__BYTE_ORDER == __BIG_ENDIAN))
+
+#if defined(_BIG_ENDIAN) || (__BYTE_ORDER == __BIG_ENDIAN)
 #define BLENDIAN 0      /* detected host arch byte order is big endian */
 #else
 #define BLENDIAN 1      /* detected host arch byte order is little endian */

--- a/src/mpi/datatype/typerep/src/typerep_util.h
+++ b/src/mpi/datatype/typerep/src/typerep_util.h
@@ -26,9 +26,13 @@
 /* Relying on the common predefined macros */
 
 /* Some platforms, like AIX, use BYTE_ORDER instead of __BYTE_ORDER */
-#if defined(BYTE_ORDER) && !defined(__BYTE_ORDER)
+#ifndef __BYTE_ORDER
+#if defined(BYTE_ORDER) /* e.g. AIX */
 #define __BYTE_ORDER BYTE_ORDER
+#elif defined(__BYTE_ORDER__)   /* e.g. clang */
+#define __BYTE_ORDER __BYTE_ORDER__
 #endif
+#endif /* __BYTE_ORDER */
 
 #if defined(WORDS_BIGENDIAN)
 #define BLENDIAN 0
@@ -37,6 +41,13 @@
 #define BLENDIAN 1
 
 #else
+
+#ifndef __BIG_ENDIAN
+#if defined(_BIG_ENDIAN)
+#define __BIG_ENDIAN _BIG_ENDIAN
+#elif define(__BIG_ENDIAN__)
+#define __BIG_ENDIAN __BIG_ENDIAN__
+#endif
 
 #if !defined(__BYTE_ORDER) || !defined(__BIG_ENDIAN)
 #error This code assumes that __BYTE_ORDER and __BIG_ENDIAN are defined


### PR DESCRIPTION
## Pull Request Description
The endian definition logic is a bit convoluted. This PR cleaned it up.

Fixes #4993

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
