### PR TITLE
config: fix python scripts for the VPATH build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5304,7 +5304,7 @@ export pkgconfigdir
 if test "$f08_works" = "yes" ; then
     PAC_CHECK_PYTHON
     PAC_FC_CHECK_REAL128
-    cmd="$PYTHON maint/gen_binding_f08.py"
+    cmd="$PYTHON $srcdir/maint/gen_binding_f08.py"
     if test "$pac_fc_has_real128" = "no" ; then
         cmd="$cmd -no-real128"
     fi

--- a/maint/gen_binding_c.py
+++ b/maint/gen_binding_c.py
@@ -8,10 +8,9 @@ from local_python.mpi_api import *
 from local_python.binding_c import *
 from local_python import RE
 import glob
-import os
 
 def main():
-    binding_dir = "src/binding"
+    binding_dir = G.get_srcdir_path("src/binding")
     c_dir = "src/binding/c"
     func_list = load_C_func_list(binding_dir)
 
@@ -46,11 +45,16 @@ def main():
             dump_mpi_c(func, False)
 
         file_path = get_func_file_path(func, c_dir)
+        G.check_write_path(file_path)
         dump_c_file(file_path, G.out)
 
         # add to mpi_sources for dump_Makefile_mk()
         G.mpi_sources.append(file_path)
 
+    G.check_write_path(c_dir)
+    G.check_write_path("src/include")
+    G.check_write_path("src/mpi_t")
+    G.check_write_path("src/include/mpi_proto.h")
     dump_Makefile_mk("%s/Makefile.mk" % c_dir)
     dump_mpir_impl_h("src/include/mpir_impl.h")
     dump_errnames_txt("%s/errnames.txt" % c_dir)

--- a/maint/gen_binding_f08.py
+++ b/maint/gen_binding_f08.py
@@ -8,13 +8,16 @@ from local_python.mpi_api import *
 from local_python.binding_common import *
 from local_python.binding_f08 import *
 from local_python import RE
+import os
 
 def main():
     # currently support -no-real128, -no-mpiio, -aint-is-int
     G.parse_cmdline()
 
-    binding_dir = "src/binding"
+    binding_dir = G.get_srcdir_path("src/binding")
     f08_dir = "src/binding/fortran/use_mpi_f08"
+    G.check_write_path("%s/wrappers_f" % f08_dir)
+    G.check_write_path("%s/wrappers_c" % f08_dir)
     func_list = load_C_func_list(binding_dir, True) # suppress noise
     if "no-mpiio" in G.opts:
         # a few MPI_File_xxx functions are already in (MPI_File_xxx_errhandler)

--- a/maint/local_python/__init__.py
+++ b/maint/local_python/__init__.py
@@ -3,8 +3,18 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
+import os
 import re
 import sys
+
+def get_srcdir():
+    m = re.match(r'(.*)\/maint\/local_python', __file__)
+    if m:
+        return m.group(1)
+    elif re.match(r'maint\/local_python', __file__):
+        return "."
+    else:
+        raise Exception("Can't determine srcdir from __file__")
 
 # RE class allows convenience of using regex capture in a condition
 class RE:
@@ -18,6 +28,15 @@ class RE:
 
 # Global data used across modules
 class MPI_API_Global:
+    srcdir = get_srcdir()
+
+    def get_srcdir_path(path):
+        # assume path is a relative path from top srcdir
+        return MPI_API_Global.srcdir + "/" + path
+
+    def check_write_path(path):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+
     # command line options and arguments
     opts = {}
     args = []
@@ -27,7 +46,7 @@ class MPI_API_Global:
     FUNCS = {}
     MAPS = {}
     default_descriptions = {}
-    # misc globals used during code genration
+    # misc globals used during code generation
     err_codes = {}
     mpi_sources = []
     mpi_declares = []

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -8,7 +8,6 @@ from local_python.binding_common import *
 from local_python import RE
 
 import sys
-import os
 import re
 import copy
 
@@ -73,8 +72,6 @@ def dump_mpi_c(func, is_large=False):
 def get_func_file_path(func, root_dir):
     file_path = None
     dir_path = root_dir + '/' + func['dir']
-    if not os.path.isdir(dir_path):
-        os.mkdir(dir_path)
     if 'file' in func:
         file_path = dir_path + '/' + func['file'] + ".c"
     elif RE.match(r'MPI_T_(\w+)', func['name'], re.IGNORECASE):


### PR DESCRIPTION
## Pull Request Description
We need to add `srcdir` in order to work in a VPATH build.

TODO:
    Need get srcdir from script path and use srcdir to load files.

Fixes #5365.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
