### PR TITLE
hydra: using HASH_REPLACE_STR instead of HASH_ADD_STR

### DIFF
--- a/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
@@ -503,15 +503,19 @@ static HYD_status fn_keyval_cache(int fd, char *args[])
                          (sizeof(struct cache_elem) * (num_elems + token_count)), status);
     for (i = 0; i < num_elems; i++) {
         struct cache_elem *elem = cache_get + i;
-        HASH_ADD_STR(hash_get, key, elem, MPL_MEM_PM);
+        struct cache_elem *replaced = NULL;
+        HASH_REPLACE_STR(hash_get, key, elem, replaced, MPL_MEM_PM);
+        /* DO NOT free replaced elem here */
     }
     for (; i < num_elems + token_count; i++) {
         struct cache_elem *elem = cache_get + i;
+        struct cache_elem *replaced = NULL;
         elem->key = MPL_strdup(tokens[i - num_elems].key);
         HYDU_ERR_CHKANDJUMP(status, NULL == elem->key, HYD_INTERNAL_ERROR, "%s", "");
         elem->val = MPL_strdup(tokens[i - num_elems].val);
         HYDU_ERR_CHKANDJUMP(status, NULL == elem->val, HYD_INTERNAL_ERROR, "%s", "");
-        HASH_ADD_STR(hash_get, key, elem, MPL_MEM_PM);
+        HASH_REPLACE_STR(hash_get, key, elem, replaced, MPL_MEM_PM);
+        /* DO NOT free replaced elem here */
     }
     num_elems += token_count;
 


### PR DESCRIPTION
## Pull Request Description
Currently PMI server adds KVSs to the hash table without checking if same key exsiting, which may cause undefined behaviors since same keys are not allowed in Uthash. 

A stable way to reproduce related bugs.

```
    char kvsname[KVSNAMELEN];
    char kvs_key[MAXKEYLEN];
    char value[MAXVALLEN];
    char get_value[MAXVALLEN];
    uint64_t key = 1001;
    uint64_t val = key;

    PMI_KVS_Get_my_name(kvsname, KVSNAMELEN);
    for (int i = 0; i < 101; ++i)
    {
        val++;
        char kvs_key[MAXKEYLEN];
        sprintf(kvs_key, "%.16"PRIx64"", key);
        sprintf(value, "%.16"PRIx64"", val);
        PMI_KVS_Put(kvsname, kvs_key, value);
        PMI_Barrier();
        PMI_KVS_Get(kvsname, kvs_key, get_value, MAXVALLEN);
        printf("P%d itr %d put %s get %s\n", comm_ptr->rank, i, value, get_value);
    }

```
Two issues can be found:
 1.Using this test case, the same key with different values can be pushed without any warning.
 2.In cases using 2 processes, the 10th and 100th iteration, the values are lost.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
