### PR TITLE
config: fix PAC_FGREP_WORD

### DIFF
--- a/confdb/aclocal_util.m4
+++ b/confdb/aclocal_util.m4
@@ -58,18 +58,23 @@ AC_DEFUN([PAC_PREFIX_ALL_FLAGS],[
 	PAC_PREFIX_FLAG($1, EXTRA_LIBS)
 ])
 
+AC_DEFUN([PAC_CHECK_FGREP_WORD],[
+    AC_PROG_FGREP
+    AC_MSG_CHECKING([if fgrep support -w option])
+    if echo 'ab*c' | $FGREP -w -e 'ab*c' >/dev/null 2>&1 ; then
+        pac_has_fgrep_word="yes"
+        AC_MSG_RESULT([$pac_has_fgrep_word])
+    else
+        pac_has_fgrep_word="no"
+        AC_MSG_RESULT([$pac_has_fgrep_word])
+        AC_MSG_WARN([fgrep does not support -w option, skip flag deduplication])
+    fi
+])
 AC_DEFUN([PAC_FGREP_WORD],[
-	AC_REQUIRE([AC_PROG_FGREP])
-        AC_CACHE_CHECK([check if fgrep support -w option], ac_cv_path_FGREP_has_word,
-           [if echo 'ab*c' | $GREP -Fw 'ab*c' >/dev/null 2>&1
-           then ac_cv_path_FGREP_has_word="yes"
-           else
-               ac_cv_path_FGREP_has_word="no"
-               AC_WARNING([grep does not support -w option, skip flag deduplication])
-           fi])
-        if test x$ac_cv_path_FGREP_has_word = "xyes"; then
+	AC_REQUIRE([PAC_CHECK_FGREP_WORD])
+        if test x$pac_has_fgrep_word = "xyes"; then
             AS_IF(
-                    [echo "$$2" | $FGREP -ew "$1" >/dev/null 2>&1],
+                    [echo "$$2" | $FGREP -w -e "$1" >/dev/null 2>&1],
                     [$3],
                     [$4]
             )


### PR DESCRIPTION

## Pull Request Description
AC_WARNING should be AC_MSG_WARN. AC_WARNING emits syntax error during autoreconf regardless of runtime.

$FGREP -ew "$1" should $FGREP -w -e "$1" (-e introduces the pattern and
allows $1 to contain leading dash.

Only check $FGREP -w once. The AC_CACHE_CHECK will print checking
message every time it is called (many many times).



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
