### PR TITLE
hwtopo: Add "numa" as alias for "numanode"

### DIFF
--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -327,6 +327,7 @@ MPIR_hwtopo_type_e MPIR_hwtopo_get_type_id(const char *name)
         {"l5ucache", MPIR_HWTOPO_TYPE__L5CACHE},
         {"l5cache", MPIR_HWTOPO_TYPE__L5CACHE},
         {"numanode", MPIR_HWTOPO_TYPE__DDR},
+        {"numa", MPIR_HWTOPO_TYPE__DDR},
         {"ddr", MPIR_HWTOPO_TYPE__DDR},
         {"hbm", MPIR_HWTOPO_TYPE__HBM},
         {NULL, MPIR_HWTOPO_TYPE__MAX}


### PR DESCRIPTION
## Pull Request Description

Add "numa" as an acceptable alias for "numanode" when identifying
hardware topology elements with hwloc, e.g. for MPI_COMM_SPLIT_TYPE
hints. This is consistent with "numa" as a valid process binding value
(-bind-to numa) in Hydra.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
