### PR TITLE
ch4/ofi: Use macro for min cq_data_size

### DIFF
--- a/src/mpid/ch4/netmod/ofi/init_settings.c
+++ b/src/mpid/ch4/netmod/ofi/init_settings.c
@@ -89,7 +89,7 @@ void MPIDI_OFI_init_hints(struct fi_info *hints)
     if (MPIDI_OFI_ENABLE_TAGGED) {
         hints->caps |= FI_TAGGED;       /* Tag matching interface  */
         hints->caps |= FI_DIRECTED_RECV;        /* Match source address    */
-        hints->domain_attr->cq_data_size = 4;   /* Minimum size for completion data entry */
+        hints->domain_attr->cq_data_size = MPIDI_OFI_MIN_CQ_DATA_SIZE;  /* Minimum size for completion data entry */
     }
 
     if (MPIDI_OFI_ENABLE_AM) {
@@ -280,7 +280,8 @@ int MPIDI_OFI_match_provider(struct fi_info *prov,
      * queue object (at least 32 bits). Previously, this was a separate capability set,
      * but as more and more providers supported this feature, the decision was made to
      * require it. */
-    CHECK_CAP(enable_tagged, !(prov->caps & FI_TAGGED) || prov->domain_attr->cq_data_size < 4);
+    CHECK_CAP(enable_tagged, !(prov->caps & FI_TAGGED) ||
+              prov->domain_attr->cq_data_size < MPIDI_OFI_MIN_CQ_DATA_SIZE);
 
     CHECK_CAP(enable_am, (prov->caps & (FI_MSG | FI_MULTI_RECV)) != (FI_MSG | FI_MULTI_RECV));
 
@@ -327,7 +328,7 @@ void MPIDI_OFI_update_global_settings(struct fi_info *prov)
     UPDATE_SETTING_BY_INFO(enable_tagged,
                            (prov->caps & FI_TAGGED) &&
                            (prov->caps & FI_DIRECTED_RECV) &&
-                           (prov->domain_attr->cq_data_size >= 4));
+                           (prov->domain_attr->cq_data_size >= MPIDI_OFI_MIN_CQ_DATA_SIZE));
     UPDATE_SETTING_BY_INFO(enable_am,
                            (prov->caps & (FI_MSG | FI_MULTI_RECV | FI_READ)) ==
                            (FI_MSG | FI_MULTI_RECV | FI_READ));

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -123,6 +123,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 #define MPIDI_OFI_COMM(comm)     ((comm)->dev.ch4.netmod.ofi)
 
 #define MPIDI_OFI_NUM_CQ_ENTRIES 8
+/* MPICH requires at least 32 bits of space in the completion queue data field. */
+#define MPIDI_OFI_MIN_CQ_DATA_SIZE 4
 
 /* Typedefs */
 enum {


### PR DESCRIPTION
## Pull Request Description

Avoid using integer values in the code and switch to a macro defined in one place instead.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
