### PR TITLE
pm/hydra: Add "numanode" as alias for "numa" bind/map option

### DIFF
--- a/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
+++ b/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
@@ -192,6 +192,7 @@ static struct hwloc_obj_info_table hwloc_obj_info[] = {
     {"socket", HWLOC_OBJ_PACKAGE},
     {"package", HWLOC_OBJ_PACKAGE},
     {"numa", HWLOC_OBJ_NUMANODE},
+    {"numanode", HWLOC_OBJ_NUMANODE},
     {"core", HWLOC_OBJ_CORE},
     {"hwthread", HWLOC_OBJ_PU},
     {"l1dcache", HWLOC_OBJ_L1CACHE},


### PR DESCRIPTION
## Pull Request Description

Since [16c0ff66], we support both "numa" and "numanode" as
communicator split hint values. Do the same for Hydra for consistency.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
