### PR TITLE
config: fix PAC_CHECK_VISIBILITY

### DIFF
--- a/confdb/aclocal_check_visibility.m4
+++ b/confdb/aclocal_check_visibility.m4
@@ -88,10 +88,13 @@ AC_DEFUN([PAC_CHECK_VISIBILITY],[
         CFLAGS="$CFLAGS_orig $mpich_add -Werror"
 
         AC_MSG_CHECKING([if $CC supports $mpich_add])
-        AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+        AC_LINK_IFELSE([AC_LANG_SOURCE([[
             #include <stdio.h>
             __attribute__((visibility("default"))) int foo;
-            ]],[[fprintf(stderr, "Hello, world\n");]])],
+            int main(void) {
+                fprintf(stderr, "Hello, world\n");
+            }
+            ]])],
             [AS_IF([test -s conftest.err],
                    [$GREP -iq visibility conftest.err
                     # If we find "visibility" in the stderr, then


### PR DESCRIPTION
## Pull Request Description
We can't use -Werror with AC_LANG_PROGRAM since it generates code like
    int main() {...}
, which triggers the old-style-definition warnings when --enable-strict
is enabled. Use AC_LANG_SOURCE instead.


The current failure in `config.log` in one of the warning tests:
```
configure:31120: checking if gcc-9 supports -fvisibility=hidden
configure:31136: gcc-9 -o conftest    -Wall -Wextra -Wstrict-prototypes -Wmissing-prototypes -DGCC_WALL -Wno-unused-parameter -Wshadow -Wmissing-declarations -Wundef -Wpointer-arith -Wbad-function-cast -Wwrite-strings -Wno-sign-compare -Wold-style-definition -Wnested-externs -Winvalid-pch -Wvariadic-macros -Wtype-limits -Werror-implicit-function-declaration -Wstack-usage=262144 -O2 -std=c99 -D_STDC_C99= -D_POSIX_C_SOURCE=200112L -fvisibility=hidden -Werror   -DNETMOD_INLINE=__netmod_inline_ofi__ -I/var/lib/jenkins-slave/workspace/mpich-main-warnings/compiler/gcc-9/config/ch4-ofi/label/centos64/mpich-main/src/mpl/include  conftest.c  >&5
conftest.c:48:1: error: function declaration isn't a prototype [-Werror=strict-prototypes]
   48 | main ()
      | ^~~~
conftest.c: In function 'main':
conftest.c:48:1: error: old-style function definition [-Werror=old-style-definition]
cc1: all warnings being treated as errors
configure:31136: $? = 1
configure: failed program was:
...
```

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
