### PR TITLE
ch4/ucx: using the ucx nbx am interface

### DIFF
--- a/src/mpid/ch4/netmod/ucx/Makefile.mk
+++ b/src/mpid/ch4/netmod/ucx/Makefile.mk
@@ -14,7 +14,7 @@ mpi_core_sources   += src/mpid/ch4/netmod/ucx/func_table.c\
                       src/mpid/ch4/netmod/ucx/ucx_spawn.c \
                       src/mpid/ch4/netmod/ucx/ucx_win.c \
                       src/mpid/ch4/netmod/ucx/ucx_part.c \
-                      src/mpid/ch4/netmod/ucx/ucx_progress.c \
+                      src/mpid/ch4/netmod/ucx/ucx_am.c \
                       src/mpid/ch4/netmod/ucx/globals.c
 
 errnames_txt_files += src/mpid/ch4/netmod/ucx/errnames.txt

--- a/src/mpid/ch4/netmod/ucx/ucx_am.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.c
@@ -6,6 +6,9 @@
 #include "mpidimpl.h"
 #include "ucx_impl.h"
 
+/* Registered with ucp_worker_set_am_handler, handles message sent from
+ * ucp_am_send_np.
+ */
 ucs_status_t MPIDI_UCX_am_handler(void *arg, void *data, size_t length, ucp_ep_h reply_ep,
                                   unsigned flags)
 {

--- a/src/mpid/ch4/netmod/ucx/ucx_am.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.c
@@ -38,12 +38,12 @@ void MPIDI_UCX_am_isend_callback(void *request, ucs_status_t status)
 {
     MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
     MPIR_Request *req = ucp_request->req;
-    int handler_id = req->dev.ch4.am.netmod_am.ucx.handler_id;
+    int handler_id = MPIDI_UCX_AM_SEND_REQUEST(req, handler_id);
 
     MPIR_FUNC_ENTER;
 
-    MPIR_gpu_free_host(req->dev.ch4.am.netmod_am.ucx.pack_buffer);
-    req->dev.ch4.am.netmod_am.ucx.pack_buffer = NULL;
+    MPIR_gpu_free_host(MPIDI_UCX_AM_SEND_REQUEST(req, pack_buffer));
+    MPIDI_UCX_AM_SEND_REQUEST(req, pack_buffer) = NULL;
     MPIDIG_global.origin_cbs[handler_id] (req);
     ucp_request->req = NULL;
 
@@ -65,3 +65,128 @@ void MPIDI_UCX_am_send_callback(void *request, ucs_status_t status)
 
     MPIR_FUNC_EXIT;
 }
+
+#ifdef HAVE_UCP_AM_NBX
+/* Am handler for messages sent from ucp_am_send_nbx. Registered with
+ * ucp_worker_set_am_recv_handler.
+ */
+ucs_status_t MPIDI_UCX_am_nbx_handler(void *arg, const void *header, size_t header_length,
+                                      void *data, size_t length, const ucp_am_recv_param_t * param)
+{
+    /* need to copy the message data for alignment purposes */
+    void *tmp = MPL_malloc(header_length, MPL_MEM_BUFFER);
+    MPIR_Memcpy(tmp, header, header_length);
+    MPIDI_UCX_am_header_t *msg_hdr = tmp;
+
+    int attr = 0;
+    MPIDIG_AM_ATTR_SET_VCIS(attr, msg_hdr->src_vci, msg_hdr->dst_vci);
+
+    bool got_data = !(param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV);
+    if (got_data) {
+        MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->payload,
+                                                           data, length, attr, NULL);
+        MPL_free(tmp);
+        return UCS_OK;
+    } else {
+        MPIR_Request *rreq;
+        attr |= MPIDIG_AM_ATTR__IS_ASYNC | MPIDIG_AM_ATTR__IS_RNDV;
+        MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->payload, NULL, 0, attr, &rreq);
+        MPL_free(tmp);
+        if (!rreq) {
+            /* ignoring data */
+            return UCS_OK;
+        } else {
+            MPIDI_UCX_AM_RECV_REQUEST(rreq, data_desc) = data;
+            MPIDI_UCX_AM_RECV_REQUEST(rreq, data_sz) = length;
+            if (MPIDIG_recv_initialized(rreq)) {
+                /* recv buffer ready, proceed */
+                MPIDI_UCX_do_am_recv(rreq);
+                return UCS_OK;
+            } else {
+                /* will wait for ch4 layer call data_copy_cb */
+                return UCS_INPROGRESS;
+            }
+        }
+    }
+}
+
+/* Called when recv buffer is posted */
+int MPIDI_UCX_do_am_recv(MPIR_Request * rreq)
+{
+    void *recv_buf;
+    bool is_contig;
+    MPI_Aint data_sz, in_data_sz;
+    int vci = MPIDI_Request_get_vci(rreq);
+
+    MPIDIG_get_recv_buffer(&recv_buf, &data_sz, &is_contig, &in_data_sz, rreq);
+    if (!is_contig || in_data_sz > data_sz) {
+        /* non-contig datatype, need receive into pack buffer */
+        /* ucx will error out if buffer size is less than the promised data size,
+         * also use a pack buffer in this case */
+        recv_buf = MPL_malloc(in_data_sz, MPL_MEM_OTHER);
+        MPIR_Assert(recv_buf);
+        MPIDI_UCX_AM_RECV_REQUEST(rreq, pack_buffer) = recv_buf;
+    } else {
+        MPIDI_UCX_AM_RECV_REQUEST(rreq, pack_buffer) = NULL;
+    }
+
+    MPIDI_UCX_ucp_request_t *ucp_request;
+    size_t received_length;
+    ucp_request_param_t param = {
+        .op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_RECV_INFO,
+        .cb.recv_am = &MPIDI_UCX_am_recv_callback_nbx,
+        .recv_info.length = &received_length,
+    };
+    void *data_desc = MPIDI_UCX_AM_RECV_REQUEST(rreq, data_desc);
+    /* note: use in_data_sz to match promised data size */
+    ucp_request = ucp_am_recv_data_nbx(MPIDI_UCX_global.ctx[vci].worker,
+                                       data_desc, recv_buf, in_data_sz, &param);
+    if (ucp_request == NULL) {
+        /* completed immediately */
+        MPIDI_UCX_ucp_request_t tmp_ucp_request;
+        tmp_ucp_request.req = rreq;
+        MPIDI_UCX_am_recv_callback_nbx(&tmp_ucp_request, UCS_OK, received_length, NULL);
+    } else {
+        ucp_request->req = rreq;
+    }
+
+    return MPI_SUCCESS;
+}
+
+/* callback for ucp_am_recv_data_nbx */
+void MPIDI_UCX_am_recv_callback_nbx(void *request, ucs_status_t status, size_t length,
+                                    void *user_data)
+{
+    MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
+    MPIR_Request *rreq = ucp_request->req;
+
+    /* FIXME: proper error handling */
+    MPIR_Assert(status == UCS_OK);
+
+    if (MPIDI_UCX_AM_RECV_REQUEST(rreq, pack_buffer)) {
+        MPIDIG_recv_copy(MPIDI_UCX_AM_RECV_REQUEST(rreq, pack_buffer), rreq);
+        MPL_free(MPIDI_UCX_AM_RECV_REQUEST(rreq, pack_buffer));
+        MPIDI_UCX_AM_RECV_REQUEST(rreq, pack_buffer) = NULL;
+    } else {
+        MPIDIG_recv_done(length, rreq);
+    }
+    MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    ucp_request->req = NULL;
+    ucp_request_release(ucp_request);
+}
+
+void MPIDI_UCX_am_isend_callback_nbx(void *request, ucs_status_t status, void *user_data)
+{
+    /* note: only difference from MPIDI_UCX_am_isend_callback is we need
+     * MPL_free in stead of MPIR_gpu_free_host
+     */
+    MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
+    MPIR_Request *req = ucp_request->req;
+    int handler_id = MPIDI_UCX_AM_SEND_REQUEST(req, handler_id);
+
+    MPL_free(MPIDI_UCX_AM_SEND_REQUEST(req, pack_buffer));
+    MPIDI_UCX_AM_SEND_REQUEST(req, pack_buffer) = NULL;
+    MPIDIG_global.origin_cbs[handler_id] (req);
+    ucp_request->req = NULL;
+}
+#endif

--- a/src/mpid/ch4/netmod/ucx/ucx_am.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.c
@@ -6,8 +6,8 @@
 #include "mpidimpl.h"
 #include "ucx_impl.h"
 
-/* Registered with ucp_worker_set_am_handler, handles message sent from
- * ucp_am_send_np.
+/* Am handler for messages sent from ucp_am_send_nb. Registered with
+ * ucp_worker_set_am_handler.
  */
 ucs_status_t MPIDI_UCX_am_handler(void *arg, void *data, size_t length, ucp_ep_h reply_ep,
                                   unsigned flags)
@@ -29,4 +29,39 @@ ucs_status_t MPIDI_UCX_am_handler(void *arg, void *data, size_t length, ucp_ep_h
 
     MPL_free(tmp);
     return UCS_OK;
+}
+
+/* callback for ucp_am_send_nb, used in MPIDI_NM_am_isend.
+ * The union request was set to sreq.
+ */
+void MPIDI_UCX_am_isend_callback(void *request, ucs_status_t status)
+{
+    MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
+    MPIR_Request *req = ucp_request->req;
+    int handler_id = req->dev.ch4.am.netmod_am.ucx.handler_id;
+
+    MPIR_FUNC_ENTER;
+
+    MPIR_gpu_free_host(req->dev.ch4.am.netmod_am.ucx.pack_buffer);
+    req->dev.ch4.am.netmod_am.ucx.pack_buffer = NULL;
+    MPIDIG_global.origin_cbs[handler_id] (req);
+    ucp_request->req = NULL;
+
+    MPIR_FUNC_EXIT;
+}
+
+/* callback for ucp_am_send_nb, used in MPIDI_NM_am_send_hdr.
+ * The union request was set to the send buffer.
+ */
+void MPIDI_UCX_am_send_callback(void *request, ucs_status_t status)
+{
+    MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
+
+    MPIR_FUNC_ENTER;
+
+    MPL_free(ucp_request->buf);
+    ucp_request->buf = NULL;
+    ucp_request_release(ucp_request);
+
+    MPIR_FUNC_EXIT;
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -40,6 +40,59 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
     ucx_hdr.dst_vci = dst_vci;
     ucx_hdr.data_sz = data_sz;
 
+#ifdef HAVE_UCP_AM_NBX
+    size_t header_size = sizeof(ucx_hdr) + am_hdr_sz;
+    void *send_buf, *header, *data_ptr;
+    /* note: since we are not copying large contig gpu data, it is less useful
+     * to use MPIR_gpu_malloc_host */
+    if (dt_contig) {
+        /* only need copy headers */
+        send_buf = MPL_malloc(header_size, MPL_MEM_OTHER);
+        MPIR_Assert(send_buf);
+        header = send_buf;
+
+        MPIR_Memcpy(header, &ucx_hdr, sizeof(ucx_hdr));
+        MPIR_Memcpy((char *) header + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
+
+        data_ptr = (char *) data + dt_true_lb;
+    } else {
+        /* need copy headers and pack data */
+        send_buf = MPL_malloc(header_size + data_sz, MPL_MEM_OTHER);
+        MPIR_Assert(send_buf);
+        header = send_buf;
+        data_ptr = (char *) send_buf + header_size;
+
+        MPIR_Memcpy(header, &ucx_hdr, sizeof(ucx_hdr));
+        MPIR_Memcpy((char *) header + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
+
+        MPI_Aint actual_pack_bytes;
+        mpi_errno = MPIR_Typerep_pack(data, count, datatype, 0, data_ptr, data_sz,
+                                      &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
+        MPIR_ERR_CHECK(mpi_errno);
+        MPIR_Assert(actual_pack_bytes == data_sz);
+    }
+    ucp_request_param_t param = {
+        .op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK,
+        .cb.send = &MPIDI_UCX_am_isend_callback_nbx,
+    };
+    ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_am_send_nbx(ep, MPIDI_UCX_AM_NBX_HANDLER_ID,
+                                                              header, header_size,
+                                                              data_ptr, data_sz, &param);
+    MPIDI_UCX_CHK_REQUEST(ucp_request);
+    /* if send is done, free all resources and complete the request */
+    if (ucp_request == NULL) {
+        MPL_free(send_buf);
+        MPIDIG_global.origin_cbs[handler_id] (sreq);
+        goto fn_exit;
+    }
+
+    MPIDI_UCX_AM_SEND_REQUEST(sreq, pack_buffer) = send_buf;
+    MPIDI_UCX_AM_SEND_REQUEST(sreq, handler_id) = handler_id;
+    ucp_request->req = sreq;
+    ucp_request_release(ucp_request);
+
+#else /* !HAVE_UCP_AM_NBX */
+
     MPL_pointer_attr_t attr;
     MPIR_GPU_query_pointer_attr(data, &attr);
     if (attr.type == MPL_GPU_POINTER_DEV) {
@@ -56,7 +109,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
         MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
         MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
 
-        ucp_dt_iov_t *iov = sreq->dev.ch4.am.netmod_am.ucx.iov;
+        ucp_dt_iov_t *iov = MPIDI_UCX_AM_SEND_REQUEST(sreq, iov);
         iov[0].buffer = send_buf;
         iov[0].length = sizeof(ucx_hdr) + am_hdr_sz;
         iov[1].buffer = MPIR_get_contig_ptr(data, dt_true_lb);
@@ -95,11 +148,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
     }
 
     /* set the ch4r request inside the UCP request */
-    sreq->dev.ch4.am.netmod_am.ucx.pack_buffer = send_buf;
-    sreq->dev.ch4.am.netmod_am.ucx.handler_id = handler_id;
+    MPIDI_UCX_AM_SEND_REQUEST(sreq, pack_buffer) = send_buf;
+    MPIDI_UCX_AM_SEND_REQUEST(sreq, handler_id) = handler_id;
     ucp_request->req = sreq;
     ucp_request_release(ucp_request);
 
+#endif /* HAVE_UCP_AM_NBX */
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -210,12 +264,23 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Ai
                                                       const void *data, MPI_Aint count,
                                                       MPI_Datatype datatype, MPIR_Request * sreq)
 {
+#ifdef HAVE_UCP_AM_NBX
+    /* ucx will handle rndv */
+    return true;
+#else
     return (am_hdr_sz + data_sz) <= (MPIDI_UCX_MAX_AM_EAGER_SZ - sizeof(MPIDI_UCX_am_header_t));
+#endif
 }
+
+int MPIDI_UCX_do_am_recv(MPIR_Request * rreq);
 
 MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_NM_am_get_data_copy_cb(uint32_t attr)
 {
+#ifdef HAVE_UCP_AM_NBX
+    return MPIDI_UCX_do_am_recv;
+#else
     return NULL;
+#endif
 }
 
 #endif /* UCX_AM_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -8,36 +8,6 @@
 
 #include "ucx_impl.h"
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_am_isend_callback(void *request, ucs_status_t status)
-{
-    MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
-    MPIR_Request *req = ucp_request->req;
-    int handler_id = req->dev.ch4.am.netmod_am.ucx.handler_id;
-
-    MPIR_FUNC_ENTER;
-
-    MPL_free(req->dev.ch4.am.netmod_am.ucx.pack_buffer);
-    req->dev.ch4.am.netmod_am.ucx.pack_buffer = NULL;
-    MPIDIG_global.origin_cbs[handler_id] (req);
-    ucp_request->req = NULL;
-
-    MPIR_FUNC_EXIT;
-}
-
-MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_am_send_callback(void *request, ucs_status_t status)
-{
-    MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
-
-    MPIR_FUNC_ENTER;
-
-    MPL_free(ucp_request->buf);
-    ucp_request->buf = NULL;
-    ucp_request_release(ucp_request);
-
-    MPIR_FUNC_EXIT;
-}
-
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                MPIR_Comm * comm,
                                                int handler_id,

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -127,6 +127,12 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_UCX_is_reachable_target(int rank, MPIR_Win *
 
 #define MPIDI_UCX_WIN_AV_TO_EP(av, vci, vci_target) MPIDI_UCX_AV((av)).dest[vci][vci_target]
 
+/* am handler for message sent by ucp_am_send_nb */
 ucs_status_t MPIDI_UCX_am_handler(void *arg, void *data, size_t length, ucp_ep_h reply_ep,
                                   unsigned flags);
+/* callback for ucp_am_send_nb, used in MPIDI_NM_am_isend */
+void MPIDI_UCX_am_isend_callback(void *request, ucs_status_t status);
+/* callback for ucp_am_send_nb, used in MPIDI_NM_am_send_hdr */
+void MPIDI_UCX_am_send_callback(void *request, ucs_status_t status);
+
 #endif /* UCX_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -6,6 +6,10 @@
 #ifndef UCX_IMPL_H_INCLUDED
 #define UCX_IMPL_H_INCLUDED
 
+#if UCP_VERSION(UCP_API_MAJOR, UCP_API_MINOR) >= UCP_VERSION(1, 10)
+#define HAVE_UCP_AM_NBX 1
+#endif
+
 #include <mpidimpl.h>
 #include "ucx_types.h"
 #include "mpidch4r.h"
@@ -134,5 +138,16 @@ ucs_status_t MPIDI_UCX_am_handler(void *arg, void *data, size_t length, ucp_ep_h
 void MPIDI_UCX_am_isend_callback(void *request, ucs_status_t status);
 /* callback for ucp_am_send_nb, used in MPIDI_NM_am_send_hdr */
 void MPIDI_UCX_am_send_callback(void *request, ucs_status_t status);
+
+#ifdef HAVE_UCP_AM_NBX
+/* am handler for message sent by ucp_am_send_nbx */
+ucs_status_t MPIDI_UCX_am_nbx_handler(void *arg, const void *header, size_t header_length,
+                                      void *data, size_t length, const ucp_am_recv_param_t * param);
+/* callback for ucp_am_send_nbx */
+void MPIDI_UCX_am_isend_callback_nbx(void *request, ucs_status_t status, void *user_data);
+/* callback for ucp_am_recv_data_nbx */
+void MPIDI_UCX_am_recv_callback_nbx(void *request, ucs_status_t status, size_t length,
+                                    void *user_data);
+#endif
 
 #endif /* UCX_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -46,6 +46,15 @@ static int init_worker(int vci)
                                            MPIDI_UCX_AM_HANDLER_ID,
                                            &MPIDI_UCX_am_handler, NULL, UCP_AM_FLAG_WHOLE_MSG);
     MPIDI_UCX_CHK_STATUS(ucx_status);
+#ifdef HAVE_UCP_AM_NBX
+    ucp_am_handler_param_t param = {
+        .field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID | UCP_AM_HANDLER_PARAM_FIELD_CB,
+        .id = MPIDI_UCX_AM_NBX_HANDLER_ID,
+        .cb = &MPIDI_UCX_am_nbx_handler,
+    };
+    ucx_status = ucp_worker_set_am_recv_handler(MPIDI_UCX_global.ctx[vci].worker, &param);
+    MPIDI_UCX_CHK_STATUS(ucx_status);
+#endif
 
   fn_exit:
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_pre.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_pre.h
@@ -30,10 +30,22 @@ typedef union {
 } MPIDI_UCX_request_t;
 
 typedef struct {
-    int handler_id;
-    char *pack_buffer;
-    ucp_dt_iov_t iov[2];
+    union {
+        struct {
+            int handler_id;
+            char *pack_buffer;
+            ucp_dt_iov_t iov[2];
+        } send;
+        struct {
+            MPI_Aint data_sz;
+            void *data_desc;
+            char *pack_buffer;
+        } recv;
+    } u;
 } MPIDI_UCX_am_request_t;
+
+#define MPIDI_UCX_AM_SEND_REQUEST(req,field) ((req)->dev.ch4.am.netmod_am.ucx.u.send.field)
+#define MPIDI_UCX_AM_RECV_REQUEST(req,field) ((req)->dev.ch4.am.netmod_am.ucx.u.recv.field)
 
 typedef struct MPIDI_UCX_am_header_t {
     uint16_t handler_id;

--- a/src/mpid/ch4/netmod/ucx/ucx_request.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_request.h
@@ -10,13 +10,10 @@
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req)
 {
-    req->dev.ch4.am.netmod_am.ucx.pack_buffer = NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
 {
-    MPL_free((req)->dev.ch4.am.netmod_am.ucx.pack_buffer);
-    /* MPIR_Request_free(req); */
 }
 
 #endif /* UCX_REQUEST_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ucx/ucx_types.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_types.h
@@ -18,8 +18,9 @@
 #define UCP_PEER_NAME_MAX         HOST_NAME_MAX
 
 /* Active Message Stuff */
-#define MPIDI_UCX_MAX_AM_EAGER_SZ      (16*1024)
+#define MPIDI_UCX_MAX_AM_EAGER_SZ      (8000)   /* internal max RTS 8256 */
 #define MPIDI_UCX_AM_HANDLER_ID        (0)
+#define MPIDI_UCX_AM_NBX_HANDLER_ID    (1)
 
 typedef struct {
     ucp_worker_h worker;


### PR DESCRIPTION
## Pull Request Description

The new ucx am interface allows internal rendezvous protocol, which allows the possibility to taking advantage of direct GPU IPC among other benefits. This PR implements ucx am mode using this new am interface.

Fixes #6636
## TODO
* [ ] update the version check to ensure the GPU is supported in the new ucp_am_send_nbx api

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
