### PR TITLE
romio gpfs: free of NULL/uninitialized address, found by hdf5

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
@@ -524,6 +524,8 @@ void ADIOI_GPFS_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset
                 ADIOI_Malloc(count_my_req_per_proc[i] * 2 * sizeof(ADIO_Offset));
             my_req[i].lens = my_req[i].offsets + count_my_req_per_proc[i];
             count_my_req_procs++;
+        } else {
+            my_req[i].offsets = NULL;
         }
         my_req[i].count = 0;    /* will be incremented where needed
                                  * later */

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -409,7 +409,9 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
      * let's free the memory
      */
     ADIOI_Free(count_my_req_per_proc);
-    ADIOI_Free(my_req[0].offsets);
+    if (my_req[0].offsets) {
+        ADIOI_Free(my_req[0].offsets);
+    }
     ADIOI_Free(my_req);
 
     /* read data in sizes of no more than ADIOI_Coll_bufsize,

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -433,7 +433,9 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     GPFSMPIO_T_CIO_SET_GET(w, 1, 1, GPFSMPIO_CIO_T_DEXCH, GPFSMPIO_CIO_T_OTHREQ);
 
     ADIOI_Free(count_my_req_per_proc);
-    ADIOI_Free(my_req[0].offsets);
+    if (my_req[0].offsets) {
+        ADIOI_Free(my_req[0].offsets);
+    }
     ADIOI_Free(my_req);
 
     /* exchange data and write in sizes of no more than coll_bufsize. */


### PR DESCRIPTION
This resembles a previous fix that I had only applied to the
others_req[] variable, but my_req[] is made similarly and also
needed the initialization of the .offsets field and a check for
non-NULL when freeing it.

I didn't whittle down the testcase to reproduce it, I just
observed the failure in a full hdf5 run.

Signed-off-by: Mark Allen <markalle@us.ibm.com>