### PR TITLE
ch4/part: Use cc_ptr in AM sub-requests

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_part.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part.h
@@ -26,7 +26,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_start(MPIR_Request * request)
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
 
     /* Indicate data transfer starts.
-     * Decrease when am request completes on sender (via completion_notification),
+     * Decrease when am request completes on sender (via cc_ptr),
      * or received data transfer AM on receiver. */
     MPIR_cc_set(request->cc_ptr, 1);
     if (request->kind == MPIR_REQUEST_KIND__PART_SEND) {

--- a/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
@@ -27,7 +27,7 @@ static int part_send_data_target_cmpl_cb(MPIR_Request * rreq)
 
     MPIDIG_recv_finish(rreq);
 
-    /* Internally set partitioned rreq complete via completion_notification. */
+    /* Completes both the internal request and user request via cc_ptr */
     MPID_Request_complete(rreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_PUT_DT_TARGET_CMPL_CB);
@@ -45,7 +45,7 @@ int MPIDIG_part_send_data_origin_cb(MPIR_Request * sreq)
     MPIR_Request *part_sreq = MPIDIG_REQUEST(sreq, req->part_am_req.part_req_ptr);
     MPIR_Assert(part_sreq);
 
-    /* Internally set partitioned sreq complete via completion_notification. */
+    /* Completes both the internal request and user request via cc_ptr */
     MPID_Request_complete(sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_PART_SEND_DATA_ORIGIN_CB);
@@ -152,7 +152,7 @@ int MPIDIG_part_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = part_send_data_target_cmpl_cb;
 
     /* Set part_rreq complete when am request completes but not decrease part_rreq refcnt */
-    rreq->completion_notification = &part_rreq->cc;
+    rreq->cc_ptr = &part_rreq->cc;
     /* Will update part_sreq status when the AM request completes.
      * TODO: can we get rid of the pointer? */
     MPIDIG_REQUEST(rreq, req->part_am_req.part_req_ptr) = part_rreq;

--- a/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
@@ -54,7 +54,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_issue_data(MPIR_Request * part_sreq)
     am_hdr.rreq_ptr = MPIDIG_PART_REQUEST(part_sreq, peer_req_ptr);
 
     /* Complete partitioned req at am request completes */
-    sreq->completion_notification = &part_sreq->cc;
+    sreq->cc_ptr = &part_sreq->cc;
     /* Will update part_sreq status when the AM request completes
      * TODO: can we get rid of the pointer? */
     MPIDIG_REQUEST(sreq, req->part_am_req.part_req_ptr) = part_sreq;


### PR DESCRIPTION
## Pull Request Description

In the default partitioned communication implementation, a sub-request is
created at the sender and receiver to track the data transfer. When this request
completes, so does the parent (user) request. Use cc_ptr instead of
completion_notification, which can save an atomic operation in the critical
path.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
