### PR TITLE
generic: Adding callback for async data copy

### DIFF
--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -46,6 +46,9 @@ Non Native API:
   am_isend_reply : int
       NM*: comm, src_rank, handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq
      SHM*: comm, src_rank, handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq
+  am_get_data_copy_cb : MPIDIG_recv_data_copy_cb
+      NM*: void
+     SHM*: void
   am_recv: int
       NM*: rreq
      SHM*: rreq

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -49,9 +49,6 @@ Non Native API:
   am_get_data_copy_cb : MPIDIG_recv_data_copy_cb
       NM*: void
      SHM*: void
-  am_recv: int
-      NM*: rreq
-     SHM*: rreq
   am_hdr_max_sz : MPI_Aint
       NM*: void
      SHM*: void

--- a/src/mpid/ch4/generic/am/mpidig_am.h
+++ b/src/mpid/ch4/generic/am/mpidig_am.h
@@ -7,7 +7,6 @@
 #define MPIDIG_AM_H_INCLUDED
 
 #define MPIDI_AM_HANDLERS_MAX (64)
-#define MPIDIG_IS_REQUEST_READY_FOR_RECV(_req) (MPIDIG_REQUEST((_req), recv_ready))
 
 enum {
     MPIDIG_SEND = 0,

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -123,19 +123,49 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexpected(void *buf, MPI_Aint count,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_HANDLE_UNEXPECTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_HANDLE_UNEXPECTED);
 
-    rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, rank);
-    rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, tag);
+    if (MPIDIG_recv_initialized(rreq)) {
+        /* if we have an unexp buffer, we just need to copy the data in it to the user buffer */
+        /* This is the fast path and we can avoid calling the target_cmpl_cb and complete the
+         * request here */
+        rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, rank);
+        rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, tag);
 
-    mpi_errno = MPIDIG_copy_from_unexp_req(rreq, buf, datatype, count);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    MPIDIG_REQUEST(rreq, req->status) &= ~MPIDIG_REQ_UNEXPECTED;
-
-    /* If this is a synchronous send, send back the reply indicating that the message has been
-     * matched. */
-    if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_PEER_SSEND) {
-        mpi_errno = MPIDIG_reply_ssend(rreq);
+        mpi_errno = MPIDIG_copy_from_unexp_req(rreq, buf, datatype, count);
         MPIR_ERR_CHECK(mpi_errno);
+        MPIDIG_REQUEST(rreq, req->status) &= ~MPIDIG_REQ_UNEXPECTED;
+
+        /* If this is a synchronous send, send back the reply indicating that the message has been
+         * matched. */
+        if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_PEER_SSEND) {
+            mpi_errno = MPIDIG_reply_ssend(rreq);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+
+        MPID_Request_complete(rreq);
+    } else {
+        /* This is the path for async data copy still need to happen. The request will be completed
+         * by the target_cmpl_cb */
+        MPI_Aint unexp_data_sz = 0;
+        /* count is the incoming unexp message size */
+        unexp_data_sz = MPIDIG_REQUEST(rreq, count);
+        if (unexp_data_sz) {
+            /* If there is no unexp buffer and there were data coming in, we just put user buffer in
+             * the request and init the receive. This would trigger the callback function to copy
+             * the data into the user buffer */
+            MPIR_Assert(MPIDIG_REQUEST(rreq, req->recv_async).data_copy_cb);
+            MPIDIG_REQUEST(rreq, req->status) &= ~MPIDIG_REQ_UNEXPECTED;
+            MPIR_Datatype_add_ref_if_not_builtin(datatype);
+            MPIDIG_REQUEST(rreq, datatype) = datatype;
+            MPIDIG_REQUEST(rreq, buffer) = (char *) buf;
+            MPIDIG_REQUEST(rreq, count) = count;
+            MPIDIG_REQUEST(rreq, req->seq_no) =
+                MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
+            MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                            (MPL_DBG_FDEST, "seq_no: me=%" PRIu64 " exp=%" PRIu64,
+                             MPIDIG_REQUEST(rreq, req->seq_no),
+                             MPL_atomic_load_uint64(&MPIDI_global.exp_seq_no)));
+            MPIDIG_recv_type_init(unexp_data_sz, rreq);
+        }
     }
 
   fn_exit:
@@ -148,6 +178,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexpected(void *buf, MPI_Aint count,
 MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexp_mrecv(MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPI_Datatype mrcv_dt = MPIDIG_REQUEST(rreq, req->rreq.mrcv_datatype);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_HANDLE_UNEXP_MRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_HANDLE_UNEXP_MRECV);
@@ -156,27 +187,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexp_mrecv(MPIR_Request * rreq)
                                          MPIDIG_REQUEST(rreq, req->rreq.mrcv_count),
                                          MPIDIG_REQUEST(rreq, req->rreq.mrcv_datatype), rreq);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->rreq.mrcv_datatype));
-    MPID_Request_complete(rreq);
+    MPIR_Datatype_release_if_not_builtin(mrcv_dt);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_HANDLE_UNEXP_MRECV);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDIG_do_am_recv(MPIR_Request * rreq)
-{
-#ifdef MPIDI_CH4_DIRECT_NETMOD
-    return MPIDI_NM_am_recv(rreq);
-#else
-    if (MPIDI_REQUEST(rreq, is_local)) {
-        return MPIDI_SHM_am_recv(rreq);
-    } else {
-        return MPIDI_NM_am_recv(rreq);
-    }
-#endif
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
@@ -206,7 +223,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
             MPIDIG_REQUEST(unexp_req, datatype) = datatype;
             MPIDIG_REQUEST(unexp_req, buffer) = (char *) buf;
             MPIDIG_REQUEST(unexp_req, count) = count;
-            MPIDIG_REQUEST(unexp_req, recv_ready) = true;
             if (*request == NULL) {
                 /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating
                  * a request. Here we simply return `unexp_req` */
@@ -227,61 +243,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
             MPIR_ERR_CHECK(mpi_errno);
             goto fn_exit;
         } else {
-            if (MPIDIG_REQUEST(unexp_req, recv_ready)) {
-                /* if the unexpected recv is ready, the data is in the unexpected buffer. Just
-                 * copy them to complete */
-                mpi_errno = MPIDIG_handle_unexpected(buf, count, datatype, unexp_req);
-                MPIR_ERR_CHECK(mpi_errno);
-                MPID_Request_complete(unexp_req);
-                if (*request == NULL) {
-                    /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating
-                     * a request. Here we simply return `unexp_req`, which is already completed. */
-                    *request = unexp_req;
-                } else {
-                    /* Enqueuing path: CH4 already allocated request as `*request`.
-                     * Since the real operations has completed in `unexp_req`, here we
-                     * simply copy the status to `*request` and complete it. */
-                    (*request)->status = unexp_req->status;
-                    MPIR_Request_add_ref(*request);
-                    MPID_Request_complete(*request);
-                    /* Need to free here because we don't return this to user */
-                    MPIDI_CH4_REQUEST_FREE(unexp_req);
-                }
+            mpi_errno = MPIDIG_handle_unexpected(buf, count, datatype, unexp_req);
+            MPIR_ERR_CHECK(mpi_errno);
+            if (*request == NULL) {
+                /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating
+                 * a request. Here we simply return `unexp_req`, which is already completed. */
+                *request = unexp_req;
             } else {
-                /* if the unexpected recv is not ready, we put user recv buffer info and let
-                 * transport layer to start the recv. */
-                /* the count for unexpected long message is the data size */
-                MPI_Aint data_sz = MPIDIG_REQUEST(unexp_req, count);
-                /* Matching receive is now posted, tell the netmod/shmmod */
-                MPIR_Datatype_add_ref_if_not_builtin(datatype);
-                MPIDIG_REQUEST(unexp_req, datatype) = datatype;
-                MPIDIG_REQUEST(unexp_req, buffer) = (char *) buf;
-                MPIDIG_REQUEST(unexp_req, count) = count;
-                MPIDIG_REQUEST(unexp_req, recv_ready) = true;
-                if (*request == NULL) {
-                    /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating
-                     * a request. Here we simply return `unexp_req` */
-                    *request = unexp_req;
-                    /* Mark `match_req` as NULL so that we know nothing else to complete when
-                     * `unexp_req` finally completes. (See below) */
-                    MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = NULL;
-                } else {
-                    /* Enqueuing path: CH4 already allocated a request.
-                     * Record the passed `*request` to `match_req` so that we can complete it
-                     * later when `unexp_req` completes.
-                     * See MPIDI_recv_target_cmpl_cb for actual completion handler. */
-                    MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = *request;
-                }
-                MPIDIG_REQUEST(unexp_req, req->status) &= ~MPIDIG_REQ_UNEXPECTED;
-                MPIDIG_REQUEST(unexp_req, req->seq_no) =
-                    MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
-                MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                                (MPL_DBG_FDEST, "seq_no: me=%" PRIu64 " exp=%" PRIu64,
-                                 MPIDIG_REQUEST(unexp_req, req->seq_no),
-                                 MPL_atomic_load_uint64(&MPIDI_global.exp_seq_no)));
-                MPIDIG_recv_type_init(data_sz, unexp_req);
-                MPIDIG_do_am_recv(unexp_req);
-                MPIR_ERR_CHECK(mpi_errno);
+                /* Enqueuing path: CH4 already allocated request as `*request`.
+                 * Since the real operations has completed in `unexp_req`, here we
+                 * simply copy the status to `*request` and complete it. */
+                (*request)->status = unexp_req->status;
+                MPIR_Request_add_ref(*request);
+                MPID_Request_complete(*request);
+                /* Need to free here because we don't return this to user */
+                MPIDI_CH4_REQUEST_FREE(unexp_req);
             }
             goto fn_exit;
         }
@@ -347,32 +323,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
         MPIDIG_REQUEST(message, datatype) = datatype;
         MPIDIG_REQUEST(message, buffer) = (char *) buf;
         MPIDIG_REQUEST(message, count) = count;
-        MPIDIG_REQUEST(message, recv_ready) = true;
         MPIDIG_REQUEST(message, req->status) &= ~MPIDIG_REQ_UNEXPECTED;
         MPIDIG_recv_type_init(data_sz, message);
         MPIDIG_do_cts(message);
     } else {
-        if (MPIDIG_REQUEST(message, recv_ready)) {
-            mpi_errno = MPIDIG_handle_unexp_mrecv(message);
-            MPIR_ERR_CHECK(mpi_errno);
-        } else {
-            /* the count for unexpected long message is the data size */
-            MPI_Aint data_sz = MPIDIG_REQUEST(message, count);
-            /* Matching receive is now posted, tell the netmod */
-            MPIDIG_REQUEST(message, datatype) = datatype;
-            MPIDIG_REQUEST(message, buffer) = (char *) buf;
-            MPIDIG_REQUEST(message, count) = count;
-            MPIDIG_REQUEST(message, recv_ready) = true;
-            MPIDIG_REQUEST(message, req->status) &= ~MPIDIG_REQ_UNEXPECTED;
-            MPIDIG_REQUEST(message, req->seq_no) =
-                MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
-            MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                            (MPL_DBG_FDEST, "seq_no: me=%" PRIu64 " exp=%" PRIu64,
-                             MPIDIG_REQUEST(message, req->seq_no),
-                             MPL_atomic_load_uint64(&MPIDI_global.exp_seq_no)));
-            MPIDIG_recv_type_init(data_sz, message);
-            MPIDIG_do_am_recv(message);
-        }
+        mpi_errno = MPIDIG_handle_unexp_mrecv(message);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     /* MPIDI_CS_EXIT(); */
 

--- a/src/mpid/ch4/generic/am/mpidig_am_recv_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv_utils.h
@@ -43,6 +43,10 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_type_init(MPI_Aint in_data_sz, MPIR_Re
     if (in_data_sz > max_data_size) {
         rreq->status.MPI_ERROR = MPIDIG_ERR_TRUNCATE(max_data_size, in_data_sz);
     }
+
+    if (MPIDIG_REQUEST(rreq, req->recv_async).data_copy_cb) {
+        MPIDIG_REQUEST(rreq, req->recv_async).data_copy_cb(rreq);
+    }
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_init(int is_contig, MPI_Aint in_data_sz,
@@ -61,6 +65,10 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_init(int is_contig, MPI_Aint in_data_s
     }
 
     MPIDIG_recv_set_buffer_attr(rreq);
+
+    if (MPIDIG_REQUEST(rreq, req->recv_async).data_copy_cb) {
+        MPIDIG_REQUEST(rreq, req->recv_async).data_copy_cb(rreq);
+    }
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_finish(MPIR_Request * rreq)
@@ -272,6 +280,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_recv_copy_seg(void *payload, MPI_Aint payloa
             return 0;
         }
     }
+}
+
+MPL_STATIC_INLINE_PREFIX bool MPIDIG_recv_initialized(MPIR_Request * rreq)
+{
+    return MPIDIG_REQUEST(rreq, req->recv_async).recv_type != MPIDIG_RECV_NONE;
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_set_data_copy_cb(MPIR_Request * rreq,
+                                                           MPIDIG_recv_data_copy_cb cb)
+{
+    MPIDIG_REQUEST(rreq, req->recv_async).data_copy_cb = cb;
 }
 
 /* internal routines */

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -150,10 +150,13 @@ typedef int (*MPIDIG_req_cmpl_cb) (MPIR_Request * req);
 
 /* structure used for supporting asynchronous payload transfer */
 typedef enum {
+    MPIDIG_RECV_NONE,
     MPIDIG_RECV_DATATYPE,       /* use the datatype info in MPIDIG_req_t */
     MPIDIG_RECV_CONTIG,         /* set and use the contig recv-buffer info */
     MPIDIG_RECV_IOV             /* set and use the iov recv-buffer info */
 } MPIDIG_recv_type;
+
+typedef int (*MPIDIG_recv_data_copy_cb) (MPIR_Request * req);
 
 typedef struct MPIDIG_req_async {
     MPIDIG_recv_type recv_type;
@@ -163,6 +166,8 @@ typedef struct MPIDIG_req_async {
     struct iovec *iov_ptr;      /* used with MPIDIG_RECV_IOV */
     int iov_num;                /* used with MPIDIG_RECV_IOV */
     struct iovec iov_one;       /* used with MPIDIG_RECV_CONTIG */
+    MPIDIG_recv_data_copy_cb data_copy_cb;      /* called in recv_init/recv_type_init for async
+                                                 * data copying */
 } MPIDIG_rreq_async_t;
 
 typedef struct MPIDIG_sreq_async {
@@ -209,7 +214,6 @@ typedef struct MPIDIG_req_t {
     int tag;
     MPIR_Context_id_t context_id;
     MPI_Datatype datatype;
-    bool recv_ready;            /* indicating if the request is ready for data */
 } MPIDIG_req_t;
 
 /* Structure to capture arguments for pt2pt persistent communications */

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -207,20 +207,6 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Ai
     }
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(MPIR_Request * rreq)
-{
-    int ret = MPI_SUCCESS;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_RECV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_RECV);
-
-    do_long_am_recv(MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).reg_sz, rreq,
-                    &MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info));
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_RECV);
-    return ret;
-}
-
 MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_NM_am_get_data_copy_cb(void)
 {
     return MPIDI_OFI_am_rdma_read_recv_cb;

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -221,4 +221,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(MPIR_Request * rreq)
     return ret;
 }
 
+MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_NM_am_get_data_copy_cb(void)
+{
+    return MPIDI_OFI_am_rdma_read_recv_cb;
+}
+
 #endif /* OFI_AM_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.c
@@ -43,3 +43,9 @@ int MPIDI_OFI_am_rdma_read_ack_handler(int handler_id, void *am_hdr, void *data,
   fn_fail:
     goto fn_exit;
 }
+
+int MPIDI_OFI_am_rdma_read_recv_cb(MPIR_Request * rreq)
+{
+    return do_long_am_recv(MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).reg_sz, rreq,
+                           &MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info));
+}

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -239,17 +239,6 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Ai
     return (am_hdr_sz + data_sz) <= (MPIDI_UCX_MAX_AM_EAGER_SZ - sizeof(MPIDI_UCX_am_header_t));
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(MPIR_Request * rreq)
-{
-    int ret = MPI_SUCCESS;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_RECV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_RECV);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_RECV);
-    return ret;
-}
-
 MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_NM_am_get_data_copy_cb(void)
 {
     return NULL;

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -250,4 +250,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(MPIR_Request * rreq)
     return ret;
 }
 
+MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_NM_am_get_data_copy_cb(void)
+{
+    return NULL;
+}
+
 #endif /* UCX_AM_H_INCLUDED */

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -134,4 +134,9 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_SHM_am_check_eager(MPI_Aint am_hdr_sz, MPI_A
     return (am_hdr_sz + data_sz) <= MPIDI_POSIX_am_eager_limit();
 }
 
+MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_SHM_am_get_data_copy_cb(void)
+{
+    return NULL;
+}
+
 #endif /* SHM_AM_H_INCLUDED */

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -77,19 +77,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Comm * comm,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_recv(MPIR_Request * rreq)
-{
-    int ret = MPI_SUCCESS;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_RECV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_RECV);
-
-    /* TODO: handle IPC receive here */
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_RECV);
-    return ret;
-}
-
 MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_SHM_am_hdr_max_sz(void)
 {
     return MPIDI_POSIX_am_hdr_max_sz();

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -31,9 +31,8 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_request_create(MPIR_Request_kind_t
                                        (void **) &MPIDIG_REQUEST(req, req));
     MPIR_Assert(MPIDIG_REQUEST(req, req));
     MPIDIG_REQUEST(req, req->status) = 0;
-    /* init the request as ready for data as this is the common case, CH4 will should set them to
-     * false when needed */
-    MPIDIG_REQUEST(req, recv_ready) = true;
+    MPIDIG_REQUEST(req, req->recv_async).data_copy_cb = NULL;
+    MPIDIG_REQUEST(req, req->recv_async).recv_type = MPIDIG_RECV_NONE;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_REQUEST_CREATE);
@@ -62,9 +61,8 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_request_init(MPIR_Request * req,
                                        (void **) &MPIDIG_REQUEST(req, req));
     MPIR_Assert(MPIDIG_REQUEST(req, req));
     MPIDIG_REQUEST(req, req->status) = 0;
-    /* init the request as ready for data as this is the common case, CH4 will should set them to
-     * false when needed */
-    MPIDIG_REQUEST(req, recv_ready) = true;
+    MPIDIG_REQUEST(req, req->recv_async).data_copy_cb = NULL;
+    MPIDIG_REQUEST(req, req->recv_async).recv_type = MPIDIG_RECV_NONE;
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_REQUEST_INIT);
     return req;


### PR DESCRIPTION
## Pull Request Description

This is an implementation of data copy callback for the cases where recv buffer is not available when a message arrives.

1. The transport layer follows the existing route of calling target CBs to get a request.
2. The transport layer may the request is not initialized for receiving data yet (through the new `MPIDIG_recv_initialized()` function). In this case, the transport layer can register a CB for data copying in the request.
3. The generic layer will try to trigger the CB at `recv_init` or `recv_type_init` time.

The generic layer no longer need that explicit `am_recv` call to figure out the case where additional transport layer work need to be performed. 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
