### PR TITLE
mpir: add CVAR to set async thread affinity

### DIFF
--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -85,5 +85,6 @@ int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
                             const int maxprocs[], struct MPIR_Info *info_ptrs[],
                             int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
                             int *pmi_errcodes);
+int MPIR_pmi_has_local_cliques(void);
 
 #endif /* MPIR_PMI_H_INCLUDED */

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -938,6 +938,13 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **mpl_gavl_create: mpl_gavl_create failed
 **mpl_gavl_delete_range: mpl_gavl_delete_range failed
 **mpl_gavl_delete_start_addr: mpl_gavl_delete_start_addr failed
+
+## Async thread affinity related error messages
+**parse_thread_affinity:Failed to parse async thread affinity string
+**parse_thread_affinity %s:Failed to parse async thread affinity string [%s]
+**set_thread_affinity:Failed to set the async thread affinity
+**set_thread_affinity %d:Failed to set the async thread affinity to the logical processor [%d]
+
 # -----------------------------------------------------------------------------
 # The following names are defined but not used (see the -careful option 
 # for extracterrmsgs) (still to do: move the undefined names here)

--- a/src/mpi/init/init_async.c
+++ b/src/mpi/init/init_async.c
@@ -31,6 +31,23 @@ cvars:
         highly system dependent but may be substantial in some cases,
         hence this recommendation.
 
+    - name        : MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY
+      category    : CH4
+      type        : string
+      default     : ""
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        Specifies affinity for all progress threads of local processes.
+        Format - comma-separated list of logical processors. In case of
+        N progress threads per process, the first N logical processors
+        from list will be assigned to threads of first local process.
+        The next N logical processors from list - to second local process
+        and so on. For example, thread affinity is "0,1,2,3", 2 progress
+        threads per process and 2 processes per node. Progress threads
+        of first local process will be pinned on logical processors "0,1",
+        progress threads of second local process - on "2,3".
 
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
@@ -59,22 +76,123 @@ static void progress_fn(void *data)
     return;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_parse_progress_thread_affinity(int *thread_affinity,
+                                                                  int async_threads_per_node)
+{
+    int th_idx, read_count = 0, mpi_errno = MPI_SUCCESS;
+    char *affinity_copy = NULL;
+    const char *affinity_to_parse = MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY;
+    char *proc_id_str, *tmp;
+    size_t proc_count;
+
+    if (!affinity_to_parse || strlen(affinity_to_parse) == 0) {
+        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**parse_thread_affinity",
+                             "**parse_thread_affinity %s", affinity_to_parse);
+    }
+
+    /* create copy of original buffer because it will be modified in strsep */
+    affinity_copy = MPL_strdup(affinity_to_parse);
+    MPIR_Assert(affinity_copy);
+    tmp = affinity_copy;
+
+    for (th_idx = 0; th_idx < async_threads_per_node; th_idx++) {
+        proc_id_str = MPL_strsep(&tmp, ",");
+        if (proc_id_str != NULL) {
+            if (strlen(proc_id_str) == 0 || (strlen(proc_id_str) > 0 && !isdigit(proc_id_str[0])) ||
+                atoi(proc_id_str) < 0) {
+                MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**parse_thread_affinity",
+                                     "**parse_thread_affinity %s", affinity_to_parse);
+            }
+            thread_affinity[th_idx] = atoi(proc_id_str);
+            read_count++;
+        } else {
+            MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**parse_thread_affinity",
+                                 "**parse_thread_affinity %s", affinity_to_parse);
+        }
+    }
+    if (read_count < async_threads_per_node) {
+        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**parse_thread_affinity",
+                             "**parse_thread_affinity %s", affinity_to_parse);
+    }
+
+  fn_exit:
+    MPL_free(affinity_copy);
+    return mpi_errno;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int get_thread_affinity(bool * apply_affinity, int **p_thread_affinity, int *affinity_idx)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int global_rank, local_rank, local_size, async_threads_per_node;
+    int *thread_affinity = NULL;
+    *apply_affinity = MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY &&
+        strlen(MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY) > 0;
+
+    if (*apply_affinity) {
+        global_rank = MPIR_Process.rank;
+        local_rank =
+            (MPIR_Process.comm_world->node_comm) ? MPIR_Process.comm_world->node_comm->rank : 0;
+        local_size =
+            (MPIR_Process.comm_world->node_comm) ? MPIR_Process.comm_world->
+            node_comm->local_size : 1;
+        async_threads_per_node = local_size;
+        thread_affinity = (int *) MPL_malloc(async_threads_per_node * sizeof(int), MPL_MEM_OTHER);
+
+        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                        (MPL_DBG_FDEST,
+                         " global_rank %d, local_rank %d, local_size %d, async_threads_per_node %d",
+                         global_rank, local_rank, local_size, async_threads_per_node));
+
+        mpi_errno = MPIDI_parse_progress_thread_affinity(thread_affinity, async_threads_per_node);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        if (MPIR_Process.rank == 0) {
+            int th_idx;
+            for (th_idx = 0; th_idx < async_threads_per_node; th_idx++) {
+                MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                                (MPL_DBG_FDEST, "affinity: thread %d, processor %d",
+                                 th_idx, thread_affinity[th_idx]));
+            }
+        }
+        *p_thread_affinity = thread_affinity;
+        *affinty_idx = local_rank;
+    }
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 /* called inside MPID_Init_async_thread to provide device override */
 int MPIR_Init_async_thread(void)
 {
-    int mpi_errno = MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS, thr_err;
+    int *thread_affinity = NULL, affinity_idx;
+    bool apply_affinity;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_INIT_ASYNC_THREAD);
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_INIT_ASYNC_THREAD);
 
+    mpi_errno = get_thread_affinity(&apply_affinity, &thread_affinity, &affinity_idx);
+    MPIR_ERR_CHECK(mpi_errno);
+
     int err = 0;
     MPID_Thread_create((MPID_Thread_func_t) progress_fn, NULL, &progress_thread_id, &err);
-    MPIR_ERR_CHKANDJUMP1(err, mpi_errno, MPI_ERR_OTHER, "**mutex_create", "**mutex_create %s",
-                         strerror(err));
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (apply_affinity) {
+        MPL_thread_set_affinity(progress_thread_id, &(thread_affinity[affinity_idx]), 1, &thr_err);
+        MPIR_ERR_CHKANDJUMP1(thr_err, mpi_errno, MPI_ERR_OTHER, "**set_thread_affinity",
+                             "**set_thread_affinity %d", thread_affinity[affinity_idx]);
+    }
 
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_INIT_ASYNC_THREAD);
 
   fn_exit:
+    MPL_free(thread_affinity);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpl/Makefile.am
+++ b/src/mpl/Makefile.am
@@ -34,7 +34,8 @@ mpl_headers =               \
     include/mpl_sockaddr.h  \
     include/mpl_iov.h       \
     include/mpl_bt.h        \
-    include/mpl_shm.h
+    include/mpl_shm.h       \
+    include/mpl_misc.h
 
 if MPL_EMBEDDED_MODE
 noinst_HEADERS += $(mpl_headers)

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -660,6 +660,24 @@ AS_CASE([$enable_yield],
 
 
 #######################################################################
+## START OF MISC CODE
+#######################################################################
+
+AC_CHECK_HEADERS(sys/sysinfo.h unistd.h)
+
+AC_CHECK_FUNCS(get_nprocs)
+AC_CHECK_DECLS([_SC_NPROCESSORS_ONLN],[],[],[[#include <unistd.h>]])
+
+if test "$ac_cv_func_get_nprocs" = "yes" -a "$ac_cv_have_decl__SC_NPROCESSORS_ONLN" = "yes"; then
+    AC_DEFINE(HAVE_MISC_GETNPROCS,1, [Define if get_nprocs or _SC_NPROCESSORS_ONLN is Vilable.])
+fi
+
+#######################################################################
+## END OF MISC CODE
+#######################################################################
+
+
+#######################################################################
 ## START OF THREADS CODE
 #######################################################################
 

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -784,6 +784,45 @@ case $with_proc_mutex_package in
     # pthread_mutexattr_setpshared is first released in Issue 5
     AC_CHECK_FUNCS(pthread_mutexattr_setpshared)
 
+    AC_CHECK_FUNCS(pthread_setaffinity_np)
+
+    #
+    # Check for the Linux functions for controlling processor affinity.
+    #
+    # LINUX: sched_setaffinity
+    # AIX:   bindprocessor
+    # OSX (Leopard): thread_policy_set
+    AC_CHECK_FUNCS([sched_setaffinity sched_getaffinity bindprocessor thread_policy_set])
+    if test "$ac_cv_func_sched_setaffinity" = "yes" ; then
+        # Test for the cpu process set type
+        AC_CACHE_CHECK([whether cpu_set_t available],pac_cv_have_cpu_set_t,[
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sched.h>]],[[cpu_set_t t;]])],
+                pac_cv_have_cpu_set_t=yes,pac_cv_have_cpu_set_t=no)
+        ])
+        if test "$pac_cv_have_cpu_set_t" = yes ; then
+            AC_DEFINE(HAVE_CPU_SET_T,1,[Define if cpu_set_t is defined in sched.h])
+
+        AC_CACHE_CHECK([whether the CPU_SET and CPU_ZERO macros are defined], pac_cv_cpu_set_defined,[
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                    #include <sched.h>
+                    ]],[[
+                    cpu_set_t t;
+                    CPU_ZERO(&t);
+                    CPU_SET(1,&t);
+                    ]])], pac_cv_cpu_set_defined=yes,pac_cv_cpu_set_defined=no)
+            ])
+	    if test "$pac_cv_cpu_set_defined" = "yes" ; then
+	        AC_DEFINE(HAVE_CPU_SET_MACROS,1,[Define if CPU_SET and CPU_ZERO defined])
+            fi
+        # FIXME: Some versions of sched_setaffinity return ENOSYS (!),
+	    # so we should test for the unfriendly and useless behavior
+        fi
+    fi
+
+    if test "$ac_cv_func_pthread_setaffinity_np" = "yes" ; then
+      AC_DEFINE(HAVE_PTHREAD_SETAFFINITY_NP,1, [Define if pthread_setaffinity_np is available.])
+    fi
+
     AC_MSG_NOTICE([POSIX will be used for interprocess mutex package.])
     PROC_MUTEX_PACKAGE_NAME=MPL_PROC_MUTEX_PACKAGE_POSIX
   ;;

--- a/src/mpl/include/mpl.h
+++ b/src/mpl/include/mpl.h
@@ -31,5 +31,6 @@
 #include "mpl_gpu.h"
 #include "mpl_gavl.h"
 #include "mpl_initlock.h"
+#include "mpl_misc.h"
 
 #endif /* MPL_H_INCLUDED */

--- a/src/mpl/include/mpl_misc.h
+++ b/src/mpl/include/mpl_misc.h
@@ -1,0 +1,16 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/* vim: set ft=c.mpich : */
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPL_MISC_H_INCLUDED
+#define MPL_MISC_H_INCLUDED
+
+#include "mplconfig.h"
+
+/* Returns the number of processors currently available in the system */
+int MPL_get_nprocs(void);
+
+#endif /* MPL_MISC_H_INCLUDED */

--- a/src/mpl/include/mpl_thread_argobots.h
+++ b/src/mpl/include/mpl_thread_argobots.h
@@ -90,6 +90,14 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
         *(same_) = (*(idp1_) == *(idp2_)) ? TRUE : FALSE;                     \
     } while (0)
 
+/* See mpl_thread_posix.h for interface description. */
+void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size, int *err)
+{
+    /* stub implementation */
+    if (err)
+        *err = MPL_THREAD_ERROR;
+}
+
 /* ======================================================================
  *    Scheduling
  * ======================================================================*/

--- a/src/mpl/include/mpl_thread_posix.h
+++ b/src/mpl/include/mpl_thread_posix.h
@@ -61,6 +61,20 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
 
 #define MPL_thread_yield MPL_sched_yield
 
+/*+C
+    MPL_thread_set_affinity - Set thread affinity
+
+    Input Parameters:
+    .   thread        - handle of thread which should be pinned
+    .   affinity_arr  - array containing logical processors for pinning
+    .   affinity_size - number of elements in affinity_arr
+
+    Output Parameters:
+    .   err - error code (MPL_SUCCESS on successful pinning, MPL_ERR_THREAD otherwise)
+ +*/
+void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size,
+                             int *err);
+
 /*
  * Thread Local Storage
  */

--- a/src/mpl/include/mpl_thread_solaris.h
+++ b/src/mpl/include/mpl_thread_solaris.h
@@ -53,6 +53,13 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
 
 #define MPL_thread_yield thr_yield
 
+/* See mpl_thread_posix.h for interface description. */
+void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size, int *err)
+{
+    /* stub implementation */
+    if (err)
+        *err = MPL_THREAD_ERROR;
+}
 
 /*
  *    Mutexes

--- a/src/mpl/include/mpl_thread_win.h
+++ b/src/mpl/include/mpl_thread_win.h
@@ -43,6 +43,14 @@ void MPL_thread_join(MPL_thread_id_t * id);
 void MPL_thread_same(MPL_thread_id_t * id1, MPL_thread_id_t * id2, int *same);
 void MPL_thread_yield();
 
+/* See mpl_thread_posix.h for interface description. */
+void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size, int *err)
+{
+    /* stub implementation */
+    if (err)
+        *err = MPL_THREAD_ERROR;
+}
+
 void MPL_thread_mutex_create(MPL_thread_mutex_t * mutex, int *err);
 void MPL_thread_mutex_destroy(MPL_thread_mutex_t * mutex, int *err);
 void MPL_thread_mutex_lock(MPL_thread_mutex_t * mutex, int *err, int prio);

--- a/src/mpl/src/Makefile.mk
+++ b/src/mpl/src/Makefile.mk
@@ -11,6 +11,7 @@ include src/mem/Makefile.mk
 include src/msg/Makefile.mk
 include src/sock/Makefile.mk
 include src/str/Makefile.mk
+include src/misc/Makefile.mk
 include src/thread/Makefile.mk
 include src/timer/Makefile.mk
 include src/shm/Makefile.mk

--- a/src/mpl/src/misc/Makefile.mk
+++ b/src/mpl/src/misc/Makefile.mk
@@ -1,0 +1,7 @@
+# -*- Mode: Makefile; -*-
+#
+# (C) 2018 by Argonne National Laboratory.
+#     See COPYRIGHT in top-level directory.
+#
+
+lib@MPLLIBNAME@_la_SOURCES += src/misc/mpl_misc.c

--- a/src/mpl/src/misc/mpl_misc.c
+++ b/src/mpl/src/misc/mpl_misc.c
@@ -1,0 +1,30 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/* vim: set ft=c.mpich : */
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include "mpl.h"
+
+#if defined (MPL_HAVE_SYS_SYSINFO_H)
+#include <sys/sysinfo.h>
+#endif
+
+#if defined (MPL_HAVE_UNISTD_H)
+#include <unistd.h>
+#endif
+
+int MPL_get_nprocs(void)
+{
+#if defined (MPL_HAVE_GET_NPROCS)
+    return get_nprocs();
+#elif defined (MPL_HAVE_DECL__SC_NPROCESSORS_ONLN)
+    int count = sysconf(_SC_NPROCESSORS_ONLN);
+    return (count > 0) ? count : 0;
+#else
+    /* Neither MPL_HAVE_GET_NPROCS nor MPL_HAVE_DECL__SC_NPROCESSORS_ONLN are defined.
+     * Should not reach here. */
+    MPIR_Assert(0);
+#endif
+}

--- a/src/mpl/src/thread/mpl_thread_posix.c
+++ b/src/mpl/src/thread/mpl_thread_posix.c
@@ -4,6 +4,7 @@
  */
 
 #include "mpl.h"
+#include <sched.h>
 
 MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 
@@ -80,6 +81,47 @@ void *MPLI_thread_start(void *arg)
     func(data);
 
     return NULL;
+}
+
+void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size,
+                             int *errp)
+{
+#if defined(MPL_HAVE_PTHREAD_SETAFFINITY_NP) && defined(MPL_HAVE_CPU_SET_MACROS)
+    int err = MPL_SUCCESS, pthread_err;
+    int proc_idx, set_size = 0;
+    cpu_set_t cpuset;
+    __CPU_ZERO_S(sizeof(cpu_set_t), &cpuset);
+
+    for (proc_idx = 0; proc_idx < affinity_size; proc_idx++)
+        __CPU_SET_S(affinity_arr[proc_idx], sizeof(cpu_set_t), &cpuset);
+
+    if ((pthread_err = pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpuset)) != 0) {
+        err = MPL_ERR_THREAD;
+        goto fn_exit;
+    }
+
+    if ((pthread_err = pthread_getaffinity_np(thread, sizeof(cpu_set_t), &cpuset)) != 0) {
+        err = MPL_ERR_THREAD;
+        goto fn_exit;
+    }
+
+    for (proc_idx = 0; proc_idx < affinity_size; proc_idx++) {
+        if (__CPU_ISSET_S(affinity_arr[proc_idx], sizeof(cpu_set_t), &cpuset))
+            set_size++;
+    }
+    if (set_size != affinity_size) {
+        err = MPL_ERR_THREAD;
+        goto fn_exit;
+    }
+
+  fn_exit:
+    if (errp != NULL)
+        *errp = err;
+#else
+    /* stub implementation */
+    if (errp)
+        *errp = MPL_ERR_THREAD;
+#endif
 }
 
 #endif

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -984,6 +984,11 @@ static int get_option_num_cliques(void)
     }
 }
 
+int MPIR_pmi_has_local_cliques(void)
+{
+    return (get_option_num_cliques() > 1);
+}
+
 /* one process per node */
 int build_nodemap_nolocal(int *nodemap, int sz, int *p_max_node_id)
 {

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -1,6 +1,7 @@
 sendself 1 test/mpi/pt2pt/sendself arg=-type=MPI_C_DOUBLE_COMPLEX arg=-sendcnt=8192 arg=-recvcnt=8192 arg=-seed=47 arg=-testsize=100
 sendself 2 test/mpi/pt2pt/sendself arg=-type=MPI_C_DOUBLE_COMPLEX arg=-sendcnt=8192 arg=-recvcnt=8192 arg=-seed=47 arg=-testsize=100
 sendrecv2 2
+sendrecv2 2 env=MPIR_CVAR_ASYNC_PROGRESS=1 env=MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY=1,2
 sendrecv3 2
 sendrecv3 2 arg=-isendrecv
 sendflood 8

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -2,6 +2,7 @@ sendself 1 test/mpi/pt2pt/sendself arg=-type=MPI_C_DOUBLE_COMPLEX arg=-sendcnt=8
 sendself 2 test/mpi/pt2pt/sendself arg=-type=MPI_C_DOUBLE_COMPLEX arg=-sendcnt=8192 arg=-recvcnt=8192 arg=-seed=47 arg=-testsize=100
 sendrecv2 2
 sendrecv2 2 env=MPIR_CVAR_ASYNC_PROGRESS=1 env=MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY=1,2
+sendrecv2 2 env=MPIR_CVAR_ASYNC_PROGRESS=1 env=MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY=auto
 sendrecv3 2
 sendrecv3 2 arg=-isendrecv
 sendflood 8

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -1,8 +1,8 @@
 sendself 1 test/mpi/pt2pt/sendself arg=-type=MPI_C_DOUBLE_COMPLEX arg=-sendcnt=8192 arg=-recvcnt=8192 arg=-seed=47 arg=-testsize=100
 sendself 2 test/mpi/pt2pt/sendself arg=-type=MPI_C_DOUBLE_COMPLEX arg=-sendcnt=8192 arg=-recvcnt=8192 arg=-seed=47 arg=-testsize=100
 sendrecv2 2
-sendrecv2 2 env=MPIR_CVAR_ASYNC_PROGRESS=1 env=MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY=1,2
-sendrecv2 2 env=MPIR_CVAR_ASYNC_PROGRESS=1 env=MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY=auto
+sendrecv2 2 env=MPIR_CVAR_ASYNC_PROGRESS=1 env=MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY=1,2 env=MPIR_CVAR_ODD_EVEN_CLIQUES=0 env=MPIR_CVAR_NUM_CLIQUES=1
+sendrecv2 2 env=MPIR_CVAR_ASYNC_PROGRESS=1 env=MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY=auto env=MPIR_CVAR_ODD_EVEN_CLIQUES=0 env=MPIR_CVAR_NUM_CLIQUES=1
 sendrecv3 2
 sendrecv3 2 arg=-isendrecv
 sendflood 8


### PR DESCRIPTION
## Pull Request Description
This PR adds support for affinity of the asynchronous progress threads to CPU cores. Such affinity can help improve performance of the async threads. Affinity can be expressed by using one of the two new CVARs introduced in this PR:
* `MPIR_CVAR_CH4_PROGRESS_THREAD_AUTO_AFFINITY`: 
  * This provides a high level way to the user to set the affinity.
  * If set to true, MPICH automatically selects the CPU cores. Currently, the cores with the highest core ids are selected. 
* `MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY`: 
  * This CVAR provides a flexibility that can be helpful in different scenarios, e.g., allows user to decide the cores for the pinning based on the knowledge of the roles or the layout of the CPU cores on a given machine.
  * When the target core ids are provided as comma separated values, async threads are pinned to those logical cores. E.g., thread affinity is "0,1", with 1 progress threads per process and 2 processes per node, async thread on the first process will be pinned on logical process 0 and that of second process gets pinned on logical process 1. In case of N progress threads per process the first N logical processors from list will be assigned to threads of first local process, the next N logical processors from list - to second local process and so on. For example, thread affinity is "0,1,2,3", 2 progress threads per process and 2 processes per node. Progress threads of first local process will be pinned on logical processors "0,1", progress threads of second local process - on "2,3". 
 
Additional patches are provided for the following:
* Corresponding test cases to exercise these new CVARs.
* Handle the case when MPIR_CVAR_NUM_CLIQUES or MPIR_CVAR_ODD_EVEN_CLIQUES is used. 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
