### PR TITLE
mpi4: misc omissions

### DIFF
--- a/doc/mansrc/mpiconsts.txt
+++ b/doc/mansrc/mpiconsts.txt
@@ -428,8 +428,10 @@ Special value for error codes array:
 . MPI_Copy_function - Function to copy attributes (see 'MPI_Keyval_create')
 . MPI_Delete_function - Function to delete attributes (see 'MPI_Keyval_create')
 . MPI_ERRORS_ARE_FATAL - Error handler that forces exit on error
-- MPI_ERRORS_RETURN - Error handler that returns error codes (as value of
+. MPI_ERRORS_RETURN - Error handler that returns error codes (as value of
  MPI routine in C and through last argument in Fortran)
+- MPI_ERRORS_ABORT - Error handler that forces exit on error (only aborts local
+ process if the error handler is invoked on a session)
 
  MPI Attribute Default Functions:
 +I MPI_COMM_NULL_COPY_FN - Predefined attribute copy function for communicators

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -460,9 +460,9 @@ typedef int MPIX_Grequest_class;
 typedef int (MPI_Copy_function) ( MPI_Comm, int, void *, void *, void *, int * );
 typedef int (MPI_Delete_function) ( MPI_Comm, int, void *, void * );
 
-#define MPI_VERSION    3
-#define MPI_SUBVERSION 1
-#define MPICH_NAME     3
+#define MPI_VERSION    4
+#define MPI_SUBVERSION 0
+#define MPICH_NAME     4
 #define MPICH         1
 #define MPICH_HAS_C2F  1
 

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -356,6 +356,8 @@ static const MPI_Datatype mpich_mpi_datatype_null MPICH_ATTR_TYPE_TAG_MUST_BE_NU
 #define MPI_MAX_ERROR_STRING   @MPI_MAX_ERROR_STRING@
 #define MPI_MAX_PORT_NAME      256
 #define MPI_MAX_OBJECT_NAME    128
+#define MPI_MAX_STRINGTAG_LEN  256
+#define MPI_MAX_PSET_NAME_LEN  256
 
 /* Pre-defined constants */
 #define MPI_UNDEFINED      (-32766)

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -732,6 +732,8 @@ typedef void (MPI_T_event_dropped_cb_function)(MPI_Count count, MPI_T_event_regi
 #define MPI_Win_f2c(win)   (MPI_Win)(win)
 #define MPI_Message_c2f(msg) ((MPI_Fint)(msg))
 #define MPI_Message_f2c(msg) ((MPI_Message)(msg))
+#define MPI_Session_c2f(session) (MPI_Fint)(session)
+#define MPI_Session_f2c(session) (MPI_Session)(session)
 
 /* PMPI versions of the handle transfer functions.  See section 4.17 */
 #define PMPI_Comm_c2f(comm) (MPI_Fint)(comm)
@@ -752,6 +754,8 @@ typedef void (MPI_T_event_dropped_cb_function)(MPI_Count count, MPI_T_event_regi
 #define PMPI_Win_f2c(win)   (MPI_Win)(win)
 #define PMPI_Message_c2f(msg) ((MPI_Fint)(msg))
 #define PMPI_Message_f2c(msg) ((MPI_Message)(msg))
+#define PMPI_Session_c2f(session) (MPI_Fint)(session)
+#define PMPI_Session_f2c(session) (MPI_Session)(session)
 
 #define MPI_STATUS_IGNORE (MPI_Status *)1
 #define MPI_STATUSES_IGNORE (MPI_Status *)1

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -913,12 +913,13 @@ typedef int (MPIX_Grequest_wait_function)(int, void **, double, MPI_Status *);
 
 #define MPI_ERR_SESSION            75  /* Invalid session handle */
 #define MPI_ERR_PROC_ABORTED       76  /* Trying to communicate with aborted processes */
+#define MPI_ERR_VALUE_TOO_LARGE    77  /* Value is too large to store */
 
-#define MPI_T_ERR_NOT_SUPPORTED    77  /* Requested functionality not supported */
+#define MPI_T_ERR_NOT_SUPPORTED    78  /* Requested functionality not supported */
 
 #define MPI_ERR_LASTCODE    0x3fffffff  /* Last valid error code for a 
 					   predefined error class */
-#define MPICH_ERR_LAST_CLASS 77     /* It is also helpful to know the
+#define MPICH_ERR_LAST_CLASS 78     /* It is also helpful to know the
 				       last valid class */
 
 #define MPICH_ERR_FIRST_MPIX 100 /* Define a gap here because sock is

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -421,6 +421,7 @@ typedef MPI_Session_errhandler_function MPI_Session_errhandler_fn;
    in 22-25), index in the low bits */
 #define MPI_ERRORS_ARE_FATAL ((MPI_Errhandler)0x54000000)
 #define MPI_ERRORS_RETURN    ((MPI_Errhandler)0x54000001)
+#define MPI_ERRORS_ABORT     ((MPI_Errhandler)0x54000003)
 /* MPIR_ERRORS_THROW_EXCEPTIONS is not part of the MPI standard, it is here to
    facilitate the c++ binding which has MPI::ERRORS_THROW_EXCEPTIONS. 
    Using the MPIR prefix preserved the MPI_ names for objects defined by

--- a/src/mpi/errhan/errhan_impl.c
+++ b/src/mpi/errhan/errhan_impl.c
@@ -259,7 +259,8 @@ static int call_errhandler(MPIR_Errhandler * errhandler, int errorcode, int hand
     int cxx_kind = 0;
 
     /* Check for predefined error handlers */
-    if (!errhandler || errhandler->handle == MPI_ERRORS_ARE_FATAL) {
+    if (!errhandler || errhandler->handle == MPI_ERRORS_ARE_FATAL ||
+        errhandler->handle == MPI_ERRORS_ABORT) {
         const char *fcname = NULL;
         if (kind == MPIR_COMM) {
             fcname = "MPI_Comm_call_errhandler";
@@ -392,7 +393,7 @@ int MPIR_File_call_errhandler_impl(MPI_File fh, int errorcode)
         goto fn_exit;
     }
 
-    if (e->handle == MPI_ERRORS_ARE_FATAL) {
+    if (e->handle == MPI_ERRORS_ARE_FATAL || e->handle == MPI_ERRORS_ABORT) {
         MPIR_Handle_fatal_error(NULL, "MPI_File_call_errhandler", errorcode);
     }
 
@@ -459,7 +460,7 @@ void MPIR_Get_file_error_routine(MPI_Errhandler e, void (**c) (MPI_File *, int *
         if (e_ptr->handle == MPI_ERRORS_RETURN) {
             *c = 0;
             *kind = 1;
-        } else if (e_ptr->handle == MPI_ERRORS_ARE_FATAL) {
+        } else if (e_ptr->handle == MPI_ERRORS_ARE_FATAL || e_ptr->handle == MPI_ERRORS_ABORT) {
             *c = 0;
             *kind = 0;
         } else {

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -279,7 +279,8 @@ int MPIR_Err_return_comm(MPIR_Comm * comm_ptr, const char fcname[], int errcode)
     errhandler = comm_ptr->errhandler;
 
     /* --BEGIN ERROR HANDLING-- */
-    if (errhandler == NULL || errhandler->handle == MPI_ERRORS_ARE_FATAL) {
+    if (errhandler == NULL || errhandler->handle == MPI_ERRORS_ARE_FATAL ||
+        errhandler->handle == MPI_ERRORS_ABORT) {
         MPID_THREAD_CS_EXIT(POBJ, comm_ptr->mutex);
         MPID_THREAD_CS_EXIT(VCI, comm_ptr->mutex);
         /* Calls MPID_Abort */
@@ -355,7 +356,8 @@ int MPIR_Err_return_win(MPIR_Win * win_ptr, const char fcname[], int errcode)
     /* --BEGIN ERROR HANDLING-- */
     if (MPIR_Err_is_fatal(errcode) ||
         win_ptr == NULL || win_ptr->errhandler == NULL ||
-        win_ptr->errhandler->handle == MPI_ERRORS_ARE_FATAL) {
+        win_ptr->errhandler->handle == MPI_ERRORS_ARE_FATAL ||
+        win_ptr->errhandler->handle == MPI_ERRORS_ABORT) {
         /* Calls MPID_Abort */
         MPIR_Handle_fatal_error(NULL, fcname, errcode);
     }

--- a/src/mpi/romio/mpi-io/glue/default/mpio_err.c
+++ b/src/mpi/romio/mpi-io/glue/default/mpio_err.c
@@ -45,8 +45,7 @@ int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
     ADIO_File adio_fh;
 
     if (mpi_fh == MPI_FILE_NULL) {
-        if (ADIOI_DFLT_ERR_HANDLER == MPI_ERRORS_ARE_FATAL ||
-            ADIOI_DFLT_ERR_HANDLER != MPI_ERRORS_RETURN) {
+        if (ADIOI_DFLT_ERR_HANDLER != MPI_ERRORS_RETURN) {
             MPI_Abort(MPI_COMM_WORLD, 1);
         } else {
             return error_code;
@@ -55,7 +54,7 @@ int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
 
     adio_fh = MPIO_File_resolve(mpi_fh);
 
-    if (adio_fh->err_handler == MPI_ERRORS_ARE_FATAL || adio_fh->err_handler != MPI_ERRORS_RETURN) {
+    if (adio_fh->err_handler != MPI_ERRORS_RETURN) {
         MPI_Abort(MPI_COMM_WORLD, 1);
     } else {
         return error_code;
@@ -68,7 +67,7 @@ int MPIO_Err_return_comm(MPI_Comm mpi_comm, int error_code)
 
     MPI_Errhandler_get(mpi_comm, &errh);
 
-    if (errh == MPI_ERRORS_ARE_FATAL || errh != MPI_ERRORS_RETURN) {
+    if (errh != MPI_ERRORS_RETURN) {
         MPI_Abort(mpi_comm, 1);
     }
 

--- a/src/mpi/romio/mpi-io/set_errh.c
+++ b/src/mpi/romio/mpi-io/set_errh.c
@@ -51,7 +51,8 @@ int MPI_File_set_errhandler(MPI_File mpi_fh, MPI_Errhandler errhandler)
         MPIO_CHECK_FILE_HANDLE(fh, myname, error_code);
         /* --END ERROR HANDLING-- */
 
-        if ((errhandler != MPI_ERRORS_RETURN) && (errhandler != MPI_ERRORS_ARE_FATAL)) {
+        if ((errhandler != MPI_ERRORS_RETURN) && (errhandler != MPI_ERRORS_ARE_FATAL) &&
+            (errhandler != MPI_ERRORS_ABORT)) {
             error_code = MPIO_Err_create_code(MPI_SUCCESS,
                                               MPIR_ERR_RECOVERABLE,
                                               myname, __LINE__,

--- a/test/mpi/f77/init/baseenvf.f
+++ b/test/mpi/f77/init/baseenvf.f
@@ -45,7 +45,7 @@ C
      &              MPI_SUBVERSION
           print *, 'Version in get_version is ', iv, '.', isubv
        endif
-       if (iv .lt. 1 .or. iv .gt. 3) then
+       if (iv .lt. 1 .or. iv .gt. 4) then
           errs = errs + 1
           print *, 'Version of MPI is invalid (=', iv, ')'
        endif

--- a/test/mpi/impls/mpich/comm/comm_dup.c
+++ b/test/mpi/impls/mpich/comm/comm_dup.c
@@ -35,10 +35,11 @@ int main(int argc, char **argv)
 #if MPI_VERSION >= 4
     MPI_Comm dup2;
     MPI_Comm_dup(dup, &dup2);
-    MPI_Comm_get_info(dup, &info_out);
+    MPI_Comm_get_info(dup2, &info_out);
     MPI_Info_get(info_out, "mpi_assert_no_any_tag", MPI_MAX_INFO_VAL, val, &flag);
-    if (flag) {
-        fprintf(stderr, "Hint was set, when not expected\n");
+    if (flag && strcmp(val, "true") == 0) {
+        fprintf(stderr,
+                "Hint (mpi_assert_no_any_tag) was not expected to be copied from original communicator\n");
         errs++;
     }
     MPI_Comm_free(&dup2);

--- a/test/mpi/mpi_t/mpit_vars.c
+++ b/test/mpi/mpi_t/mpit_vars.c
@@ -84,10 +84,10 @@ int PrintSources(FILE * fp)
     MPI_T_source_get_num(&num_sources);
     if (verbose)
         fprintf(fp, "%d MPI Event Sources\n", num_sources);
-    for (i = 0; i < num_sources; i++) {
+    for (int i = 0; i < num_sources; i++) {
         name_len = sizeof(name);
         desc_len = sizeof(desc);
-        MPI_T_source_get_info(i, name, &name_len, desc, &desc_len, &verbosity, &ordering,
+        MPI_T_source_get_info(i, name, &name_len, desc, &desc_len, &ordering,
                               &ticks_per_second, &max_ticks, NULL);
         if (verbose) {
             fprintf(fp, "name: %s\n", name);
@@ -117,7 +117,7 @@ int PrintEvents(FILE * fp)
     MPI_T_event_get_num(&num_events);
     if (verbose)
         fprintf(fp, "%d MPI Events\n", num_events);
-    for (i = 0; i < num_events; i++) {
+    for (int i = 0; i < num_events; i++) {
         name_len = sizeof(name);
         desc_len = sizeof(desc);
         MPI_T_event_get_info(i, name, &name_len, &verbosity, NULL, NULL, NULL, &enumtype, NULL,


### PR DESCRIPTION
## Pull Request Description

We missed some macros definitions that are introduced in MPI 4 standard. This PR adds them.

Fixes #5400 
Fixes #5401 
Fixes #5402 
Fixes #5403 
Fixes #5404 
Fixes #5405

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
