### PR TITLE
coll: fix gpu buffer swap in reduce

### DIFF
--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -218,7 +218,9 @@ void MPIR_Coll_host_buffer_alloc(const void *sendbuf, const void *recvbuf, MPI_A
         *host_sendbuf = NULL;
     }
 
-    if (sendbuf == MPI_IN_PLACE) {
+    if (recvbuf == NULL) {
+        *host_recvbuf = NULL;
+    } else if (sendbuf == MPI_IN_PLACE) {
         tmp = MPIR_gpu_host_swap(recvbuf, count, datatype);
         *host_recvbuf = tmp;
     } else {

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -259,10 +259,10 @@ void MPIR_Coll_host_buffer_swap_back(void *host_sendbuf, void *host_recvbuf, voi
     request->u.nbc.coll.host_recvbuf = host_recvbuf;
     if (host_recvbuf) {
         request->u.nbc.coll.user_recvbuf = in_recvbuf;
-        request->u.nbc.coll.count = count;
-        request->u.nbc.coll.datatype = datatype;
-        MPIR_Datatype_add_ref_if_not_builtin(datatype);
     }
+    request->u.nbc.coll.count = count;
+    request->u.nbc.coll.datatype = datatype;
+    MPIR_Datatype_add_ref_if_not_builtin(datatype);
 }
 
 void MPIR_Coll_host_buffer_persist_set(void *host_sendbuf, void *host_recvbuf, void *in_recvbuf,

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -79,13 +79,14 @@ int MPIR_Request_completion_processing(MPIR_Request * request_ptr, MPI_Status * 
             {
                 MPII_Coll_req_t *coll = &request_ptr->u.nbc.coll;
 
-                if (coll->host_sendbuf) {
-                    MPIR_gpu_host_free(coll->host_sendbuf, coll->count, coll->datatype);
-                }
-
-                if (coll->host_recvbuf) {
-                    MPIR_gpu_swap_back(coll->host_recvbuf, coll->user_recvbuf,
-                                       coll->count, coll->datatype);
+                if (coll->host_sendbuf || coll->host_recvbuf) {
+                    if (coll->host_sendbuf) {
+                        MPIR_gpu_host_free(coll->host_sendbuf, coll->count, coll->datatype);
+                    }
+                    if (coll->host_recvbuf) {
+                        MPIR_gpu_swap_back(coll->host_recvbuf, coll->user_recvbuf,
+                                           coll->count, coll->datatype);
+                    }
                     MPIR_Datatype_release_if_not_builtin(coll->datatype);
                 }
 


### PR DESCRIPTION
For MPI_Reduce, MPI_Ireduce, and MPI_Reduce_init, we need ignore recvbuf
for non-root processes.

We also missed an MPIR_Localcopy to swap the recv buffer back in
gen_coll.py for blocking routines.

Fixes #5397 

[skip warnings]
## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
