### PR TITLE
coll: fix MPI_Reduce_init validation check

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2012,7 +2012,7 @@ def dump_validate_userbuffer_reduce(func, sbuf, rbuf, ct, dt, op):
         G.out.append("}")
         G.out.append("MPIR_ERRTEST_NAMED_BUF_INPLACE(%s, \"%s\", %s, mpi_errno);" % (sbuf, sbuf, ct))
         G.out.append("MPIR_ERRTEST_NAMED_BUF_INPLACE(%s, \"%s\", %s, mpi_errno);" % (rbuf, rbuf, ct))
-    elif RE.match(r'mpi_i?reduce$', func['name'], re.IGNORECASE):
+    elif RE.match(r'mpi_i?reduce(_init)?$', func['name'], re.IGNORECASE):
         G.out.append("if (" + cond_intra + ") {")
         G.out.append("    MPIR_ERRTEST_INTRA_ROOT(comm_ptr, root, mpi_errno);")
         G.out.append("} else {")


### PR DESCRIPTION
## Pull Request Description

The validation logic for MPI_Reduce_init should be the same as
MPI_Reduce and MPI_Ireduce. This is missing due to an incomplete regex
pattern in binding_c.py. 

Fixes #5407



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
