### PR TITLE
misc: fix parameter types in MPI_Info_create_env

### DIFF
--- a/maint/gen_coll.py
+++ b/maint/gen_coll.py
@@ -592,7 +592,7 @@ def get_func_params(func):
             params.append("MPIR_Comm * comm_ptr")
             args.append("comm_ptr")
         else:
-            s = get_C_param(p, mapping)
+            s = get_C_param(p, func, mapping)
             if p['kind'].startswith('POLY'):
                 s = re.sub(r'\bint ', 'MPI_Aint ', s)
             params.append(s)

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2255,7 +2255,7 @@ def get_declare_function(func, is_large, kind=""):
 def get_C_params(func, mapping):
     param_list = []
     for p in func['c_parameters']:
-        param_list.append(get_C_param(p, mapping))
+        param_list.append(get_C_param(p, func, mapping))
     if not len(param_list):
         return ["void"]
     else:
@@ -2264,7 +2264,7 @@ def get_C_params(func, mapping):
 def get_impl_param(func, param):
     mapping = get_kind_map('C', func['_is_large'])
 
-    s = get_C_param(param, mapping)
+    s = get_C_param(param, func, mapping)
     if RE.match(r'POLY', param['kind']):
         if func['_is_large']:
             # internally we always use MPI_Aint for poly type

--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -74,7 +74,7 @@ def dump_f08_wrappers_c(func, is_large):
         end_list.append("if (%s_i != %s) PMPI_Type_free(&%s_i);" % (dt, dt, dt))
 
     def dump_p(p):
-        c_param_list.append(get_C_param(p, c_mapping))
+        c_param_list.append(get_C_param(p, func, c_mapping))
         c_arg_list.append(p['name'])
 
     n = len(func['parameters'])

--- a/src/mpi/info/info_impl.c
+++ b/src/mpi/info/info_impl.c
@@ -253,7 +253,7 @@ int MPIR_Info_get_string_impl(MPIR_Info * info_ptr, const char *key, int *buflen
     return MPI_SUCCESS;
 }
 
-int MPIR_Info_create_env_impl(int *argc, char ***argv, MPIR_Info ** new_info_ptr)
+int MPIR_Info_create_env_impl(int argc, char **argv, MPIR_Info ** new_info_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/test/mpi/info/infocreateenv.c
+++ b/test/mpi/info/infocreateenv.c
@@ -16,13 +16,13 @@ int main(int argc, char *argv[])
     int nerrs = 0;
     MPI_Info info1, info2;
 
-    MPI_Info_create_env(&argc, &argv, &info1);
-    MPI_Info_create_env(&argc, &argv, &info2);
+    MPI_Info_create_env(argc, argv, &info1);
+    MPI_Info_create_env(argc, argv, &info2);
     nerrs += test_info(info1, info2);
 
     /* Free info1 and create it again */
     MPI_Info_free(&info1);
-    MPI_Info_create_env(&argc, &argv, &info1);
+    MPI_Info_create_env(argc, argv, &info1);
     nerrs += test_info(info1, info2);
 
     MPI_Init(&argc, &argv);
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
 
     /* Free info1 and create it again */
     MPI_Info_free(&info1);
-    MPI_Info_create_env(&argc, &argv, &info1);
+    MPI_Info_create_env(argc, argv, &info1);
     nerrs += test_info(info1, info2);
 
     MPI_Finalize();
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
 
     /* Free info1 and create it again */
     MPI_Info_free(&info1);
-    MPI_Info_create_env(&argc, &argv, &info1);
+    MPI_Info_create_env(argc, argv, &info1);
     nerrs += test_info(info1, info2);
 
     MPI_Info_free(&info1);


### PR DESCRIPTION
## Pull Request Description
The parameters for MPI_Info_create_env should be:
```
int MPI_Info_create_env(int argc, char *argv[], MPI_Info *info)
```

Fixes #5399

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
