### PR TITLE
ROMIO: gpfs: avoid freeing NULL in more places

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -409,7 +409,9 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
      * let's free the memory
      */
     ADIOI_Free(count_my_req_per_proc);
-    ADIOI_Free(my_req[0].offsets);
+    if (my_req[0].offsets) {
+        ADIOI_Free(my_req[0].offsets);
+    }
     ADIOI_Free(my_req);
 
     /* read data in sizes of no more than ADIOI_Coll_bufsize,

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -433,7 +433,9 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     GPFSMPIO_T_CIO_SET_GET(w, 1, 1, GPFSMPIO_CIO_T_DEXCH, GPFSMPIO_CIO_T_OTHREQ);
 
     ADIOI_Free(count_my_req_per_proc);
-    ADIOI_Free(my_req[0].offsets);
+    if (my_req[0].offsets) {
+        ADIOI_Free(my_req[0].offsets);
+    }
     ADIOI_Free(my_req);
 
     /* exchange data and write in sizes of no more than coll_bufsize. */


### PR DESCRIPTION
## Pull Request Description

While `free(NULL)` is legal, the malloc/free wrappers can on some platforms fail to handle NULL correctly.

Catches a few spots missed in 313289a82.

Closes: https://github.com/pmodels/mpich/issues/5339

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
