### PR TITLE
binding/c: add buffer group check for partitioned init

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1841,6 +1841,8 @@ def dump_validation(func, t):
         p = name.split(',')
         if kind == "USERBUFFER-simple":
             dump_validate_userbuffer_simple(func, p[0], p[1], p[2])
+        elif kind == "USERBUFFER-partition":
+            dump_validate_userbuffer_partition(func, p[0], p[1], p[2], p[3])
         elif kind == "USERBUFFER-reduce":
             G.err_codes['MPI_ERR_OP'] = 1
             dump_validate_userbuffer_reduce(func, p[0], p[1], p[2], p[3], p[4])
@@ -1982,6 +1984,12 @@ def dump_validate_userbuffer_simple(func, buf, ct, dt):
         dump_if_close()
     if check_no_op:
         dump_if_close()
+
+def dump_validate_userbuffer_partition(func, buf, partitions, ct, dt):
+    dump_validate_userbuffer_simple(func, buf, ct, dt)
+    dump_if_open("%s > 0" % ct)
+    G.out.append("MPIR_ERRTEST_ARGNONPOS(%s, \"%s\", mpi_errno, MPI_ERR_ARG);" % (partitions, partitions))
+    dump_if_close()
 
 def dump_validate_userbuffer_neighbor_vw(func, kind, buf, ct, dt, disp):
     dump_validate_get_topo_size(func)

--- a/maint/local_python/binding_common.py
+++ b/maint/local_python/binding_common.py
@@ -207,6 +207,9 @@ def get_userbuffer_group(func_name, parameters, i):
     elif RE.match(r'mpi_i?(allreduce|reduce|scan|exscan)', func_name, re.IGNORECASE):
         group_kind = "USERBUFFER-reduce"
         group_count = 5
+    elif RE.match(r'mpi_p(send|recv)_init', func_name, re.IGNORECASE):
+        group_kind = "USERBUFFER-partition"
+        group_count = 4
     elif RE.search(r'XFER_NUM_ELEM', p2['kind']) and RE.search(r'DATATYPE', p3['kind']):
         group_kind = "USERBUFFER-simple"
         group_count = 3


### PR DESCRIPTION
## Pull Request Description
MPI_Psend_init and MPI_Precv_init uses buffer group of
    `buf, partitions, count, datatype`
Add separate validation group for it.

Fixes #5412

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
