### PR TITLE
mpi-4: implement MPI_Intercomm_create_from_groups

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -551,7 +551,11 @@ def process_func_parameters(func):
         elif RE.match(r'(COUNT|TAG)$', kind):
             validation_list.append({'kind': RE.m.group(1), 'name': name})
         elif RE.match(r'RANK(_NNI)?$', kind):
-            validation_list.append({'kind': 'RANK', 'name': name})
+            if RE.match(r'mpi_intercomm_create_from_groups', func_name, re.IGNORECASE):
+                # TODO: add validation
+                pass
+            else:
+                validation_list.append({'kind': 'RANK', 'name': name})
         elif RE.match(r'(POLY)?(XFER_NUM_ELEM|DTYPE_NUM_ELEM_NNI|DTYPE_PACK_SIZE)', kind):
             validation_list.append({'kind': "COUNT", 'name': name})
         elif RE.match(r'(POLY)?DTYPE_NUM_ELEM', kind):

--- a/src/binding/c/comm_api.txt
+++ b/src/binding/c/comm_api.txt
@@ -202,6 +202,9 @@ MPI_Comm_test_inter:
     *flag = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM);
 }
 
+MPI_Intercomm_create_from_groups:
+    .desc: Create an intercommuncator from local and remote groups
+
 MPI_Intercomm_create:
     .desc: Creates an intercommuncator from two intracommunicators
     .skip: validate-RANK

--- a/src/binding/mpi_standard_api.txt
+++ b/src/binding/mpi_standard_api.txt
@@ -1305,9 +1305,9 @@ MPI_Intercomm_create:
     newintercomm: COMMUNICATOR, direction=out, [new inter-communicator]
 MPI_Intercomm_create_from_groups:
     local_group: GROUP, [local group]
-    local_leader: RANK, [rank of local group leader in local\_group]
-    remote_group: GROUP, [remote group, significant only at local\_leader]
-    remote_leader: RANK, [rank of remote group leader in remote\_group, significant only at local\_leader]
+    local_leader: RANK, [rank of local group leader in local_group]
+    remote_group: GROUP, [remote group, significant only at local_leader]
+    remote_leader: RANK, [rank of remote group leader in remote_group, significant only at local_leader]
     stringtag: STRING, constant=True, [unique idenitifier for this operation]
     info: INFO, [info object]
     errhandler: ERRHANDLER, [error handler to be attached to new inter-communicator]

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -111,7 +111,8 @@ enum MPIR_COMM_HINT_PREDEFINED_t {
   receiving.  In the case of an Intracommunicator, they are the same
   context id.  They differ in the case of intercommunicators, where
   they may come from processes in different comm worlds (in the
-  case of MPI-2 dynamic process intercomms).
+  case of MPI-2 dynamic process intercomms). With intercomms, we are
+  sending with context_id, which is the same as peer's recvcontext_id.
 
   The virtual connection table is an explicit member of this structure.
   This contains the information used to contact a particular process,
@@ -154,7 +155,7 @@ struct MPIR_Comm {
     MPIR_OBJECT_HEADER;         /* adds handle and ref_count fields */
     MPID_Thread_mutex_t mutex;
     MPIR_Context_id_t context_id;       /* Send context id.  See notes */
-    MPIR_Context_id_t recvcontext_id;   /* Send context id.  See notes */
+    MPIR_Context_id_t recvcontext_id;   /* Recv context id (locally allocated).  See notes */
     int remote_size;            /* Value of MPI_Comm_(remote)_size */
     int rank;                   /* Value of MPI_Comm_rank */
     MPIR_Attribute *attributes; /* List of attributes */


### PR DESCRIPTION
## Pull Request Description
Add a basic implementation that assuming comm_world exist and remote
group is also part of comm_world.

We simply create local comm from the local group then call `MPIR_Intercomm_create_impl` to create the intercommunication.

Fixes #5406 

TODO:
* [x] add tests
* [ ] allow remote group to be from another comm_world -- Does a group with remote comm_world work?
      -- Postpone until we revamp the dynamic process infrastrstucture.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
