### PR TITLE
datatype: Avoid NULL dereferencing during get_yaksa_type

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
@@ -346,6 +346,7 @@ yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type)
                 } else {
                     MPIR_Datatype *typeptr;
                     MPIR_Datatype_get_ptr(type, typeptr);
+                    MPIR_Assert(typeptr != NULL);
                     yaksa_type = ((yaksa_type_t) (intptr_t) typeptr->typerep.handle);
                 }
             }


### PR DESCRIPTION
## Pull Request Description

A simple patch to fix a Klocwork issue. 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
