### PR TITLE
ch4: remove an unnecessary assertion

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -86,7 +86,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_copy_from_unexp_req(MPIR_Request * req, void
              * the absolute address of the buffer (e.g. buf == MPI_BOTTOM).
              */
             char *addr = (char *) user_buf + dt_true_lb;
-            assert(addr);       /* to suppress gcc-8 warning: -Wnonnull */
             MPIR_Typerep_copy(addr, MPIDIG_REQUEST(req, buffer), nbytes);
         }
     }


### PR DESCRIPTION
## Pull Request Description

Since we are calling MPIR_Typerep_copy instead of memcpy, the old gcc
warning suppression is no longer needed.

Currently clang (FreeBSD clang version 10.0.1) have a weird optimization
bug that will trigger the assertion when user_buf is `0` even though
`addr` is not.

Current nightly test failure (on freebsd -ch4-ofi):
```
not ok  - ./io/setviewcur 4
  ---
  Directory: ./io
  File: setviewcur
  Num-procs: 4
  Timeout: 180
  Date: "Thu Jul  8 02:08:47 2021"
  ...
## Test output (expected 'No Errors'):
## Assertion failed: (addr), function MPIDIG_copy_from_unexp_req, file ./src/mpid/ch4/generic/am/mpidig_am_recv.h, line 89.
## 
## ===================================================================================
## =   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES
## =   PID 56583 RUNNING AT pmrs-freebsd64-240-02
## =   EXIT CODE: 134
## =   CLEANING UP REMAINING PROCESSES
## =   YOU CAN IGNORE THE BELOW CLEANUP MESSAGES
## ===================================================================================
## YOUR APPLICATION TERMINATED WITH THE EXIT STRING: Abort trap (signal 6)
## This typically refers to a problem with your application.
## Please see the FAQ page for debugging suggestions
```

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
