### PR TITLE
mpi: remove redundant error check on partitions

### DIFF
--- a/src/binding/c/part_api.txt
+++ b/src/binding/c/part_api.txt
@@ -1,13 +1,8 @@
 MPI_Psend_init:
     .desc: Creates a partitioned communication send request
     .seealso: MPI_Pready, MPI_Pready_range, MPI_Pready_list, MPI_Start, MPI_Startall, MPI_Request_free
-{ -- error_check -- partitions
-    MPIR_ERRTEST_PARTITIONS(partitions, mpi_errno);
-}
 {
     MPIR_Request *request_ptr = NULL;
-
-    MPIR_ERRTEST_PARTITIONS(partitions, mpi_errno);
 
     mpi_errno = MPID_Psend_init(buf, partitions, count, datatype, dest, tag, comm_ptr,
                                 info_ptr, &request_ptr);
@@ -21,9 +16,6 @@ MPI_Psend_init:
 MPI_Precv_init:
     .desc: Creates a partitioned communication receive request
     .seealso: MPI_Parrived, MPI_Request_free
-{ -- error_check -- partitions
-    MPIR_ERRTEST_PARTITIONS(partitions, mpi_errno);
-}
 {
     MPIR_Request *request_ptr = NULL;
 

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -262,18 +262,6 @@ cvars:
         goto fn_fail;                                           \
     }
 
-#define MPIR_ERRTEST_PARTITIONS(partitions,err)                 \
-    if ((partitions) < 0) {                                     \
-        err = MPIR_Err_create_code(MPI_SUCCESS,                 \
-                                   MPIR_ERR_RECOVERABLE,        \
-                                   __func__, __LINE__,          \
-                                   MPI_ERR_OTHER,               \
-                                   "**partitionsneg",           \
-                                   "**partitionsneg %d",        \
-                                   partitions);                 \
-        goto fn_fail;                                           \
-    }
-
 #define MPIR_ERRTEST_DISP(disp,err)                             \
     if ((disp) < 0) {                                           \
         err = MPIR_Err_create_code(MPI_SUCCESS,                 \

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -233,8 +233,6 @@ MPI_TYPECLASS_INTEGER, or MPI_TYPECLASS_COMPLEX
 **invalidmembind %d: cannot bind memory to object (%d). \
 A memory object id was expected but a non-memory object id was passed instead
 
-**partitionsneg: Negative partitions
-**partitionsneg %d: Negative partitions, value is %d
 **partitioninvalid: Invalid partition
 **partitioninvalid %d: Invalid partition, value is %d 
 **partitioninvalid %d %d: Invalid partition range, values are %d %d


### PR DESCRIPTION
## Pull Request Description
The non-negativity of the partitions parameter is now checked with
`MPIR_ERRTEST_ARGNONPOS` (generated in bindings_c.py - see PR #5420). The old
`MPIR_ERRTEST_PARTITIONS` is now redundant. Since `MPIR_ERRTEST_PARTITIONS`
generates error code `MPI_ERR_OTHER`, it is no more clarifying than
MPIR_ERRTEST_ARGNONPOS, which generates error code `MPI_ERR_ARG`, thus,
it is removed.


[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
