### PR TITLE
ch4: cleanup netmod/shm API calls with CH4_CALL

### DIFF
--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -321,8 +321,6 @@ Native API:
      MPIDIG: assert, win
   rank_is_local : int
       NM*: target, comm
-  av_is_local : int
-      NM*: av
   mpi_barrier : int
       NM*: comm, errflag
      SHM*: comm, errflag

--- a/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
@@ -20,18 +20,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_issue_cts(MPIR_Request * rreq_ptr)
     am_hdr.rreq_ptr = rreq_ptr;
 
     int source = MPIDI_PART_REQUEST(rreq_ptr, rank);
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(rreq_ptr, is_local))
-        mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(rreq_ptr->comm, source, MPIDIG_PART_CTS, &am_hdr,
-                                        sizeof(am_hdr));
-    else
-#endif
-    {
-        mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(rreq_ptr->comm, source, MPIDIG_PART_CTS, &am_hdr,
-                                       sizeof(am_hdr));
-    }
+    CH4_CALL(am_send_hdr_reply(rreq_ptr->comm, source, MPIDIG_PART_CTS, &am_hdr, sizeof(am_hdr)),
+             MPIDI_REQUEST(rreq_ptr, is_local), mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_PART_ISSUE_CTS);
     return mpi_errno;
@@ -65,22 +55,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_issue_data(MPIR_Request * part_sreq)
     MPIR_Assert(MPIDI_PART_REQUEST(part_sreq, count) * part_sreq->u.part.partitions <
                 MPIR_AINT_MAX);
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(part_sreq, is_local)) {
-        mpi_errno = MPIDI_SHM_am_isend(MPIDI_PART_REQUEST(part_sreq, rank),
-                                       part_sreq->comm, MPIDIG_PART_SEND_DATA,
-                                       &am_hdr, sizeof(am_hdr),
-                                       MPIDI_PART_REQUEST(part_sreq, buffer), count,
-                                       MPIDI_PART_REQUEST(part_sreq, datatype), sreq);
-    } else
-#endif
-    {
-        mpi_errno = MPIDI_NM_am_isend(MPIDI_PART_REQUEST(part_sreq, rank),
-                                      part_sreq->comm, MPIDIG_PART_SEND_DATA,
-                                      &am_hdr, sizeof(am_hdr),
-                                      MPIDI_PART_REQUEST(part_sreq, buffer), count,
-                                      MPIDI_PART_REQUEST(part_sreq, datatype), sreq);
-    }
+    CH4_CALL(am_isend(MPIDI_PART_REQUEST(part_sreq, rank), part_sreq->comm, MPIDIG_PART_SEND_DATA,
+                      &am_hdr, sizeof(am_hdr),
+                      MPIDI_PART_REQUEST(part_sreq, buffer), count,
+                      MPIDI_PART_REQUEST(part_sreq, datatype), sreq),
+             MPIDI_REQUEST(part_sreq, is_local), mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_PART_ISSUE_DATA);

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -104,21 +104,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_reply_ssend(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_REPLY_SSEND);
     ack_msg.sreq_ptr = MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr);
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(rreq, is_local))
-        mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(rreq->comm,
-                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK, &ack_msg,
-                                        (MPI_Aint) sizeof(ack_msg));
-    else
-#endif
-    {
-        mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(rreq->comm,
-                                       MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK, &ack_msg,
-                                       (MPI_Aint) sizeof(ack_msg));
-    }
-
+    CH4_CALL(am_send_hdr_reply(rreq->comm, MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK,
+                               &ack_msg, (MPI_Aint) sizeof(ack_msg)),
+             MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_REPLY_SSEND);

--- a/src/mpid/ch4/netmod/ofi/ofi_proc.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_proc.h
@@ -21,19 +21,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rank_is_local(int rank, MPIR_Comm * comm)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_av_is_local(MPIDI_av_entry_t * av)
-{
-    int ret = 0;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AV_IS_LOCAL);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AV_IS_LOCAL);
-
-    ret = MPIDIU_av_is_local(av);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AV_IS_LOCAL);
-    return ret;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr,
                                                     int idx, int *lpid_ptr, bool is_remote)
 {

--- a/src/mpid/ch4/netmod/ucx/ucx_proc.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_proc.h
@@ -20,18 +20,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rank_is_local(int rank, MPIR_Comm * comm)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_av_is_local(MPIDI_av_entry_t * av)
-{
-    int ret;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AV_IS_LOCAL);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AV_IS_LOCAL);
-
-    ret = MPIDIU_av_is_local(av);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AV_IS_LOCAL);
-    return ret;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr,
                                                     int idx, int *lpid_ptr, bool is_remote)
 {

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -15,6 +15,23 @@
 int MPIDIG_get_context_index(uint64_t context_id);
 uint64_t MPIDIG_generate_win_id(MPIR_Comm * comm_ptr);
 
+/* define CH4_CALL to call netmod or shm API based on is_local */
+#ifdef MPIDI_CH4_DIRECT_NETMOD
+#define CH4_CALL(FUNC, is_local_, err_) \
+    do { \
+        err_ = MPIDI_NM_ ## FUNC; \
+    } while (0)
+#else
+#define CH4_CALL(FUNC, is_local_, err_) \
+    do { \
+        if (is_local_) { \
+            err_ = MPIDI_SHM_ ## FUNC; \
+        } else { \
+            err_ = MPIDI_NM_ ## FUNC; \
+        } \
+    } while (0)
+#endif
+
 /* Request creation with locking for LOCKLESS MT model */
 #define MPIDI_CH4_REQUEST_CREATE(req, kind, pool, ref_count)            \
     do {                                                                \

--- a/src/mpid/ch4/src/ch4_proc.h
+++ b/src/mpid/ch4/src/ch4_proc.h
@@ -34,9 +34,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_av_is_local(MPIDI_av_entry_t * av)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_AV_IS_LOCAL);
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    /* Ask the netmod for locality information. If it decided not to build it,
-     * it will call back up to the MPIDIU function to get the infomration. */
-    ret = MPIDI_NM_av_is_local(av);
+    ret = 0;
 #else
     ret = MPIDIU_av_is_local(av);
 #endif

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -228,21 +228,9 @@ static int ack_put(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_ACK_PUT);
 
     ack_msg.preq_ptr = MPIDIG_REQUEST(rreq, req->preq.preq_ptr);
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(rreq, is_local))
-        mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
-                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_ACK,
-                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
-    else
-#endif
-    {
-        mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
-                                       MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_ACK,
-                                       &ack_msg, (MPI_Aint) sizeof(ack_msg));
-    }
-
+    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+                               MPIDIG_PUT_ACK, &ack_msg, sizeof(ack_msg)),
+             MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_ACK_PUT);
@@ -267,23 +255,10 @@ static int ack_cswap(MPIR_Request * rreq)
     MPIR_cc_inc(rreq->cc_ptr);
     ack_msg.req_ptr = MPIDIG_REQUEST(rreq, req->creq.creq_ptr);
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(rreq, is_local))
-        mpi_errno =
-            MPIDI_SHM_am_isend_reply(rreq->u.rma.win->comm_ptr,
-                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_CSWAP_ACK, &ack_msg,
-                                     (MPI_Aint) sizeof(ack_msg), result_addr, 1,
-                                     MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
-    else
-#endif
-    {
-        mpi_errno =
-            MPIDI_NM_am_isend_reply(rreq->u.rma.win->comm_ptr,
-                                    MPIDIG_REQUEST(rreq, rank), MPIDIG_CSWAP_ACK, &ack_msg,
-                                    (MPI_Aint) sizeof(ack_msg), result_addr, 1,
-                                    MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
-    }
-
+    CH4_CALL(am_isend_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+                            MPIDIG_CSWAP_ACK, &ack_msg, sizeof(ack_msg), result_addr, 1,
+                            MPIDIG_REQUEST(rreq, req->creq.datatype), rreq),
+             MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_ACK_CSWAP);
@@ -301,21 +276,9 @@ static int ack_acc(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_ACK_ACC);
 
     ack_msg.req_ptr = MPIDIG_REQUEST(rreq, req->areq.req_ptr);
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(rreq, is_local))
-        mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
-                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_ACK,
-                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
-    else
-#endif
-    {
-        mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
-                                       MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_ACK,
-                                       &ack_msg, (MPI_Aint) sizeof(ack_msg));
-    }
-
+    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+                               MPIDIG_ACC_ACK, &ack_msg, sizeof(ack_msg)),
+             MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_ACK_ACC);
@@ -335,26 +298,11 @@ static int ack_get_acc(MPIR_Request * rreq)
     MPIR_cc_inc(rreq->cc_ptr);
     ack_msg.req_ptr = MPIDIG_REQUEST(rreq, req->areq.req_ptr);
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(rreq, is_local))
-        mpi_errno =
-            MPIDI_SHM_am_isend_reply(rreq->u.rma.win->comm_ptr,
-                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_ACK,
-                                     &ack_msg, (MPI_Aint) sizeof(ack_msg),
-                                     MPIDIG_REQUEST(rreq, req->areq.data),
-                                     MPIDIG_REQUEST(rreq, req->areq.result_data_sz), MPI_BYTE,
-                                     rreq);
-    else
-#endif
-    {
-        mpi_errno =
-            MPIDI_NM_am_isend_reply(rreq->u.rma.win->comm_ptr,
-                                    MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_ACK,
-                                    &ack_msg, (MPI_Aint) sizeof(ack_msg),
-                                    MPIDIG_REQUEST(rreq, req->areq.data),
-                                    MPIDIG_REQUEST(rreq, req->areq.result_data_sz), MPI_BYTE, rreq);
-    }
-
+    CH4_CALL(am_isend_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+                            MPIDIG_GET_ACC_ACK, &ack_msg, sizeof(ack_msg),
+                            MPIDIG_REQUEST(rreq, req->areq.data),
+                            MPIDIG_REQUEST(rreq, req->areq.result_data_sz), MPI_BYTE, rreq),
+             MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_ACK_GET_ACC);
@@ -396,19 +344,8 @@ static int win_lock_advance(MPIR_Win * win)
         else
             MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**rmasync");
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        if (MPIDI_rank_is_local(lock->rank, win->comm_ptr))
-            mpi_errno = MPIDI_SHM_am_send_hdr_reply(win->comm_ptr,
-                                                    lock->rank, handler_id,
-                                                    &msg, (MPI_Aint) sizeof(msg));
-        else
-#endif
-        {
-            mpi_errno = MPIDI_NM_am_send_hdr_reply(win->comm_ptr,
-                                                   lock->rank, handler_id,
-                                                   &msg, (MPI_Aint) sizeof(msg));
-        }
-
+        CH4_CALL(am_send_hdr_reply(win->comm_ptr, lock->rank, handler_id, &msg, sizeof(msg)),
+                 MPIDI_rank_is_local(lock->rank, win->comm_ptr), mpi_errno);
         MPIR_ERR_CHECK(mpi_errno);
         MPL_free(lock);
 
@@ -488,20 +425,8 @@ static void win_unlock_proc(const MPIDIG_win_cntrl_msg_t * info, int is_local, M
     msg.win_id = MPIDIG_WIN(win, win_id);
     msg.origin_rank = win->comm_ptr->rank;
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (is_local)
-        mpi_errno = MPIDI_SHM_am_send_hdr_reply(win->comm_ptr,
-                                                info->origin_rank,
-                                                MPIDIG_WIN_UNLOCK_ACK,
-                                                &msg, (MPI_Aint) sizeof(msg));
-    else
-#endif
-    {
-        mpi_errno = MPIDI_NM_am_send_hdr_reply(win->comm_ptr,
-                                               info->origin_rank,
-                                               MPIDIG_WIN_UNLOCK_ACK, &msg, (MPI_Aint) sizeof(msg));
-    }
-
+    CH4_CALL(am_send_hdr_reply(win->comm_ptr, info->origin_rank, MPIDIG_WIN_UNLOCK_ACK,
+                               &msg, sizeof(msg)), is_local, mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_WIN_UNLOCK_PROC);
@@ -740,25 +665,12 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
     if (MPIDIG_REQUEST(rreq, req->greq.flattened_dt) == NULL) {
         MPIDI_Datatype_check_size(MPIDIG_REQUEST(rreq, req->greq.datatype),
                                   MPIDIG_REQUEST(rreq, req->greq.count), get_ack.target_data_sz);
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        if (MPIDI_REQUEST(rreq, is_local))
-            mpi_errno = MPIDI_SHM_am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
-                                                 MPIDIG_GET_ACK,
-                                                 &get_ack, (MPI_Aint) sizeof(get_ack),
-                                                 (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
-                                                 MPIDIG_REQUEST(rreq, req->greq.count),
-                                                 MPIDIG_REQUEST(rreq, req->greq.datatype), rreq);
-        else
-#endif
-        {
-            mpi_errno = MPIDI_NM_am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
-                                                MPIDIG_GET_ACK,
-                                                &get_ack, (MPI_Aint) sizeof(get_ack),
-                                                (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
-                                                MPIDIG_REQUEST(rreq, req->greq.count),
-                                                MPIDIG_REQUEST(rreq, req->greq.datatype), rreq);
-        }
-
+        CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+                                MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
+                                (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
+                                MPIDIG_REQUEST(rreq, req->greq.count),
+                                MPIDIG_REQUEST(rreq, req->greq.datatype), rreq),
+                 MPIDI_REQUEST(rreq, is_local), mpi_errno);
         MPID_Request_complete(rreq);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
@@ -777,23 +689,11 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
     get_ack.target_data_sz = MPIDIG_REQUEST(rreq, req->greq.count);
     MPIDIG_REQUEST(rreq, req->greq.count) /= dt->size;
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(rreq, is_local))
-        mpi_errno = MPIDI_SHM_am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
-                                             MPIDIG_GET_ACK, &get_ack, (MPI_Aint) sizeof(get_ack),
-                                             MPIDIG_REQUEST(rreq, req->greq.addr),
-                                             MPIDIG_REQUEST(rreq, req->greq.count), dt->handle,
-                                             rreq);
-    else
-#endif
-    {
-        mpi_errno = MPIDI_NM_am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
-                                            MPIDIG_GET_ACK, &get_ack, (MPI_Aint) sizeof(get_ack),
-                                            MPIDIG_REQUEST(rreq, req->greq.addr),
-                                            MPIDIG_REQUEST(rreq, req->greq.count), dt->handle,
-                                            rreq);
-    }
-
+    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+                            MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
+                            MPIDIG_REQUEST(rreq, req->greq.addr),
+                            MPIDIG_REQUEST(rreq, req->greq.count), dt->handle, rreq),
+             MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPID_Request_complete(rreq);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
@@ -839,21 +739,9 @@ static int put_dt_target_cmpl_cb(MPIR_Request * rreq)
     ack_msg.origin_preq_ptr = MPIDIG_REQUEST(rreq, req->preq.preq_ptr);
     ack_msg.target_preq_ptr = rreq;
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(rreq, is_local))
-        mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
-                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_DT_ACK,
-                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
-    else
-#endif
-    {
-        mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
-                                       MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_DT_ACK,
-                                       &ack_msg, (MPI_Aint) sizeof(ack_msg));
-    }
-
+    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+                               MPIDIG_PUT_DT_ACK, &ack_msg, sizeof(ack_msg)),
+             MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -874,21 +762,9 @@ static int acc_dt_target_cmpl_cb(MPIR_Request * rreq)
     ack_msg.origin_preq_ptr = MPIDIG_REQUEST(rreq, req->areq.req_ptr);
     ack_msg.target_preq_ptr = rreq;
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(rreq, is_local))
-        mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
-                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_DT_ACK,
-                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
-    else
-#endif
-    {
-        mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
-                                       MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_DT_ACK,
-                                       &ack_msg, (MPI_Aint) sizeof(ack_msg));
-    }
-
+    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+                               MPIDIG_ACC_DT_ACK, &ack_msg, sizeof(ack_msg)),
+             MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -909,21 +785,9 @@ static int get_acc_dt_target_cmpl_cb(MPIR_Request * rreq)
     ack_msg.origin_preq_ptr = MPIDIG_REQUEST(rreq, req->areq.req_ptr);
     ack_msg.target_preq_ptr = rreq;
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(rreq, is_local))
-        mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
-                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_DT_ACK,
-                                        &ack_msg, (MPI_Aint) sizeof(ack_msg));
-    else
-#endif
-    {
-        mpi_errno =
-            MPIDI_NM_am_send_hdr_reply(rreq->u.rma.win->comm_ptr,
-                                       MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_DT_ACK,
-                                       &ack_msg, (MPI_Aint) sizeof(ack_msg));
-    }
-
+    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+                               MPIDIG_GET_ACC_DT_ACK, &ack_msg, sizeof(ack_msg)),
+             MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -1434,29 +1298,12 @@ int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
     win = origin_req->u.rma.win;
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (is_local)
-        mpi_errno = MPIDI_SHM_am_isend_reply(win->comm_ptr,
-                                             MPIDIG_REQUEST(origin_req, rank),
-                                             MPIDIG_PUT_DAT_REQ,
-                                             &dat_msg, (MPI_Aint) sizeof(dat_msg),
-                                             MPIDIG_REQUEST(origin_req, req->preq.origin_addr),
-                                             MPIDIG_REQUEST(origin_req, req->preq.origin_count),
-                                             MPIDIG_REQUEST(origin_req, req->preq.origin_datatype),
-                                             rreq);
-    else
-#endif
-    {
-        mpi_errno = MPIDI_NM_am_isend_reply(win->comm_ptr,
-                                            MPIDIG_REQUEST(origin_req, rank),
-                                            MPIDIG_PUT_DAT_REQ,
-                                            &dat_msg, (MPI_Aint) sizeof(dat_msg),
-                                            MPIDIG_REQUEST(origin_req, req->preq.origin_addr),
-                                            MPIDIG_REQUEST(origin_req, req->preq.origin_count),
-                                            MPIDIG_REQUEST(origin_req, req->preq.origin_datatype),
-                                            rreq);
-    }
-
+    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, rank),
+                            MPIDIG_PUT_DAT_REQ, &dat_msg, sizeof(dat_msg),
+                            MPIDIG_REQUEST(origin_req, req->preq.origin_addr),
+                            MPIDIG_REQUEST(origin_req, req->preq.origin_count),
+                            MPIDIG_REQUEST(origin_req, req->preq.origin_datatype), rreq),
+             is_local, mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->preq.origin_datatype));
 
@@ -1492,29 +1339,12 @@ int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
     win = origin_req->u.rma.win;
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (is_local)
-        mpi_errno = MPIDI_SHM_am_isend_reply(win->comm_ptr,
-                                             MPIDIG_REQUEST(origin_req, rank),
-                                             MPIDIG_ACC_DAT_REQ,
-                                             &dat_msg, (MPI_Aint) sizeof(dat_msg),
-                                             MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
-                                             MPIDIG_REQUEST(origin_req, req->areq.origin_count),
-                                             MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
-                                             rreq);
-    else
-#endif
-    {
-        mpi_errno = MPIDI_NM_am_isend_reply(win->comm_ptr,
-                                            MPIDIG_REQUEST(origin_req, rank),
-                                            MPIDIG_ACC_DAT_REQ,
-                                            &dat_msg, (MPI_Aint) sizeof(dat_msg),
-                                            MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
-                                            MPIDIG_REQUEST(origin_req, req->areq.origin_count),
-                                            MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
-                                            rreq);
-    }
-
+    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, rank),
+                            MPIDIG_ACC_DAT_REQ, &dat_msg, sizeof(dat_msg),
+                            MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
+                            MPIDIG_REQUEST(origin_req, req->areq.origin_count),
+                            MPIDIG_REQUEST(origin_req, req->areq.origin_datatype), rreq),
+             is_local, mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->areq.origin_datatype));
 
@@ -1551,29 +1381,12 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
     win = origin_req->u.rma.win;
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (is_local)
-        mpi_errno = MPIDI_SHM_am_isend_reply(win->comm_ptr,
-                                             MPIDIG_REQUEST(origin_req, rank),
-                                             MPIDIG_GET_ACC_DAT_REQ,
-                                             &dat_msg, (MPI_Aint) sizeof(dat_msg),
-                                             MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
-                                             MPIDIG_REQUEST(origin_req, req->areq.origin_count),
-                                             MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
-                                             rreq);
-    else
-#endif
-    {
-        mpi_errno = MPIDI_NM_am_isend_reply(win->comm_ptr,
-                                            MPIDIG_REQUEST(origin_req, rank),
-                                            MPIDIG_GET_ACC_DAT_REQ,
-                                            &dat_msg, (MPI_Aint) sizeof(dat_msg),
-                                            MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
-                                            MPIDIG_REQUEST(origin_req, req->areq.origin_count),
-                                            MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
-                                            rreq);
-    }
-
+    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, rank),
+                            MPIDIG_GET_ACC_DAT_REQ, &dat_msg, sizeof(dat_msg),
+                            MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
+                            MPIDIG_REQUEST(origin_req, req->areq.origin_count),
+                            MPIDIG_REQUEST(origin_req, req->areq.origin_datatype), rreq),
+             is_local, mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->areq.origin_datatype));
 

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -207,17 +207,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_complete(MPIR_Win * win)
     for (win_grp_idx = 0; win_grp_idx < group->size; ++win_grp_idx) {
         peer = ranks_in_win_grp[win_grp_idx];
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        if (MPIDI_rank_is_local(peer, win->comm_ptr))
-            mpi_errno = MPIDI_SHM_am_send_hdr(peer, win->comm_ptr,
-                                              MPIDIG_WIN_COMPLETE, &msg, (MPI_Aint) sizeof(msg));
-        else
-#endif
-        {
-            mpi_errno = MPIDI_NM_am_send_hdr(peer, win->comm_ptr,
-                                             MPIDIG_WIN_COMPLETE, &msg, (MPI_Aint) sizeof(msg));
-        }
-
+        CH4_CALL(am_send_hdr(peer, win->comm_ptr, MPIDIG_WIN_COMPLETE, &msg, sizeof(msg)),
+                 MPIDI_rank_is_local(peer, win->comm_ptr), mpi_errno);
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
     }
@@ -276,17 +267,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_post(MPIR_Group * group, int assert,
     for (win_grp_idx = 0; win_grp_idx < group->size; ++win_grp_idx) {
         peer = ranks_in_win_grp[win_grp_idx];
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        if (MPIDI_rank_is_local(peer, win->comm_ptr))
-            mpi_errno = MPIDI_SHM_am_send_hdr(peer, win->comm_ptr,
-                                              MPIDIG_WIN_POST, &msg, (MPI_Aint) sizeof(msg));
-        else
-#endif
-        {
-            mpi_errno = MPIDI_NM_am_send_hdr(peer, win->comm_ptr,
-                                             MPIDIG_WIN_POST, &msg, (MPI_Aint) sizeof(msg));
-        }
-
+        CH4_CALL(am_send_hdr(peer, win->comm_ptr, MPIDIG_WIN_POST, &msg, sizeof(msg)),
+                 MPIDI_rank_is_local(peer, win->comm_ptr), mpi_errno);
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
     }
@@ -391,16 +373,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock(int lock_type, int rank, int as
     msg.lock_type = lock_type;
 
     locked = slock->locked + 1;
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_rank_is_local(rank, win->comm_ptr))
-        mpi_errno = MPIDI_SHM_am_send_hdr(rank, win->comm_ptr,
-                                          MPIDIG_WIN_LOCK, &msg, (MPI_Aint) sizeof(msg));
-    else
-#endif
-    {
-        mpi_errno = MPIDI_NM_am_send_hdr(rank, win->comm_ptr,
-                                         MPIDIG_WIN_LOCK, &msg, (MPI_Aint) sizeof(msg));
-    }
+    CH4_CALL(am_send_hdr(rank, win->comm_ptr, MPIDIG_WIN_LOCK, &msg, sizeof(msg)),
+             MPIDI_rank_is_local(rank, win->comm_ptr), mpi_errno);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
@@ -468,18 +442,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
     msg.origin_rank = win->comm_ptr->rank;
     unlocked = slock->locked - 1;
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_rank_is_local(rank, win->comm_ptr))
-        mpi_errno =
-            MPIDI_SHM_am_send_hdr(rank, win->comm_ptr,
-                                  MPIDIG_WIN_UNLOCK, &msg, (MPI_Aint) sizeof(msg));
-    else
-#endif
-    {
-        mpi_errno = MPIDI_NM_am_send_hdr(rank, win->comm_ptr,
-                                         MPIDIG_WIN_UNLOCK, &msg, (MPI_Aint) sizeof(msg));
-    }
-
+    CH4_CALL(am_send_hdr(rank, win->comm_ptr, MPIDIG_WIN_UNLOCK, &msg, sizeof(msg)),
+             MPIDI_rank_is_local(rank, win->comm_ptr), mpi_errno);
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
 
@@ -736,17 +700,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
         msg.win_id = MPIDIG_WIN(win, win_id);
         msg.origin_rank = win->comm_ptr->rank;
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        if (MPIDI_rank_is_local(i, win->comm_ptr))
-            mpi_errno = MPIDI_SHM_am_send_hdr(i, win->comm_ptr,
-                                              MPIDIG_WIN_UNLOCKALL, &msg, (MPI_Aint) sizeof(msg));
-        else
-#endif
-        {
-            mpi_errno = MPIDI_NM_am_send_hdr(i, win->comm_ptr,
-                                             MPIDIG_WIN_UNLOCKALL, &msg, (MPI_Aint) sizeof(msg));
-        }
-
+        CH4_CALL(am_send_hdr(i, win->comm_ptr, MPIDIG_WIN_UNLOCKALL, &msg, sizeof(msg)),
+                 MPIDI_rank_is_local(i, win->comm_ptr), mpi_errno);
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
     }
@@ -897,17 +852,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock_all(int assert, MPIR_Win * win)
         msg.origin_rank = win->comm_ptr->rank;
         msg.lock_type = MPI_LOCK_SHARED;
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        if (MPIDI_rank_is_local(i, win->comm_ptr))
-            mpi_errno = MPIDI_SHM_am_send_hdr(i, win->comm_ptr,
-                                              MPIDIG_WIN_LOCKALL, &msg, (MPI_Aint) sizeof(msg));
-        else
-#endif
-        {
-            mpi_errno = MPIDI_NM_am_send_hdr(i, win->comm_ptr,
-                                             MPIDIG_WIN_LOCKALL, &msg, (MPI_Aint) sizeof(msg));
-        }
-
+        CH4_CALL(am_send_hdr(i, win->comm_ptr, MPIDIG_WIN_LOCKALL, &msg, sizeof(msg)),
+                 MPIDI_rank_is_local(i, win->comm_ptr), mpi_errno);
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
     }


### PR DESCRIPTION
## Pull Request Description

Every time we call netmod and shm API call, we need check both the macro `MPIDI_CH4_DIRECT_NETMOD` and `is_local` and repeat the same long function calls 2-3 times. Not only it becomes very tedious each time we need to modify the code, more critically, it makes reading code very difficult since it breaks the visual structure of the code and creates unnecessary visual noise.

This PR introduces `CH4_CALL` macro to clean up such code.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
