### PR TITLE
Move MPL_ilog function into tree_utils

### DIFF
--- a/src/mpi/coll/algorithms/treealgo/treeutil.c
+++ b/src/mpi/coll/algorithms/treealgo/treeutil.c
@@ -19,6 +19,16 @@ static int tree_add_child(MPIR_Treealgo_tree_t * t, int rank)
     return mpi_errno;
 }
 
+/* Routine to calculate log_k of an integer. Specific to tree based calculations */
+static int tree_ilog(int k, int number)
+{
+    int i = 1, p = k - 1;
+
+    for (; p - 1 < number; i++)
+        p *= k;
+
+    return i;
+}
 
 int MPII_Treeutil_tree_kary_init(int rank, int nranks, int k, int root, MPIR_Treealgo_tree_t * ct)
 {
@@ -188,7 +198,7 @@ int MPII_Treeutil_tree_knomial_2_init(int rank, int nranks, int k, int root,
     if (lrank <= 0)
         ct->parent = -1;
     else {
-        depth = MPL_ilog(k, nranks - 1);
+        depth = tree_ilog(k, nranks - 1);
 
         for (i = 0; i < depth; i++) {
             if (MPL_getdigit(k, lrank, i)) {
@@ -199,7 +209,7 @@ int MPII_Treeutil_tree_knomial_2_init(int rank, int nranks, int k, int root,
     }
 
     /* Children calculation */
-    depth = MPL_ilog(k, nranks - 1);
+    depth = tree_ilog(k, nranks - 1);
     flip_bit = (int *) MPL_calloc(depth, sizeof(int), MPL_MEM_COLL);
 
     for (j = 0; j < depth; j++) {

--- a/src/mpl/include/mpl_math.h
+++ b/src/mpl/include/mpl_math.h
@@ -42,17 +42,6 @@ static inline int MPL_is_pof2(int val, int *ceil_pof2)
         return 0;
 }
 
-/* Routine to calculate log_k of an integer */
-static inline int MPL_ilog(int k, int number)
-{
-    int i = 1, p = k - 1;
-
-    for (; p - 1 < number; i++)
-        p *= k;
-
-    return i;
-}
-
 /* Routing to calculate base^exp for integers */
 static inline int MPL_ipow(int base, int exp)
 {


### PR DESCRIPTION
The function to calculate log with integer base is not implemented
generic enough. It produces different results from one would expect.
Seems like it is specific to tree based calcuations. So moving it from
MPL to tree utils, which will avoid any incorrect results in future, in
case this function is used somewhere else.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
