### PR TITLE
typerep/yaksa: Support disabling GPU support with info hint [3.4.x]

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_internal.h
+++ b/src/mpi/datatype/typerep/src/typerep_internal.h
@@ -14,6 +14,9 @@
 #if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
 
 #include "yaksa.h"
+
+extern yaksa_info_t MPII_yaksa_info_nogpu;
+
 yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type);
 
 #else

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
@@ -364,7 +364,15 @@ void MPIR_Typerep_init(void)
 
     MPI_Aint size;
 
-    yaksa_init(NULL);
+    yaksa_info_create(&MPII_yaksa_info_nogpu);
+    yaksa_info_keyval_append(MPII_yaksa_info_nogpu, "yaksa_gpu_driver", "nogpu", 6);
+
+    if (MPIR_CVAR_ENABLE_GPU) {
+        yaksa_init(NULL);
+    } else {
+        /* prevent yaksa to query gpu devices, which can be very expensive */
+        yaksa_init(MPII_yaksa_info_nogpu);
+    }
 
     MPIR_Datatype_get_size_macro(MPI_REAL16, size);
     yaksa_type_create_contig(size, YAKSA_TYPE__BYTE, NULL, &TYPEREP_YAKSA_TYPE__REAL16);
@@ -374,9 +382,6 @@ void MPIR_Typerep_init(void)
 
     MPIR_Datatype_get_size_macro(MPI_INTEGER16, size);
     yaksa_type_create_contig(size, YAKSA_TYPE__BYTE, NULL, &TYPEREP_YAKSA_TYPE__INTEGER16);
-
-    yaksa_info_create(&MPII_yaksa_info_nogpu);
-    yaksa_info_keyval_append(MPII_yaksa_info_nogpu, "yaksa_gpu_driver", "nogpu", 6);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_INIT);
 }

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
@@ -11,6 +11,8 @@ static yaksa_type_t TYPEREP_YAKSA_TYPE__REAL16;
 static yaksa_type_t TYPEREP_YAKSA_TYPE__COMPLEX32;
 static yaksa_type_t TYPEREP_YAKSA_TYPE__INTEGER16;
 
+yaksa_info_t MPII_yaksa_info_nogpu;
+
 yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPII_TYPEREP_GET_YAKSA_TYPE);
@@ -373,6 +375,9 @@ void MPIR_Typerep_init(void)
     MPIR_Datatype_get_size_macro(MPI_INTEGER16, size);
     yaksa_type_create_contig(size, YAKSA_TYPE__BYTE, NULL, &TYPEREP_YAKSA_TYPE__INTEGER16);
 
+    yaksa_info_create(&MPII_yaksa_info_nogpu);
+    yaksa_info_keyval_append(MPII_yaksa_info_nogpu, "yaksa_gpu_driver", "nogpu", 6);
+
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_INIT);
 }
 
@@ -384,6 +389,8 @@ void MPIR_Typerep_finalize(void)
     yaksa_type_free(TYPEREP_YAKSA_TYPE__REAL16);
     yaksa_type_free(TYPEREP_YAKSA_TYPE__COMPLEX32);
     yaksa_type_free(TYPEREP_YAKSA_TYPE__INTEGER16);
+
+    yaksa_info_free(MPII_yaksa_info_nogpu);
 
     yaksa_finalize();
 


### PR DESCRIPTION
## Pull Request Description

As is possible in `main`, add support for disabling yaksa GPU support with an info hint. This makes it possible to run GPU-aware MPICH on non-GPU nodes, if desired.

Fixes #5423

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
