### PR TITLE
ch4: return node_id -1 for remote processes

### DIFF
--- a/src/mpid/ch4/src/ch4r_proc.c
+++ b/src/mpid/ch4/src/ch4r_proc.c
@@ -20,7 +20,11 @@ int MPIDIU_get_node_id(MPIR_Comm * comm, int rank, int *id_p)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_GET_NODE_ID);
 
     MPIDIU_comm_rank_to_pid(comm, rank, &lpid, &avtid);
-    *id_p = MPIDI_global.node_map[avtid][lpid];
+    if (avtid != 0) {
+        *id_p = -1;
+    } else {
+        *id_p = MPIDI_global.node_map[avtid][lpid];
+    }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_GET_NODE_ID);
     return mpi_errno;


### PR DESCRIPTION
## Pull Request Description
Remote processes, coming from different MPI_COMM_WORLD, can't use shared
memory because the necessary initialization is not done. Let's return
node_id -1 MPIDU_get_node_id as an indication that the process is
remote. This will prevent MPIR_Find_local to include remote processes as
part of local processes.

Fixes #5372 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
