### PR TITLE
ch4/ucx: Cleanup pack/unpack datatype handling

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.c
@@ -26,13 +26,14 @@ static void finish_pack(void *state);
 static void *start_pack(void *context, const void *buffer, size_t count)
 {
     struct pack_state *state;
+    MPIR_Datatype *dt_ptr = context;
 
     /* Todo: Add error handling */
     state = MPL_malloc(sizeof(struct pack_state), MPL_MEM_DATATYPE);
 
     state->buffer = (void *) buffer;
     state->count = count;
-    state->datatype = *((MPI_Datatype *) context);
+    state->datatype = dt_ptr->handle;
 
     return (void *) state;
 }
@@ -40,13 +41,14 @@ static void *start_pack(void *context, const void *buffer, size_t count)
 static void *start_unpack(void *context, void *buffer, size_t count)
 {
     struct pack_state *state;
+    MPIR_Datatype *dt_ptr = context;
 
     /* Todo: Add error handling */
     state = MPL_malloc(sizeof(struct pack_state), MPL_MEM_DATATYPE);
 
     state->buffer = buffer;
     state->count = count;
-    state->datatype = *((MPI_Datatype *) context);
+    state->datatype = dt_ptr->handle;
 
     return (void *) state;
 }


### PR DESCRIPTION
## Pull Request Description

UCX generic datatypes take a context pointer from the user. MPICH passes a
pointer to the MPIR_Datatype struct, but then casted/dereferenced that as an
MPI_Datatype pointer. This worked because the datatype handle is the first
element in the struct, but is fragile and confusing to the reader. Make it more
explicit by accessing the handle directly.

[split out from #5426 since it is mostly unrelated]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
