### PR TITLE
Add reduction support in GPU for MPI collectives

### DIFF
--- a/maint/gen_coll.py
+++ b/maint/gen_coll.py
@@ -467,8 +467,8 @@ def dump_mpir(name, blocking_type):
 
     def dump_buffer_swap_pre():
         G.out.append("void *in_recvbuf = recvbuf;")
-        G.out.append("void *host_sendbuf;")
-        G.out.append("void *host_recvbuf;")
+        G.out.append("void *host_sendbuf = NULL;")
+        G.out.append("void *host_recvbuf = NULL;")
         G.out.append("")
         if name == "reduce_scatter":
             G.out.append("int count = 0;")
@@ -484,7 +484,10 @@ def dump_mpir(name, blocking_type):
         else:
             use_recvbuf = "recvbuf"
 
-        G.out.append("MPIR_Coll_host_buffer_alloc(sendbuf, %s, count, datatype, &host_sendbuf, &host_recvbuf);" % use_recvbuf)
+        G.out.append("if(!MPIR_Typerep_reduce_is_supported(op, datatype))") 
+        G.out.append("  MPIR_Coll_host_buffer_alloc(sendbuf, %s, count, datatype, &host_sendbuf, &host_recvbuf);" % use_recvbuf)
+        G.out.append("")
+
         for buf in ("sendbuf", "recvbuf"):
             G.out.append("if (host_%s) {" % buf);
             G.out.append("    %s = host_%s;" % (buf, buf));

--- a/src/include/mpir_typerep.h
+++ b/src/include/mpir_typerep.h
@@ -85,4 +85,6 @@ int MPIR_Typerep_reduce_is_supported(MPI_Op op, MPI_Datatype datatype);
 int MPIR_Typerep_op(void *source_buf, MPI_Aint source_count, MPI_Datatype source_dtp,
                     void *target_buf, MPI_Aint target_count, MPI_Datatype target_dtp, MPI_Op op,
                     bool source_is_packed);
+int MPIR_Typerep_reduce(const void *in_buf, void *out_buf, MPI_Aint count, MPI_Datatype datatype,
+                        MPI_Op op);
 #endif /* MPIR_TYPEREP_H_INCLUDED */

--- a/src/mpi/coll/reduce_local/reduce_local.c
+++ b/src/mpi/coll/reduce_local/reduce_local.c
@@ -61,9 +61,15 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Dat
         if (mpi_errno != MPI_SUCCESS)
             goto fn_exit;
         /* --END ERROR HANDLING-- */
-        /* get the function by indexing into the op table */
-        uop = MPIR_OP_HDL_TO_FN(op);
-        (*uop) ((void *) inbuf, inoutbuf, &count, &datatype);
+        if (MPIR_Typerep_reduce_is_supported(op, datatype)) {
+            mpi_errno = MPIR_Typerep_reduce(inbuf, inoutbuf, count, datatype, op);
+            if (mpi_errno != MPI_SUCCESS)
+                goto fn_exit;
+        } else {
+            /* get the function by indexing into the op table */
+            uop = MPIR_OP_HDL_TO_FN(op);
+            (*uop) ((void *) inbuf, inoutbuf, &count, &datatype);
+        }
     } else {
         MPIR_Op_get_ptr(op, op_ptr);
 

--- a/src/mpi/datatype/typerep/dataloop/dataloop.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop.c
@@ -190,6 +190,17 @@ int MPIR_Typerep_reduce_is_supported(MPI_Op op, MPI_Datatype datatype)
     return 0;
 }
 
+int MPIR_Typerep_reduce(const void *in_buf, void *out_buf, MPI_Aint count, MPI_Datatype datatype,
+                        MPI_Op op)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    /* This function is supposed to return non-zero only for yaksa */
+    MPIR_Assert(0);
+
+    return mpi_errno;
+}
+
 /*@
   MPII_Dataloop_update - update pointers after a copy operation
 

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -429,6 +429,25 @@ static int typerep_op_unpack(void *source_buf, void *target_buf, MPI_Aint count,
 static int typerep_op_pack(void *source_buf, void *target_buf, MPI_Aint count,
                            MPI_Datatype datatype, MPI_Op op);
 
+int MPIR_Typerep_reduce(const void *in_buf, void *out_buf, MPI_Aint count, MPI_Datatype datatype,
+                        MPI_Op op)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TYPEREP_REDUCE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TYPEREP_REDUCE);
+
+    mpi_errno = typerep_op_pack((void *) in_buf, out_buf, count, datatype, op);
+
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TYPEREP_REDUCE);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPIR_Typerep_op(void *source_buf, MPI_Aint source_count, MPI_Datatype source_dtp,
                     void *target_buf, MPI_Aint target_count, MPI_Datatype target_dtp, MPI_Op op,
                     bool source_is_packed)


### PR DESCRIPTION
The compute collectives do not need to move data from GPU to host if
the operation is supported in yaksa. MPI collectives use built-in ops
only for built-in datatypes (for user-defined types, the ops also have
 to be user-defined). Therefore, for collectives, yaksa reduction is
 supported for built-in types.

## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
