### PR TITLE
examples: remove call to `exit` from thread function

### DIFF
--- a/examples/developers/threads.c
+++ b/examples/developers/threads.c
@@ -91,7 +91,6 @@ void *thrdsub(void *arg)
             MPI_Recv(r_buff, 1024, MPI_CHAR, 1, mythrdrank, MPI_COMM_WORLD, &status);
             if (strcmp(s_buff, r_buff) != 0) {
                 printf("comm_rank=%d mythrdrank=%d bad recv\n", comm_rank, mythrdrank);
-                exit(-1);
             }
             if (thread_level_provided == MPI_THREAD_SINGLE ||
                 thread_level_provided == MPI_THREAD_FUNNELED) {
@@ -106,7 +105,6 @@ void *thrdsub(void *arg)
             MPI_Recv(r_buff, 1024, MPI_CHAR, 0, mythrdrank, MPI_COMM_WORLD, &status);
             if (strcmp(s_buff, r_buff) != 0) {
                 printf("comm_rank=%d mythrdrank=%d bad recv\n", comm_rank, mythrdrank);
-                exit(-1);
             }
             MPI_Send(s_buff, strlen(s_buff) + 1, MPI_CHAR, 0, mythrdrank, MPI_COMM_WORLD);
             if (thread_level_provided == MPI_THREAD_SINGLE ||


### PR DESCRIPTION
## Pull Request Description
The exit call in the thread functions have potential thread racing
issues and may leave another process hanging. I think it is unnecessary
for the example and may cause more confusion.

Fixes #5444

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
