### PR TITLE
test: fix io/zero_count test fo out-of-tree execution

### DIFF
--- a/test/mpi/io/zero_count.c
+++ b/test/mpi/io/zero_count.c
@@ -18,14 +18,14 @@ int main(int argc, char **argv)
     int errs = 0;
     int len, rank, get_size;
     char buf[10];
-    const char *filename = __FILE__;
+    const char *filename = argv[0];
     MPI_File fh;
     MPI_Status status;
 
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
+    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
 
     if (rank == 0)
         len = 10;


### PR DESCRIPTION
## Pull Request Description
The io/zero_count test tries to read from its source file. This only works as long the source file is located within the directory where the test is executed (e.g., directly within the source tree). This patch opens the binary for reading instead always fulfilling this condition.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
