### PR TITLE
ch4/part: Revert nm/shm hooks

### DIFF
--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -150,9 +150,6 @@ Native API:
   mpi_precv_init : int
       NM: buf-2, partitions, count, datatype, rank, tag, comm, info, av, req_p
      SHM: buf-2, partitions, count, datatype, rank, tag, comm, info, av, req_p
-  precv_matched_hook : int
-      NM: req
-     SHM: req
   part_start : int
       NM*: req
       SHM*: req

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -144,10 +144,10 @@ Native API:
   mpi_cancel_recv : int
       NM*: rreq
      SHM*: rreq
-  mpi_psend_init_hook : int
+  mpi_psend_init : int
       NM: buf-2, partitions, count, datatype, rank, tag, comm, info, av, req_p
      SHM: buf-2, partitions, count, datatype, rank, tag, comm, info, av, req_p
-  mpi_precv_init_hook : int
+  mpi_precv_init : int
       NM: buf-2, partitions, count, datatype, rank, tag, comm, info, av, req_p
      SHM: buf-2, partitions, count, datatype, rank, tag, comm, info, av, req_p
   precv_matched_hook : int

--- a/src/mpid/ch4/generic/am/mpidig_am_part.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part.c
@@ -87,14 +87,6 @@ void MPIDIG_precv_matched(MPIR_Request * part_req)
                                      (int) rdata_size, (int) sdata_size);
         }
     }
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(part_req, is_local))
-        MPIDI_SHM_precv_matched_hook(part_req);
-    else
-#endif
-    {
-        MPIDI_NM_precv_matched_hook(part_req);
-    }
 }
 
 int MPIDIG_mpi_psend_init(void *buf, int partitions, MPI_Aint count,

--- a/src/mpid/ch4/netmod/ofi/ofi_part.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_part.c
@@ -23,8 +23,3 @@ int MPIDI_OFI_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
     return MPIDIG_mpi_precv_init(buf, partitions, count, datatype, source, tag, comm,
                                  info, request);
 }
-
-int MPIDI_OFI_precv_matched_hook(MPIR_Request * part_req)
-{
-    return MPI_SUCCESS;
-}

--- a/src/mpid/ch4/netmod/ofi/ofi_part.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_part.c
@@ -7,20 +7,21 @@
 #include "ofi_impl.h"
 #include "ofi_noinline.h"
 
-int MPIDI_OFI_mpi_psend_init_hook(void *buf, int partitions, MPI_Aint count,
-                                  MPI_Datatype datatype, int dest, int tag,
-                                  MPIR_Comm * comm, MPIR_Info * info,
-                                  MPIDI_av_entry_t * av, MPIR_Request ** request)
+int MPIDI_OFI_mpi_psend_init(void *buf, int partitions, MPI_Aint count,
+                             MPI_Datatype datatype, int dest, int tag,
+                             MPIR_Comm * comm, MPIR_Info * info,
+                             MPIDI_av_entry_t * av, MPIR_Request ** request)
 {
-    return MPI_SUCCESS;
+    return MPIDIG_mpi_psend_init(buf, partitions, count, datatype, dest, tag, comm, info, request);
 }
 
-int MPIDI_OFI_mpi_precv_init_hook(void *buf, int partitions, MPI_Aint count,
-                                  MPI_Datatype datatype, int source, int tag,
-                                  MPIR_Comm * comm, MPIR_Info * info,
-                                  MPIDI_av_entry_t * av, MPIR_Request ** request)
+int MPIDI_OFI_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
+                             MPI_Datatype datatype, int source, int tag,
+                             MPIR_Comm * comm, MPIR_Info * info,
+                             MPIDI_av_entry_t * av, MPIR_Request ** request)
 {
-    return MPI_SUCCESS;
+    return MPIDIG_mpi_precv_init(buf, partitions, count, datatype, source, tag, comm,
+                                 info, request);
 }
 
 int MPIDI_OFI_precv_matched_hook(MPIR_Request * part_req)

--- a/src/mpid/ch4/netmod/ucx/ucx_part.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_part.c
@@ -7,20 +7,21 @@
 #include "ucx_impl.h"
 #include "ucx_noinline.h"
 
-int MPIDI_UCX_mpi_psend_init_hook(void *buf, int partitions, MPI_Aint count,
-                                  MPI_Datatype datatype, int dest, int tag,
-                                  MPIR_Comm * comm, MPIR_Info * info,
-                                  MPIDI_av_entry_t * av, MPIR_Request ** request)
+int MPIDI_UCX_mpi_psend_init(void *buf, int partitions, MPI_Aint count,
+                             MPI_Datatype datatype, int dest, int tag,
+                             MPIR_Comm * comm, MPIR_Info * info,
+                             MPIDI_av_entry_t * av, MPIR_Request ** request)
 {
-    return MPI_SUCCESS;
+    return MPIDIG_mpi_psend_init(buf, partitions, count, datatype, dest, tag, comm, info, request);
 }
 
-int MPIDI_UCX_mpi_precv_init_hook(void *buf, int partitions, MPI_Aint count,
-                                  MPI_Datatype datatype, int source, int tag,
-                                  MPIR_Comm * comm, MPIR_Info * info,
-                                  MPIDI_av_entry_t * av, MPIR_Request ** request)
+int MPIDI_UCX_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
+                             MPI_Datatype datatype, int source, int tag,
+                             MPIR_Comm * comm, MPIR_Info * info,
+                             MPIDI_av_entry_t * av, MPIR_Request ** request)
 {
-    return MPI_SUCCESS;
+    return MPIDIG_mpi_precv_init(buf, partitions, count, datatype, source, tag, comm,
+                                 info, request);
 }
 
 int MPIDI_UCX_precv_matched_hook(MPIR_Request * part_req)

--- a/src/mpid/ch4/netmod/ucx/ucx_part.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_part.c
@@ -5,7 +5,6 @@
 
 #include "mpidimpl.h"
 #include "ucx_impl.h"
-#include "ucx_noinline.h"
 
 int MPIDI_UCX_mpi_psend_init(void *buf, int partitions, MPI_Aint count,
                              MPI_Datatype datatype, int dest, int tag,
@@ -22,9 +21,4 @@ int MPIDI_UCX_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
 {
     return MPIDIG_mpi_precv_init(buf, partitions, count, datatype, source, tag, comm,
                                  info, request);
-}
-
-int MPIDI_UCX_precv_matched_hook(MPIR_Request * part_req)
-{
-    return MPI_SUCCESS;
 }

--- a/src/mpid/ch4/shm/posix/posix_part.c
+++ b/src/mpid/ch4/shm/posix/posix_part.c
@@ -6,20 +6,21 @@
 #include "mpidimpl.h"
 #include "posix_noinline.h"
 
-int MPIDI_POSIX_mpi_psend_init_hook(void *buf, int partitions, MPI_Aint count,
-                                    MPI_Datatype datatype, int dest, int tag,
-                                    MPIR_Comm * comm, MPIR_Info * info,
-                                    MPIDI_av_entry_t * av, MPIR_Request ** request)
+int MPIDI_POSIX_mpi_psend_init(void *buf, int partitions, MPI_Aint count,
+                               MPI_Datatype datatype, int dest, int tag,
+                               MPIR_Comm * comm, MPIR_Info * info,
+                               MPIDI_av_entry_t * av, MPIR_Request ** request)
 {
-    return MPI_SUCCESS;
+    return MPIDIG_mpi_psend_init(buf, partitions, count, datatype, dest, tag, comm, info, request);
 }
 
-int MPIDI_POSIX_mpi_precv_init_hook(void *buf, int partitions, MPI_Aint count,
-                                    MPI_Datatype datatype, int source, int tag,
-                                    MPIR_Comm * comm, MPIR_Info * info,
-                                    MPIDI_av_entry_t * av, MPIR_Request ** request)
+int MPIDI_POSIX_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
+                               MPI_Datatype datatype, int source, int tag,
+                               MPIR_Comm * comm, MPIR_Info * info,
+                               MPIDI_av_entry_t * av, MPIR_Request ** request)
 {
-    return MPI_SUCCESS;
+    return MPIDIG_mpi_precv_init(buf, partitions, count, datatype, source, tag, comm,
+                                 info, request);
 }
 
 int MPIDI_POSIX_precv_matched_hook(MPIR_Request * part_req)

--- a/src/mpid/ch4/shm/posix/posix_part.c
+++ b/src/mpid/ch4/shm/posix/posix_part.c
@@ -22,8 +22,3 @@ int MPIDI_POSIX_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
     return MPIDIG_mpi_precv_init(buf, partitions, count, datatype, source, tag, comm,
                                  info, request);
 }
-
-int MPIDI_POSIX_precv_matched_hook(MPIR_Request * part_req)
-{
-    return MPI_SUCCESS;
-}

--- a/src/mpid/ch4/shm/src/shm_part.c
+++ b/src/mpid/ch4/shm/src/shm_part.c
@@ -7,22 +7,22 @@
 #include "shm_noinline.h"
 #include "../posix/posix_noinline.h"
 
-int MPIDI_SHM_mpi_psend_init_hook(void *buf, int partitions, MPI_Aint count,
-                                  MPI_Datatype datatype, int dest, int tag,
-                                  MPIR_Comm * comm, MPIR_Info * info,
-                                  MPIDI_av_entry_t * av, MPIR_Request ** request)
+int MPIDI_SHM_mpi_psend_init(void *buf, int partitions, MPI_Aint count,
+                             MPI_Datatype datatype, int dest, int tag,
+                             MPIR_Comm * comm, MPIR_Info * info,
+                             MPIDI_av_entry_t * av, MPIR_Request ** request)
 {
-    return MPIDI_POSIX_mpi_psend_init_hook(buf, partitions, count, datatype, dest, tag, comm,
-                                           info, av, request);
+    return MPIDI_POSIX_mpi_psend_init(buf, partitions, count, datatype, dest, tag, comm,
+                                      info, av, request);
 }
 
-int MPIDI_SHM_mpi_precv_init_hook(void *buf, int partitions, MPI_Aint count,
-                                  MPI_Datatype datatype, int source, int tag,
-                                  MPIR_Comm * comm, MPIR_Info * info,
-                                  MPIDI_av_entry_t * av, MPIR_Request ** request)
+int MPIDI_SHM_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
+                             MPI_Datatype datatype, int source, int tag,
+                             MPIR_Comm * comm, MPIR_Info * info,
+                             MPIDI_av_entry_t * av, MPIR_Request ** request)
 {
-    return MPIDI_POSIX_mpi_precv_init_hook(buf, partitions, count, datatype, source, tag, comm,
-                                           info, av, request);
+    return MPIDI_POSIX_mpi_precv_init(buf, partitions, count, datatype, source, tag, comm,
+                                      info, av, request);
 }
 
 int MPIDI_SHM_precv_matched_hook(MPIR_Request * part_req)

--- a/src/mpid/ch4/shm/src/shm_part.c
+++ b/src/mpid/ch4/shm/src/shm_part.c
@@ -24,8 +24,3 @@ int MPIDI_SHM_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
     return MPIDI_POSIX_mpi_precv_init(buf, partitions, count, datatype, source, tag, comm,
                                       info, av, request);
 }
-
-int MPIDI_SHM_precv_matched_hook(MPIR_Request * part_req)
-{
-    return MPIDI_POSIX_precv_matched_hook(part_req);
-}

--- a/src/mpid/ch4/src/ch4_part.c
+++ b/src/mpid/ch4/src/ch4_part.c
@@ -16,19 +16,15 @@ int MPID_Psend_init(void *buf, int partitions, MPI_Aint count,
 
     MPIDI_av_entry_t *av = MPIDIU_comm_rank_to_av(comm, dest);
 
-    mpi_errno =
-        MPIDIG_mpi_psend_init(buf, partitions, count, datatype, dest, tag, comm, info, request);
-    MPIR_ERR_CHECK(mpi_errno);
-
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(*request, is_local)) {
-        mpi_errno = MPIDI_SHM_mpi_psend_init_hook(buf, partitions, count, datatype, dest, tag,
-                                                  comm, info, av, request);
+        mpi_errno = MPIDI_SHM_mpi_psend_init(buf, partitions, count, datatype, dest, tag,
+                                             comm, info, av, request);
     } else
 #endif
     {
-        mpi_errno = MPIDI_NM_mpi_psend_init_hook(buf, partitions, count, datatype, dest, tag,
-                                                 comm, info, av, request);
+        mpi_errno = MPIDI_NM_mpi_psend_init(buf, partitions, count, datatype, dest, tag,
+                                            comm, info, av, request);
     }
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -50,19 +46,15 @@ int MPID_Precv_init(void *buf, int partitions, MPI_Aint count,
 
     MPIDI_av_entry_t *av = MPIDIU_comm_rank_to_av(comm, source);
 
-    mpi_errno =
-        MPIDIG_mpi_precv_init(buf, partitions, count, datatype, source, tag, comm, info, request);
-    MPIR_ERR_CHECK(mpi_errno);
-
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(*request, is_local)) {
-        mpi_errno = MPIDI_SHM_mpi_precv_init_hook(buf, partitions, count, datatype,
-                                                  source, tag, comm, info, av, request);
+        mpi_errno = MPIDI_SHM_mpi_precv_init(buf, partitions, count, datatype,
+                                             source, tag, comm, info, av, request);
     } else
 #endif
     {
-        mpi_errno = MPIDI_NM_mpi_precv_init_hook(buf, partitions, count, datatype,
-                                                 source, tag, comm, info, av, request);
+        mpi_errno = MPIDI_NM_mpi_precv_init(buf, partitions, count, datatype,
+                                            source, tag, comm, info, av, request);
     }
     MPIR_ERR_CHECK(mpi_errno);
 


### PR DESCRIPTION
## Pull Request Description

The work to add nm/shm hooks into the partitioned communication initialization process has been negatively received. Revert the hooks that have been added. Future PRs will reimplement generic layer initialization in the lower layers.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
