### PR TITLE
ch4/part: fix typo in checking locality

### DIFF
--- a/src/mpid/ch4/src/ch4_part.c
+++ b/src/mpid/ch4/src/ch4_part.c
@@ -16,16 +16,8 @@ int MPID_Psend_init(void *buf, int partitions, MPI_Aint count,
 
     MPIDI_av_entry_t *av = MPIDIU_comm_rank_to_av(comm, dest);
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(*request, is_local)) {
-        mpi_errno = MPIDI_SHM_mpi_psend_init(buf, partitions, count, datatype, dest, tag,
-                                             comm, info, av, request);
-    } else
-#endif
-    {
-        mpi_errno = MPIDI_NM_mpi_psend_init(buf, partitions, count, datatype, dest, tag,
-                                            comm, info, av, request);
-    }
+    CH4_CALL(mpi_psend_init(buf, partitions, count, datatype, dest, tag, comm, info, av, request),
+             MPIDI_av_is_local(av), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -46,16 +38,9 @@ int MPID_Precv_init(void *buf, int partitions, MPI_Aint count,
 
     MPIDI_av_entry_t *av = MPIDIU_comm_rank_to_av(comm, source);
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(*request, is_local)) {
-        mpi_errno = MPIDI_SHM_mpi_precv_init(buf, partitions, count, datatype,
-                                             source, tag, comm, info, av, request);
-    } else
-#endif
-    {
-        mpi_errno = MPIDI_NM_mpi_precv_init(buf, partitions, count, datatype,
-                                            source, tag, comm, info, av, request);
-    }
+    CH4_CALL(mpi_precv_init(buf, partitions, count, datatype,
+                            source, tag, comm, info, av, request),
+             MPIDI_av_is_local(av), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:


### PR DESCRIPTION
## Pull Request Description
Previous reverts (#5459) resulted in broken code in checking locality. We can't
use request to check for locality when it is not allocated.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
