### PR TITLE
ch4/shm: fix a potential wrong package level

### DIFF
--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -161,12 +161,13 @@ int MPIR_Comm_split_type_hw_guided(MPIR_Comm * comm_ptr, int key, MPIR_Info * in
     /* only proceed when we have a proper gid, i.e. bindset belongs to a
      * single instance of given resource_type */
     MPIR_hwtopo_gid_t gid = MPIR_hwtopo_get_obj_by_name(resource_type);
-    if (gid != MPIR_HWTOPO_GID_ROOT) {
-        mpi_errno = MPIR_Comm_split_impl(node_comm, gid, key, newcomm_ptr);
-        MPIR_ERR_CHECK(mpi_errno);
-    } else {
+    mpi_errno = MPIR_Comm_split_impl(node_comm, gid, key, newcomm_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if ((*newcomm_ptr)->remote_size == node_comm->remote_size) {
+        /* failed to result in a proper split */
+        MPIR_Comm_free_impl(*newcomm_ptr);
         *newcomm_ptr = NULL;
-        goto fn_exit;
     }
 
   fn_exit:

--- a/src/mpid/ch4/shm/src/topotree.c
+++ b/src/mpid/ch4/shm/src/topotree.c
@@ -126,7 +126,7 @@ int MPIDI_SHM_topotree_get_package_level(int topo_depth, int *max_entries_per_le
         }
     }
     /* STEP 3.3. Determine the package level based on first level (top-down) with #nodes >1 */
-    socket_level = topo_depth;
+    socket_level = 0;   /* if all ranks are in the same index at all levels, just use level 0 */
     {
         for (i = topo_depth - 1; i >= 0; --i) {
             if (max_entries_per_level[i] > 1) {

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -198,6 +198,9 @@ if (defined($ENV{'MPITEST_PPNMAX'})) {
 if (defined($ENV{'MPITEST_TIMELIMITARG'})) {
     $timelimitArg = $ENV{'MPITEST_TIMELIMITARG'};
 }
+if (defined($ENV{'MPITEST_MPIEXECARG'})) {
+    $g_opt->{mpiexecargs} = $ENV{'MPITEST_MPIEXECARG'};
+}
 
 #---------------------------------------------------------------------------
 # Process arguments and override any defaults
@@ -702,6 +705,9 @@ sub RunMPIProgram {
     my $progArgs = join(' ', @{$test_opt->{args}});
     my $progEnv = join(' ', @{$test_opt->{envs}});
     my $mpiexecArgs = join(' ', @{$test_opt->{mpiexecargs}});
+    if (!$mpiexecArgs and $g_opt->{mpiexecargs}) {
+        $mpiexecArgs = $g_opt->{mpiexecargs};
+    }
 
     my $found_error   = 0;
     my $found_noerror = 0;


### PR DESCRIPTION
## Pull Request Description
In MPIDI_SHM_topotree_get_package_level, when all ranks are in the same
index at all levels (e.g. with --bind-to core:2), the old code result in
package_level to topo_depth, which is an invalid index. Use 0 in stead.

Partially fixes #5133 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
