### PR TITLE
autogen: add set -e

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -756,6 +756,7 @@ else
     error "README.vin file not present, unable to update README version number (perhaps we are running in a release tarball source tree?)"
 fi
 
+set -e
 
 ########################################################################
 ## Building subsys_include.m4
@@ -1004,7 +1005,7 @@ if [ "$do_build_configure" = "yes" ] ; then
             # Patching ltmain.sh
             if [ -f $amdir/confdb/ltmain.sh ] ; then
                 echo_n "Patching ltmain.sh for compatibility with Intel compiler options... "
-                patch -N -s -l $amdir/confdb/ltmain.sh maint/patches/optional/confdb/intel-compiler.patch
+                patch -N -s -l $amdir/confdb/ltmain.sh maint/patches/optional/confdb/intel-compiler.patch && :
                 if [ $? -eq 0 ] ; then
                     # Remove possible leftovers, which don't imply a failure
                     rm -f $amdir/confdb/ltmain.sh.orig
@@ -1031,7 +1032,7 @@ if [ "$do_build_configure" = "yes" ] ; then
                 sys_lib_dlsearch_path_patch_requires_rebuild=no
                 macos_patch_requires_rebuild=no
                 echo_n "Patching libtool.m4 for system dynamic library search path..."
-                patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/sys_lib_dlsearch_path_spec.patch
+                patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/sys_lib_dlsearch_path_spec.patch && :
                 if [ $? -eq 0 ] ; then
                     sys_lib_dlsearch_path_patch_requires_rebuild=yes
                     # Remove possible leftovers, which don't imply a failure
@@ -1041,7 +1042,7 @@ if [ "$do_build_configure" = "yes" ] ; then
                     echo "failed"
                 fi
                 echo_n "Patching libtool.m4 for compatibility macOS BigSur..."
-                patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/big-sur.patch
+                patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/big-sur.patch && :
                 if [ $? -eq 0 ] ; then
                     macos_patch_requires_rebuild=yes
                     # Remove possible leftovers, which don't imply a failure
@@ -1052,7 +1053,7 @@ if [ "$do_build_configure" = "yes" ] ; then
                 fi
                 if [ $do_bindings = "yes" ] ; then
                     echo_n "Patching libtool.m4 for compatibility with ifort on OSX... "
-                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/darwin-ifort.patch
+                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/darwin-ifort.patch && :
                     if [ $? -eq 0 ] ; then
                         ifort_patch_requires_rebuild=yes
                         # Remove possible leftovers, which don't imply a failure
@@ -1062,7 +1063,7 @@ if [ "$do_build_configure" = "yes" ] ; then
                         echo "failed"
                     fi
                     echo_n "Patching libtool.m4 for fort compatibility with Oracle Dev Studio 12.6..."
-                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/oracle-fort.patch
+                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/oracle-fort.patch && :
                     if [ $? -eq 0 ] ; then
                         oracle_patch_requires_rebuild=yes
                         # Remove possible leftovers, which don't imply a failure
@@ -1072,7 +1073,7 @@ if [ "$do_build_configure" = "yes" ] ; then
                         echo "failed"
                     fi
                     echo_n "Patching libtool.m4 for compatibility with Flang..."
-                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/flang.patch
+                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/flang.patch && :
                     if [ $? -eq 0 ] ; then
                         flang_patch_requires_rebuild=yes
                         # Remove possible leftovers, which don't imply a failure
@@ -1082,7 +1083,7 @@ if [ "$do_build_configure" = "yes" ] ; then
                         echo "failed"
                     fi
                     echo_n "Patching libtool.m4 for compatibility with Arm LLVM compilers..."
-                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/arm-compiler.patch
+                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/arm-compiler.patch && :
                     if [ $? -eq 0 ] ; then
                         arm_patch_requires_rebuild=yes
                         # Remove possible leftovers, which don't imply a failure
@@ -1092,7 +1093,7 @@ if [ "$do_build_configure" = "yes" ] ; then
                         echo "failed"
                     fi
                     echo_n "Patching libtool.m4 for compatibility with IBM XL Fortran compilers..."
-                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/ibm-xlf.patch
+                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/ibm-xlf.patch && :
                     if [ $? -eq 0 ] ; then
                         ibm_patch_requires_rebuild=yes
                         # Remove possible leftovers, which don't imply a failure


### PR DESCRIPTION
## Pull Request Description
Add set -e so the autogen will fail when one of the command fail. The
set -e is added in the middle of the script after basic checks are done
-- other wise it will always trigger. This should prevent it proceed
happily after a python script error and difficult for user to spot
issues.

Fixes #5455
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
