### PR TITLE
romio: properly free my_req and others_req

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.h
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.h
@@ -56,28 +56,18 @@ void ADIOI_GPFS_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset
                             int **count_my_req_per_proc_ptr,
                             ADIOI_Access ** my_req_ptr, MPI_Aint ** buf_idx_ptr);
 
-    /*
-     * ADIOI_Calc_others_req
-     *
-     * param[in]  count_my_req_procs        Number of processes whose file domain my
-     *                                        request touches.
-     * param[in]  count_my_req_per_proc     count_my_req_per_proc[i] gives the no. of
-     *                                        contig. requests of this process in
-     *                                        process i's file domain.
-     * param[in]  my_req                    A structure defining my request
-     * param[in]  nprocs                    Number of nodes in the block
-     * param[in]  myrank                    Rank of this node
-     * param[out] count_others_req_proc_ptr Number of processes whose requests lie in
-     *                                        my process's file domain (including my
-     *                                        process itself)
-     * param[out] others_req_ptr            Array of other process' requests that lie
-     *                                        in my process's file domain
-     */
+void ADIOI_GPFS_Free_my_req(int nprocs, int *count_my_req_per_proc,
+                            ADIOI_Access * my_req, MPI_Aint * buf_idx);
+
 void ADIOI_GPFS_Calc_others_req(ADIO_File fd, int count_my_req_procs,
                                 int *count_my_req_per_proc,
                                 ADIOI_Access * my_req,
                                 int nprocs, int myrank,
-                                int *count_others_req_procs_ptr, ADIOI_Access ** others_req_ptr);
+                                int *count_others_req_procs_ptr,
+                                int **count_others_req_per_proc_ptr,
+                                ADIOI_Access ** others_req_ptr);
 
+void ADIOI_GPFS_Free_others_req(int nprocs, int *count_others_req_per_proc,
+                                ADIOI_Access * others_req);
 
 #endif /* AD_GPFS_AGGRS_H_INCLUDED */

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -101,7 +101,8 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
 
     int i, filetype_is_contig, nprocs, nprocs_for_coll, myrank;
     int contig_access_count = 0, interleave_count = 0, buftype_is_contig;
-    int *count_my_req_per_proc, count_my_req_procs, count_others_req_procs;
+    int *count_my_req_per_proc, count_my_req_procs;
+    int *count_others_req_per_proc, count_others_req_procs;
     ADIO_Offset start_offset, end_offset, orig_fp, fd_size, min_st_offset, off;
     ADIO_Offset *offset_list = NULL, *st_offsets = NULL, *fd_start = NULL,
         *fd_end = NULL, *end_offsets = NULL;
@@ -397,22 +398,15 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
     if (gpfsmpio_tuneblocking)
         ADIOI_GPFS_Calc_others_req(fd, count_my_req_procs,
                                    count_my_req_per_proc, my_req,
-                                   nprocs, myrank, &count_others_req_procs, &others_req);
+                                   nprocs, myrank, &count_others_req_procs,
+                                   &count_others_req_per_proc, &others_req);
     else
         ADIOI_Calc_others_req(fd, count_my_req_procs,
                               count_my_req_per_proc, my_req,
-                              nprocs, myrank, &count_others_req_procs, &others_req);
+                              nprocs, myrank, &count_others_req_procs,
+                              &count_others_req_per_proc, &others_req);
 
     GPFSMPIO_T_CIO_SET_GET(r, 1, 1, GPFSMPIO_CIO_T_DEXCH, GPFSMPIO_CIO_T_OTHREQ);
-
-    /* my_req[] and count_my_req_per_proc aren't needed at this point, so
-     * let's free the memory
-     */
-    ADIOI_Free(count_my_req_per_proc);
-    if (my_req[0].offsets) {
-        ADIOI_Free(my_req[0].offsets);
-    }
-    ADIOI_Free(my_req);
 
     /* read data in sizes of no more than ADIOI_Coll_bufsize,
      * communicate, and fill user buf.
@@ -427,15 +421,14 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
     GPFSMPIO_T_CIO_REPORT(0, fd, myrank, nprocs);
 
     /* free all memory allocated for collective I/O */
-    if (others_req[0].offsets) {
-        ADIOI_Free(others_req[0].offsets);
+    if (gpfsmpio_tuneblocking) {
+        ADIOI_GPFS_Free_my_req(nprocs, count_my_req_per_proc, my_req, buf_idx);
+        ADIOI_GPFS_Free_others_req(nprocs, count_others_req_per_proc, others_req);
+    } else {
+        ADIOI_Free_my_req(nprocs, count_my_req_per_proc, my_req, buf_idx);
+        ADIOI_Free_others_req(nprocs, count_others_req_per_proc, others_req);
     }
-    if (others_req[0].mem_ptrs) {
-        ADIOI_Free(others_req[0].mem_ptrs);
-    }
-    ADIOI_Free(others_req);
 
-    ADIOI_Free(buf_idx);
     ADIOI_Free(offset_list);
     ADIOI_Free(st_offsets);
     ADIOI_Free(fd_start);

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -108,7 +108,8 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
 
     int i, filetype_is_contig, nprocs, nprocs_for_coll, myrank;
     int contig_access_count = 0, interleave_count = 0, buftype_is_contig;
-    int *count_my_req_per_proc, count_my_req_procs, count_others_req_procs;
+    int *count_my_req_per_proc, count_my_req_procs;
+    int *count_others_req_per_proc, count_others_req_procs;
     ADIO_Offset orig_fp, start_offset, end_offset, fd_size, min_st_offset, off;
     ADIO_Offset *offset_list = NULL, *st_offsets = NULL, *fd_start = NULL,
         *fd_end = NULL, *end_offsets = NULL;
@@ -424,19 +425,15 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     if (gpfsmpio_tuneblocking)
         ADIOI_GPFS_Calc_others_req(fd, count_my_req_procs,
                                    count_my_req_per_proc, my_req,
-                                   nprocs, myrank, &count_others_req_procs, &others_req);
+                                   nprocs, myrank, &count_others_req_procs,
+                                   &count_others_req_per_proc, &others_req);
     else
         ADIOI_Calc_others_req(fd, count_my_req_procs,
                               count_my_req_per_proc, my_req,
-                              nprocs, myrank, &count_others_req_procs, &others_req);
+                              nprocs, myrank, &count_others_req_procs,
+                              &count_my_req_per_proc, &others_req);
 
     GPFSMPIO_T_CIO_SET_GET(w, 1, 1, GPFSMPIO_CIO_T_DEXCH, GPFSMPIO_CIO_T_OTHREQ);
-
-    ADIOI_Free(count_my_req_per_proc);
-    if (my_req[0].offsets) {
-        ADIOI_Free(my_req[0].offsets);
-    }
-    ADIOI_Free(my_req);
 
     /* exchange data and write in sizes of no more than coll_bufsize. */
     ADIOI_Exch_and_write(fd, buf, datatype, nprocs, myrank,
@@ -449,15 +446,14 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     GPFSMPIO_T_CIO_REPORT(1, fd, myrank, nprocs);
 
     /* free all memory allocated for collective I/O */
-    if (others_req[0].offsets) {
-        ADIOI_Free(others_req[0].offsets);
+    if (gpfsmpio_tuneblocking) {
+        ADIOI_GPFS_Free_my_req(nprocs, count_my_req_per_proc, my_req, buf_idx);
+        ADIOI_GPFS_Free_others_req(nprocs, count_others_req_per_proc, others_req);
+    } else {
+        ADIOI_Free_my_req(nprocs, count_my_req_per_proc, my_req, buf_idx);
+        ADIOI_Free_others_req(nprocs, count_others_req_per_proc, others_req);
     }
-    if (others_req[0].mem_ptrs) {
-        ADIOI_Free(others_req[0].mem_ptrs);
-    }
-    ADIOI_Free(others_req);
 
-    ADIOI_Free(buf_idx);
     ADIOI_Free(offset_list);
     ADIOI_Free(st_offsets);
     ADIOI_Free(fd_start);

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre.h
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre.h
@@ -84,6 +84,8 @@ void ADIOI_LUSTRE_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list,
                               int *count_my_req_procs_ptr,
                               int **count_my_req_per_proc_ptr,
                               ADIOI_Access ** my_req_ptr, ADIO_Offset *** buf_idx_ptr);
+void ADIOI_LUSTRE_Free_my_req(int nprocs, int *count_my_req_per_proc,
+                              ADIOI_Access * my_req, ADIO_Offset ** buf_idx);
 
 int ADIOI_LUSTRE_Calc_aggregator(ADIO_File fd, ADIO_Offset off,
                                  ADIO_Offset * len, int *striping_info);

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_aggregate.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_aggregate.c
@@ -311,3 +311,12 @@ int ADIOI_LUSTRE_Docollect(ADIO_File fd, int contig_access_count,
 
     return docollect;
 }
+
+void ADIOI_LUSTRE_Free_my_req(int nprocs, int *count_my_req_per_proc,
+                              ADIOI_Access * my_req, ADIO_Offset ** buf_idx)
+{
+    ADIOI_Free(count_my_req_per_proc);
+    ADIOI_Free(buf_idx[0]);
+    ADIOI_Free(buf_idx);
+    ADIOI_Free(my_req);
+}

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -105,7 +105,8 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
 
     int i, filetype_is_contig, nprocs, myrank, do_collect = 0;
     int contig_access_count = 0, buftype_is_contig, interleave_count = 0;
-    int *count_my_req_per_proc, count_my_req_procs, count_others_req_procs;
+    int *count_my_req_per_proc, count_my_req_procs;
+    int *count_others_req_per_proc, count_others_req_procs;
     ADIO_Offset orig_fp, start_offset, end_offset, off;
     ADIO_Offset *offset_list = NULL, *st_offsets = NULL, *end_offsets = NULL;
     ADIO_Offset *len_list = NULL;
@@ -295,8 +296,8 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
      */
 
     ADIOI_Calc_others_req(fd, count_my_req_procs, count_my_req_per_proc,
-                          my_req, nprocs, myrank, &count_others_req_procs, &others_req);
-    ADIOI_Free(count_my_req_per_proc);
+                          my_req, nprocs, myrank, &count_others_req_procs,
+                          &count_others_req_per_proc, &others_req);
 
     /* exchange data and write in sizes of no more than stripe_size. */
     ADIOI_LUSTRE_Exch_and_write(fd, buf, datatype, nprocs, myrank,
@@ -338,12 +339,8 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
 
     /* free all memory allocated for collective I/O */
     /* free others_req */
-    ADIOI_Free(others_req[0].offsets);
-    ADIOI_Free(others_req[0].mem_ptrs);
-    ADIOI_Free(others_req);
-    ADIOI_Free(buf_idx[0]);     /* also my_req[*].offsets and my_req[*].lens */
-    ADIOI_Free(buf_idx);
-    ADIOI_Free(my_req);
+    ADIOI_LUSTRE_Free_my_req(nprocs, count_my_req_per_proc, my_req, buf_idx);
+    ADIOI_Free_others_req(nprocs, count_others_req_per_proc, others_req);
     ADIOI_Free(offset_list);
     ADIOI_Free(st_offsets);
 

--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -453,14 +453,6 @@ static void ADIOI_GEN_IreadStridedColl_read(ADIOI_NBC_Request * nbc_req, int *er
 {
     ADIOI_GEN_IreadStridedColl_vars *vars = nbc_req->data.rd.rsc_vars;
     ADIOI_Iread_and_exch_vars *rae_vars = NULL;
-    ADIOI_Access *my_req = vars->my_req;
-
-    /* my_req[] and count_my_req_per_proc aren't needed at this point, so
-     * let's free the memory
-     */
-    ADIOI_Free(vars->count_my_req_per_proc);
-    ADIOI_Free(my_req[0].offsets);
-    ADIOI_Free(my_req);
 
     /* read data in sizes of no more than ADIOI_Coll_bufsize,
      * communicate, and fill user buf.
@@ -492,13 +484,13 @@ static void ADIOI_GEN_IreadStridedColl_free(ADIOI_NBC_Request * nbc_req, int *er
     ADIO_File fd = vars->fd;
     ADIOI_Access *others_req = vars->others_req;
 
-
     /* free all memory allocated for collective I/O */
+    ADIOI_Free_my_req(vars->nprocs, vars->count_my_req_per_proc, vars->my_req, vars->buf_idx);
+
     ADIOI_Free(others_req[0].offsets);
     ADIOI_Free(others_req[0].mem_ptrs);
     ADIOI_Free(others_req);
 
-    ADIOI_Free(vars->buf_idx);
     ADIOI_Free(vars->offset_list);
     ADIOI_Free(vars->st_offsets);
     ADIOI_Free(vars->fd_start);

--- a/src/mpi/romio/adio/common/ad_iwrite_coll.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_coll.c
@@ -449,11 +449,6 @@ static void ADIOI_GEN_IwriteStridedColl_exch(ADIOI_NBC_Request * nbc_req, int *e
 {
     ADIOI_GEN_IwriteStridedColl_vars *vars = nbc_req->data.wr.wsc_vars;
     ADIOI_Iexch_and_write_vars *eaw_vars = NULL;
-    ADIOI_Access *my_req = vars->my_req;
-
-    ADIOI_Free(vars->count_my_req_per_proc);
-    ADIOI_Free(my_req[0].offsets);
-    ADIOI_Free(my_req);
 
     /* exchange data and write in sizes of no more than coll_bufsize. */
     /* Cast away const'ness for the below function */
@@ -534,11 +529,12 @@ static void ADIOI_GEN_IwriteStridedColl_free(ADIOI_NBC_Request * nbc_req, int *e
         *error_code = old_error;
 
     /* free all memory allocated for collective I/O */
+    ADIOI_Free_my_req(vars->nprocs, vars->count_my_req_per_proc, vars->my_req, vars->buf_idx);
+
     ADIOI_Free(others_req[0].offsets);
     ADIOI_Free(others_req[0].mem_ptrs);
     ADIOI_Free(others_req);
 
-    ADIOI_Free(vars->buf_idx);
     ADIOI_Free(vars->offset_list);
     ADIOI_Free(vars->st_offsets);
     ADIOI_Free(vars->fd_start);

--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -89,7 +89,8 @@ void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
 
     int i, filetype_is_contig, nprocs, nprocs_for_coll, myrank;
     int contig_access_count = 0, interleave_count = 0, buftype_is_contig;
-    int *count_my_req_per_proc, count_my_req_procs, count_others_req_procs;
+    int *count_my_req_per_proc, count_my_req_procs;
+    int *count_others_req_per_proc, count_others_req_procs;
     ADIO_Offset start_offset, end_offset, orig_fp, fd_size, min_st_offset, off;
     ADIO_Offset *offset_list = NULL, *st_offsets = NULL, *fd_start = NULL,
         *fd_end = NULL, *end_offsets = NULL;
@@ -223,14 +224,8 @@ void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
      */
     ADIOI_Calc_others_req(fd, count_my_req_procs,
                           count_my_req_per_proc, my_req,
-                          nprocs, myrank, &count_others_req_procs, &others_req);
-
-    /* my_req[] and count_my_req_per_proc aren't needed at this point, so
-     * let's free the memory
-     */
-    ADIOI_Free(count_my_req_per_proc);
-    ADIOI_Free(my_req[0].offsets);
-    ADIOI_Free(my_req);
+                          nprocs, myrank, &count_others_req_procs, &count_others_req_per_proc,
+                          &others_req);
 
     /* read data in sizes of no more than ADIOI_Coll_bufsize,
      * communicate, and fill user buf.
@@ -242,11 +237,9 @@ void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
 
 
     /* free all memory allocated for collective I/O */
-    ADIOI_Free(others_req[0].offsets);
-    ADIOI_Free(others_req[0].mem_ptrs);
-    ADIOI_Free(others_req);
+    ADIOI_Free_my_req(nprocs, count_my_req_per_proc, my_req, buf_idx);
+    ADIOI_Free_others_req(nprocs, count_others_req_per_proc, others_req);
 
-    ADIOI_Free(buf_idx);
     ADIOI_Free(offset_list);
     ADIOI_Free(st_offsets);
     ADIOI_Free(fd_start);

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -489,11 +489,15 @@ void ADIOI_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list,
                        int *count_my_req_procs_ptr,
                        int **count_my_req_per_proc_ptr,
                        ADIOI_Access ** my_req_ptr, MPI_Aint ** buf_idx_ptr);
+void ADIOI_Free_my_req(int nprocs, int *count_my_req_per_proc,
+                       ADIOI_Access * my_req, MPI_Aint * buf_idx);
 void ADIOI_Calc_others_req(ADIO_File fd, int count_my_req_procs,
                            int *count_my_req_per_proc,
                            ADIOI_Access * my_req,
                            int nprocs, int myrank,
-                           int *count_others_req_procs_ptr, ADIOI_Access ** others_req_ptr);
+                           int *count_others_req_procs_ptr,
+                           int **count_others_req_per_proc_ptr, ADIOI_Access ** others_req_ptr);
+void ADIOI_Free_others_req(int nprocs, int *count_others_req_per_proc, ADIOI_Access * others_req);
 
 
 /* Nonblocking Collective I/O internals */


### PR DESCRIPTION
## Pull Request Description

The array my_req and others_req are allocated in the driver and need be
freed by the driver as well. This is critical since different drivers
may make different decisions on what buffers are allocated and need be
freed.

There is a bit of asymmetry between `Calc_my_req` and `Calc_others_req`, with the latter internally frees the `count_others_req_per_proc`. Well, the `gpfs` driver needs it. And it is always better to keep symmetry even if it is redundant. This PR unifies them.

Fixes #5339
Fixes #5340

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
