### PR TITLE
configure: remove option --enable-alloca

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4416,16 +4416,6 @@ AC_CHECK_FUNCS([qsort])
 
 PAC_C_MACRO_VA_ARGS
 
-# Check for alloca function.  May set HAVE_ALLOCA_H and HAVE_ALLOCA
-AC_FUNC_ALLOCA
-# We don't use alloca unless USE_ALLOCA is also set.
-AC_ARG_ENABLE(alloca,
-	AS_HELP_STRING([--enable-alloca],
-		[Use alloca to allocate temporary memory if available]),,enable_alloca=no)
-if test "$enable_alloca" = yes ; then
-    AC_DEFINE(USE_ALLOCA,1,[Define if alloca should be used if available])
-fi
-
 if test "$enable_g_mem" != "yes" ; then
     # Strdup is needed only if memory tracing is not enabled.
     AC_CHECK_FUNCS(strdup)

--- a/maint/checkbuilds.in
+++ b/maint/checkbuilds.in
@@ -74,7 +74,6 @@ $hasDemon   = 0;
                   'mutex-timing',
                   'multi-aliases',
                   'predefined-refcount',
-                  'alloca',
                   'yield;sched_yield;yield;select;usleep;sleep',
                   'checkpointing',
 		  'runtimevalues',   # Fortran true/false

--- a/src/include/mpir_mem.h
+++ b/src/include/mpir_mem.h
@@ -99,26 +99,6 @@ extern "C" {
 
     /* CHKPMEM_REGISTER is used for memory allocated within another routine */
 
-/* Memory used and freed within the current scope (alloca if feasible) */
-/* Configure with --enable-alloca to set USE_ALLOCA */
-#if defined(HAVE_ALLOCA) && defined(USE_ALLOCA)
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif                          /* HAVE_ALLOCA_H */
-/* Define decl with a dummy definition to allow us to put a semi-colon
-   after the macro without causing the declaration block to end (restriction
-   imposed by C) */
-#define MPIR_CHKLMEM_DECL(n_) int dummy_ ATTRIBUTE((unused))
-#define MPIR_CHKLMEM_FREEALL()
-#define MPIR_CHKLMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,class_,stmt_) \
-    {                                                                   \
-        pointer_ = (type_)alloca(nbytes_);                              \
-        if (!(pointer_) && (nbytes_ > 0)) {                             \
-            MPIR_CHKMEM_SETERR(rc_,nbytes_,name_);                      \
-            stmt_;                                                      \
-        }                                                               \
-    }
-#else                           /* defined(HAVE_ALLOCA) && defined(USE_ALLOCA) */
 #define MPIR_CHKLMEM_DECL(n_)                                   \
     void *(mpiu_chklmem_stk_[n_]) = { NULL };                   \
     int mpiu_chklmem_stk_sp_=0;                                 \
@@ -141,7 +121,7 @@ extern "C" {
             MPL_free(mpiu_chklmem_stk_[--mpiu_chklmem_stk_sp_]);        \
         }                                                               \
     } while (0)
-#endif                          /* defined(HAVE_ALLOCA) && defined(USE_ALLOCA) */
+
 #define MPIR_CHKLMEM_MALLOC(pointer_,type_,nbytes_,rc_,name_,class_)    \
     MPIR_CHKLMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_,class_)
 #define MPIR_CHKLMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_,class_) \

--- a/src/pmi/pmi2/simple/simple_pmiutil.h
+++ b/src/pmi/pmi2/simple/simple_pmiutil.h
@@ -115,23 +115,6 @@ extern int PMI2_pmiverbose;     /* Set this to true to print PMI debugging info 
 #endif
 
 
-#if defined(HAVE_ALLOCA) && defined(USE_ALLOCA)
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
-/* Define decl with a dummy definition to allow us to put a semi-colon
-   after the macro without causing the declaration block to end (restriction
-   imposed by C) */
-#define PMI2U_CHKLMEM_DECL(n_) int dummy_ ATTRIBUTE((unused))
-#define PMI2U_CHKLMEM_FREEALL()
-#define PMI2U_CHKLMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,stmt_) do {        \
-        pointer_ = (type_)alloca(nbytes_);                                              \
-        if (!(pointer_)) {                                                              \
-            PMI2U_CHKMEM_SETERR(rc_,nbytes_,name_);                                     \
-            stmt_;                                                                      \
-        }                                                                               \
-    } while (0)
-#else
 #define PMI2U_CHKLMEM_DECL(n_)                                  \
     void *(pmi2u_chklmem_stk_[n_]) = {0};                       \
     int pmi2u_chklmem_stk_sp_=0;                                \
@@ -150,7 +133,7 @@ extern int PMI2_pmiverbose;     /* Set this to true to print PMI debugging info 
 #define PMI2U_CHKLMEM_FREEALL()                                         \
     while (pmi2u_chklmem_stk_sp_ > 0) {                                 \
         PMI2U_Free(pmi2u_chklmem_stk_[--pmi2u_chklmem_stk_sp_]); }
-#endif /* HAVE_ALLOCA */
+
 #define PMI2U_CHKLMEM_MALLOC(pointer_,type_,nbytes_,rc_,name_) \
     PMI2U_CHKLMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_)
 #define PMI2U_CHKLMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_) \

--- a/src/pmi/pmi2/simple/simple_pmiutil.h
+++ b/src/pmi/pmi2/simple/simple_pmiutil.h
@@ -139,34 +139,6 @@ extern int PMI2_pmiverbose;     /* Set this to true to print PMI debugging info 
 #define PMI2U_CHKLMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_) \
     PMI2U_CHKLMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,goto fn_fail)
 
-/* In some cases, we need to allocate large amounts of memory. This can
-   be a problem if alloca is used, as the available stack space may be small.
-   This is the same approach for the temporary memory as is used when alloca
-   is not available. */
-#define PMI2U_CHKLBIGMEM_DECL(n_)                                       \
-    void *(pmi2u_chklbigmem_stk_[n_]);                                  \
-    int pmi2u_chklbigmem_stk_sp_ = 0;                                   \
-    PMI2U_AssertDeclValue(const int pmi2u_chklbigmem_stk_sz_,n_)
-
-#define PMI2U_CHKLBIGMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,stmt_) do {     \
-        pointer_ = (type_)PMI2U_Malloc(nbytes_);                                        \
-        if (pointer_) {                                                                 \
-            PMI2U_Assert(pmi2u_chklbigmem_stk_sp_<pmi2u_chklbigmem_stk_sz_);            \
-            pmi2u_chklbigmem_stk_[pmi2u_chklbigmem_stk_sp_++] = pointer_;               \
-        } else {                                                                        \
-            PMI2U_CHKMEM_SETERR(rc_,nbytes_,name_);                                     \
-            stmt_;                                                                      \
-        }                                                                               \
-    } while (0)
-#define PMI2U_CHKLBIGMEM_FREEALL()                                              \
-    while (pmi2u_chklbigmem_stk_sp_ > 0) {                                      \
-        PMI2U_Free(pmi2u_chklbigmem_stk_[--pmi2u_chklbigmem_stk_sp_]); }
-
-#define PMI2U_CHKLBIGMEM_MALLOC(pointer_,type_,nbytes_,rc_,name_)       \
-    PMI2U_CHKLBIGMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_)
-#define PMI2U_CHKLBIGMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_)                \
-    PMI2U_CHKLBIGMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,goto fn_fail)
-
 /* Persistent memory that we may want to recover if something goes wrong */
 #define PMI2U_CHKPMEM_DECL(n_)                                  \
     void *(pmi2u_chkpmem_stk_[n_]) = {0};                       \


### PR DESCRIPTION
## Pull Request Description
Alloca is not safe to use. We'll always need explicit check before using
it, thus a blanket configure option doesn't really work or help.
Remove the option to avoid confusing users.

Fixes #1704


[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
