### PR TITLE
ch4/ofi: Confirm provider NIC is up

### DIFF
--- a/src/mpid/ch4/netmod/ofi/init_provider.c
+++ b/src/mpid/ch4/netmod/ofi/init_provider.c
@@ -240,6 +240,11 @@ static struct fi_info *pick_provider_from_list(struct fi_info *list)
     int best_pref_score = 0;
     struct fi_info *best_prov = NULL;
     for (struct fi_info * prov = list; prov; prov = prov->next) {
+        /* Confirm the NIC backed by the provider is actually up. */
+        if (!MPIDI_OFI_nic_is_up(prov)) {
+            continue;
+        }
+
         int score = MPIDI_OFI_match_provider(prov, &optimal_settings, &minimal_settings);
         int pref_score = provider_preference(prov->fabric_attr->prov_name);
         if (best_score < score || (best_score == score && best_pref_score < pref_score)) {

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -35,4 +35,6 @@ bool MPIDI_OFI_nic_already_used(const struct fi_info *prov, struct fi_info **oth
 int MPIDI_OFI_addr_exchange_root_ctx(void);
 int MPIDI_OFI_addr_exchange_all_ctx(void);
 
+bool MPIDI_OFI_nic_is_up(struct fi_info *prov);
+
 #endif /* OFI_INIT_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -98,6 +98,9 @@ int MPIDI_OFI_init_multi_nic(struct fi_info *prov)
         if (MPIR_CVAR_OFI_SKIP_IPV6 && p->addr_format == FI_SOCKADDR_IN6) {
             continue;
         }
+        if (!MPIDI_OFI_nic_is_up(p)) {
+            continue;
+        }
         if (!first_prov) {
             first_prov = p;
         }
@@ -262,4 +265,15 @@ static int setup_multi_nic(int nic_count)
     MPIR_Info_set_impl(info_ptr, "num_close_nics", nics_str);
 
     return mpi_errno;
+}
+
+bool MPIDI_OFI_nic_is_up(struct fi_info * prov)
+{
+    /* Make sure the NIC returned by OFI is not down. Some providers don't include NIC
+     * information so we need to skip those. */
+    if (prov->nic != NULL && prov->nic->link_attr->state != FI_LINK_UP) {
+        return false;
+    }
+
+    return true;
 }


### PR DESCRIPTION
## Pull Request Description

Some providers choose to report the NIC status in the struct returned by
fi_getinfo rather than filtering out NICs that are down before returning
them. In this case, we need to check the status of the link state in the
nic part of the provider struct before we use it.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
