### PR TITLE
ch4: miscellaneous patches related to VCI/VNI address

### DIFF
--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -78,6 +78,10 @@ static bool is_vci_restricted_to_zero()
         vci_restricted |= true;
     }
 #endif /* ifdef  MPIDI_OFI_VNI_USE_DOMAIN */
+
+    if (!(comm->comm_kind == MPIR_COMM_KIND__INTRACOMM && !comm->tainted)) {
+        vci_restricted |= true;
+    }
     return vci_restricted;
 }
 


### PR DESCRIPTION
## Pull Request Description
This PR includes small patches to fix problems during VCI/VNI address setup and access:
* Use vci 0 at init time under multiple-domains
* Use vci 0 for intercomm and tainted comm
* Propagate `tainted` flags to sub-comms

Base PR: https://github.com/pmodels/mpich/pull/5175


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
