### PR TITLE
ipc: cleanup code that maps remote memory

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -49,7 +49,7 @@ static void ipc_handle_free_hook(void *dptr)
         MPIR_Assert(mpl_err == MPL_SUCCESS);
 
         MPIR_GPU_query_pointer_attr(pbase, &gpu_attr);
-        MPL_gpu_get_dev_id(gpu_attr.device, &local_dev_id);
+        local_dev_id = MPL_gpu_get_dev_id_from_attr(&gpu_attr);
         global_dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
 
         for (int i = 0; i < MPIR_Process.local_size; ++i) {

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -38,9 +38,8 @@ static void ipc_handle_free_hook(void *dptr)
 {
     void *pbase;
     uintptr_t len;
-    int mpl_err, local_dev_id;
+    int mpl_err, local_dev_id, global_dev_id;
     MPL_pointer_attr_t gpu_attr;
-    MPIDI_GPUI_dev_id_t *tmp;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_IPC_HANDLE_FREE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_IPC_HANDLE_FREE_HOOK);
@@ -51,11 +50,11 @@ static void ipc_handle_free_hook(void *dptr)
 
         MPIR_GPU_query_pointer_attr(pbase, &gpu_attr);
         MPL_gpu_get_dev_id(gpu_attr.device, &local_dev_id);
-        HASH_FIND_INT(MPIDI_GPUI_global.local_to_global_map, &local_dev_id, tmp);
+        global_dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
 
         for (int i = 0; i < MPIR_Process.local_size; ++i) {
-            mpl_err = MPL_gavl_tree_delete_range(MPIDI_GPUI_global.ipc_handle_track_trees[i]
-                                                 [tmp->global_dev_id], pbase, len);
+            MPL_gavl_tree_t track_tree = MPIDI_GPUI_global.ipc_handle_track_trees[i][global_dev_id];
+            mpl_err = MPL_gavl_tree_delete_range(track_tree, pbase, len);
             MPIR_Assert(mpl_err == MPL_SUCCESS);
         }
     }
@@ -74,7 +73,6 @@ int MPIDI_GPU_init_world(void)
     int mpl_err, mpi_errno = MPI_SUCCESS;
     int device_count;
     int my_max_dev_id, node_max_dev_id = -1;
-    MPL_gpu_device_handle_t dev_handle;
 
     MPIR_CHKPMEM_DECL(1);
 
@@ -84,32 +82,6 @@ int MPIDI_GPU_init_world(void)
     if (device_count < 0)
         goto fn_exit;
 
-    int *global_ids = MPL_malloc(sizeof(int) * device_count, MPL_MEM_OTHER);
-    MPIR_Assert(global_ids);
-
-    mpl_err = MPL_gpu_get_global_dev_ids(global_ids, device_count);
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                        "**gpu_get_global_dev_ids");
-
-    MPIDI_GPUI_global.local_to_global_map = NULL;
-    MPIDI_GPUI_global.global_to_local_map = NULL;
-    for (int i = 0; i < device_count; ++i) {
-        MPIDI_GPUI_dev_id_t *id_obj =
-            (MPIDI_GPUI_dev_id_t *) MPL_malloc(sizeof(MPIDI_GPUI_dev_id_t), MPL_MEM_OTHER);
-        MPIR_Assert(id_obj);
-        MPL_gpu_get_dev_handle(i, &dev_handle);
-        MPL_gpu_get_dev_id(dev_handle, &id_obj->local_dev_id);
-        id_obj->global_dev_id = global_ids[i];
-        HASH_ADD_INT(MPIDI_GPUI_global.local_to_global_map, local_dev_id, id_obj, MPL_MEM_OTHER);
-
-        id_obj = (MPIDI_GPUI_dev_id_t *) MPL_malloc(sizeof(MPIDI_GPUI_dev_id_t), MPL_MEM_OTHER);
-        MPIR_Assert(id_obj);
-        id_obj->local_dev_id = i;
-        id_obj->global_dev_id = global_ids[i];
-        HASH_ADD_INT(MPIDI_GPUI_global.global_to_local_map, global_dev_id, id_obj, MPL_MEM_OTHER);
-    }
-
-    MPL_free(global_ids);
     MPIDU_Init_shm_put(&my_max_dev_id, sizeof(int));
     MPIDU_Init_shm_barrier();
 
@@ -134,9 +106,7 @@ int MPIDI_GPU_init_world(void)
 
         if (i == MPIR_Process.local_rank) {
             for (int j = 0; j < (MPIDI_GPUI_global.global_max_dev_id + 1); ++j) {
-                MPIDI_GPUI_dev_id_t *tmp = NULL;
-                HASH_FIND_INT(MPIDI_GPUI_global.global_to_local_map, &j, tmp);
-                if (tmp)
+                if (MPL_gpu_global_to_local_dev_id(j) != -1)
                     MPIDI_GPUI_global.visible_dev_global_id[i][j] = 1;
                 else
                     MPIDI_GPUI_global.visible_dev_global_id[i][j] = 0;
@@ -237,21 +207,11 @@ int MPIDI_GPU_init_world(void)
 int MPIDI_GPU_mpi_finalize_hook(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIDI_GPUI_dev_id_t *current, *tmp;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GPU_MPI_FINALIZE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GPU_MPI_FINALIZE_HOOK);
 
     if (MPIDI_GPUI_global.initialized) {
-        HASH_ITER(hh, MPIDI_GPUI_global.local_to_global_map, current, tmp) {
-            HASH_DEL(MPIDI_GPUI_global.local_to_global_map, current);
-            MPL_free(current);
-        }
-
-        HASH_ITER(hh, MPIDI_GPUI_global.global_to_local_map, current, tmp) {
-            HASH_DEL(MPIDI_GPUI_global.global_to_local_map, current);
-            MPL_free(current);
-        }
         MPL_free(MPIDI_GPUI_global.local_ranks);
         for (int i = 0; i < MPIR_Process.local_size; ++i)
             MPL_free(MPIDI_GPUI_global.visible_dev_global_id[i]);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -218,8 +218,7 @@ int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
     return mpi_errno;
 }
 
-int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle,
-                             MPL_gpu_device_handle_t dev_handle,
+int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int local_dev_id,
                              MPI_Datatype datatype, void **vaddr)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -243,8 +242,6 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle,
         }
     }
 
-    int local_dev_id;
-    MPL_gpu_get_dev_id(dev_handle, &local_dev_id);
     mpi_errno = get_map_device(handle.global_dev_id, local_dev_id, datatype, &dev_id);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -175,7 +175,7 @@ int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
     recv_lrank = MPIDI_GPUI_global.local_ranks[MPIDIU_rank_to_lpid(rank, comm)];
     ipc_attr->ipc_type = MPIDI_IPCI_TYPE__GPU;
 
-    MPL_gpu_get_dev_id(ipc_attr->gpu_attr.device, &local_dev_id);
+    local_dev_id = MPL_gpu_get_dev_id_from_attr(&ipc_attr->gpu_attr);
     int global_dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
 
     mpl_err = MPL_gpu_get_buffer_bounds(vaddr, &pbase, &len);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -256,8 +256,7 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle,
 
     if (handle_obj == NULL) {
         bool insert_successful = false;
-        MPL_gpu_get_dev_handle(dev_id, &dev_handle);
-        mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, dev_handle, &pbase);
+        mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, dev_id, &pbase);
         MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                             "**gpu_ipc_handle_map");
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -28,8 +28,7 @@ cvars:
 
 int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
                            MPIDI_IPCI_ipc_attr_t * ipc_attr);
-int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle,
-                             MPL_gpu_device_handle_t dev_handle,
+int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int dev_id,
                              MPI_Datatype recv_type, void **vaddr);
 int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle);
 int MPIDI_GPU_init_local(void);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
@@ -15,8 +15,6 @@ typedef struct MPIDI_GPUI_dev_id {
 } MPIDI_GPUI_dev_id_t;
 
 typedef struct {
-    MPIDI_GPUI_dev_id_t *local_to_global_map;
-    MPIDI_GPUI_dev_id_t *global_to_local_map;
     int **visible_dev_global_id;
     int *local_ranks;
     int *local_procs;

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -116,18 +116,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
     rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, rank);
     rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, tag);
 
-    MPL_pointer_attr_t attr;
-    MPIR_GPU_query_pointer_attr(MPIDIG_REQUEST(rreq, buffer), &attr);
-
     /* attach remote buffer */
     switch (ipc_type) {
         case MPIDI_IPCI_TYPE__XPMEM:
             mpi_errno = MPIDI_XPMEM_ipc_handle_map(ipc_handle.xpmem, &src_buf);
             break;
         case MPIDI_IPCI_TYPE__GPU:
-            mpi_errno =
-                MPIDI_GPU_ipc_handle_map(ipc_handle.gpu, attr.device,
-                                         MPIDIG_REQUEST(rreq, datatype), &src_buf);
+            {
+                MPL_pointer_attr_t attr;
+                int dev_id;
+                MPIR_GPU_query_pointer_attr(MPIDIG_REQUEST(rreq, buffer), &attr);
+                MPL_gpu_get_dev_id(attr.device, &dev_id);
+                mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_handle.gpu, dev_id,
+                                                     MPIDIG_REQUEST(rreq, datatype), &src_buf);
+            }
             break;
         case MPIDI_IPCI_TYPE__NONE:
             /* no-op */

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -124,9 +124,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
         case MPIDI_IPCI_TYPE__GPU:
             {
                 MPL_pointer_attr_t attr;
-                int dev_id;
                 MPIR_GPU_query_pointer_attr(MPIDIG_REQUEST(rreq, buffer), &attr);
-                MPL_gpu_get_dev_id(attr.device, &dev_id);
+                int dev_id = MPL_gpu_get_dev_id_from_attr(&attr);
                 mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_handle.gpu, dev_id,
                                                      MPIDIG_REQUEST(rreq, datatype), &src_buf);
             }

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -167,11 +167,14 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
                 case MPIDI_IPCI_TYPE__GPU:
                     /* FIXME: remote win buffer should be mapped to each of their corresponding
                      * local GPU device. */
-                    mpi_errno =
-                        MPIDI_GPU_ipc_handle_map(ipc_shared_table[i].ipc_handle.gpu,
-                                                 ipc_attr.gpu_attr.device, MPI_BYTE,
-                                                 &shared_table[i].shm_base_addr);
-                    MPIR_ERR_CHECK(mpi_errno);
+                    {
+                        int dev_id;
+                        MPL_gpu_get_dev_id(ipc_attr.gpu_attr.device, &dev_id);
+                        mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_shared_table[i].ipc_handle.gpu,
+                                                             dev_id, MPI_BYTE,
+                                                             &shared_table[i].shm_base_addr);
+                        MPIR_ERR_CHECK(mpi_errno);
+                    }
                     break;
                 case MPIDI_IPCI_TYPE__NONE:
                     /* no-op */

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -168,8 +168,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
                     /* FIXME: remote win buffer should be mapped to each of their corresponding
                      * local GPU device. */
                     {
-                        int dev_id;
-                        MPL_gpu_get_dev_id(ipc_attr.gpu_attr.device, &dev_id);
+                        int dev_id = MPL_gpu_get_dev_id_from_attr(&ipc_attr.gpu_attr);
                         mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_shared_table[i].ipc_handle.gpu,
                                                              dev_id, MPI_BYTE,
                                                              &shared_table[i].shm_base_addr);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -75,8 +75,7 @@ int MPL_gpu_finalize(void);
 int MPL_gpu_global_to_local_dev_id(int global_dev_id);
 int MPL_gpu_local_to_global_dev_id(int local_dev_id);
 
-int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id);
-int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle);
+int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr);
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len);
 
 int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr));

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -73,9 +73,11 @@ int MPL_gpu_free(void *ptr);
 int MPL_gpu_init(void);
 int MPL_gpu_finalize(void);
 
+int MPL_gpu_global_to_local_dev_id(int global_dev_id);
+int MPL_gpu_local_to_global_dev_id(int local_dev_id);
+
 int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id);
 int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle);
-int MPL_gpu_get_global_dev_ids(int *global_ids, int count);
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len);
 
 int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr));

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -58,8 +58,7 @@ int MPL_gpu_query_support(MPL_gpu_type_t * type);
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle);
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
-                           void **ptr);
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr);
 int MPL_gpu_ipc_handle_unmap(void *ptr);
 
 int MPL_gpu_malloc_host(void **ptr, size_t size);

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -90,14 +90,13 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
-                           void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
 {
     cudaError_t ret;
     int prev_devid;
 
     cudaGetDevice(&prev_devid);
-    cudaSetDevice(dev_handle);
+    cudaSetDevice(dev_id);
     ret = cudaIpcOpenMemHandle(ptr, ipc_handle, cudaIpcMemLazyEnablePeerAccess);
     CUDA_ERR_CHECK(ret);
 

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -293,16 +293,9 @@ int MPL_gpu_local_to_global_dev_id(int local_dev_id)
     return local_to_global_map[local_dev_id];
 }
 
-int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id)
+int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr)
 {
-    *dev_id = dev_handle;
-    return MPL_SUCCESS;
-}
-
-int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
-{
-    *dev_handle = dev_id;
-    return MPL_SUCCESS;
+    return attr->device;
 }
 
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -19,6 +19,9 @@ static int gpu_initialized = 0;
 static int device_count = -1;
 static int max_dev_id = -1;
 
+static int *local_to_global_map;        /* [device_count] */
+static int *global_to_local_map;        /* [max_dev_id + 1]   */
+
 static gpu_free_hook_s *free_hook_chain = NULL;
 
 static CUresult CUDAAPI(*sys_cuMemFree) (CUdeviceptr dptr);
@@ -197,26 +200,51 @@ int MPL_gpu_free(void *ptr)
 
 int MPL_gpu_init()
 {
+    if (gpu_initialized) {
+        goto fn_exit;
+    }
+
     cudaError_t ret = cudaGetDeviceCount(&device_count);
     CUDA_ERR_CHECK(ret);
 
+    if (device_count <= 0) {
+        gpu_initialized = 1;
+        goto fn_exit;
+    }
+
     char *visible_devices = getenv("CUDA_VISIBLE_DEVICES");
     if (visible_devices) {
+        local_to_global_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
+
         uintptr_t len = strlen(visible_devices);
         char *devices = MPL_malloc(len + 1, MPL_MEM_OTHER);
         char *free_ptr = devices;
         memcpy(devices, visible_devices, len + 1);
         for (int i = 0; i < device_count; i++) {
-            int global_dev_id;
             char *tmp = strtok(devices, ",");
             assert(tmp);
-            global_dev_id = atoi(tmp);
-            if (global_dev_id > max_dev_id)
-                max_dev_id = global_dev_id;
+            local_to_global_map[i] = atoi(tmp);
+            if (max_dev_id < local_to_global_map[i]) {
+                max_dev_id = local_to_global_map[i];
+            }
             devices = NULL;
         }
         MPL_free(free_ptr);
+
+        global_to_local_map = MPL_malloc((max_dev_id + 1) * sizeof(int), MPL_MEM_OTHER);
+        for (int i = 0; i < max_dev_id + 1; i++) {
+            global_to_local_map[i] = -1;
+        }
+        for (int i = 0; i < device_count; i++) {
+            global_to_local_map[local_to_global_map[i]] = i;
+        }
     } else {
+        local_to_global_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
+        global_to_local_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
+        for (int i = 0; i < device_count; i++) {
+            local_to_global_map[i] = i;
+            global_to_local_map[i] = i;
+        }
         max_dev_id = device_count - 1;
     }
 
@@ -236,13 +264,34 @@ int MPL_gpu_init()
 
 int MPL_gpu_finalize()
 {
+    if (device_count <= 0) {
+        goto fn_exit;
+    }
+
+    MPL_free(local_to_global_map);
+    MPL_free(global_to_local_map);
+
     gpu_free_hook_s *prev;
     while (free_hook_chain) {
         prev = free_hook_chain;
         free_hook_chain = free_hook_chain->next;
         MPL_free(prev);
     }
+
+  fn_exit:
     return MPL_SUCCESS;
+}
+
+int MPL_gpu_global_to_local_dev_id(int global_dev_id)
+{
+    assert(global_dev_id <= max_dev_id);
+    return global_to_local_map[global_dev_id];
+}
+
+int MPL_gpu_local_to_global_dev_id(int local_dev_id)
+{
+    assert(local_dev_id < device_count);
+    return local_to_global_map[local_dev_id];
 }
 
 int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id)
@@ -255,34 +304,6 @@ int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
 {
     *dev_handle = dev_id;
     return MPL_SUCCESS;
-}
-
-int MPL_gpu_get_global_dev_ids(int *global_ids, int count)
-{
-    char *visible_devices = getenv("CUDA_VISIBLE_DEVICES");
-
-    if (visible_devices) {
-        uintptr_t len = strlen(visible_devices);
-        char *devices = MPL_malloc(len + 1, MPL_MEM_OTHER);
-        char *free_ptr = devices;
-        memcpy(devices, visible_devices, len + 1);
-        for (int i = 0; i < count; i++) {
-            char *tmp = strtok(devices, ",");
-            assert(tmp);
-            global_ids[i] = atoi(tmp);
-            devices = NULL;
-        }
-        MPL_free(free_ptr);
-    } else {
-        for (int i = 0; i < count; i++) {
-            global_ids[i] = i;
-        }
-    }
-
-  fn_exit:
-    return MPL_SUCCESS;
-  fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
 }
 
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -73,14 +73,9 @@ int MPL_gpu_finalize(void)
     return MPL_SUCCESS;
 }
 
-int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id)
+int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr)
 {
-    return MPL_SUCCESS;
-}
-
-int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
-{
-    return MPL_SUCCESS;
+    return -1;
 }
 
 int MPL_gpu_global_to_local_dev_id(int global_dev_id)

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -84,9 +84,14 @@ int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
     return MPL_SUCCESS;
 }
 
-int MPL_gpu_get_global_dev_ids(int *global_ids, int count)
+int MPL_gpu_global_to_local_dev_id(int global_dev_id)
 {
-    return MPL_SUCCESS;
+    return -1;
+}
+
+int MPL_gpu_local_to_global_dev_id(int local_dev_id)
+{
+    return -1;
 }
 
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -17,8 +17,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
-                           void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -19,6 +19,9 @@ static int gpu_initialized = 0;
 static int device_count = -1;
 static int max_dev_id = -1;
 
+static int *local_to_global_map;        /* [device_count] */
+static int *global_to_local_map;        /* [max_dev_id + 1]   */
+
 static gpu_free_hook_s *free_hook_chain = NULL;
 
 static hipError_t(*sys_hipFree) (void *dptr);
@@ -197,6 +200,8 @@ int MPL_gpu_init()
 
     char *visible_devices = getenv("HIP_VISIBLE_DEVICES");
     if (visible_devices) {
+        local_to_global_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
+
         uintptr_t len = strlen(visible_devices);
         char *devices = MPL_malloc(len + 1, MPL_MEM_OTHER);
         char *free_ptr = devices;
@@ -205,13 +210,28 @@ int MPL_gpu_init()
             int global_dev_id;
             char *tmp = strtok(devices, ",");
             assert(tmp);
-            global_dev_id = atoi(tmp);
-            if (global_dev_id > max_dev_id)
-                max_dev_id = global_dev_id;
+            local_to_global_map[i] = atoi(tmp);
+            if (max_dev_id < local_to_global_map[i]) {
+                max_dev_id = local_to_global_map[i];
+            }
             devices = NULL;
         }
         MPL_free(free_ptr);
+
+        global_to_local_map = MPL_malloc((max_dev_id + 1) * sizeof(int), MPL_MEM_OTHER);
+        for (int i = 0; i < max_dev_id + 1; i++) {
+            global_to_local_map[i] = -1;
+        }
+        for (int i = 0; i < device_count; i++) {
+            global_to_local_map[local_to_global_map[i]] = i;
+        }
     } else {
+        local_to_global_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
+        global_to_local_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
+        for (int i = 0; i < device_count; i++) {
+            local_to_global_map[i] = i;
+            global_to_local_map[i] = i;
+        }
         max_dev_id = device_count - 1;
     }
 
@@ -231,13 +251,34 @@ int MPL_gpu_init()
 
 int MPL_gpu_finalize()
 {
+    if (device_count <= 0) {
+        goto fn_exit;
+    }
+
+    MPL_free(local_to_global_map);
+    MPL_free(global_to_local_map);
+
     gpu_free_hook_s *prev;
     while (free_hook_chain) {
         prev = free_hook_chain;
         free_hook_chain = free_hook_chain->next;
         MPL_free(prev);
     }
+
+  fn_exit:
     return MPL_SUCCESS;
+}
+
+int MPL_gpu_global_to_local_dev_id(int global_dev_id)
+{
+    assert(global_dev_id <= max_dev_id);
+    return global_to_local_map[global_dev_id];
+}
+
+int MPL_gpu_local_to_global_dev_id(int local_dev_id)
+{
+    assert(local_dev_id < device_count);
+    return local_to_global_map[local_dev_id];
 }
 
 int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id)
@@ -250,34 +291,6 @@ int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
 {
     *dev_handle = dev_id;
     return MPL_SUCCESS;
-}
-
-int MPL_gpu_get_global_dev_ids(int *global_ids, int count)
-{
-    char *visible_devices = getenv("HIP_VISIBLE_DEVICES");
-
-    if (visible_devices) {
-        uintptr_t len = strlen(visible_devices);
-        char *devices = MPL_malloc(len + 1, MPL_MEM_OTHER);
-        char *free_ptr = devices;
-        memcpy(devices, visible_devices, len + 1);
-        for (int i = 0; i < count; i++) {
-            char *tmp = strtok(devices, ",");
-            assert(tmp);
-            global_ids[i] = atoi(tmp);
-            devices = NULL;
-        }
-        MPL_free(free_ptr);
-    } else {
-        for (int i = 0; i < count; i++) {
-            global_ids[i] = i;
-        }
-    }
-
-  fn_exit:
-    return MPL_SUCCESS;
-  fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
 }
 
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -279,16 +279,9 @@ int MPL_gpu_local_to_global_dev_id(int local_dev_id)
     return local_to_global_map[local_dev_id];
 }
 
-int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id)
+int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr)
 {
-    *dev_id = dev_handle;
-    return MPL_SUCCESS;
-}
-
-int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
-{
-    *dev_handle = dev_id;
-    return MPL_SUCCESS;
+    return attr->device;
 }
 
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -84,15 +84,13 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int
-MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle,
-                       MPL_gpu_device_handle_t dev_handle, void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
 {
     hipError_t ret;
     int prev_devid;
 
     hipGetDevice(&prev_devid);
-    hipSetDevice(dev_handle);
+    hipSetDevice(dev_id);
     ret = hipIpcOpenMemHandle(ptr, ipc_handle, hipIpcMemLazyEnablePeerAccess);
     HIP_ERR_CHECK(ret);
 

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -180,13 +180,14 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, MPL_gpu_device_handle_t dev_handle,
-                           void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
-    ret =
-        zeMemOpenIpcHandle(global_ze_context, dev_handle, ipc_handle, ZE_IPC_MEMORY_FLAG_TBD, ptr);
+    MPL_gpu_device_handle_t dev_handle = global_ze_devices_handle[dev_id];
+
+    ret = zeMemOpenIpcHandle(global_ze_context, dev_handle, ipc_handle,
+                             ZE_IPC_MEMORY_FLAG_TBD, ptr);
     if (ret != ZE_RESULT_SUCCESS) {
         mpl_err = MPL_ERR_GPU_INTERNAL;
         goto fn_fail;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -14,6 +14,9 @@ static int gpu_initialized = 0;
 static int device_count;
 static int max_dev_id;
 
+static int *local_to_global_map;        /* [device_count] */
+static int *global_to_local_map;        /* [max_dev_id + 1]   */
+
 /* Level-zero API v1.0:
  * http://spec.oneapi.com/level-zero/latest/index.html
  */
@@ -48,7 +51,16 @@ int MPL_gpu_init()
     if (ret_error != MPL_SUCCESS)
         goto fn_fail;
 
-    max_dev_id = device_count = global_ze_device_count;
+    device_count = global_ze_device_count;
+    max_dev_id = device_count - 1;
+
+    local_to_global_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
+    global_to_local_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
+    for (int i = 0; i < device_count; i++) {
+        local_to_global_map[i] = i;
+        global_to_local_map[i] = i;
+    }
+
     gpu_initialized = 1;
 
   fn_exit:
@@ -138,8 +150,22 @@ static int gpu_ze_init_driver()
 
 int MPL_gpu_finalize()
 {
+    MPL_free(local_to_global_map);
+    MPL_free(global_to_local_map);
     MPL_free(global_ze_devices_handle);
     return MPL_SUCCESS;
+}
+
+int MPL_gpu_global_to_local_dev_id(int global_dev_id)
+{
+    assert(global_dev_id <= max_dev_id);
+    return global_to_local_map[global_dev_id];
+}
+
+int MPL_gpu_local_to_global_dev_id(int local_dev_id)
+{
+    assert(local_dev_id < device_count);
+    return local_to_global_map[local_dev_id];
 }
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
@@ -299,13 +325,6 @@ int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id)
 int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
 {
     *dev_handle = global_ze_devices_handle[dev_id];
-    return MPL_SUCCESS;
-}
-
-int MPL_gpu_get_global_dev_ids(int *global_ids, int count)
-{
-    for (int i = 0; i < count; ++i)
-        global_ids[i] = i;
     return MPL_SUCCESS;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -317,16 +317,16 @@ int MPL_gpu_unregister_host(const void *ptr)
     return MPL_SUCCESS;
 }
 
-int MPL_gpu_get_dev_id(MPL_gpu_device_handle_t dev_handle, int *dev_id)
+int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr)
 {
-    *dev_id = dev_handle;
-    return MPL_SUCCESS;
-}
-
-int MPL_gpu_get_dev_handle(int dev_id, MPL_gpu_device_handle_t * dev_handle)
-{
-    *dev_handle = global_ze_devices_handle[dev_id];
-    return MPL_SUCCESS;
+    int dev_id = -1;
+    for (int i = 0; i < global_ze_device_count; i++) {
+        if (global_ze_devices_handle[i] == attr->device) {
+            dev_id = i;
+            break;
+        }
+    }
+    return dev_id;
 }
 
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)


### PR DESCRIPTION
## Pull Request Description

The device id conversion is part of gpu environment rather than
MPIR-logic, thus it is better to be handled by MPL. Besides, the global
device id may not be sequential interges -- e.g. UUIDs, thus wrap inside
MPL allows future changes to add driver specific conversions.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
