### PR TITLE
mpi/coll: fix for blocking collectives that call nonblocking

### DIFF
--- a/src/mpi/coll/allgather/allgather_allcomm_nb.c
+++ b/src/mpi/coll/allgather/allgather_allcomm_nb.c
@@ -10,7 +10,6 @@ int MPIR_Allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -18,11 +17,10 @@ int MPIR_Allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
         MPIR_Iallgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
                         &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
@@ -11,7 +11,6 @@ int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                                MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -19,11 +18,10 @@ int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Data
         MPIR_Iallgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
                          comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
+++ b/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
@@ -10,17 +10,15 @@ int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count
                               MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Iallreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
+++ b/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
@@ -10,7 +10,6 @@ int MPIR_Alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -18,11 +17,10 @@ int MPIR_Alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
         MPIR_Ialltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
                        &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
@@ -11,7 +11,6 @@ int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -19,11 +18,10 @@ int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
         MPIR_Ialltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls,
                         recvtype, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
@@ -12,7 +12,6 @@ int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
                               MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -20,11 +19,10 @@ int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
         MPIR_Ialltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls,
                         recvtypes, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/barrier/barrier_allcomm_nb.c
+++ b/src/mpi/coll/barrier/barrier_allcomm_nb.c
@@ -8,17 +8,15 @@
 int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ibarrier(comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/bcast/bcast_allcomm_nb.c
+++ b/src/mpi/coll/bcast/bcast_allcomm_nb.c
@@ -9,17 +9,15 @@ int MPIR_Bcast_allcomm_nb(void *buffer, MPI_Aint count, MPI_Datatype datatype, i
                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ibcast(buffer, count, datatype, root, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/exscan/exscan_allcomm_nb.c
+++ b/src/mpi/coll/exscan/exscan_allcomm_nb.c
@@ -10,17 +10,15 @@ int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
                            MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Iexscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/gather/gather_allcomm_nb.c
+++ b/src/mpi/coll/gather/gather_allcomm_nb.c
@@ -10,19 +10,16 @@ int MPIR_Gather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype
                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Igather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr,
                      &req_ptr);
-    MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
@@ -11,7 +11,6 @@ int MPIR_Gatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
                             MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -19,11 +18,10 @@ int MPIR_Gatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
         MPIR_Igatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root,
                       comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
@@ -10,19 +10,18 @@ int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
+    MPIR_Errflag_t errflag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Ineighbor_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
                                  comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, &errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
@@ -11,20 +11,18 @@ int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
+    MPIR_Errflag_t errflag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ineighbor_allgatherv(sendbuf, sendcount, sendtype,
                                           recvbuf, recvcounts, displs, recvtype, comm_ptr,
                                           &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, &errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
@@ -10,18 +10,17 @@ int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
+    MPIR_Errflag_t errflag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ineighbor_alltoall(sendbuf, sendcount, sendtype,
                                         recvbuf, recvcount, recvtype, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, &errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
@@ -12,19 +12,18 @@ int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint sendc
                                        MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
+    MPIR_Errflag_t errflag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Ineighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts,
                                  rdispls, recvtype, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, &errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
@@ -12,19 +12,18 @@ int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendc
                                        MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
+    MPIR_Errflag_t errflag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts,
                                  rdispls, recvtypes, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, &errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/reduce/reduce_allcomm_nb.c
+++ b/src/mpi/coll/reduce/reduce_allcomm_nb.c
@@ -10,17 +10,15 @@ int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
                            MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ireduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
@@ -10,18 +10,16 @@ int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const MPI
                                    MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
@@ -10,18 +10,16 @@ int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, MPI
                                          MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/scan/scan_allcomm_nb.c
+++ b/src/mpi/coll/scan/scan_allcomm_nb.c
@@ -9,17 +9,15 @@ int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI
                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Iscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/scatter/scatter_allcomm_nb.c
+++ b/src/mpi/coll/scatter/scatter_allcomm_nb.c
@@ -10,7 +10,6 @@ int MPIR_Scatter_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -18,11 +17,10 @@ int MPIR_Scatter_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
         MPIR_Iscatter(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr,
                       &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
@@ -11,7 +11,6 @@ int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -19,11 +18,10 @@ int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
         MPIR_Iscatterv(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root,
                        comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
 
-    mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIC_Wait(req_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
+    MPIR_Request_free(req_ptr);
 
   fn_exit:
     return mpi_errno;


### PR DESCRIPTION
Call MPIC_wait instead of MPIR_Wait. calling MPIR_Wait requires
convert MPIR_Request to its MPI_Request, and get pointer back again.
During finalize, this process may be broken if such a collective is called after the handle pool is destroyed. 
This commit switch the call to  MPIC_Wait, which takes MPIR_Request directly as a parameter.

## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
