### PR TITLE
ch4/am: refactor ch4 am rndv

### DIFF
--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -263,7 +263,7 @@ int MPII_Comm_create_calculate_mapping(MPIR_Group * group_ptr,
             /* This mapping is relative to comm world */
             MPL_DBG_MSG_FMT(MPIR_DBG_COMM, VERBOSE,
                             (MPL_DBG_FDEST,
-                             "comm-create - mapping into world[%d] = %d", i, g_lpid));
+                             "comm-create - mapping into world[%d] = %ld", i, g_lpid));
             if (g_lpid < wsize) {
                 mapping[i] = g_lpid;
             } else {

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -47,8 +47,8 @@ Non Native API:
       NM*: comm, src_rank, handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq
      SHM*: comm, src_rank, handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq
   am_get_data_copy_cb : MPIDIG_recv_data_copy_cb
-      NM*: void
-     SHM*: void
+      NM*: attr
+     SHM*: attr
   am_hdr_max_sz : MPI_Aint
       NM*: void
      SHM*: void
@@ -471,6 +471,7 @@ PARAM:
     am_hdrs: struct iovec *
     appnum: int
     assert: int
+    attr: int
     av: MPIDI_av_entry_t *
     base: void *
     base-2: const void *

--- a/src/mpid/ch4/generic/am/mpidig_am.h
+++ b/src/mpid/ch4/generic/am/mpidig_am.h
@@ -7,6 +7,7 @@
 #define MPIDIG_AM_H_INCLUDED
 
 #define MPIDI_AM_HANDLERS_MAX (64)
+#define MPIDI_AM_RNDV_CB_MAX  (10)
 
 enum {
     MPIDIG_SEND = 0,
@@ -64,6 +65,12 @@ enum {
     MPIDIG_HANDLER_STATIC_MAX
 };
 
+enum {
+    MPIDIG_RNDV_GENERIC = 0,
+
+    MPIDIG_RNDV_STATIC_MAX
+};
+
 typedef int (*MPIDIG_am_target_cmpl_cb) (MPIR_Request * req);
 typedef int (*MPIDIG_am_origin_cb) (MPIR_Request * req);
 
@@ -100,10 +107,12 @@ typedef int (*MPIDIG_am_origin_cb) (MPIR_Request * req);
 
 typedef int (*MPIDIG_am_target_msg_cb) (void *am_hdr, void *data, MPI_Aint data_sz,
                                         uint32_t attr, MPIR_Request ** req);
+typedef int (*MPIDIG_am_rndv_cb) (MPIR_Request * rreq);
 
 typedef struct MPIDIG_global_t {
     MPIDIG_am_target_msg_cb target_msg_cbs[MPIDI_AM_HANDLERS_MAX];
     MPIDIG_am_origin_cb origin_cbs[MPIDI_AM_HANDLERS_MAX];
+    MPIDIG_am_rndv_cb rndv_cbs[MPIDI_AM_RNDV_CB_MAX];
     /* Control parameters for global progress of RMA target-side active messages.
      * TODO: performance loss need be studied since we add atomic operations
      * in RMA sync and callback routines.*/
@@ -117,6 +126,7 @@ extern MPIDIG_global_t MPIDIG_global;
 void MPIDIG_am_reg_cb(int handler_id,
                       MPIDIG_am_origin_cb origin_cb, MPIDIG_am_target_msg_cb target_msg_cb);
 int MPIDIG_am_reg_cb_dynamic(MPIDIG_am_origin_cb origin_cb, MPIDIG_am_target_msg_cb target_msg_cb);
+void MPIDIG_am_rndv_reg_cb(int rndv_id, MPIDIG_am_rndv_cb rndv_cb);
 
 int MPIDIG_am_init(void);
 void MPIDIG_am_finalize(void);

--- a/src/mpid/ch4/generic/am/mpidig_am.h
+++ b/src/mpid/ch4/generic/am/mpidig_am.h
@@ -98,8 +98,7 @@ typedef int (*MPIDIG_am_origin_cb) (MPIR_Request * req);
         attr |= ((src_vci) << MPIDIG_AM_ATTR_SRC_VCI_SHIFT) | ((dst_vci) << MPIDIG_AM_ATTR_DST_VCI_SHIFT); \
     } while (0)
 
-typedef int (*MPIDIG_am_target_msg_cb) (int handler_id, void *am_hdr,
-                                        void *data, MPI_Aint data_sz,
+typedef int (*MPIDIG_am_target_msg_cb) (void *am_hdr, void *data, MPI_Aint data_sz,
                                         uint32_t attr, MPIR_Request ** req);
 
 typedef struct MPIDIG_global_t {

--- a/src/mpid/ch4/generic/am/mpidig_am_comm_abort.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_comm_abort.c
@@ -8,8 +8,8 @@
 
 static int comm_abort_origin_cb(MPIR_Request * sreq);
 static int comm_abort_target_msg_cb(int handler_id, void *am_hdr,
-                                    void *data, MPI_Aint data_sz,
-                                    int is_local, int is_async, MPIR_Request ** req);
+                                    void *data, MPI_Aint data_sz, uint32_t attr,
+                                    MPIR_Request ** req);
 
 void MPIDIG_am_comm_abort_init(void)
 {
@@ -73,8 +73,8 @@ static int comm_abort_origin_cb(MPIR_Request * sreq)
 }
 
 static int comm_abort_target_msg_cb(int handler_id, void *am_hdr,
-                                    void *data, MPI_Aint data_sz,
-                                    int is_local, int is_async, MPIR_Request ** req)
+                                    void *data, MPI_Aint data_sz, uint32_t attr,
+                                    MPIR_Request ** req)
 {
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch4/generic/am/mpidig_am_comm_abort.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_comm_abort.c
@@ -7,7 +7,7 @@
 #include "mpidch4r.h"
 
 static int comm_abort_origin_cb(MPIR_Request * sreq);
-static int comm_abort_target_msg_cb(int handler_id, void *am_hdr,
+static int comm_abort_target_msg_cb(void *am_hdr,
                                     void *data, MPI_Aint data_sz, uint32_t attr,
                                     MPIR_Request ** req);
 
@@ -72,7 +72,7 @@ static int comm_abort_origin_cb(MPIR_Request * sreq)
     return MPID_Request_complete(sreq);
 }
 
-static int comm_abort_target_msg_cb(int handler_id, void *am_hdr,
+static int comm_abort_target_msg_cb(void *am_hdr,
                                     void *data, MPI_Aint data_sz, uint32_t attr,
                                     MPIR_Request ** req)
 {

--- a/src/mpid/ch4/generic/am/mpidig_am_init.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_init.c
@@ -175,16 +175,16 @@ int MPIDIG_am_init(void)
     MPIDIG_am_reg_cb(MPIDIG_ACC_ACK, NULL, &MPIDIG_acc_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_GET_ACC_ACK,
                      &MPIDIG_get_acc_ack_origin_cb, &MPIDIG_get_acc_ack_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_WIN_COMPLETE, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_WIN_POST, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_WIN_LOCK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_WIN_LOCK_ACK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCK_ACK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_WIN_LOCKALL, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_WIN_LOCKALL_ACK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCKALL, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCKALL_ACK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_WIN_COMPLETE, NULL, &MPIDIG_win_complete_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_WIN_POST, NULL, &MPIDIG_win_post_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_WIN_LOCK, NULL, &MPIDIG_win_lock_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_WIN_LOCK_ACK, NULL, &MPIDIG_win_lock_ack_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCK, NULL, &MPIDIG_win_unlock_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCK_ACK, NULL, &MPIDIG_win_unlock_ack_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_WIN_LOCKALL, NULL, &MPIDIG_win_lockall_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_WIN_LOCKALL_ACK, NULL, &MPIDIG_win_localall_ack_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCKALL, NULL, &MPIDIG_win_unlockall_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCKALL_ACK, NULL, &MPIDIG_win_unlockall_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_PUT_DT_REQ, &MPIDIG_put_dt_origin_cb, &MPIDIG_put_dt_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_PUT_DT_ACK, NULL, &MPIDIG_put_dt_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_PUT_DAT_REQ,

--- a/src/mpid/ch4/generic/am/mpidig_am_init.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_init.c
@@ -182,7 +182,7 @@ int MPIDIG_am_init(void)
     MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCK, NULL, &MPIDIG_win_unlock_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCK_ACK, NULL, &MPIDIG_win_unlock_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_WIN_LOCKALL, NULL, &MPIDIG_win_lockall_target_msg_cb);
-    MPIDIG_am_reg_cb(MPIDIG_WIN_LOCKALL_ACK, NULL, &MPIDIG_win_localall_ack_target_msg_cb);
+    MPIDIG_am_reg_cb(MPIDIG_WIN_LOCKALL_ACK, NULL, &MPIDIG_win_lockall_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCKALL, NULL, &MPIDIG_win_unlockall_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCKALL_ACK, NULL, &MPIDIG_win_unlockall_ack_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_PUT_DT_REQ, &MPIDIG_put_dt_origin_cb, &MPIDIG_put_dt_target_msg_cb);

--- a/src/mpid/ch4/generic/am/mpidig_am_init.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_init.c
@@ -117,6 +117,17 @@ void MPIDIG_am_reg_cb(int handler_id,
     MPIR_FUNC_EXIT;
 }
 
+void MPIDIG_am_rndv_reg_cb(int rndv_id, MPIDIG_am_rndv_cb rndv_cb)
+{
+    MPIR_FUNC_ENTER;
+
+    MPIR_Assert(rndv_id < MPIDIG_RNDV_STATIC_MAX);
+    MPIDIG_global.rndv_cbs[rndv_id] = rndv_cb;
+
+    MPIR_FUNC_EXIT;
+}
+
+
 int MPIDIG_am_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -198,6 +209,8 @@ int MPIDIG_am_init(void)
                      &MPIDIG_acc_data_origin_cb, &MPIDIG_acc_data_target_msg_cb);
     MPIDIG_am_reg_cb(MPIDIG_GET_ACC_DAT_REQ,
                      &MPIDIG_get_acc_data_origin_cb, &MPIDIG_get_acc_data_target_msg_cb);
+
+    MPIDIG_am_rndv_reg_cb(MPIDIG_RNDV_GENERIC, &MPIDIG_do_cts);
 
     MPIDIG_am_comm_abort_init();
 

--- a/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
@@ -53,8 +53,7 @@ int MPIDIG_part_send_data_origin_cb(MPIR_Request * sreq)
 /* Callback used on receiver, triggered when received the send_init AM.
  * It tries to match with a local posted part_rreq or store as unexpected. */
 int MPIDIG_part_send_init_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                        MPI_Aint in_data_sz, int is_local, int is_async,
-                                        MPIR_Request ** req)
+                                        MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
@@ -87,8 +86,9 @@ int MPIDIG_part_send_init_target_msg_cb(int handler_id, void *am_hdr, void *data
         MPIDIG_enqueue_request(unexp_req, &MPIDI_global.part_unexp_list, MPIDIG_PART);
     }
 
-    if (is_async)
+    if (attr & MPIDIG_AM_ATTR__IS_ASYNC) {
         *req = NULL;
+    }
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -102,8 +102,7 @@ int MPIDIG_part_send_init_target_msg_cb(int handler_id, void *am_hdr, void *data
  * data transfer if all partitions have been marked as ready.
  */
 int MPIDIG_part_cts_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                  MPI_Aint in_data_sz, int is_local, int is_async,
-                                  MPIR_Request ** req)
+                                  MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
@@ -125,8 +124,7 @@ int MPIDIG_part_cts_target_msg_cb(int handler_id, void *am_hdr, void *data,
 /* Callback on receiver, triggered when received actual data from sender.
  * It copies data into recvbuf and set local part_rreq complete. */
 int MPIDIG_part_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                        MPI_Aint in_data_sz, int is_local, int is_async,
-                                        MPIR_Request ** req)
+                                        MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
@@ -157,7 +155,7 @@ int MPIDIG_part_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data
     /* Data may be segmented in pipeline AM type; initialize with total send size */
     MPIDIG_recv_type_init(MPIDIG_PART_REQUEST(part_rreq, u.recv).sdata_size, rreq);
 
-    if (is_async) {
+    if (attr & MPIDIG_AM_ATTR__IS_ASYNC) {
         *req = rreq;
     } else {
         MPIDIG_recv_copy(data, rreq);

--- a/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
@@ -52,7 +52,7 @@ int MPIDIG_part_send_data_origin_cb(MPIR_Request * sreq)
 
 /* Callback used on receiver, triggered when received the send_init AM.
  * It tries to match with a local posted part_rreq or store as unexpected. */
-int MPIDIG_part_send_init_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_part_send_init_target_msg_cb(void *am_hdr, void *data,
                                         MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -101,7 +101,7 @@ int MPIDIG_part_send_init_target_msg_cb(int handler_id, void *am_hdr, void *data
  * It stores rreq pointer, updates local status, and optionally initiates
  * data transfer if all partitions have been marked as ready.
  */
-int MPIDIG_part_cts_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_part_cts_target_msg_cb(void *am_hdr, void *data,
                                   MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -123,7 +123,7 @@ int MPIDIG_part_cts_target_msg_cb(int handler_id, void *am_hdr, void *data,
 
 /* Callback on receiver, triggered when received actual data from sender.
  * It copies data into recvbuf and set local part_rreq complete. */
-int MPIDIG_part_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_part_send_data_target_msg_cb(void *am_hdr, void *data,
                                         MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.h
@@ -9,12 +9,10 @@
 int MPIDIG_part_send_data_origin_cb(MPIR_Request * req);
 
 int MPIDIG_part_send_init_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                        MPI_Aint in_data_sz, int is_local, int is_async,
-                                        MPIR_Request ** req);
+                                        MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
 int MPIDIG_part_cts_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                  int is_local, int is_async, MPIR_Request ** req);
+                                  uint32_t attr, MPIR_Request ** req);
 int MPIDIG_part_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                        MPI_Aint in_data_sz, int is_local, int is_async,
-                                        MPIR_Request ** req);
+                                        MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
 
 #endif /* MPIDIG_AM_PART_CALLBACKS_H_INCLUDED */

--- a/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.h
@@ -8,11 +8,11 @@
 
 int MPIDIG_part_send_data_origin_cb(MPIR_Request * req);
 
-int MPIDIG_part_send_init_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_part_send_init_target_msg_cb(void *am_hdr, void *data,
                                         MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
-int MPIDIG_part_cts_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_part_cts_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                   uint32_t attr, MPIR_Request ** req);
-int MPIDIG_part_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_part_send_data_target_msg_cb(void *am_hdr, void *data,
                                         MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
 
 #endif /* MPIDIG_AM_PART_CALLBACKS_H_INCLUDED */

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -233,9 +233,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
                 MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = *request;
             }
             MPIDIG_REQUEST(unexp_req, req->status) &= ~MPIDIG_REQ_UNEXPECTED;
-            MPIDIG_recv_type_init(data_sz, unexp_req);
-            mpi_errno = MPIDIG_do_cts(unexp_req);
-            MPIR_ERR_CHECK(mpi_errno);
+            /* MPIDIG_recv_type_init will call the callback to finish the rndv protocol */
+            mpi_errno = MPIDIG_recv_type_init(data_sz, unexp_req);
             goto fn_exit;
         } else {
             mpi_errno = MPIDIG_handle_unexpected(buf, count, datatype, unexp_req);
@@ -319,7 +318,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
         MPIDIG_REQUEST(message, count) = count;
         MPIDIG_REQUEST(message, req->status) &= ~MPIDIG_REQ_UNEXPECTED;
         MPIDIG_recv_type_init(data_sz, message);
-        MPIDIG_do_cts(message);
     } else {
         mpi_errno = MPIDIG_handle_unexp_mrecv(message);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/generic/am/mpidig_am_recv_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv_utils.h
@@ -36,6 +36,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_recv_check_rndv_cb(MPIR_Request * rreq)
         mpi_errno = MPIDIG_REQUEST(rreq, req->recv_async).data_copy_cb(rreq);
         MPIR_ERR_CHECK(mpi_errno);
 
+        if (MPIDIG_REQUEST(rreq, rndv_hdr)) {
+            MPL_free(MPIDIG_REQUEST(rreq, rndv_hdr));
+            MPIDIG_REQUEST(rreq, rndv_hdr) = NULL;
+        }
         /* the data_copy_cb may complete rreq (e.g. ucx am_send_hdr may invoke
          * progress recursively and finish several callbacks before it return.
          * Thus we need check MPIDIG_REQUEST(rreq, req) still there. */
@@ -319,6 +323,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_recv_copy_seg(void *payload, MPI_Aint payloa
 MPL_STATIC_INLINE_PREFIX bool MPIDIG_recv_initialized(MPIR_Request * rreq)
 {
     return MPIDIG_REQUEST(rreq, req->recv_async).recv_type != MPIDIG_RECV_NONE;
+}
+
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDIG_recv_in_data_sz(MPIR_Request * rreq)
+{
+    return MPIDIG_REQUEST(rreq, req->recv_async).in_data_sz;
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_set_data_copy_cb(MPIR_Request * rreq,

--- a/src/mpid/ch4/generic/am/mpidig_am_send.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_send.h
@@ -76,6 +76,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
     MPI_Aint data_sz;
     MPIDI_Datatype_check_size(datatype, count, data_sz);
     am_hdr.data_sz = data_sz;
+    am_hdr.rndv_hdr_sz = 0;
 
 #ifdef HAVE_DEBUGGER_SUPPORT
     MPIDIG_REQUEST(sreq, datatype) = datatype;
@@ -98,7 +99,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
         MPIDIG_REQUEST(sreq, req->sreq).context_id = am_hdr.context_id;
         MPIDIG_REQUEST(sreq, rank) = rank;
         MPIR_Datatype_add_ref_if_not_builtin(datatype);
-        am_hdr.flags |= MPIDIG_AM_SEND_FLAGS_RTS;
         MPIDIG_AM_SEND_SET_RNDV(am_hdr.flags, MPIDIG_RNDV_GENERIC);
 
         CH4_CALL(am_send_hdr(rank, comm, MPIDIG_SEND, &am_hdr, am_hdr_sz), is_local, mpi_errno);

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -398,8 +398,8 @@ typedef struct MPIDIG_win_info_args_t {
 struct MPIDIG_win_lock {
     struct MPIDIG_win_lock *next;
     int rank;
-    uint16_t mtype;
-    uint16_t type;
+    uint16_t mtype;             /* MPIDIG_WIN_LOCK or MPIDIG_WIN_LOCKALL */
+    uint16_t type;              /* MPI_LOCK_EXCLUSIVE or MPI_LOCK_SHARED */
 };
 
 typedef struct MPIDIG_win_lock_recvd {

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -209,6 +209,7 @@ typedef struct MPIDIG_req_t {
 #endif
     MPIDIG_req_ext_t *req;
     void *buffer;
+    void *rndv_hdr;
     MPI_Aint count;
     int rank;
     int tag;

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -203,8 +203,9 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Ai
     }
 }
 
-MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_NM_am_get_data_copy_cb(void)
+MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_NM_am_get_data_copy_cb(int attr)
 {
+    MPIR_Assert(attr & MPIDI_OFI_AM_ATTR__RDMA);
     return MPIDI_OFI_am_rdma_read_recv_cb;
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.c
@@ -6,7 +6,7 @@
 #include "mpidimpl.h"
 #include "ofi_am_events.h"
 
-int MPIDI_OFI_am_rdma_read_ack_handler(int handler_id, void *am_hdr, void *data,
+int MPIDI_OFI_am_rdma_read_ack_handler(void *am_hdr, void *data,
                                        MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.c
@@ -7,8 +7,7 @@
 #include "ofi_am_events.h"
 
 int MPIDI_OFI_am_rdma_read_ack_handler(int handler_id, void *am_hdr, void *data,
-                                       MPI_Aint in_data_sz, int is_local, int is_async,
-                                       MPIR_Request ** req)
+                                       MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -95,9 +95,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_short_am(MPIDI_OFI_am_header_t * m
 
     MPIR_FUNC_ENTER;
 
-    /* note: setting is_local, is_async, req to 0, 0, NULL */
+    int attr = 0;               /* is_local = 0, is_async = 0 */
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                       p_data, msg_hdr->payload_sz, 0, 0, NULL);
+                                                       p_data, msg_hdr->payload_sz, attr, NULL);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -122,10 +122,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_pipeline(MPIDI_OFI_am_header_t * m
     rreq = cache_rreq;
 
     if (!rreq) {
-        /* no cached request, this must be the first segment */
-        /* note: setting is_local, is_async, req to 0, 1, rreq */
+        int attr = MPIDIG_AM_ATTR__IS_ASYNC;
         MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr, p_data,
-                                                           msg_hdr->payload_sz, 0, 1, &rreq);
+                                                           msg_hdr->payload_sz, attr, &rreq);
         MPIDIG_recv_setup(rreq);
         MPIDIG_req_cache_add(MPIDI_OFI_global.req_map, (uint64_t) msg_hdr->fi_src_addr, rreq);
     }
@@ -147,8 +146,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_short_am_hdr(MPIDI_OFI_am_header_t
 
     MPIR_FUNC_ENTER;
 
+    int attr = 0;
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                       NULL, 0, 0, 0, NULL);
+                                                       NULL, 0, attr, NULL);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -235,9 +235,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_rdma_read(MPIDI_OFI_am_header_t * 
 
     MPIR_FUNC_ENTER;
 
-    /* note: setting is_local, is_async to 0, 1 */
+    int attr = MPIDIG_AM_ATTR__IS_ASYNC;
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                       NULL, msg_hdr->payload_sz, 0, 1, &rreq);
+                                                       NULL, msg_hdr->payload_sz, attr, &rreq);
 
     if (!rreq)
         goto fn_exit;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -234,7 +234,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_rdma_read(MPIDI_OFI_am_header_t * 
 
     MPIR_FUNC_ENTER;
 
-    int attr = MPIDIG_AM_ATTR__IS_ASYNC | MPIDIG_AM_ATTR__IS_RNDV;
+    int attr = MPIDIG_AM_ATTR__IS_ASYNC | MPIDIG_AM_ATTR__IS_RNDV | MPIDI_OFI_AM_ATTR__RDMA;
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, NULL, 0, attr, &rreq);
 
     if (!rreq)

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -96,7 +96,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_short_am(MPIDI_OFI_am_header_t * m
     MPIR_FUNC_ENTER;
 
     int attr = 0;               /* is_local = 0, is_async = 0 */
-    MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
+    MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr,
                                                        p_data, msg_hdr->payload_sz, attr, NULL);
 
     MPIR_FUNC_EXIT;
@@ -123,8 +123,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_pipeline(MPIDI_OFI_am_header_t * m
 
     if (!rreq) {
         int attr = MPIDIG_AM_ATTR__IS_ASYNC;
-        MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr, p_data,
-                                                           msg_hdr->payload_sz, attr, &rreq);
+        MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, p_data, msg_hdr->payload_sz,
+                                                           attr, &rreq);
         MPIDIG_recv_setup(rreq);
         MPIDIG_req_cache_add(MPIDI_OFI_global.req_map, (uint64_t) msg_hdr->fi_src_addr, rreq);
     }
@@ -147,8 +147,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_short_am_hdr(MPIDI_OFI_am_header_t
     MPIR_FUNC_ENTER;
 
     int attr = 0;
-    MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                       NULL, 0, attr, NULL);
+    MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, NULL, 0, attr, NULL);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -235,9 +234,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_rdma_read(MPIDI_OFI_am_header_t * 
 
     MPIR_FUNC_ENTER;
 
-    int attr = MPIDIG_AM_ATTR__IS_ASYNC;
-    MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                       NULL, msg_hdr->payload_sz, attr, &rreq);
+    int attr = MPIDIG_AM_ATTR__IS_ASYNC | MPIDIG_AM_ATTR__IS_RNDV;
+    MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, NULL, 0, attr, &rreq);
 
     if (!rreq)
         goto fn_exit;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -9,6 +9,8 @@
 #include "ofi_impl.h"
 #include "mpidu_genq.h"
 
+#define MPIDI_OFI_AM_ATTR__RDMA 0x100
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_progress_do_queue(int vni_idx);
 
 /* Acquire a sequence number to send, and record the next number */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -309,10 +309,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_set(int ctx_idx, int val)
 int MPIDI_OFI_handle_cq_error_util(int ctx_idx, ssize_t ret);
 int MPIDI_OFI_retry_progress(void);
 int MPIDI_OFI_control_handler(int handler_id, void *am_hdr, void *data, MPI_Aint data_sz,
-                              int is_local, int is_async, MPIR_Request ** req);
+                              uint32_t attr, MPIR_Request ** req);
 int MPIDI_OFI_am_rdma_read_ack_handler(int handler_id, void *am_hdr, void *data,
-                                       MPI_Aint in_data_sz, int is_local, int is_async,
-                                       MPIR_Request ** req);
+                                       MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
 int MPIDI_OFI_control_dispatch(void *buf);
 void MPIDI_OFI_index_datatypes(struct fid_ep *ep);
 int MPIDI_OFI_mr_key_allocator_init(void);

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -308,9 +308,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_set(int ctx_idx, int val)
 #define MPIDI_OFI_INVALID_MR_KEY 0xFFFFFFFFFFFFFFFFULL
 int MPIDI_OFI_handle_cq_error_util(int ctx_idx, ssize_t ret);
 int MPIDI_OFI_retry_progress(void);
-int MPIDI_OFI_control_handler(int handler_id, void *am_hdr, void *data, MPI_Aint data_sz,
+int MPIDI_OFI_control_handler(void *am_hdr, void *data, MPI_Aint data_sz,
                               uint32_t attr, MPIR_Request ** req);
-int MPIDI_OFI_am_rdma_read_ack_handler(int handler_id, void *am_hdr, void *data,
+int MPIDI_OFI_am_rdma_read_ack_handler(void *am_hdr, void *data,
                                        MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
 int MPIDI_OFI_control_dispatch(void *buf);
 void MPIDI_OFI_index_datatypes(struct fid_ep *ep);

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -243,13 +243,14 @@ static int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
 }
 
 int MPIDI_OFI_control_handler(int handler_id, void *am_hdr, void *data, MPI_Aint data_sz,
-                              int is_local, int is_async, MPIR_Request ** req)
+                              uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_send_control_t *ctrlsend = (MPIDI_OFI_send_control_t *) am_hdr;
 
-    if (is_async)
+    if (attr & MPIDIG_AM_ATTR__IS_ASYNC) {
         *req = NULL;
+    }
 
     switch (ctrlsend->type) {
         case MPIDI_OFI_CTRL_HUGEACK:{

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -242,7 +242,7 @@ static int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
     goto fn_exit;
 }
 
-int MPIDI_OFI_control_handler(int handler_id, void *am_hdr, void *data, MPI_Aint data_sz,
+int MPIDI_OFI_control_handler(void *am_hdr, void *data, MPI_Aint data_sz,
                               uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -233,7 +233,7 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Ai
     return (am_hdr_sz + data_sz) <= (MPIDI_UCX_MAX_AM_EAGER_SZ - sizeof(MPIDI_UCX_am_header_t));
 }
 
-MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_NM_am_get_data_copy_cb(void)
+MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_NM_am_get_data_copy_cb(int attr)
 {
     return NULL;
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.c
@@ -19,9 +19,9 @@ ucs_status_t MPIDI_UCX_am_handler(void *arg, void *data, size_t length, ucp_ep_h
     p_data = (char *) msg_hdr->payload + (length - msg_hdr->data_sz - sizeof(*msg_hdr));
     data_sz = msg_hdr->data_sz;
 
-    /* note: setting is_local, is_async to 0, 0 */
+    int attr = 0;               /* is_local = 0, is_async = 0 */
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, msg_hdr->payload,
-                                                       p_data, data_sz, 0, 0, NULL);
+                                                       p_data, data_sz, attr, NULL);
 
     MPL_free(tmp);
     return UCS_OK;

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.c
@@ -20,7 +20,7 @@ ucs_status_t MPIDI_UCX_am_handler(void *arg, void *data, size_t length, ucp_ep_h
     data_sz = msg_hdr->data_sz;
 
     int attr = 0;               /* is_local = 0, is_async = 0 */
-    MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, msg_hdr->payload,
+    MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->payload,
                                                        p_data, data_sz, attr, NULL);
 
     MPL_free(tmp);

--- a/src/mpid/ch4/shm/posix/posix_progress.h
+++ b/src/mpid/ch4/shm/posix/posix_progress.h
@@ -64,15 +64,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_progress_recv(int blocking)
         switch (msg_hdr->am_type) {
             case MPIDI_POSIX_AM_TYPE__HDR:
             case MPIDI_POSIX_AM_TYPE__SHORT:
-                MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                                   payload, payload_left,
+                MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, payload, payload_left,
                                                                    MPIDIG_AM_ATTR__IS_LOCAL, NULL);
                 MPIDI_POSIX_eager_recv_commit(&transaction);
                 goto fn_exit;
                 break;
             case MPIDI_POSIX_AM_TYPE__PIPELINE:
-                MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                                   NULL, payload_left,
+                MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, NULL, payload_left,
                                                                    MPIDIG_AM_ATTR__IS_LOCAL |
                                                                    MPIDIG_AM_ATTR__IS_ASYNC, &rreq);
                 /* prepare for asynchronous transfer */

--- a/src/mpid/ch4/shm/posix/posix_progress.h
+++ b/src/mpid/ch4/shm/posix/posix_progress.h
@@ -64,17 +64,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_progress_recv(int blocking)
         switch (msg_hdr->am_type) {
             case MPIDI_POSIX_AM_TYPE__HDR:
             case MPIDI_POSIX_AM_TYPE__SHORT:
-                /* note: setting is_local, is_async to 1, 0 */
                 MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                                   payload, payload_left, 1, 0,
-                                                                   NULL);
+                                                                   payload, payload_left,
+                                                                   MPIDIG_AM_ATTR__IS_LOCAL, NULL);
                 MPIDI_POSIX_eager_recv_commit(&transaction);
                 goto fn_exit;
                 break;
             case MPIDI_POSIX_AM_TYPE__PIPELINE:
-                /* note: setting is_local, is_async to 1, 1 */
                 MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                                   NULL, payload_left, 1, 1, &rreq);
+                                                                   NULL, payload_left,
+                                                                   MPIDIG_AM_ATTR__IS_LOCAL |
+                                                                   MPIDIG_AM_ATTR__IS_ASYNC, &rreq);
                 /* prepare for asynchronous transfer */
                 MPIDIG_recv_setup(rreq);
 

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -115,7 +115,7 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_SHM_am_check_eager(MPI_Aint am_hdr_sz, MPI_A
     return (am_hdr_sz + data_sz) <= MPIDI_POSIX_am_eager_limit();
 }
 
-MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_SHM_am_get_data_copy_cb(void)
+MPL_STATIC_INLINE_PREFIX MPIDIG_recv_data_copy_cb MPIDI_SHM_am_get_data_copy_cb(int attr)
 {
     return NULL;
 }

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -70,7 +70,8 @@ typedef struct MPIDIG_hdr_t {
     int error_bits;
     int flags;
     MPIR_Request *sreq_ptr;
-    size_t data_sz;
+    MPI_Aint data_sz;
+    MPI_Aint rndv_hdr_sz;
 } MPIDIG_hdr_t;
 
 typedef struct MPIDIG_send_cts_msg_t {

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -68,7 +68,7 @@ typedef struct MPIDIG_hdr_t {
     int tag;
     MPIR_Context_id_t context_id;
     int error_bits;
-    uint8_t flags;
+    int flags;
     MPIR_Request *sreq_ptr;
     size_t data_sz;
 } MPIDIG_hdr_t;

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -311,18 +311,18 @@ static int allocate_unexp_req_pack_buf(MPIR_Request * rreq, MPI_Aint data_sz)
     return mpi_errno;
 }
 
-static void set_rreq_data_copy_cb(MPIR_Request * rreq, int is_local)
+static void set_rreq_data_copy_cb(MPIR_Request * rreq, int attr)
 {
     MPIR_FUNC_ENTER;
     MPIDIG_recv_data_copy_cb data_copy_cb = NULL;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (is_local) {
-        data_copy_cb = MPIDI_SHM_am_get_data_copy_cb();
+    if (attr & MPIDIG_AM_ATTR__IS_LOCAL) {
+        data_copy_cb = MPIDI_SHM_am_get_data_copy_cb(attr);
     } else {
-        data_copy_cb = MPIDI_NM_am_get_data_copy_cb();
+        data_copy_cb = MPIDI_NM_am_get_data_copy_cb(attr);
     }
 #else
-    data_copy_cb = MPIDI_NM_am_get_data_copy_cb();
+    data_copy_cb = MPIDI_NM_am_get_data_copy_cb(attr);
 #endif
     MPIDIG_recv_set_data_copy_cb(rreq, data_copy_cb);
     MPIR_FUNC_EXIT;
@@ -413,7 +413,7 @@ int MPIDIG_send_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
             set_rndv_cb(rreq);
         } else {        /* MSG_MODE_TRANSPORT_RNDV */
             MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_RTS;
-            set_rreq_data_copy_cb(rreq, is_local);
+            set_rreq_data_copy_cb(rreq, attr);
         }
 
         MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -217,147 +217,230 @@ int MPIDIG_send_data_origin_cb(MPIR_Request * sreq)
     return mpi_errno;
 }
 
-int MPIDIG_send_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
-                              uint32_t attr, MPIR_Request ** req)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *rreq = NULL;
-    MPIDIG_hdr_t *hdr = (MPIDIG_hdr_t *) am_hdr;
-    void *pack_buf = NULL;
-    bool do_cts = false;
+/* Handling send_target_msg_cb. There 2 paths, 3 types, totalling 6 outcomes
+ *     2 paths: unexpected or matched
+ *     3 types: eager, rndv, transport rndv
+ *
+ * With unexpected path, we create unexp_req and enqueue to unexpected list. If it is
+ * eager message, we mark BUSY start data copy. Otherwise, setup callback.
+ *
+ * With matched path, if it is eager message, start data copy. Otherwise, call cts.
+ *
+ */
 
+static int match_posted_rreq(int rank, int tag, MPIR_Context_id_t context_id, MPIR_Request ** req)
+{
+#ifdef MPIDI_CH4_DIRECT_NETMOD
+    *req = MPIDIG_rreq_dequeue(rank, tag, context_id,
+                               &MPIDI_global.posted_list, MPIDIG_PT2PT_POSTED);
+    return MPI_SUCCESS;
+#else
+    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
-    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                    (MPL_DBG_FDEST, "HDR: data_sz=%ld, flags=0x%X", hdr->data_sz, hdr->flags));
-    /* MPIDI_CS_ENTER(); */
+
+    *req = NULL;
     while (TRUE) {
-        rreq =
-            MPIDIG_rreq_dequeue(hdr->src_rank, hdr->tag, hdr->context_id,
-                                &MPIDI_global.posted_list, MPIDIG_PT2PT_POSTED);
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        if (rreq) {
+        *req = MPIDIG_rreq_dequeue(rank, tag, context_id,
+                                   &MPIDI_global.posted_list, MPIDIG_PT2PT_POSTED);
+        if (*req) {
             int is_cancelled;
-            mpi_errno = MPIDI_anysrc_try_cancel_partner(rreq, &is_cancelled);
+            mpi_errno = MPIDI_anysrc_try_cancel_partner(*req, &is_cancelled);
             MPIR_ERR_CHECK(mpi_errno);
             if (!is_cancelled) {
-                MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
+                MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(*req, datatype));
                 continue;
             }
         }
-#endif /* MPIDI_CH4_DIRECT_NETMOD */
         break;
     }
-    /* MPIDI_CS_EXIT(); */
 
-    if (rreq == NULL) {
-        rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2);
-        MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        /* for unexpected message, always recv as MPI_BYTE into unexpected buffer. They will be
-         * set to the recv side datatype and count when it is matched */
-        MPIDIG_REQUEST(rreq, datatype) = MPI_BYTE;
-        MPIDIG_REQUEST(rreq, count) = hdr->data_sz;
-        /* Note the hdr->data_sz means how much data the incoming AM message has, the in_data_sz is
-         * how much data there is along with the incoming header. The sender may have decided to
-         * send the header and the data separately (for example in RNDV protocol) which would result
-         * in in_data_sz == 0 and hdr->data_sz != 0. */
-        if (in_data_sz) {
-            /* If there is inline data, we allocate unexpected buffer */
-            MPIR_Assert(in_data_sz <= MPIR_CVAR_CH4_AM_PACK_BUFFER_SIZE);
-            mpi_errno =
-                MPIDU_genq_private_pool_alloc_cell(MPIDI_global.unexp_pack_buf_pool, &pack_buf);
-            MPIR_Assert(pack_buf);
-            MPIDIG_REQUEST(rreq, buffer) = pack_buf;
-        } else {
-            /* The SEND is a zero byte messeage */
-            MPIDIG_REQUEST(rreq, buffer) = NULL;
-        }
-        MPIDIG_REQUEST(rreq, rank) = hdr->src_rank;
-        MPIDIG_REQUEST(rreq, tag) = hdr->tag;
-        MPIDIG_REQUEST(rreq, context_id) = hdr->context_id;
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+#endif /* MPIDI_CH4_DIRECT_NETMOD */
+}
 
-        MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_UNEXPECTED;
-        rreq->status.MPI_ERROR = hdr->error_bits;
-        if (hdr->flags & MPIDIG_AM_SEND_FLAGS_RTS) {
-            /* this is unexpected RNDV */
-            MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = hdr->sreq_ptr;
-            MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_RTS;
-            MPIDIG_REQUEST(rreq, req->rreq.match_req) = NULL;
-        } else {
-            /* this is unexpected EAGER */
-            if (!(attr & MPIDIG_AM_ATTR__IS_RNDV)) {
-                /* marking the request busy to prevent another thread touching it before transport
-                 * finishes and calls the recv_target_cmpl_cb, or transport setup the data_copy_cb.
-                 * */
-                MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_BUSY;
-                MPIDIG_recv_type_init(hdr->data_sz, rreq);
-            } else {
-                /* transport rndv, set up data_copy_cb */
-                MPIDIG_recv_data_copy_cb data_copy_cb = NULL;
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-                if (attr & MPIDIG_AM_ATTR__IS_LOCAL) {
-                    data_copy_cb = MPIDI_SHM_am_get_data_copy_cb();
-                } else {
-#endif
-                    data_copy_cb = MPIDI_NM_am_get_data_copy_cb();
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-                }
-#endif
-                MPIDIG_recv_set_data_copy_cb(rreq, data_copy_cb);
+static int create_unexp_rreq(int rank, int tag, MPIR_Context_id_t context_id,
+                             MPI_Aint data_sz, int error_bits, int is_local, MPIR_Request ** req)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_ENTER;
 
-            }
-        }
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        MPIDI_REQUEST(rreq, is_local) = (attr & MPIDIG_AM_ATTR__IS_LOCAL) ? 1 : 0;
-#endif
-        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
-        MPIDIG_enqueue_request(rreq, &MPIDI_global.unexp_list, MPIDIG_PT2PT_UNEXP);
-        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
-    } else {
-        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        (MPL_DBG_FDEST, "posted req %p handle=0x%x", rreq, rreq->handle));
+    MPIR_Request *rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2);
+    MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
-        MPIDIG_REQUEST(rreq, rank) = hdr->src_rank;
-        MPIDIG_REQUEST(rreq, tag) = hdr->tag;
-        MPIDIG_REQUEST(rreq, context_id) = hdr->context_id;
+    *req = rreq;
+
+    /* for unexpected message, always recv as MPI_BYTE into unexpected buffer. They will be
+     * set to the recv side datatype and count when it is matched */
+    MPIDIG_REQUEST(rreq, datatype) = MPI_BYTE;
+    MPIDIG_REQUEST(rreq, count) = data_sz;
+    MPIDIG_REQUEST(rreq, buffer) = NULL;        /* default */
+    MPIDIG_REQUEST(rreq, rank) = rank;
+    MPIDIG_REQUEST(rreq, tag) = tag;
+    MPIDIG_REQUEST(rreq, context_id) = context_id;
+
+    MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_UNEXPECTED;
+    MPIDIG_REQUEST(rreq, req->rreq.match_req) = NULL;
+    rreq->status.MPI_ERROR = error_bits;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-        MPIDI_REQUEST(rreq, is_local) = (attr & MPIDIG_AM_ATTR__IS_LOCAL) ? 1 : 0;
+    MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
 
-        rreq->status.MPI_ERROR = hdr->error_bits;
-        if (hdr->flags & MPIDIG_AM_SEND_FLAGS_RTS) {
-            /* this is expected RNDV, init a special recv into unexp buffer */
-            MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = hdr->sreq_ptr;
-            MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_RTS;
-            MPIDIG_REQUEST(rreq, req->rreq.match_req) = NULL;
-            do_cts = true;
-        }
-        MPIDIG_recv_type_init(hdr->data_sz, rreq);
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int allocate_unexp_req_pack_buf(MPIR_Request * rreq, MPI_Aint data_sz)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_ENTER;
+    if (data_sz > 0) {
+        void *pack_buf;
+        MPIR_Assert(data_sz <= MPIR_CVAR_CH4_AM_PACK_BUFFER_SIZE);
+        mpi_errno = MPIDU_genq_private_pool_alloc_cell(MPIDI_global.unexp_pack_buf_pool, &pack_buf);
+        MPIR_Assert(pack_buf);
+        MPIDIG_REQUEST(rreq, buffer) = pack_buf;
     }
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+}
 
+static void set_rreq_data_copy_cb(MPIR_Request * rreq, int is_local)
+{
+    MPIR_FUNC_ENTER;
+    MPIDIG_recv_data_copy_cb data_copy_cb = NULL;
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    if (is_local) {
+        data_copy_cb = MPIDI_SHM_am_get_data_copy_cb();
+    } else {
+        data_copy_cb = MPIDI_NM_am_get_data_copy_cb();
+    }
+#else
+    data_copy_cb = MPIDI_NM_am_get_data_copy_cb();
+#endif
+    MPIDIG_recv_set_data_copy_cb(rreq, data_copy_cb);
+    MPIR_FUNC_EXIT;
+}
+
+static void set_rndv_cb(MPIR_Request * rreq)
+{
+    MPIDIG_recv_set_data_copy_cb(rreq, MPIDIG_do_cts);
+}
+
+static void call_rndv_cb(MPIR_Request * rreq)
+{
+    MPIDIG_do_cts(rreq);
+}
+
+static void set_matched_rreq_fields(MPIR_Request * rreq, int rank, int tag,
+                                    MPIR_Context_id_t context_id, int error_bits, int is_local)
+{
+    MPIR_FUNC_ENTER;
+    MPIDIG_REQUEST(rreq, rank) = rank;
+    MPIDIG_REQUEST(rreq, tag) = tag;
+    MPIDIG_REQUEST(rreq, context_id) = context_id;
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_REQUEST(rreq, is_local) = is_local;
+#endif
+
+    rreq->status.MPI_ERROR = error_bits;
+    MPIR_FUNC_EXIT;
+}
+
+static void set_rreq_common(MPIR_Request * rreq, MPIDIG_hdr_t * hdr)
+{
+    MPIR_FUNC_ENTER;
     if (hdr->flags & MPIDIG_AM_SEND_FLAGS_SYNC) {
         MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = hdr->sreq_ptr;
         MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_PEER_SSEND;
     }
 
     MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_IN_PROGRESS;
-
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = recv_target_cmpl_cb;
+    MPIR_FUNC_EXIT;
+}
 
-    if (attr & MPIDIG_AM_ATTR__IS_ASYNC) {
-        if (hdr->flags & MPIDIG_AM_SEND_FLAGS_RTS) {
-            *req = NULL;
-        } else {
-            *req = rreq;
-        }
+#define MSG_MODE_EAGER 1
+#define MSG_MODE_RNDV_RTS 2
+#define MSG_MODE_TRANSPORT_RNDV 3
+
+int MPIDIG_send_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
+                              uint32_t attr, MPIR_Request ** req)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_ENTER;
+
+    MPIR_Request *rreq = NULL;
+    MPIDIG_hdr_t *hdr = (MPIDIG_hdr_t *) am_hdr;
+    void *pack_buf = NULL;
+    bool is_unexp = false;
+    int is_local = (attr & MPIDIG_AM_ATTR__IS_LOCAL) ? 1 : 0;
+
+    int msg_mode;
+    if (hdr->flags & MPIDIG_AM_SEND_FLAGS_RTS) {
+        msg_mode = MSG_MODE_RNDV_RTS;
+    } else if (attr & MPIDIG_AM_ATTR__IS_RNDV) {
+        msg_mode = MSG_MODE_TRANSPORT_RNDV;
     } else {
-        if (!(hdr->flags & MPIDIG_AM_SEND_FLAGS_RTS)) {
-            MPIDIG_recv_copy(data, rreq);
-            MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+        msg_mode = MSG_MODE_EAGER;
+    }
+
+    mpi_errno = match_posted_rreq(hdr->src_rank, hdr->tag, hdr->context_id, &rreq);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (rreq == NULL) {
+        /* unexpected path */
+        mpi_errno = create_unexp_rreq(hdr->src_rank, hdr->tag, hdr->context_id,
+                                      hdr->data_sz, hdr->error_bits, is_local, &rreq);
+        MPIR_ERR_CHECK(mpi_errno);
+        set_rreq_common(rreq, hdr);
+
+        if (msg_mode == MSG_MODE_EAGER) {
+            allocate_unexp_req_pack_buf(rreq, hdr->data_sz);
+            /* marking the request busy to prevent recv swapout the request
+             * before transport finishes. */
+            MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_BUSY;
+            MPIDIG_recv_type_init(hdr->data_sz, rreq);
+        } else if (msg_mode == MSG_MODE_RNDV_RTS) {
+            MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = hdr->sreq_ptr;
+            MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_RTS;
+            set_rndv_cb(rreq);
+        } else {        /* MSG_MODE_TRANSPORT_RNDV */
+            MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_RTS;
+            set_rreq_data_copy_cb(rreq, is_local);
+        }
+
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
+        MPIDIG_enqueue_request(rreq, &MPIDI_global.unexp_list, MPIDIG_PT2PT_UNEXP);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
+    } else {
+        /* matched path */
+        set_matched_rreq_fields(rreq, hdr->src_rank, hdr->tag, hdr->context_id,
+                                hdr->error_bits, is_local);
+        set_rreq_common(rreq, hdr);
+        MPIDIG_recv_type_init(hdr->data_sz, rreq);
+
+        if (msg_mode == MSG_MODE_EAGER) {
+            /* either we or transport will finish recv_copy depending on ASYNC attr */
+        } else if (msg_mode == MSG_MODE_RNDV_RTS) {
+            MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = hdr->sreq_ptr;
+            call_rndv_cb(rreq);
+        } else {        /* MSG_MODE_TRANSPORT_RNDV */
+            /* transport will finish the rndv */
         }
     }
 
-    if (do_cts) {
-        MPIDIG_do_cts(rreq);
+    if (attr & MPIDIG_AM_ATTR__IS_ASYNC) {
+        *req = rreq;
+    } else if (msg_mode == MSG_MODE_EAGER) {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
     }
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -217,7 +217,7 @@ int MPIDIG_send_data_origin_cb(MPIR_Request * sreq)
     return mpi_errno;
 }
 
-int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_send_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                               uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -372,7 +372,7 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
     goto fn_exit;
 }
 
-int MPIDIG_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_send_data_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                    uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -395,7 +395,7 @@ int MPIDIG_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI
     return mpi_errno;
 }
 
-int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_ssend_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                    uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -414,7 +414,7 @@ int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI
     return mpi_errno;
 }
 
-int MPIDIG_send_cts_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_send_cts_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                   uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -20,13 +20,12 @@ int MPIDIG_send_origin_cb(MPIR_Request * sreq);
 int MPIDIG_send_data_origin_cb(MPIR_Request * sreq);
 int MPIDIG_ssend_ack_origin_cb(MPIR_Request * req);
 int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                              int is_local, int is_async, MPIR_Request ** req);
+                              uint32_t attr, MPIR_Request ** req);
 int MPIDIG_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                   int is_local, int is_async, MPIR_Request ** req);
+                                   uint32_t attr, MPIR_Request ** req);
 int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                   MPI_Aint p_data_sz, int is_local, int is_async,
-                                   MPIR_Request ** req);
+                                   MPI_Aint p_data_sz, uint32_t attr, MPIR_Request ** req);
 int MPIDIG_send_cts_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint p_data_sz,
-                                  int is_local, int is_async, MPIR_Request ** req);
+                                  uint32_t attr, MPIR_Request ** req);
 
 #endif /* CH4R_CALLBACKS_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -19,13 +19,13 @@ void MPIDIG_progress_compl_list(void);
 int MPIDIG_send_origin_cb(MPIR_Request * sreq);
 int MPIDIG_send_data_origin_cb(MPIR_Request * sreq);
 int MPIDIG_ssend_ack_origin_cb(MPIR_Request * req);
-int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_send_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                               uint32_t attr, MPIR_Request ** req);
-int MPIDIG_send_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_send_data_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                    uint32_t attr, MPIR_Request ** req);
-int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_ssend_ack_target_msg_cb(void *am_hdr, void *data,
                                    MPI_Aint p_data_sz, uint32_t attr, MPIR_Request ** req);
-int MPIDIG_send_cts_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint p_data_sz,
+int MPIDIG_send_cts_target_msg_cb(void *am_hdr, void *data, MPI_Aint p_data_sz,
                                   uint32_t attr, MPIR_Request ** req);
 
 #endif /* CH4R_CALLBACKS_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -355,7 +355,7 @@ static int win_lock_advance(MPIR_Win * win)
     goto fn_exit;
 }
 
-static void win_lock_req_proc(int handler_id, const MPIDIG_win_cntrl_msg_t * info, MPIR_Win * win)
+static void win_lock_req_proc(int mtype, const MPIDIG_win_cntrl_msg_t * info, MPIR_Win * win)
 {
     MPIR_FUNC_ENTER;
 
@@ -363,7 +363,7 @@ static void win_lock_req_proc(int handler_id, const MPIDIG_win_cntrl_msg_t * inf
     struct MPIDIG_win_lock *lock = (struct MPIDIG_win_lock *)
         MPL_calloc(1, sizeof(struct MPIDIG_win_lock), MPL_MEM_RMA);
 
-    lock->mtype = handler_id;
+    lock->mtype = mtype;        /* MPIDIG_WIN_LOCK or MPIDIG_WIN_LOCKALL */
     lock->rank = info->origin_rank;
     lock->type = info->lock_type;
     MPIDIG_win_lock_recvd_t *lock_recvd_q = &MPIDIG_WIN(win, sync).lock_recvd;
@@ -1060,9 +1060,8 @@ int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI
     return mpi_errno;
 }
 
-
-int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                  uint32_t attr, MPIR_Request ** req)
+static int win_ctrl_handler(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                            uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDIG_win_cntrl_msg_t *msg_hdr = (MPIDIG_win_cntrl_msg_t *) am_hdr;
@@ -1118,6 +1117,66 @@ int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_win_ctrl);
     MPIR_FUNC_EXIT;
     return mpi_errno;
+}
+
+int MPIDIG_win_lock_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                  uint32_t attr, MPIR_Request ** req)
+{
+    return win_ctrl_handler(MPIDIG_WIN_LOCK, am_hdr, data, in_data_sz, attr, req);
+}
+
+int MPIDIG_win_lockall_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                     uint32_t attr, MPIR_Request ** req)
+{
+    return win_ctrl_handler(MPIDIG_WIN_LOCKALL, am_hdr, data, in_data_sz, attr, req);
+}
+
+int MPIDIG_win_unlock_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                    uint32_t attr, MPIR_Request ** req)
+{
+    return win_ctrl_handler(MPIDIG_WIN_UNLOCK, am_hdr, data, in_data_sz, attr, req);
+}
+
+int MPIDIG_win_unlockall_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                       MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
+{
+    return win_ctrl_handler(MPIDIG_WIN_UNLOCKALL, am_hdr, data, in_data_sz, attr, req);
+}
+
+int MPIDIG_win_lock_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                      uint32_t attr, MPIR_Request ** req)
+{
+    return win_ctrl_handler(MPIDIG_WIN_LOCK_ACK, am_hdr, data, in_data_sz, attr, req);
+}
+
+int MPIDIG_win_unlock_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                        MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
+{
+    return win_ctrl_handler(MPIDIG_WIN_UNLOCK_ACK, am_hdr, data, in_data_sz, attr, req);
+}
+
+int MPIDIG_win_lockall_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                         MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
+{
+    return win_ctrl_handler(MPIDIG_WIN_LOCKALL_ACK, am_hdr, data, in_data_sz, attr, req);
+}
+
+int MPIDIG_win_unlockall_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                           MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
+{
+    return win_ctrl_handler(MPIDIG_WIN_UNLOCKALL_ACK, am_hdr, data, in_data_sz, attr, req);
+}
+
+int MPIDIG_win_post_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                  uint32_t attr, MPIR_Request ** req)
+{
+    return win_ctrl_handler(MPIDIG_WIN_POST, am_hdr, data, in_data_sz, attr, req);
+}
+
+int MPIDIG_win_complete_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                      uint32_t attr, MPIR_Request ** req)
+{
+    return win_ctrl_handler(MPIDIG_WIN_COMPLETE, am_hdr, data, in_data_sz, attr, req);
 }
 
 int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -930,7 +930,7 @@ static int cswap_ack_target_cmpl_cb(MPIR_Request * rreq)
     return mpi_errno;
 }
 
-int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_put_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                  uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -960,7 +960,7 @@ int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_A
     return mpi_errno;
 }
 
-int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_acc_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                  uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -990,7 +990,7 @@ int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_A
     return mpi_errno;
 }
 
-int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_acc_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                      uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1028,7 +1028,7 @@ int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, M
     return mpi_errno;
 }
 
-int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_cswap_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                    uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1119,67 +1119,67 @@ static int win_ctrl_handler(int handler_id, void *am_hdr, void *data, MPI_Aint i
     return mpi_errno;
 }
 
-int MPIDIG_win_lock_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_lock_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                   uint32_t attr, MPIR_Request ** req)
 {
     return win_ctrl_handler(MPIDIG_WIN_LOCK, am_hdr, data, in_data_sz, attr, req);
 }
 
-int MPIDIG_win_lockall_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_lockall_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                      uint32_t attr, MPIR_Request ** req)
 {
     return win_ctrl_handler(MPIDIG_WIN_LOCKALL, am_hdr, data, in_data_sz, attr, req);
 }
 
-int MPIDIG_win_unlock_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_unlock_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                     uint32_t attr, MPIR_Request ** req)
 {
     return win_ctrl_handler(MPIDIG_WIN_UNLOCK, am_hdr, data, in_data_sz, attr, req);
 }
 
-int MPIDIG_win_unlockall_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_win_unlockall_target_msg_cb(void *am_hdr, void *data,
                                        MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     return win_ctrl_handler(MPIDIG_WIN_UNLOCKALL, am_hdr, data, in_data_sz, attr, req);
 }
 
-int MPIDIG_win_lock_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_lock_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                       uint32_t attr, MPIR_Request ** req)
 {
     return win_ctrl_handler(MPIDIG_WIN_LOCK_ACK, am_hdr, data, in_data_sz, attr, req);
 }
 
-int MPIDIG_win_unlock_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_win_unlock_ack_target_msg_cb(void *am_hdr, void *data,
                                         MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     return win_ctrl_handler(MPIDIG_WIN_UNLOCK_ACK, am_hdr, data, in_data_sz, attr, req);
 }
 
-int MPIDIG_win_lockall_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_win_lockall_ack_target_msg_cb(void *am_hdr, void *data,
                                          MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     return win_ctrl_handler(MPIDIG_WIN_LOCKALL_ACK, am_hdr, data, in_data_sz, attr, req);
 }
 
-int MPIDIG_win_unlockall_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_win_unlockall_ack_target_msg_cb(void *am_hdr, void *data,
                                            MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     return win_ctrl_handler(MPIDIG_WIN_UNLOCKALL_ACK, am_hdr, data, in_data_sz, attr, req);
 }
 
-int MPIDIG_win_post_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_post_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                   uint32_t attr, MPIR_Request ** req)
 {
     return win_ctrl_handler(MPIDIG_WIN_POST, am_hdr, data, in_data_sz, attr, req);
 }
 
-int MPIDIG_win_complete_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_complete_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                       uint32_t attr, MPIR_Request ** req)
 {
     return win_ctrl_handler(MPIDIG_WIN_COMPLETE, am_hdr, data, in_data_sz, attr, req);
 }
 
-int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_put_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                              uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1253,7 +1253,7 @@ int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint 
     goto fn_exit;
 }
 
-int MPIDIG_put_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_put_dt_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                 uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1308,7 +1308,7 @@ int MPIDIG_put_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Ai
     goto fn_exit;
 }
 
-int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_put_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                     uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1349,7 +1349,7 @@ int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
     goto fn_exit;
 }
 
-int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_acc_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                     uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1390,7 +1390,7 @@ int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
     goto fn_exit;
 }
 
-int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_get_acc_dt_ack_target_msg_cb(void *am_hdr, void *data,
                                         MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1432,7 +1432,7 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data
     goto fn_exit;
 }
 
-int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_put_data_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                   uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1476,7 +1476,7 @@ int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_
     goto fn_exit;
 }
 
-int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_acc_data_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                   uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1505,7 +1505,7 @@ int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_
     return mpi_errno;
 }
 
-int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_acc_data_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                       uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1533,7 +1533,7 @@ int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, 
     return mpi_errno;
 }
 
-int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_cswap_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1595,7 +1595,7 @@ int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Ain
     goto fn_exit;
 }
 
-int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_acc_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                              uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1675,7 +1675,7 @@ int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint 
 }
 
 
-int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_acc_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                  uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1686,7 +1686,7 @@ int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_A
     /* the same handling processing as ACC except the completion handler function. */
     /* set is_async to 1 so we can get rreq back */
     MPIR_Request *rreq;
-    mpi_errno = MPIDIG_acc_target_msg_cb(handler_id, am_hdr, data, in_data_sz,
+    mpi_errno = MPIDIG_acc_target_msg_cb(am_hdr, data, in_data_sz,
                                          attr | MPIDIG_AM_ATTR__IS_ASYNC, &rreq);
 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = get_acc_target_cmpl_cb;
@@ -1704,7 +1704,7 @@ int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_A
     return mpi_errno;
 }
 
-int MPIDIG_acc_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_acc_dt_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                 uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1764,7 +1764,7 @@ int MPIDIG_acc_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Ai
     goto fn_exit;
 }
 
-int MPIDIG_get_acc_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_acc_dt_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                     uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1775,7 +1775,7 @@ int MPIDIG_get_acc_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
     /* the same handling processing as ACC except the completion handler function. */
     /* set is_async to 1 so we can get rreq back */
     MPIR_Request *rreq;
-    mpi_errno = MPIDIG_acc_dt_target_msg_cb(handler_id, am_hdr, data, in_data_sz,
+    mpi_errno = MPIDIG_acc_dt_target_msg_cb(am_hdr, data, in_data_sz,
                                             attr | MPIDIG_AM_ATTR__IS_ASYNC, &rreq);
 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = get_acc_dt_target_cmpl_cb;
@@ -1793,7 +1793,7 @@ int MPIDIG_get_acc_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MP
     return mpi_errno;
 }
 
-int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                              uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1853,7 +1853,7 @@ int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint 
     goto fn_exit;
 }
 
-int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                  uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -34,63 +34,63 @@ extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_acc_data ATTRIBUTE((unused));
 extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get_acc_data ATTRIBUTE((unused));
 
 int MPIDIG_RMA_Init_targetcb_pvars(void);
-int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_put_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                  uint32_t attr, MPIR_Request ** req);
-int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_acc_ack_target_msg_cb(void *am_hdr, void *data,
                                  MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
-int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_acc_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                      uint32_t attr, MPIR_Request ** req);
-int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_cswap_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                    uint32_t attr, MPIR_Request ** req);
-int MPIDIG_win_complete_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_complete_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                       uint32_t attr, MPIR_Request ** req);
-int MPIDIG_win_post_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_post_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                   uint32_t attr, MPIR_Request ** req);
-int MPIDIG_win_lock_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_lock_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                   uint32_t attr, MPIR_Request ** req);
-int MPIDIG_win_lockall_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_lockall_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                      uint32_t attr, MPIR_Request ** req);
-int MPIDIG_win_unlock_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_unlock_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                     uint32_t attr, MPIR_Request ** req);
-int MPIDIG_win_unlockall_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_win_unlockall_target_msg_cb(void *am_hdr, void *data,
                                        MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
-int MPIDIG_win_lock_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_lock_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                       uint32_t attr, MPIR_Request ** req);
-int MPIDIG_win_lockall_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_win_lockall_ack_target_msg_cb(void *am_hdr, void *data,
                                          MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
-int MPIDIG_win_unlock_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_win_unlock_ack_target_msg_cb(void *am_hdr, void *data,
                                         MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
-int MPIDIG_win_unlockall_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_win_unlockall_ack_target_msg_cb(void *am_hdr, void *data,
                                            MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
-int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_put_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                              uint32_t attr, MPIR_Request ** req);
-int MPIDIG_put_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_put_dt_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                 uint32_t attr, MPIR_Request ** req);
-int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_put_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                     uint32_t attr, MPIR_Request ** req);
-int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_acc_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                     uint32_t attr, MPIR_Request ** req);
-int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+int MPIDIG_get_acc_dt_ack_target_msg_cb(void *am_hdr, void *data,
                                         MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
-int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_put_data_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                   uint32_t attr, MPIR_Request ** req);
-int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_acc_data_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                   uint32_t attr, MPIR_Request ** req);
-int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_acc_data_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                       uint32_t attr, MPIR_Request ** req);
-int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_cswap_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                uint32_t attr, MPIR_Request ** req);
-int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_acc_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                              uint32_t attr, MPIR_Request ** req);
-int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_acc_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                  uint32_t attr, MPIR_Request ** req);
-int MPIDIG_acc_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_acc_dt_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                 uint32_t attr, MPIR_Request ** req);
-int MPIDIG_get_acc_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_acc_dt_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                     uint32_t attr, MPIR_Request ** req);
-int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                              uint32_t attr, MPIR_Request ** req);
-int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_get_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                  uint32_t attr, MPIR_Request ** req);
 
 #endif /* CH4R_RMA_TARGET_CALLBACKS_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -42,8 +42,26 @@ int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, M
                                      uint32_t attr, MPIR_Request ** req);
 int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
                                    uint32_t attr, MPIR_Request ** req);
-int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+int MPIDIG_win_complete_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                      uint32_t attr, MPIR_Request ** req);
+int MPIDIG_win_post_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
                                   uint32_t attr, MPIR_Request ** req);
+int MPIDIG_win_lock_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                  uint32_t attr, MPIR_Request ** req);
+int MPIDIG_win_lockall_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                     uint32_t attr, MPIR_Request ** req);
+int MPIDIG_win_unlock_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                    uint32_t attr, MPIR_Request ** req);
+int MPIDIG_win_unlockall_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                       MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
+int MPIDIG_win_lock_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                      uint32_t attr, MPIR_Request ** req);
+int MPIDIG_win_lockall_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                         MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
+int MPIDIG_win_unlock_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                        MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
+int MPIDIG_win_unlockall_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                           MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
 int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
                              uint32_t attr, MPIR_Request ** req);
 int MPIDIG_put_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -35,46 +35,44 @@ extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get_acc_data ATTRIBUTE((unuse
 
 int MPIDIG_RMA_Init_targetcb_pvars(void);
 int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                 int is_local, int is_async, MPIR_Request ** req);
+                                 uint32_t attr, MPIR_Request ** req);
 int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                 MPI_Aint in_data_sz, int is_local, int is_async,
-                                 MPIR_Request ** req);
+                                 MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
 int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                     int is_local, int is_async, MPIR_Request ** req);
+                                     uint32_t attr, MPIR_Request ** req);
 int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                   int is_local, int is_async, MPIR_Request ** req);
+                                   uint32_t attr, MPIR_Request ** req);
 int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                  int is_local, int is_async, MPIR_Request ** req);
+                                  uint32_t attr, MPIR_Request ** req);
 int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                             int is_local, int is_async, MPIR_Request ** req);
+                             uint32_t attr, MPIR_Request ** req);
 int MPIDIG_put_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                int is_local, int is_async, MPIR_Request ** req);
+                                uint32_t attr, MPIR_Request ** req);
 int MPIDIG_put_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                    int is_local, int is_async, MPIR_Request ** req);
+                                    uint32_t attr, MPIR_Request ** req);
 int MPIDIG_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                    int is_local, int is_async, MPIR_Request ** req);
+                                    uint32_t attr, MPIR_Request ** req);
 int MPIDIG_get_acc_dt_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
-                                        MPI_Aint in_data_sz, int is_local, int is_async,
-                                        MPIR_Request ** req);
+                                        MPI_Aint in_data_sz, uint32_t attr, MPIR_Request ** req);
 int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                  int is_local, int is_async, MPIR_Request ** req);
+                                  uint32_t attr, MPIR_Request ** req);
 int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                  int is_local, int is_async, MPIR_Request ** req);
+                                  uint32_t attr, MPIR_Request ** req);
 int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                      int is_local, int is_async, MPIR_Request ** req);
+                                      uint32_t attr, MPIR_Request ** req);
 int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                               int is_local, int is_async, MPIR_Request ** req);
+                               uint32_t attr, MPIR_Request ** req);
 int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                             int is_local, int is_async, MPIR_Request ** req);
+                             uint32_t attr, MPIR_Request ** req);
 int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                 int is_local, int is_async, MPIR_Request ** req);
+                                 uint32_t attr, MPIR_Request ** req);
 int MPIDIG_acc_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                int is_local, int is_async, MPIR_Request ** req);
+                                uint32_t attr, MPIR_Request ** req);
 int MPIDIG_get_acc_dt_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                    int is_local, int is_async, MPIR_Request ** req);
+                                    uint32_t attr, MPIR_Request ** req);
 int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                             int is_local, int is_async, MPIR_Request ** req);
+                             uint32_t attr, MPIR_Request ** req);
 int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
-                                 int is_local, int is_async, MPIR_Request ** req);
+                                 uint32_t attr, MPIR_Request ** req);
 
 #endif /* CH4R_RMA_TARGET_CALLBACKS_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description
The current code has IPC duplicate most of the ch4 AM code in handling send/recv and rndv exchange. The existing ch4 AM code was very complex. The duplication of the IPC path and the necessary glues to make it work makes the code extremely difficult to develop and maintain.

This PR refactors the ch4 send/recv am path with a framework to handle multiple rndv-like protocols. As a result, the IPC path can be simply implemented as a couple of callback functions. We can easily extend IPC to add support for receive side devices in the future.

* [x] the ipc commits are moved into #5493 and will remove after the tests

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
