### PR TITLE
coll: add error return to gentran routines

### DIFF
--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -872,6 +872,19 @@ cvars:
     do {                                                        \
         (err_) = MPIR_Err_combine_codes((err_), (newerr_));     \
     } while (0)
+
+/* For collective communication errors, record the error and continue */
+/* NOTE: this one assumes we are using mpi_errno and mpi_errno_ret */
+/* TODO: document the cases or criteria that we can safely do this */
+#define MPIR_ERR_COLL_CHECKANDCONT(err_, errflag_) \
+    do { \
+        if (err_) { \
+            errflag_ = (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(err_)) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER; \
+            MPIR_ERR_SET(mpi_errno, errflag_, "**fail"); \
+            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno); \
+        } \
+    } while (0)
+
 #else
 /* Simply set the class, being careful not to override a previously
    set class. */
@@ -936,6 +949,12 @@ cvars:
         if (!err_)                              \
             err_ = newerr_;                     \
     } while (0)
+
+#define MPIR_ERR_COLL_CHECKANDCONT(err_, errflag_) \
+    do { \
+        errflag_ = (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(err_)) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER; \
+    } while (0)
+
 #endif
 
 /* The following definitions are the same independent of the choice of

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
@@ -13,17 +13,20 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                        MPIR_Comm * comm, int k, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int i, j;
     int nphases = 0;
     int n_invtcs;
     int tag;
     int count, left_count;
     int src, dst, p_of_k = 0;   /* Largest power of k that is (strictly) smaller than 'size' */
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     int rank = MPIR_Comm_rank(comm);
     int size = MPIR_Comm_size(comm);
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int max = size - 1;
+    int vtx_id;
 
     MPI_Aint sendtype_extent, sendtype_lb;
     MPI_Aint recvtype_extent, recvtype_lb;
@@ -74,14 +77,16 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
         tmp_recvbuf = MPIR_TSP_sched_malloc(size * recvcount * recvtype_extent, sched);
 
     /* Step1: copy own data from sendbuf to top of recvbuf. */
-    if (is_inplace && rank != 0)
-        MPIR_TSP_sched_localcopy((char *) recvbuf + rank * recvcount * recvtype_extent,
-                                 recvcount, recvtype, tmp_recvbuf, recvcount, recvtype, sched, 0,
-                                 NULL);
-    else if (!is_inplace)
-        MPIR_TSP_sched_localcopy(sendbuf, sendcount, sendtype, tmp_recvbuf,
-                                 recvcount, recvtype, sched, 0, NULL);
+    if (is_inplace && rank != 0) {
+        mpi_errno = MPIR_TSP_sched_localcopy((char *) recvbuf + rank * recvcount * recvtype_extent,
+                                             recvcount, recvtype, tmp_recvbuf, recvcount, recvtype,
+                                             sched, 0, NULL, &vtx_id);
+    } else if (!is_inplace) {
+        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, sendcount, sendtype, tmp_recvbuf,
+                                             recvcount, recvtype, sched, 0, NULL, &vtx_id);
+    }
 
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     /* All following sends/recvs and copies depend on this dtcopy */
     MPIR_TSP_sched_fence(sched);
 
@@ -109,17 +114,21 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             }
 
             /* Receive at the exact location. */
-            recv_id[i_recv++] =
+            mpi_errno =
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + j * recvcount * delta * recvtype_extent,
-                                     count, recvtype, src, tag, comm, sched, 0, NULL);
+                                     count, recvtype, src, tag, comm, sched, 0, NULL, &vtx_id);
 
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            recv_id[i_recv++] = vtx_id;
             /* Send from the start of recv till `count` amount of data. */
             if (i == 0)
-                MPIR_TSP_sched_isend(tmp_recvbuf, count, recvtype, dst, tag, comm, sched, 0, NULL);
+                mpi_errno =
+                    MPIR_TSP_sched_isend(tmp_recvbuf, count, recvtype, dst, tag, comm, sched, 0,
+                                         NULL, &vtx_id);
             else
-                MPIR_TSP_sched_isend(tmp_recvbuf, count, recvtype, dst, tag,
-                                     comm, sched, n_invtcs, recv_id);
-
+                mpi_errno = MPIR_TSP_sched_isend(tmp_recvbuf, count, recvtype, dst, tag,
+                                                 comm, sched, n_invtcs, recv_id, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
         n_invtcs += (k - 1);
         delta *= k;
@@ -127,13 +136,17 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     MPIR_TSP_sched_fence(sched);
 
     if (rank != 0) {    /* No shift required for rank 0 */
-        MPIR_TSP_sched_localcopy((char *) tmp_recvbuf + (size - rank) * recvcount * recvtype_extent,
-                                 rank * recvcount, recvtype, (char *) recvbuf, rank * recvcount,
-                                 recvtype, sched, 0, NULL);
-
-        MPIR_TSP_sched_localcopy((char *) tmp_recvbuf, (size - rank) * recvcount, recvtype,
-                                 (char *) recvbuf + rank * recvcount * recvtype_extent,
-                                 (size - rank) * recvcount, recvtype, sched, 0, NULL);
+        mpi_errno =
+            MPIR_TSP_sched_localcopy((char *) tmp_recvbuf +
+                                     (size - rank) * recvcount * recvtype_extent, rank * recvcount,
+                                     recvtype, (char *) recvbuf, rank * recvcount, recvtype, sched,
+                                     0, NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        mpi_errno =
+            MPIR_TSP_sched_localcopy((char *) tmp_recvbuf, (size - rank) * recvcount, recvtype,
+                                     (char *) recvbuf + rank * recvcount * recvtype_extent,
+                                     (size - rank) * recvcount, recvtype, sched, 0, NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
   fn_exit:

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring.c
@@ -12,6 +12,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
                                          MPIR_Comm * comm, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int i, src, dst, copy_dst;
     /* Temporary buffers to execute the ring algorithm */
     void *buf1, *buf2, *data_buf, *rbuf, *sbuf;
@@ -20,6 +21,8 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
     int rank = MPIR_Comm_rank(comm);
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int tag;
+    int vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPI_Aint recvtype_lb, recvtype_extent;
     MPI_Aint sendtype_lb, sendtype_extent;
@@ -51,20 +54,22 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
     int dtcopy_id[3];
     if (is_inplace) {
         /* Copy data to buf1 from sendbuf or recvbuf(in case of inplace) */
-        dtcopy_id[0] =
+        mpi_errno =
             MPIR_TSP_sched_localcopy((char *) data_buf + rank * recvcount * recvtype_extent,
                                      sendcount, sendtype, (char *) buf1, recvcount, recvtype, sched,
-                                     0, NULL);
+                                     0, NULL, &dtcopy_id[0]);
     } else {
         /* Copy your data into your recvbuf from your sendbuf */
-        MPIR_TSP_sched_localcopy((char *) sendbuf, sendcount, sendtype,
-                                 (char *) recvbuf + rank * recvcount * recvtype_extent,
-                                 recvcount, recvtype, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_localcopy((char *) sendbuf, sendcount, sendtype,
+                                             (char *) recvbuf + rank * recvcount * recvtype_extent,
+                                             recvcount, recvtype, sched, 0, NULL, &vtx_id);
 
         /* Copy data from sendbuf to buf1 to send the data */
-        dtcopy_id[0] = MPIR_TSP_sched_localcopy((char *) data_buf, sendcount, sendtype,
-                                                (char *) buf1, recvcount, recvtype, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_localcopy((char *) data_buf, sendcount, sendtype,
+                                             (char *) buf1, recvcount, recvtype, sched, 0, NULL,
+                                             &dtcopy_id[0]);
     }
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
     /* In ring algorithm src and dst are fixed */
     src = (size + rank - 1) % size;
@@ -85,15 +90,15 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
         if (i == 0) {
             nvtcs = 1;
             vtcs[0] = dtcopy_id[0];
-            send_id[0] = MPIR_TSP_sched_isend((char *) sbuf, recvcount, recvtype,
-                                              dst, tag, comm, sched, nvtcs, vtcs);
+            mpi_errno = MPIR_TSP_sched_isend((char *) sbuf, recvcount, recvtype,
+                                             dst, tag, comm, sched, nvtcs, vtcs, &send_id[0]);
             nvtcs = 0;
         } else {
             nvtcs = 2;
             vtcs[0] = recv_id[(i - 1) % 3];
             vtcs[1] = send_id[(i - 1) % 3];
-            send_id[i % 3] = MPIR_TSP_sched_isend((char *) sbuf, recvcount, recvtype,
-                                                  dst, tag, comm, sched, nvtcs, vtcs);
+            mpi_errno = MPIR_TSP_sched_isend((char *) sbuf, recvcount, recvtype,
+                                             dst, tag, comm, sched, nvtcs, vtcs, &send_id[i % 3]);
             if (i == 1) {
                 nvtcs = 2;
                 vtcs[0] = send_id[0];
@@ -105,15 +110,21 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
                 vtcs[2] = recv_id[(i - 1) % 3];
             }
         }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
-        recv_id[i % 3] = MPIR_TSP_sched_irecv((char *) rbuf, recvcount, recvtype,
-                                              src, tag, comm, sched, nvtcs, vtcs);
+        mpi_errno = MPIR_TSP_sched_irecv((char *) rbuf, recvcount, recvtype,
+                                         src, tag, comm, sched, nvtcs, vtcs, &recv_id[i % 3]);
+
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
         copy_dst = (size + rank - i - 1) % size;        /* Destination offset of the copy */
-        dtcopy_id[i % 3] = MPIR_TSP_sched_localcopy((char *) rbuf, recvcount, recvtype,
-                                                    (char *) recvbuf +
-                                                    copy_dst * recvcount * recvtype_extent,
-                                                    recvcount, recvtype, sched, 1, &recv_id[i % 3]);
+        mpi_errno = MPIR_TSP_sched_localcopy((char *) rbuf, recvcount, recvtype,
+                                             (char *) recvbuf +
+                                             copy_dst * recvcount * recvtype_extent,
+                                             recvcount, recvtype, sched, 1, &recv_id[i % 3],
+                                             &dtcopy_id[i % 3]);
+
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
         data_buf = sbuf;
         sbuf = rbuf;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
@@ -53,14 +53,17 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     int **s_counts = NULL;
     int **r_counts = NULL;
     int tmp_sum = 0;
-    int idx = 0;
+    int idx = 0, vtx_id;
     int index_sum = 0;
     int prev_delta = 0;
     int count_length, top_count, bottom_count, left_count;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
+
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
@@ -111,6 +114,8 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
         tmp_recvbuf = recvbuf;
     else
         tmp_recvbuf = MPIR_TSP_sched_malloc(total_recvcount * recvtype_extent, sched);
+    MPIR_ERR_CHKANDJUMP(!tmp_recvbuf, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
 
     r_counts = (int **) MPL_malloc(sizeof(int *) * nphases, MPL_MEM_COLL);
     if (nphases > 0)
@@ -189,12 +194,14 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
 
     /* Step1: copy own data from sendbuf to top of recvbuf */
     if (is_inplace && rank != 0)
-        MPIR_TSP_sched_localcopy((char *) recvbuf + displs[rank] * recvtype_extent,
-                                 recvcounts[rank], recvtype, tmp_recvbuf,
-                                 recvcounts[rank], recvtype, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_localcopy((char *) recvbuf + displs[rank] * recvtype_extent,
+                                             recvcounts[rank], recvtype, tmp_recvbuf,
+                                             recvcounts[rank], recvtype, sched, 0, NULL, &vtx_id);
     else if (!is_inplace)
-        MPIR_TSP_sched_localcopy(sendbuf, sendcount, sendtype, tmp_recvbuf,
-                                 recvcounts[rank], recvtype, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, sendcount, sendtype, tmp_recvbuf,
+                                             recvcounts[rank], recvtype, sched, 0, NULL, &vtx_id);
+
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_TSP_sched_fence(sched);
 
@@ -209,15 +216,20 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             dst = (int) (size + (rank - delta * j)) % size;
             src = (int) (rank + delta * j) % size;
             /* Recv at the exact location */
-            recv_id[idx] =
+            mpi_errno =
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + recv_index[idx] * recvtype_extent,
-                                     r_counts[i][j - 1], recvtype, src, tag, comm, sched, 0, NULL);
+                                     r_counts[i][j - 1], recvtype, src, tag, comm, sched, 0, NULL,
+                                     &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
+            recv_id[idx] = vtx_id;
             idx++;
 
             /* Send from the start of recv till the count amount of data */
-            MPIR_TSP_sched_isend(tmp_recvbuf, s_counts[i][j - 1], recvtype, dst, tag, comm, sched,
-                                 n_invtcs, recv_id);
-
+            mpi_errno =
+                MPIR_TSP_sched_isend(tmp_recvbuf, s_counts[i][j - 1], recvtype, dst, tag, comm,
+                                     sched, n_invtcs, recv_id, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
         n_invtcs += (k - 1);
         delta *= k;
@@ -234,20 +246,26 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
 
             bottom_count = idx;
             top_count = total_recvcount - idx;
-            MPIR_TSP_sched_localcopy((char *) tmp_recvbuf + bottom_count * recvtype_extent,
-                                     top_count, recvtype, recvbuf, top_count, recvtype, sched, 0,
-                                     NULL);
-            MPIR_TSP_sched_localcopy(tmp_recvbuf, bottom_count, recvtype,
-                                     (char *) recvbuf + top_count * recvtype_extent, bottom_count,
-                                     recvtype, sched, 0, NULL);
+            mpi_errno =
+                MPIR_TSP_sched_localcopy((char *) tmp_recvbuf + bottom_count * recvtype_extent,
+                                         top_count, recvtype, recvbuf, top_count, recvtype, sched,
+                                         0, NULL, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
+            mpi_errno = MPIR_TSP_sched_localcopy(tmp_recvbuf, bottom_count, recvtype,
+                                                 (char *) recvbuf + top_count * recvtype_extent,
+                                                 bottom_count, recvtype, sched, 0, NULL, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         } else {
             for (i = 0; i < size; i++) {
                 src = (rank + i) % size;        /* Rank whose data it is copying */
                 idx += (i == 0) ? 0 : recvcounts[(rank + i - 1) % size];
-                MPIR_TSP_sched_localcopy((char *) tmp_recvbuf + idx * recvtype_extent,
-                                         recvcounts[src], recvtype,
-                                         (char *) recvbuf + displs[src] * recvtype_extent,
-                                         recvcounts[src], recvtype, sched, 0, NULL);
+                mpi_errno = MPIR_TSP_sched_localcopy((char *) tmp_recvbuf + idx * recvtype_extent,
+                                                     recvcounts[src], recvtype,
+                                                     (char *) recvbuf +
+                                                     displs[src] * recvtype_extent, recvcounts[src],
+                                                     recvtype, sched, 0, NULL, &vtx_id);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             }
         }
     }

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
@@ -17,8 +17,10 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int 
                                                                   MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int partner, offset, count, send_offset, recv_offset;
-    int i, send_count, recv_count;
+    int i, send_count, recv_count, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -37,8 +39,10 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int 
                         (MPL_DBG_FDEST, "data exchange with %d send_offset %d count %d \n", partner,
                          send_offset, send_count));
         /* send my data to partner */
-        MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), send_count, recvtype, partner,
-                             tag, comm, sched, 0, NULL);
+        mpi_errno =
+            MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), send_count, recvtype, partner,
+                                 tag, comm, sched, 0, NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
         /* calculate offset and count of the data to be received from the partner */
         MPII_Recexchalgo_get_count_and_offset(partner, 0, k, nranks, &count, &offset);
@@ -50,8 +54,9 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int 
                         (MPL_DBG_FDEST, "data exchange with %d recv_offset %d count %d \n", partner,
                          recv_offset, recv_count));
         /* recv data from my partner */
-        MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), recv_count, recvtype,
-                             partner, tag, comm, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), recv_count, recvtype,
+                                         partner, tag, comm, sched, 0, NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     MPIR_FUNC_EXIT;
@@ -71,7 +76,10 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int 
                                                           MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int send_offset, recv_offset, i;
+    int mpi_errno_ret = MPI_SUCCESS;
+    int send_offset, recv_offset, i, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+
 
     MPIR_FUNC_ENTER;
 
@@ -82,14 +90,18 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int 
             buf_to_send = ((char *) recvbuf + send_offset);
         else
             buf_to_send = (void *) sendbuf;
-        MPIR_TSP_sched_isend(buf_to_send, recvcounts[rank], recvtype, step1_sendto, tag, comm,
-                             sched, 0, NULL);
-
+        mpi_errno =
+            MPIR_TSP_sched_isend(buf_to_send, recvcounts[rank], recvtype, step1_sendto, tag, comm,
+                                 sched, 0, NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets the data from non-participating rank */
             recv_offset = displs[step1_recvfrom[i]] * recv_extent;
-            MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), recvcounts[step1_recvfrom[i]],
-                                 recvtype, step1_recvfrom[i], tag, comm, sched, n_invtcs, invtx);
+            mpi_errno =
+                MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset),
+                                     recvcounts[step1_recvfrom[i]], recvtype, step1_recvfrom[i],
+                                     tag, comm, sched, n_invtcs, invtx, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
     }
 
@@ -109,10 +121,12 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
                                                    MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int phase, i, j, count, nbr, send_offset, recv_offset, offset, rank_for_offset;
-    int x, send_count, recv_count;
+    int x, send_count, recv_count, vtx_id;
     int *recv_id = *recv_id_;
     int nrecvs = 0;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -135,8 +149,9 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
             send_count = 0;
             for (x = 0; x < count; x++)
                 send_count += recvcounts[offset + x];
-            MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), send_count, recvtype,
-                                 nbr, tag, comm, sched, nrecvs, recv_id);
+            mpi_errno = MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), send_count, recvtype,
+                                             nbr, tag, comm, sched, nrecvs, recv_id, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
                              "phase %d nbr is %d send offset %d count %d depend on %d \n", phase,
@@ -154,9 +169,12 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
             recv_count = 0;
             for (x = 0; x < count; x++)
                 recv_count += recvcounts[offset + x];
-            recv_id[j * (k - 1) + i] =
+            mpi_errno =
                 MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), recv_count, recvtype,
-                                     nbr, tag, comm, sched, 0, NULL);
+                                     nbr, tag, comm, sched, 0, NULL, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
+            recv_id[j * (k - 1) + i] = vtx_id;
             nrecvs++;
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
@@ -187,7 +205,9 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step3(int step1_sendto, int 
                                                           MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int total_count = 0, i;
+    int mpi_errno_ret = MPI_SUCCESS;
+    int total_count = 0, i, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -196,13 +216,16 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step3(int step1_sendto, int 
         total_count += recvcounts[i];
 
     if (step1_sendto != -1) {
-        MPIR_TSP_sched_irecv(recvbuf, total_count, recvtype, step1_sendto, tag, comm, sched,
-                             0, NULL);
+        mpi_errno =
+            MPIR_TSP_sched_irecv(recvbuf, total_count, recvtype, step1_sendto, tag, comm, sched, 0,
+                                 NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     for (i = 0; i < step1_nrecvs; i++) {
-        MPIR_TSP_sched_isend(recvbuf, total_count, recvtype, step1_recvfrom[i],
-                             tag, comm, sched, nrecvs, recv_id);
+        mpi_errno = MPIR_TSP_sched_isend(recvbuf, total_count, recvtype, step1_recvfrom[i],
+                                         tag, comm, sched, nrecvs, recv_id, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     MPIR_FUNC_EXIT;
@@ -256,11 +279,11 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, MPI_Aint sendc
 
     if (!is_inplace && is_instep2) {
         /* copy the data to recvbuf but only if you are a rank participating in Step 2 */
-        dtcopy_id =
+        mpi_errno =
             MPIR_TSP_sched_localcopy(sendbuf, sendcount, sendtype,
                                      (char *) recvbuf + displs[rank] * recv_extent,
-                                     recvcounts[rank], recvtype, sched, 0, NULL);
-
+                                     recvcounts[rank], recvtype, sched, 0, NULL, &dtcopy_id);
+        MPIR_ERR_CHECK(mpi_errno);
         invtx = dtcopy_id;
         n_invtcs = 1;
     } else {

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
@@ -15,6 +15,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                                             MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int is_inplace, i, j;
     int dtcopy_id = -1;
     size_t extent;
@@ -33,7 +34,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     void *tmp_buf;
     void **step1_recvbuf = NULL;
     void **nbr_buffer;
-    int tag;
+    int tag, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -64,8 +66,9 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     MPIR_Assert(send_id != NULL && reduce_id != NULL && recv_id != NULL && vtcs != NULL);
 
     if (in_step2 && !is_inplace && count > 0) { /* copy the data to recvbuf but only if you are a rank participating in Step 2 */
-        dtcopy_id = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
-                                             recvbuf, count, datatype, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
+                                             recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     /* Step 1 */
@@ -121,9 +124,11 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                     vtcs[nvtcs++] = reduce_id[k - 2];
                 }
             }
-            dtcopy_id =
+            mpi_errno =
                 MPIR_TSP_sched_localcopy(recvbuf, count, datatype, tmp_buf, count, datatype, sched,
-                                         nvtcs, vtcs);
+                                         nvtcs, vtcs, &dtcopy_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
         }
         /* myidx is the index in the neighbors list such that
          * all neighbors before myidx have ranks less than my rank
@@ -147,8 +152,10 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             }
 
             nbr = step2_nbrs[phase][i];
-            send_id[i] =
-                MPIR_TSP_sched_isend(tmp_buf, count, datatype, nbr, tag, comm, sched, nvtcs, vtcs);
+            mpi_errno =
+                MPIR_TSP_sched_isend(tmp_buf, count, datatype, nbr, tag, comm, sched, nvtcs, vtcs,
+                                     &send_id[i]);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             if (rank > nbr) {
                 myidx = i + 1;
             }
@@ -161,9 +168,10 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             if (count != 0 && per_nbr_buffer == 0 && (phase != 0 || counter != 0)) {
                 vtcs[nvtcs++] = (counter == 0) ? reduce_id[k - 2] : reduce_id[counter - 1];
             }
-            recv_id[buf] =
+            mpi_errno =
                 MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
-                                     vtcs);
+                                     vtcs, &recv_id[buf]);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
             if (count != 0) {
                 nvtcs = 1;
@@ -173,9 +181,10 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                 } else {
                     vtcs[nvtcs++] = reduce_id[counter - 1];
                 }
-                reduce_id[counter] =
+                mpi_errno =
                     MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
-                                                sched, nvtcs, vtcs);
+                                                sched, nvtcs, vtcs, &reduce_id[counter]);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             }
 
         }
@@ -187,9 +196,11 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             if (count != 0 && per_nbr_buffer == 0 && (phase != 0 || counter != 0)) {
                 vtcs[nvtcs++] = (counter == 0) ? reduce_id[k - 2] : reduce_id[counter - 1];
             }
-            recv_id[buf] =
+            mpi_errno =
                 MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
-                                     vtcs);
+                                     vtcs, &recv_id[buf]);
+
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
             if (count != 0) {
                 nvtcs = 1;
@@ -200,16 +211,20 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                     vtcs[nvtcs++] = reduce_id[counter - 1];
                 }
                 if (is_commutative) {
-                    reduce_id[counter] =
+                    mpi_errno =
                         MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
-                                                    sched, nvtcs, vtcs);
+                                                    sched, nvtcs, vtcs, &reduce_id[counter]);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
                 } else {
-                    reduce_id[counter] =
+                    mpi_errno =
                         MPIR_TSP_sched_reduce_local(recvbuf, nbr_buffer[buf], count, datatype, op,
-                                                    sched, nvtcs, vtcs);
-                    reduce_id[counter] =
+                                                    sched, nvtcs, vtcs, &reduce_id[counter]);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                    mpi_errno =
                         MPIR_TSP_sched_localcopy(nbr_buffer[buf], count, datatype, recvbuf, count,
-                                                 datatype, sched, 1, &reduce_id[counter]);
+                                                 datatype, sched, 1, &reduce_id[counter], &vtx_id);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                    reduce_id[counter] = vtx_id;
                 }
             }
         }
@@ -218,7 +233,10 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
      * send the data to non-partcipating ranks */
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
-        MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, sched, 0, NULL);
+        mpi_errno =
+            MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, sched, 0, NULL,
+                                 &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {
             if (count == 0) {
@@ -235,8 +253,10 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                 nvtcs = 1;
                 vtcs[0] = reduce_id[k - 2];
             }
-            MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm, sched,
-                                 nvtcs, vtcs);
+            mpi_errno =
+                MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm, sched,
+                                     nvtcs, vtcs, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
     }
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
@@ -20,6 +20,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
                                                                               sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int is_inplace, i;
     int dtcopy_id = -1;
     size_t extent;
@@ -36,7 +37,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     bool in_step2 = false;
     void *tmp_recvbuf;
     void **step1_recvbuf = NULL;
-    int tag;
+    int tag, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int allgather_algo_type = MPIR_IALLGATHER_RECEXCH_TYPE_DISTANCE_HALVING;
     int redscat_algo_type = IREDUCE_SCATTER_RECEXCH_TYPE_DISTANCE_HALVING;
     MPIR_CHKLMEM_DECL(2);
@@ -72,8 +74,9 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Beforeinitial dt copy\n"));
     if (in_step2 && !is_inplace && count > 0) { /* copy the data to tmp_recvbuf but only if you are a rank participating in Step 2 */
-        dtcopy_id = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
-                                             recvbuf, count, datatype, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
+                                             recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After initial dt copy\n"));
 
@@ -135,11 +138,16 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
      * send the data to non-partcipating ranks */
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
-        MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, sched, 1, &sink_id);
+        mpi_errno =
+            MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, sched, 1,
+                                 &sink_id, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {
-            MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm, sched,
-                                 nvtcs, recv_id);
+            mpi_errno =
+                MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm, sched,
+                                     nvtcs, recv_id, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
     }
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.c
@@ -36,7 +36,6 @@ Input Parameters:
 - sched - scheduler (handle)
 
 */
-
 int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                                                   void *recvbuf,
                                                   MPI_Aint count,
@@ -50,8 +49,10 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                                                   MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int i, nvtcs;
+    int i, nvtcs, vtx_id;
+    int mpi_errno_ret = MPI_SUCCESS;
     void **step1_recvbuf;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
     /* Step 1 */
@@ -62,7 +63,15 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
             buf_to_send = (const void *) recvbuf;
         else
             buf_to_send = sendbuf;
-        MPIR_TSP_sched_isend(buf_to_send, count, datatype, step1_sendto, tag, comm, sched, 0, NULL);
+        mpi_errno =
+            MPIR_TSP_sched_isend(buf_to_send, count, datatype, step1_sendto, tag, comm, sched, 0,
+                                 NULL, &vtx_id);
+        if (mpi_errno) {
+            /* for communication errors, just record the error but continue */
+            errflag = MPIR_ERR_OTHER;
+            MPIR_ERR_SET(mpi_errno, errflag, "**fail");
+            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+        }
     } else {    /* Step 2 participating rank */
         step1_recvbuf = *step1_recvbuf_ =
             (void **) MPL_malloc(sizeof(void *) * step1_nrecvs, MPL_MEM_COLL);
@@ -86,8 +95,10 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                                 (MPL_DBG_FDEST, "step1 recv depend on reduce_id[%d] %d", i - 1,
                                  reduce_id[i - 1]));
             }
-            recv_id[i] = MPIR_TSP_sched_irecv(step1_recvbuf[i], count, datatype,
-                                              step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs);
+            mpi_errno = MPIR_TSP_sched_irecv(step1_recvbuf[i], count, datatype,
+                                             step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
+                                             &recv_id[i]);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             if (count != 0) {   /* Reduce only if data is present */
                 /* setup reduce dependencies */
                 nvtcs = 1;
@@ -103,9 +114,10 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                     else if (i != 0)
                         vtcs[nvtcs++] = reduce_id[i - 1];
                 }
-                reduce_id[i] = MPIR_TSP_sched_reduce_local(step1_recvbuf[i], recvbuf, count,
-                                                           datatype, op, sched, nvtcs, vtcs);
-
+                mpi_errno = MPIR_TSP_sched_reduce_local(step1_recvbuf[i], recvbuf, count,
+                                                        datatype, op, sched, nvtcs, vtcs,
+                                                        &reduce_id[i]);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             }
         }
     }

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.h
@@ -17,5 +17,4 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                                                   int *step1_recvfrom, int per_nbr_buffer,
                                                   void ***step1_recvbuf_, MPIR_Comm * comm,
                                                   MPIR_TSP_sched_t sched);
-
 #endif /* IALLREDUCE_TSP_RECURSIVE_EXCHANGE_COMMON_H_INCLUDED */

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
@@ -15,6 +15,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
                                          MPIR_Comm * comm, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int i, src, dst;
     int nranks, is_inplace, rank;
     size_t extent;
@@ -23,7 +24,8 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
     int recv_id, *reduce_id, nvtcs, vtcs;
     int send_rank, recv_rank, total_count;
     void *tmpbuf;
-    int tag;
+    int tag, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
     MPIR_CHKLMEM_DECL(4);
@@ -60,8 +62,10 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
 
     /* Phase 1: copy to tmp buf */
     if (!is_inplace) {
-        MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype, sched, 0,
-                                 NULL);
+        mpi_errno =
+            MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype, sched, 0,
+                                     NULL, &vtx_id);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_TSP_sched_fence(sched);
     }
 
@@ -83,16 +87,22 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
 
         nvtcs = (i == 0) ? 0 : 1;
         vtcs = (i == 0) ? 0 : reduce_id[(i - 1) % 2];
-        recv_id =
+        mpi_errno =
             MPIR_TSP_sched_irecv(tmpbuf, cnts[recv_rank], datatype, src, tag, comm, sched, nvtcs,
-                                 &vtcs);
+                                 &vtcs, &recv_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
-        reduce_id[i % 2] =
+        mpi_errno =
             MPIR_TSP_sched_reduce_local(tmpbuf, (char *) recvbuf + displs[recv_rank] * extent,
-                                        cnts[recv_rank], datatype, op, sched, 1, &recv_id);
+                                        cnts[recv_rank], datatype, op, sched, 1, &recv_id,
+                                        &reduce_id[i % 2]);
 
-        MPIR_TSP_sched_isend((char *) recvbuf + displs[send_rank] * extent, cnts[send_rank],
-                             datatype, dst, tag, comm, sched, nvtcs, &vtcs);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        mpi_errno =
+            MPIR_TSP_sched_isend((char *) recvbuf + displs[send_rank] * extent, cnts[send_rank],
+                                 datatype, dst, tag, comm, sched, nvtcs, &vtcs, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
     MPIR_CHKLMEM_MALLOC(reduce_id, int *, 2 * sizeof(int), mpi_errno, "reduce_id", MPL_MEM_COLL);
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
@@ -14,6 +14,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
                                          int buffer_per_child, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int i, j, t;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
     int offset = 0;
@@ -30,8 +31,9 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
     int *vtcs = NULL, *recv_id = NULL, *reduce_id = NULL;       /* Arrays to store graph vertex ids */
     int sink_id;
     int nvtcs;
-    int tag;
+    int tag, vtx_id;
     int root = 0;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_ENTER;
@@ -89,8 +91,9 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
     /* FIXME: This can also be pipelined along with rest of the reduction */
     reduce_buffer = recvbuf;
     if (sendbuf != MPI_IN_PLACE) {
-        dtcopy_id = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
-                                             recvbuf, count, datatype, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
+                                             recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     /* initialize arrays to store graph vertex indices */
@@ -132,16 +135,19 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
                 nvtcs = 1;
             }
 
-            recv_id[i] = MPIR_TSP_sched_irecv(recv_address, msgsize, datatype, child, tag, comm,
-                                              sched, nvtcs, vtcs);
+            mpi_errno = MPIR_TSP_sched_irecv(recv_address, msgsize, datatype, child, tag, comm,
+                                             sched, nvtcs, vtcs, &recv_id[i]);
 
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             /* Setup dependencies for reduction. Reduction depends on the corresponding recv to complete */
             vtcs[0] = recv_id[i];
             nvtcs = 1;
 
             if (is_commutative) {       /* reduction order does not matter */
-                reduce_id[i] = MPIR_TSP_sched_reduce_local(recv_address, reduce_address, msgsize,
-                                                           datatype, op, sched, nvtcs, vtcs);
+                mpi_errno = MPIR_TSP_sched_reduce_local(recv_address, reduce_address, msgsize,
+                                                        datatype, op, sched, nvtcs, vtcs,
+                                                        &reduce_id[i]);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             } else {    /* wait for the previous allreduce to complete */
 
                 /* NOTE: Make sure that knomial tree is being constructed differently for allreduce for optimal performance.
@@ -151,12 +157,15 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
                     vtcs[nvtcs] = reduce_id[i - 1];
                     nvtcs++;
                 }
-                reduce_id[i] =
+                mpi_errno =
                     MPIR_TSP_sched_reduce_local(reduce_address, recv_address, msgsize, datatype, op,
-                                                sched, nvtcs, vtcs);
-                reduce_id[i] =
+                                                sched, nvtcs, vtcs, &reduce_id[i]);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                mpi_errno =
                     MPIR_TSP_sched_localcopy(recv_address, msgsize, datatype, reduce_address,
-                                             msgsize, datatype, sched, 1, &reduce_id[i]);
+                                             msgsize, datatype, sched, 1, &reduce_id[i], &vtx_id);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                reduce_id[i] = vtx_id;
             }
         }
 
@@ -171,9 +180,12 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
         }
 
         /* send data to the parent */
-        if (rank != root)
-            MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, my_tree.parent, tag, comm,
-                                 sched, nvtcs, vtcs);
+        if (rank != root) {
+            mpi_errno =
+                MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, my_tree.parent, tag, comm,
+                                     sched, nvtcs, vtcs, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        }
 
         /* Broadcast start here */
         mpi_errno = MPIR_TSP_sched_sink(sched, &sink_id);
@@ -183,17 +195,20 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
         /* Receive message from parent */
         int bcast_recv_id = sink_id;
         if (my_tree.parent != -1) {
-            bcast_recv_id =
+            mpi_errno =
                 MPIR_TSP_sched_irecv(reduce_address, msgsize, datatype,
-                                     my_tree.parent, tag, comm, sched, 1, &sink_id);
+                                     my_tree.parent, tag, comm, sched, 1, &sink_id, &bcast_recv_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
 
         if (num_children) {
             /* Multicast data to the children */
             nvtcs = 1;
             vtcs[0] = bcast_recv_id;
-            MPIR_TSP_sched_imcast(reduce_address, msgsize, datatype,
-                                  my_tree.children, num_children, tag, comm, sched, nvtcs, vtcs);
+            mpi_errno = MPIR_TSP_sched_imcast(reduce_address, msgsize, datatype,
+                                              my_tree.children, num_children, tag, comm, sched,
+                                              nvtcs, vtcs, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
 
         offset += msgsize;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
@@ -39,11 +39,13 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                         MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int i, src, dst, copy_dst;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     /* Temporary buffers to execute the ring algorithm */
     void *buf1, *buf2, *data_buf, *sbuf, *rbuf;
-    int tag;
+    int tag, vtx_id;
 
     int size = MPIR_Comm_size(comm);
     int rank = MPIR_Comm_rank(comm);
@@ -80,9 +82,10 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
      * TODO: We could avoid this copy but that would make the implementation more
      * complicated */
     int dtcopy_id[3];
-    dtcopy_id[0] = MPIR_TSP_sched_localcopy((char *) data_buf, size * recvcount, recvtype,
-                                            (char *) buf1, size * recvcount, recvtype, sched, 0,
-                                            NULL);
+    mpi_errno = MPIR_TSP_sched_localcopy((char *) data_buf, size * recvcount, recvtype,
+                                         (char *) buf1, size * recvcount, recvtype, sched, 0,
+                                         NULL, &dtcopy_id[0]);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                     (MPL_DBG_FDEST,
@@ -96,10 +99,11 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                          (char *) sendbuf + rank * sendcount * sendtype_extent,
                          (char *) recvbuf + rank * recvcount * recvtype_extent));
 
-        MPIR_TSP_sched_localcopy((char *) sendbuf + rank * sendcount * sendtype_extent,
-                                 sendcount, sendtype,
-                                 (char *) recvbuf + rank * recvcount * recvtype_extent,
-                                 recvcount, recvtype, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_localcopy((char *) sendbuf + rank * sendcount * sendtype_extent,
+                                             sendcount, sendtype,
+                                             (char *) recvbuf + rank * recvcount * recvtype_extent,
+                                             recvcount, recvtype, sched, 0, NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     /* in ring algorithm, source and destination of messages are fixed */
@@ -127,10 +131,10 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
             vtcs[1] = send_id[(i - 1) % 3];
         }
 
-        send_id[i % 3] =
+        mpi_errno =
             MPIR_TSP_sched_isend((char *) sbuf, size * recvcount, recvtype, dst, tag, comm, sched,
-                                 nvtcs, vtcs);
-
+                                 nvtcs, vtcs, &send_id[i % 3]);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         /* schedule recv */
         if (i == 0)
             nvtcs = 0;
@@ -145,9 +149,10 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
             vtcs[2] = recv_id[(i - 1) % 3];
         }
 
-        recv_id[i % 3] =
+        mpi_errno =
             MPIR_TSP_sched_irecv((char *) rbuf, size * recvcount, recvtype, src, tag, comm, sched,
-                                 nvtcs, vtcs);
+                                 nvtcs, vtcs, &recv_id[i % 3]);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
         /* destination offset of the copy */
         copy_dst = (size + rank - i - 1) % size;
@@ -156,12 +161,14 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                          (char *) rbuf + rank * recvcount * recvtype_extent,
                          (char *) recvbuf + copy_dst * recvcount * recvtype_extent));
         /* schedule data copy */
-        dtcopy_id[i % 3] =
+        mpi_errno =
             MPIR_TSP_sched_localcopy((char *) rbuf + rank * recvcount * recvtype_extent, recvcount,
                                      recvtype,
                                      (char *) recvbuf + copy_dst * recvcount * recvtype_extent,
-                                     recvcount, recvtype, sched, 1, &recv_id[i % 3]);
+                                     recvcount, recvtype, sched, 1, &recv_id[i % 3],
+                                     &dtcopy_id[i % 3]);
 
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         /* swap sbuf and rbuf - using data_buf as intermediate buffer */
         data_buf = sbuf;
         sbuf = rbuf;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
@@ -41,6 +41,7 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
                                              MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int src, dst;
     int i, j, ww;
     int invtcs;
@@ -49,9 +50,10 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
     size_t recvtype_extent;
     size_t sendtype_extent;
     MPI_Aint recvtype_lb, sendtype_lb, sendtype_true_extent, recvtype_true_extent;
-    int size, rank;
+    int size, rank, vtx_id;
     int is_inplace;
     int tag = 0;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -93,8 +95,11 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
     if (is_inplace) {
         data_buf = (void *) MPIR_TSP_sched_malloc(size * recvcount * recvtype_extent, sched);
         MPIR_Assert(data_buf != NULL);
-        MPIR_TSP_sched_localcopy((char *) recvbuf, size * recvcount, recvtype, (char *) data_buf,
-                                 size * recvcount, recvtype, sched, 0, NULL);
+        mpi_errno =
+            MPIR_TSP_sched_localcopy((char *) recvbuf, size * recvcount, recvtype,
+                                     (char *) data_buf, size * recvcount, recvtype, sched, 0, NULL,
+                                     &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         MPIR_TSP_sched_fence(sched);
     } else {
         data_buf = (void *) sendbuf;
@@ -103,13 +108,16 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
     /* First, post bblock number of sends/recvs */
     for (i = 0; i < bblock; i++) {
         src = (rank + i) % size;
-        recv_id[i] =
+        mpi_errno =
             MPIR_TSP_sched_irecv((char *) recvbuf + src * recvcount * recvtype_extent,
-                                 recvcount, recvtype, src, tag, comm, sched, 0, NULL);
+                                 recvcount, recvtype, src, tag, comm, sched, 0, NULL, &recv_id[i]);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
         dst = (rank - i + size) % size;
-        send_id[i] =
+        mpi_errno =
             MPIR_TSP_sched_isend((char *) data_buf + dst * sendcount * sendtype_extent,
-                                 sendcount, sendtype, dst, tag, comm, sched, 0, NULL);
+                                 sendcount, sendtype, dst, tag, comm, sched, 0, NULL, &send_id[i]);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     /* Post more send/recv pairs as the previous ones finish */
@@ -123,16 +131,22 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
             vtcs[idx++] = recv_id[(i + j) % bblock];
             vtcs[idx++] = send_id[(i + j) % bblock];
         }
-        invtcs = MPIR_TSP_sched_selective_sink(sched, 2 * ww, vtcs);
+        mpi_errno = MPIR_TSP_sched_selective_sink(sched, 2 * ww, vtcs, &invtcs);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         for (j = 0; j < ww; j++) {
             src = (rank + i + j) % size;
-            recv_id[(i + j) % bblock] =
+            mpi_errno =
                 MPIR_TSP_sched_irecv((char *) recvbuf + src * recvcount * recvtype_extent,
-                                     recvcount, recvtype, src, tag, comm, sched, 1, &invtcs);
+                                     recvcount, recvtype, src, tag, comm, sched, 1, &invtcs,
+                                     &recv_id[(i + j) % bblock]);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
             dst = (rank - i - j + size) % size;
-            send_id[(i + j) % bblock] =
+            mpi_errno =
                 MPIR_TSP_sched_isend((char *) data_buf + dst * sendcount * sendtype_extent,
-                                     sendcount, sendtype, dst, tag, comm, sched, 1, &invtcs);
+                                     sendcount, sendtype, dst, tag, comm, sched, 1, &invtcs,
+                                     &send_id[(i + j) % bblock]);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
     }
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
@@ -14,12 +14,14 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                                             MPIR_Comm * comm, int bblock, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int is_inplace;
     size_t recv_extent, send_extent, sendtype_size, recvtype_size;
     MPI_Aint recv_lb, send_lb, true_extent;
     int nranks, rank;
     int i, j, comm_block, dst;
-    int tag = 0;
+    int tag = 0, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -54,16 +56,20 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
         for (j = 0; j < comm_block; j++) {
             dst = (rank + j + i) % nranks;
             if (recvcounts[dst] && recvtype_size) {
-                MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[dst] * recv_extent,
-                                     recvcounts[dst], recvtype, dst, tag, comm, sched, 0, NULL);
+                mpi_errno = MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[dst] * recv_extent,
+                                                 recvcounts[dst], recvtype, dst, tag, comm, sched,
+                                                 0, NULL, &vtx_id);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             }
         }
 
         for (j = 0; j < comm_block; j++) {
             dst = (rank - j - i + nranks) % nranks;
             if (sendcounts[dst] && sendtype_size) {
-                MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst] * send_extent,
-                                     sendcounts[dst], sendtype, dst, tag, comm, sched, 0, NULL);
+                mpi_errno = MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst] * send_extent,
+                                                 sendcounts[dst], sendtype, dst, tag, comm, sched,
+                                                 0, NULL, &vtx_id);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             }
         }
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
@@ -14,6 +14,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
                                             MPIR_Comm * comm, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     size_t recv_extent;
     MPI_Aint recv_lb, true_extent;
     int nranks, rank, nvtcs;
@@ -21,6 +22,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
     int max_count;
     void *tmp_buf = NULL;
     int tag = 0;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -49,21 +51,24 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
             nvtcs = (dtcopy_id == -1) ? 0 : 1;
             vtcs[0] = dtcopy_id;
 
-            send_id = MPIR_TSP_sched_isend((char *) recvbuf + rdispls[dst] * recv_extent,
-                                           recvcounts[dst], recvtype, dst, tag, comm,
-                                           sched, nvtcs, vtcs);
+            mpi_errno = MPIR_TSP_sched_isend((char *) recvbuf + rdispls[dst] * recv_extent,
+                                             recvcounts[dst], recvtype, dst, tag, comm,
+                                             sched, nvtcs, vtcs, &send_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
-            recv_id =
+            mpi_errno =
                 MPIR_TSP_sched_irecv(tmp_buf, recvcounts[dst], recvtype, dst, tag, comm,
-                                     sched, nvtcs, vtcs);
+                                     sched, nvtcs, vtcs, &recv_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
             nvtcs = 2;
             vtcs[0] = send_id;
             vtcs[1] = recv_id;
-            dtcopy_id = MPIR_TSP_sched_localcopy(tmp_buf, recvcounts[dst], recvtype,
+            mpi_errno = MPIR_TSP_sched_localcopy(tmp_buf, recvcounts[dst], recvtype,
                                                  ((char *) recvbuf +
                                                   rdispls[dst] * recv_extent), recvcounts[dst],
-                                                 recvtype, sched, nvtcs, vtcs);
+                                                 recvtype, sched, nvtcs, vtcs, &dtcopy_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
     }
 

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
@@ -15,10 +15,12 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                                             int bblock, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int tag;
+    int mpi_errno_ret = MPI_SUCCESS;
+    int tag, vtx_id;
     size_t sendtype_size, recvtype_size;
     int nranks, rank;
     int i, j, comm_block, dst;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -45,9 +47,10 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
             if (recvcounts[dst]) {
                 MPIR_Datatype_get_size_macro(recvtypes[dst], recvtype_size);
                 if (recvtype_size) {
-                    MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[dst],
-                                         recvcounts[dst], recvtypes[dst], dst, tag, comm, sched,
-                                         0, NULL);
+                    mpi_errno = MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[dst],
+                                                     recvcounts[dst], recvtypes[dst], dst, tag,
+                                                     comm, sched, 0, NULL, &vtx_id);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
                 }
             }
         }
@@ -57,9 +60,10 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
             if (sendcounts[dst]) {
                 MPIR_Datatype_get_size_macro(sendtypes[dst], sendtype_size);
                 if (sendtype_size) {
-                    MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst],
-                                         sendcounts[dst], sendtypes[dst], dst, tag, comm, sched,
-                                         0, NULL);
+                    mpi_errno = MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst],
+                                                     sendcounts[dst], sendtypes[dst], dst, tag,
+                                                     comm, sched, 0, NULL, &vtx_id);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
                 }
             }
         }

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
@@ -15,6 +15,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
                                             MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int tag;
     size_t recv_extent;
     MPI_Aint true_extent, true_lb;
@@ -22,6 +23,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
     int i, dst, send_id, recv_id, dtcopy_id = -1, vtcs[2];
     int max_size;
     void *tmp_buf = NULL, *adj_tmp_buf = NULL;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -56,20 +58,22 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
             MPIR_Type_get_true_extent_impl(recvtypes[i], &true_lb, &true_extent);
             adj_tmp_buf = (void *) ((char *) tmp_buf - true_lb);
 
-            send_id = MPIR_TSP_sched_isend((char *) recvbuf + rdispls[dst],
-                                           recvcounts[dst], recvtypes[dst], dst, tag, comm, sched,
-                                           nvtcs, vtcs);
-
-            recv_id =
+            mpi_errno = MPIR_TSP_sched_isend((char *) recvbuf + rdispls[dst],
+                                             recvcounts[dst], recvtypes[dst], dst, tag, comm, sched,
+                                             nvtcs, vtcs, &send_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            mpi_errno =
                 MPIR_TSP_sched_irecv(adj_tmp_buf, recvcounts[dst], recvtypes[dst], dst, tag, comm,
-                                     sched, nvtcs, vtcs);
+                                     sched, nvtcs, vtcs, &recv_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
             nvtcs = 2;
             vtcs[0] = send_id;
             vtcs[1] = recv_id;
-            dtcopy_id = MPIR_TSP_sched_localcopy(adj_tmp_buf, recvcounts[dst], recvtypes[dst],
+            mpi_errno = MPIR_TSP_sched_localcopy(adj_tmp_buf, recvcounts[dst], recvtypes[dst],
                                                  ((char *) recvbuf + rdispls[dst]), recvcounts[dst],
-                                                 recvtypes[dst], sched, nvtcs, vtcs);
+                                                 recvtypes[dst], sched, nvtcs, vtcs, &dtcopy_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
     }
 

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
@@ -13,6 +13,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
                                                     int allgatherv_k, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     size_t extent, type_size;
     MPI_Aint true_lb, true_extent;
     int size, rank, tag;
@@ -20,11 +21,12 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
     void *tmp_buf = NULL;
     MPI_Aint *cnts, *displs;
     size_t nbytes;
-    int tree_type;
+    int tree_type, vtx_id, recv_id;
     MPIR_Treealgo_tree_t my_tree, parents_tree;
-    int current_child, next_child, lrank, total_count, recv_id, sink_id;
+    int current_child, next_child, lrank, total_count, sink_id;
     int num_children, *child_subtree_size = NULL;
     int recv_size, num_send_dependencies;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     /* For correctness, transport based collectives need to get the
@@ -79,7 +81,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
         if (rank == root) {
             mpi_errno =
                 MPIR_TSP_sched_localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, sched,
-                                         0, NULL);
+                                         0, NULL, &vtx_id);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_TSP_sched_fence(sched);
         }
@@ -137,10 +139,12 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
 
     /* receive data from the parent */
     if (my_tree.parent != -1) {
-        recv_id =
+        mpi_errno =
             MPIR_TSP_sched_irecv((char *) tmp_buf + displs[rank], recv_size, MPI_BYTE,
-                                 my_tree.parent, tag, comm, sched, 0, NULL);
+                                 my_tree.parent, tag, comm, sched, 0, NULL, &recv_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "rank:%d posts recv", rank));
+
     }
 
     /* send data to children */
@@ -151,9 +155,11 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
         else
             num_send_dependencies = 0;
 
-        MPIR_TSP_sched_isend((char *) tmp_buf + displs[child],
-                             child_subtree_size[i], MPI_BYTE,
-                             child, tag, comm, sched, num_send_dependencies, &recv_id);
+        mpi_errno = MPIR_TSP_sched_isend((char *) tmp_buf + displs[child],
+                                         child_subtree_size[i], MPI_BYTE,
+                                         child, tag, comm, sched, num_send_dependencies, &recv_id,
+                                         &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
 
@@ -175,7 +181,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
 
             mpi_errno =
                 MPIR_TSP_sched_localcopy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, sched,
-                                         1, &sink_id);
+                                         1, &sink_id, &vtx_id);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/igather/igather_tsp_tree.c
+++ b/src/mpi/coll/igather/igather_tsp_tree.c
@@ -14,6 +14,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                                       int k, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int size, rank, lrank;
     int i, j, tag, is_inplace = false;
     MPI_Aint sendtype_lb, sendtype_extent, sendtype_true_extent;
@@ -21,10 +22,11 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     int dtcopy_id, *recv_id = NULL;
     void *tmp_buf = NULL;
     const void *data_buf = NULL;
-    int tree_type;
+    int tree_type, vtx_id;
     MPIR_Treealgo_tree_t my_tree, parents_tree;
     int next_child, num_children, *child_subtree_size = NULL, *child_data_offset = NULL;
     int offset, recv_size, num_dependencies;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_ENTER;
@@ -129,8 +131,10 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                         mpi_errno, "recv_id buffer", MPL_MEM_COLL);
     /* Leaf nodes send to parent */
     if (num_children == 0) {
-        MPIR_TSP_sched_isend(tmp_buf, sendcount, sendtype, my_tree.parent, tag, comm, sched, 0,
-                             NULL);
+        mpi_errno =
+            MPIR_TSP_sched_isend(tmp_buf, sendcount, sendtype, my_tree.parent, tag, comm, sched, 0,
+                                 NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "rank:%d posts recv\n", rank));
     } else {
         num_dependencies = 0;
@@ -141,36 +145,41 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
             else
                 data_buf = (void *) sendbuf;
 
-            dtcopy_id =
+            mpi_errno =
                 MPIR_TSP_sched_localcopy(data_buf, sendcount, sendtype,
-                                         tmp_buf, recvcount, recvtype, sched, 0, NULL);
+                                         tmp_buf, recvcount, recvtype, sched, 0, NULL, &dtcopy_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             num_dependencies++;
         }
 
         for (i = 0; i < num_children; i++) {
             int child = *(int *) utarray_eltptr(my_tree.children, i);
-            recv_id[i] =
+            mpi_errno =
                 MPIR_TSP_sched_irecv((char *) tmp_buf + child_data_offset[i] * recvtype_extent,
                                      child_subtree_size[i] * recvcount, recvtype, child, tag, comm,
-                                     sched, num_dependencies, &dtcopy_id);
+                                     sched, num_dependencies, &dtcopy_id, &recv_id[i]);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
 
-        if (my_tree.parent != -1)
-            MPIR_TSP_sched_isend(tmp_buf, recv_size, recvtype, my_tree.parent,
-                                 tag, comm, sched, num_children, recv_id);
+        if (my_tree.parent != -1) {
+            mpi_errno = MPIR_TSP_sched_isend(tmp_buf, recv_size, recvtype, my_tree.parent,
+                                             tag, comm, sched, num_children, recv_id, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        }
 
     }
 
     if (lrank == 0 && root != 0) {      /* root puts data in recvbuf */
-        dtcopy_id = MPIR_TSP_sched_localcopy(tmp_buf, (size - root) * recvcount, recvtype,
+        mpi_errno = MPIR_TSP_sched_localcopy(tmp_buf, (size - root) * recvcount, recvtype,
                                              (char *) recvbuf + root * recvcount * recvtype_extent,
                                              (size - root) * recvcount, recvtype, sched,
-                                             num_children, recv_id);
-
-        MPIR_TSP_sched_localcopy((char *) tmp_buf + (size - root) * recvcount * recvtype_extent,
-                                 root * recvcount, recvtype, recvbuf,
-                                 root * recvcount, recvtype, sched, 1, &dtcopy_id);
-
+                                             num_children, recv_id, &dtcopy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        mpi_errno =
+            MPIR_TSP_sched_localcopy((char *) tmp_buf + (size - root) * recvcount * recvtype_extent,
+                                     root * recvcount, recvtype, recvbuf, root * recvcount,
+                                     recvtype, sched, 1, &dtcopy_id, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     MPIR_Treealgo_tree_free(&my_tree);

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
@@ -16,11 +16,13 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
                                                        MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int indegree, outdegree, weighted;
     int k, l;
     int *srcs, *dsts;
-    int tag;
+    int tag, vtx_id;
     MPI_Aint recvtype_extent;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(2);
 
     MPIR_FUNC_ENTER;
@@ -42,12 +44,18 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
     MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
-        MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0, NULL);
+        mpi_errno =
+            MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0,
+                                 NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + displs[l] * recvtype_extent;
-        MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, sched, 0, NULL);
+        mpi_errno =
+            MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, sched, 0,
+                                 NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
   fn_exit:

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
@@ -18,10 +18,12 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
                                                       MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int indegree, outdegree, weighted;
     int k, l;
     int *srcs, *dsts;
-    int tag;
+    int tag, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPI_Aint sendtype_extent, recvtype_extent;
 
     MPIR_FUNC_ENTER;
@@ -47,12 +49,18 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
 
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + sdispls[k] * sendtype_extent;
-        MPIR_TSP_sched_isend(sb, sendcounts[k], sendtype, dsts[k], tag, comm_ptr, sched, 0, NULL);
+        mpi_errno =
+            MPIR_TSP_sched_isend(sb, sendcounts[k], sendtype, dsts[k], tag, comm_ptr, sched, 0,
+                                 NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + rdispls[l] * recvtype_extent;
-        MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, sched, 0, NULL);
+        mpi_errno =
+            MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, sched, 0,
+                                 NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
   fn_exit:

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
@@ -18,10 +18,12 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
                                                       MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int indegree, outdegree, weighted;
     int k, l;
     int *srcs, *dsts;
-    int tag;
+    int tag, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -45,16 +47,20 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
         char *sb;
 
         sb = ((char *) sendbuf) + sdispls[k];
-        MPIR_TSP_sched_isend(sb, sendcounts[k], sendtypes[k], dsts[k], tag, comm_ptr, sched, 0,
-                             NULL);
+        mpi_errno =
+            MPIR_TSP_sched_isend(sb, sendcounts[k], sendtypes[k], dsts[k], tag, comm_ptr, sched, 0,
+                                 NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb;
 
         rb = ((char *) recvbuf) + rdispls[l];
-        MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtypes[l], srcs[l], tag, comm_ptr, sched, 0,
-                             NULL);
+        mpi_errno =
+            MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtypes[l], srcs[l], tag, comm_ptr, sched, 0,
+                                 NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
   fn_exit:

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree.c
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree.c
@@ -14,6 +14,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
                                       int buffer_per_child, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int i, j, t;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
     int offset = 0;
@@ -21,7 +22,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
     MPI_Aint type_lb, true_extent;
     int is_commutative;
     int size;
-    int rank;
+    int rank, vtx_id;
     int num_children = 0;
     int tree_root;              /* Root of the tree over which reduction is performed.
                                  * This can be different from root of the collective operation.
@@ -37,6 +38,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
     int dtcopy_id = -1;
     int nvtcs;
     int tag;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_ENTER;
@@ -104,23 +106,23 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
     if (is_tree_root && is_root) {
         reduce_buffer = recvbuf;
         if (sendbuf != MPI_IN_PLACE)
-            dtcopy_id = MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype,
-                                                 sched, 0, NULL);
+            mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype,
+                                                 sched, 0, NULL, &dtcopy_id);
     } else if (is_tree_root && !is_root) {
         reduce_buffer = MPIR_TSP_sched_malloc(extent * count, sched);
         reduce_buffer = (void *) ((char *) reduce_buffer - type_lb);
-        dtcopy_id = MPIR_TSP_sched_localcopy(sendbuf, count, datatype, reduce_buffer, count,
-                                             datatype, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype, reduce_buffer, count,
+                                             datatype, sched, 0, NULL, &dtcopy_id);
     } else if (is_tree_intermediate && is_root) {
         reduce_buffer = recvbuf;
         if (sendbuf != MPI_IN_PLACE)
-            dtcopy_id = MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype,
-                                                 sched, 0, NULL);
+            mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype,
+                                                 sched, 0, NULL, &dtcopy_id);
     } else if (is_tree_intermediate && !is_root) {
         reduce_buffer = MPIR_TSP_sched_malloc(extent * count, sched);
         reduce_buffer = (void *) ((char *) reduce_buffer - type_lb);
-        dtcopy_id = MPIR_TSP_sched_localcopy(sendbuf, count, datatype, reduce_buffer, count,
-                                             datatype, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype, reduce_buffer, count,
+                                             datatype, sched, 0, NULL, &dtcopy_id);
     } else if (is_tree_leaf && is_root) {
         if (sendbuf == MPI_IN_PLACE)
             reduce_buffer = recvbuf;
@@ -129,6 +131,8 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
     } else {    /* is_tree_leaf && !is_root */
         reduce_buffer = (void *) sendbuf;
     }
+
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
     /* initialize arrays to store graph vertex indices */
     MPIR_CHKLMEM_MALLOC(vtcs, int *, sizeof(int) * (num_children + 1),
@@ -170,16 +174,18 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
                 nvtcs = 1;
             }
 
-            recv_id[i] = MPIR_TSP_sched_irecv(recv_address, msgsize, datatype, child, tag, comm,
-                                              sched, nvtcs, vtcs);
+            mpi_errno = MPIR_TSP_sched_irecv(recv_address, msgsize, datatype, child, tag, comm,
+                                             sched, nvtcs, vtcs, &recv_id[i]);
 
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             /* Setup dependencies for reduction. Reduction depends on the corresponding recv to complete */
             vtcs[0] = recv_id[i];
             nvtcs = 1;
 
             if (is_commutative) {       /* reduction order does not matter */
-                reduce_id[i] = MPIR_TSP_sched_reduce_local(recv_address, reduce_address, msgsize,
-                                                           datatype, op, sched, nvtcs, vtcs);
+                mpi_errno = MPIR_TSP_sched_reduce_local(recv_address, reduce_address, msgsize,
+                                                        datatype, op, sched, nvtcs, vtcs,
+                                                        &reduce_id[i]);
             } else {    /* wait for the previous reduce to complete */
 
                 /* NOTE: Make sure that knomial tree is being constructed differently for reduce for optimal performance.
@@ -189,13 +195,16 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
                     vtcs[nvtcs] = reduce_id[i - 1];
                     nvtcs++;
                 }
-                reduce_id[i] =
+                mpi_errno =
                     MPIR_TSP_sched_reduce_local(reduce_address, recv_address, msgsize, datatype, op,
-                                                sched, nvtcs, vtcs);
-                reduce_id[i] =
+                                                sched, nvtcs, vtcs, &reduce_id[i]);
+                mpi_errno =
                     MPIR_TSP_sched_localcopy(recv_address, msgsize, datatype, reduce_address,
-                                             msgsize, datatype, sched, 1, &reduce_id[i]);
+                                             msgsize, datatype, sched, 1, &reduce_id[i], &vtx_id);
+                reduce_id[i] = vtx_id;
+
             }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
 
         if (is_commutative && buffer_per_child) {       /* wait for all the reductions */
@@ -209,19 +218,25 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
         }
 
         /* send data to the parent */
-        if (!is_tree_root)
-            MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, my_tree.parent, tag, comm,
-                                 sched, nvtcs, vtcs);
+        if (!is_tree_root) {
+            mpi_errno =
+                MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, my_tree.parent, tag, comm,
+                                     sched, nvtcs, vtcs, &vtx_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        }
 
         /* send data to the root of the collective operation */
         if (tree_root != root) {
             if (is_tree_root) { /* tree_root sends data to root */
-                MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, root, tag, comm, sched,
-                                     nvtcs, vtcs);
+                mpi_errno =
+                    MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, root, tag, comm, sched,
+                                         nvtcs, vtcs, &vtx_id);
             } else if (is_root) {       /* root receives data from tree_root */
-                MPIR_TSP_sched_irecv((char *) recvbuf + offset * extent, msgsize, datatype,
-                                     tree_root, tag, comm, sched, 0, NULL);
+                mpi_errno =
+                    MPIR_TSP_sched_irecv((char *) recvbuf + offset * extent, msgsize, datatype,
+                                         tree_root, tag, comm, sched, 0, NULL, &vtx_id);
             }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
 
         offset += msgsize;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
@@ -48,10 +48,12 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                                                        MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int x, i, j, phase;
     int current_cnt, offset, rank_for_offset, dst;
     int send_cnt, recv_cnt, send_offset, recv_offset, nvtcs, vtcs[2];
     int send_id, recv_id, reduce_id = -1;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -82,9 +84,10 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                             (MPL_DBG_FDEST,
                              "phase %d sending to %d send_offset %d send_count %d", phase, dst,
                              send_offset, send_cnt));
-            send_id =
+            mpi_errno =
                 MPIR_TSP_sched_isend((char *) tmp_results + send_offset, send_cnt,
-                                     datatype, dst, tag, comm, sched, nvtcs, vtcs);
+                                     datatype, dst, tag, comm, sched, nvtcs, vtcs, &send_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
             rank_for_offset =
                 (is_dist_halving) ? MPII_Recexchalgo_reverse_digits_step2(rank, nranks, k) : rank;
@@ -98,17 +101,20 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                             (MPL_DBG_FDEST,
                              "phase %d recving from %d recv_offset %d recv_count %d", phase, dst,
                              recv_offset, recv_cnt));
-            recv_id =
+            mpi_errno =
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + recv_offset, recv_cnt,
-                                     datatype, dst, tag, comm, sched, nvtcs, vtcs);
+                                     datatype, dst, tag, comm, sched, nvtcs, vtcs, &recv_id);
+
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
             nvtcs = 2;
             vtcs[0] = send_id;
             vtcs[1] = recv_id;
-            reduce_id =
+            mpi_errno =
                 MPIR_TSP_sched_reduce_local((char *) tmp_recvbuf + recv_offset,
                                             (char *) tmp_results + recv_offset,
-                                            recv_cnt, datatype, op, sched, nvtcs, vtcs);
+                                            recv_cnt, datatype, op, sched, nvtcs, vtcs, &reduce_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
     }
 
@@ -128,6 +134,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
                                                  int k, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int is_inplace;
     size_t extent;
     MPI_Aint lb, true_extent;
@@ -141,7 +148,8 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
     int nvtcs, vtcs[2];
     void *tmp_recvbuf = NULL, *tmp_results = NULL;
     MPI_Aint *displs;
-    int tag;
+    int tag, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(1);
 
     MPIR_FUNC_ENTER;
@@ -187,13 +195,14 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
 
     if (in_step2) {
         if (!is_inplace)
-            dtcopy_id = MPIR_TSP_sched_localcopy(sendbuf, total_count, datatype,
+            mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, total_count, datatype,
                                                  tmp_results, total_count, datatype, sched, 0,
-                                                 NULL);
+                                                 NULL, &dtcopy_id);
         else
-            dtcopy_id = MPIR_TSP_sched_localcopy(recvbuf, total_count, datatype,
+            mpi_errno = MPIR_TSP_sched_localcopy(recvbuf, total_count, datatype,
                                                  tmp_results, total_count, datatype, sched, 0,
-                                                 NULL);
+                                                 NULL, &dtcopy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After initial dt copy"));
 
@@ -205,20 +214,25 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
             buf_to_send = recvbuf;
         else
             buf_to_send = (void *) sendbuf;
-        MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, step1_sendto, tag, comm, sched, 0,
-                             NULL);
+        mpi_errno =
+            MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, step1_sendto, tag, comm, sched,
+                                 0, NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
     } else {    /* Step 2 participating rank */
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
             /* recv dependencies */
             nvtcs = 1;
             vtcs[0] = (i == 0) ? dtcopy_id : reduce_id;
-            recv_id = MPIR_TSP_sched_irecv(tmp_recvbuf, total_count, datatype,
-                                           step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs);
-
+            mpi_errno = MPIR_TSP_sched_irecv(tmp_recvbuf, total_count, datatype,
+                                             step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
+                                             &recv_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             nvtcs++;
             vtcs[1] = recv_id;
-            reduce_id = MPIR_TSP_sched_reduce_local(tmp_recvbuf, tmp_results, total_count,
-                                                    datatype, op, sched, nvtcs, vtcs);
+            mpi_errno = MPIR_TSP_sched_reduce_local(tmp_recvbuf, tmp_results, total_count,
+                                                    datatype, op, sched, nvtcs, vtcs, &reduce_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
     }
 
@@ -237,9 +251,10 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         /* copy data from tmp_results buffer correct position into recvbuf for all participating ranks */
         nvtcs = 1;
         vtcs[0] = reduce_id;    /* This assignment will also be used in step3 sends */
-        MPIR_TSP_sched_localcopy((char *) tmp_results + displs[rank] * extent,
-                                 recvcounts[rank], datatype, recvbuf, recvcounts[rank],
-                                 datatype, sched, nvtcs, vtcs);
+        mpi_errno = MPIR_TSP_sched_localcopy((char *) tmp_results + displs[rank] * extent,
+                                             recvcounts[rank], datatype, recvbuf, recvcounts[rank],
+                                             datatype, sched, nvtcs, vtcs, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After Step 2"));
@@ -247,15 +262,18 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
     /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
      * send the data to non-partcipating ranks */
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
-        MPIR_TSP_sched_irecv(recvbuf, recvcounts[rank], datatype, step1_sendto, tag, comm, sched, 1,
-                             &sink_id);
+        mpi_errno =
+            MPIR_TSP_sched_irecv(recvbuf, recvcounts[rank], datatype, step1_sendto, tag, comm,
+                                 sched, 1, &sink_id, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
     for (i = 0; i < step1_nrecvs; i++) {
         nvtcs = 1;
         /* vtcs will be assigned to last reduce_id in step2 function */
-        MPIR_TSP_sched_isend((char *) tmp_results + displs[step1_recvfrom[i]] * extent,
-                             recvcounts[step1_recvfrom[i]], datatype, step1_recvfrom[i], tag, comm,
-                             sched, nvtcs, vtcs);
+        mpi_errno = MPIR_TSP_sched_isend((char *) tmp_results + displs[step1_recvfrom[i]] * extent,
+                                         recvcounts[step1_recvfrom[i]], datatype, step1_recvfrom[i],
+                                         tag, comm, sched, nvtcs, vtcs, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Done Step 3"));

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
@@ -14,6 +14,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
                                                        MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int is_inplace;
     size_t extent;
     MPI_Aint lb, true_extent;
@@ -27,7 +28,8 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
     int dtcopy_id = -1, send_id = -1, recv_id = -1, reduce_id = -1, step1_id = -1;
     int nvtcs, vtcs[2];
     void *tmp_recvbuf = NULL, *tmp_results = NULL;
-    int tag;
+    int tag, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -56,13 +58,14 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
 
     if (in_step2) {
         if (!is_inplace)
-            dtcopy_id = MPIR_TSP_sched_localcopy(sendbuf, total_count, datatype,
+            mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, total_count, datatype,
                                                  tmp_results, total_count, datatype, sched, 0,
-                                                 NULL);
+                                                 NULL, &dtcopy_id);
         else
-            dtcopy_id = MPIR_TSP_sched_localcopy(recvbuf, total_count, datatype,
+            mpi_errno = MPIR_TSP_sched_localcopy(recvbuf, total_count, datatype,
                                                  tmp_results, total_count, datatype, sched, 0,
-                                                 NULL);
+                                                 NULL, &dtcopy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     /* Step 1 */
@@ -73,20 +76,24 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             buf_to_send = recvbuf;
         else
             buf_to_send = (void *) sendbuf;
-        MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, step1_sendto, tag, comm, sched, 0,
-                             NULL);
+        mpi_errno =
+            MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, step1_sendto, tag, comm, sched,
+                                 0, NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     } else {    /* Step 2 participating rank */
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
             /* recv dependencies */
             nvtcs = 1;
             vtcs[0] = (i == 0) ? dtcopy_id : reduce_id;
-            recv_id = MPIR_TSP_sched_irecv(tmp_recvbuf, total_count, datatype,
-                                           step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs);
-
+            mpi_errno = MPIR_TSP_sched_irecv(tmp_recvbuf, total_count, datatype,
+                                             step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
+                                             &recv_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             nvtcs++;
             vtcs[1] = recv_id;
-            reduce_id = MPIR_TSP_sched_reduce_local(tmp_recvbuf, tmp_results, total_count,
-                                                    datatype, op, sched, nvtcs, vtcs);
+            mpi_errno = MPIR_TSP_sched_reduce_local(tmp_recvbuf, tmp_results, total_count,
+                                                    datatype, op, sched, nvtcs, vtcs, &reduce_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
     }
 
@@ -111,46 +118,57 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             MPII_Recexchalgo_get_count_and_offset(dst, phase, k, nranks, &send_cnt, &offset);
             send_offset = offset * extent * recvcount;
 
-            send_id =
+            mpi_errno =
                 MPIR_TSP_sched_isend((char *) tmp_results + send_offset, send_cnt * recvcount,
-                                     datatype, dst, tag, comm, sched, nvtcs, vtcs);
+                                     datatype, dst, tag, comm, sched, nvtcs, vtcs, &send_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
             MPII_Recexchalgo_get_count_and_offset(rank, phase, k, nranks, &recv_cnt, &offset);
             recv_offset = offset * extent * recvcount;
 
-            recv_id =
+            mpi_errno =
                 MPIR_TSP_sched_irecv(tmp_recvbuf, recv_cnt * recvcount,
-                                     datatype, dst, tag, comm, sched, nvtcs, vtcs);
+                                     datatype, dst, tag, comm, sched, nvtcs, vtcs, &recv_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
             nvtcs = 2;
             vtcs[0] = send_id;
             vtcs[1] = recv_id;
-            reduce_id =
+            mpi_errno =
                 MPIR_TSP_sched_reduce_local(tmp_recvbuf,
                                             (char *) tmp_results + recv_offset,
-                                            recv_cnt * recvcount, datatype, op, sched, nvtcs, vtcs);
+                                            recv_cnt * recvcount, datatype, op, sched, nvtcs, vtcs,
+                                            &reduce_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
     }
     if (in_step2) {
         nvtcs = 1;
         vtcs[0] = reduce_id;
         /* copy data from tmp_results buffer correct position into recvbuf for all participating ranks */
-        dtcopy_id =
+        mpi_errno =
             MPIR_TSP_sched_localcopy((char *) tmp_results + rank * recvcount * extent, recvcount,
-                                     datatype, recvbuf, recvcount, datatype, sched, nvtcs, vtcs);
+                                     datatype, recvbuf, recvcount, datatype, sched, nvtcs, vtcs,
+                                     &dtcopy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
      * send the data to non-partcipating ranks */
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
-        MPIR_TSP_sched_irecv(recvbuf, recvcount, datatype, step1_sendto, tag, comm, sched, 1,
-                             &step1_id);
+        mpi_errno =
+            MPIR_TSP_sched_irecv(recvbuf, recvcount, datatype, step1_sendto, tag, comm, sched, 1,
+                                 &step1_id, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
     for (i = 0; i < step1_nrecvs; i++) {
         nvtcs = 1;
         vtcs[0] = reduce_id;
-        MPIR_TSP_sched_isend((char *) tmp_results + recvcount * step1_recvfrom[i] * extent,
-                             recvcount, datatype, step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs);
+        mpi_errno =
+            MPIR_TSP_sched_isend((char *) tmp_results + recvcount * step1_recvfrom[i] * extent,
+                                 recvcount, datatype, step1_recvfrom[i], tag, comm, sched, nvtcs,
+                                 vtcs, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
   fn_exit:

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
@@ -12,6 +12,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     MPI_Aint extent, true_extent;
     MPI_Aint lb;
     int nranks, rank;
@@ -20,7 +21,8 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
     int dst, loop_count;
     void *partial_scan = NULL;
     void *tmp_buf = NULL;
-    int tag = 0;
+    int tag = 0, vtx_id;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -44,15 +46,19 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
     if (sendbuf != MPI_IN_PLACE) {
         /* Since this is an inclusive scan, copy local contribution into
          * recvbuf. */
-        MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype, sched, 0,
-                                 NULL);
-        dtcopy_id =
+        mpi_errno =
+            MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype, sched, 0,
+                                     NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        mpi_errno =
             MPIR_TSP_sched_localcopy(sendbuf, count, datatype, partial_scan, count, datatype, sched,
-                                     0, NULL);
+                                     0, NULL, &dtcopy_id);
     } else
-        dtcopy_id =
+        mpi_errno =
             MPIR_TSP_sched_localcopy(recvbuf, count, datatype, partial_scan, count, datatype, sched,
-                                     0, NULL);
+                                     0, NULL, &dtcopy_id);
+
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
     tmp_buf = MPIR_TSP_sched_malloc(count * extent, sched);
     mask = 0x1;
@@ -68,36 +74,54 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
             /* Send partial_scan to dst. Recv into tmp_buf */
             nvtcs = 1;
             vtcs[0] = (loop_count == 0) ? dtcopy_id : reduce_id;
-            send_id =
+            mpi_errno =
                 MPIR_TSP_sched_isend(partial_scan, count, datatype, dst, tag, comm, sched, nvtcs,
-                                     vtcs);
+                                     vtcs, &send_id);
+
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
             if (recv_reduce != -1) {
                 nvtcs++;
                 vtcs[1] = recv_reduce;
             }
-            recv_id =
-                MPIR_TSP_sched_irecv(tmp_buf, count, datatype, dst, tag, comm, sched, nvtcs, vtcs);
+            mpi_errno =
+                MPIR_TSP_sched_irecv(tmp_buf, count, datatype, dst, tag, comm, sched, nvtcs, vtcs,
+                                     &recv_id);
+
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
             nvtcs = 2;
             vtcs[0] = send_id;
             vtcs[1] = recv_id;
             if (rank > dst) {
-                reduce_id = MPIR_TSP_sched_reduce_local(tmp_buf, partial_scan, count,
-                                                        datatype, op, sched, nvtcs, vtcs);
-                recv_reduce = MPIR_TSP_sched_reduce_local(tmp_buf, recvbuf, count,
-                                                          datatype, op, sched, nvtcs, vtcs);
+                mpi_errno = MPIR_TSP_sched_reduce_local(tmp_buf, partial_scan, count,
+                                                        datatype, op, sched, nvtcs, vtcs,
+                                                        &reduce_id);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
+                mpi_errno = MPIR_TSP_sched_reduce_local(tmp_buf, recvbuf, count,
+                                                        datatype, op, sched, nvtcs, vtcs,
+                                                        &recv_reduce);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             } else {
                 if (is_commutative) {
-                    reduce_id = MPIR_TSP_sched_reduce_local(tmp_buf, partial_scan, count,
-                                                            datatype, op, sched, nvtcs, vtcs);
+                    mpi_errno = MPIR_TSP_sched_reduce_local(tmp_buf, partial_scan, count,
+                                                            datatype, op, sched, nvtcs, vtcs,
+                                                            &reduce_id);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
                 } else {
-                    reduce_id = MPIR_TSP_sched_reduce_local(partial_scan, tmp_buf, count,
-                                                            datatype, op, sched, nvtcs, vtcs);
+                    mpi_errno = MPIR_TSP_sched_reduce_local(partial_scan, tmp_buf, count,
+                                                            datatype, op, sched, nvtcs, vtcs,
+                                                            &reduce_id);
 
-                    reduce_id = MPIR_TSP_sched_localcopy(tmp_buf, count, datatype,
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
+                    mpi_errno = MPIR_TSP_sched_localcopy(tmp_buf, count, datatype,
                                                          partial_scan, count, datatype, sched, 1,
-                                                         &reduce_id);
+                                                         &reduce_id, &vtx_id);
+                    reduce_id = vtx_id;
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
                 }
                 recv_reduce = -1;
             }

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree.c
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree.c
@@ -15,6 +15,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     MPIR_FUNC_ENTER;
 
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int size, rank;
     int i, j, is_inplace = false;
     int lrank;
@@ -22,7 +23,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     MPI_Aint recvtype_lb, recvtype_extent, recvtype_true_extent;
     int dtcopy_id[2];
     void *tmp_buf = NULL;
-    int recv_id;
+    int recv_id, vtx_id;
     int tree_type;
     MPIR_Treealgo_tree_t my_tree, parents_tree;
     int next_child;
@@ -30,6 +31,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     int offset, recv_size;
     int tag;
     int num_send_dependencies;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(2);
 
     size = MPIR_Comm_size(comm);
@@ -119,14 +121,18 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
 
     if (root != 0 && lrank == 0) {      /* reorganize sendbuf in tmp_buf */
         tmp_buf = MPIR_TSP_sched_malloc(recv_size * sendtype_extent, sched);
-        dtcopy_id[0] =
+        mpi_errno =
             MPIR_TSP_sched_localcopy((char *) sendbuf + root * sendcount * sendtype_extent,
                                      (size - root) * sendcount, sendtype, tmp_buf,
-                                     (size - root) * sendcount, sendtype, sched, 0, NULL);
-        dtcopy_id[1] =
+                                     (size - root) * sendcount, sendtype, sched, 0, NULL,
+                                     &dtcopy_id[0]);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        mpi_errno =
             MPIR_TSP_sched_localcopy(sendbuf, root * sendcount, sendtype,
                                      (char *) tmp_buf + (size - root) * sendcount * sendtype_extent,
-                                     root * sendcount, sendtype, sched, 0, NULL);
+                                     root * sendcount, sendtype, sched, 0, NULL, &dtcopy_id[1]);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
         num_send_dependencies = 2;
     } else if (root == 0 && lrank == 0) {
         tmp_buf = (void *) sendbuf;
@@ -141,28 +147,32 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
 
     /* receive data from the parent */
     if (my_tree.parent != -1) {
-        recv_id = MPIR_TSP_sched_irecv(tmp_buf, recv_size, recvtype, my_tree.parent,
-                                       tag, comm, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_irecv(tmp_buf, recv_size, recvtype, my_tree.parent,
+                                         tag, comm, sched, 0, NULL, &recv_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "rank:%d posts recv", rank));
     }
 
     /* send data to children */
     for (i = 0; i < num_children; i++) {
         int child = *(int *) utarray_eltptr(my_tree.children, i);
-        MPIR_TSP_sched_isend((char *) tmp_buf + child_data_offset[i] * sendtype_extent,
-                             child_subtree_size[i] * sendcount, sendtype,
-                             child, tag, comm, sched, num_send_dependencies,
-                             (lrank == 0) ? dtcopy_id : &recv_id);
+        mpi_errno = MPIR_TSP_sched_isend((char *) tmp_buf + child_data_offset[i] * sendtype_extent,
+                                         child_subtree_size[i] * sendcount, sendtype,
+                                         child, tag, comm, sched, num_send_dependencies,
+                                         (lrank == 0) ? dtcopy_id : &recv_id, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     if (num_children > 0 && lrank != 0) {       /* copy data from tmp_buf to recvbuf */
-        MPIR_TSP_sched_localcopy(tmp_buf, recvcount, recvtype, recvbuf,
-                                 recvcount, recvtype, sched, 1, &recv_id);
+        mpi_errno = MPIR_TSP_sched_localcopy(tmp_buf, recvcount, recvtype, recvbuf,
+                                             recvcount, recvtype, sched, 1, &recv_id, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     if (lrank == 0 && !is_inplace) {    /* root puts data in recvbuf */
-        MPIR_TSP_sched_localcopy(tmp_buf, sendcount, sendtype, recvbuf,
-                                 recvcount, recvtype, sched, 0, NULL);
+        mpi_errno = MPIR_TSP_sched_localcopy(tmp_buf, sendcount, sendtype, recvbuf,
+                                             recvcount, recvtype, sched, 0, NULL, &vtx_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     MPIR_Treealgo_tree_free(&my_tree);

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -140,16 +140,16 @@ int MPIR_TSP_sched_isend(const void *buf,
                          MPI_Datatype dt,
                          int dest,
                          int tag,
-                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs)
+                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs,
+                         int *vtx_id)
 {
     MPII_Genutil_sched_t *sched = s;
     vtx_t *vtxp;
-    int vtx_id;
-
+    int mpi_errno = MPI_SUCCESS;
     /* assign a new vertex */
-    vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
+    *vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
     vtxp->vtx_kind = MPII_GENUTIL_VTX_KIND__ISEND;
-    MPII_Genutil_vtx_add_dependencies(sched, vtx_id, n_in_vtcs, in_vtcs);
+    MPII_Genutil_vtx_add_dependencies(sched, *vtx_id, n_in_vtcs, in_vtcs);
 
     /* store the arguments */
     vtxp->u.isend.buf = buf;
@@ -160,9 +160,9 @@ int MPIR_TSP_sched_isend(const void *buf,
     vtxp->u.isend.comm = comm_ptr;
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                    (MPL_DBG_FDEST, "Gentran: schedule [%d] isend", vtx_id));
+                    (MPL_DBG_FDEST, "Gentran: schedule [%d] isend", *vtx_id));
 
-    return vtx_id;
+    return mpi_errno;
 }
 
 
@@ -171,17 +171,17 @@ int MPIR_TSP_sched_irecv(void *buf,
                          MPI_Datatype dt,
                          int source,
                          int tag,
-                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs)
+                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs,
+                         int *vtx_id)
 {
     MPII_Genutil_sched_t *sched = s;
     vtx_t *vtxp;
-    int vtx_id;
-
+    int mpi_errno = MPI_SUCCESS;
     /* assign a new vertex */
-    vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
+    *vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
 
     vtxp->vtx_kind = MPII_GENUTIL_VTX_KIND__IRECV;
-    MPII_Genutil_vtx_add_dependencies(sched, vtx_id, n_in_vtcs, in_vtcs);
+    MPII_Genutil_vtx_add_dependencies(sched, *vtx_id, n_in_vtcs, in_vtcs);
 
     /* record the arguments */
     vtxp->u.irecv.buf = buf;
@@ -192,9 +192,9 @@ int MPIR_TSP_sched_irecv(void *buf,
     vtxp->u.irecv.comm = comm_ptr;
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                    (MPL_DBG_FDEST, "Gentran: schedule [%d] irecv", vtx_id));
+                    (MPL_DBG_FDEST, "Gentran: schedule [%d] irecv", *vtx_id));
 
-    return vtx_id;
+    return mpi_errno;
 }
 
 
@@ -204,16 +204,16 @@ int MPIR_TSP_sched_imcast(const void *buf,
                           UT_array * dests,
                           int num_dests,
                           int tag,
-                          MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs)
+                          MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs,
+                          int *vtx_id)
 {
     MPII_Genutil_sched_t *sched = s;
     vtx_t *vtxp;
-    int vtx_id;
-
+    int mpi_errno = MPI_SUCCESS;
     /* assign a new vertex */
-    vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
+    *vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
     vtxp->vtx_kind = MPII_GENUTIL_VTX_KIND__IMCAST;
-    MPII_Genutil_vtx_add_dependencies(sched, vtx_id, n_in_vtcs, in_vtcs);
+    MPII_Genutil_vtx_add_dependencies(sched, *vtx_id, n_in_vtcs, in_vtcs);
 
     /* store the arguments */
     vtxp->u.imcast.buf = (void *) buf;
@@ -230,8 +230,8 @@ int MPIR_TSP_sched_imcast(const void *buf,
     vtxp->u.imcast.last_complete = -1;
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                    (MPL_DBG_FDEST, "Gentran: schedule [%d] imcast", vtx_id));
-    return vtx_id;
+                    (MPL_DBG_FDEST, "Gentran: schedule [%d] imcast", *vtx_id));
+    return mpi_errno;
 }
 
 int MPIR_TSP_sched_issend(const void *buf,
@@ -239,16 +239,16 @@ int MPIR_TSP_sched_issend(const void *buf,
                           MPI_Datatype dt,
                           int dest,
                           int tag,
-                          MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs)
+                          MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs,
+                          int *vtx_id)
 {
     MPII_Genutil_sched_t *sched = s;
     vtx_t *vtxp;
-    int vtx_id;
-
+    int mpi_errno = MPI_SUCCESS;
     /* assign a new vertex */
-    vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
+    *vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
     vtxp->vtx_kind = MPII_GENUTIL_VTX_KIND__ISSEND;
-    MPII_Genutil_vtx_add_dependencies(sched, vtx_id, n_in_vtcs, in_vtcs);
+    MPII_Genutil_vtx_add_dependencies(sched, *vtx_id, n_in_vtcs, in_vtcs);
 
     /* store the arguments */
     vtxp->u.issend.buf = buf;
@@ -259,24 +259,23 @@ int MPIR_TSP_sched_issend(const void *buf,
     vtxp->u.issend.comm = comm_ptr;
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                    (MPL_DBG_FDEST, "Gentran: schedule [%d] issend", vtx_id));
+                    (MPL_DBG_FDEST, "Gentran: schedule [%d] issend", *vtx_id));
 
-    return vtx_id;
+    return mpi_errno;
 }
 
 int MPIR_TSP_sched_reduce_local(const void *inbuf, void *inoutbuf, int count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_TSP_sched_t s,
-                                int n_in_vtcs, int *in_vtcs)
+                                int n_in_vtcs, int *in_vtcs, int *vtx_id)
 {
     MPII_Genutil_sched_t *sched = s;
     vtx_t *vtxp;
-    int vtx_id;
-
+    int mpi_errno = MPI_SUCCESS;
     /* assign a new vertex */
-    vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
+    *vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
 
     vtxp->vtx_kind = MPII_GENUTIL_VTX_KIND__REDUCE_LOCAL;
-    MPII_Genutil_vtx_add_dependencies(sched, vtx_id, n_in_vtcs, in_vtcs);
+    MPII_Genutil_vtx_add_dependencies(sched, *vtx_id, n_in_vtcs, in_vtcs);
 
     /* record the arguments */
     vtxp->u.reduce_local.inbuf = inbuf;
@@ -286,25 +285,24 @@ int MPIR_TSP_sched_reduce_local(const void *inbuf, void *inoutbuf, int count,
     vtxp->u.reduce_local.op = op;
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                    (MPL_DBG_FDEST, "Gentran: schedule [%d] reduce_local", vtx_id));
+                    (MPL_DBG_FDEST, "Gentran: schedule [%d] reduce_local", *vtx_id));
 
-    return vtx_id;
+    return mpi_errno;
 }
 
 
 int MPIR_TSP_sched_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                             MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs)
+                             MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs, int *vtx_id)
 {
     MPII_Genutil_sched_t *sched = s;
     vtx_t *vtxp;
-    int vtx_id;
-
+    int mpi_errno = MPI_SUCCESS;
     /* assign a new vertex */
-    vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
+    *vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
 
     vtxp->vtx_kind = MPII_GENUTIL_VTX_KIND__LOCALCOPY;
-    MPII_Genutil_vtx_add_dependencies(sched, vtx_id, n_in_vtcs, in_vtcs);
+    MPII_Genutil_vtx_add_dependencies(sched, *vtx_id, n_in_vtcs, in_vtcs);
 
     /* record the arguments */
     vtxp->u.localcopy.sendbuf = sendbuf;
@@ -315,9 +313,9 @@ int MPIR_TSP_sched_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
     vtxp->u.localcopy.recvtype = recvtype;
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                    (MPL_DBG_FDEST, "Gentran: schedule [%d] localcopy", vtx_id));
+                    (MPL_DBG_FDEST, "Gentran: schedule [%d] localcopy", *vtx_id));
 
-    return vtx_id;
+    return mpi_errno;
 }
 
 
@@ -390,23 +388,21 @@ void MPIR_TSP_sched_fence(MPIR_TSP_sched_t s)
     MPIR_Assert(MPI_SUCCESS == mpi_errno);
 }
 
-int MPIR_TSP_sched_selective_sink(MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs)
+int MPIR_TSP_sched_selective_sink(MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs, int *vtx_id)
 {
     MPII_Genutil_sched_t *sched = s;
     vtx_t *vtxp;
-    int vtx_id;
-
+    int mpi_errno = MPI_SUCCESS;
     /* assign a new vertex */
-    vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
+    *vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
 
     vtxp->vtx_kind = MPII_GENUTIL_VTX_KIND__SELECTIVE_SINK;
-    MPII_Genutil_vtx_add_dependencies(sched, vtx_id, n_in_vtcs, in_vtcs);
+    MPII_Genutil_vtx_add_dependencies(sched, *vtx_id, n_in_vtcs, in_vtcs);
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                    (MPL_DBG_FDEST, "Gentran: schedule [%d] selective_sink task", vtx_id));
+                    (MPL_DBG_FDEST, "Gentran: schedule [%d] selective_sink task", *vtx_id));
 
-    return vtx_id;
-
+    return mpi_errno;
 }
 
 void *MPIR_TSP_sched_malloc(size_t size, MPIR_TSP_sched_t s)

--- a/src/mpi/coll/transports/tsp_impl.h
+++ b/src/mpi/coll/transports/tsp_impl.h
@@ -46,7 +46,8 @@ int MPIR_TSP_sched_isend(const void *buf,
                          MPI_Datatype dt,
                          int dest,
                          int tag,
-                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs);
+                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs,
+                         int *vtx_id);
 
 /* Transport function to schedule a issend vertex */
 int MPIR_TSP_sched_issend(const void *buf,
@@ -55,7 +56,7 @@ int MPIR_TSP_sched_issend(const void *buf,
                           int dest,
                           int tag,
                           MPIR_Comm * comm_ptr,
-                          MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs);
+                          MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs, int *vtx_id);
 
 /* Transport function to schedule an irecv vertex */
 int MPIR_TSP_sched_irecv(void *buf,
@@ -63,7 +64,8 @@ int MPIR_TSP_sched_irecv(void *buf,
                          MPI_Datatype dt,
                          int source,
                          int tag,
-                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs);
+                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs,
+                         int *vtx_id);
 
 /* Transport function to schedule an imcast vertex */
 int MPIR_TSP_sched_imcast(const void *buf,
@@ -73,22 +75,22 @@ int MPIR_TSP_sched_imcast(const void *buf,
                           int num_dests,
                           int tag,
                           MPIR_Comm * comm_ptr,
-                          MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs);
+                          MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs, int *vtx_id);
 
 
 /* Transport function to schedule a local reduce vertex */
 int MPIR_TSP_sched_reduce_local(const void *inbuf, void *inoutbuf, int count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_TSP_sched_t sched,
-                                int n_in_vtcs, int *in_vtcs);
+                                int n_in_vtcs, int *in_vtcs, int *vtx_id);
 
 /* Transport function to schedule a local data copy */
 int MPIR_TSP_sched_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                             MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs);
+                             MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs, int *vtx_id);
 
 /* Transport function to schedule a vertex that completes when all the incoming vertices have
  * completed */
-int MPIR_TSP_sched_selective_sink(MPIR_TSP_sched_t sched, int n_in_vtcs, int *invtcs);
+int MPIR_TSP_sched_selective_sink(MPIR_TSP_sched_t sched, int n_in_vtcs, int *invtcs, int *vtx_id);
 
 /* Transport function to allocate memory required for schedule execution */
 void *MPIR_TSP_sched_malloc(size_t size, MPIR_TSP_sched_t sched);


### PR DESCRIPTION
## Pull Request Description
Currently, the gentran functions for different types of vertex creation returns the corresponding `vtx_id`. This PR changes the functions to return `mpi_errno` instead. This changes the function signatures for the gentran APIs and the collective algorithms that invoke the APIs are also changed accordingly. 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
