### PR TITLE
mpl: fix mpl_misc.c

### DIFF
--- a/src/mpi/init/init_async.c
+++ b/src/mpi/init/init_async.c
@@ -31,8 +31,8 @@ cvars:
         highly system dependent but may be substantial in some cases,
         hence this recommendation.
 
-    - name        : MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY
-      category    : CH4
+    - name        : MPIR_CVAR_PROGRESS_THREAD_AFFINITY
+      category    : THREADS
       type        : string
       default     : ""
       class       : device
@@ -90,7 +90,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_parse_progress_thread_affinity(int *thread_af
 {
     int th_idx, read_count = 0, mpi_errno = MPI_SUCCESS;
     char *affinity_copy = NULL;
-    const char *affinity_to_parse = MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY;
+    const char *affinity_to_parse = MPIR_CVAR_PROGRESS_THREAD_AFFINITY;
     char *proc_id_str, *tmp;
     size_t proc_count;
 
@@ -153,8 +153,8 @@ static int get_thread_affinity(bool * apply_affinity, int **p_thread_affinity, i
     int *thread_affinity = NULL;
     int have_cliques;
 
-    *apply_affinity = MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY &&
-        strlen(MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY) > 0;
+    *apply_affinity = MPIR_CVAR_PROGRESS_THREAD_AFFINITY &&
+        strlen(MPIR_CVAR_PROGRESS_THREAD_AFFINITY) > 0;
     have_cliques = MPIR_pmi_has_local_cliques();
 
 
@@ -182,7 +182,7 @@ static int get_thread_affinity(bool * apply_affinity, int **p_thread_affinity, i
         async_threads_per_node = local_size;
         thread_affinity = (int *) MPL_malloc(async_threads_per_node * sizeof(int), MPL_MEM_OTHER);
 
-        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+        MPL_DBG_MSG_FMT(MPIR_DBG_INIT, VERBOSE,
                         (MPL_DBG_FDEST,
                          " global_rank %d, local_rank %d, local_size %d, async_threads_per_node %d",
                          global_rank, local_rank, local_size, async_threads_per_node));
@@ -193,7 +193,7 @@ static int get_thread_affinity(bool * apply_affinity, int **p_thread_affinity, i
         if (MPIR_Process.rank == 0) {
             int th_idx;
             for (th_idx = 0; th_idx < async_threads_per_node; th_idx++) {
-                MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                MPL_DBG_MSG_FMT(MPIR_DBG_INIT, VERBOSE,
                                 (MPL_DBG_FDEST, "affinity: thread %d, processor %d",
                                  th_idx, thread_affinity[th_idx]));
             }

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -668,7 +668,7 @@ AC_CHECK_HEADERS(sys/sysinfo.h unistd.h)
 AC_CHECK_FUNCS(get_nprocs)
 AC_CHECK_DECLS([_SC_NPROCESSORS_ONLN],[],[],[[#include <unistd.h>]])
 
-if test "$ac_cv_func_get_nprocs" = "yes" -a "$ac_cv_have_decl__SC_NPROCESSORS_ONLN" = "yes"; then
+if test "$ac_cv_func_get_nprocs" = "yes" -o "$ac_cv_have_decl__SC_NPROCESSORS_ONLN" = "yes"; then
     AC_DEFINE(HAVE_MISC_GETNPROCS,1, [Define if get_nprocs or _SC_NPROCESSORS_ONLN is Vilable.])
 fi
 

--- a/src/mpl/include/mpl_posix_mutex_native.h
+++ b/src/mpl/include/mpl_posix_mutex_native.h
@@ -21,7 +21,7 @@ int pthread_mutexattr_settype(pthread_mutexattr_t * attr, int kind);
 
 /* FIXME: using constant initializer if available */
 
-/* FIXME: convert errors to an MPL_THREAD_ERR value */
+/* FIXME: convert errors to an MPL_ERR_THREAD value */
 
 #if !defined(MPL_PTHREAD_MUTEX_ERRORCHECK_VALUE)
 

--- a/src/mpl/include/mpl_thread_argobots.h
+++ b/src/mpl/include/mpl_thread_argobots.h
@@ -91,12 +91,8 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
     } while (0)
 
 /* See mpl_thread_posix.h for interface description. */
-void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size, int *err)
-{
-    /* stub implementation */
-    if (err)
-        *err = MPL_ERR_THREAD;
-}
+void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size,
+                             int *err);
 
 /* ======================================================================
  *    Scheduling

--- a/src/mpl/include/mpl_thread_argobots.h
+++ b/src/mpl/include/mpl_thread_argobots.h
@@ -95,7 +95,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
 {
     /* stub implementation */
     if (err)
-        *err = MPL_THREAD_ERROR;
+        *err = MPL_ERR_THREAD;
 }
 
 /* ======================================================================

--- a/src/mpl/include/mpl_thread_priv.h
+++ b/src/mpl/include/mpl_thread_priv.h
@@ -31,7 +31,7 @@ void MPLI_cleanup_tls(void *a);
             break;                                                      \
         thread_ptr = MPL_calloc(1, sizeof(var), class_);                \
         if (unlikely(!thread_ptr)) {                                    \
-            *((int *) err_ptr_) = MPL_THREAD_ERROR;                     \
+            *((int *) err_ptr_) = MPL_ERR_THREAD;                       \
             break;                                                      \
         }                                                               \
         MPL_thread_tls_set(&(key), thread_ptr, err_ptr_);               \
@@ -46,7 +46,7 @@ void MPLI_cleanup_tls(void *a);
         if (!thread_ptr) {                                              \
             thread_ptr = MPL_calloc(1, sizeof(var), MPL_MEM_OTHER);     \
             if (unlikely(!thread_ptr)) {                                \
-                *((int *) err_ptr_) = MPL_THREAD_ERROR;                 \
+                *((int *) err_ptr_) = MPL_ERR_THREAD;                   \
                 break;                                                  \
             }                                                           \
             MPL_thread_tls_set(&(key), thread_ptr, err_ptr_);           \

--- a/src/mpl/include/mpl_thread_solaris.h
+++ b/src/mpl/include/mpl_thread_solaris.h
@@ -72,7 +72,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) = mutex_init(mutex_ptr_, USYNC_THREAD, NULL);   \
-            /* FIXME: convert error to an MPL_THREAD_ERR value */       \
+            /* FIXME: convert error to an MPL_ERR_THREAD value */       \
         }                                                               \
     } while (0)
 
@@ -83,7 +83,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) = mutex_destroy(mutex_ptr_);                    \
-            /* FIXME: convert error to an MPL_THREAD_ERR value */       \
+            /* FIXME: convert error to an MPL_ERR_THREAD value */       \
         }                                                               \
     } while (0)
 
@@ -94,7 +94,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) = mutex_lock(mutex_ptr_);                       \
-            /* FIXME: convert error to an MPL_THREAD_ERR value */       \
+            /* FIXME: convert error to an MPL_ERR_THREAD value */       \
         }                                                               \
     } while (0)
 
@@ -105,7 +105,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) = mutex_unlock(mutex_ptr_);                     \
-            /* FIXME: convert error to an MPL_THREAD_ERR value */       \
+            /* FIXME: convert error to an MPL_ERR_THREAD value */       \
         }                                                               \
     } while (0)
 
@@ -121,7 +121,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) == cond_init(cond_ptr_, NULL, NULL);            \
-            /* FIXME: convert error to an MPL_THREAD_ERR value */       \
+            /* FIXME: convert error to an MPL_ERR_THREAD value */       \
         }                                                               \
     } while (0)
 
@@ -132,7 +132,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) = cond_destroy(cond_ptr_);                      \
-            /* FIXME: convert error to a MPL_THREAD_ERR value */        \
+            /* FIXME: convert error to a MPL_ERR_THREAD value */        \
         }                                                               \
     } while (0)
 
@@ -143,7 +143,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) = cond_wait((cond_ptr_), (mutex_ptr_));         \
-            /* FIXME: convert error to a MPL_THREAD_ERR value */        \
+            /* FIXME: convert error to a MPL_ERR_THREAD value */        \
         }                                                               \
     } while (0)
 
@@ -154,7 +154,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) = cond_broadcast(cond_ptr_);                    \
-            /* FIXME: convert error to a MPL_THREAD_ERR value */        \
+            /* FIXME: convert error to a MPL_ERR_THREAD value */        \
         }                                                               \
     } while (0)
 
@@ -165,7 +165,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) = cond_signal(cond_ptr_);                       \
-            /* FIXME: convert error to a MPL_THREAD_ERR value */        \
+            /* FIXME: convert error to a MPL_ERR_THREAD value */        \
         }                                                               \
     } while (0)
 
@@ -180,7 +180,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) = thr_keycreate((tls_ptr_), (exit_func_ptr_));  \
-            /* FIXME: convert error to a MPL_THREAD_ERR value */        \
+            /* FIXME: convert error to a MPL_ERR_THREAD value */        \
         }                                                               \
     } while (0)
 
@@ -205,7 +205,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) = thr_setspecific(*(tls_ptr_), (value_));       \
-            /* FIXME: convert error to a MPL_THREAD_ERR value */        \
+            /* FIXME: convert error to a MPL_ERR_THREAD value */        \
         }                                                               \
     } while (0)
 
@@ -216,7 +216,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
         }                                                               \
         else {                                                          \
             *(err_ptr_) = thr_setspecific(*(tls_ptr_), (value_ptr_));   \
-            /* FIXME: convert error to a MPL_THREAD_ERR value */        \
+            /* FIXME: convert error to a MPL_ERR_THREAD value */        \
         }                                                               \
     } while (0)
 

--- a/src/mpl/include/mpl_thread_solaris.h
+++ b/src/mpl/include/mpl_thread_solaris.h
@@ -54,12 +54,8 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
 #define MPL_thread_yield thr_yield
 
 /* See mpl_thread_posix.h for interface description. */
-void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size, int *err)
-{
-    /* stub implementation */
-    if (err)
-        *err = MPL_ERR_THREAD;
-}
+void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size,
+                             int *err);
 
 /*
  *    Mutexes

--- a/src/mpl/include/mpl_thread_solaris.h
+++ b/src/mpl/include/mpl_thread_solaris.h
@@ -58,7 +58,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
 {
     /* stub implementation */
     if (err)
-        *err = MPL_THREAD_ERROR;
+        *err = MPL_ERR_THREAD;
 }
 
 /*

--- a/src/mpl/include/mpl_thread_win.h
+++ b/src/mpl/include/mpl_thread_win.h
@@ -48,7 +48,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
 {
     /* stub implementation */
     if (err)
-        *err = MPL_THREAD_ERROR;
+        *err = MPL_ERR_THREAD;
 }
 
 void MPL_thread_mutex_create(MPL_thread_mutex_t * mutex, int *err);

--- a/src/mpl/include/mpl_thread_win.h
+++ b/src/mpl/include/mpl_thread_win.h
@@ -44,12 +44,8 @@ void MPL_thread_same(MPL_thread_id_t * id1, MPL_thread_id_t * id2, int *same);
 void MPL_thread_yield();
 
 /* See mpl_thread_posix.h for interface description. */
-void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size, int *err)
-{
-    /* stub implementation */
-    if (err)
-        *err = MPL_ERR_THREAD;
-}
+void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size,
+                             int *err);
 
 void MPL_thread_mutex_create(MPL_thread_mutex_t * mutex, int *err);
 void MPL_thread_mutex_destroy(MPL_thread_mutex_t * mutex, int *err);

--- a/src/mpl/src/misc/mpl_misc.c
+++ b/src/mpl/src/misc/mpl_misc.c
@@ -19,7 +19,7 @@ int MPL_get_nprocs(void)
 {
 #if defined (MPL_HAVE_GET_NPROCS)
     return get_nprocs();
-#elif defined (MPL_HAVE_DECL__SC_NPROCESSORS_ONLN)
+#elif defined (MPL_HAVE_DECL__SC_NPROCESSORS_ONLN) && MPL_HAVE_DECL__SC_NPROCESSORS_ONLN
     int count = sysconf(_SC_NPROCESSORS_ONLN);
     return (count > 0) ? count : 1;
 #else

--- a/src/mpl/src/misc/mpl_misc.c
+++ b/src/mpl/src/misc/mpl_misc.c
@@ -1,11 +1,11 @@
-/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
-/* vim: set ft=c.mpich : */
 /*
- *  (C) 2018 by Argonne National Laboratory.
- *      See COPYRIGHT in top-level directory.
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
  */
 
 #include "mpl.h"
+#include <assert.h>
+
 
 #if defined (MPL_HAVE_SYS_SYSINFO_H)
 #include <sys/sysinfo.h>
@@ -21,10 +21,11 @@ int MPL_get_nprocs(void)
     return get_nprocs();
 #elif defined (MPL_HAVE_DECL__SC_NPROCESSORS_ONLN)
     int count = sysconf(_SC_NPROCESSORS_ONLN);
-    return (count > 0) ? count : 0;
+    return (count > 0) ? count : 1;
 #else
     /* Neither MPL_HAVE_GET_NPROCS nor MPL_HAVE_DECL__SC_NPROCESSORS_ONLN are defined.
      * Should not reach here. */
-    MPIR_Assert(0);
+    assert(0);
+    return 1;
 #endif
 }

--- a/src/mpl/src/thread/mpl_thread_argobots.c
+++ b/src/mpl/src/thread/mpl_thread_argobots.c
@@ -71,4 +71,11 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
     }
 }
 
+void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size, int *err)
+{
+    /* stub implementation */
+    if (err)
+        *err = MPL_ERR_THREAD;
+}
+
 #endif

--- a/src/mpl/src/thread/mpl_thread_posix.c
+++ b/src/mpl/src/thread/mpl_thread_posix.c
@@ -51,7 +51,7 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
         thread_info->data = data;
 
         err = pthread_create(idp, NULL, MPLI_thread_start, thread_info);
-        /* FIXME: convert error to an MPL_THREAD_ERR value */
+        /* FIXME: convert error to an MPL_ERR_THREAD value */
     } else {
         err = 1000000000;
     }

--- a/src/mpl/src/thread/mpl_thread_solaris.c
+++ b/src/mpl/src/thread/mpl_thread_solaris.c
@@ -79,4 +79,12 @@ void *MPLI_thread_start(void *arg)
     return NULL;
 }
 
+/* See mpl_thread_posix.h for interface description. */
+void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size, int *err)
+{
+    /* stub implementation */
+    if (err)
+        *err = MPL_ERR_THREAD;
+}
+
 #endif

--- a/src/mpl/src/thread/mpl_thread_solaris.c
+++ b/src/mpl/src/thread/mpl_thread_solaris.c
@@ -49,7 +49,7 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
         thread_info->data = data;
 
         err = thr_create(NULL, 0, MPLI_thread_start, thread_info, THR_DETACHED, idp);
-        /* FIXME: convert error to an MPL_THREAD_ERR value */
+        /* FIXME: convert error to an MPL_ERR_THREAD value */
     } else {
         err = 1000000000;
     }

--- a/src/mpl/src/thread/mpl_thread_win.c
+++ b/src/mpl/src/thread/mpl_thread_win.c
@@ -349,4 +349,11 @@ void MPL_thread_cond_signal(MPL_thread_cond_t * cond, int *err)
     }
 }
 
+void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size, int *err)
+{
+    /* stub implementation */
+    if (err)
+        *err = MPL_ERR_THREAD;
+}
+
 #endif


### PR DESCRIPTION
## Pull Request Description
This fixes PR #5398, which broke a lot of configurations.

We can't use MPIR_Assert in mpl.

The function get_nprocs should return 1 by default. Return 0 will break
caller code.

Use normalized copyright comment block.

`AC_CHEKC_DECL` is weird that it defines the macro to `0` when check fails.

Accidentally used/leaked CH4 symbols

`MPL_THREAD_ERROR` doesn't exist. It should be `MPL_ERR_THREAD`.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
