### PR TITLE
ch4/ipc: extend ipc to support non-contig datatypes

### DIFF
--- a/src/mpid/ch4/shm/ipc/src/ipc_control.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.c
@@ -32,11 +32,10 @@ int MPIDI_IPC_rndv_cb(MPIR_Request * rreq)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPIDI_IPC_hdr *hdr = MPIDIG_REQUEST(rreq, rndv_hdr);
     MPI_Aint in_data_sz = MPIDIG_recv_in_data_sz(rreq);
     MPIR_Request *sreq_ptr = MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr);
 
-    mpi_errno = MPIDI_IPCI_handle_lmt_recv(hdr->ipc_type, hdr->ipc_handle,
+    mpi_errno = MPIDI_IPCI_handle_lmt_recv(MPIDIG_REQUEST(rreq, rndv_hdr),
                                            in_data_sz, sreq_ptr, rreq);
 
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/shm/ipc/src/ipc_control.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.c
@@ -11,7 +11,7 @@ int MPIDI_IPC_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                 uint32_t attr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIDI_IPC_ctrl_send_contig_lmt_fin_t *hdr = am_hdr;
+    MPIDI_IPC_ack_t *hdr = am_hdr;
     MPIR_Request *sreq = hdr->req_ptr;
 
     MPIR_FUNC_ENTER;

--- a/src/mpid/ch4/shm/ipc/src/ipc_init.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_init.c
@@ -11,6 +11,8 @@ int MPIDI_IPC_init_local(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    MPL_COMPILE_TIME_ASSERT(offsetof(MPIDI_IPC_rts_t, ipc_hdr) == sizeof(MPIDIG_hdr_t));
+
 #ifdef MPL_USE_DBG_LOGGING
     MPIDI_IPCI_DBG_GENERAL = MPL_dbg_class_alloc("SHM_IPC", "shm_ipc");
 #endif

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
-    MPIDI_IPC_ctrl_send_contig_lmt_rts_t slmt_req_hdr;
+    MPIDI_IPC_rts_t am_hdr;
 
     /* FIXME: handle all send types */
     int flags = 0;
@@ -60,19 +60,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
     MPIDIG_REQUEST(sreq, count) = count;
     MPIDIG_REQUEST(sreq, context_id) = comm->context_id + context_offset;
 
-    slmt_req_hdr.ipc_hdr.ipc_type = ipc_attr.ipc_type;
-    slmt_req_hdr.ipc_hdr.ipc_handle = ipc_attr.ipc_handle;
+    am_hdr.ipc_hdr.ipc_type = ipc_attr.ipc_type;
+    am_hdr.ipc_hdr.ipc_handle = ipc_attr.ipc_handle;
 
     /* message matching info */
-    slmt_req_hdr.hdr.src_rank = comm->rank;
-    slmt_req_hdr.hdr.tag = tag;
-    slmt_req_hdr.hdr.context_id = comm->context_id + context_offset;
-    slmt_req_hdr.hdr.data_sz = data_sz;
-    slmt_req_hdr.hdr.rndv_hdr_sz = sizeof(MPIDI_IPC_hdr);
-    slmt_req_hdr.hdr.sreq_ptr = sreq;
-    slmt_req_hdr.hdr.error_bits = error_bits;
-    slmt_req_hdr.hdr.flags = flags;
-    MPIDIG_AM_SEND_SET_RNDV(slmt_req_hdr.hdr.flags, MPIDIG_RNDV_IPC);
+    am_hdr.hdr.src_rank = comm->rank;
+    am_hdr.hdr.tag = tag;
+    am_hdr.hdr.context_id = comm->context_id + context_offset;
+    am_hdr.hdr.data_sz = data_sz;
+    am_hdr.hdr.rndv_hdr_sz = sizeof(MPIDI_IPC_hdr);
+    am_hdr.hdr.sreq_ptr = sreq;
+    am_hdr.hdr.error_bits = error_bits;
+    am_hdr.hdr.flags = flags;
+    MPIDIG_AM_SEND_SET_RNDV(am_hdr.hdr.flags, MPIDIG_RNDV_IPC);
 
     if (flags & MPIDIG_AM_SEND_FLAGS_SYNC) {
         MPIR_cc_inc(sreq->cc_ptr);      /* expecting SSEND_ACK */
@@ -84,8 +84,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
     }
 
     int is_local = 1;
-    MPI_Aint hdr_sz = sizeof(slmt_req_hdr);
-    CH4_CALL(am_send_hdr(rank, comm, MPIDIG_SEND, &slmt_req_hdr, hdr_sz, vsi_src, vsi_dst),
+    MPI_Aint hdr_sz = sizeof(am_hdr);
+    CH4_CALL(am_send_hdr(rank, comm, MPIDIG_SEND, &am_hdr, hdr_sz, vsi_src, vsi_dst),
              is_local, mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -170,7 +170,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPCI_type_t ipc_ty
         MPIR_Assert(0);
     }
 
-    MPIDI_IPC_ctrl_send_contig_lmt_fin_t am_hdr;
+    MPIDI_IPC_ack_t am_hdr;
     am_hdr.ipc_type = ipc_type;
     am_hdr.req_ptr = sreq_ptr;
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -62,7 +62,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
 
     slmt_req_hdr.ipc_hdr.ipc_type = ipc_attr.ipc_type;
     slmt_req_hdr.ipc_hdr.ipc_handle = ipc_attr.ipc_handle;
-    slmt_req_hdr.ipc_hdr.src_lrank = MPIR_Process.local_rank;
 
     /* message matching info */
     slmt_req_hdr.hdr.src_rank = comm->rank;

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -29,14 +29,13 @@ int MPIDI_IPC_rndv_cb(MPIR_Request * rreq);
 int MPIDI_IPC_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                 uint32_t attr, MPIR_Request ** req);
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Aint count,
-                                                        MPI_Datatype datatype, uintptr_t data_sz,
-                                                        int is_contig,
-                                                        int rank, int tag, MPIR_Comm * comm,
-                                                        int context_offset, MPIDI_av_entry_t * addr,
-                                                        MPIDI_IPCI_ipc_attr_t ipc_attr,
-                                                        int vsi_src, int vsi_dst,
-                                                        MPIR_Request ** request)
+MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count,
+                                                 MPI_Datatype datatype, uintptr_t data_sz,
+                                                 int is_contig,
+                                                 int rank, int tag, MPIR_Comm * comm,
+                                                 int context_offset, MPIDI_av_entry_t * addr,
+                                                 MPIDI_IPCI_ipc_attr_t ipc_attr,
+                                                 int vsi_src, int vsi_dst, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -28,32 +28,66 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi_src).lock);
 
+    if (rank == comm->rank) {
+        goto fn_exit;
+    }
+
+    MPIR_Datatype *dt_ptr;
     bool dt_contig;
     MPI_Aint true_lb;
     uintptr_t data_sz;
-    MPIDI_Datatype_check_contig_size_lb(datatype, count, dt_contig, data_sz, true_lb);
+    MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, true_lb);
 
-    void *vaddr = (char *) buf + true_lb;
+    if (!dt_contig && (dt_ptr->true_lb < 0 || dt_ptr->extent < 0)) {
+        /* TODO: handle offset */
+        goto fn_exit;
+    }
+
+    MPI_Aint mem_size;
+    void *mem_addr;
+    if (dt_contig) {
+        mem_addr = (char *) buf + true_lb;
+        mem_size = data_sz;
+    } else {
+        mem_addr = (char *) buf;
+        mem_size = dt_ptr->true_ub + (count - 1) * dt_ptr->extent;
+    }
     MPIDI_IPCI_ipc_attr_t ipc_attr;
-    MPIR_GPU_query_pointer_attr(vaddr, &ipc_attr.gpu_attr);
+    MPIR_GPU_query_pointer_attr(mem_addr, &ipc_attr.gpu_attr);
 
     if (ipc_attr.gpu_attr.type == MPL_GPU_POINTER_DEV) {
-        mpi_errno = MPIDI_GPU_get_ipc_attr(vaddr, rank, comm, &ipc_attr);
+        mpi_errno = MPIDI_GPU_get_ipc_attr(mem_addr, rank, comm, &ipc_attr);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
-        mpi_errno = MPIDI_XPMEM_get_ipc_attr(vaddr, data_sz, &ipc_attr);
+        mpi_errno = MPIDI_XPMEM_get_ipc_attr(mem_addr, mem_size, &ipc_attr);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    if (rank != comm->rank && ipc_attr.ipc_type != MPIDI_IPCI_TYPE__NONE &&
-        data_sz >= ipc_attr.threshold.send_lmt_sz) {
-        if (dt_contig) {
-            mpi_errno = MPIDI_IPCI_send_contig_lmt(buf, count, datatype, data_sz, rank, tag, comm,
-                                                   context_offset, addr, ipc_attr, vsi_src, vsi_dst,
-                                                   request);
-            MPIR_ERR_CHECK(mpi_errno);
-            *done = true;
+    if (ipc_attr.ipc_type == MPIDI_IPCI_TYPE__NONE) {
+        goto fn_exit;
+    }
+    if (data_sz < ipc_attr.threshold.send_lmt_sz) {
+        goto fn_exit;
+    }
+
+    bool do_ipc = false;
+    if (dt_contig) {
+        do_ipc = true;
+    } else if (!dt_contig) {
+        int flattened_sz;
+        void *flattened_dt;
+        MPIR_Datatype_get_flattened(datatype, &flattened_dt, &flattened_sz);
+        if (sizeof(MPIDI_IPC_rts_t) + flattened_sz < MPIDI_POSIX_am_hdr_max_sz()) {
+            do_ipc = true;
         }
+    }
+    if (do_ipc) {
+        mpi_errno = MPIDI_IPCI_send_contig_lmt(buf, count, datatype, data_sz, dt_contig,
+                                               rank, tag, comm,
+                                               context_offset, addr, ipc_attr,
+                                               vsi_src, vsi_dst, request);
+        MPIR_ERR_CHECK(mpi_errno);
+        *done = true;
         /* TODO: add flattening datatype protocol for noncontig send. Different
          * threshold may be required to tradeoff the flattening overhead.*/
     }

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -82,10 +82,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
         }
     }
     if (do_ipc) {
-        mpi_errno = MPIDI_IPCI_send_contig_lmt(buf, count, datatype, data_sz, dt_contig,
-                                               rank, tag, comm,
-                                               context_offset, addr, ipc_attr,
-                                               vsi_src, vsi_dst, request);
+        mpi_errno = MPIDI_IPCI_send_lmt(buf, count, datatype, data_sz, dt_contig,
+                                        rank, tag, comm, context_offset, addr, ipc_attr,
+                                        vsi_src, vsi_dst, request);
         MPIR_ERR_CHECK(mpi_errno);
         *done = true;
         /* TODO: add flattening datatype protocol for noncontig send. Different

--- a/src/mpid/ch4/shm/ipc/src/ipc_types.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_types.h
@@ -36,15 +36,15 @@ typedef struct MPIDI_IPC_rndv_hdr {
     MPIDI_IPCI_ipc_handle_t ipc_handle;
 } MPIDI_IPC_hdr;
 
-typedef struct MPIDI_IPC_ctrl_send_contig_lmt_rts {
+typedef struct MPIDI_IPC_rts {
     MPIDIG_hdr_t hdr;
     MPIDI_IPC_hdr ipc_hdr;
-} MPIDI_IPC_ctrl_send_contig_lmt_rts_t;
+} MPIDI_IPC_rts_t;
 
-typedef struct MPIDI_IPC_ctrl_send_contig_lmt_fin {
+typedef struct MPIDI_IPC_ack {
     MPIDI_IPCI_type_t ipc_type;
     MPIR_Request *req_ptr;
-} MPIDI_IPC_ctrl_send_contig_lmt_fin_t;
+} MPIDI_IPC_ack_t;
 
 #ifdef MPL_USE_DBG_LOGGING
 extern MPL_dbg_class MPIDI_IPCI_DBG_GENERAL;

--- a/src/mpid/ch4/shm/ipc/src/ipc_types.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_types.h
@@ -34,6 +34,10 @@ typedef struct MPIDI_IPCI_ipc_attr {
 typedef struct MPIDI_IPC_rndv_hdr {
     MPIDI_IPCI_type_t ipc_type;
     MPIDI_IPCI_ipc_handle_t ipc_handle;
+    uint64_t is_contig:8;
+    uint64_t flattened_sz:24;   /* only if it's non-contig, flattened type
+                                 * will be attached after this header. */
+    MPI_Aint count;             /* only if it's non-contig */
 } MPIDI_IPC_hdr;
 
 typedef struct MPIDI_IPC_rts {

--- a/src/mpid/ch4/shm/ipc/src/ipc_types.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_types.h
@@ -34,7 +34,6 @@ typedef struct MPIDI_IPCI_ipc_attr {
 typedef struct MPIDI_IPC_rndv_hdr {
     MPIDI_IPCI_type_t ipc_type;
     MPIDI_IPCI_ipc_handle_t ipc_handle;
-    int src_lrank;              /* sender rank on local node */
 } MPIDI_IPC_hdr;
 
 typedef struct MPIDI_IPC_ctrl_send_contig_lmt_rts {

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
@@ -45,6 +45,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_ipc_attr(const void *vaddr, uintptr
 
     memset(&ipc_attr->ipc_handle, 0, sizeof(MPIDI_IPCI_ipc_handle_t));
 
+    if (vaddr == MPI_BOTTOM) {
+        goto fn_none;
+    }
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
     if (MPIR_CVAR_CH4_XPMEM_ENABLE) {
         ipc_attr->ipc_type = MPIDI_IPCI_TYPE__XPMEM;
@@ -56,6 +59,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_ipc_attr(const void *vaddr, uintptr
     }
 #endif
 
+  fn_none:
     ipc_attr->ipc_type = MPIDI_IPCI_TYPE__NONE;
     ipc_attr->threshold.send_lmt_sz = MPIR_AINT_MAX;
 

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -9,13 +9,7 @@
 #include <mpi.h>
 #include "release_gather_types.h"
 
-#define MPIDI_POSIX_MAX_AM_HDR_SIZE     ((1 << MPIDI_POSIX_AM_HDR_SZ_BITS) - 1)
-
-#define MPIDI_POSIX_AM_HANDLER_ID_BITS  (8)     /* up to 64 */
-#define MPIDI_POSIX_AM_HDR_SZ_BITS      (8)
-#define MPIDI_POSIX_AM_TYPE_BITS     (8)
-#define MPIDI_POSIX_AM_UNUSED_BITS     (40)
-
+#define MPIDI_POSIX_MAX_AM_HDR_SIZE     800     /* constrained by MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE */
 #define MPIDI_POSIX_AM_MSG_HEADER_SIZE  (sizeof(MPIDI_POSIX_am_header_t))
 #define MPIDI_POSIX_MAX_IOV_NUM         (3)     /* am_hdr, [padding], payload */
 
@@ -59,10 +53,10 @@ typedef struct {
 } MPIDI_POSIX_request_t;
 
 typedef struct MPIDI_POSIX_am_header {
-    uint64_t handler_id:MPIDI_POSIX_AM_HANDLER_ID_BITS;
-    uint64_t am_hdr_sz:MPIDI_POSIX_AM_HDR_SZ_BITS;
-    uint64_t am_type:MPIDI_POSIX_AM_TYPE_BITS;
-    uint64_t unused:MPIDI_POSIX_AM_UNUSED_BITS;
+    int8_t am_type;
+    int8_t handler_id;
+    int16_t am_hdr_sz;
+    int32_t unused;
 } MPIDI_POSIX_am_header_t;
 
 typedef struct MPIDI_POSIX_am_request_header {


### PR DESCRIPTION
## Pull Request Description

When the flattened datatype can fit in the header, we'll simply attatch
the flattened sender datatype in the header so the receiver can handle
the data copy.

TODO:
* [x] enhance the non-contig device check


[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
