### PR TITLE
coll: fix bcast_intra_scatter_recursive_doubling_allgather

### DIFF
--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -51,12 +51,6 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     rank = comm_ptr->rank;
     relative_rank = (rank >= root) ? rank - root : rank - root + comm_size;
 
-#ifdef HAVE_ERROR_CHECKING
-    /* This algorithm can currently handle only power of 2 cases,
-     * non-power of 2 is still experimental */
-    MPIR_Assert(MPL_is_pof2(comm_size, NULL));
-#endif /* HAVE_ERROR_CHECKING */
-
     if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;
     else {

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -99,6 +99,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
     /* curr_size is the amount of data that this process now has stored in
      * buffer at byte offset (relative_rank*scatter_size) */
+    /* Note: since we are rounding up scatter_size, higher ranks may not have data and nbytes-offset may be negative */
     curr_size = MPL_MIN(scatter_size, (nbytes - (relative_rank * scatter_size)));
     if (curr_size < 0)
         curr_size = 0;
@@ -224,7 +225,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                     /* printf("Rank %d waiting to recv from rank %d\n",
                      * relative_rank, dst); */
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
-                                          nbytes - offset,
+                                          nbytes - offset < 0 ? 0 : nbytes - offset,
                                           MPI_BYTE, dst, MPIR_BCAST_TAG,
                                           comm_ptr, &status, errflag);
                     /* nprocs_completed is also equal to the no. of processes

--- a/src/mpi/coll/coll_algorithms.txt
+++ b/src/mpi/coll/coll_algorithms.txt
@@ -52,7 +52,6 @@ ibarrier-inter:
 bcast-intra:
     binomial
     scatter_recursive_doubling_allgather
-        restrictions: power-of-two
     scatter_ring_allgather
     smp
         restrictions: parent-comm


### PR DESCRIPTION
## Pull Request Description

Add an extra check to see if we are using negative recv size and in that case use zero. Also enable the algorithm to be used for non power of 2 comm size.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
