### PR TITLE
ch4/part: Fix race condition in generic partitioned send

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_part.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part.c
@@ -56,10 +56,10 @@ static int part_req_create(void *buf, int partitions, MPI_Aint count,
 static void part_req_am_init(MPIR_Request * part_req)
 {
     MPIDIG_PART_REQUEST(part_req, peer_req_ptr) = NULL;
-    MPIDIG_PART_REQUEST(part_req, send_epoch) = 0;
-    MPIDIG_PART_REQUEST(part_req, recv_epoch) = 0;
     if (part_req->kind == MPIR_REQUEST_KIND__PART_SEND) {
-        MPIR_cc_set(&MPIDIG_PART_REQUEST(part_req, u.send).ready_cntr, part_req->u.part.partitions);
+        /* partitions + 1: once all partitions are ready and CTS is received, data can be issued */
+        MPIR_cc_set(&MPIDIG_PART_REQUEST(part_req, u.send).ready_cntr,
+                    part_req->u.part.partitions + 1);
     }
 }
 

--- a/src/mpid/ch4/generic/am/mpidig_am_part.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part.c
@@ -59,7 +59,7 @@ static void part_req_am_init(MPIR_Request * part_req)
     MPIDIG_PART_REQUEST(part_req, send_epoch) = 0;
     MPIDIG_PART_REQUEST(part_req, recv_epoch) = 0;
     if (part_req->kind == MPIR_REQUEST_KIND__PART_SEND) {
-        MPIR_cc_set(&MPIDIG_PART_REQUEST(part_req, u.send).ready_cntr, 0);
+        MPIR_cc_set(&MPIDIG_PART_REQUEST(part_req, u.send).ready_cntr, part_req->u.part.partitions);
     }
 }
 

--- a/src/mpid/ch4/generic/am/mpidig_am_part.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part.h
@@ -28,10 +28,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_start(MPIR_Request * request)
      * Decrease when am request completes on sender (via completion_notification),
      * or received data transfer AM on receiver. */
     MPIR_cc_set(request->cc_ptr, 1);
-    if (request->kind == MPIR_REQUEST_KIND__PART_SEND) {
-        MPIR_cc_set(&MPIDIG_PART_REQUEST(request, u.send).ready_cntr, request->u.part.partitions);
-        MPIDIG_PART_REQUEST(request, send_epoch)++;
-    }
 
     /* No need to increase refcnt for comm and datatype objects,
      * because it is erroneous to free an active partitioned req if it is not complete.*/
@@ -45,32 +41,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_start(MPIR_Request * request)
     return mpi_errno;
 }
 
-/*
- * Checks whether all partitions are ready and MPIDIG_PART_REQ_CTS has been received,
- */
-MPL_STATIC_INLINE_PREFIX bool MPIDIG_part_can_issue_data(MPIR_Request * part_sreq)
-{
-    /* note: already in critical section */
-    return MPIR_cc_get(MPIDIG_PART_REQUEST(part_sreq, u.send).ready_cntr) ==
-        0 &&
-        MPIDIG_PART_REQUEST(part_sreq, send_epoch) == MPIDIG_PART_REQUEST(part_sreq, recv_epoch);
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_pready_range(int partition_low, int partition_high,
                                                      MPIR_Request * part_sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    int c = 0, i;
+    int incomplete = 1, i;
     for (i = partition_low; i <= partition_high; i++)
-        MPIR_cc_decr(&MPIDIG_PART_REQUEST(part_sreq, u.send).ready_cntr, &c);
+        MPIR_cc_decr(&MPIDIG_PART_REQUEST(part_sreq, u.send).ready_cntr, &incomplete);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    if (MPIDIG_part_can_issue_data(part_sreq)) {
+    if (!incomplete) {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDIG_part_issue_data(part_sreq, MPIDIG_PART_REGULAR);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -82,15 +67,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_pready_list(int length, int array_of_par
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    int i, c = 0;
+    int i, incomplete = 1;
     for (i = 0; i < length; i++)
-        MPIR_cc_decr(&MPIDIG_PART_REQUEST(part_sreq, u.send).ready_cntr, &c);
+        MPIR_cc_decr(&MPIDIG_PART_REQUEST(part_sreq, u.send).ready_cntr, &incomplete);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    if (MPIDIG_part_can_issue_data(part_sreq)) {
+    if (!incomplete) {
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
         mpi_errno = MPIDIG_part_issue_data(part_sreq, MPIDIG_PART_REGULAR);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     }
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
@@ -112,8 +112,9 @@ int MPIDIG_part_cts_target_msg_cb(void *am_hdr, void *data,
     MPIR_Assert(part_sreq);
 
     MPIDIG_PART_REQUEST(part_sreq, peer_req_ptr) = msg_hdr->rreq_ptr;
-    MPIDIG_PART_REQUEST(part_sreq, recv_epoch)++;
-    if (MPIDIG_part_can_issue_data(part_sreq)) {
+    int incomplete;
+    MPIR_cc_decr(&MPIDIG_PART_REQUEST(part_sreq, u.send).ready_cntr, &incomplete);
+    if (!incomplete) {
         mpi_errno = MPIDIG_part_issue_data(part_sreq, MPIDIG_PART_REPLY);
     }
 

--- a/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_utils.h
@@ -75,6 +75,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_issue_data(MPIR_Request * part_sreq,
                  mpi_errno);
     }
 
+    /* reset ready counter */
+    MPIR_cc_set(&MPIDIG_PART_REQUEST(part_sreq, u.send).ready_cntr,
+                part_sreq->u.part.partitions + 1);
+
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -238,8 +238,6 @@ typedef struct MPIDIG_part_rreq {
 } MPIDIG_part_rreq_t;
 
 typedef struct MPIDIG_part_request {
-    uint8_t send_epoch;
-    uint8_t recv_epoch;
     MPIR_Request *peer_req_ptr;
     union {
         MPIDIG_part_sreq_t send;


### PR DESCRIPTION
## Pull Request Description

Fix a race condition that could cause data from a partitioned send request to be sent to the receiver more than once per MPI_START, potentially causing a crash in MPI_THREAD_MULTIPLE applications.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
