### PR TITLE
Tweak CVAR in gentran for progressing multiple non-blocking collectives

### DIFF
--- a/src/mpi/coll/transports/gentran/gentran_impl.c
+++ b/src/mpi/coll/transports/gentran/gentran_impl.c
@@ -10,7 +10,7 @@ cvars:
     - name        : MPIR_CVAR_PROGRESS_MAX_COLLS
       category    : COLLECTIVE
       type        : int
-      default     : 8
+      default     : 0
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -341,17 +341,17 @@ int MPII_Genutil_progress_hook(int *made_progress)
     in_genutil_progress = 1;
 
     if (made_progress)
-        *made_progress = FALSE;
+        *made_progress = false;
 
     /* Go over up to MPIR_COLL_PROGRESS_MAX_COLLS collecives in the
      * queue and make progress on them */
     DL_FOREACH_SAFE(MPII_coll_queue.head, coll_req, coll_req_tmp) {
         /* make progress on the collective operation */
-        int done;
+        int done, progress = false;
         MPII_Genutil_sched_t *sched = (MPII_Genutil_sched_t *) (coll_req->sched);
 
         /* make progress on the collective */
-        mpi_errno = MPII_Genutil_sched_poke(sched, &done, made_progress);
+        mpi_errno = MPII_Genutil_sched_poke(sched, &done, &progress);
 
         if (done) {
             MPIR_Request *req;
@@ -362,9 +362,15 @@ int MPII_Genutil_progress_hook(int *made_progress)
             DL_DELETE(MPII_coll_queue.head, coll_req);
             MPIR_Request_complete(req);
         }
-        if (++count >= MPIR_CVAR_PROGRESS_MAX_COLLS)
+        if (progress) {
+            count++;
+        }
+        if (count >= MPIR_CVAR_PROGRESS_MAX_COLLS)
             break;
     }
+
+    if (made_progress && count)
+        *made_progress = true;
 
     if (MPII_coll_queue.head == NULL)
         MPIR_Progress_hook_deactivate(MPII_Genutil_progress_hook_id);

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -365,7 +365,7 @@ int MPII_Genutil_progress_hook(int *made_progress)
         if (progress) {
             count++;
         }
-        if (count >= MPIR_CVAR_PROGRESS_MAX_COLLS)
+        if (MPIR_CVAR_PROGRESS_MAX_COLLS > 0 && count >= MPIR_CVAR_PROGRESS_MAX_COLLS)
             break;
     }
 


### PR DESCRIPTION
## Pull Request Description

This PR changes the behavior of gentran progress hook function when involving multiple schedules.
(1) If we were to always process the first few schedule under the limit set by the CVAR, it may ended up repeatedly processing the first few schedules even though they may be stuck waiting. This PR change to count only those collectives with progress being made.
(2) change the CVAR to 0 to disable such limit, i.e. progress engine will try to progress every pending collectives. 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
