### PR TITLE
test: impls/mpich/threads tests need be optional

### DIFF
--- a/test/mpi/impls/mpich/Makefile.am
+++ b/test/mpi/impls/mpich/Makefile.am
@@ -7,11 +7,11 @@ include $(top_srcdir)/Makefile_single.mtest
 
 EXTRA_DIST = testlist.in
 
-static_subdirs = mpi_t comm threads
+static_subdirs = mpi_t comm
 # For future tests - note that the IO and RMA directories are optional,
 # and need to be handled as shown in this comment
 #SUBDIRS      = $(static_subdirs) $(iodir) $(rmadir)
-SUBDIRS      = $(static_subdirs)
+SUBDIRS      = $(static_subdirs) $(threadsdir)
 # For future tests, as noted above
 #DIST_SUBDIRS = $(static_subdirs) io rma
 DIST_SUBDIRS = $(static_subdirs)

--- a/test/mpi/impls/mpich/testlist.in
+++ b/test/mpi/impls/mpich/testlist.in
@@ -1,6 +1,6 @@
 mpi_t
 comm
-threads
+@threadsdir@
 # The IO and RMA directories are optional and need to be handled in
 # a special way.  Uncomment these as appropriate when a test is added.
 #@iodir@


### PR DESCRIPTION
## Pull Request Description

PR #5488 added `impls/mpich/threads` tests without being optional. It breaks the nightly tests on `thread-single` configurations.

Configure option --enable-thread=single should be able to turn off the
threads tests.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
