### PR TITLE
Fix multi-nic with old OFI and PSM2

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -8,6 +8,7 @@
 #include "ofi_init.h"
 #include "mpir_hwtopo.h"
 
+#ifdef HAVE_LIBFABRIC_NIC
 /* Return the parent object (typically socket) of the NIC */
 static MPIR_hwtopo_gid_t get_nic_parent(struct fi_info *info)
 {
@@ -75,6 +76,7 @@ bool MPIDI_OFI_nic_already_used(const struct fi_info * prov, struct fi_info ** o
     }
     return false;
 }
+#endif
 
 /* Setup the multi-NIC data structures to use the fi_info structure given in prov */
 static int setup_single_nic(void);
@@ -104,6 +106,7 @@ int MPIDI_OFI_init_multi_nic(struct fi_info *prov)
         if (!first_prov) {
             first_prov = p;
         }
+#ifdef HAVE_LIBFABRIC_NIC
         /* check the nic */
         struct fid_nic *nic = p->nic;
         if (nic && nic->bus_attr->bus_type == FI_BUS_PCI &&
@@ -115,6 +118,7 @@ int MPIDI_OFI_init_multi_nic(struct fi_info *prov)
                 break;
             }
         }
+#endif
     }
 
     if (nic_count == 0) {
@@ -123,11 +127,15 @@ int MPIDI_OFI_init_multi_nic(struct fi_info *prov)
         MPIR_Assert(MPIDI_OFI_global.prov_use[0]);
         mpi_errno = setup_single_nic();
         MPIR_ERR_CHECK(mpi_errno);
-    } else if (nic_count == 1) {
-        mpi_errno = setup_single_nic();
-        MPIR_ERR_CHECK(mpi_errno);
-    } else {
+    }
+#ifdef HAVE_LIBFABRIC_NIC
+    else if (nic_count >= 1) {
         mpi_errno = setup_multi_nic(nic_count);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+#endif
+    else {
+        mpi_errno = setup_single_nic();
         MPIR_ERR_CHECK(mpi_errno);
     }
     MPIR_Assert(MPIDI_OFI_global.num_nics > 0);
@@ -160,6 +168,7 @@ static int setup_single_nic(void)
     return MPI_SUCCESS;
 }
 
+#ifdef HAVE_LIBFABRIC_NIC
 /* TODO: Now that multiple NICs are detected, sort them based on preferred-ness,
  * closeness and count of other processes using the NIC. */
 static int setup_multi_nic(int nic_count)
@@ -266,14 +275,17 @@ static int setup_multi_nic(int nic_count)
 
     return mpi_errno;
 }
+#endif
 
 bool MPIDI_OFI_nic_is_up(struct fi_info * prov)
 {
+#ifdef HAVE_LIBFABRIC_NIC
     /* Make sure the NIC returned by OFI is not down. Some providers don't include NIC
      * information so we need to skip those. */
     if (prov->nic != NULL && prov->nic->link_attr->state != FI_LINK_UP) {
         return false;
     }
+#endif
 
     return true;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -282,7 +282,7 @@ bool MPIDI_OFI_nic_is_up(struct fi_info * prov)
 #ifdef HAVE_LIBFABRIC_NIC
     /* Make sure the NIC returned by OFI is not down. Some providers don't include NIC
      * information so we need to skip those. */
-    if (prov->nic != NULL && prov->nic->link_attr->state != FI_LINK_UP) {
+    if (prov->nic != NULL && prov->nic->link_attr->state == FI_LINK_DOWN) {
         return false;
     }
 #endif

--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -340,6 +340,19 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         AC_DEFINE(MPIDI_OFI_VNI_USE_DOMAIN, 1, [CH4/OFI should use domain for vni contexts])
     fi
 
+    AC_MSG_CHECKING([if fi_info struct has nic field])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "rdma/fabric.h"],
+                       [struct fi_info info;
+                       if (info.nic) {
+                         return 0;
+                       } else {
+                         return 1;
+                       }])],[have_libfabric_nic=yes],[have_libfabric_nic=no])
+    AC_MSG_RESULT([$have_libfabric_nic])
+    if test "$have_libfabric_nic" = "yes" ; then
+        AC_DEFINE(HAVE_LIBFABRIC_NIC,1,[Define if libfabric library has nic field in fi_info struct])
+    fi
+
 ])dnl end AM_COND_IF(BUILD_CH4_NETMOD_OFI,...)
 ])dnl end _BODY
 


### PR DESCRIPTION
## Pull Request Description

Older versions (pre-1.7) of libfabric do not have the nic symbol so we need to check to make sure the field is there so we can compile. If the field isn't present, avoid all of the multi-nic code.

PSM2 also doesn't reliably set `FI_LINK_UP`. It usually (always?) sets the status to `FI_LINK_UNDEFINED`. So instead of checking for `FI_LINK_UP`, the best we can do is checking for not `FI_LINK_DOWN`.

Fixes https://github.com/pmodels/mpich/issues/5507

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
