### PR TITLE
coll: fix MPIR_ERR_COLL_CHECKANDCONT

### DIFF
--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -952,7 +952,9 @@ cvars:
 
 #define MPIR_ERR_COLL_CHECKANDCONT(err_, errflag_) \
     do { \
-        errflag_ = (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(err_)) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER; \
+        if (err_) { \
+            errflag_ = (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(err_)) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER; \
+        } \
     } while (0)
 
 #endif


### PR DESCRIPTION

## Pull Request Description
When error checking is turned off, we still need check mpi_errno before
setting errflag.

This one fixes the posix bcast failures whith noerrorchecking build.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
