### PR TITLE
ch4/ucx: Fix pt2pt/rqfreeb test failures

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -391,8 +391,8 @@ int MPIDI_UCX_mpi_finalize_hook(void)
 
     /* now complete the outstaning requests! Important: call progress in between, otherwise we
      * deadlock! */
-    int completed = p;
-    while (completed != 0) {
+    int completed;
+    do {
         for (int i = 0; i < MPIDI_UCX_global.num_vnis; i++) {
             ucp_worker_progress(MPIDI_UCX_global.ctx[i].worker);
         }
@@ -401,7 +401,7 @@ int MPIDI_UCX_mpi_finalize_hook(void)
             if (ucp_request_is_completed(pending[i]) != 0)
                 completed -= 1;
         }
-    }
+    } while (completed != 0);
 
     for (int i = 0; i < p; i++) {
         ucp_request_release(pending[i]);

--- a/test/mpi/pt2pt/rqfreeb.c
+++ b/test/mpi/pt2pt/rqfreeb.c
@@ -100,16 +100,13 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "message %d (%d) should be %d\n", i, rmsg[i], 10 + i);
             }
         }
-        /* The MPI standard says that there is no way to use MPI_Request_free
-         * safely with receive requests.  A strict MPI implementation may
-         * choose to consider these erroreous (an IBM MPI implementation
-         * does so)  */
-#ifdef USE_STRICT_MPI
-        MPI_Wait(&r[4], MPI_STATUS_IGNORE);
-#else
+        /* Previously, this test was thought to be non-standard behavior. However,
+         * recent MPI Forum discussions have concluded that freeing a request without
+         * explicit completion via MPI_TEST/MPI_WAIT is allowed. The implementation is
+         * required to complete the request during MPI_FINALIZE. (2021-08-24)
+         */
         MTestPrintfMsg(10, "About  free Irecv request\n");
         MPI_Request_free(&r[4]);
-#endif
     }
 
     if (rank != dest && rank != src) {


### PR DESCRIPTION
## Pull Request Description

`test/mpi/pt2pt/rqfreeb` periodically fails in Jenkins tests (see #3469). The issue is that the freed recv request may not complete before ucp_worker_destroy. To fix, we make it so worker progress is always triggered after disconnecting all endpoints. This way, even if disconnect reports immediate success in all cases, progress still has a chance to execute callbacks for any outstanding receive requests.

Ultimately this may be a bug in `ucp_disconnect_nb`, which is supposed to flush all outstanding operations on the endpoint. I'll raise an issue with the UCX folks to try and get a better understanding. This fix is needed for current and past UCX releases in any case.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
