### PR TITLE
ch4/stub: remove calls to MPIDIG functions in stub

### DIFF
--- a/maint/gen_ch4_api.py
+++ b/maint/gen_ch4_api.py
@@ -403,10 +403,13 @@ def dump_stub_file(stub_file, mod, is_inline, is_nm):
             print("{", file=Out)
             if a['ret'] == 'int':
                 print("    int mpi_errno = MPI_SUCCESS;", file=Out)
+                print("    MPIR_Assert(0);", file=Out)
                 print("    return mpi_errno;", file=Out)
             elif a['ret'] == 'void':
+                print("    MPIR_Assert(0);", file=Out)
                 print("    return;", file=Out)
             else:
+                print("    MPIR_Assert(0);", file=Out)
                 print("    return 0;", file=Out)
             print("}", file=Out)
         if is_inline:

--- a/maint/gen_ch4_api.py
+++ b/maint/gen_ch4_api.py
@@ -49,7 +49,7 @@ def load_ch4_api(ch4_api_txt):
             if RE.match(r'(.*API|PARAM):', line):
                 flag = RE.m.group(1)
             elif re.search(r'API$', flag):
-                if RE.match(r'\s+(NM|SHM|MPIDIG)(\*?)\s*:\s*(.+)', line):
+                if RE.match(r'\s+(NM|SHM)(\*?)\s*:\s*(.+)', line):
                     nm, inline, t = RE.m.group(1, 2, 3)
                     tlist = re.split(r',\s*', t)
                     if nm == "NM":
@@ -58,8 +58,6 @@ def load_ch4_api(ch4_api_txt):
                     elif nm == 'SHM':
                         cur_api['shm_params'] = tlist
                         cur_api['shm_inline'] = inline
-                    elif nm == 'MPIDIG':
-                        cur_api['mpidig_params'] = tlist
                 elif RE.match(r'\s+(\w+)\s*:\s*(.+)', line):
                     name, ret = RE.m.group(1, 2)
                     cur_api = {'name': name, 'ret': ret}
@@ -404,12 +402,8 @@ def dump_stub_file(stub_file, mod, is_inline, is_nm):
             dump_s_param_tail(Out, s, params, ")")
             print("{", file=Out)
             if a['ret'] == 'int':
-                if 'mpidig_params' in a:
-                    s = "    return MPIDIG_%s(" % a['name']
-                    dump_s_param_tail(Out, s, a['mpidig_params'], ");", is_arg=True)
-                else:
-                    print("    int mpi_errno = MPI_SUCCESS;", file=Out)
-                    print("    return mpi_errno;", file=Out)
+                print("    int mpi_errno = MPI_SUCCESS;", file=Out)
+                print("    return mpi_errno;", file=Out)
             elif a['ret'] == 'void':
                 print("    return;", file=Out)
             else:

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -117,15 +117,12 @@ Native API:
   mpi_isend : int
       NM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
      SHM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
-     MPIDIG: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
   isend_coll : int
       NM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
      SHM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
-     MPIDIG: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
   mpi_issend : int
       NM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
      SHM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
-     MPIDIG: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
   mpi_cancel_send : int
       NM*: sreq
      SHM*: sreq
@@ -159,143 +156,104 @@ Native API:
   mpi_alloc_mem : void *
       NM : size-2, info
      SHM : size-2, info
-     MPIDIG: size-2, info
   mpi_free_mem : int
       NM : ptr
      SHM : ptr
-     MPIDIG: ptr
   mpi_improbe : int
       NM*: source, tag, comm, context_offset, addr, flag, message_p, status
      SHM*: source, tag, comm, context_offset, flag, message_p, status
-     MPIDIG: source, tag, comm, context_offset, flag, message_p, status
   mpi_iprobe : int
       NM*: source, tag, comm, context_offset, addr, flag, status
      SHM*: source, tag, comm, context_offset, flag, status
-     MPIDIG: source, tag, comm, context_offset, flag, status
   mpi_win_set_info : int
       NM : win, info
      SHM : win, info
-     MPIDIG: win, info
   mpi_win_shared_query : int
       NM*: win, rank, size_p, disp_unit_p, baseptr
-     MPIDIG: win, rank, size_p, disp_unit_p, baseptr
   mpi_put : int
       NM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, addr, winattr
      SHM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, winattr
-     MPIDIG: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win
   mpi_win_start : int
       NM*: group, assert, win
-     MPIDIG: group, assert, win
   mpi_win_complete : int
       NM*: win
-     MPIDIG: win
   mpi_win_post : int
       NM*: group, assert, win
-     MPIDIG: group, assert, win
   mpi_win_wait : int
       NM*: win
-     MPIDIG: win
   mpi_win_test : int
       NM*: win, flag
-     MPIDIG: win, flag
   mpi_win_lock : int
       NM*: lock_type, rank, assert, win, addr
-     MPIDIG: lock_type, rank, assert, win
   mpi_win_unlock : int
       NM*: rank, win, addr
-     MPIDIG: rank, win
   mpi_win_get_info : int
       NM : win, info_p
      SHM : win, info_p
-     MPIDIG: win, info_p
   mpi_get : int
       NM*: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, addr, winattr
      SHM*: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, winattr
-     MPIDIG: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win
   mpi_win_free : int
       NM : win_p
      SHM : win_p
-     MPIDIG: win_p
   mpi_win_fence : int
       NM*: assert, win
-     MPIDIG: assert, win
   mpi_win_create : int
       NM : base, length, disp_unit, info, comm_ptr, win_p
      SHM : base, length, disp_unit, info, comm_ptr, win_p
-     MPIDIG: base, length, disp_unit, info, comm_ptr, win_p
   mpi_accumulate : int
       NM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, addr, winattr
      SHM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, winattr
-     MPIDIG: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win
   mpi_win_attach : int
       NM : win, base, size-2
      SHM : win, base, size-2
-     MPIDIG: win, base, size-2
   mpi_win_allocate_shared : int
       NM : size-2, disp_unit, info, comm_ptr, baseptr_p, win_p
      SHM : size-2, disp_unit, info, comm_ptr, baseptr_p, win_p
-     MPIDIG: size-2, disp_unit, info, comm_ptr, base_ptr, win_p
   mpi_rput : int
       NM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, addr, winattr, req_p
      SHM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, winattr, req_p
-     MPIDIG: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, req_p
   mpi_win_flush_local : int
       NM*: rank, win, addr
-     MPIDIG: rank, win
   mpi_win_detach : int
       NM : win, base-2
      SHM : win, base-2
-     MPIDIG: win, base-2
   mpi_compare_and_swap : int
       NM*: origin_addr, compare_addr, result_addr, datatype, target_rank, target_disp, win, addr, winattr
      SHM*: origin_addr, compare_addr, result_addr, datatype, target_rank, target_disp, win, winattr
-     MPIDIG: origin_addr, compare_addr, result_addr, datatype, target_rank, target_disp, win
   mpi_raccumulate : int
       NM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, addr, winattr, req_p
      SHM*: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, winattr, req_p
-     MPIDIG: origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, req_p
   mpi_rget_accumulate : int
       NM*: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, addr, winattr, req_p
      SHM*: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, winattr, req_p
-     MPIDIG: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, req_p
   mpi_fetch_and_op : int
       NM*: origin_addr, result_addr, datatype, target_rank, target_disp, op, win, addr, winattr
      SHM*: origin_addr, result_addr, datatype, target_rank, target_disp, op, win, winattr
-     MPIDIG: origin_addr, result_addr, datatype, target_rank, target_disp, op, win
   mpi_win_allocate : int
       NM : size-2, disp_unit, info, comm, baseptr, win_p
      SHM : size-2, disp_unit, info, comm, baseptr, win_p
-     MPIDIG : size-2, disp_unit, info, comm, baseptr, win_p
   mpi_win_flush : int
       NM*: rank, win, addr
-      MPIDIG: rank, win
   mpi_win_flush_local_all : int
       NM*: win
-     MPIDIG: win
   mpi_win_unlock_all : int
       NM*: win
-      MPIDIG: win
   mpi_win_create_dynamic : int
       NM : info, comm, win_p
      SHM : info, comm, win_p
-     MPIDIG : info, comm, win_p
   mpi_rget : int
       NM*: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, addr, winattr, req_p
      SHM*: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, winattr, req_p
-     MPIDIG: origin_addr-2, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, req_p
   mpi_win_sync : int
       NM*: win
-     MPIDIG: win
   mpi_win_flush_all : int
       NM*: win
-     MPIDIG: win
   mpi_get_accumulate : int
       NM*: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, addr, winattr
      SHM*: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, winattr
-     MPIDIG: origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win
   mpi_win_lock_all : int
       NM*: assert, win
-     MPIDIG: assert, win
   rank_is_local : int
       NM*: target, comm
   mpi_barrier : int


### PR DESCRIPTION

## Pull Request Description

The netmod/shm stub implementations are not supposed to be functional.
Having incomplete routines calling MPIDIG fallbacks only adds
maintenance cost and is potentially confusing.

Use empty implementations in stub functions instead.


[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
