### PR TITLE
ch4/am: Fix debug queue pointer types

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -526,8 +526,8 @@ typedef unsigned MPIDI_locality_t;
 typedef struct MPIDIG_comm_t {
     uint32_t window_instance;
 #ifdef HAVE_DEBUGGER_SUPPORT
-    MPIDIG_rreq_t **posted_head_ptr;
-    MPIDIG_rreq_t **unexp_head_ptr;
+    MPIDI_Devreq_t **posted_head_ptr;
+    MPIDI_Devreq_t **unexp_head_ptr;
 #endif
 } MPIDIG_comm_t;
 


### PR DESCRIPTION
## Pull Request Description

After [25ba182b4e44], receive queues were based on the MPIDI_Devreq_t
struct type. Update the debugger support to use the right type.

Fixes pmodels/mpich#5505.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
