### PR TITLE
Fix Lots of Warnings

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -562,6 +562,7 @@ if test "$enable_strict_done" != "yes" ; then
         -Wtype-limits
         -Werror-implicit-function-declaration
         -Wstack-usage=262144
+        -fno-var-tracking
     "
 
     case "$pac_cv_cc_vendor" in

--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -403,6 +403,63 @@ else
 fi
 ])
 
+dnl
+dnl PAC_CC_VENDOR:
+dnl Try to get a version string for the C compiler.  We may
+dnl need this to find likely command-line arguments for accessing
+dnl shared libraries
+dnl
+AC_DEFUN([PAC_CC_VENDOR],[
+AC_MSG_CHECKING([for C compiler vendor])
+# This is complicated by some compilers (such as the Intel 8.1 ifort)
+# that return a non-zero status even when they accept the -V option
+# (a zero status is returned only if there is a file).
+pac_cv_cc_vendor="unknown"
+# Try to use the compiler name
+if test "$CC" = "icc" ; then
+    pac_cv_cc_vendor=icc
+elif test "$CC" = "icx" ; then
+    pac_cv_cc_vendor=icx
+elif test "$CC" = "pgcc" ; then
+    pac_cv_cc_vendor=pgi
+elif test "$CC" = "xlcc" ; then
+    pac_cv_cc_vendor=ibm
+fi
+
+if test "$pac_cv_cc_vendor" = "unknown" ; then
+    for arg in --version -V -v ; do
+        rm -f conftest.txt
+        PAC_RUNLOG([$CC $arg </dev/null >conftest.txt 2>&1])
+        # Ignore the return code, because some compilers set the
+        # return code to zero on invalid arguments and some to
+        # non-zero on success (with no files to compile)
+        if test -f conftest.txt ; then
+            if grep 'Portland Group' conftest.txt >/dev/null 2>&1 ; then
+                pac_cv_cc_vendor=pgi
+            elif grep 'Sun Workshop' conftest.txt >/dev/null 2>&1 ; then
+                pac_cv_cc_vendor=sun
+            elif grep 'Sun C' conftest.txt >/dev/null 2>&1 ; then
+                pac_cv_cc_vendor=sun
+            elif grep 'Absoft' conftest.txt >/dev/null 2>&1 ; then
+                pac_cv_cc_vendor=absoft
+            elif grep 'Free Software Foundation, Inc.' conftest.txt >/dev/null 2>&1 ; then
+                pac_cv_cc_vendor=gnu
+            elif grep "Intel (R) oneAPI DPC++" conftest.txt >/dev/null 2>&1 ; then
+                pac_cv_cc_vendor=icx
+            elif grep Intel conftest.txt >/dev/null 2>&1 ; then
+                pac_cv_cc_vendor=icc
+            elif grep clang conftest.txt >/dev/null 2>&1 ; then
+                pac_cv_cc_vendor=clang
+            fi
+        fi
+        if test "$pac_cv_cc_vendor" != "unknown" ; then break ; fi
+    done
+fi
+AC_MSG_RESULT([$pac_cv_cc_vendor])
+rm -f conftest.txt
+# End of checking for C compiler vendor
+])
+
 dnl Use the value of enable-strict to update CFLAGS
 dnl pac_cc_strict_flags contains the strict flags.
 dnl
@@ -414,6 +471,7 @@ dnl had trouble with gcc 2.95.3 accepting -std=c89 but then trying to
 dnl compile program with a invalid set of options 
 dnl (-D __STRICT_ANSI__-trigraphs)
 AC_DEFUN([PAC_CC_STRICT],[
+PAC_CC_VENDOR()
 export enable_strict_done
 if test "$enable_strict_done" != "yes" ; then
     # make sure we don't add the below flags multiple times
@@ -428,9 +486,6 @@ if test "$enable_strict_done" != "yes" ; then
     #       warning at 256k.
     #
     # These were added to reduce warnings:
-    #   -Wno-missing-field-initializers  -- We want to allow a struct to be 
-    #       initialized to zero using "struct x y = {0};" and not require 
-    #       each field to be initialized individually.
     #   -Wno-unused-parameter -- For portability, some parameters go unused
     #	    when we have different implementations of functions for 
     #	    different platforms
@@ -508,6 +563,21 @@ if test "$enable_strict_done" != "yes" ; then
         -Werror-implicit-function-declaration
         -Wstack-usage=262144
     "
+
+    case "$pac_cv_cc_vendor" in
+        gnu)
+            pac_common_strict_flags="${pac_common_strict_flags}
+                -Wno-unused-label
+            "
+            ;;
+        icx)
+            pac_common_strict_flags="${pac_common_strict_flags}
+                -Wno-unused-label
+            "
+            ;;
+        *)
+            ;;
+    esac
 
     if test -z "$1"; then
         flags=no

--- a/maint/clmake.in
+++ b/maint/clmake.in
@@ -132,6 +132,7 @@ foreach $_ (@ARGV) {
 # commandline.
 #
 $cmdline = "";
+$inside_module = 0;
 T:
 while ($line = <>) {
     if (eof()) { next; }
@@ -171,15 +172,18 @@ while ($line = <>) {
 
     # Is the line a command (including a directory change?)
     # Check first for a directory change
-    if ($line =~ /^\s*make.* Entering directory \`([^\']*)\'/) {
+    if ($line =~ /^\s*make.* Entering directory \'([^\']*)\'/) {
         my $dirname = $1;
         $dirstack[$#dirstack+1] = $dirname;
         $dirprinted[$#dirprinted+1] = 0;
         print ">>entering $dirname\n" if $debugDir;
+        if ($dirname =~ /modules/) {
+            $inside_module++;
+        }
         $cmdline = "";
         next;
     }
-    elsif ($line =~ /^\s*make.* Leaving directory \`([^\']*)\'/) {
+    elsif ($line =~ /^\s*make.* Leaving directory \'([^\']*)\'/) {
         # We should check that the directory names match
         my $dirname = $1;
         print ">>leaving $dirname\n" if $debugDir;
@@ -188,7 +192,14 @@ while ($line = <>) {
         }
         $#dirstack--;
         $#dirprinted--;
+        if ($dirname =~ /modules/) {
+            $inside_module--;
+        }
         $cmdline = "";
+        next;
+    }
+    elsif ($inside_module > 0) {
+        # Ignore warnings coming from inside other modules. These are outside of MPICH's control
         next;
     }
     else {

--- a/maint/clmake.in
+++ b/maint/clmake.in
@@ -17,58 +17,59 @@ $rootSrcDir = "";
 # We include /bin/rm and /bin/mv because some Makefile authors prefer
 # to get the full path for these routines
 @commands = ( "cc", "pgcc", "gcc", "icc", "acc", 
-              "rm", "mv", "cp", "ar", "ranlib", "perl", "for", 
-	      "/bin/rm", "/bin/mv", "/bin/cp", "/bin/chmod",
-	      "rm", "mv", "cp", "chmod",
-	      "if", "make", "gnumake", 
-	      "[A-Za-z0-9_\/\.-]*\/mpicc",
-	      "[A-Za-z0-9_\/\.-]*\/mpifort",
-	      "[A-Za-z0-9_\/\.-]*\/mpicxx",
-	      "cleaning", "sleep", "date", "g77", "f77", "f90", "f95", "pgCC",
-	      "pgf77", "pgf90", "CC", "g95", "g\\+\\+", "c\\+\\+",
-	      "acc\\+\\+", "xlc", "xlf", "xlC", "xlf90", "gfortran", 
-	      "ifort", "ifc", "test",
-	      "true", "false", "/[A-Za-z0-9_\/\.-]*createshlib", 
-	      "/bin/sh\\s+[A-Za-z0-9_\/\.-]*libtool\\s+\(--tag=\\w+\)*\\s+--mode=\\w+",
-	      "/bin/bash\\s+[A-Za-z0-9_\/\.-]*libtool\\s+--mode=\\w+",
-	      "/bin/sh\\s+[A-Za-z0-9_\/\.-]*libtool\\s+--finish",
-	      "/bin/bash\\s+[A-Za-z0-9_\/\.-]*libtool\\s+--finish",
-	      "libtool:\\s+compile:",
-	      "libtool:\\s+link:",
-	      "libtool:\\s+install:",
-	      "libtool:\\s+finish:",
-	      "[A-Za-z0-9_\/-]*\/icc",
-	      "[A-Za-z0-9_\/-]*\/install-sh",
-	      "/usr/bin/ar", "mkdir",
-              "/bin/mkdir",
-              "/.*bin/mkdir",
-	      "/usr/ucb/ld",
-	      "mpicc", "mpicxx",
-	      "compiling ROMIO in", 
-	      "Make completed",
-	      "echo", "cat",
-	      "NVCC", "CC", "CCLD", "AR", "RANLIB", "LIBTOOL", "MV",
-              "MOD", "GEN", "F77", "FC", "CXXLD", "CXX", "FCLD",
-	      "CP", "LN", # "terse" make versions
-	      "\\(?cd",
-	      "\\(\\s*cd",
-	      "creating\s+lib.*",
-	      "cd\\s+\&\&\\s+make",
-	      "sed -e",
-	      "PATH=\"\\\$PATH.*\\sldconfig\\s",
-	      "building profiling interface in directory",
-              "/usr/bin/sed",
-	      "/usr/bin/install",
-              "/.*bin/install",
-              ".*confdb/install-sh",
-	      "Copying Upshot",
-	      "Cleaning directory",
-	      "[*][*][*][*] Making .*\.\.\.\.",
-	      "Making .* in .*",
-	      "Making upshot", "\\s*\$",
-              "ld: warning: directory not found for option '-L\\S*src/mpl'",
-              "ld: warning: directory not found for option '-L\\S*src/openpa/src'",
-	      "copying selected object files to avoid basename conflicts...",
+    "rm", "mv", "cp", "ar", "ranlib", "perl", "for", 
+    "/bin/rm", "/bin/mv", "/bin/cp", "/bin/chmod",
+    "rm", "mv", "cp", "chmod",
+    "if", "make", "gnumake", 
+    "[A-Za-z0-9_\/\.-]*\/mpicc",
+    "[A-Za-z0-9_\/\.-]*\/mpifort",
+    "[A-Za-z0-9_\/\.-]*\/mpicxx",
+    "cleaning", "sleep", "date", "g77", "f77", "f90", "f95", "pgCC",
+    "pgf77", "pgf90", "CC", "g95", "g\\+\\+", "c\\+\\+",
+    "acc\\+\\+", "xlc", "xlf", "xlC", "xlf90", "gfortran", 
+    "ifort", "ifc", "test",
+    "true", "false", "/[A-Za-z0-9_\/\.-]*createshlib", 
+    "/bin/sh\\s+[A-Za-z0-9_\/\.-]*libtool\\s+\(--tag=\\w+\)*\\s+--mode=\\w+",
+    "/bin/bash\\s+[A-Za-z0-9_\/\.-]*libtool\\s+--mode=\\w+",
+    "/bin/sh\\s+[A-Za-z0-9_\/\.-]*libtool\\s+--finish",
+    "/bin/bash\\s+[A-Za-z0-9_\/\.-]*libtool\\s+--finish",
+    "libtool:\\s+compile:",
+    "libtool:\\s+link:",
+    "libtool:\\s+install:",
+    "libtool:\\s+finish:",
+    "[A-Za-z0-9_\/-]*\/icc",
+    "[A-Za-z0-9_\/-]*\/install-sh",
+    "/usr/bin/ar", "mkdir",
+    "/bin/mkdir",
+    "/.*bin/mkdir",
+    "/usr/ucb/ld",
+    "mpicc", "mpicxx",
+    "compiling ROMIO in", 
+    "Make completed",
+    "echo", "cat",
+    "NVCC", "CC", "CCLD", "AR", "RANLIB", "LIBTOOL", "MV",
+    "MOD", "GEN", "F77", "FC", "CXXLD", "CXX", "FCLD",
+    "CP", "LN", # "terse" make versions
+    "\\(?cd",
+    "\\(\\s*cd",
+    "creating\s+lib.*",
+    "cd\\s+\&\&\\s+make",
+    "sed -e",
+    "PATH=\"\\\$PATH.*\\sldconfig\\s",
+    "building profiling interface in directory",
+    "/usr/bin/sed",
+    "/usr/bin/install",
+    "/.*bin/install",
+    ".*confdb/install-sh",
+    "Copying Upshot",
+    "Cleaning directory",
+    "[*][*][*][*] Making .*\.\.\.\.",
+    "Making .* in .*",
+    "Making upshot", "\\s*\$",
+    "ld: warning: directory not found for option '-L\\S*src/mpl'",
+    "ld: warning: directory not found for option '-L\\S*src/openpa/src'",
+    "copying selected object files to avoid basename conflicts...",
+    "libtool", "Entering directory", "touch", "cd", "config.status:", "\\(CDPATH=.*",
 );
 
 # OtherNoise is an array of patterns that describe blocks of
@@ -78,18 +79,18 @@ $rootSrcDir = "";
 # small incompatibilities with the system header file /usr/include/unistd.h
 #
 @OtherNoise = ( 'Libraries have been installed in:<SEP>more information, such as the ld\(1\) and ld.so\(8\) manual pages.<SEP>20',
-		'^\s*-+\s*$<SEP><SEP>1', 
-		'^In directory:<SEP><SEP>1',
-		'^creating\s<SEP><SEP>1', 
-#		'^PGC-W-0114-More than one type.*/usr/include/unistd.h: 189<SEP>^PGC-W-0143-Useless typedef.*/usr/include/unistd.h: 189<SEP>2',
-#		'^PGC-W-0114-More than one type.*/usr/include/unistd.h: 243<SEP>^PGC-W-0143-Useless typedef.*/usr/include/unistd.h: 243<SEP>2',
-		'^PGC.*: compilation completed with warnings<SEP><SEP>1',
-# This next is a general version to handle all of these mistakes
-		'^PGC-W-0114-More than one type specified.*/usr/include<SEP>^PGC-W-0143-Useless typedef declaration \(no declarators present\).*/usr/include<SEP>2',
-		'copying python',
-		'LOOP WAS VECTORIZED',
-		'Using variables ',
-		);
+    '^\s*-+\s*$<SEP><SEP>1', 
+    '^In directory:<SEP><SEP>1',
+    '^creating\s<SEP><SEP>1', 
+    #		'^PGC-W-0114-More than one type.*/usr/include/unistd.h: 189<SEP>^PGC-W-0143-Useless typedef.*/usr/include/unistd.h: 189<SEP>2',
+    #		'^PGC-W-0114-More than one type.*/usr/include/unistd.h: 243<SEP>^PGC-W-0143-Useless typedef.*/usr/include/unistd.h: 243<SEP>2',
+    '^PGC.*: compilation completed with warnings<SEP><SEP>1',
+    # This next is a general version to handle all of these mistakes
+    '^PGC-W-0114-More than one type specified.*/usr/include<SEP>^PGC-W-0143-Useless typedef declaration \(no declarators present\).*/usr/include<SEP>2',
+    'copying python',
+    'LOOP WAS VECTORIZED',
+    'Using variables ',
+);
 # In the past, we also needed
 # WARNING 84.*not used for resolving any symbol
 # Info: File not optimized
@@ -114,9 +115,9 @@ foreach $_ (@ARGV) {
     elsif (/^--?summary/) { $summaryOutput = 1; }
     elsif (/^--?notrimcompileline/) { $trimCompileLine = 0; }
     elsif (/^-/) {
-	print STDERR "Unrecognized argument $_\n";
-	print STDERR "clmake [ -debug ] [ -showdir ] [ -summary ]\n";
-	exit(1);
+        print STDERR "Unrecognized argument $_\n";
+        print STDERR "clmake [ -debug ] [ -showdir ] [ -summary ]\n";
+        exit(1);
     }
     else { last; }
     shift @ARGV;
@@ -139,109 +140,109 @@ while ($line = <>) {
 
     # Read the next line, including handling any continuation lines
     while ($line =~ /\\$/) {
-	print "Read continuation line (cmd) ... \n" if $debug;
-	$line .= <>;
+        print "Read continuation line (cmd) ... \n" if $debug;
+        $line .= <>;
     }
 
     # Check for noise
     foreach my $pat (@OtherNoise) {
-	# maxlines is the maximum number of lines to match
-	my ($beginpat,$endpat,$maxlines) = split( '<SEP>', $pat );
-	print "Trying to match $beginpat\n" if $gDebugOther;
-	if ($line =~ /$beginpat/) {
-	    $maxlines --;
-	    print "Found match to $beginpat\n" if $gDebugOther;
-	    # Found the beginning.  Look for the end (if one requested)
-	    if ($endpat =~ /\S/) {
-		print "Trying to match endpat $endpat\n" if $gDebugOther;
-		while ($line = <>) {
-		    if (eof()) { last; }
-		    print "Trying to match to $line" if $gDebugOther;
-		    if ($line =~ /$endpat/) { last; }
-		    if ($maxlines-- <= 0) { 
-			print STDOUT "Failed to match $endpat; last line was $line";
-			last; 
-		    }
-		}
-	    }
-	    next T;
-	}
+        # maxlines is the maximum number of lines to match
+        my ($beginpat,$endpat,$maxlines) = split( '<SEP>', $pat );
+        print "Trying to match $beginpat\n" if $gDebugOther;
+        if ($line =~ /$beginpat/) {
+            $maxlines --;
+            print "Found match to $beginpat\n" if $gDebugOther;
+            # Found the beginning.  Look for the end (if one requested)
+            if ($endpat =~ /\S/) {
+                print "Trying to match endpat $endpat\n" if $gDebugOther;
+                while ($line = <>) {
+                    if (eof()) { last; }
+                    print "Trying to match to $line" if $gDebugOther;
+                    if ($line =~ /$endpat/) { last; }
+                    if ($maxlines-- <= 0) { 
+                        print STDOUT "Failed to match $endpat; last line was $line";
+                        last; 
+                    }
+                }
+            }
+            next T;
+        }
     }
-    
+
     # Is the line a command (including a directory change?)
     # Check first for a directory change
     if ($line =~ /^\s*make.* Entering directory \`([^\']*)\'/) {
-	my $dirname = $1;
-	$dirstack[$#dirstack+1] = $dirname;
-	$dirprinted[$#dirprinted+1] = 0;
-	print ">>entering $dirname\n" if $debugDir;
-	$cmdline = "";
-	next;
+        my $dirname = $1;
+        $dirstack[$#dirstack+1] = $dirname;
+        $dirprinted[$#dirprinted+1] = 0;
+        print ">>entering $dirname\n" if $debugDir;
+        $cmdline = "";
+        next;
     }
     elsif ($line =~ /^\s*make.* Leaving directory \`([^\']*)\'/) {
-	# We should check that the directory names match
-	my $dirname = $1;
-	print ">>leaving $dirname\n" if $debugDir;
-	if ($dirname ne $dirstack[$#dirstack]) {
-	    print STDERR "Warning: leaving directory $dirname but expected to leave directory " . $dirstack[$#dirstack] . "\n";
-	}
-	$#dirstack--;
-	$#dirprinted--;
-	$cmdline = "";
-	next;
+        # We should check that the directory names match
+        my $dirname = $1;
+        print ">>leaving $dirname\n" if $debugDir;
+        if ($dirname ne $dirstack[$#dirstack]) {
+            print STDERR "Warning: leaving directory $dirname but expected to leave directory " . $dirstack[$#dirstack] . "\n";
+        }
+        $#dirstack--;
+        $#dirprinted--;
+        $cmdline = "";
+        next;
     }
     else {
-	$is_command = 0;
-	foreach $cmdname (@commands) {
-	    if ($line =~ /^\s*$cmdname\W/) {
-		$is_command = 1;
-		$cmdline = $line;
-		last;
-	    }
-	}
-	if ($is_command) { 
-	    if ($summaryOutput) {
-		# FIXME: Summarize the command
-		if ($terseOutput) {
-		    if ($rootSrcDir eq "") {
-			if ($line =~ /\s(\/\S+\/src\/)/) {
-			    $rootSrcDir = $1;
-			    print "rootSrcDir = $rootSrcDir\n";
-			}
-		    }
-		    else {
-			$line =~ s/$rootSrcDir//g;
-		    }
-		    # Compiler options to remove
-		    $line =~ s/-I\S+\s+//g;
-		    $line =~ s/-W\S+\s+//g;
-		    $line =~ s/-D\S+\s+//g;
-		}
-		print $line;
-	    }
-	    next; 
-	}
+        $is_command = 0;
+        foreach $cmdname (@commands) {
+            if ($line =~ /^\s*$cmdname\W/) {
+                $is_command = 1;
+                $cmdline = $line;
+                last;
+            }
+        }
+        if ($is_command) { 
+            if ($summaryOutput) {
+                # FIXME: Summarize the command
+                if ($terseOutput) {
+                    if ($rootSrcDir eq "") {
+                        if ($line =~ /\s(\/\S+\/src\/)/) {
+                            $rootSrcDir = $1;
+                            print "rootSrcDir = $rootSrcDir\n";
+                        }
+                    }
+                    else {
+                        $line =~ s/$rootSrcDir//g;
+                    }
+                    # Compiler options to remove
+                    $line =~ s/-I\S+\s+//g;
+                    $line =~ s/-W\S+\s+//g;
+                    $line =~ s/-D\S+\s+//g;
+                }
+                print $line;
+            }
+            next; 
+        }
     }
 
     # If we got to this point, the line was not a recognized command or
     # ignorable output.  Output the line, including the command if this 
     # is the first time.  We can then forget the command 
     if ($#dirstack >= 0 && $dirprinted[$#dirstack] == 0) {
-	print "In directory: ". $dirstack[$#dirstack] . "\n";
-	$dirprinted[$#dirstack] = 1;
+        print "In directory: ". $dirstack[$#dirstack] . "\n";
+        $dirprinted[$#dirstack] = 1;
     }
     if ($cmdline ne "") { 
-	if ($trimCompileLine) {
-	    # Simplify the command line before printing
-	    $cmdline =~ s/-I\S*\s+//g;
-	    $cmdline =~ s/-ansi//g;
-	    $cmdline =~ s/-W\S*\s+//g;
-	    $cmdline =~ s/-DHAVE_CONFIG_H//g;
-	    $cmdline =~ s/-DGCC_WALL//g;
-	}
-	# We could print a newline here to separate commands
-	print $cmdline;
-	$cmdline = "";
+        if ($trimCompileLine) {
+            # Simplify the command line before printing
+            $cmdline =~ s/-I\S*\s+//g;
+            $cmdline =~ s/-ansi//g;
+            $cmdline =~ s/-W\S*\s+//g;
+            $cmdline =~ s/-DHAVE_CONFIG_H//g;
+            $cmdline =~ s/-DGCC_WALL//g;
+        }
+        # We could print a newline here to separate commands
+        print $cmdline;
+        $cmdline = "";
     }
     print $line;
 }

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1413,7 +1413,7 @@ def dump_body_impl(func, prefix='mpir'):
         for p in func['_has_handle_out']:
             (name, kind) = (p['name'], p['kind'])
             mpir_type = G.handle_mpir_types[kind]
-            G.out.append("%s *%s_ptr = NULL;" % (mpir_type, name))
+            G.out.append("%s *%s_ptr ATTRIBUTE((unused)) = NULL;" % (mpir_type, name))
             if kind in G.handle_NULLs:
                 G.out.append("*%s = %s;" % (name, G.handle_NULLs[kind]))
     elif RE.match(r'mpi_type_', func['name'], re.IGNORECASE):
@@ -1608,7 +1608,7 @@ def dump_handle_ptr_var(func, p):
             G.out.append("MPIR_Request **request_ptrs = request_ptr_array;")
     else:
         mpir = G.handle_mpir_types[kind]
-        G.out.append("%s *%s_ptr = NULL;" % (mpir, name))
+        G.out.append("%s *%s_ptr ATTRIBUTE((unused)) = NULL;" % (mpir, name))
 
 def dump_validate_handle(func, p):
     func_name = func['name']
@@ -2183,7 +2183,7 @@ def dump_validate_userbuffer_coll(func, kind, buf, ct, dt, disp):
 def dump_validate_datatype(func, dt):
     G.out.append("MPIR_ERRTEST_DATATYPE(%s, \"datatype\", mpi_errno);" % dt)
     G.out.append("if (!HANDLE_IS_BUILTIN(%s)) {" % dt)
-    G.out.append("    MPIR_Datatype *datatype_ptr = NULL;")
+    G.out.append("    MPIR_Datatype *datatype_ptr ATTRIBUTE((unused)) = NULL;")
     G.out.append("    MPIR_Datatype_get_ptr(%s, datatype_ptr);" % dt)
     G.out.append("    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);")
     dump_error_check("    ")

--- a/src/binding/c/misc_api.txt
+++ b/src/binding/c/misc_api.txt
@@ -193,7 +193,7 @@ MPIX_Query_cuda_support:
     .skip: global_cs, Errors
 {
     int is_supported = 0;
-    int mpi_errno;
+    int mpi_errno ATTRIBUTE((unused));
 
     mpi_errno = PMPIX_GPU_query_support(MPIX_GPU_SUPPORT_CUDA, &is_supported);
     assert(mpi_errno);
@@ -207,7 +207,7 @@ MPIX_Query_ze_support:
     .skip: global_cs, Errors
 {
     int is_supported = 0;
-    int mpi_errno;
+    int mpi_errno ATTRIBUTE((unused));
 
     mpi_errno = PMPIX_GPU_query_support(MPIX_GPU_SUPPORT_ZE, &is_supported);
     assert(mpi_errno);

--- a/src/include/mpir_refcount_pobj.h
+++ b/src/include/mpir_refcount_pobj.h
@@ -52,7 +52,7 @@ static inline int MPIR_cc_is_complete(MPIR_cc_t * cc_ptr)
 
 #define MPIR_cc_dec(cc_ptr_) \
     do { \
-        int ctr_;                                               \
+        int ctr_ ATTRIBUTE((unused));                \
         ctr_ = MPL_atomic_fetch_sub_int(cc_ptr_, 1); \
         MPIR_Assert(ctr_ >= 1); \
     } while (0)

--- a/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
+++ b/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
@@ -272,7 +272,7 @@ int MPII_Recexchalgo_reverse_digits_step2(int rank, int comm_size, int k)
     int i, T, rem, power, step2rank, step2_reverse_rank = 0;
     int pofk = 1, log_pofk = 0;
     int *digit, *digit_reverse;
-    int mpi_errno = MPI_SUCCESS;
+    int mpi_errno ATTRIBUTE((unused)) = MPI_SUCCESS;
     MPIR_CHKLMEM_DECL(2);
 
     MPIR_FUNC_ENTER;

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
@@ -13,14 +13,14 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                        MPIR_Comm * comm, int k, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, j;
     int nphases = 0;
     int n_invtcs;
     int tag;
     int count, left_count;
     int src, dst, p_of_k = 0;   /* Largest power of k that is (strictly) smaller than 'size' */
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     int rank = MPIR_Comm_rank(comm);
     int size = MPIR_Comm_size(comm);

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
@@ -16,9 +16,9 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int n
                                                                  MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int partner, offset, count, send_offset, recv_offset, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -66,10 +66,10 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step1(int step1_sendto, int *
                                                          MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int send_offset, recv_offset, i;
     int vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
 
     MPIR_FUNC_ENTER;
@@ -110,11 +110,11 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int s
                                                          MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int phase, i, j, count, nbr, send_offset, recv_offset, offset, rank_for_offset;
     int *recv_id = *recv_id_;
     int nrecvs = 0, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
 
     MPIR_FUNC_ENTER;
@@ -190,9 +190,9 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step3(int step1_sendto, int *
                                                          MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -230,7 +230,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
                                             MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int is_inplace, i;
     int nranks, rank;
     size_t recv_extent;
@@ -243,7 +243,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
     int nrecvs;
     int *recv_id;
     int tag;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(1);
 
     MPIR_FUNC_ENTER;

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring.c
@@ -12,7 +12,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
                                          MPIR_Comm * comm, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, src, dst, copy_dst;
     /* Temporary buffers to execute the ring algorithm */
     void *buf1, *buf2, *data_buf, *rbuf, *sbuf;
@@ -22,7 +22,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int tag;
     int vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPI_Aint recvtype_lb, recvtype_extent;
     MPI_Aint sendtype_lb, sendtype_extent;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
@@ -57,12 +57,12 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     int index_sum = 0;
     int prev_delta = 0;
     int count_length, top_count, bottom_count, left_count;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
@@ -17,10 +17,10 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int 
                                                                   MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int partner, offset, count, send_offset, recv_offset;
     int i, send_count, recv_count, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -76,9 +76,9 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int 
                                                           MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int send_offset, recv_offset, i, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
 
     MPIR_FUNC_ENTER;
@@ -121,12 +121,12 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
                                                    MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int phase, i, j, count, nbr, send_offset, recv_offset, offset, rank_for_offset;
     int x, send_count, recv_count, vtx_id;
     int *recv_id = *recv_id_;
     int nrecvs = 0;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -205,9 +205,9 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step3(int step1_sendto, int 
                                                           MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int total_count = 0, i, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring.c
@@ -16,14 +16,14 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
     size_t extent;
     MPI_Aint lb, true_extent;
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, src, dst;
     int nranks, is_inplace, rank;
     int send_rank, recv_rank;
     void *data_buf, *buf1, *buf2, *sbuf, *rbuf;
     int max_count;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
@@ -15,7 +15,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                                             MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int is_inplace, i, j;
     int dtcopy_id = -1;
     size_t extent;
@@ -35,7 +35,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     void **step1_recvbuf = NULL;
     void **nbr_buffer;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
@@ -20,7 +20,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
                                                                               sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int is_inplace, i;
     int dtcopy_id = -1;
     size_t extent;
@@ -38,7 +38,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     void *tmp_recvbuf;
     void **step1_recvbuf = NULL;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     int allgather_algo_type = MPIR_IALLGATHER_RECEXCH_TYPE_DISTANCE_HALVING;
     int redscat_algo_type = IREDUCE_SCATTER_RECEXCH_TYPE_DISTANCE_HALVING;
     MPIR_CHKLMEM_DECL(2);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
@@ -15,7 +15,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
                                          MPIR_Comm * comm, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, src, dst;
     int nranks, is_inplace, rank;
     size_t extent;
@@ -25,7 +25,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
     int send_rank, recv_rank, total_count;
     void *tmpbuf;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
     MPIR_CHKLMEM_DECL(4);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
@@ -14,7 +14,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
                                          int buffer_per_child, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, j, t;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
     int offset = 0;
@@ -33,7 +33,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
     int nvtcs;
     int tag, vtx_id;
     int root = 0;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_ENTER;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
@@ -52,8 +52,8 @@ brucks_sched_pup(int pack, void *rbuf, void *pupbuf, MPI_Datatype rtype, int cou
     int counter;
     int sink_id, vtx_id;
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -118,7 +118,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                       int k, int buffer_per_phase, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, j;
     int pack_ninvtcs, recv_ninvtcs, unpack_ninvtcs;
     int *pack_invtcs, *recv_invtcs, *unpack_invtcs;
@@ -136,7 +136,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     void *tmp_buf = NULL;
     const void *senddata;
     int tag;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_CHKLMEM_DECL(6);
 

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
@@ -39,9 +39,9 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                         MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, src, dst, copy_dst;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     /* Temporary buffers to execute the ring algorithm */
     void *buf1, *buf2, *data_buf, *sbuf, *rbuf;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
@@ -41,7 +41,7 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
                                              MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int src, dst;
     int i, j, ww;
     int invtcs;
@@ -53,7 +53,7 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
     int size, rank, vtx_id;
     int is_inplace;
     int tag = 0;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
@@ -14,19 +14,18 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                                             MPIR_Comm * comm, int bblock, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
-    int is_inplace;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     size_t recv_extent, send_extent, sendtype_size, recvtype_size;
     MPI_Aint recv_lb, send_lb, true_extent;
     int nranks, rank;
     int i, j, comm_block, dst;
     int tag = 0, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
-    is_inplace = (sendbuf == MPI_IN_PLACE);
-    MPIR_Assert(!is_inplace);
+    MPIR_Assert(sendbuf != MPI_IN_PLACE);
+
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
@@ -14,7 +14,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
                                             MPIR_Comm * comm, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     size_t recv_extent;
     MPI_Aint recv_lb, true_extent;
     int nranks, rank, nvtcs;
@@ -22,7 +22,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
     int max_count;
     void *tmp_buf = NULL;
     int tag = 0;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
@@ -15,13 +15,13 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
                                               MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int src, dst;
     int i, j, ww;
     int invtcs;
     int tag;
     int *vtcs, *recv_id, *send_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_Assert(!(sendbuf == MPI_IN_PLACE));

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
@@ -15,12 +15,12 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                                             int bblock, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int tag, vtx_id;
     size_t sendtype_size, recvtype_size;
     int nranks, rank;
     int i, j, comm_block, dst;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
@@ -15,7 +15,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
                                             MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int tag;
     size_t recv_extent;
     MPI_Aint true_extent, true_lb;
@@ -23,7 +23,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
     int i, dst, send_id, recv_id, dtcopy_id = -1, vtcs[2];
     int max_size;
     void *tmp_buf = NULL, *adj_tmp_buf = NULL;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_smp.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_smp.c
@@ -6,6 +6,7 @@
 #include "mpiimpl.h"
 #include "ibcast.h"
 
+#ifdef HAVE_ERROR_CHECKING
 static int sched_test_length(MPIR_Comm * comm, int tag, void *state)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -21,6 +22,7 @@ static int sched_test_length(MPIR_Comm * comm, int tag, void *state)
     }
     return mpi_errno;
 }
+#endif
 
 /* This routine purely handles the hierarchical version of bcast, and does not
  * currently make any decision about which particular algorithm to use for any

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
@@ -13,7 +13,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
                                                     int allgatherv_k, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     size_t extent, type_size;
     MPI_Aint true_lb, true_extent;
     int size, rank, tag;
@@ -26,7 +26,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
     int current_child, next_child, lrank, total_count, sink_id;
     int num_children, *child_subtree_size = NULL;
     int recv_size, num_send_dependencies;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     /* For correctness, transport based collectives need to get the

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree.c
@@ -14,7 +14,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype 
                                      MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
     int offset = 0;
@@ -26,7 +26,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype 
     int num_children;
     MPIR_Treealgo_tree_t my_tree;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/igather/igather_tsp_tree.c
+++ b/src/mpi/coll/igather/igather_tsp_tree.c
@@ -14,7 +14,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                                       int k, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int size, rank, lrank;
     int i, j, tag, is_inplace = false;
     MPI_Aint sendtype_lb, sendtype_extent, sendtype_true_extent;
@@ -26,7 +26,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     MPIR_Treealgo_tree_t my_tree, parents_tree;
     int next_child, num_children, *child_subtree_size = NULL, *child_data_offset = NULL;
     int offset, recv_size, num_dependencies;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_ENTER;

--- a/src/mpi/coll/igatherv/igatherv_tsp_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_tsp_linear.c
@@ -24,13 +24,13 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
                                            MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, vtx_id;
     int comm_size, rank;
     MPI_Aint extent;
     int min_procs;
     int tag;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     rank = comm_ptr->rank;
 

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear.c
@@ -14,13 +14,13 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, MPI_A
                                                       MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int indegree, outdegree, weighted;
     int k, l;
     int *srcs, *dsts;
     int tag, vtx_id;
     MPI_Aint recvtype_extent;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
@@ -16,13 +16,13 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
                                                        MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int indegree, outdegree, weighted;
     int k, l;
     int *srcs, *dsts;
     int tag, vtx_id;
     MPI_Aint recvtype_extent;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(2);
 
     MPIR_FUNC_ENTER;

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
@@ -14,13 +14,13 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Ai
                                                      MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int indegree, outdegree, weighted;
     int k, l;
     int *srcs, *dsts;
     MPI_Aint sendtype_extent, recvtype_extent;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
@@ -18,12 +18,12 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
                                                       MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int indegree, outdegree, weighted;
     int k, l;
     int *srcs, *dsts;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPI_Aint sendtype_extent, recvtype_extent;
 
     MPIR_FUNC_ENTER;

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
@@ -18,12 +18,12 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
                                                       MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int indegree, outdegree, weighted;
     int k, l;
     int *srcs, *dsts;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree.c
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree.c
@@ -14,7 +14,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
                                       int buffer_per_child, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, j, t;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
     int offset = 0;
@@ -38,7 +38,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
     int dtcopy_id = -1;
     int nvtcs;
     int tag;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_ENTER;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
@@ -48,12 +48,12 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                                                        MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int x, i, j, phase;
     int current_cnt, offset, rank_for_offset, dst;
     int send_cnt, recv_cnt, send_offset, recv_offset, nvtcs, vtcs[2];
     int send_id, recv_id, reduce_id = -1;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -134,7 +134,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
                                                  int k, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int is_inplace;
     size_t extent;
     MPI_Aint lb, true_extent;
@@ -149,7 +149,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
     void *tmp_recvbuf = NULL, *tmp_results = NULL;
     MPI_Aint *displs;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(1);
 
     MPIR_FUNC_ENTER;

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
@@ -14,7 +14,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
                                                        MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int is_inplace;
     size_t extent;
     MPI_Aint lb, true_extent;
@@ -29,7 +29,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
     int nvtcs, vtcs[2];
     void *tmp_recvbuf = NULL, *tmp_results = NULL;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
@@ -12,7 +12,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     MPI_Aint extent, true_extent;
     MPI_Aint lb;
     int nranks, rank;
@@ -22,7 +22,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
     void *partial_scan = NULL;
     void *tmp_buf = NULL;
     int tag = 0, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree.c
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree.c
@@ -15,7 +15,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     MPIR_FUNC_ENTER;
 
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int size, rank;
     int i, j, is_inplace = false;
     int lrank;
@@ -31,7 +31,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     int offset, recv_size;
     int tag;
     int num_send_dependencies;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(2);
 
     size = MPIR_Comm_size(comm);

--- a/src/mpi/coll/iscatterv/iscatterv_tsp_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_tsp_linear.c
@@ -14,12 +14,12 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint 
                                             MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int rank, comm_size;
     MPI_Aint extent;
     int i;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpi/coll/src/csel.c
+++ b/src/mpi/coll/src/csel.c
@@ -320,7 +320,7 @@ static void validate_tree(csel_node_s * node)
 static csel_node_s *parse_json_tree(struct json_object *obj,
                                     void *(*create_container) (struct json_object *))
 {
-    enum json_type type;
+    enum json_type type ATTRIBUTE((unused));
     csel_node_s *prevnode = NULL, *tmp, *node = NULL;
 
     json_object_object_foreach(obj, key, val) {

--- a/src/mpi/coll/src/csel.c
+++ b/src/mpi/coll/src/csel.c
@@ -451,8 +451,9 @@ static csel_node_s *parse_json_tree(struct json_object *obj,
                 tmp->u.collective.coll_type = MPIR_CSEL_COLL_TYPE__SCATTER;
             else if (!strcmp(str, "scatterv"))
                 tmp->u.collective.coll_type = MPIR_CSEL_COLL_TYPE__SCATTERV;
-            else
+            else {
                 MPIR_Assert(0);
+            }
         } else if (!strcmp(ckey, "comm_size=pow2")) {
             tmp->type = CSEL_NODE_TYPE__OPERATOR__COMM_SIZE_POW2;
         } else if (!strcmp(ckey, "comm_size=node_comm_size")) {
@@ -693,8 +694,9 @@ int MPIR_Csel_prune(void *root_csel, MPIR_Comm * comm_ptr, void **comm_csel_)
 
     /* if the tree is not NULL, we should be at a collective branch at
      * this point */
-    if (node)
+    if (node) {
         MPIR_Assert(node->type == CSEL_NODE_TYPE__OPERATOR__COLLECTIVE);
+    }
 
     while (node) {
         /* see if any additional pruning is possible once the

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -26,7 +26,7 @@ static inline void vtx_record_issue(MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sche
 
 static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t * sched)
 {
-    int mpi_errno = MPI_SUCCESS;
+    int mpi_errno ATTRIBUTE((unused)) = MPI_SUCCESS;
     MPIR_Request *r = sched->req;
     int i;
 

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -50,7 +50,7 @@ int MPIR_TSP_sched_create(MPIR_TSP_sched_t * s, bool is_persistent)
 int MPIR_TSP_sched_free(MPIR_TSP_sched_t s)
 {
     MPII_Genutil_sched_t *sched = s;
-    int mpi_errno = MPI_SUCCESS;
+    int mpi_errno ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i;
     vtx_t *vtx;
     void **p;
@@ -504,7 +504,7 @@ int MPIR_TSP_sched_sink(MPIR_TSP_sched_t s, int *vtx_id)
 int MPIR_TSP_sched_fence(MPIR_TSP_sched_t s)
 {
     MPII_Genutil_sched_t *sched = s;
-    int mpi_errno = MPI_SUCCESS;
+    int mpi_errno ATTRIBUTE((unused)) = MPI_SUCCESS;
     int fence_id;
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Gentran: scheduling a fence"));
 

--- a/src/mpi/datatype/type_create.c
+++ b/src/mpi/datatype/type_create.c
@@ -981,7 +981,7 @@ int MPIR_Type_create_resized_impl(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint ex
                                   MPI_Datatype * newtype)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Datatype new_handle;
+    MPI_Datatype new_handle = MPI_DATATYPE_NULL;
     MPIR_Datatype *new_dtp;
     MPI_Aint aints[2];
 
@@ -1008,7 +1008,7 @@ int MPIR_Type_create_resized_large_impl(MPI_Datatype oldtype, MPI_Aint lb, MPI_A
                                         MPI_Datatype * newtype)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Datatype new_handle;
+    MPI_Datatype new_handle = MPI_DATATYPE_NULL;
     MPIR_Datatype *new_dtp;
     MPI_Aint counts[2];
 

--- a/src/mpi/datatype/typerep/src/typerep_internal.h
+++ b/src/mpi/datatype/typerep/src/typerep_internal.h
@@ -30,7 +30,7 @@ static inline yaksa_info_t MPII_yaksa_get_info(MPL_pointer_attr_t * inattr,
 #ifdef MPL_HAVE_GPU
     /* Note: MPL_GPU_TYPE_CUDA/ZE are enums, can't be used in #if-expression. Use a branch
      * in stead. The branch should be optimized away. */
-    int rc;
+    int rc ATTRIBUTE((unused));
     if (MPL_HAVE_GPU == MPL_GPU_TYPE_CUDA) {
         yaksa_info_keyval_append(info, "yaksa_gpu_driver", "cuda", 5);
         rc = yaksa_info_keyval_append(info, "yaksa_cuda_inbuf_ptr_attr", &inattr->device_attr,

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
@@ -17,7 +17,7 @@ yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type)
 {
     MPIR_FUNC_ENTER;
 
-    yaksa_type_t yaksa_type;
+    yaksa_type_t yaksa_type = YAKSA_TYPE__NULL;
 
     if (type == MPI_DATATYPE_NULL) {
         yaksa_type = YAKSA_TYPE__NULL;

--- a/src/mpi/debugger/dbginit.c
+++ b/src/mpi/debugger/dbginit.c
@@ -414,7 +414,7 @@ void MPII_Sendq_remember(MPIR_Request * req, int rank, int tag, int context_id)
 void MPII_Sendq_forget(MPIR_Request * req)
 {
 #if defined HAVE_DEBUGGER_SUPPORT
-    MPIR_Sendq *p, *prev;
+    MPIR_Sendq *p = NULL, *prev = NULL;
 
     MPID_THREAD_CS_ENTER(VCI, lock);
     MPID_THREAD_CS_ENTER(POBJ, lock);

--- a/src/mpid/ch4/generic/am/mpidig_am_init.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_init.c
@@ -85,7 +85,7 @@ static void host_free_buffer_registered(void *ptr)
 int MPIDIG_am_check_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t buf_size_limit = 0;
+    size_t buf_size_limit ATTRIBUTE((unused)) = 0;
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     buf_size_limit = MPIDI_NM_am_eager_buf_limit();
 #else

--- a/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
+++ b/src/mpid/ch4/generic/am/mpidig_am_part_callbacks.c
@@ -21,8 +21,7 @@ static int part_send_data_target_cmpl_cb(MPIR_Request * rreq)
 
     MPIR_FUNC_ENTER;
 
-    MPIR_Request *part_rreq = MPIDIG_REQUEST(rreq, req->part_am_req.part_req_ptr);
-    MPIR_Assert(part_rreq);
+    MPIR_Assert(MPIDIG_REQUEST(rreq, req->part_am_req.part_req_ptr));
 
     MPIDIG_recv_finish(rreq);
 
@@ -40,8 +39,7 @@ int MPIDIG_part_send_data_origin_cb(MPIR_Request * sreq)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPIR_Request *part_sreq = MPIDIG_REQUEST(sreq, req->part_am_req.part_req_ptr);
-    MPIR_Assert(part_sreq);
+    MPIR_Assert(MPIDIG_REQUEST(sreq, req->part_am_req.part_req_ptr));
 
     /* Internally set partitioned sreq complete via completion_notification. */
     MPID_Request_complete(sreq);

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -42,6 +42,7 @@
  * The following routines ensures we can do that. It is static now, but we can
  * easily export to global when we need to.
  */
+ATTRIBUTE((unused))
 static int get_av_table_index(int rank, int nic, int vni)
 {
     if (nic == 0 && vni == 0) {
@@ -156,7 +157,7 @@ int MPIDI_OFI_addr_exchange_root_ctx(void)
 /* Macros to reduce clutter, so we can focus on the ordering logics.
  * Note: they are not perfectly-wraaped, but tolearable since only used here. */
 #define GET_AV_AND_ADDRNAMES(rank) \
-    MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(&MPIDIU_get_av(0, rank)); \
+    MPIDI_OFI_addr_t *av ATTRIBUTE((unused)) = &MPIDI_OFI_AV(&MPIDIU_get_av(0, rank)); \
     char *r_names = all_names + rank * num_vnis * num_nics * name_len;
 
 #define DO_AV_INSERT(ctx_idx, nic, vni) \
@@ -291,7 +292,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
   fn_check:
     if (MPIDI_OFI_ENABLE_AV_TABLE) {
         for (int r = 0; r < size; r++) {
-            MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(&MPIDIU_get_av(0, r));
+            MPIDI_OFI_addr_t *av ATTRIBUTE((unused)) = &MPIDI_OFI_AV(&MPIDIU_get_av(0, r));
             for (int nic = 0; nic < num_nics; nic++) {
                 for (int vni = 0; vni < num_vnis; vni++) {
                     MPIR_Assert(av->dest[nic][vni] == get_av_table_index(r, nic, vni));

--- a/src/mpid/ch4/netmod/ofi/init_provider.c
+++ b/src/mpid/ch4/netmod/ofi/init_provider.c
@@ -76,7 +76,7 @@ static int find_provider(struct fi_info **prov_out)
     int mpi_errno = MPI_SUCCESS;
     int ret;                    /* return from fi_getinfo() */
 
-    const char *provname;
+    const char *provname = NULL;
     if (MPIR_CVAR_OFI_USE_PROVIDER != NULL) {
         fprintf(stderr, "MPIR_CVAR_OFI_USE_PROVIDER is no longer supported in CH4. Use FI_PROVIDER"
                 "instead\n");

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -613,7 +613,7 @@ static void dwin_close_mr(void *obj)
     /* Close local MR */
     struct fid_mr *mr = (struct fid_mr *) obj;
     if (mr) {
-        int ret;
+        int ret ATTRIBUTE((unused));
         if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
             uint64_t requested_key = fi_mr_key(mr);
             MPIDI_OFI_mr_key_free(MPIDI_OFI_LOCAL_MR_KEY, requested_key);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -9,7 +9,7 @@
 
 static void ipc_handle_cache_free(void *handle_obj)
 {
-    int mpl_err;
+    int mpl_err ATTRIBUTE((unused));
 
     MPIR_FUNC_ENTER;
 
@@ -36,7 +36,8 @@ static void ipc_handle_free_hook(void *dptr)
 {
     void *pbase;
     uintptr_t len;
-    int mpl_err, local_dev_id, global_dev_id;
+    int mpl_err ATTRIBUTE((unused));
+    int local_dev_id, global_dev_id;
     MPL_pointer_attr_t gpu_attr;
 
     MPIR_FUNC_ENTER;

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -66,7 +66,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_rma_outstanding_req_flushall(MPIDI_POS
     MPIDI_POSIX_rma_req_t *req, *req_tmp;
     /* No dependency between requests, thus can safely wait one by one. */
     LL_FOREACH_SAFE(posix_win->outstanding_reqs_head, req, req_tmp) {
-        int mpi_errno;
+        int mpi_errno ATTRIBUTE((unused));
         mpi_errno = MPIR_Typerep_wait(req->typerep_req);
         MPIR_Assert(mpi_errno == MPI_SUCCESS);
 

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -438,7 +438,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_free(MPIR_Comm * comm_ptr)
 
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     /* Clean up is not required for NULL struct */
     if (RELEASE_GATHER_FIELD(comm_ptr, is_initialized) == 0) {

--- a/src/mpid/ch4/shm/src/topotree.c
+++ b/src/mpid/ch4/shm/src/topotree.c
@@ -40,7 +40,7 @@ static int gen_tree(int k_val, int *shared_region, int num_packages,
 static int create_template_tree(MPIDI_SHM_topotree_t * template_tree, int k_val,
                                 bool right_skewed, int max_ranks, MPIR_Errflag_t * errflag)
 {
-    int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS, mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int child_id, child_idx;
 
     mpi_errno = MPIDI_SHM_topotree_allocate(template_tree, max_ranks, k_val);
@@ -243,7 +243,7 @@ static int gen_tree(int k_val, int *shared_region, int num_packages,
                     int package_level, int num_ranks, bool package_leaders_first,
                     bool right_skewed, MPIR_Errflag_t * errflag)
 {
-    int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS, mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int rank, idx;
     int package_count = 0;
     MPIDI_SHM_topotree_t package_tree, tree, template_tree;

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -315,7 +315,7 @@ static int generic_init(void)
 int MPID_Init(int requested, int *provided)
 {
     int mpi_errno = MPI_SUCCESS;
-    char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+    char strerrbuf[MPIR_STRERROR_BUF_SIZE] ATTRIBUTE((unused));
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch4/src/ch4_spawn.c
+++ b/src/mpid/ch4/src/ch4_spawn.c
@@ -226,14 +226,14 @@ static int get_conn_name_from_port(const char *port_name, char *connname, int *l
 int MPID_Open_port(MPIR_Info * info_ptr, char *port_name)
 {
     int mpi_errno;
+    char *addrname = NULL;
+    int *addrname_size = NULL;
     MPIR_FUNC_ENTER;
 
     int tag = -1;
     mpi_errno = get_port_name_tag(&tag);
     MPIR_ERR_CHECK(mpi_errno);
 
-    char *addrname = NULL;
-    int *addrname_size = NULL;
     mpi_errno = MPIDI_NM_get_local_upids(MPIR_Process.comm_self, &addrname_size, &addrname);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/src/ch4r_init.c
+++ b/src/mpid/ch4/src/ch4r_init.c
@@ -8,7 +8,7 @@
 
 int MPIDIG_init_comm(MPIR_Comm * comm)
 {
-    int mpi_errno = MPI_SUCCESS, subcomm_type, is_localcomm;
+    int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
@@ -16,12 +16,6 @@ int MPIDIG_init_comm(MPIR_Comm * comm)
 
     if (MPIR_CONTEXT_READ_FIELD(DYNAMIC_PROC, comm->recvcontext_id))
         goto fn_exit;
-
-    subcomm_type = MPIR_CONTEXT_READ_FIELD(SUBCOMM, comm->recvcontext_id);
-    is_localcomm = MPIR_CONTEXT_READ_FIELD(IS_LOCALCOMM, comm->recvcontext_id);
-
-    MPIR_Assert(subcomm_type <= 3);
-    MPIR_Assert(is_localcomm <= 1);
 
     MPIDIG_COMM(comm, window_instance) = 0;
   fn_exit:
@@ -31,16 +25,11 @@ int MPIDIG_init_comm(MPIR_Comm * comm)
 
 int MPIDIG_destroy_comm(MPIR_Comm * comm)
 {
-    int mpi_errno = MPI_SUCCESS, subcomm_type, is_localcomm;
+    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
     if (MPIR_CONTEXT_READ_FIELD(DYNAMIC_PROC, comm->recvcontext_id))
         goto fn_exit;
-    subcomm_type = MPIR_CONTEXT_READ_FIELD(SUBCOMM, comm->recvcontext_id);
-    is_localcomm = MPIR_CONTEXT_READ_FIELD(IS_LOCALCOMM, comm->recvcontext_id);
-
-    MPIR_Assert(subcomm_type <= 3);
-    MPIR_Assert(is_localcomm <= 1);
 
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/src/ch4r_proc.c
+++ b/src/mpid/ch4/src/ch4r_proc.c
@@ -158,7 +158,8 @@ int MPIDIU_avt_init(void)
 
     MPIR_FUNC_ENTER;
 
-    int first_avtid = get_next_avtid();
+    int first_avtid ATTRIBUTE((unused));
+    first_avtid = get_next_avtid();
     MPIR_Assert(first_avtid == 0);
 
     int size = MPIR_Process.size;

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -1541,7 +1541,7 @@ int MPIDIG_cswap_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     MPI_Aint data_sz;
     MPIR_Win *win;
 
-    int dt_contig;
+    int dt_contig ATTRIBUTE((unused));
     void *p_data;
 
     MPIDIG_cswap_req_msg_t *msg_hdr = (MPIDIG_cswap_req_msg_t *) am_hdr;

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -132,10 +132,8 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
     int mpi_errno = MPI_SUCCESS;
 
     /* FIXME: rank, size, nodemap parameters are not needed */
-    int my_rank = MPIR_Process.rank;
-    int my_size = MPIR_Process.size;
-    MPIR_Assert(my_rank == rank);
-    MPIR_Assert(my_size == size);
+    MPIR_Assert(MPIR_Process.rank == rank);
+    MPIR_Assert(MPIR_Process.size == size);
 
     int recv_bc_len = bc_len;
     if (!same_len) {

--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -112,17 +112,13 @@ static int Init_shm_barrier(void)
 int MPIDU_Init_shm_init(void)
 {
     int mpi_errno = MPI_SUCCESS, mpl_err = 0;
-    int local_leader;
-    int rank;
     MPIR_CHKPMEM_DECL(1);
     MPIR_CHKLMEM_DECL(1);
 
     MPIR_FUNC_ENTER;
 
-    rank = MPIR_Process.rank;
     local_size = MPIR_Process.local_size;
     my_local_rank = MPIR_Process.local_rank;
-    local_leader = MPIR_Process.node_local_map[0];
 
     size_t segment_len = MPIDU_SHM_CACHE_LINE_LEN + sizeof(MPIDU_Init_shm_block_t) * local_size;
 
@@ -155,7 +151,7 @@ int MPIDU_Init_shm_init(void)
                                                     (void **) &(memory.base_addr), 0);
             MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
 
-            MPIR_Assert(local_leader == rank);
+            MPIR_Assert(MPIR_Process.node_local_map[0] == MPIR_Process.rank);
 
             mpl_err = MPL_shm_hnd_get_serialized_by_ref(memory.hnd, &serialized_hnd);
             MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");

--- a/src/mpid/common/shm/mpidu_init_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_init_shm_alloc.c
@@ -43,10 +43,8 @@ int MPIDU_Init_shm_alloc(size_t len, void **ptr)
     int mpi_errno = MPI_SUCCESS, mpl_err = 0;
     void *current_addr;
     size_t segment_len = len;
-    int rank = MPIR_Process.rank;
     int local_rank = MPIR_Process.local_rank;
     int num_local = MPIR_Process.local_size;
-    int local_procs_0 = MPIR_Process.node_local_map[0];
     MPIDU_shm_seg_t *memory = NULL;
     memory_list_t *memory_node = NULL;
     MPIR_CHKPMEM_DECL(3);
@@ -86,7 +84,7 @@ int MPIDU_Init_shm_alloc(size_t len, void **ptr)
                                                     (void **) &(memory->base_addr), 0);
             MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
 
-            MPIR_Assert(local_procs_0 == rank);
+            MPIR_Assert(MPIR_Process.node_local_map[0] == MPIR_Process.rank);
 
             mpl_err = MPL_shm_hnd_get_serialized_by_ref(memory->hnd, &serialized_hnd);
             MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");

--- a/src/mpl/include/mpl_initlock.h
+++ b/src/mpl/include/mpl_initlock.h
@@ -25,7 +25,7 @@
 
 static inline void MPL_initlock_lock(MPL_initlock_t * lock)
 {
-    int ret = pthread_mutex_lock(lock);
+    int ret ATTRIBUTE((unused)) = pthread_mutex_lock(lock);
     assert(ret == 0);
 }
 
@@ -37,7 +37,7 @@ static inline int MPL_initlock_trylock(MPL_initlock_t * lock)
 
 static inline void MPL_initlock_unlock(MPL_initlock_t * lock)
 {
-    int ret = pthread_mutex_unlock(lock);
+    int ret ATTRIBUTE((unused)) = pthread_mutex_unlock(lock);
     assert(ret == 0);
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -197,7 +197,7 @@ int MPL_gpu_free(void *ptr)
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_init()
+int MPL_gpu_init(void)
 {
     if (gpu_initialized) {
         goto fn_exit;
@@ -261,7 +261,7 @@ int MPL_gpu_init()
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_finalize()
+int MPL_gpu_finalize(void)
 {
     if (device_count <= 0) {
         goto fn_exit;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -43,6 +43,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
+    int mpl_err = MPL_SUCCESS;
     cudaError_t ret;
     ret = cudaPointerGetAttributes(&attr->device_attr, ptr);
     if (ret == cudaSuccess) {
@@ -72,26 +73,30 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     }
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
+    int mpl_err = MPL_SUCCESS;
     cudaError_t ret;
 
     ret = cudaIpcGetMemHandle(ipc_handle, (void *) ptr);
     CUDA_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
 {
+    int mpl_err = MPL_SUCCESS;
     cudaError_t ret;
     int prev_devid;
 
@@ -102,74 +107,85 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
 
   fn_exit:
     cudaSetDevice(prev_devid);
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_ipc_handle_unmap(void *ptr)
 {
+    int mpl_err = MPL_SUCCESS;
     cudaError_t ret;
     ret = cudaIpcCloseMemHandle(ptr);
     CUDA_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_malloc_host(void **ptr, size_t size)
 {
+    int mpl_err = MPL_SUCCESS;
     cudaError_t ret;
     ret = cudaMallocHost(ptr, size);
     CUDA_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_free_host(void *ptr)
 {
+    int mpl_err = MPL_SUCCESS;
     cudaError_t ret;
     ret = cudaFreeHost(ptr);
     CUDA_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_register_host(const void *ptr, size_t size)
 {
+    int mpl_err = MPL_SUCCESS;
     cudaError_t ret;
     ret = cudaHostRegister((void *) ptr, size, cudaHostRegisterDefault);
     CUDA_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_unregister_host(const void *ptr)
 {
+    int mpl_err = MPL_SUCCESS;
     cudaError_t ret;
     ret = cudaHostUnregister((void *) ptr);
     CUDA_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device)
 {
-    int mpl_errno = MPL_SUCCESS;
+    int mpl_err = MPL_SUCCESS;
     int prev_devid;
     cudaError_t ret;
     cudaGetDevice(&prev_devid);
@@ -179,26 +195,29 @@ int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device)
 
   fn_exit:
     cudaSetDevice(prev_devid);
-    return mpl_errno;
+    return mpl_err;
   fn_fail:
-    mpl_errno = MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
     goto fn_exit;
 }
 
 int MPL_gpu_free(void *ptr)
 {
+    int mpl_err = MPL_SUCCESS;
     cudaError_t ret;
     ret = cudaFree(ptr);
     CUDA_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_init(void)
 {
+    int mpl_err = MPL_SUCCESS;
     if (gpu_initialized) {
         goto fn_exit;
     }
@@ -256,9 +275,10 @@ int MPL_gpu_init(void)
     gpu_initialized = 1;
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_finalize(void)
@@ -300,15 +320,17 @@ int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr)
 
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
 {
+    int mpl_err = MPL_SUCCESS;
     CUresult curet;
 
     curet = cuMemGetAddressRange((CUdeviceptr *) pbase, (size_t *) len, (CUdeviceptr) ptr);
     CU_ERR_CHECK(curet);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 static void gpu_free_hooks_cb(void *dptr)

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -191,7 +191,7 @@ int MPL_gpu_free(void *ptr)
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_init()
+int MPL_gpu_init(void)
 {
     hipError_t ret = hipGetDeviceCount(&device_count);
     HIP_ERR_CHECK(ret);
@@ -247,7 +247,7 @@ int MPL_gpu_init()
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_finalize()
+int MPL_gpu_finalize(void)
 {
     if (device_count <= 0) {
         goto fn_exit;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -42,6 +42,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
+    int mpl_err = MPL_SUCCESS;
     hipError_t ret;
     ret = hipPointerGetAttributes(&attr->device_attr, ptr);
     if (ret == hipSuccess) {
@@ -66,26 +67,30 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     }
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
+    int mpl_err = MPL_SUCCESS;
     hipError_t ret;
 
     ret = hipIpcGetMemHandle(ipc_handle, (void *) ptr);
     HIP_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
 {
+    int mpl_err = MPL_SUCCESS;
     hipError_t ret;
     int prev_devid;
 
@@ -96,74 +101,85 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
 
   fn_exit:
     hipSetDevice(prev_devid);
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_ipc_handle_unmap(void *ptr)
 {
+    int mpl_err = MPL_SUCCESS;
     hipError_t ret;
     ret = hipIpcCloseMemHandle(ptr);
     HIP_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_malloc_host(void **ptr, size_t size)
 {
+    int mpl_err = MPL_SUCCESS;
     hipError_t ret;
     ret = hipHostMalloc(ptr, size, hipHostMallocDefault);
     HIP_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_free_host(void *ptr)
 {
+    int mpl_err = MPL_SUCCESS;
     hipError_t ret;
     ret = hipHostFree(ptr);
     HIP_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_register_host(const void *ptr, size_t size)
 {
+    int mpl_err = MPL_SUCCESS;
     hipError_t ret;
     ret = hipHostRegister((void *) ptr, size, hipHostRegisterDefault);
     HIP_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_unregister_host(const void *ptr)
 {
+    int mpl_err = MPL_SUCCESS;
     hipError_t ret;
     ret = hipHostUnregister((void *) ptr);
     HIP_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device)
 {
-    int mpl_errno = MPL_SUCCESS;
+    int mpl_err = MPL_SUCCESS;
     int prev_devid;
     hipError_t ret;
     hipGetDevice(&prev_devid);
@@ -173,26 +189,29 @@ int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device)
 
   fn_exit:
     hipSetDevice(prev_devid);
-    return mpl_errno;
+    return mpl_err;
   fn_fail:
-    mpl_errno = MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
     goto fn_exit;
 }
 
 int MPL_gpu_free(void *ptr)
 {
+    int mpl_err = MPL_SUCCESS;
     hipError_t ret;
     ret = hipFree(ptr);
     HIP_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_init(void)
 {
+    int mpl_err = MPL_SUCCESS;
     hipError_t ret = hipGetDeviceCount(&device_count);
     HIP_ERR_CHECK(ret);
 
@@ -242,9 +261,10 @@ int MPL_gpu_init(void)
     gpu_initialized = 1;
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_finalize(void)
@@ -286,15 +306,17 @@ int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr)
 
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
 {
+    int mpl_err = MPL_SUCCESS;
     hipError_t hiret;
 
     hiret = hipMemGetAddressRange((hipDeviceptr_t *) pbase, (size_t *) len, (hipDeviceptr_t) ptr);
     HI_ERR_CHECK(hiret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 static void gpu_free_hooks_cb(void *dptr)

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -23,7 +23,7 @@ static int *global_to_local_map;        /* [max_dev_id + 1]   */
 ze_driver_handle_t global_ze_driver_handle;
 ze_device_handle_t *global_ze_devices_handle = NULL;
 ze_context_handle_t global_ze_context;
-int global_ze_device_count;
+uint32_t global_ze_device_count;
 static int gpu_ze_init_driver(void);
 
 #define ZE_ERR_CHECK(ret) \

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -44,7 +44,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
     return ret;
 }
 
-int MPL_gpu_init()
+int MPL_gpu_init(void)
 {
     int ret_error;
     ret_error = gpu_ze_init_driver();
@@ -70,7 +70,7 @@ int MPL_gpu_init()
 }
 
 /* Loads a global ze driver */
-static int gpu_ze_init_driver()
+static int gpu_ze_init_driver(void)
 {
     uint32_t driver_count = 0;
     ze_result_t ret;
@@ -148,7 +148,7 @@ static int gpu_ze_init_driver()
     goto fn_exit;
 }
 
-int MPL_gpu_finalize()
+int MPL_gpu_finalize(void)
 {
     MPL_free(local_to_global_map);
     MPL_free(global_to_local_map);

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -46,9 +46,9 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 
 int MPL_gpu_init(void)
 {
-    int ret_error;
-    ret_error = gpu_ze_init_driver();
-    if (ret_error != MPL_SUCCESS)
+    int mpl_err;
+    mpl_err = gpu_ze_init_driver();
+    if (mpl_err != MPL_SUCCESS)
         goto fn_fail;
 
     device_count = global_ze_device_count;
@@ -64,9 +64,9 @@ int MPL_gpu_init(void)
     gpu_initialized = 1;
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return ret_error;
+    goto fn_exit;
 }
 
 /* Loads a global ze driver */
@@ -170,14 +170,16 @@ int MPL_gpu_local_to_global_dev_id(int local_dev_id)
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
+    int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
     ret = zeMemGetIpcHandle(global_ze_context, ptr, ipc_handle);
     ZE_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
@@ -201,18 +203,23 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
 
 int MPL_gpu_ipc_handle_unmap(void *ptr)
 {
+    int mpl_err = MPL_SUCCESS;
+
     ze_result_t ret;
     ret = zeMemCloseIpcHandle(global_ze_context, ptr);
     ZE_ERR_CHECK(ret);
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
+    int mpl_err = MPL_SUCCESS;
+
     ze_result_t ret;
     memset(&attr->device_attr.prop, 0, sizeof(ze_memory_allocation_properties_t));
     ret = zeMemGetAllocProperties(global_ze_context, ptr,
@@ -237,13 +244,15 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     }
 
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device)
 {
+    int mpl_err = MPL_SUCCESS;
     int ret;
     size_t mem_alignment;
     ze_device_mem_alloc_desc_t device_desc = {
@@ -258,14 +267,17 @@ int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device)
     ret = zeMemAllocDevice(global_ze_context, &device_desc, size, mem_alignment, h_device, ptr);
 
     ZE_ERR_CHECK(ret);
+
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_malloc_host(void **ptr, size_t size)
 {
+    int mpl_err = MPL_SUCCESS;
     int ret;
     size_t mem_alignment;
     ze_host_mem_alloc_desc_t host_desc = {
@@ -279,32 +291,38 @@ int MPL_gpu_malloc_host(void **ptr, size_t size)
     mem_alignment = 1;
     ret = zeMemAllocHost(global_ze_context, &host_desc, size, mem_alignment, ptr);
     ZE_ERR_CHECK(ret);
+
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_free(void *ptr)
 {
-    int ret;
-    ret = zeMemFree(global_ze_context, ptr);
-    ZE_ERR_CHECK(ret);
+    int mpl_err = MPL_SUCCESS;
+    mpl_err = zeMemFree(global_ze_context, ptr);
+    ZE_ERR_CHECK(mpl_err);
+
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_free_host(void *ptr)
 {
-    int ret;
-    ret = zeMemFree(global_ze_context, ptr);
-    ZE_ERR_CHECK(ret);
+    int mpl_err;
+    mpl_err = zeMemFree(global_ze_context, ptr);
+    ZE_ERR_CHECK(mpl_err);
+
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_register_host(const void *ptr, size_t size)
@@ -331,13 +349,16 @@ int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr)
 
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
 {
+    int mpl_err = MPL_SUCCESS;
     int ret;
     ret = zeMemGetAddressRange(global_ze_context, ptr, pbase, len);
     ZE_ERR_CHECK(ret);
+
   fn_exit:
-    return MPL_SUCCESS;
+    return mpl_err;
   fn_fail:
-    return MPL_ERR_GPU_INTERNAL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr))

--- a/src/mpl/src/sock/mpl_sockaddr.c
+++ b/src/mpl/src/sock/mpl_sockaddr.c
@@ -210,7 +210,7 @@ void MPL_set_listen_attr(int use_loopback, int max_conn)
 int MPL_listen(int sock_fd, unsigned short port)
 {
     MPL_sockaddr_t addr;
-    int ret;
+    int ret = 0;
 
     if (_use_loopback) {
         MPL_get_sockaddr_direct(MPL_SOCKADDR_LOOPBACK, &addr);
@@ -235,7 +235,7 @@ int MPL_listen(int sock_fd, unsigned short port)
 int MPL_listen_anyport(int sock_fd, unsigned short *p_port)
 {
     MPL_sockaddr_t addr;
-    int ret;
+    int ret = 0;
 
     if (_use_loopback) {
         MPL_get_sockaddr_direct(MPL_SOCKADDR_LOOPBACK, &addr);

--- a/src/pm/hydra/pm/pmiserv/common.c
+++ b/src/pm/hydra/pm/pmiserv/common.c
@@ -121,7 +121,8 @@ char *HYD_pmcd_pmi_find_token_keyval(struct HYD_pmcd_token *tokens, int count, c
 HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_pmcd_pmi_kvs ** kvs, int pgid)
 {
     HYD_status status = HYD_SUCCESS;
-    char hostname[MAX_HOSTNAME_LEN];
+    char hostname[MAX_HOSTNAME_LEN - 40];       /* Remove space taken up by the integers and other
+                                                 * characters below. */
     unsigned int seed;
     MPL_time_t tv;
     double secs;

--- a/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
+++ b/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
@@ -61,7 +61,7 @@ static HYD_status list_to_nodes(char *str)
     regmatch_t rmatch[MAX_RMATCH];
     regmatch_t ematch[MAX_EMATCH];
     char hostname[MAX_HOSTNAME_LEN];
-    char base_str[MAX_HOSTNAME_LEN];
+    char base_str[MAX_HOSTNAME_LEN - MAX_NNODES_STRLEN];
     char rbegin[MAX_NNODES_STRLEN];
     char rend[MAX_NNODES_STRLEN];
     char *gpattern[2];
@@ -143,7 +143,7 @@ static HYD_status list_to_nodes(char *str)
 
             if (regexec(&rmatch_old, rpattern, MAX_RMATCH, rmatch, 0) == 0) {
                 /* matched range: (h)(00)-(h)(12) */
-                MPL_snprintf_nowarn(base_str, MAX_HOSTNAME_LEN, "%.*s",
+                MPL_snprintf_nowarn(base_str, MAX_HOSTNAME_LEN - MAX_NNODES_STRLEN, "%.*s",
                                     (int) (rmatch[1].rm_eo - rmatch[1].rm_so),
                                     rpattern + rmatch[1].rm_so);
                 MPL_snprintf_nowarn(rbegin, MAX_NNODES_STRLEN, "%.*s",
@@ -189,7 +189,7 @@ static HYD_status list_to_nodes(char *str)
         *(gpattern[0] + gmatch[0][0].rm_eo) = 0;
 
         /* extranct base_str from atom 2 in group-0 */
-        MPL_snprintf_nowarn(base_str, MAX_HOSTNAME_LEN, "%.*s",
+        MPL_snprintf_nowarn(base_str, MAX_HOSTNAME_LEN - MAX_NNODES_STRLEN, "%.*s",
                             (int) (gmatch[0][2].rm_eo - gmatch[0][2].rm_so),
                             gpattern[0] + gmatch[0][2].rm_so);
 

--- a/src/util/mpir_nodemap.h
+++ b/src/util/mpir_nodemap.h
@@ -19,7 +19,7 @@ static inline int MPIR_NODEMAP_publish_node_id(int sz, int myrank)
     int key_max_sz;
     char *kvs_name;
     char hostname[MAX_HOSTNAME_LEN];
-    char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+    char strerrbuf[MPIR_STRERROR_BUF_SIZE] ATTRIBUTE((unused));
     MPIR_CHKLMEM_DECL(2);
 
     /* set hostname */
@@ -292,7 +292,7 @@ static inline int MPIR_NODEMAP_build_nodemap_fallback(int sz, int myrank, int *o
     char *key = MPL_malloc(key_max_sz, MPL_MEM_OTHER);
     char **node_names = MPL_malloc(sz * sizeof(char *), MPL_MEM_OTHER);
     char *node_name_buf = MPL_malloc(sz * key_max_sz, MPL_MEM_OTHER);
-    char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+    char strerrbuf[MPIR_STRERROR_BUF_SIZE] ATTRIBUTE((unused));
 
     for (int i = 0; i < sz; ++i) {
         node_names[i] = &node_name_buf[i * key_max_sz];


### PR DESCRIPTION
## Pull Request Description

This is a grab bag of warning fixes for things not currently covered by the warning checker job. Most of this is related to unused labels that show up when you compile with error checking off (i.e., all of the `MPIR_ERR_CHECK` and `MPIR_Assert` macros disappear), but there are a few others.

Most of these can be reproduced by using `--enable-strict` and `--disable-error-checking`. A few others come from using ICC/ICX instead of GCC.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
