### PR TITLE
ch4/ofi: use separate req_hdr for send and receive

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -32,7 +32,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_progress_do_queue(int vni_idx);
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req)
 {
-    MPIDI_OFI_AMREQUEST(req, req_hdr) = NULL;
+    MPIDI_OFI_AMREQUEST(req, sreq_hdr) = NULL;
+    MPIDI_OFI_AMREQUEST(req, rreq_hdr) = NULL;
     MPIDI_OFI_AMREQUEST(req, am_type_choice) = MPIDI_AMTYPE_NONE;
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.c
@@ -20,17 +20,17 @@ int MPIDI_OFI_am_rdma_read_ack_handler(void *am_hdr, void *data,
     sreq = ack_msg->sreq_ptr;
 
     if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
-        uint64_t mr_key = fi_mr_key(MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr));
+        uint64_t mr_key = fi_mr_key(MPIDI_OFI_AM_SREQ_HDR(sreq, lmt_mr));
         MPIDI_OFI_mr_key_free(MPIDI_OFI_LOCAL_MR_KEY, mr_key);
     }
-    MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr)->fid), mr_unreg);
+    MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_AM_SREQ_HDR(sreq, lmt_mr)->fid), mr_unreg);
     MPL_atomic_fetch_sub_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs, 1);
 
-    MPIR_gpu_free_host(MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer));
+    MPIR_gpu_free_host(MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer));
 
     /* retrieve the handler_id of the original send request for origin cb. Note the handler_id
      * parameter is MPIDI_OFI_AM_RDMA_READ_ACK and should never be called with origin_cbs */
-    src_handler_id = MPIDI_OFI_AMREQUEST_HDR(sreq, msg_hdr).handler_id;
+    src_handler_id = MPIDI_OFI_AM_SREQ_HDR(sreq, msg_hdr).handler_id;
     mpi_errno = MPIDIG_global.origin_cbs[src_handler_id] (sreq);
     MPIR_ERR_CHECK(mpi_errno);
     MPID_Request_complete(sreq);
@@ -44,6 +44,6 @@ int MPIDI_OFI_am_rdma_read_ack_handler(void *am_hdr, void *data,
 
 int MPIDI_OFI_am_rdma_read_recv_cb(MPIR_Request * rreq)
 {
-    return do_long_am_recv(MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).reg_sz, rreq,
-                           &MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info));
+    return do_long_am_recv(MPIDI_OFI_AM_RREQ_HDR(rreq, lmt_info).reg_sz, rreq,
+                           &MPIDI_OFI_AM_RREQ_HDR(rreq, lmt_info));
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -488,12 +488,12 @@ static int am_isend_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 
     MPIR_FUNC_ENTER;
 
-    msg_hdr = &MPIDI_OFI_AMREQUEST_HDR(sreq, msg_hdr);
+    msg_hdr = &MPIDI_OFI_AM_SREQ_HDR(sreq, msg_hdr);
     MPID_Request_complete(sreq);
 
     MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.pack_buf_pool,
-                                      MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer));
-    MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer) = NULL;
+                                      MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer));
+    MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer) = NULL;
     mpi_errno = MPIDIG_global.origin_cbs[msg_hdr->handler_id] (sreq);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -687,14 +687,14 @@ static int am_read_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_
     MPIR_FUNC_ENTER;
 
     ofi_req = MPL_container_of(wc->op_context, MPIDI_OFI_am_request_t, context);
-    rreq = (MPIR_Request *) ofi_req->req_hdr->rreq_ptr;
+    rreq = (MPIR_Request *) ofi_req->rreq_hdr->rreq_ptr;
 
-    if (ofi_req->req_hdr->lmt_type == MPIDI_OFI_AM_LMT_IOV) {
-        ofi_req->req_hdr->lmt_u.lmt_cntr--;
-        if (ofi_req->req_hdr->lmt_u.lmt_cntr) {
+    if (ofi_req->rreq_hdr->lmt_type == MPIDI_OFI_AM_LMT_IOV) {
+        ofi_req->rreq_hdr->lmt_u.lmt_cntr--;
+        if (ofi_req->rreq_hdr->lmt_u.lmt_cntr) {
             goto fn_exit;
         }
-    } else if (ofi_req->req_hdr->lmt_type == MPIDI_OFI_AM_LMT_UNPACK) {
+    } else if (ofi_req->rreq_hdr->lmt_type == MPIDI_OFI_AM_LMT_UNPACK) {
         int done = MPIDI_OFI_am_lmt_unpack_event(rreq);
         if (!done) {
             goto fn_exit;
@@ -707,9 +707,8 @@ static int am_read_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_
     } else {
         comm = rreq->comm;
     }
-    mpi_errno = MPIDI_OFI_do_am_rdma_read_ack(MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).src_rank,
-                                              comm,
-                                              MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).sreq_ptr);
+    mpi_errno = MPIDI_OFI_do_am_rdma_read_ack(MPIDI_OFI_AM_RREQ_HDR(rreq, lmt_info).src_rank,
+                                              comm, MPIDI_OFI_AM_RREQ_HDR(rreq, lmt_info).sreq_ptr);
 
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -160,7 +160,8 @@ typedef struct MPIDI_OFI_deferred_am_isend_req {
 typedef struct {
     struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];       /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
-    MPIDI_OFI_am_request_header_t *req_hdr;
+    MPIDI_OFI_am_request_header_t *sreq_hdr;
+    MPIDI_OFI_am_request_header_t *rreq_hdr;
     MPIDI_OFI_deferred_am_isend_req_t *deferred_req;    /* saving information when an AM isend is
                                                          * deferred */
     uint8_t am_type_choice;     /* save amtype to avoid double checking */

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -114,8 +114,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 
 /* Field accessor macros */
 #define MPIDI_OFI_AMREQUEST(req,field)     ((req)->dev.ch4.am.netmod_am.ofi.field)
-#define MPIDI_OFI_AMREQUEST_HDR(req,field) ((req)->dev.ch4.am.netmod_am.ofi.req_hdr->field)
-#define MPIDI_OFI_AMREQUEST_HDR_PTR(req)   ((req)->dev.ch4.am.netmod_am.ofi.req_hdr)
+#define MPIDI_OFI_AM_SREQ_HDR(req,field) ((req)->dev.ch4.am.netmod_am.ofi.sreq_hdr->field)
+#define MPIDI_OFI_AM_RREQ_HDR(req,field) ((req)->dev.ch4.am.netmod_am.ofi.rreq_hdr->field)
 #define MPIDI_OFI_REQUEST(req,field)       ((req)->dev.ch4.netmod.ofi.field)
 #define MPIDI_OFI_AV(av)                   ((av)->netmod.ofi)
 


### PR DESCRIPTION
## Pull Request Description
During an active message protocol, the same request may switch from a
send request into a receive request, and in the rdma case, the ofi
receive side need some persistent data storage that is currently using
the same req_hdr as the send side. However, at the point of recv, the
previous send completion may not have run yet (rare, but happens), and
overwriting the req_hdr corrupts the data when send completion finally
run. Because the send-side origin_cbs are often simple and similar, this
doesn't result in many failures by accident, but nevertheless, it is
erroneous code. One case that currently triggers is the
rma/win_dynamic_rma_flush_get test, which only fails 1 out of 1000
repeats.

This patch allocates separate sreq_hdr and rreq_hdr so send and recv
won't compete for persistent strorage space, fixing the bug.

Fixes #4976.

Pending:
* [x] https://github.com/pmodels/mpich/pull/5533
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
