### PR TITLE
mpicc: fix recursive checking

### DIFF
--- a/src/env/mpicc.bash.in
+++ b/src/env/mpicc.bash.in
@@ -61,16 +61,6 @@ Show=
 # End of initialization of variables
 #---------------------------------------------------------------------
 
-# Check recursive situations
-# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
-# this script. A simple check to bail if that's the case.
-if [ -n "$MPICH_RECURSION_CHECK" ] ; then
-    echo "This script ($0) is being called recursively, check that MPICH_CC does not refer to mpicc."
-    exit 1
-fi
-MPICH_RECURSION_CHECK=1
-export MPICH_RECURSION_CHECK
-
 # Environment Variables.
 # The environment variables MPICH_CC may be used to override the 
 # default choices.
@@ -223,6 +213,16 @@ if [ $# -eq 0 ] ; then
     "$0" -help
     exit 1
 fi
+
+# Check recursive situations
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_CC does not refer to mpicc."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
 
 # -----------------------------------------------------------------------
 # Derived variables.  These are assembled from variables set from the

--- a/src/env/mpicc.sh.in
+++ b/src/env/mpicc.sh.in
@@ -61,16 +61,6 @@ Show=eval
 # End of initialization of variables
 #---------------------------------------------------------------------
 
-# Check recursive situations
-# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
-# this script. A simple check to bail if that's the case.
-if [ -n "$MPICH_RECURSION_CHECK" ] ; then
-    echo "This script ($0) is being called recursively, check that MPICH_CC does not refer to mpicc."
-    exit 1
-fi
-MPICH_RECURSION_CHECK=1
-export MPICH_RECURSION_CHECK
-
 # Environment Variables.
 # The environment variables MPICH_CC may be used to override the 
 # default choices.
@@ -229,6 +219,16 @@ if [ $# -eq 0 ] ; then
     "$0" -help
     exit 1
 fi
+
+# Check recursive situations
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_CC does not refer to mpicc."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
 
 # -----------------------------------------------------------------------
 # Derived variables.  These are assembled from variables set from the


### PR DESCRIPTION

## Pull Request Description

When user run mpicc without argument, the script will try call itself
with `-help` option. This triggers the recursive checking, resulting
rather confusing error message to the user. Move the recursive checking
after the commandline processing should fix it.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
