### PR TITLE
ch4/ofi: Add few missing inline specifiers

### DIFF
--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -1044,17 +1044,17 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_rma_set_am_flag(void)
     MPL_atomic_store_int(&MPIDIG_global.rma_am_flag, 1);
 }
 
-static void update_sender_vci(MPIR_Comm * comm, int value)
+MPL_STATIC_INLINE_PREFIX void update_sender_vci(MPIR_Comm * comm, int value)
 {
     comm->hints[MPIR_COMM_HINT_SENDER_VCI] = value % MPIDI_global.n_vcis;
 }
 
-static void update_receiver_vci(MPIR_Comm * comm, int value)
+MPL_STATIC_INLINE_PREFIX void update_receiver_vci(MPIR_Comm * comm, int value)
 {
     comm->hints[MPIR_COMM_HINT_RECEIVER_VCI] = value % MPIDI_global.n_vcis;
 }
 
-static void update_comm_vci(MPIR_Comm * comm, int value)
+MPL_STATIC_INLINE_PREFIX void update_comm_vci(MPIR_Comm * comm, int value)
 {
     /* update the comm hints vci, sender_vci, and receiver_vci */
     comm->hints[MPIR_COMM_HINT_VCI] = value % MPIDI_global.n_vcis;


### PR DESCRIPTION
## Pull Request Description

Adding the `inline` specifier that was missing in a few APIs. 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
