### PR TITLE
mpi: MPI_Initialized should not depend on MPI_Finalize

### DIFF
--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -86,7 +86,9 @@ static inline void MPII_world_set_finalized(void)
 
 static inline bool MPII_world_is_initialized(void)
 {
-    return (MPL_atomic_load_int(&MPIR_world_model_state) == MPICH_WORLD_MODEL_INITIALIZED);
+    /* Note: the standards says that whether MPI_FINALIZE has been called does
+     * not affect the behavior of MPI_INITIALIZED. */
+    return (MPL_atomic_load_int(&MPIR_world_model_state) != MPICH_WORLD_MODEL_UNINITIALIZED);
 }
 
 static inline bool MPII_world_is_finalized(void)


### PR DESCRIPTION
## Pull Request Description

The standard says that whether MPI_FINALIZE has been called does not
affect the behavior of MPI_INITIALIZED.

Fixes #5529


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
