### PR TITLE
ch4/ofi:  avoid fi_sendv

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.c
@@ -44,6 +44,6 @@ int MPIDI_OFI_am_rdma_read_ack_handler(void *am_hdr, void *data,
 
 int MPIDI_OFI_am_rdma_read_recv_cb(MPIR_Request * rreq)
 {
-    return do_long_am_recv(MPIDI_OFI_AM_RREQ_HDR(rreq, lmt_info).reg_sz, rreq,
-                           &MPIDI_OFI_AM_RREQ_HDR(rreq, lmt_info));
+    MPIDI_OFI_lmt_msg_payload_t *lmt_info = (void *) MPIDI_OFI_AM_RREQ_HDR(rreq, am_hdr_buf);
+    return do_long_am_recv(lmt_info->reg_sz, rreq, lmt_info);
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -205,6 +205,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_init_sreq(const void *am_hdr, size_t a
 
         sreq_hdr->am_hdr = (void *) &sreq_hdr->am_hdr_buf[0];
         sreq_hdr->am_hdr_sz = am_hdr_sz;
+        sreq_hdr->pack_buffer = NULL;
     } else {
         sreq_hdr = MPIDI_OFI_AMREQUEST(sreq, sreq_hdr);
     }
@@ -229,6 +230,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_init_rreq(MPIR_Request * rreq)
                                            (void **) &rreq_hdr);
         MPIR_Assert(rreq_hdr);
         MPIDI_OFI_AMREQUEST(rreq, rreq_hdr) = rreq_hdr;
+        rreq_hdr->pack_buffer = NULL;
     }
 
     MPIR_FUNC_EXIT;
@@ -510,7 +512,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_eager(int rank, MPIR_Comm * c
     } else {
         MPIDI_Datatype_check_lb(datatype, dt_true_lb);
         send_buf = (char *) buf + dt_true_lb;
-        MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer) = NULL;
     }
 
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -710,7 +711,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
                                            (void **) &send_req);
         MPIR_Assert(send_req);
         send_req->sreq = sreq;
-        send_req->pack_buffer = NULL;
     }
 
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -807,7 +807,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_rdma_read(int rank, MPIR_Comm
     } else {
         MPIDI_Datatype_check_lb(datatype, dt_true_lb);
         send_buf = (char *) buf + dt_true_lb;
-        MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer) = NULL;
     }
 
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,

--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -9,9 +9,6 @@
 #define MPIDI_OFI_OFF     0
 #define MPIDI_OFI_ON      1
 
-/* FIXME: check capability for fi_sendv */
-#define MPIDI_OFI_ENABLE_SENDV 0
-
 /* Check to see if the OFI library supports FI_ORDER_ATOMIC_* flags. */
 #if defined(FI_ORDER_ATOMIC_RAR) && defined(FI_ORDER_ATOMIC_RAW) && defined(FI_ORDER_ATOMIC_WAR) && defined(FI_ORDER_ATOMIC_WAW)
 /* Support for atomic flags was added in OFI 1.8. */

--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -9,6 +9,9 @@
 #define MPIDI_OFI_OFF     0
 #define MPIDI_OFI_ON      1
 
+/* FIXME: check capability for fi_sendv */
+#define MPIDI_OFI_ENABLE_SENDV 0
+
 /* Check to see if the OFI library supports FI_ORDER_ATOMIC_* flags. */
 #if defined(FI_ORDER_ATOMIC_RAR) && defined(FI_ORDER_ATOMIC_RAW) && defined(FI_ORDER_ATOMIC_WAR) && defined(FI_ORDER_ATOMIC_WAW)
 /* Support for atomic flags was added in OFI 1.8. */

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -711,8 +711,8 @@ static int am_read_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * 
     } else {
         comm = rreq->comm;
     }
-    mpi_errno = MPIDI_OFI_do_am_rdma_read_ack(MPIDI_OFI_AM_RREQ_HDR(rreq, lmt_info).src_rank,
-                                              comm, MPIDI_OFI_AM_RREQ_HDR(rreq, lmt_info).sreq_ptr);
+    MPIDI_OFI_lmt_msg_payload_t *lmt_info = (void *) MPIDI_OFI_AM_RREQ_HDR(rreq, am_hdr_buf);
+    mpi_errno = MPIDI_OFI_do_am_rdma_read_ack(lmt_info->src_rank, comm, lmt_info->sreq_ptr);
 
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -531,7 +531,7 @@ static int am_isend_pipeline_event(int vni, struct fi_cq_tagged_entry *wc,
     MPIR_FUNC_ENTER;
 
     ofi_req = MPL_container_of(wc->op_context, MPIDI_OFI_am_send_pipeline_request_t, context);
-    msg_hdr = &ofi_req->msg_hdr;
+    msg_hdr = ofi_req->msg_hdr;
     sreq = ofi_req->sreq;
     MPID_Request_complete(sreq);        /* FIXME: Should not call MPIDI in NM ? */
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1474,6 +1474,15 @@ static void dump_global_settings(void)
     fprintf(stdout, "rx_iov_limit: " MPI_AINT_FMT_DEC_SPEC "\n", MPIDI_OFI_global.rx_iov_limit);
     fprintf(stdout, "rma_iov_limit: " MPI_AINT_FMT_DEC_SPEC "\n", MPIDI_OFI_global.rma_iov_limit);
     fprintf(stdout, "max_mr_key_size: %" PRIu64 "\n", MPIDI_OFI_global.max_mr_key_size);
+    /* Print various size limits */
+    fprintf(stdout, "==== Various sizes and limits ====\n");
+    fprintf(stdout, "MPIDI_OFI_AM_MSG_HEADER_SIZE: %d\n", (int) MPIDI_OFI_AM_MSG_HEADER_SIZE);
+    fprintf(stdout, "MPIDI_OFI_MAX_AM_HDR_SIZE: %d\n", (int) MPIDI_OFI_MAX_AM_HDR_SIZE);
+    fprintf(stdout, "sizeof(MPIDI_OFI_am_request_header_t): %d\n",
+            (int) sizeof(MPIDI_OFI_am_request_header_t));
+    fprintf(stdout, "MPIDI_OFI_AM_HDR_POOL_CELL_SIZE: %d\n", (int) MPIDI_OFI_AM_HDR_POOL_CELL_SIZE);
+    fprintf(stdout, "MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE: %d\n",
+            (int) MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE);
 }
 
 static void dump_dynamic_settings(void)

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -136,16 +136,25 @@ typedef struct {
         uint64_t lmt_cntr;
         MPIDI_OFI_lmt_unpack_t unpack;
     } lmt_u;
-    void *pack_buffer;
     MPIR_Request *rreq_ptr;
     void *am_hdr;
     uint16_t am_hdr_sz;
-    uint8_t pad[6];
-    MPIDI_OFI_am_header_t msg_hdr;
-    uint8_t am_hdr_buf[MPIDI_OFI_MAX_AM_HDR_SIZE];
+    /* used for packing non-contig data or the whole am message when payload doesn't fit */
+    void *pack_buffer;
     /* FI_ASYNC_IOV requires an iov storage to be alive until a request completes */
     struct iovec iov[3];
+    /* AM send buffers, must be together so we can send without sendv.
+     * Note: since we allocate from genq pool, there may be some additional space
+     * to pack a small payload */
+    MPIDI_OFI_am_header_t msg_hdr;
+    uint8_t am_hdr_buf[MPIDI_OFI_MAX_AM_HDR_SIZE];
 } MPIDI_OFI_am_request_header_t;
+
+#define MPIDI_OFI_AM_HDR_POOL_CELL_SIZE             (1024)
+#define MPIDI_OFI_AM_HDR_POOL_NUM_CELLS_PER_CHUNK   (1024)
+/* maximum am message size that can fit into request header buffer */
+#define MPIDI_OFI_AM_MAX_MSG_SIZE \
+    (MPIDI_OFI_AM_HDR_POOL_CELL_SIZE - offsetof(MPIDI_OFI_am_request_header_t, msg_hdr))
 
 typedef struct MPIDI_OFI_deferred_am_isend_req {
     int op;

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -116,6 +116,7 @@ typedef struct {
 } MPIDI_OFI_lmt_msg_t;
 
 typedef struct {
+    uint64_t rma_key;
     void *unpack_buffer;
     MPI_Aint pack_size;
     uint64_t src_offset;
@@ -129,7 +130,6 @@ typedef enum {
 } MPIDI_OFI_lmt_type_t;
 
 typedef struct {
-    MPIDI_OFI_lmt_msg_payload_t lmt_info;
     struct fid_mr *lmt_mr;
     MPIDI_OFI_lmt_type_t lmt_type;
     union {

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -172,11 +172,11 @@ typedef struct MPIDI_OFI_am_send_pipeline_request {
     struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];       /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     MPIR_Request *sreq;
-    void *pack_buffer;
+    void *pack_buffer;          /* always allocated from pack_buf_pool */
+    void *msg_hdr;
     void *am_hdr;
-    uint16_t am_hdr_sz;
-    MPIDI_OFI_am_header_t msg_hdr MPL_ATTR_ALIGNED(MAX_ALIGNMENT);
-    uint8_t am_hdr_buf[MPIDI_OFI_MAX_AM_HDR_SIZE] MPL_ATTR_ALIGNED(MAX_ALIGNMENT);
+    void *am_data;
+    MPIDI_OFI_am_header_t msg_hdr_data MPL_ATTR_ALIGNED(MAX_ALIGNMENT);
     /* FI_ASYNC_IOV requires an iov storage to be alive until a request completes */
     struct iovec iov[3];
 } MPIDI_OFI_am_send_pipeline_request_t;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -31,8 +31,6 @@
 #define MPIDI_OFI_MAX_NUM_AM_BUFFERS       (8)
 #define MPIDI_OFI_AM_BUFF_SZ               (1 * 1024 * 1024)
 #define MPIDI_OFI_IOV_MAX                  (32)
-#define MPIDI_OFI_AM_HDR_POOL_CELL_SIZE            (1024)
-#define MPIDI_OFI_AM_HDR_POOL_NUM_CELLS_PER_CHUNK   (1024)
 #define MPIDI_OFI_NUM_CQ_BUFFERED          (1024)
 #define MPIDI_OFI_STRIPE_CHUNK_SIZE        (2048)       /* First chunk sent through the preferred NIC during striping */
 


### PR DESCRIPTION
## Pull Request Description
`fi_sendv` may not be available for some providers. Add options to not to use `fi_sendv`
in the ofi am paths.

TODO:
* [x] request_pool is not registered, double check it is not used as gpu pack buffer.
* [ ] evaluate performance impact

## Notes
The changes look a bit complex than they actually are. Part of the reason is this deferred branch that convolute all paths. With #5533, we may be able to remove the deferred options altogether, and the changes here (and the code overall) should be much simpler.
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
