### PR TITLE
ch4/ofi: enable am even when RMA is disabled

### DIFF
--- a/src/mpid/ch4/netmod/ofi/init_settings.c
+++ b/src/mpid/ch4/netmod/ofi/init_settings.c
@@ -341,8 +341,7 @@ void MPIDI_OFI_update_global_settings(struct fi_info *prov)
                            (prov->caps & FI_DIRECTED_RECV) &&
                            (prov->domain_attr->cq_data_size >= MPIDI_OFI_MIN_CQ_DATA_SIZE));
     UPDATE_SETTING_BY_INFO(enable_am,
-                           (prov->caps & (FI_MSG | FI_MULTI_RECV | FI_READ)) ==
-                           (FI_MSG | FI_MULTI_RECV | FI_READ));
+                           (prov->caps & (FI_MSG | FI_MULTI_RECV)) == (FI_MSG | FI_MULTI_RECV));
     UPDATE_SETTING_BY_INFO(enable_rma, prov->caps & FI_RMA);
     UPDATE_SETTING_BY_INFO(enable_atomics, prov->caps & FI_ATOMICS);
 #ifdef FI_HMEM


### PR DESCRIPTION
## Pull Request Description

Now we have the pipeline mode, we can fallback to am even when rdma is
not available. The am facility no longer depend on the `FI_READ` capability.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
