### PR TITLE
ch4/ucx: enable multiple vci in am

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -54,7 +54,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
 
     MPIR_FUNC_ENTER;
 
-    ep = MPIDI_UCX_COMM_TO_EP(comm, rank, 0, 0);
+    int src_vni = src_vci % MPIDI_UCX_global.num_vnis;
+    int dst_vni = dst_vci % MPIDI_UCX_global.num_vnis;
+    ep = MPIDI_UCX_COMM_TO_EP(comm, rank, src_vni, dst_vni);
 
     int dt_contig;
     size_t data_sz;
@@ -182,7 +184,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
 
     MPIR_FUNC_ENTER;
 
-    ep = MPIDI_UCX_COMM_TO_EP(comm, rank, 0, 0);
+    int src_vni = src_vci % MPIDI_UCX_global.num_vnis;
+    int dst_vni = dst_vci % MPIDI_UCX_global.num_vnis;
+    ep = MPIDI_UCX_COMM_TO_EP(comm, rank, src_vni, dst_vni);
 
     /* initialize our portion of the hdr */
     ucx_hdr.handler_id = handler_id;

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -66,6 +66,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
 
     /* initialize our portion of the hdr */
     ucx_hdr.handler_id = handler_id;
+    ucx_hdr.src_vci = src_vni;
+    ucx_hdr.dst_vci = dst_vni;
     ucx_hdr.data_sz = data_sz;
 
     MPL_pointer_attr_t attr;
@@ -190,6 +192,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
 
     /* initialize our portion of the hdr */
     ucx_hdr.handler_id = handler_id;
+    ucx_hdr.src_vci = src_vni;
+    ucx_hdr.dst_vci = dst_vni;
     ucx_hdr.data_sz = 0;
 
     /* just pack and send for now */

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -75,6 +75,11 @@ static int init_worker(int vni)
     MPIDI_UCX_CHK_STATUS(ucx_status);
     MPIR_Assert(MPIDI_UCX_global.ctx[vni].addrname_len <= INT_MAX);
 
+    ucx_status = ucp_worker_set_am_handler(MPIDI_UCX_global.ctx[vni].worker,
+                                           MPIDI_UCX_AM_HANDLER_ID,
+                                           &MPIDI_UCX_am_handler, NULL, UCP_AM_FLAG_WHOLE_MSG);
+    MPIDI_UCX_CHK_STATUS(ucx_status);
+
   fn_exit:
     return mpi_errno;
   fn_fail:
@@ -278,11 +283,6 @@ int MPIDI_UCX_init_world(void)
     /* initialize worker for vni 0 */
     mpi_errno = init_worker(0);
     MPIR_ERR_CHECK(mpi_errno);
-
-    ucs_status_t ucx_status =
-        ucp_worker_set_am_handler(MPIDI_UCX_global.ctx[0].worker, MPIDI_UCX_AM_HANDLER_ID,
-                                  &MPIDI_UCX_am_handler, NULL, UCP_AM_FLAG_WHOLE_MSG);
-    MPIDI_UCX_CHK_STATUS(ucx_status);
 
     mpi_errno = initial_address_exchange();
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/netmod/ucx/ucx_pre.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_pre.h
@@ -36,7 +36,9 @@ typedef struct {
 } MPIDI_UCX_am_request_t;
 
 typedef struct MPIDI_UCX_am_header_t {
-    uint64_t handler_id;
+    uint16_t handler_id;
+    uint8_t src_vci;
+    uint8_t dst_vci;
     uint64_t data_sz;
     uint64_t payload[];
 } MPIDI_UCX_am_header_t;

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.c
@@ -20,6 +20,7 @@ ucs_status_t MPIDI_UCX_am_handler(void *arg, void *data, size_t length, ucp_ep_h
     data_sz = msg_hdr->data_sz;
 
     int attr = 0;               /* is_local = 0, is_async = 0 */
+    MPIDIG_AM_ATTR_SET_VCIS(attr, msg_hdr->src_vci, msg_hdr->dst_vci);
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->payload,
                                                        p_data, data_sz, attr, NULL);
 

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -176,8 +176,7 @@ static int win_init(MPIR_Win * win)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    /* TODO: MPIDI_WIN(win, am_vci) %= MPIDI_UCX_global.num_vnis; */
-    MPIDI_WIN(win, am_vci) = 0;
+    MPIDI_WIN(win, am_vci) %= MPIDI_UCX_global.num_vnis;
 
     memset(&MPIDI_UCX_WIN(win), 0, sizeof(MPIDI_UCX_win_t));
 

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -8,12 +8,25 @@
 
 #include "ch4_impl.h"
 
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_CH4_GLOBAL_PROGRESS
+      category    : CH4
+      type        : boolean
+      default     : 1
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        If on, poll global progress every once a while. With per-vci configuration, turning global progress off may improve the threading performance.
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
 /* Global progress (polling every vci) is required for correctness. Currently we adopt the
  * simple approach to do global progress every MPIDI_CH4_PROG_POLL_MASK.
- *
- * TODO: every time we do global progress, there will be a performance lag. We could --
- * * amortize the cost by rotating the global vci to be polled (might be insufficient)
- * * accept user hints (require new user interface)
  */
 #define MPIDI_CH4_PROG_POLL_MASK 0xff
 
@@ -34,7 +47,7 @@ extern int global_vci_poll_count;
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_do_global_progress(void)
 {
-    if (MPIDI_global.n_vcis == 1 || !MPIDI_global.is_initialized) {
+    if (MPIDI_global.n_vcis == 1 || !MPIDI_global.is_initialized || !MPIR_CVAR_CH4_GLOBAL_PROGRESS) {
         return 0;
     } else {
         global_vci_poll_count++;

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1565,6 +1565,7 @@
 /threads/mpi_t/mpit_threading
 /threads/part/parrived_wait
 /threads/perf/mt_pt2pt_msgrate
+/threads/perf/mt_rma_msgrate
 /threads/pt2pt/alltoall
 /threads/pt2pt/greq_test
 /threads/pt2pt/greq_wait

--- a/test/mpi/threads/perf/Makefile.am
+++ b/test/mpi/threads/perf/Makefile.am
@@ -7,4 +7,6 @@ include $(top_srcdir)/Makefile_threads.mtest
 
 EXTRA_DIST = testlist
 
-noinst_PROGRAMS = mt_pt2pt_msgrate
+noinst_PROGRAMS = \
+	mt_pt2pt_msgrate \
+	mt_rma_msgrate

--- a/test/mpi/threads/perf/mt_rma_msgrate.c
+++ b/test/mpi/threads/perf/mt_rma_msgrate.c
@@ -15,7 +15,10 @@
 #include "mpitest.h"
 #include "mpithreadtest.h"
 
-#define CACHELINE_SIZE 64
+/* Alignment prevents either false-sharing on the CPU or serialization in the
+ * NIC's parallel TLB engine. At least it need be cacheline size. Using page
+ * size for optimum results. */
+#define BUFFER_ALIGNMENT 4096
 
 #define MESSAGE_SIZE 8
 #define NUM_MESSAGES 64000
@@ -55,16 +58,13 @@ MTEST_THREAD_RETURN_TYPE thread_fn(void *arg)
     win_posts = NUM_MESSAGES / WINDOW_SIZE;
     assert(win_posts * WINDOW_SIZE == NUM_MESSAGES);
 
-    /* Allocate a cache-aligned buffer to prevent potential effects of serialization:
-     * either false-sharing on the CPU or serialization in the NIC's parallel TLB
-     * engine
-     */
-    error = posix_memalign(&buf, CACHELINE_SIZE, MESSAGE_SIZE * sizeof(char));
+    /* Allocate origin buffer */
+    error = posix_memalign(&buf, BUFFER_ALIGNMENT, MESSAGE_SIZE * sizeof(char));
     if (error) {
         fprintf(stderr, "Thread %d: Error in allocating origin buffer\n", tid);
     }
     /* Allocate result_buf for OP_GACC */
-    error = posix_memalign(&result_buf, CACHELINE_SIZE, MESSAGE_SIZE * sizeof(char));
+    error = posix_memalign(&result_buf, BUFFER_ALIGNMENT, MESSAGE_SIZE * sizeof(char));
     if (error) {
         fprintf(stderr, "Thread %d: Error in allocating result buffer\n", tid);
     }
@@ -160,8 +160,8 @@ int main(int argc, char *argv[])
 
     /* Create a window per thread */
     int window_size = MESSAGE_SIZE;
-    if (window_size % CACHELINE_SIZE) {
-        window_size += (CACHELINE_SIZE - window_size % CACHELINE_SIZE);
+    if (window_size % BUFFER_ALIGNMENT) {
+        window_size += (BUFFER_ALIGNMENT - window_size % BUFFER_ALIGNMENT);
     }
     for (int i = 0; i < num_threads; i++) {
         void *mybase;

--- a/test/mpi/threads/perf/mt_rma_msgrate.c
+++ b/test/mpi/threads/perf/mt_rma_msgrate.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+/* This program provides a simple test of send-receive performance between
+   two (or more) processes.  This sometimes called head-to-head or
+   ping-ping test, as both processes send at the same time.
+*/
+
+#include "mpi.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "mpitest.h"
+#include "mpithreadtest.h"
+
+#define CACHELINE_SIZE 64
+
+#define MESSAGE_SIZE 8
+#define NUM_MESSAGES 64000
+#define WINDOW_SIZE 64
+
+#define ERROR_MARGIN 0.05       /* FIXME: a better margin? */
+
+enum RMA_OPs {
+    OP_PUT,
+    OP_GET,
+    OP_ACC,
+    OP_GACC,
+    OP_INVALID
+};
+
+int rma_op = OP_INVALID;
+int world_rank;
+MPI_Comm *thread_wins;
+double *t_elapsed;
+
+MTEST_THREAD_RETURN_TYPE thread_fn(void *arg);
+
+MTEST_THREAD_RETURN_TYPE thread_fn(void *arg)
+{
+    int error;
+    int tid;
+    MPI_Win my_win;
+    int win_i, win_post_i, win_posts;
+    void *buf, *result_buf;
+    MPI_Request requests[WINDOW_SIZE];
+    MPI_Status statuses[WINDOW_SIZE];
+    double t_start, t_end;
+
+    tid = (int) (long) arg;
+    my_win = thread_wins[tid];
+
+    win_posts = NUM_MESSAGES / WINDOW_SIZE;
+    assert(win_posts * WINDOW_SIZE == NUM_MESSAGES);
+
+    /* Allocate a cache-aligned buffer to prevent potential effects of serialization:
+     * either false-sharing on the CPU or serialization in the NIC's parallel TLB
+     * engine
+     */
+    error = posix_memalign(&buf, CACHELINE_SIZE, MESSAGE_SIZE * sizeof(char));
+    if (error) {
+        fprintf(stderr, "Thread %d: Error in allocating origin buffer\n", tid);
+    }
+    /* Allocate result_buf for OP_GACC */
+    error = posix_memalign(&result_buf, CACHELINE_SIZE, MESSAGE_SIZE * sizeof(char));
+    if (error) {
+        fprintf(stderr, "Thread %d: Error in allocating result buffer\n", tid);
+    }
+
+    /* Benchmark */
+    t_start = MPI_Wtime();
+
+    for (win_post_i = 0; win_post_i < win_posts; win_post_i++) {
+        MPI_Win_fence(0, my_win);
+        if (world_rank == 0) {
+            for (win_i = 0; win_i < WINDOW_SIZE; win_i++) {
+                if (rma_op == OP_PUT) {
+                    MPI_Put(buf, MESSAGE_SIZE, MPI_CHAR, 1, 0, MESSAGE_SIZE, MPI_CHAR, my_win);
+                } else if (rma_op == OP_GET) {
+                    MPI_Get(buf, MESSAGE_SIZE, MPI_CHAR, 1, 0, MESSAGE_SIZE, MPI_CHAR, my_win);
+                } else if (rma_op == OP_ACC) {
+                    MPI_Accumulate(buf, MESSAGE_SIZE, MPI_CHAR, 1, 0, MESSAGE_SIZE, MPI_CHAR,
+                                   MPI_REPLACE, my_win);
+                } else if (rma_op == OP_GACC) {
+                    MPI_Get_accumulate(buf, MESSAGE_SIZE, MPI_CHAR,
+                                       result_buf, MESSAGE_SIZE, MPI_CHAR,
+                                       1, 0, MESSAGE_SIZE, MPI_CHAR, MPI_NO_OP, my_win);
+                }
+            }
+        }
+        MPI_Win_fence(0, my_win);
+    }
+
+    if (world_rank == 0) {
+        t_end = MPI_Wtime();
+        t_elapsed[tid] = t_end - t_start;
+    }
+
+    free(buf);
+    free(result_buf);
+    return 0;
+}
+
+
+int main(int argc, char *argv[])
+{
+    int size;
+    int provided;
+    int num_threads;
+    double onethread_msg_rate, multithread_msg_rate;
+    int errors;
+
+    if (argc > 2) {
+        fprintf(stderr, "Can support at most only the -nthreads argument.\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+
+    if (provided != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr, "MPI_THREAD_MULTIPLE required for this test.\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    if (size != 2) {
+        fprintf(stderr, "please run with exactly two processes.\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    errors = MTest_thread_barrier_init();
+    if (errors) {
+        fprintf(stderr, "Could not create thread barrier\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MTestArgList *head = MTestArgListCreate(argc, argv);
+    num_threads = MTestArgListGetInt_with_default(head, "nthreads", 4);
+    const char *tmp_str = MTestArgListGetString_with_default(head, "op", "put");
+    if (strcmp(tmp_str, "put") == 0) {
+        rma_op = OP_PUT;
+    } else if (strcmp(tmp_str, "get") == 0) {
+        rma_op = OP_GET;
+    } else if (strcmp(tmp_str, "acc") == 0) {
+        rma_op = OP_ACC;
+    } else if (strcmp(tmp_str, "gacc") == 0) {
+        rma_op = OP_GACC;
+    } else {
+        fprintf(stderr, "Invalid op - %s\n", tmp_str);
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MTestArgListDestroy(head);
+
+    thread_wins = (MPI_Win *) malloc(sizeof(MPI_Win) * num_threads);
+    t_elapsed = calloc(num_threads, sizeof(double));
+
+    /* Create a window per thread */
+    int window_size = MESSAGE_SIZE;
+    if (window_size % CACHELINE_SIZE) {
+        window_size += (CACHELINE_SIZE - window_size % CACHELINE_SIZE);
+    }
+    for (int i = 0; i < num_threads; i++) {
+        void *mybase;
+        MPI_Win_allocate(window_size, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &mybase, &thread_wins[i]);
+    }
+
+    /* Run test with 1 thread */
+    thread_fn((void *) 0);
+    onethread_msg_rate = ((double) NUM_MESSAGES / t_elapsed[0]) / 1e6;
+
+    /* Run test with multiple threads */
+    for (int i = 1; i < num_threads; i++) {
+        MTest_Start_thread(thread_fn, (void *) (long) i);
+    }
+    thread_fn((void *) 0);
+
+    MTest_Join_threads();
+
+    MTest_thread_barrier_free();
+
+    /* Calculate message rate with multiple threads */
+    if (world_rank == 0) {
+        MTestPrintfMsg(1, "Number of messages: %d\n", NUM_MESSAGES);
+        MTestPrintfMsg(1, "Message size: %d\n", MESSAGE_SIZE);
+        MTestPrintfMsg(1, "Window size: %d\n", WINDOW_SIZE);
+        MTestPrintfMsg(1, "Mmsgs/s with one thread: %-10.2f\n\n", onethread_msg_rate);
+        MTestPrintfMsg(1, "%-10s\t%-10s\t%-10s\n", "Thread", "Mmsgs/s", "Error");
+
+        multithread_msg_rate = 0;
+        errors = 0;
+        for (int tid = 0; tid < num_threads; tid++) {
+            double my_msg_rate = ((double) NUM_MESSAGES / t_elapsed[tid]) / 1e6;
+            int my_error = 0;
+            if ((1 - (my_msg_rate / onethread_msg_rate)) > ERROR_MARGIN) {
+                /* Erroneous */
+                errors++;
+                my_error = 1;
+                fprintf(stderr,
+                        "Thread %d message rate below threshold: %.2f / %.2f = %.2f (threshold = %.2f)\n",
+                        tid, my_msg_rate, onethread_msg_rate, (my_msg_rate / onethread_msg_rate),
+                        ERROR_MARGIN);
+            }
+            MTestPrintfMsg(1, "%-10d\t%-10.2f\t%-10d\n", tid, my_msg_rate, my_error);
+            multithread_msg_rate += my_msg_rate;
+        }
+        MTestPrintfMsg(1, "\n%-10s\t%-10s\t%-10s\t%-10s\n", "Size", "Threads", "Mmsgs/s", "Errors");
+        MTestPrintfMsg(1, "%-10d\t%-10d\t%-10.2f\t%-10d\n", MESSAGE_SIZE, num_threads,
+                       multithread_msg_rate, errors);
+    }
+
+    for (int i = 0; i < num_threads; i++) {
+        MPI_Win_free(&thread_wins[i]);
+    }
+    free(thread_wins);
+    free(t_elapsed);
+
+    MTest_Finalize(errors);
+
+    return 0;
+}


### PR DESCRIPTION
## Pull Request Description
This PR is based on https://github.com/pmodels/mpich/pull/5543 

Enable ucx netmod to use multiple vci in the active message path. Currently, ucx doesn't have a fallback path for pt2pt operations, so we only need to enable it for the RMA functions.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
