### PR TITLE
ch4/ofi: enable multiple vci for am

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -19,6 +19,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_short_am(MPIDI_OFI_am_header_t * m
     MPIR_FUNC_ENTER;
 
     int attr = 0;               /* is_local = 0, is_async = 0 */
+    MPIDIG_AM_ATTR_SET_VCIS(attr, msg_hdr->vni_src, msg_hdr->vni_dst);
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr,
                                                        p_data, msg_hdr->payload_sz, attr, NULL);
 
@@ -46,6 +47,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_pipeline(MPIDI_OFI_am_header_t * m
 
     if (!rreq) {
         int attr = MPIDIG_AM_ATTR__IS_ASYNC;
+        MPIDIG_AM_ATTR_SET_VCIS(attr, msg_hdr->vni_src, msg_hdr->vni_dst);
         MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, p_data, msg_hdr->payload_sz,
                                                            attr, &rreq);
         MPIDIG_recv_setup(rreq);
@@ -70,6 +72,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_short_am_hdr(MPIDI_OFI_am_header_t
     MPIR_FUNC_ENTER;
 
     int attr = 0;
+    MPIDIG_AM_ATTR_SET_VCIS(attr, msg_hdr->vni_src, msg_hdr->vni_dst);
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, NULL, 0, attr, NULL);
 
     MPIR_FUNC_EXIT;
@@ -159,6 +162,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_rdma_read(MPIDI_OFI_am_header_t * 
     MPIR_FUNC_ENTER;
 
     int attr = MPIDIG_AM_ATTR__IS_ASYNC | MPIDIG_AM_ATTR__IS_RNDV | MPIDI_OFI_AM_ATTR__RDMA;
+    MPIDIG_AM_ATTR_SET_VCIS(attr, msg_hdr->vni_src, msg_hdr->vni_dst);
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, NULL, 0, attr, &rreq);
 
     if (!rreq)

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -93,7 +93,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
         curr_len = MPL_MIN(rem, MPIDI_OFI_global.max_msg_size);
 
         MPIR_Assert(sizeof(MPIDI_OFI_am_request_t) <= MPIDI_OFI_AM_HDR_POOL_CELL_SIZE);
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.am_hdr_buf_pool, (void **) &am_req);
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[0].am_hdr_buf_pool,
+                                           (void **) &am_req);
         MPIR_Assert(am_req);
 
         am_req->rreq_hdr = MPIDI_OFI_AMREQUEST(rreq, rreq_hdr);

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -89,11 +89,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
 
     rem = data_sz;
 
+    int vni_local = MPIDIG_REQUEST(rreq, req->local_vci);
+    int vni_remote = MPIDIG_REQUEST(rreq, req->remote_vci);
     while (done != data_sz) {
         curr_len = MPL_MIN(rem, MPIDI_OFI_global.max_msg_size);
 
         MPIR_Assert(sizeof(MPIDI_OFI_am_request_t) <= MPIDI_OFI_AM_HDR_POOL_CELL_SIZE);
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[0].am_hdr_buf_pool,
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[vni_local].am_hdr_buf_pool,
                                            (void **) &am_req);
         MPIR_Assert(am_req);
 
@@ -106,9 +108,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
         }
         MPIR_Assert(comm);
 
-        /* am uses vni 0 */
-        int vni_local = 0;
-        int vni_remote = 0;
+        /* am uses nic 0 */
         int nic = 0;
         MPIDI_OFI_cntr_incr(comm, vni_local, nic);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -256,6 +256,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
     msg_hdr->am_hdr_sz = MPIDI_OFI_AM_SREQ_HDR(sreq, am_hdr_sz);
     msg_hdr->payload_sz = 0;    /* LMT info sent as header */
     msg_hdr->am_type = MPIDI_AMTYPE_RDMA_READ;
+    msg_hdr->vni_src = vni_src;
+    msg_hdr->vni_dst = vni_dst;
     msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank, vni_src);
     msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, vni_src, vni_src);
 
@@ -334,6 +336,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm
     msg_hdr->am_hdr_sz = MPIDI_OFI_AM_SREQ_HDR(sreq, am_hdr_sz);
     msg_hdr->payload_sz = data_sz;
     msg_hdr->am_type = MPIDI_AMTYPE_SHORT;
+    msg_hdr->vni_src = vni_src;
+    msg_hdr->vni_dst = vni_dst;
     msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank, vni_src);
     msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, vni_src, vni_src);
 
@@ -382,6 +386,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
     msg_hdr->handler_id = handler_id;
     msg_hdr->payload_sz = seg_sz;
     msg_hdr->am_type = MPIDI_AMTYPE_PIPELINE;
+    msg_hdr->vni_src = vni_src;
+    msg_hdr->vni_dst = vni_dst;
     msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank, vni_src);
     msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, vni_src, vni_src);
 
@@ -586,6 +592,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
     msg_hdr.am_hdr_sz = am_hdr_sz;
     msg_hdr.payload_sz = 0;
     msg_hdr.am_type = MPIDI_AMTYPE_SHORT_HDR;
+    msg_hdr.vni_src = vni_src;
+    msg_hdr.vni_dst = vni_dst;
     msg_hdr.seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank, vni_src);
     msg_hdr.fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, vni_src, vni_src);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -11,7 +11,7 @@
 
 #define MPIDI_OFI_AM_ATTR__RDMA (1 << MPIDIG_AM_ATTR_TRANSPORT_SHIFT)
 
-int MPIDI_OFI_am_repost_buffer(int am_idx);
+int MPIDI_OFI_am_repost_buffer(int vni, int am_idx);
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_progress_do_queue(int vni_idx);
 
 /* active message ordering --
@@ -27,23 +27,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_progress_do_queue(int vni_idx);
  */
 
 MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_fetch_incr_send_seqno(MPIR_Comm * comm,
-                                                                     int dest_rank)
+                                                                     int dest_rank, int vni)
 {
     int nic = 0;
-    fi_addr_t addr = MPIDI_OFI_comm_to_phys(comm, dest_rank, nic, 0, 0);
+    fi_addr_t addr = MPIDI_OFI_comm_to_phys(comm, dest_rank, nic, vni, 0);
     uint64_t id = addr;
     uint16_t seq, old_seq;
     void *ret;
 
-    ret = MPIDIU_map_lookup(MPIDI_OFI_global.per_vni[0].am_send_seq_tracker, id);
+    ret = MPIDIU_map_lookup(MPIDI_OFI_global.per_vni[vni].am_send_seq_tracker, id);
     if (ret == MPIDIU_MAP_NOT_FOUND)
         old_seq = 0;
     else
         old_seq = (uint16_t) (uintptr_t) ret;
 
     seq = old_seq + 1;
-    MPIDIU_map_update(MPIDI_OFI_global.per_vni[0].am_send_seq_tracker, id, (void *) (uintptr_t) seq,
-                      MPL_MEM_OTHER);
+    MPIDIU_map_update(MPIDI_OFI_global.per_vni[vni].am_send_seq_tracker, id,
+                      (void *) (uintptr_t) seq, MPL_MEM_OTHER);
 
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     (MPL_DBG_FDEST,
@@ -55,34 +55,36 @@ MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_fetch_incr_send_seqno(MPIR_Comm *
     return old_seq;
 }
 
-MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_get_next_recv_seqno(fi_addr_t addr)
+MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_get_next_recv_seqno(int vni, fi_addr_t addr)
 {
     uint64_t id = addr;
     void *r;
 
-    r = MPIDIU_map_lookup(MPIDI_OFI_global.per_vni[0].am_recv_seq_tracker, id);
+    r = MPIDIU_map_lookup(MPIDI_OFI_global.per_vni[vni].am_recv_seq_tracker, id);
     if (r == MPIDIU_MAP_NOT_FOUND) {
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         (MPL_DBG_FDEST, "First time adding recv seqno addr=%" PRIx64 "\n", addr));
-        MPIDIU_map_set(MPIDI_OFI_global.per_vni[0].am_recv_seq_tracker, id, 0, MPL_MEM_OTHER);
+        MPIDIU_map_set(MPIDI_OFI_global.per_vni[vni].am_recv_seq_tracker, id, 0, MPL_MEM_OTHER);
         return 0;
     } else {
         return (uint16_t) (uintptr_t) r;
     }
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_am_set_next_recv_seqno(fi_addr_t addr, uint16_t seqno)
+MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_am_set_next_recv_seqno(int vni, fi_addr_t addr,
+                                                               uint16_t seqno)
 {
     uint64_t id = addr;
 
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     (MPL_DBG_FDEST, "Next recv seqno=%d addr=%" PRIx64 "\n", seqno, addr));
 
-    MPIDIU_map_update(MPIDI_OFI_global.per_vni[0].am_recv_seq_tracker, id,
+    MPIDIU_map_update(MPIDI_OFI_global.per_vni[vni].am_recv_seq_tracker, id,
                       (void *) (uintptr_t) seqno, MPL_MEM_OTHER);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_enqueue_unordered_msg(const MPIDI_OFI_am_header_t *
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_enqueue_unordered_msg(int vni,
+                                                                const MPIDI_OFI_am_header_t *
                                                                 am_hdr)
 {
     MPIDI_OFI_am_unordered_msg_t *uo_msg;
@@ -101,7 +103,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_enqueue_unordered_msg(const MPIDI_OFI_
     packet_len = sizeof(*am_hdr) + am_hdr->am_hdr_sz + am_hdr->payload_sz;
     MPIR_Memcpy(&uo_msg->am_hdr, am_hdr, packet_len);
 
-    DL_APPEND(MPIDI_OFI_global.per_vni[0].am_unordered_msgs, uo_msg);
+    DL_APPEND(MPIDI_OFI_global.per_vni[vni].am_unordered_msgs, uo_msg);
 
     return MPI_SUCCESS;
 }
@@ -109,7 +111,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_enqueue_unordered_msg(const MPIDI_OFI_
 /* Find and dequeue a message that matches (comm, src_rank, seqno), then return it.
  * Caller must free the returned pointer. */
 MPL_STATIC_INLINE_PREFIX MPIDI_OFI_am_unordered_msg_t
-    * MPIDI_OFI_am_claim_unordered_msg(fi_addr_t addr, uint16_t seqno)
+    * MPIDI_OFI_am_claim_unordered_msg(int vni, fi_addr_t addr, uint16_t seqno)
 {
     MPIDI_OFI_am_unordered_msg_t *uo_msg;
 
@@ -118,7 +120,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_OFI_am_unordered_msg_t
      * in the queue is extremely small.
      * If it's not the case, we should consider using better data structure and algorithm
      * to look up. */
-    DL_FOREACH(MPIDI_OFI_global.per_vni[0].am_unordered_msgs, uo_msg) {
+    DL_FOREACH(MPIDI_OFI_global.per_vni[vni].am_unordered_msgs, uo_msg) {
         if (uo_msg->am_hdr.fi_src_addr == addr && uo_msg->am_hdr.seqno == seqno) {
             MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, TERSE,
                             (MPL_DBG_FDEST,
@@ -175,8 +177,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_am_clear_request(MPIR_Request * req)
 {
     MPIR_FUNC_ENTER;
 
-    MPIDI_OFI_AM_FREE_REQ_HDR(MPIDI_OFI_AMREQUEST(req, sreq_hdr), 0);
-    MPIDI_OFI_AM_FREE_REQ_HDR(MPIDI_OFI_AMREQUEST(req, rreq_hdr), 0);
+    int vni = MPIDI_Request_get_vci(req);
+    MPIDI_OFI_AM_FREE_REQ_HDR(MPIDI_OFI_AMREQUEST(req, sreq_hdr), vni);
+    MPIDI_OFI_AM_FREE_REQ_HDR(MPIDI_OFI_AMREQUEST(req, rreq_hdr), vni);
 
     MPIR_FUNC_EXIT;
 }
@@ -194,7 +197,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_init_sreq(const void *am_hdr, size_t a
     MPIR_Assert(am_hdr_sz < (1ULL << MPIDI_OFI_AM_HDR_SZ_BITS));
 
     if (MPIDI_OFI_AMREQUEST(sreq, sreq_hdr) == NULL) {
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[0].am_hdr_buf_pool,
+        int vni = MPIDI_Request_get_vci(sreq);
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[vni].am_hdr_buf_pool,
                                            (void **) &sreq_hdr);
         MPIR_Assert(sreq_hdr);
         MPIDI_OFI_AMREQUEST(sreq, sreq_hdr) = sreq_hdr;
@@ -233,14 +237,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_init_rreq(MPIR_Request * rreq)
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm, int handler_id,
                                                      const void *data, MPI_Aint data_sz,
-                                                     MPIR_Request * sreq)
+                                                     MPIR_Request * sreq, int vni_src, int vni_dst)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *msg_hdr;
     MPIDI_OFI_lmt_msg_payload_t *lmt_info;
     struct iovec *iov;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, 0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_src, nic);
 
     MPIR_FUNC_ENTER;
 
@@ -252,8 +256,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
     msg_hdr->am_hdr_sz = MPIDI_OFI_AM_SREQ_HDR(sreq, am_hdr_sz);
     msg_hdr->payload_sz = 0;    /* LMT info sent as header */
     msg_hdr->am_type = MPIDI_AMTYPE_RDMA_READ;
-    msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank);
-    msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, 0, 0);
+    msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank, vni_src);
+    msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, vni_src, vni_src);
 
     lmt_info = &MPIDI_OFI_AM_SREQ_HDR(sreq, lmt_info);
     lmt_info->context_id = comm->context_id;
@@ -300,7 +304,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
     iov[2].iov_len = sizeof(*lmt_info);
     MPIDI_OFI_AMREQUEST(sreq, event_id) = MPIDI_OFI_EVENT_AM_SEND_RDMA;
     MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_global.ctx[ctx_idx].tx, iov, NULL, 3,
-                                     MPIDI_OFI_comm_to_phys(comm, rank, nic, 0, 0),
+                                     MPIDI_OFI_comm_to_phys(comm, rank, nic, vni_src, vni_dst),
                                      &MPIDI_OFI_AMREQUEST(sreq, context)), sendv);
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -311,13 +315,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm, int handler_id,
                                                       const void *data, MPI_Aint data_sz,
-                                                      MPIR_Request * sreq)
+                                                      MPIR_Request * sreq, int vni_src, int vni_dst)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *msg_hdr;
     struct iovec *iov;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, 0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_src, nic);
 
     MPIR_FUNC_ENTER;
 
@@ -330,8 +334,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm
     msg_hdr->am_hdr_sz = MPIDI_OFI_AM_SREQ_HDR(sreq, am_hdr_sz);
     msg_hdr->payload_sz = data_sz;
     msg_hdr->am_type = MPIDI_AMTYPE_SHORT;
-    msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank);
-    msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, 0, 0);
+    msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank, vni_src);
+    msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, vni_src, vni_src);
 
     iov = MPIDI_OFI_AM_SREQ_HDR(sreq, iov);
 
@@ -347,7 +351,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm
     MPIR_cc_inc(sreq->cc_ptr);
     MPIDI_OFI_AMREQUEST(sreq, event_id) = MPIDI_OFI_EVENT_AM_SEND;
     MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_global.ctx[ctx_idx].tx, iov, NULL, 3,
-                                     MPIDI_OFI_comm_to_phys(comm, rank, nic, 0, 0),
+                                     MPIDI_OFI_comm_to_phys(comm, rank, nic, vni_src, vni_dst),
                                      &MPIDI_OFI_AMREQUEST(sreq, context)), sendv);
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -360,13 +364,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
                                                          const void *data, MPI_Aint seg_sz,
                                                          MPI_Aint data_sz, MPIR_Request * sreq,
                                                          MPIDI_OFI_am_send_pipeline_request_t *
-                                                         send_req)
+                                                         send_req, int vni_src, int vni_dst)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIDI_OFI_am_header_t *msg_hdr;
     struct iovec *iov;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, 0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_src, nic);
 
     MPIR_FUNC_ENTER;
 
@@ -378,8 +382,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
     msg_hdr->handler_id = handler_id;
     msg_hdr->payload_sz = seg_sz;
     msg_hdr->am_type = MPIDI_AMTYPE_PIPELINE;
-    msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank);
-    msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, 0, 0);
+    msg_hdr->seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank, vni_src);
+    msg_hdr->fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, vni_src, vni_src);
 
     iov = send_req->iov;
 
@@ -405,7 +409,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
     num_iov++;
 
     MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_global.ctx[ctx_idx].tx, iov, NULL, num_iov,
-                                     MPIDI_OFI_comm_to_phys(comm, rank, nic, 0, 0),
+                                     MPIDI_OFI_comm_to_phys(comm, rank, nic, vni_src, vni_dst),
                                      &send_req->context), sendv);
 
   fn_exit:
@@ -429,14 +433,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
         MPIDI_OFI_AMREQUEST(sreq, deferred_req)->sreq = sreq; \
         MPIDI_OFI_AMREQUEST(sreq, deferred_req)->data_sz = data_sz; \
         MPIDI_OFI_AMREQUEST(sreq, deferred_req)->need_packing = need_packing; \
-        DL_APPEND(MPIDI_OFI_global.per_vni[0].deferred_am_isend_q, MPIDI_OFI_AMREQUEST(sreq, deferred_req)); \
+        MPIDI_OFI_AMREQUEST(sreq, deferred_req)->vni_src = vni_src; \
+        MPIDI_OFI_AMREQUEST(sreq, deferred_req)->vni_dst = vni_dst; \
+        DL_APPEND(MPIDI_OFI_global.per_vni[vni_src].deferred_am_isend_q, MPIDI_OFI_AMREQUEST(sreq, deferred_req)); \
     } while (0)
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_eager(int rank, MPIR_Comm * comm,
                                                          int handler_id, const void *am_hdr,
                                                          size_t am_hdr_sz, const void *buf,
                                                          size_t count, MPI_Datatype datatype,
-                                                         MPIR_Request * sreq, bool issue_deferred)
+                                                         MPIR_Request * sreq, bool issue_deferred,
+                                                         int vni_src, int vni_dst)
 {
     int dt_contig, mpi_errno = MPI_SUCCESS;
     char *send_buf;
@@ -469,7 +476,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_eager(int rank, MPIR_Comm * c
         need_packing = MPIDI_OFI_AMREQUEST(sreq, deferred_req)->need_packing;
     }
 
-    if (!issue_deferred && MPIDI_OFI_global.per_vni[0].deferred_am_isend_q) {
+    if (!issue_deferred && MPIDI_OFI_global.per_vni[vni_src].deferred_am_isend_q) {
         /* if the deferred queue is not empty, all new ops must be deferred to maintain ordering */
         goto fn_deferred;
     }
@@ -480,7 +487,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_eager(int rank, MPIR_Comm * c
          * we should not allocate the entire buffer and do the packing at once. */
         /* TODO: (1) Skip packing for high-density datatypes; */
         MPIR_Assert(data_sz <= MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE);
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool,
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[vni_src].pack_buf_pool,
                                            (void **) &send_buf);
         if (send_buf == NULL) {
             if (!issue_deferred) {
@@ -504,10 +511,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_eager(int rank, MPIR_Comm * c
                     (MPL_DBG_FDEST,
                      "issue eager seg for req handle=0x%x send_size %ld", sreq->handle, data_sz));
 
-    mpi_errno = MPIDI_OFI_am_isend_short(rank, comm, handler_id, send_buf, data_sz, sreq);
+    mpi_errno =
+        MPIDI_OFI_am_isend_short(rank, comm, handler_id, send_buf, data_sz, sreq, vni_src, vni_dst);
     MPIR_ERR_CHECK(mpi_errno);
     if (issue_deferred) {
-        DL_DELETE(MPIDI_OFI_global.per_vni[0].deferred_am_isend_q,
+        DL_DELETE(MPIDI_OFI_global.per_vni[vni_src].deferred_am_isend_q,
                   MPIDI_OFI_AMREQUEST(sreq, deferred_req));
         MPL_free(MPIDI_OFI_AMREQUEST(sreq, deferred_req));
     }
@@ -524,14 +532,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_eager(int rank, MPIR_Comm * c
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(MPIR_Comm * comm, fi_addr_t addr,
                                                           const MPIDI_OFI_am_header_t * msg_hdrp,
-                                                          const void *am_hdr, size_t am_hdr_sz)
+                                                          const void *am_hdr, size_t am_hdr_sz,
+                                                          int vni_src, int vni_dst)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;
     char *ibuf;
     size_t len;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, 0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_src, nic);
 
     MPIDI_CH4_REQUEST_CREATE(sreq, MPIR_REQUEST_KIND__SEND, 0, 1);
     MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
@@ -557,7 +566,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(MPIR_Comm * comm, fi_a
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
                                                  MPIR_Comm * comm,
                                                  int handler_id, const void *am_hdr,
-                                                 size_t am_hdr_sz)
+                                                 size_t am_hdr_sz, int vni_src, int vni_dst)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t msg_hdr;
@@ -565,7 +574,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
     char *buff;
     size_t buff_len;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, 0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_src, nic);
     MPIR_CHKLMEM_DECL(1);
 
     MPIR_FUNC_ENTER;
@@ -577,15 +586,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
     msg_hdr.am_hdr_sz = am_hdr_sz;
     msg_hdr.payload_sz = 0;
     msg_hdr.am_type = MPIDI_AMTYPE_SHORT_HDR;
-    msg_hdr.seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank);
-    msg_hdr.fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, 0, 0);
+    msg_hdr.seqno = MPIDI_OFI_am_fetch_incr_send_seqno(comm, rank, vni_src);
+    msg_hdr.fi_src_addr = MPIDI_OFI_rank_to_phys(MPIR_Process.rank, nic, vni_src, vni_src);
 
     MPIR_Assert((uint64_t) comm->rank < (1ULL << MPIDI_OFI_AM_RANK_BITS));
 
-    addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, 0, 0);
+    addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vni_src, vni_dst);
 
     if (unlikely(am_hdr_sz + sizeof(msg_hdr) > MPIDI_OFI_global.max_buffered_send)) {
-        mpi_errno = MPIDI_OFI_do_emulated_inject(comm, addr, &msg_hdr, am_hdr, am_hdr_sz);
+        mpi_errno =
+            MPIDI_OFI_do_emulated_inject(comm, addr, &msg_hdr, am_hdr, am_hdr_sz, vni_src, vni_dst);
         goto fn_exit;
     }
 
@@ -610,7 +620,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
                                                             size_t am_hdr_sz, const void *buf,
                                                             size_t count, MPI_Datatype datatype,
                                                             MPIR_Request * sreq, MPI_Aint data_sz,
-                                                            bool issue_deferred)
+                                                            bool issue_deferred,
+                                                            int vni_src, int vni_dst)
 {
     int dt_contig, mpi_errno = MPI_SUCCESS;
     char *send_buf;
@@ -654,7 +665,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
         need_packing = MPIDI_OFI_AMREQUEST(sreq, deferred_req)->need_packing;
     }
 
-    if (!issue_deferred && MPIDI_OFI_global.per_vni[0].deferred_am_isend_q) {
+    if (!issue_deferred && MPIDI_OFI_global.per_vni[vni_src].deferred_am_isend_q) {
         /* if the deferred queue is not empty, all new ops must be deferred to maintain ordering */
         goto fn_deferred;
     }
@@ -664,7 +675,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
          * we should not do packing unless needed. Also, for large low-density types
          * we should not allocate the entire buffer and do the packing at once. */
         /* TODO: (1) Skip packing for high-density datatypes; */
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool,
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[vni_src].pack_buf_pool,
                                            (void **) &send_buf);
         if (send_buf == NULL) {
             if (!issue_deferred) {
@@ -679,7 +690,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
         MPIR_ERR_CHECK(mpi_errno);
         send_size = packed_size;
 
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[0].am_hdr_buf_pool,
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[vni_src].am_hdr_buf_pool,
                                            (void **) &send_req);
         MPIR_Assert(send_req);
         send_req->sreq = sreq;
@@ -687,7 +698,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
     } else {
         MPIDI_Datatype_check_lb(datatype, dt_true_lb);
         send_buf = (char *) buf + dt_true_lb + offset;
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[0].am_hdr_buf_pool,
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[vni_src].am_hdr_buf_pool,
                                            (void **) &send_req);
         MPIR_Assert(send_req);
         send_req->sreq = sreq;
@@ -700,7 +711,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
                      send_size));
 
     mpi_errno = MPIDI_OFI_am_isend_pipeline(rank, comm, handler_id, send_buf, send_size,
-                                            data_sz, sreq, send_req);
+                                            data_sz, sreq, send_req, vni_src, vni_dst);
     MPIDIG_am_send_async_issue_seg(sreq, send_size);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -712,7 +723,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
             goto fn_deferred;
         }
     } else if (issue_deferred) {
-        DL_DELETE(MPIDI_OFI_global.per_vni[0].deferred_am_isend_q,
+        DL_DELETE(MPIDI_OFI_global.per_vni[vni_src].deferred_am_isend_q,
                   MPIDI_OFI_AMREQUEST(sreq, deferred_req));
         MPL_free(MPIDI_OFI_AMREQUEST(sreq, deferred_req));
     }
@@ -732,7 +743,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_rdma_read(int rank, MPIR_Comm
                                                              size_t am_hdr_sz, const void *buf,
                                                              size_t count, MPI_Datatype datatype,
                                                              MPIR_Request * sreq,
-                                                             bool issue_deferred)
+                                                             bool issue_deferred,
+                                                             int vni_src, int vni_dst)
 {
     int dt_contig, mpi_errno = MPI_SUCCESS;
     char *send_buf;
@@ -765,7 +777,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_rdma_read(int rank, MPIR_Comm
         need_packing = MPIDI_OFI_AMREQUEST(sreq, deferred_req)->need_packing;
     }
 
-    if (!issue_deferred && MPIDI_OFI_global.per_vni[0].deferred_am_isend_q) {
+    if (!issue_deferred && MPIDI_OFI_global.per_vni[vni_src].deferred_am_isend_q) {
         /* if the deferred queue is not empty, all new ops must be deferred to maintain ordering */
         goto fn_deferred;
     }
@@ -794,10 +806,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_rdma_read(int rank, MPIR_Comm
                     (MPL_DBG_FDEST,
                      "send RDMA read for req handle=0x%x send_size %ld", sreq->handle, data_sz));
 
-    mpi_errno = MPIDI_OFI_am_isend_long(rank, comm, handler_id, send_buf, data_sz, sreq);
+    mpi_errno =
+        MPIDI_OFI_am_isend_long(rank, comm, handler_id, send_buf, data_sz, sreq, vni_src, vni_dst);
     MPIR_ERR_CHECK(mpi_errno);
     if (issue_deferred) {
-        DL_DELETE(MPIDI_OFI_global.per_vni[0].deferred_am_isend_q,
+        DL_DELETE(MPIDI_OFI_global.per_vni[vni_src].deferred_am_isend_q,
                   MPIDI_OFI_AMREQUEST(sreq, deferred_req));
         MPL_free(MPIDI_OFI_AMREQUEST(sreq, deferred_req));
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_control.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_control.h
@@ -25,7 +25,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_control_send(MPIDI_OFI_send_control_t 
 
     mpi_errno = MPIDI_OFI_do_inject(rank, comm_ptr,
                                     MPIDI_OFI_INTERNAL_HANDLER_CONTROL,
-                                    (void *) control, sizeof(*control));
+                                    (void *) control, sizeof(*control), 0, 0);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -12,23 +12,24 @@
  * value that is generally common across the different providers. */
 #define MPIDI_OFI_MAX_ERR_DATA_SIZE 64
 
-static int peek_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-static int peek_empty_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-static int recv_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-static int send_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
-static int ssend_ack_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
+static int peek_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
+static int peek_empty_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
+static int recv_huge_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
+static int send_huge_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
+static int ssend_ack_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
 static uintptr_t recv_rbase(MPIDI_OFI_huge_recv_t * recv);
-static int chunk_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
-static int inject_emu_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
-static int accept_probe_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-static int dynproc_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-static int am_isend_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
-static int am_isend_rdma_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
-static int am_isend_pipeline_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_me);
-static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-static int am_read_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_me);
+static int chunk_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
+static int inject_emu_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
+static int accept_probe_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
+static int dynproc_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
+static int am_isend_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
+static int am_isend_rdma_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
+static int am_isend_pipeline_event(int vni, struct fi_cq_tagged_entry *wc,
+                                   MPIR_Request * dont_use_me);
+static int am_recv_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
+static int am_read_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_me);
 
-static int peek_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
+static int peek_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t count = 0;
@@ -104,7 +105,7 @@ static int peek_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     goto fn_exit;
 }
 
-static int peek_empty_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
+static int peek_empty_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     MPIR_FUNC_ENTER;
     MPIDI_OFI_dynamic_process_request_t *ctrl;
@@ -135,7 +136,7 @@ static int peek_empty_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 
 /* If we posted a huge receive, this event gets called to translate the
  * completion queue entry into a get huge event */
-static int recv_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
+static int recv_huge_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_huge_recv_t *recv_elem = NULL;
@@ -151,7 +152,7 @@ static int recv_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
           (wc->len > MPIDI_OFI_STRIPE_CHUNK_SIZE && wc->len < MPIDI_OFI_global.stripe_threshold)) &&
          MPIDI_OFI_COMM(rreq->comm).enable_striping) ||
         (wc->len < MPIDI_OFI_global.max_msg_size && !MPIDI_OFI_COMM(rreq->comm).enable_striping)) {
-        return MPIDI_OFI_recv_event(wc, rreq, MPIDI_OFI_REQUEST(rreq, event_id));
+        return MPIDI_OFI_recv_event(vni, wc, rreq, MPIDI_OFI_REQUEST(rreq, event_id));
     }
 
     comm_ptr = rreq->comm;
@@ -227,7 +228,7 @@ static int recv_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
         recv_elem->cur_offset = MPIDI_OFI_global.max_msg_size;
     }
     if (ready_to_get) {
-        MPIDI_OFI_get_huge_event(NULL, (MPIR_Request *) recv_elem);
+        MPIDI_OFI_get_huge_event(vni, NULL, (MPIR_Request *) recv_elem);
     }
 
   fn_exit:
@@ -237,7 +238,7 @@ static int recv_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     goto fn_exit;
 }
 
-static int send_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
+static int send_huge_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     int c, num_nics;
@@ -291,13 +292,14 @@ static int send_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
     goto fn_exit;
 }
 
-static int ssend_ack_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
+static int ssend_ack_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 {
     int mpi_errno;
     MPIDI_OFI_ssendack_request_t *req = (MPIDI_OFI_ssendack_request_t *) sreq;
     MPIR_FUNC_ENTER;
     mpi_errno =
-        MPIDI_OFI_send_event(NULL, req->signal_req, MPIDI_OFI_REQUEST(req->signal_req, event_id));
+        MPIDI_OFI_send_event(vni, NULL, req->signal_req,
+                             MPIDI_OFI_REQUEST(req->signal_req, event_id));
 
     MPL_free(req);
     MPIR_FUNC_EXIT;
@@ -324,7 +326,7 @@ static uintptr_t recv_rbase(MPIDI_OFI_huge_recv_t * recv_elem)
  *
  * 3. As the event function when RDMA read (issued here) completes.
  */
-int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
+int MPIDI_OFI_get_huge_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_huge_recv_t *recv_elem = (MPIDI_OFI_huge_recv_t *) req;
@@ -360,7 +362,7 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
          * Need to backup the handle here for later use with MPIDIU_map_erase. */
         uint64_t key_to_erase = recv_elem->localreq->handle;
         recv_elem->wc.len = recv_elem->cur_offset;
-        recv_elem->done_fn(&recv_elem->wc, recv_elem->localreq, recv_elem->event_id);
+        recv_elem->done_fn(vni, &recv_elem->wc, recv_elem->localreq, recv_elem->event_id);
         ctrl.type = MPIDI_OFI_CTRL_HUGEACK;
         mpi_errno =
             MPIDI_OFI_do_control_send(&ctrl, NULL, 0, recv_elem->remote_info.origin_rank,
@@ -427,7 +429,7 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
     goto fn_exit;
 }
 
-static int chunk_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
+static int chunk_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req)
 {
     int c;
     MPIR_FUNC_ENTER;
@@ -443,7 +445,7 @@ static int chunk_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
     return MPI_SUCCESS;
 }
 
-static int inject_emu_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
+static int inject_emu_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req)
 {
     int incomplete;
     MPIR_FUNC_ENTER;
@@ -460,7 +462,7 @@ static int inject_emu_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
     return MPI_SUCCESS;
 }
 
-static int accept_probe_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
+static int accept_probe_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     MPIR_FUNC_ENTER;
     MPIDI_OFI_dynamic_process_request_t *ctrl = (MPIDI_OFI_dynamic_process_request_t *) rreq;
@@ -472,7 +474,7 @@ static int accept_probe_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq
     return MPI_SUCCESS;
 }
 
-static int dynproc_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
+static int dynproc_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     MPIR_FUNC_ENTER;
     MPIDI_OFI_dynamic_process_request_t *ctrl = (MPIDI_OFI_dynamic_process_request_t *) rreq;
@@ -481,7 +483,7 @@ static int dynproc_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq
     return MPI_SUCCESS;
 }
 
-static int am_isend_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
+static int am_isend_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -491,7 +493,7 @@ static int am_isend_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
     msg_hdr = &MPIDI_OFI_AM_SREQ_HDR(sreq, msg_hdr);
     MPID_Request_complete(sreq);
 
-    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool,
+    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[vni].pack_buf_pool,
                                       MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer));
     MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer) = NULL;
     mpi_errno = MPIDIG_global.origin_cbs[msg_hdr->handler_id] (sreq);
@@ -504,7 +506,7 @@ static int am_isend_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
     goto fn_exit;
 }
 
-static int am_isend_rdma_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
+static int am_isend_rdma_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -518,7 +520,8 @@ static int am_isend_rdma_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sre
     return mpi_errno;
 }
 
-static int am_isend_pipeline_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_me)
+static int am_isend_pipeline_event(int vni, struct fi_cq_tagged_entry *wc,
+                                   MPIR_Request * dont_use_me)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -532,10 +535,10 @@ static int am_isend_pipeline_event(struct fi_cq_tagged_entry *wc, MPIR_Request *
     sreq = ofi_req->sreq;
     MPID_Request_complete(sreq);        /* FIXME: Should not call MPIDI in NM ? */
 
-    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool,
+    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[vni].pack_buf_pool,
                                       ofi_req->pack_buffer);
 
-    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[0].am_hdr_buf_pool, ofi_req);
+    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[vni].am_hdr_buf_pool, ofi_req);
 
     int is_done = MPIDIG_am_send_async_finish_seg(sreq);
 
@@ -552,7 +555,7 @@ static int am_isend_pipeline_event(struct fi_cq_tagged_entry *wc, MPIR_Request *
     goto fn_exit;
 }
 
-static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
+static int am_recv_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *am_hdr;
@@ -584,7 +587,7 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     }
 #endif
 
-    expected_seqno = MPIDI_OFI_am_get_next_recv_seqno(am_hdr->fi_src_addr);
+    expected_seqno = MPIDI_OFI_am_get_next_recv_seqno(vni, am_hdr->fi_src_addr);
     if (am_hdr->seqno != expected_seqno) {
         /* This message came earlier than the one that we were expecting.
          * Put it in the queue to process it later. */
@@ -593,7 +596,7 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
                          "Expected seqno=%d but got %d (am_type=%d addr=%" PRIx64 "). "
                          "Enqueueing it to the queue.\n",
                          expected_seqno, am_hdr->seqno, am_hdr->am_type, am_hdr->fi_src_addr));
-        mpi_errno = MPIDI_OFI_am_enqueue_unordered_msg(orig_buf);
+        mpi_errno = MPIDI_OFI_am_enqueue_unordered_msg(vni, orig_buf);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -658,7 +661,7 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     MPL_free(uo_msg);
 
     /* See if we can process other messages in the queue */
-    if ((uo_msg = MPIDI_OFI_am_claim_unordered_msg(fi_src_addr, next_seqno)) != NULL) {
+    if ((uo_msg = MPIDI_OFI_am_claim_unordered_msg(vni, fi_src_addr, next_seqno)) != NULL) {
         am_hdr = &uo_msg->am_hdr;
         orig_buf = am_hdr;
 #ifdef NEEDS_STRICT_ALIGNMENT
@@ -670,7 +673,7 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     }
 
     /* Record the next expected sequence number from fi_src_addr */
-    MPIDI_OFI_am_set_next_recv_seqno(fi_src_addr, next_seqno);
+    MPIDI_OFI_am_set_next_recv_seqno(vni, fi_src_addr, next_seqno);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -679,7 +682,7 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     goto fn_exit;
 }
 
-static int am_read_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_me)
+static int am_read_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_me)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
@@ -716,7 +719,7 @@ static int am_read_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
     MPID_Request_complete(rreq);
   fn_exit:
-    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[0].am_hdr_buf_pool, ofi_req);
+    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[vni].am_hdr_buf_pool, ofi_req);
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
@@ -730,87 +733,87 @@ int MPIDI_OFI_dispatch_function(int vni, struct fi_cq_tagged_entry *wc, MPIR_Req
     if (MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_SEND) {
         /* Passing the event_id as a parameter; do not need to load it from the
          * request object each time the send_event handler is invoked */
-        mpi_errno = MPIDI_OFI_send_event(wc, req, MPIDI_OFI_EVENT_SEND);
+        mpi_errno = MPIDI_OFI_send_event(vni, wc, req, MPIDI_OFI_EVENT_SEND);
         goto fn_exit;
     } else if (MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_RECV) {
         /* Passing the event_id as a parameter; do not need to load it from the
          * request object each time the send_event handler is invoked */
-        mpi_errno = MPIDI_OFI_recv_event(wc, req, MPIDI_OFI_EVENT_RECV);
+        mpi_errno = MPIDI_OFI_recv_event(vni, wc, req, MPIDI_OFI_EVENT_RECV);
         goto fn_exit;
     } else if (likely(MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_AM_SEND)) {
-        mpi_errno = am_isend_event(wc, req);
+        mpi_errno = am_isend_event(vni, wc, req);
         goto fn_exit;
     } else if (likely(MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_AM_SEND_RDMA)) {
-        mpi_errno = am_isend_rdma_event(wc, req);
+        mpi_errno = am_isend_rdma_event(vni, wc, req);
         goto fn_exit;
     } else if (likely(MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_AM_SEND_PIPELINE)) {
-        mpi_errno = am_isend_pipeline_event(wc, req);
+        mpi_errno = am_isend_pipeline_event(vni, wc, req);
         goto fn_exit;
     } else if (likely(MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_AM_RECV)) {
         if (wc->flags & FI_RECV)
-            mpi_errno = am_recv_event(wc, req);
+            mpi_errno = am_recv_event(vni, wc, req);
 
         if (unlikely(wc->flags & FI_MULTI_RECV)) {
             MPIDI_OFI_am_repost_request_t *am = (MPIDI_OFI_am_repost_request_t *) req;
-            mpi_errno = MPIDI_OFI_am_repost_buffer(am->index);
+            mpi_errno = MPIDI_OFI_am_repost_buffer(vni, am->index);
         }
 
         goto fn_exit;
     } else if (likely(MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_AM_READ)) {
-        mpi_errno = am_read_event(wc, req);
+        mpi_errno = am_read_event(vni, wc, req);
         goto fn_exit;
     } else if (unlikely(1)) {
         switch (MPIDI_OFI_REQUEST(req, event_id)) {
             case MPIDI_OFI_EVENT_PEEK:
-                mpi_errno = peek_event(wc, req);
+                mpi_errno = peek_event(vni, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_RECV_HUGE:
-                mpi_errno = recv_huge_event(wc, req);
+                mpi_errno = recv_huge_event(vni, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_RECV_PACK:
-                mpi_errno = MPIDI_OFI_recv_event(wc, req, MPIDI_OFI_EVENT_RECV_PACK);
+                mpi_errno = MPIDI_OFI_recv_event(vni, wc, req, MPIDI_OFI_EVENT_RECV_PACK);
                 break;
 
             case MPIDI_OFI_EVENT_RECV_NOPACK:
-                mpi_errno = MPIDI_OFI_recv_event(wc, req, MPIDI_OFI_EVENT_RECV_NOPACK);
+                mpi_errno = MPIDI_OFI_recv_event(vni, wc, req, MPIDI_OFI_EVENT_RECV_NOPACK);
                 break;
 
             case MPIDI_OFI_EVENT_SEND_HUGE:
-                mpi_errno = send_huge_event(wc, req);
+                mpi_errno = send_huge_event(vni, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_SEND_PACK:
-                mpi_errno = MPIDI_OFI_send_event(wc, req, MPIDI_OFI_EVENT_SEND_PACK);
+                mpi_errno = MPIDI_OFI_send_event(vni, wc, req, MPIDI_OFI_EVENT_SEND_PACK);
                 break;
 
             case MPIDI_OFI_EVENT_SEND_NOPACK:
-                mpi_errno = MPIDI_OFI_send_event(wc, req, MPIDI_OFI_EVENT_SEND_NOPACK);
+                mpi_errno = MPIDI_OFI_send_event(vni, wc, req, MPIDI_OFI_EVENT_SEND_NOPACK);
                 break;
 
             case MPIDI_OFI_EVENT_SSEND_ACK:
-                mpi_errno = ssend_ack_event(wc, req);
+                mpi_errno = ssend_ack_event(vni, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_GET_HUGE:
-                mpi_errno = MPIDI_OFI_get_huge_event(wc, req);
+                mpi_errno = MPIDI_OFI_get_huge_event(vni, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_CHUNK_DONE:
-                mpi_errno = chunk_done_event(wc, req);
+                mpi_errno = chunk_done_event(vni, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_INJECT_EMU:
-                mpi_errno = inject_emu_event(wc, req);
+                mpi_errno = inject_emu_event(vni, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_DYNPROC_DONE:
-                mpi_errno = dynproc_done_event(wc, req);
+                mpi_errno = dynproc_done_event(vni, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_ACCEPT_PROBE:
-                mpi_errno = accept_probe_event(wc, req);
+                mpi_errno = accept_probe_event(vni, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_ABORT:
@@ -881,7 +884,7 @@ int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret)
 
                 case FI_ENOMSG:
                     req = MPIDI_OFI_context_to_request(e.op_context);
-                    mpi_errno = peek_empty_event(NULL, req);
+                    mpi_errno = peek_empty_event(vni, NULL, req);
                     break;
 
                 default:

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -491,7 +491,7 @@ static int am_isend_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
     msg_hdr = &MPIDI_OFI_AM_SREQ_HDR(sreq, msg_hdr);
     MPID_Request_complete(sreq);
 
-    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.pack_buf_pool,
+    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool,
                                       MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer));
     MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer) = NULL;
     mpi_errno = MPIDIG_global.origin_cbs[msg_hdr->handler_id] (sreq);
@@ -532,9 +532,10 @@ static int am_isend_pipeline_event(struct fi_cq_tagged_entry *wc, MPIR_Request *
     sreq = ofi_req->sreq;
     MPID_Request_complete(sreq);        /* FIXME: Should not call MPIDI in NM ? */
 
-    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.pack_buf_pool, ofi_req->pack_buffer);
+    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool,
+                                      ofi_req->pack_buffer);
 
-    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.am_hdr_buf_pool, ofi_req);
+    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[0].am_hdr_buf_pool, ofi_req);
 
     int is_done = MPIDIG_am_send_async_finish_seg(sreq);
 
@@ -715,7 +716,7 @@ static int am_read_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
     MPID_Request_complete(rreq);
   fn_exit:
-    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.am_hdr_buf_pool, ofi_req);
+    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[0].am_hdr_buf_pool, ofi_req);
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -14,7 +14,7 @@
 
 int MPIDI_OFI_rma_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * in_req);
 int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
-int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
+int MPIDI_OFI_dispatch_function(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_cqe_get_source(struct fi_cq_tagged_entry *wc, bool has_err)
 {
@@ -138,7 +138,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_optimized(struct fi_cq_tagged_entry *wc,
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_optimized(int vni, struct fi_cq_tagged_entry *wc,
                                                           MPIR_Request * req)
 {
     /* fast path */
@@ -149,7 +149,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_optimized(struct fi_cq_tagged_en
     }
 
     /* slow path */
-    return MPIDI_OFI_dispatch_function(wc, req);
+    return MPIDI_OFI_dispatch_function(vni, wc, req);
 }
 
 #endif /* OFI_EVENTS_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -12,8 +12,8 @@
 #include "ofi_control.h"
 #include "utlist.h"
 
-int MPIDI_OFI_rma_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * in_req);
-int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
+int MPIDI_OFI_rma_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * in_req);
+int MPIDI_OFI_get_huge_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
 int MPIDI_OFI_dispatch_function(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_cqe_get_source(struct fi_cq_tagged_entry *wc, bool has_err)
@@ -24,7 +24,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_cqe_get_source(struct fi_cq_tagged_entry 
     return wc->data;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(struct fi_cq_tagged_entry *wc /* unused */ ,
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(int vni,
+                                                  struct fi_cq_tagged_entry *wc /* unused */ ,
                                                   MPIR_Request * sreq, int event_id)
 {
     int c;
@@ -47,7 +48,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(struct fi_cq_tagged_entry *wc 
     return MPI_SUCCESS;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vni, struct fi_cq_tagged_entry *wc,
                                                   MPIR_Request * rreq, int event_id)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -117,6 +118,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
         int vni_dst = MPIDI_OFI_get_vni(DST_VCI_FROM_RECVER, c, r, c->rank, rreq->status.MPI_TAG);
         int vni_local = vni_dst;
         int vni_remote = vni_src;
+        MPIR_Assert(vni_local == vni);
         int nic = 0;
         int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni_local, nic);
         MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx, NULL /* buf */ ,
@@ -143,9 +145,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_optimized(int vni, struct fi_cq_
 {
     /* fast path */
     if (MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_SEND) {
-        return MPIDI_OFI_send_event(wc, req, MPIDI_OFI_EVENT_SEND);
+        return MPIDI_OFI_send_event(vni, wc, req, MPIDI_OFI_EVENT_SEND);
     } else if (MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_RECV) {
-        return MPIDI_OFI_recv_event(wc, req, MPIDI_OFI_EVENT_RECV);
+        return MPIDI_OFI_recv_event(vni, wc, req, MPIDI_OFI_EVENT_RECV);
     }
 
     /* slow path */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -40,7 +40,7 @@ ATTRIBUTE((unused));
 #define MPIDI_OFI_WIN(win)     ((win)->dev.netmod.ofi)
 
 int MPIDI_OFI_progress_uninlined(int vni);
-int MPIDI_OFI_handle_cq_error(int ctx_idx, ssize_t ret);
+int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret);
 
 /* vni mapping */
 /* NOTE: concerned by the modulo? If we restrict num_vnis to power of 2,
@@ -654,7 +654,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_progress_do_queue(int vni)
             goto fn_exit;
 
         if (ret < 0) {
-            mpi_errno = MPIDI_OFI_handle_cq_error(ctx_idx, ret);
+            mpi_errno = MPIDI_OFI_handle_cq_error(vni, nic, ret);
             goto fn_fail;
         }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -627,11 +627,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_multx_receiver_nic_index(MPIR_Comm * comm
  */
 
 /* local macros to make the code cleaner */
-#define CQ_S_LIST MPIDI_OFI_global.cq_buffered_static_list
-#define CQ_S_HEAD MPIDI_OFI_global.cq_buffered_static_head
-#define CQ_S_TAIL MPIDI_OFI_global.cq_buffered_static_tail
-#define CQ_D_HEAD MPIDI_OFI_global.cq_buffered_dynamic_head
-#define CQ_D_TAIL MPIDI_OFI_global.cq_buffered_dynamic_tail
+#define CQ_S_LIST MPIDI_OFI_global.per_vni[vni].cq_buffered_static_list
+#define CQ_S_HEAD MPIDI_OFI_global.per_vni[vni].cq_buffered_static_head
+#define CQ_S_TAIL MPIDI_OFI_global.per_vni[vni].cq_buffered_static_tail
+#define CQ_D_HEAD MPIDI_OFI_global.per_vni[vni].cq_buffered_dynamic_head
+#define CQ_D_TAIL MPIDI_OFI_global.per_vni[vni].cq_buffered_dynamic_tail
 
 MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_has_cq_buffered(int vni)
 {
@@ -667,7 +667,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_progress_do_queue(int vni)
             list_entry->cq_entry = cq_entry;
             LL_APPEND(CQ_D_HEAD, CQ_D_TAIL, list_entry);
         } else {
-            CQ_S_LIST[CQ_S_HEAD].cq_entry = cq_entry;
+            CQ_S_LIST[CQ_S_HEAD] = cq_entry;
             CQ_S_HEAD = (CQ_S_HEAD + 1) % MPIDI_OFI_NUM_CQ_BUFFERED;
         }
     }
@@ -686,7 +686,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_buffered(int vni, struct fi_cq_tagged
     if (1) {
         /* If the static list isn't empty, do so first */
         if (CQ_S_HEAD != CQ_S_TAIL) {
-            wc[0] = CQ_S_LIST[CQ_S_TAIL].cq_entry;
+            wc[0] = CQ_S_LIST[CQ_S_TAIL];
             CQ_S_TAIL = (CQ_S_TAIL + 1) % MPIDI_OFI_NUM_CQ_BUFFERED;
         }
         /* If there's anything in the dynamic list, it goes second. */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1573,12 +1573,12 @@ int ofi_am_post_recv(int vni, int nic)
 }
 
 /* called in MPIDI_OFI_dispatch_function when FI_MULTI_RECV is flagged */
-int MPIDI_OFI_am_repost_buffer(int am_idx)
+int MPIDI_OFI_am_repost_buffer(int vni, int am_idx)
 {
     int mpi_errno = MPI_SUCCESS;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, 0);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, 0);
     MPIDI_OFI_CALL_RETRY_AM(fi_recvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx,
-                                       &MPIDI_OFI_global.per_vni[0].am_msg[am_idx],
+                                       &MPIDI_OFI_global.per_vni[vni].am_msg[am_idx],
                                        FI_MULTI_RECV | FI_COMPLETION), prepost);
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -562,24 +562,12 @@ int MPIDI_OFI_init_local(int *tag_bits)
     MPIDIU_map_create(&MPIDI_OFI_global.huge_send_counters, MPL_MEM_COMM);
     MPIDIU_map_create(&MPIDI_OFI_global.huge_recv_counters, MPL_MEM_COMM);
 
-    /* Create pack buffer pool */
-    mpi_errno =
-        MPIDU_genq_private_pool_create_unsafe(MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE,
-                                              MPIR_CVAR_CH4_OFI_NUM_PACK_BUFFERS_PER_CHUNK,
-                                              MPIR_CVAR_CH4_OFI_MAX_NUM_PACK_BUFFERS,
-                                              host_alloc_registered,
-                                              host_free_registered,
-                                              &MPIDI_OFI_global.pack_buf_pool);
-    MPIR_ERR_CHECK(mpi_errno);
-
     /* Initialize RMA keys allocator */
     MPIDI_OFI_mr_key_allocator_init();
 
     MPIR_Comm_register_hint(MPIR_COMM_HINT_EAGAIN, "eagain", NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, 0);
     MPIDI_OFI_global.num_comms_enabled_striping = 0;
     MPIDI_OFI_global.num_comms_enabled_hashing = 0;
-
-    MPIDI_OFI_global.deferred_am_isend_q = NULL;
 
     mpi_errno = ofi_pvar_init();
     MPIR_ERR_CHECK(mpi_errno);
@@ -655,6 +643,18 @@ int MPIDI_OFI_init_local(int *tag_bits)
 
     /* index datatypes for RMA atomics. */
     MPIDI_OFI_index_datatypes(MPIDI_OFI_global.ctx[0].tx);
+
+    /* Create pack buffer pool */
+    for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
+        mpi_errno =
+            MPIDU_genq_private_pool_create_unsafe(MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE,
+                                                  MPIR_CVAR_CH4_OFI_NUM_PACK_BUFFERS_PER_CHUNK,
+                                                  MPIR_CVAR_CH4_OFI_MAX_NUM_PACK_BUFFERS,
+                                                  host_alloc_registered,
+                                                  host_free_registered,
+                                                  &MPIDI_OFI_global.per_vni[vni].pack_buf_pool);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
     ofi_am_init();
     ofi_am_post_recv(0, 0);
@@ -741,6 +741,10 @@ int MPIDI_OFI_post_init(void)
 
     if (MPIDI_OFI_global.num_vnis > 1 || MPIDI_OFI_global.num_nics > 1) {
         mpi_errno = MPIDI_OFI_addr_exchange_all_ctx();
+    }
+
+    for (int vni = 1; vni < MPIDI_OFI_global.num_vnis; vni++) {
+        ofi_am_post_recv(vni, 0);
     }
 
   fn_exit:
@@ -904,24 +908,29 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     MPIDIU_map_destroy(MPIDI_OFI_global.huge_recv_counters);
 
     if (MPIDI_OFI_ENABLE_AM) {
-        while (MPIDI_OFI_global.am_unordered_msgs) {
-            MPIDI_OFI_am_unordered_msg_t *uo_msg = MPIDI_OFI_global.am_unordered_msgs;
-            DL_DELETE(MPIDI_OFI_global.am_unordered_msgs, uo_msg);
+        for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
+            while (MPIDI_OFI_global.per_vni[vni].am_unordered_msgs) {
+                MPIDI_OFI_am_unordered_msg_t *uo_msg =
+                    MPIDI_OFI_global.per_vni[vni].am_unordered_msgs;
+                DL_DELETE(MPIDI_OFI_global.per_vni[vni].am_unordered_msgs, uo_msg);
+            }
+            MPIDIU_map_destroy(MPIDI_OFI_global.per_vni[vni].am_send_seq_tracker);
+            MPIDIU_map_destroy(MPIDI_OFI_global.per_vni[vni].am_recv_seq_tracker);
+
+            for (i = 0; i < MPIDI_OFI_NUM_AM_BUFFERS; i++)
+                MPIR_gpu_free_host(MPIDI_OFI_global.per_vni[vni].am_bufs[i]);
+
+            MPIDU_genq_private_pool_destroy_unsafe(MPIDI_OFI_global.per_vni[vni].am_hdr_buf_pool);
+
+            MPIR_Assert(MPIDI_OFI_global.per_vni[vni].cq_buffered_static_head ==
+                        MPIDI_OFI_global.per_vni[vni].cq_buffered_static_tail);
+            MPIR_Assert(NULL == MPIDI_OFI_global.per_vni[vni].cq_buffered_dynamic_head);
         }
-        MPIDIU_map_destroy(MPIDI_OFI_global.am_send_seq_tracker);
-        MPIDIU_map_destroy(MPIDI_OFI_global.am_recv_seq_tracker);
-
-        for (i = 0; i < MPIDI_OFI_NUM_AM_BUFFERS; i++)
-            MPIR_gpu_free_host(MPIDI_OFI_global.am_bufs[i]);
-
-        MPIDU_genq_private_pool_destroy_unsafe(MPIDI_OFI_global.am_hdr_buf_pool);
-
-        MPIR_Assert(MPIDI_OFI_global.cq_buffered_static_head ==
-                    MPIDI_OFI_global.cq_buffered_static_tail);
-        MPIR_Assert(NULL == MPIDI_OFI_global.cq_buffered_dynamic_head);
     }
 
-    MPIDU_genq_private_pool_destroy_unsafe(MPIDI_OFI_global.pack_buf_pool);
+    for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
+        MPIDU_genq_private_pool_destroy_unsafe(MPIDI_OFI_global.per_vni[vni].pack_buf_pool);
+    }
 
     int err;
     MPID_Thread_mutex_destroy(&MPIDI_OFI_THREAD_UTIL_MUTEX, &err);
@@ -1489,22 +1498,26 @@ int ofi_am_init(void)
                                 < MPIDI_OFI_AM_HDR_POOL_CELL_SIZE);
         MPL_COMPILE_TIME_ASSERT(MPIDI_OFI_AM_HDR_POOL_CELL_SIZE
                                 >= sizeof(MPIDI_OFI_am_send_pipeline_request_t));
-        mpi_errno =
-            MPIDU_genq_private_pool_create_unsafe(MPIDI_OFI_AM_HDR_POOL_CELL_SIZE,
-                                                  MPIDI_OFI_AM_HDR_POOL_NUM_CELLS_PER_CHUNK,
-                                                  0,
-                                                  host_alloc, host_free,
-                                                  &MPIDI_OFI_global.am_hdr_buf_pool);
-        MPIR_ERR_CHECK(mpi_errno);
+        for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
+            mpi_errno = MPIDU_genq_private_pool_create_unsafe(MPIDI_OFI_AM_HDR_POOL_CELL_SIZE,
+                                                              MPIDI_OFI_AM_HDR_POOL_NUM_CELLS_PER_CHUNK,
+                                                              0 /* unlimited */ ,
+                                                              host_alloc, host_free,
+                                                              &MPIDI_OFI_global.
+                                                              per_vni[vni].am_hdr_buf_pool);
+            MPIR_ERR_CHECK(mpi_errno);
 
-        MPIDI_OFI_global.cq_buffered_dynamic_head = MPIDI_OFI_global.cq_buffered_dynamic_tail =
-            NULL;
-        MPIDI_OFI_global.cq_buffered_static_head = MPIDI_OFI_global.cq_buffered_static_tail = 0;
+            MPIDI_OFI_global.per_vni[vni].cq_buffered_dynamic_head = NULL;
+            MPIDI_OFI_global.per_vni[vni].cq_buffered_dynamic_tail = NULL;
+            MPIDI_OFI_global.per_vni[vni].cq_buffered_static_head = 0;
+            MPIDI_OFI_global.per_vni[vni].cq_buffered_static_tail = 0;
 
-        MPIDIU_map_create(&MPIDI_OFI_global.am_recv_seq_tracker, MPL_MEM_BUFFER);
-        MPIDIU_map_create(&MPIDI_OFI_global.am_send_seq_tracker, MPL_MEM_BUFFER);
-        MPIDI_OFI_global.am_unordered_msgs = NULL;
+            MPIDIU_map_create(&MPIDI_OFI_global.per_vni[vni].am_recv_seq_tracker, MPL_MEM_BUFFER);
+            MPIDIU_map_create(&MPIDI_OFI_global.per_vni[vni].am_send_seq_tracker, MPL_MEM_BUFFER);
+            MPIDI_OFI_global.per_vni[vni].am_unordered_msgs = NULL;
 
+            MPIDI_OFI_global.per_vni[vni].deferred_am_isend_q = NULL;
+        }
         MPIDIG_am_reg_cb(MPIDI_OFI_INTERNAL_HANDLER_CONTROL, NULL, &MPIDI_OFI_control_handler);
         MPIDIG_am_reg_cb(MPIDI_OFI_AM_RDMA_READ_ACK, NULL, &MPIDI_OFI_am_rdma_read_ack_handler);
     }
@@ -1521,8 +1534,8 @@ int ofi_am_post_recv(int vni, int nic)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    /* Only root ctx for now */
-    MPIR_Assert(vni == 0 && nic == 0);
+    /* Only nic 0 for now */
+    MPIR_Assert(nic == 0);
 
     if (MPIDI_OFI_ENABLE_AM) {
         int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
@@ -1533,19 +1546,22 @@ int ofi_am_post_recv(int vni, int nic)
                                  FI_OPT_MIN_MULTI_RECV, &optlen, sizeof(optlen)), setopt);
 
         for (int i = 0; i < MPIDI_OFI_NUM_AM_BUFFERS; i++) {
-            MPIR_gpu_malloc_host(&(MPIDI_OFI_global.am_bufs[i]), MPIDI_OFI_AM_BUFF_SZ);
-            MPIDI_OFI_global.am_reqs[i].event_id = MPIDI_OFI_EVENT_AM_RECV;
-            MPIDI_OFI_global.am_reqs[i].index = i;
-            MPIR_Assert(MPIDI_OFI_global.am_bufs[i]);
-            MPIDI_OFI_global.am_iov[i].iov_base = MPIDI_OFI_global.am_bufs[i];
-            MPIDI_OFI_global.am_iov[i].iov_len = MPIDI_OFI_AM_BUFF_SZ;
-            MPIDI_OFI_global.am_msg[i].msg_iov = &MPIDI_OFI_global.am_iov[i];
-            MPIDI_OFI_global.am_msg[i].desc = NULL;
-            MPIDI_OFI_global.am_msg[i].addr = FI_ADDR_UNSPEC;
-            MPIDI_OFI_global.am_msg[i].context = &MPIDI_OFI_global.am_reqs[i].context;
-            MPIDI_OFI_global.am_msg[i].iov_count = 1;
+            MPIR_gpu_malloc_host(&(MPIDI_OFI_global.per_vni[vni].am_bufs[i]), MPIDI_OFI_AM_BUFF_SZ);
+            MPIDI_OFI_global.per_vni[vni].am_reqs[i].event_id = MPIDI_OFI_EVENT_AM_RECV;
+            MPIDI_OFI_global.per_vni[vni].am_reqs[i].index = i;
+            MPIR_Assert(MPIDI_OFI_global.per_vni[vni].am_bufs[i]);
+            MPIDI_OFI_global.per_vni[vni].am_iov[i].iov_base =
+                MPIDI_OFI_global.per_vni[vni].am_bufs[i];
+            MPIDI_OFI_global.per_vni[vni].am_iov[i].iov_len = MPIDI_OFI_AM_BUFF_SZ;
+            MPIDI_OFI_global.per_vni[vni].am_msg[i].msg_iov =
+                &MPIDI_OFI_global.per_vni[vni].am_iov[i];
+            MPIDI_OFI_global.per_vni[vni].am_msg[i].desc = NULL;
+            MPIDI_OFI_global.per_vni[vni].am_msg[i].addr = FI_ADDR_UNSPEC;
+            MPIDI_OFI_global.per_vni[vni].am_msg[i].context =
+                &MPIDI_OFI_global.per_vni[vni].am_reqs[i].context;
+            MPIDI_OFI_global.per_vni[vni].am_msg[i].iov_count = 1;
             MPIDI_OFI_CALL_RETRY(fi_recvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx,
-                                            &MPIDI_OFI_global.am_msg[i],
+                                            &MPIDI_OFI_global.per_vni[vni].am_msg[i],
                                             FI_MULTI_RECV | FI_COMPLETION), 0, prepost, FALSE);
         }
     }
@@ -1562,7 +1578,7 @@ int MPIDI_OFI_am_repost_buffer(int am_idx)
     int mpi_errno = MPI_SUCCESS;
     int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, 0);
     MPIDI_OFI_CALL_RETRY_AM(fi_recvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx,
-                                       &MPIDI_OFI_global.am_msg[am_idx],
+                                       &MPIDI_OFI_global.per_vni[0].am_msg[am_idx],
                                        FI_MULTI_RECV | FI_COMPLETION), prepost);
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -87,6 +87,13 @@ typedef struct MPIDI_OFI_am_header_t {
     uint64_t payload_sz:MPIDI_OFI_AM_PAYLOAD_SZ_BITS;   /* data size on this OFI message. This
                                                          * could be the size of a pipeline segment
                                                          * */
+    /* vnis are needed for callbacks and to reply.
+     * Note: technically the vni_dst don't need be transported since the receiver
+     * always know which vni it receives the message. However, having both of them
+     * in the header makes the design symmetric and thus easier to maintain.
+     */
+    uint8_t vni_src;
+    uint8_t vni_dst;
     uint16_t seqno:MPIDI_OFI_AM_SEQ_NO_BITS;    /* Sequence number of this message.
                                                  * Number is unique to (fi_src_addr,
                                                  * fi_dest_addr) pair. */

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -150,8 +150,9 @@ typedef struct MPIDI_OFI_deferred_am_isend_req {
     MPI_Datatype datatype;
     MPIR_Request *sreq;
     bool need_packing;
-
     MPI_Aint data_sz;
+    int vni_src;
+    int vni_dst;
 
     struct MPIDI_OFI_deferred_am_isend_req *prev;
     struct MPIDI_OFI_deferred_am_isend_req *next;

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -126,13 +126,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
 
     MPIR_FUNC_ENTER;
 
+    int vni_src, vni_dst;
+    MPIDI_OFI_PROBE_VNIS(vni_src, vni_dst);
+
     if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, 0, flag, message, status);
+        mpi_errno =
+            MPIDIG_mpi_improbe(source, tag, comm, context_offset, vni_dst, flag, message, status);
         goto fn_exit;
     }
 
-    int vni_src, vni_dst;
-    MPIDI_OFI_PROBE_VNIS(vni_src, vni_dst);
     MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_dst);
     /* Set flags for mprobe peek, when ready */
     mpi_errno = MPIDI_OFI_do_iprobe(source, tag, comm, context_offset, addr, vni_src, vni_dst,
@@ -156,11 +158,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+    int vni_src, vni_dst;
+    MPIDI_OFI_PROBE_VNIS(vni_src, vni_dst);
+
     if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, 0, flag, status);
+        mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, vni_dst, flag, status);
     } else {
-        int vni_src, vni_dst;
-        MPIDI_OFI_PROBE_VNIS(vni_src, vni_dst);
         MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_dst);
         mpi_errno = MPIDI_OFI_do_iprobe(source, tag, comm, context_offset, addr,
                                         vni_src, vni_dst, flag, status, NULL, 0ULL);

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -48,7 +48,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_deferred_ops(void)
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_entries(struct fi_cq_tagged_entry *wc, ssize_t num)
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_entries(int vni, struct fi_cq_tagged_entry *wc,
+                                                         ssize_t num)
 {
     int i, mpi_errno = MPI_SUCCESS;
     MPIR_Request *req;
@@ -56,7 +57,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_entries(struct fi_cq_tagged_ent
 
     for (i = 0; i < num; i++) {
         req = MPIDI_OFI_context_to_request(wc[i].op_context);
-        mpi_errno = MPIDI_OFI_dispatch_optimized(&wc[i], req);
+        mpi_errno = MPIDI_OFI_dispatch_optimized(vni, &wc[i], req);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -86,7 +87,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
 
     if (unlikely(MPIDI_OFI_has_cq_buffered(vni))) {
         ret = MPIDI_OFI_get_buffered(vni, wc);
-        mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1);
+        mpi_errno = MPIDI_OFI_handle_cq_entries(vni, wc, 1);
     } else if (likely(1)) {
         for (int nic = 0; nic < MPIDI_OFI_global.num_nics; nic++) {
             int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
@@ -94,11 +95,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
                              MPIDI_OFI_NUM_CQ_ENTRIES);
 
             if (likely(ret > 0))
-                mpi_errno = MPIDI_OFI_handle_cq_entries(wc, ret);
+                mpi_errno = MPIDI_OFI_handle_cq_entries(vni, wc, ret);
             else if (ret == -FI_EAGAIN)
                 mpi_errno = MPI_SUCCESS;
             else
-                mpi_errno = MPIDI_OFI_handle_cq_error(ctx_idx, ret);
+                mpi_errno = MPIDI_OFI_handle_cq_error(vni, nic, ret);
         }
 
         if (unlikely(mpi_errno == MPI_SUCCESS && MPIDI_OFI_global.per_vni[vni].deferred_am_isend_q)) {

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -12,7 +12,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_deferred_ops(void)
 {
 
     int mpi_errno = MPI_SUCCESS;
-    MPIDI_OFI_deferred_am_isend_req_t *dreq = MPIDI_OFI_global.deferred_am_isend_q;
+    MPIDI_OFI_deferred_am_isend_req_t *dreq = MPIDI_OFI_global.per_vni[0].deferred_am_isend_q;
 
     MPIR_FUNC_ENTER;
 
@@ -101,7 +101,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
                 mpi_errno = MPIDI_OFI_handle_cq_error(ctx_idx, ret);
         }
 
-        if (unlikely(mpi_errno == MPI_SUCCESS && MPIDI_OFI_global.deferred_am_isend_q)) {
+        if (unlikely(mpi_errno == MPI_SUCCESS && MPIDI_OFI_global.per_vni[vni].deferred_am_isend_q)) {
             mpi_errno = MPIDI_OFI_handle_deferred_ops();
         }
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -327,15 +327,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
+    int vni_src, vni_dst;
+    MPIDI_OFI_RECV_VNIS(vni_src, vni_dst);
     /* For anysource recv, we may be called while holding the vci lock of shm request (to
      * prevent shm progress). Therefore, recursive locking is allowed here */
     if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno =
-            MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, 0, request, 0,
-                             partner);
+        mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
+                                     vni_dst, request, 0, partner);
     } else {
-        int vni_src, vni_dst;
-        MPIDI_OFI_RECV_VNIS(vni_src, vni_dst);
         MPIDI_OFI_THREAD_CS_ENTER_REC_VCI_OPTIONAL(vni_dst);
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, rank, tag, comm,
                                        context_offset, addr, vni_src, vni_dst, request,

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -41,7 +41,8 @@ void MPIDI_OFI_complete_chunks(MPIDI_OFI_win_request_t * winreq)
         }
 
         MPIDI_OFI_pack_chunk *next = chunk->next;
-        MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.pack_buf_pool, chunk->pack_buffer);
+        MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool,
+                                          chunk->pack_buffer);
         MPL_free(chunk);
         chunk = next;
     }
@@ -198,7 +199,7 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
     int j = req->noncontig.put.target.iov_cur;
     size_t msg_len;
     while (req->noncontig.put.origin.pack_offset < req->noncontig.put.origin.total_bytes) {
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.pack_buf_pool, &pack_buffer);
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool, &pack_buffer);
         if (pack_buffer == NULL)
             break;
 
@@ -288,7 +289,7 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
     int j = req->noncontig.get.target.iov_cur;
     size_t msg_len;
     while (req->noncontig.get.origin.pack_offset < req->noncontig.get.origin.total_bytes) {
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.pack_buf_pool, &pack_buffer);
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool, &pack_buffer);
         if (pack_buffer == NULL)
             break;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -28,6 +28,7 @@ static MPIDI_OFI_pack_chunk *create_chunk(void *pack_buffer, MPI_Aint unpack_siz
 void MPIDI_OFI_complete_chunks(MPIDI_OFI_win_request_t * winreq)
 {
     MPIDI_OFI_pack_chunk *chunk = winreq->chunks;
+    int vni = winreq->vni;
 
     while (chunk) {
         if (chunk->unpack_size > 0) {
@@ -41,7 +42,7 @@ void MPIDI_OFI_complete_chunks(MPIDI_OFI_win_request_t * winreq)
         }
 
         MPIDI_OFI_pack_chunk *next = chunk->next;
-        MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool,
+        MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[vni].pack_buf_pool,
                                           chunk->pack_buffer);
         MPL_free(chunk);
         chunk = next;
@@ -71,6 +72,7 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    req->vni = MPIDI_OFI_WIN(win).vni;
     req->next = MPIDI_OFI_WIN(win).syncQ;
     MPIDI_OFI_WIN(win).syncQ = req;
     req->sigreq = sigreq;
@@ -190,6 +192,7 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
     struct fi_rma_iov riov;
     uint64_t flags;
     void *pack_buffer;
+    int vni = req->vni;
 
     if (sigreq)
         flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
@@ -199,7 +202,8 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
     int j = req->noncontig.put.target.iov_cur;
     size_t msg_len;
     while (req->noncontig.put.origin.pack_offset < req->noncontig.put.origin.total_bytes) {
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool, &pack_buffer);
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[vni].pack_buf_pool,
+                                           &pack_buffer);
         if (pack_buffer == NULL)
             break;
 
@@ -225,7 +229,6 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         MPIDI_OFI_pack_chunk *chunk = create_chunk(pack_buffer, 0, 0, req);
         MPIR_ERR_CHKANDSTMT(chunk == NULL, mpi_errno, MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
 
-        int vni = MPIDI_OFI_WIN(win).vni;
         int nic = 0;
         msg.desc = NULL;
         msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.put.target.addr, nic, vni, vni);
@@ -280,6 +283,7 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
     struct fi_rma_iov riov;
     uint64_t flags;
     void *pack_buffer;
+    int vni = req->vni;
 
     if (sigreq)
         flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
@@ -289,7 +293,8 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
     int j = req->noncontig.get.target.iov_cur;
     size_t msg_len;
     while (req->noncontig.get.origin.pack_offset < req->noncontig.get.origin.total_bytes) {
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[0].pack_buf_pool, &pack_buffer);
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vni[vni].pack_buf_pool,
+                                           &pack_buffer);
         if (pack_buffer == NULL)
             break;
 
@@ -310,7 +315,6 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
             create_chunk(pack_buffer, msg_len, req->noncontig.get.origin.pack_offset, req);
         MPIR_ERR_CHKANDSTMT(chunk == NULL, mpi_errno, MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
 
-        int vni = MPIDI_OFI_WIN(win).vni;
         int nic = 0;
         msg.desc = NULL;
         msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.get.target.addr, nic, vni, vni);
@@ -373,6 +377,7 @@ int MPIDI_OFI_pack_put(const void *origin_addr, int origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    req->vni = MPIDI_OFI_WIN(win).vni;
     req->sigreq = sigreq;
 
     /* allocate target iovecs */
@@ -433,6 +438,7 @@ int MPIDI_OFI_pack_get(void *origin_addr, int origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    req->vni = MPIDI_OFI_WIN(win).vni;
     req->sigreq = sigreq;
 
     /* allocate target iovecs */

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -439,13 +439,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+    int vni_src, vni_dst;
+    MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
     if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno =
-            MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                             request);
+        mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                     vni_src, vni_dst, request);
     } else {
-        int vni_src, vni_dst;
-        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
         MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, vni_src, vni_dst,
@@ -481,14 +480,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    /* NOTE: collective use vci 0 and critical section taken at ch4-layer */
+    int vni_src, vni_dst;
+    MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
     if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno =
-            MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                              0, 0, request, errflag);
+        mpi_errno = MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                      vni_src, vni_dst, request, errflag);
     } else {
-        int vni_src, vni_dst;
-        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
         MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, vni_src, vni_dst, request, 0, 0ULL,
@@ -508,13 +505,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+    int vni_src, vni_dst;
+    MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
     if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno =
-            MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                              request);
+        mpi_errno = MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                      vni_src, vni_dst, request);
     } else {
-        int vni_src, vni_dst;
-        MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);  /* defined just above */
         MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, vni_src, vni_dst, request, 0,

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -265,7 +265,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                                                  vni_remote), match_bits),
                              vni_local, tinjectdata, FALSE /* eagain */);
         MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
-        MPIDI_OFI_send_event(NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
+        MPIDI_OFI_send_event(vni_src, NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
     } else if ((data_sz < MPIDI_OFI_global.max_msg_size && !MPIDI_OFI_COMM(comm).enable_striping)
                || (data_sz < MPIDI_OFI_global.stripe_threshold &&
                    MPIDI_OFI_COMM(comm).enable_striping)) {

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -425,6 +425,7 @@ typedef struct MPIDI_OFI_pack_chunk {
 typedef struct MPIDI_OFI_win_request {
     struct MPIDI_OFI_win_request *next;
     struct MPIDI_OFI_win_request *prev;
+    int vni;
     int rma_type;
     MPIR_Request **sigreq;
     MPIDI_OFI_pack_chunk *chunks;
@@ -492,7 +493,7 @@ typedef struct MPIDI_OFI_huge_recv {
     char pad[MPIDI_REQUEST_HDR_SIZE];
     struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];       /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
-    int (*done_fn) (struct fi_cq_tagged_entry * wc, MPIR_Request * req, int event_id);
+    int (*done_fn) (int vni, struct fi_cq_tagged_entry * wc, MPIR_Request * req, int event_id);
     MPIDI_OFI_send_control_t remote_info;
     bool peek;                  /* Flag to indicate whether this struct has been created to track an uncompleted peek
                                  * operation. */

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -30,7 +30,6 @@
 #define MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE  (16 * 1024)
 #define MPIDI_OFI_MAX_NUM_AM_BUFFERS       (8)
 #define MPIDI_OFI_AM_BUFF_SZ               (1 * 1024 * 1024)
-#define MPIDI_OFI_CACHELINE_SIZE           (MPL_CACHELINE_SIZE)
 #define MPIDI_OFI_IOV_MAX                  (32)
 #define MPIDI_OFI_AM_HDR_POOL_CELL_SIZE            (1024)
 #define MPIDI_OFI_AM_HDR_POOL_NUM_CELLS_PER_CHUNK   (1024)
@@ -272,8 +271,8 @@ typedef struct {
 
 typedef union {
     MPID_Thread_mutex_t m;
-    char cacheline[MPIDI_OFI_CACHELINE_SIZE];
-} MPIDI_OFI_cacheline_mutex_t MPL_ATTR_ALIGNED(MPIDI_OFI_CACHELINE_SIZE);
+    char cacheline[MPL_CACHELINE_SIZE];
+} MPIDI_OFI_cacheline_mutex_t;
 
 typedef struct {
     unsigned enable_av_table:1;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -281,8 +281,7 @@ static int win_set_per_win_sync(MPIR_Win * win)
 
 static void win_init_am(MPIR_Win * win)
 {
-    /* TODO: MPIDI_WIN(win, am_vci) %= MPIDI_OFI_global.num_vnis; */
-    MPIDI_WIN(win, am_vci) = 0;
+    MPIDI_WIN(win, am_vci) %= MPIDI_OFI_global.num_vnis;
 }
 
 /*

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -152,7 +152,7 @@ void MPIDI_OFI_mr_key_allocator_destroy(void)
 
 /* Translate the control message to get a huge message into a request to
  * actually perform the data transfer. */
-static int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
+static int MPIDI_OFI_get_huge(int vni, MPIDI_OFI_send_control_t * info)
 {
     MPIDI_OFI_huge_recv_t *recv_elem = NULL;
     int mpi_errno = MPI_SUCCESS;
@@ -220,7 +220,7 @@ static int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
     recv_elem->remote_info = *info;
     recv_elem->next = NULL;
     if (ready_to_get) {
-        MPIDI_OFI_get_huge_event(NULL, (MPIR_Request *) recv_elem);
+        MPIDI_OFI_get_huge_event(vni, NULL, (MPIR_Request *) recv_elem);
     }
 
     MPIR_FUNC_EXIT;
@@ -250,7 +250,7 @@ int MPIDI_OFI_control_handler(void *am_hdr, void *data, MPI_Aint data_sz,
             break;
 
         case MPIDI_OFI_CTRL_HUGE:{
-                mpi_errno = MPIDI_OFI_get_huge(ctrlsend);
+                mpi_errno = MPIDI_OFI_get_huge(0, ctrlsend);
                 goto fn_exit;
             }
             break;

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -243,7 +243,8 @@ int MPIDI_OFI_control_handler(void *am_hdr, void *data, MPI_Aint data_sz,
 
     switch (ctrlsend->type) {
         case MPIDI_OFI_CTRL_HUGEACK:{
-                mpi_errno = MPIDI_OFI_dispatch_function(NULL, ctrlsend->ackreq);
+                /* FIXME: need vni from the callback parameters */
+                mpi_errno = MPIDI_OFI_dispatch_function(0, NULL, ctrlsend->ackreq);
                 goto fn_exit;
             }
             break;

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -106,6 +106,9 @@
 # freebsd failures
 * * debug ch3:tcp freebsd64     /^comm_create_group_threads/     xfail=issue4372        test/mpi/threads/comm/testlist
 
+# timeout due to lack of passive progress
+* * vci ch4:ofi *       /^rma_contig.*iter=32768/        xfail=issue5565        test/mpi/rma/testlist
+
 # Job-sepecific xfails
 # Our Arm servers are too slow for some tests
 mpich-main-arm.* * * * * /^sendflood /          xfail=ticket0       test/mpi/pt2pt/testlist

--- a/test/mpi/rma/rma_contig.c
+++ b/test/mpi/rma/rma_contig.c
@@ -15,6 +15,7 @@
 #define MIN_NUM_ITERATIONS 8
 #define NUM_WARMUP_ITER 1
 
+int max_num_iterations = MAX_NUM_ITERATIONS;
 const int verbose = 0;
 static int rank;
 
@@ -64,7 +65,7 @@ static void run_test(int lock_mode, int lock_assert)
     for (target_rank = 0; rank == 0 && target_rank < nproc; target_rank++) {
         for (data_size = sizeof(double); data_size <= MAX_DATA_SIZE; data_size *= 2) {
             double t_get, t_put, t_acc;
-            int num_iter = MAX_NUM_ITERATIONS;
+            int num_iter = max_num_iterations;
 
             /* Scale the number of iterations by log_2 of the data size, so
              * that we run each test for a reasonable amount of time. */
@@ -125,8 +126,11 @@ static void run_test(int lock_mode, int lock_assert)
 
 int main(int argc, char **argv)
 {
-    MTest_Init(&argc, &argv);
+    MTestArgList *head = MTestArgListCreate(argc, argv);
+    max_num_iterations = MTestArgListGetInt_with_default(head, "iter", MAX_NUM_ITERATIONS);
+    MTestArgListDestroy(head);
 
+    MTest_Init(&argc, &argv);
     run_test(MPI_LOCK_EXCLUSIVE, 0);
     run_test(MPI_LOCK_EXCLUSIVE, MPI_MODE_NOCHECK);
     run_test(MPI_LOCK_SHARED, 0);

--- a/test/mpi/rma/testlist.in
+++ b/test/mpi/rma/testlist.in
@@ -131,7 +131,8 @@ mutex_bench 4
 mutex_bench_shared 4
 mutex_bench_shm 4
 mutex_bench_shm_ordered 4
-rma_contig 2 timeLimit=720
+rma_contig 2 arg=-iter=10
+rma_contig 2 arg=-iter=32768
 badrma 2
 acc_loc 4
 acc_ordering 2


### PR DESCRIPTION
## Pull Request Description

Based on https://github.com/pmodels/mpich/pull/5543

Enable multiple vci for am in the ofi netmod.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
