### PR TITLE
ch4/shm: enable multiple vci for am in the shmmod

### DIFF
--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -34,6 +34,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
                                                         int rank, int tag, MPIR_Comm * comm,
                                                         int context_offset, MPIDI_av_entry_t * addr,
                                                         MPIDI_IPCI_ipc_attr_t ipc_attr,
+                                                        int vsi_src, int vsi_dst,
                                                         MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -48,7 +49,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
 
     /* Create send request */
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2, 0, 0);
+    sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2, vsi_src, vsi_dst);
     MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     *request = sreq;
     sreq->comm = comm;
@@ -85,7 +86,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_contig_lmt(const void *buf, MPI_Ain
 
     int is_local = 1;
     MPI_Aint hdr_sz = sizeof(slmt_req_hdr);
-    CH4_CALL(am_send_hdr(rank, comm, MPIDIG_SEND, &slmt_req_hdr, hdr_sz, 0, 0),
+    CH4_CALL(am_send_hdr(rank, comm, MPIDIG_SEND, &slmt_req_hdr, hdr_sz, vsi_src, vsi_dst),
              is_local, mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -22,7 +22,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    /* note: MPIDI_POSIX_SEND_VSIS defined in posix_send.h */
+    int vsi_src, vsi_dst;
+    MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi_src).lock);
 
     bool dt_contig;
     MPI_Aint true_lb;
@@ -45,7 +49,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
         data_sz >= ipc_attr.threshold.send_lmt_sz) {
         if (dt_contig) {
             mpi_errno = MPIDI_IPCI_send_contig_lmt(buf, count, datatype, data_sz, rank, tag, comm,
-                                                   context_offset, addr, ipc_attr, request);
+                                                   context_offset, addr, ipc_attr, vsi_src, vsi_dst,
+                                                   request);
             MPIR_ERR_CHECK(mpi_errno);
             *done = true;
         }
@@ -53,7 +58,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
          * threshold may be required to tradeoff the flattening overhead.*/
     }
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi_src).lock);
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
@@ -16,9 +16,10 @@ typedef int (*MPIDI_POSIX_eager_finalize_t) (void);
 typedef int (*MPIDI_POSIX_eager_send_t) (int grank, MPIDI_POSIX_am_header_t * msg_hdr,
                                          const void *am_hdr, MPI_Aint am_hdr_sz, const void *buf,
                                          MPI_Aint count, MPI_Datatype datatype, MPI_Aint offset,
-                                         MPI_Aint * bytes_sent);
+                                         int src_vsi, int dst_vsi, MPI_Aint * bytes_sent);
 
-typedef int (*MPIDI_POSIX_eager_recv_begin_t) (MPIDI_POSIX_eager_recv_transaction_t * transaction);
+typedef int (*MPIDI_POSIX_eager_recv_begin_t) (int vsi,
+                                               MPIDI_POSIX_eager_recv_transaction_t * transaction);
 
 typedef void (*MPIDI_POSIX_eager_recv_memcpy_t) (MPIDI_POSIX_eager_recv_transaction_t * transaction,
                                                  void *dst, const void *src, size_t size);
@@ -61,9 +62,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_he
                                                     const void *am_hdr, MPI_Aint am_hdr_sz,
                                                     const void *buf, MPI_Aint count,
                                                     MPI_Datatype datatype, MPI_Aint offset,
+                                                    int src_vsi, int dst_vsi,
                                                     MPI_Aint * bytes_sent) MPL_STATIC_INLINE_SUFFIX;
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t *
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(int vsi,
+                                                          MPIDI_POSIX_eager_recv_transaction_t *
                                                           transaction) MPL_STATIC_INLINE_SUFFIX;
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_eager_recv_memcpy(MPIDI_POSIX_eager_recv_transaction_t *

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager_impl.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager_impl.h
@@ -13,16 +13,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_he
                                                     const void *am_hdr, MPI_Aint am_hdr_sz,
                                                     const void *buf, MPI_Aint count,
                                                     MPI_Datatype datatype, MPI_Aint offset,
-                                                    MPI_Aint * bytes_sent)
+                                                    int src_vsi, int dst_vsi, MPI_Aint * bytes_sent)
 {
     return MPIDI_POSIX_eager_func->send(grank, msg_hdr, am_hdr, am_hdr_sz, buf, count, datatype,
-                                        offset, bytes_sent);
+                                        offset, src_vsi, dst_vsi, bytes_sent);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t *
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(int vsi,
+                                                          MPIDI_POSIX_eager_recv_transaction_t *
                                                           transaction)
 {
-    return MPIDI_POSIX_eager_func->recv_begin(transaction);
+    return MPIDI_POSIX_eager_func->recv_begin(vsi, transaction);
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_eager_recv_memcpy(MPIDI_POSIX_eager_recv_transaction_t *

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager_transaction.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager_transaction.h
@@ -18,6 +18,8 @@ typedef struct MPIDI_POSIX_eager_recv_transaction {
     size_t payload_sz;          /* 2GB limit */
 
     int src_local_rank;
+    int src_vsi;
+    int dst_vsi;
 
     /* Private */
 

--- a/src/mpid/ch4/shm/posix/eager/iqueue/Makefile.mk
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/Makefile.mk
@@ -9,8 +9,7 @@ noinst_HEADERS += src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h \
                   src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h \
                   src/mpid/ch4/shm/posix/eager/iqueue/posix_eager_inline.h
 
-mpi_core_sources += src/mpid/ch4/shm/posix/eager/iqueue/globals.c \
-                    src/mpid/ch4/shm/posix/eager/iqueue/func_table.c \
+mpi_core_sources += src/mpid/ch4/shm/posix/eager/iqueue/func_table.c \
                     src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
 
 endif

--- a/src/mpid/ch4/shm/posix/eager/iqueue/globals.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/globals.c
@@ -1,9 +1,0 @@
-/*
- * Copyright (C) by Argonne National Laboratory
- *     See COPYRIGHT in top-level directory
- */
-
-#include "iqueue_impl.h"
-#include "iqueue_types.h"
-
-MPIDI_POSIX_eager_iqueue_transport_t MPIDI_POSIX_eager_iqueue_transport_global;

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -34,42 +34,48 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
+MPIDI_POSIX_eager_iqueue_global_t MPIDI_POSIX_eager_iqueue_global;
+
 int MPIDI_POSIX_iqueue_init(int rank, int size)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIDI_POSIX_eager_iqueue_transport_t *transport;
-    size_t size_of_terminals;
 
     MPIR_FUNC_ENTER;
-
-    /* Get the internal data structure to describe the iqueues */
-    transport = MPIDI_POSIX_eager_iqueue_get_transport();
-
-    transport->num_cells = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_NUM_CELLS;
-    transport->size_of_cell = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE;
 
     /* ensure max alignment for payload */
     MPIR_Assert((MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE & (MAX_ALIGNMENT - 1)) == 0);
     MPIR_Assert((sizeof(MPIDI_POSIX_eager_iqueue_cell_t) & (MAX_ALIGNMENT - 1)) == 0);
 
-    mpi_errno = MPIDU_genq_shmem_pool_create_unsafe(transport->size_of_cell, transport->num_cells,
-                                                    MPIDI_POSIX_global.num_local,
-                                                    MPIDI_POSIX_global.my_local_rank,
-                                                    &transport->cell_pool);
-    MPIR_ERR_CHECK(mpi_errno);
-
+    size_t size_of_terminals;
     /* Create one terminal for each process with which we will be able to communicate. */
     size_of_terminals = (size_t) MPIDI_POSIX_global.num_local * sizeof(MPIDU_genq_shmem_queue_u);
 
-    /* Create the shared memory regions that will be used for the iqueue cells and terminals. */
-    mpi_errno = MPIDU_Init_shm_alloc(size_of_terminals, (void *) &transport->terminals);
-    MPIR_ERR_CHECK(mpi_errno);
+    for (int vsi_src = 0; vsi_src < MPIDI_POSIX_global.num_vsis; vsi_src++) {
+        for (int vsi_dst = 0; vsi_dst < MPIDI_POSIX_global.num_vsis; vsi_dst++) {
+            MPIDI_POSIX_eager_iqueue_transport_t *transport;
+            transport = MPIDI_POSIX_eager_iqueue_get_transport(vsi_src, vsi_dst);
 
-    transport->my_terminal = &transport->terminals[MPIDI_POSIX_global.my_local_rank];
+            transport->num_cells = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_NUM_CELLS;
+            transport->size_of_cell = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE;
 
-    mpi_errno = MPIDU_genq_shmem_queue_init(transport->my_terminal,
-                                            MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC);
-    MPIR_ERR_CHECK(mpi_errno);
+            mpi_errno =
+                MPIDU_genq_shmem_pool_create_unsafe(transport->size_of_cell, transport->num_cells,
+                                                    MPIDI_POSIX_global.num_local,
+                                                    MPIDI_POSIX_global.my_local_rank,
+                                                    &transport->cell_pool);
+            MPIR_ERR_CHECK(mpi_errno);
+
+            /* Create the shared memory regions that will be used for the iqueue cells and terminals. */
+            mpi_errno = MPIDU_Init_shm_alloc(size_of_terminals, (void *) &transport->terminals);
+            MPIR_ERR_CHECK(mpi_errno);
+
+            transport->my_terminal = &transport->terminals[MPIDI_POSIX_global.my_local_rank];
+
+            mpi_errno = MPIDU_genq_shmem_queue_init(transport->my_terminal,
+                                                    MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+    }
 
     /* Run local procs barrier */
     mpi_errno = MPIDU_Init_shm_barrier();
@@ -79,23 +85,30 @@ int MPIDI_POSIX_iqueue_init(int rank, int size)
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
-    MPIDU_Init_shm_free(transport->terminals);
-    MPIDU_genq_shmem_pool_destroy_unsafe(transport->cell_pool);
     goto fn_exit;
 }
 
 int MPIDI_POSIX_iqueue_finalize(void)
 {
-    MPIDI_POSIX_eager_iqueue_transport_t *transport;
-    int mpi_errno;
+    int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    transport = MPIDI_POSIX_eager_iqueue_get_transport();
+    for (int vsi_src = 0; vsi_src < MPIDI_POSIX_global.num_vsis; vsi_src++) {
+        for (int vsi_dst = 0; vsi_dst < MPIDI_POSIX_global.num_vsis; vsi_dst++) {
+            MPIDI_POSIX_eager_iqueue_transport_t *transport;
+            transport = MPIDI_POSIX_eager_iqueue_get_transport(vsi_src, vsi_dst);
 
-    mpi_errno = MPIDU_Init_shm_free(transport->terminals);
-    mpi_errno = MPIDU_genq_shmem_pool_destroy_unsafe(transport->cell_pool);
+            mpi_errno = MPIDU_Init_shm_free(transport->terminals);
+            MPIR_ERR_CHECK(mpi_errno);
+            mpi_errno = MPIDU_genq_shmem_pool_destroy_unsafe(transport->cell_pool);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+    }
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
@@ -10,7 +10,7 @@
 #include "mpidu_genq.h"
 
 MPL_STATIC_INLINE_PREFIX int
-MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t * transaction)
+MPIDI_POSIX_eager_recv_begin(int vsi, MPIDI_POSIX_eager_recv_transaction_t * transaction)
 {
     MPIDI_POSIX_eager_iqueue_transport_t *transport;
     MPIDI_POSIX_eager_iqueue_cell_t *cell = NULL;
@@ -18,26 +18,31 @@ MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t * transaction)
 
     MPIR_FUNC_ENTER;
 
-    /* Get the transport with the global variables */
-    transport = MPIDI_POSIX_eager_iqueue_get_transport();
+    /* TODO: measure the latency overhead due to multiple vsi */
+    for (int vsi_src = 0; vsi_src < MPIDI_POSIX_global.num_vsis; vsi_src++) {
+        transport = MPIDI_POSIX_eager_iqueue_get_transport(vsi_src, vsi);
 
-    MPIDU_genq_shmem_queue_dequeue(transport->cell_pool, transport->my_terminal, (void **) &cell);
+        MPIDU_genq_shmem_queue_dequeue(transport->cell_pool, transport->my_terminal,
+                                       (void **) &cell);
+        if (cell) {
+            transaction->src_local_rank = cell->from;
+            transaction->src_vsi = vsi_src;
+            transaction->dst_vsi = vsi;
+            transaction->payload = MPIDI_POSIX_EAGER_IQUEUE_CELL_PAYLOAD(cell);
+            transaction->payload_sz = cell->payload_size;
 
-    if (cell) {
-        transaction->src_local_rank = cell->from;
-        transaction->payload = MPIDI_POSIX_EAGER_IQUEUE_CELL_PAYLOAD(cell);
-        transaction->payload_sz = cell->payload_size;
+            if (likely(cell->type == MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_HDR)) {
+                transaction->msg_hdr = &cell->am_header;
+            } else {
+                MPIR_Assert(cell->type == MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_DATA);
+                transaction->msg_hdr = NULL;
+            }
 
-        if (likely(cell->type == MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_HDR)) {
-            transaction->msg_hdr = &cell->am_header;
-        } else {
-            MPIR_Assert(cell->type == MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_DATA);
-            transaction->msg_hdr = NULL;
+            transaction->transport.iqueue.pointer_to_cell = cell;
+
+            ret = MPIDI_POSIX_OK;
+            break;
         }
-
-        transaction->transport.iqueue.pointer_to_cell = cell;
-
-        ret = MPIDI_POSIX_OK;
     }
 
     MPIR_FUNC_EXIT;
@@ -59,7 +64,7 @@ MPIDI_POSIX_eager_recv_commit(MPIDI_POSIX_eager_recv_transaction_t * transaction
 
     MPIR_FUNC_ENTER;
 
-    transport = MPIDI_POSIX_eager_iqueue_get_transport();
+    transport = MPIDI_POSIX_eager_iqueue_get_transport(transaction->src_vsi, transaction->dst_vsi);
     cell = (MPIDI_POSIX_eager_iqueue_cell_t *) transaction->transport.iqueue.pointer_to_cell;
     MPIDU_genq_shmem_pool_cell_free(transport->cell_pool, cell);
 

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_eager_buf_limit(void)
 MPL_STATIC_INLINE_PREFIX int
 MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void *am_hdr,
                        MPI_Aint am_hdr_sz, const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                       MPI_Aint offset, MPI_Aint * bytes_sent)
+                       MPI_Aint offset, int src_vsi, int dst_vsi, MPI_Aint * bytes_sent)
 {
     MPIDI_POSIX_eager_iqueue_transport_t *transport;
     MPIDI_POSIX_eager_iqueue_cell_t *cell;
@@ -50,7 +50,7 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
     MPIR_FUNC_ENTER;
 
     /* Get the transport object that holds all of the global variables. */
-    transport = MPIDI_POSIX_eager_iqueue_get_transport();
+    transport = MPIDI_POSIX_eager_iqueue_get_transport(src_vsi, dst_vsi);
 
     /* Try to get a new cell to hold the message */
     MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell);

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_types.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_types.h
@@ -33,12 +33,17 @@ typedef struct MPIDI_POSIX_eager_iqueue_transport {
     MPIDU_genq_shmem_pool_t cell_pool;
 } MPIDI_POSIX_eager_iqueue_transport_t;
 
-extern MPIDI_POSIX_eager_iqueue_transport_t MPIDI_POSIX_eager_iqueue_transport_global;
+typedef struct MPIDI_POSIX_eager_iqueue_global {
+    /* 2d array indexed with [src_vsi][dst_vsi] */
+    MPIDI_POSIX_eager_iqueue_transport_t transports[MPIDI_CH4_MAX_VCIS][MPIDI_CH4_MAX_VCIS];
+} MPIDI_POSIX_eager_iqueue_global_t;
+
+extern MPIDI_POSIX_eager_iqueue_global_t MPIDI_POSIX_eager_iqueue_global;
 
 MPL_STATIC_INLINE_PREFIX MPIDI_POSIX_eager_iqueue_transport_t
-    * MPIDI_POSIX_eager_iqueue_get_transport(void)
+    * MPIDI_POSIX_eager_iqueue_get_transport(int vsi_src, int vsi_dst)
 {
-    return &MPIDI_POSIX_eager_iqueue_transport_global;
+    return &MPIDI_POSIX_eager_iqueue_global.transports[vsi_src][vsi_dst];
 }
 
 #define MPIDI_POSIX_EAGER_IQUEUE_CELL_PAYLOAD(cell) \

--- a/src/mpid/ch4/shm/posix/globals.c
+++ b/src/mpid/ch4/shm/posix/globals.c
@@ -3,6 +3,7 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mpidimpl.h"
 #include "posix_impl.h"
 #include "posix_types.h"
 

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -18,22 +18,21 @@ MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_POSIX_am_eager_limit(void)
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_send_hdr(int grank,
                                                         MPIDI_POSIX_am_header_t * msg_hdr,
-                                                        const void *am_hdr, bool issue_deferred);
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int rank,
-                                                     MPIDI_POSIX_am_header_t * msg_hdr,
-                                                     const void *am_hdr,
-                                                     MPI_Aint am_hdr_sz,
-                                                     const void *data,
-                                                     MPI_Aint count,
+                                                        const void *am_hdr, bool issue_deferred,
+                                                        int src_vsi, int dst_vsi);
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int rank, MPIDI_POSIX_am_header_t * msg_hdr,
+                                                     const void *am_hdr, MPI_Aint am_hdr_sz,
+                                                     const void *data, MPI_Aint count,
                                                      MPI_Datatype datatype, MPIR_Request * sreq,
-                                                     bool issue_deferred);
+                                                     bool issue_deferred, int src_vsi, int dst_vsi);
 
 /* Enqueue a request header onto the postponed message queue. This is a helper function and most
  * likely shouldn't be used outside of this file. */
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, MPI_Aint am_hdr_sz,
                                                             const int grank,
                                                             MPIDI_POSIX_am_header_t * msg_hdr_p,
-                                                            MPIR_Request * sreq)
+                                                            MPIR_Request * sreq, int src_vsi,
+                                                            int dst_vsi)
 {
     MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = MPIDI_POSIX_AMREQUEST(sreq, req_hdr);
     int mpi_errno = MPI_SUCCESS;
@@ -48,7 +47,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, 
         /* Prepare private storage */
 
         mpi_errno = MPIDI_POSIX_am_init_req_hdr(am_hdr, am_hdr_sz,
-                                                &MPIDI_POSIX_AMREQUEST(sreq, req_hdr), sreq);
+                                                &MPIDI_POSIX_AMREQUEST(sreq, req_hdr), sreq,
+                                                src_vsi);
         MPIR_ERR_CHECK(mpi_errno);
 
         curr_sreq_hdr = MPIDI_POSIX_AMREQUEST(sreq, req_hdr);
@@ -61,8 +61,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, 
     curr_sreq_hdr->msg_hdr_buf = *msg_hdr_p;
 
     curr_sreq_hdr->request = sreq;
+    curr_sreq_hdr->src_vsi = src_vsi;
+    curr_sreq_hdr->dst_vsi = dst_vsi;
 
-    DL_APPEND(MPIDI_POSIX_global.postponed_queue, curr_sreq_hdr);
+    DL_APPEND(MPIDI_POSIX_global.per_vsi[src_vsi].postponed_queue, curr_sreq_hdr);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -90,8 +92,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
     msg_hdr.handler_id = handler_id;
     msg_hdr.am_hdr_sz = am_hdr_sz;
 
+    MPIR_Assert(src_vci < MPIDI_POSIX_global.num_vsis);
+    MPIR_Assert(dst_vci < MPIDI_POSIX_global.num_vsis);
+    int src_vsi = src_vci;
+    int dst_vsi = dst_vci;
     mpi_errno = MPIDI_POSIX_do_am_isend(grank, &msg_hdr, am_hdr, am_hdr_sz, data, count,
-                                        datatype, sreq, false);
+                                        datatype, sreq, false, src_vsi, dst_vsi);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -138,7 +144,8 @@ MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_POSIX_am_eager_buf_limit(void)
  * likely shouldn't be used outside of this file. */
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, MPI_Aint am_hdr_sz,
                                                             const int grank,
-                                                            MPIDI_POSIX_am_header_t * msg_hdr)
+                                                            MPIDI_POSIX_am_header_t * msg_hdr,
+                                                            int src_vsi, int dst_vsi)
 {
     MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = NULL;
     int mpi_errno = MPI_SUCCESS;
@@ -148,17 +155,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, 
     MPIR_Assert(msg_hdr);
 
     /* Prepare private storage */
-    mpi_errno = MPIDI_POSIX_am_init_req_hdr(am_hdr, am_hdr_sz, &curr_sreq_hdr, NULL);
+    mpi_errno = MPIDI_POSIX_am_init_req_hdr(am_hdr, am_hdr_sz, &curr_sreq_hdr, NULL, src_vsi);
     MPIR_ERR_CHECK(mpi_errno);
 
     curr_sreq_hdr->dst_grank = grank;
+    curr_sreq_hdr->src_vsi = src_vsi;
+    curr_sreq_hdr->dst_vsi = dst_vsi;
 
     /* Header hasn't been sent so we should copy it from stack */
     curr_sreq_hdr->msg_hdr = &curr_sreq_hdr->msg_hdr_buf;
     curr_sreq_hdr->msg_hdr_buf = *msg_hdr;
 
     curr_sreq_hdr->request = NULL;
-    DL_APPEND(MPIDI_POSIX_global.postponed_queue, curr_sreq_hdr);
+    DL_APPEND(MPIDI_POSIX_global.per_vsi[src_vsi].postponed_queue, curr_sreq_hdr);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -181,7 +190,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank, MPIR_Comm * comm,
     msg_hdr.am_hdr_sz = am_hdr_sz;
     msg_hdr.am_type = MPIDI_POSIX_AM_TYPE__HDR;
 
-    mpi_errno = MPIDI_POSIX_do_am_send_hdr(grank, &msg_hdr, am_hdr, false);
+    MPIR_Assert(src_vci < MPIDI_POSIX_global.num_vsis);
+    MPIR_Assert(dst_vci < MPIDI_POSIX_global.num_vsis);
+    int src_vsi = src_vci;
+    int dst_vsi = dst_vci;
+    mpi_errno = MPIDI_POSIX_do_am_send_hdr(grank, &msg_hdr, am_hdr, false, src_vsi, dst_vsi);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -189,21 +202,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank, MPIR_Comm * comm,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_send_hdr(int grank,
                                                         MPIDI_POSIX_am_header_t * msg_hdr,
-                                                        const void *am_hdr, bool issue_deferred)
+                                                        const void *am_hdr, bool issue_deferred,
+                                                        int src_vsi, int dst_vsi)
 {
     int mpi_errno = MPI_SUCCESS;
     int rc = MPIDI_POSIX_OK;
 
     MPIR_FUNC_ENTER;
 
-    if (!issue_deferred && MPIDI_POSIX_global.postponed_queue) {
+    if (!issue_deferred && MPIDI_POSIX_global.per_vsi[src_vsi].postponed_queue) {
         goto fn_deferred;
     }
 
     MPIR_Assert(msg_hdr);
 
     rc = MPIDI_POSIX_eager_send(grank, msg_hdr, am_hdr, msg_hdr->am_hdr_sz, NULL, 0,
-                                MPI_DATATYPE_NULL, 0, NULL);
+                                MPI_DATATYPE_NULL, 0, src_vsi, dst_vsi, NULL);
 
     if (rc == MPIDI_POSIX_NOK) {
         if (!issue_deferred) {
@@ -215,8 +229,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_send_hdr(int grank,
 
     /* hdr is sent, dequeue if was issuing deferred op */
     if (issue_deferred) {
-        MPIDI_POSIX_am_request_header_t *curr_req_hdr = MPIDI_POSIX_global.postponed_queue;
-        DL_DELETE(MPIDI_POSIX_global.postponed_queue, curr_req_hdr);
+        MPIDI_POSIX_am_request_header_t *curr_req_hdr =
+            MPIDI_POSIX_global.per_vsi[src_vsi].postponed_queue;
+        DL_DELETE(MPIDI_POSIX_global.per_vsi[src_vsi].postponed_queue, curr_req_hdr);
         MPIDI_POSIX_am_release_req_hdr(&curr_req_hdr);
     }
 
@@ -224,7 +239,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_send_hdr(int grank,
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_deferred:
-    mpi_errno = MPIDI_POSIX_am_enqueue_req_hdr(am_hdr, msg_hdr->am_hdr_sz, grank, msg_hdr);
+    mpi_errno = MPIDI_POSIX_am_enqueue_req_hdr(am_hdr, msg_hdr->am_hdr_sz, grank, msg_hdr,
+                                               src_vsi, dst_vsi);
     goto fn_exit;
 }
 
@@ -253,7 +269,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int grank,
                                                      const void *data,
                                                      MPI_Aint count,
                                                      MPI_Datatype datatype, MPIR_Request * sreq,
-                                                     bool issue_deferred)
+                                                     bool issue_deferred, int src_vsi, int dst_vsi)
 {
     int mpi_errno = MPI_SUCCESS;
     int rc = 0;
@@ -284,20 +300,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int grank,
         msg_hdr_p = MPIDI_POSIX_AMREQUEST_HDR(sreq, msg_hdr);
     }
 
-    if (!issue_deferred && MPIDI_POSIX_global.postponed_queue) {
+    if (!issue_deferred && MPIDI_POSIX_global.per_vsi[src_vsi].postponed_queue) {
         goto fn_deferred;
     }
 
     send_size = MPIDIG_am_send_async_get_data_sz_left(sreq);
     offset = MPIDIG_am_send_async_get_offset(sreq);
+    MPI_Aint *bytes_sent_out = MPIDIG_am_send_async_get_data_sz_left(sreq) ? &send_size : NULL;
     if (offset) {
         rc = MPIDI_POSIX_eager_send(grank, NULL, NULL, 0, data, count, datatype, offset,
-                                    MPIDIG_am_send_async_get_data_sz_left(sreq) ? &send_size
-                                    : NULL);
+                                    src_vsi, dst_vsi, bytes_sent_out);
     } else {
         rc = MPIDI_POSIX_eager_send(grank, msg_hdr, am_hdr, am_hdr_sz, data, count, datatype,
-                                    offset, MPIDIG_am_send_async_get_data_sz_left(sreq) ? &send_size
-                                    : NULL);
+                                    offset, src_vsi, dst_vsi, bytes_sent_out);
     }
 
     if (rc == MPIDI_POSIX_NOK) {
@@ -324,8 +339,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int grank,
     } else {
         /* all segments are sent, complete regularly and dequeue (if was issuing deferred op) */
         if (issue_deferred) {
-            MPIDI_POSIX_am_request_header_t *curr_req_hdr = MPIDI_POSIX_global.postponed_queue;
-            DL_DELETE(MPIDI_POSIX_global.postponed_queue, curr_req_hdr);
+            MPIDI_POSIX_am_request_header_t *curr_req_hdr =
+                MPIDI_POSIX_global.per_vsi[src_vsi].postponed_queue;
+            DL_DELETE(MPIDI_POSIX_global.per_vsi[src_vsi].postponed_queue, curr_req_hdr);
 
             MPL_free(MPIDI_POSIX_AMREQUEST_HDR(sreq, pack_buffer));
             MPIDI_POSIX_AMREQUEST_HDR(sreq, pack_buffer) = NULL;
@@ -343,7 +359,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_isend(int grank,
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     (MPL_DBG_FDEST, "deferred posix_am_isend req handle=0x%x", sreq->handle));
 
-    mpi_errno = MPIDI_POSIX_am_enqueue_request(am_hdr, am_hdr_sz, grank, msg_hdr_p, sreq);
+    mpi_errno =
+        MPIDI_POSIX_am_enqueue_request(am_hdr, am_hdr_sz, grank, msg_hdr_p, sreq, src_vsi, dst_vsi);
     MPIDI_POSIX_AMREQUEST_HDR(sreq, buf) = data;
     MPIDI_POSIX_AMREQUEST_HDR(sreq, datatype) = datatype;
     MPIDI_POSIX_AMREQUEST_HDR(sreq, count) = count;

--- a/src/mpid/ch4/shm/posix/posix_am_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_am_impl.h
@@ -17,7 +17,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_release_req_hdr(MPIDI_POSIX_am_reque
     MPIR_FUNC_ENTER;
 
 #ifndef POSIX_AM_REQUEST_INLINE
-    MPIDU_genq_private_pool_free_cell(MPIDI_POSIX_global.am_hdr_buf_pool, (*req_hdr_ptr));
+    int vsi = (*req_hdr_ptr)->src_vsi;
+    MPIDU_genq_private_pool_free_cell(MPIDI_POSIX_global.per_vsi[vsi].am_hdr_buf_pool,
+                                      (*req_hdr_ptr));
 #endif
 
     MPIR_FUNC_EXIT;
@@ -27,7 +29,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_release_req_hdr(MPIDI_POSIX_am_reque
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_init_req_hdr(const void *am_hdr,
                                                          size_t am_hdr_sz,
                                                          MPIDI_POSIX_am_request_header_t **
-                                                         req_hdr_ptr, MPIR_Request * sreq)
+                                                         req_hdr_ptr, MPIR_Request * sreq, int vsi)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_am_request_header_t *req_hdr = *req_hdr_ptr;
@@ -40,7 +42,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_init_req_hdr(const void *am_hdr,
 #endif /* POSIX_AM_REQUEST_INLINE */
 
     if (req_hdr == NULL) {
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_POSIX_global.am_hdr_buf_pool, (void **) &req_hdr);
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_POSIX_global.per_vsi[vsi].am_hdr_buf_pool,
+                                           (void **) &req_hdr);
         MPIR_ERR_CHKANDJUMP(!req_hdr, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         req_hdr->am_hdr = (void *) &req_hdr->am_hdr_buf[0];

--- a/src/mpid/ch4/shm/posix/posix_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_impl.h
@@ -14,4 +14,10 @@
 #include "posix_eager_impl.h"
 #include "posix_progress.h"
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_get_vsi(int flag, MPIR_Comm * comm_ptr,
+                                                 int src_rank, int dst_rank, int tag)
+{
+    return MPIDI_get_vci(flag, comm_ptr, src_rank, dst_rank, tag) % MPIDI_POSIX_global.num_vsis;
+}
+
 #endif /* POSIX_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -153,6 +153,7 @@ int MPIDI_POSIX_init_local(int *tag_bits /* unused */)
 
     MPIDI_POSIX_global.local_rank_0 = local_rank_0;
 
+    MPIDI_POSIX_global.num_vsis = MPIDI_global.n_vcis;
     /* This is used to track messages that the eager submodule was not ready to send. */
     MPIDI_POSIX_global.postponed_queue = NULL;
 

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -125,16 +125,10 @@ int MPIDI_POSIX_init_local(int *tag_bits /* unused */)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, local_rank_0 = -1;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL(MPIDI_CH4_MAX_VCIS);
 
     MPL_COMPILE_TIME_ASSERT(sizeof(MPIDI_POSIX_am_request_header_t)
                             < MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE);
-    mpi_errno = MPIDU_genq_private_pool_create_unsafe(MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE,
-                                                      MPIDI_POSIX_AM_HDR_POOL_NUM_CELLS_PER_CHUNK,
-                                                      0,
-                                                      host_alloc, host_free,
-                                                      &MPIDI_POSIX_global.am_hdr_buf_pool);
-    MPIR_ERR_CHECK(mpi_errno);
 
     /* Populate these values with transformation information about each rank and its original
      * information in MPI_COMM_WORLD. */
@@ -155,14 +149,25 @@ int MPIDI_POSIX_init_local(int *tag_bits /* unused */)
 
     MPIDI_POSIX_global.num_vsis = MPIDI_global.n_vcis;
     /* This is used to track messages that the eager submodule was not ready to send. */
-    MPIDI_POSIX_global.postponed_queue = NULL;
+    for (int vsi = 0; vsi < MPIDI_CH4_MAX_VCIS; vsi++) {
+        mpi_errno = MPIDU_genq_private_pool_create_unsafe(MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE,
+                                                          MPIDI_POSIX_AM_HDR_POOL_NUM_CELLS_PER_CHUNK,
+                                                          0 /* unlimited */ ,
+                                                          host_alloc, host_free,
+                                                          &MPIDI_POSIX_global.
+                                                          per_vsi[vsi].am_hdr_buf_pool);
+        MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_global.active_rreq, MPIR_Request **,
-                        MPIR_Process.local_size * sizeof(MPIR_Request *), mpi_errno,
-                        "active recv req", MPL_MEM_SHM);
+        MPIDI_POSIX_global.per_vsi[vsi].postponed_queue = NULL;
 
-    for (i = 0; i < MPIR_Process.local_size; i++) {
-        MPIDI_POSIX_global.active_rreq[i] = NULL;
+        MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_global.per_vsi[vsi].active_rreq, MPIR_Request **,
+                            MPIR_Process.local_size * sizeof(MPIR_Request *), mpi_errno,
+                            "active recv req", MPL_MEM_SHM);
+
+        for (i = 0; i < MPIR_Process.local_size; i++) {
+            MPIDI_POSIX_global.per_vsi[vsi].active_rreq[i] = NULL;
+        }
+
     }
 
     choose_posix_eager();
@@ -212,9 +217,10 @@ int MPIDI_POSIX_mpi_finalize_hook(void)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    MPIDU_genq_private_pool_destroy_unsafe(MPIDI_POSIX_global.am_hdr_buf_pool);
-
-    MPL_free(MPIDI_POSIX_global.active_rreq);
+    for (int vsi = 0; vsi < MPIDI_CH4_MAX_VCIS; vsi++) {
+        MPIDU_genq_private_pool_destroy_unsafe(MPIDI_POSIX_global.per_vsi[vsi].am_hdr_buf_pool);
+        MPL_free(MPIDI_POSIX_global.per_vsi[vsi].active_rreq);
+    }
 
     MPL_free(MPIDI_POSIX_global.local_ranks);
 

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -70,8 +70,10 @@ typedef struct MPIDI_POSIX_am_request_header {
     void *rreq_ptr;
     void *am_hdr;
 
+    int8_t src_vsi;
+    int8_t dst_vsi;
     uint16_t am_hdr_sz;
-    uint8_t pad[6];
+    uint8_t pad[4];
 
     MPIDI_POSIX_am_header_t *msg_hdr;
     MPIDI_POSIX_am_header_t msg_hdr_buf;

--- a/src/mpid/ch4/shm/posix/posix_probe.h
+++ b/src/mpid/ch4/shm/posix/posix_probe.h
@@ -17,7 +17,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_improbe(int source,
                                                      int *flag, MPIR_Request ** message,
                                                      MPI_Status * status)
 {
-    return MPIDIG_mpi_improbe(source, tag, comm, context_offset, 0, flag, message, status);
+    int vsi = MPIDI_POSIX_get_vsi(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
+    return MPIDIG_mpi_improbe(source, tag, comm, context_offset, vsi, flag, message, status);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iprobe(int source,
@@ -26,7 +27,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iprobe(int source,
                                                     int context_offset, int *flag,
                                                     MPI_Status * status)
 {
-    return MPIDIG_mpi_iprobe(source, tag, comm, context_offset, 0, flag, status);
+    int vsi = MPIDI_POSIX_get_vsi(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
+    return MPIDIG_mpi_iprobe(source, tag, comm, context_offset, vsi, flag, status);
 }
 
 #endif /* POSIX_PROBE_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/posix_progress.h
+++ b/src/mpid/ch4/shm/posix/posix_progress.h
@@ -49,18 +49,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_progress_recv(int vsi, int blocking)
         payload += msg_hdr->am_hdr_sz;
         payload_left -= msg_hdr->am_hdr_sz;
 
+        uint32_t attr = MPIDIG_AM_ATTR__IS_LOCAL;
+        MPIDIG_AM_ATTR_SET_VCIS(attr, transaction.src_vsi, transaction.dst_vsi);
         switch (msg_hdr->am_type) {
             case MPIDI_POSIX_AM_TYPE__HDR:
             case MPIDI_POSIX_AM_TYPE__SHORT:
                 MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, payload, payload_left,
-                                                                   MPIDIG_AM_ATTR__IS_LOCAL, NULL);
+                                                                   attr, NULL);
                 MPIDI_POSIX_eager_recv_commit(&transaction);
                 goto fn_exit;
                 break;
             case MPIDI_POSIX_AM_TYPE__PIPELINE:
                 MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, NULL, payload_left,
-                                                                   MPIDIG_AM_ATTR__IS_LOCAL |
-                                                                   MPIDIG_AM_ATTR__IS_ASYNC, &rreq);
+                                                                   attr | MPIDIG_AM_ATTR__IS_ASYNC,
+                                                                   &rreq);
                 /* prepare for asynchronous transfer */
                 MPIDIG_recv_setup(rreq);
 

--- a/src/mpid/ch4/shm/posix/posix_recv.h
+++ b/src/mpid/ch4/shm/posix/posix_recv.h
@@ -10,6 +10,13 @@
 #include "posix_eager.h"
 #include "ch4_impl.h"
 
+/* Active message only need local vsi since all messages go to the same per-vsi queue */
+#define MPIDI_OFI_RECV_VSI(vsi_) \
+    do { \
+        /* NOTE: hashing is based on target rank */ \
+        vsi_ = MPIDI_POSIX_get_vsi(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
+    } while (0)
+
 /* Hook triggered after posting a SHM receive request.
  * It hints the SHM/POSIX internal transport that the user is expecting
  * an incoming message from a specific rank, thus allowing the transport
@@ -36,9 +43,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_irecv(void *buf,
                                                    MPIR_Comm * comm, int context_offset,
                                                    MPIR_Request ** request)
 {
-    int mpi_errno =
-        MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, 0, request, 1,
-                         NULL);
+    int vsi = MPIDI_POSIX_get_vsi(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag);
+    int mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
+                                     vsi, request, 1, NULL);
     MPIDI_POSIX_recv_posted_hook(*request, rank, comm);
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -16,13 +16,22 @@
 
 #include "posix_impl.h"
 
+#define MPIDI_POSIX_SEND_VSIS(vsi_src_, vsi_dst_) \
+    do { \
+        vsi_src_ = MPIDI_POSIX_get_vsi(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+        vsi_dst_ = MPIDI_POSIX_get_vsi(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+    } while (0)
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint count,
                                                    MPI_Datatype datatype, int rank, int tag,
                                                    MPIR_Comm * comm, int context_offset,
                                                    MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                            request);
+    int vsi_src, vsi_dst;
+    MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
+
+    return MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                            vsi_src, vsi_dst, request);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_isend_coll(const void *buf, MPI_Aint count,
@@ -32,8 +41,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_isend_coll(const void *buf, MPI_Aint co
                                                     MPIR_Request ** request,
                                                     MPIR_Errflag_t * errflag)
 {
-    return MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                             request, errflag);
+    int vsi_src, vsi_dst;
+    MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
+
+    return MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                             vsi_src, vsi_dst, request, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_issend(const void *buf, MPI_Aint count,
@@ -42,8 +54,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_issend(const void *buf, MPI_Aint co
                                                     MPIDI_av_entry_t * addr,
                                                     MPIR_Request ** request)
 {
-    return MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                             request);
+    int vsi_src, vsi_dst;
+    MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
+
+    return MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                             vsi_src, vsi_dst, request);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_cancel_send(MPIR_Request * sreq)

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -42,6 +42,7 @@ typedef struct {
     int *local_ranks;
     int *local_procs;
     int local_rank_0;
+    int num_vsis;
 } MPIDI_POSIX_global_t;
 
 extern MPIDI_POSIX_global_t MPIDI_POSIX_global;

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -26,15 +26,13 @@ enum {
 
 typedef struct {
     MPIDU_genq_private_pool_t am_hdr_buf_pool;
-
-    /* Postponed queue */
     MPIDI_POSIX_am_request_header_t *postponed_queue;
-
-    /* Active recv requests array */
     MPIR_Request **active_rreq;
+} MPIDI_POSIX_per_vsi_t;
 
+typedef struct {
+    MPIDI_POSIX_per_vsi_t per_vsi[MPIDI_CH4_MAX_VCIS];
     void *shm_ptr;
-
     /* Keep track of all of the local processes in MPI_COMM_WORLD and what their original rank was
      * in that communicator. */
     int num_local;


### PR DESCRIPTION
## Pull Request Description
Based on https://github.com/pmodels/mpich/pull/5543

Enable multiple vci for the am path in the shmmod.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
