### PR TITLE
hydra: fix warnings in gethostname

### DIFF
--- a/src/pm/hydra/pm/pmiserv/common.c
+++ b/src/pm/hydra/pm/pmiserv/common.c
@@ -130,7 +130,7 @@ HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_pmcd_pmi_kvs ** kvs, int pgid)
 
     HYDU_FUNC_ENTER();
 
-    if (gethostname(hostname, MAX_HOSTNAME_LEN) < 0)
+    if (gethostname(hostname, MAX_HOSTNAME_LEN - 40) < 0)
         HYDU_ERR_SETANDJUMP(status, HYD_SOCK_ERROR, "unable to get local hostname\n");
 
     MPL_wtime(&tv);


### PR DESCRIPTION
## Pull Request Description

We shrank the hostname space by 40 bytes but forgot the corresponding
usage in `gethostname`, resulting in a more severe warning. This was
introduced in PR #5522.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
