### PR TITLE
build: avoid duplicated build of hwloc and mpl

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1019,6 +1019,9 @@ if [ "$do_build_configure" = "yes" ] ; then
            echo "------------------------------------------------------------------------"
            echo "running third-party initialization in $external"
            (cd $external && ./autogen.sh) || exit 1
+       else
+           error "external directory $external missing"
+           exit 1
        fi
     done
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -424,61 +424,64 @@ _EOF
     fi
 fi
 
-########################################################################
-## Verify autoconf version
-########################################################################
+if test $do_quick = "yes" ; then
+    : # skip autotool versions check in quick mode (since it is too slow)
+else
+    ########################################################################
+    ## Verify autoconf version
+    ########################################################################
 
-echo_n "Checking for autoconf version... "
-recreate_tmp
-ver=2.67
-# petsc.mcs.anl.gov's /usr/bin/autoreconf is version 2.65 which returns OK
-# if configure.ac has AC_PREREQ() withOUT AC_INIT.
-#
-# ~/> hostname
-# petsc
-# ~> /usr/bin/autoconf --version
-# autoconf (GNU Autoconf) 2.65
-# ....
-# ~/> cat configure.ac
-# AC_PREREQ(2.68)
-# ~/> /usr/bin/autoconf ; echo "rc=$?"
-# configure.ac:1: error: Autoconf version 2.68 or higher is required
-# configure.ac:1: the top level
-# autom4te: /usr/bin/m4 failed with exit status: 63
-# rc=63
-# ~/> /usr/bin/autoreconf ; echo "rc=$?"
-# rc=0
-cat > .tmp/configure.ac<<EOF
+    echo_n "Checking for autoconf version... "
+    recreate_tmp
+    ver=2.67
+    # petsc.mcs.anl.gov's /usr/bin/autoreconf is version 2.65 which returns OK
+    # if configure.ac has AC_PREREQ() withOUT AC_INIT.
+    #
+    # ~/> hostname
+    # petsc
+    # ~> /usr/bin/autoconf --version
+    # autoconf (GNU Autoconf) 2.65
+    # ....
+    # ~/> cat configure.ac
+    # AC_PREREQ(2.68)
+    # ~/> /usr/bin/autoconf ; echo "rc=$?"
+    # configure.ac:1: error: Autoconf version 2.68 or higher is required
+    # configure.ac:1: the top level
+    # autom4te: /usr/bin/m4 failed with exit status: 63
+    # rc=63
+    # ~/> /usr/bin/autoreconf ; echo "rc=$?"
+    # rc=0
+    cat > .tmp/configure.ac<<EOF
 AC_INIT
 AC_PREREQ($ver)
 AC_OUTPUT
 EOF
-if (cd .tmp && $autoreconf $autoreconf_args >/dev/null 2>&1 ) ; then
-    echo ">= $ver"
-else
-    echo "bad autoconf installation"
-    cat <<EOF
+    if (cd .tmp && $autoreconf $autoreconf_args >/dev/null 2>&1 ) ; then
+        echo ">= $ver"
+    else
+        echo "bad autoconf installation"
+        cat <<EOF
 You either do not have autoconf in your path or it is too old (version
 $ver or higher required). You may be able to use
 
-     autoconf --version
+    autoconf --version
 
 Unfortunately, there is no standard format for the version output and
 it changes between autotools versions.  In addition, some versions of
 autoconf choose among many versions and provide incorrect output).
 EOF
-    exit 1
-fi
+        exit 1
+    fi
 
 
-########################################################################
-## Verify automake version
-########################################################################
+    ########################################################################
+    ## Verify automake version
+    ########################################################################
 
-echo_n "Checking for automake version... "
-recreate_tmp
-ver=1.15
-cat > .tmp/configure.ac<<EOF
+    echo_n "Checking for automake version... "
+    recreate_tmp
+    ver=1.15
+    cat > .tmp/configure.ac<<EOF
 AC_INIT(testver,1.0)
 AC_CONFIG_AUX_DIR([m4])
 AC_CONFIG_MACRO_DIR([m4])
@@ -490,33 +493,33 @@ EOF
 cat <<EOF >.tmp/Makefile.am
 ACLOCAL_AMFLAGS = -I m4
 EOF
-if [ ! -d .tmp/m4 ] ; then mkdir .tmp/m4 >/dev/null 2>&1 ; fi
-if (cd .tmp && $autoreconf $autoreconf_args >/dev/null 2>&1 ) ; then
-    echo ">= $ver"
-else
-    echo "bad automake installation"
-    cat <<EOF
+    if [ ! -d .tmp/m4 ] ; then mkdir .tmp/m4 >/dev/null 2>&1 ; fi
+    if (cd .tmp && $autoreconf $autoreconf_args >/dev/null 2>&1 ) ; then
+        echo ">= $ver"
+    else
+        echo "bad automake installation"
+        cat <<EOF
 You either do not have automake in your path or it is too old (version
 $ver or higher required). You may be able to use
 
-     automake --version
+    automake --version
 
 Unfortunately, there is no standard format for the version output and
 it changes between autotools versions.  In addition, some versions of
 autoconf choose among many versions and provide incorrect output).
 EOF
-    exit 1
-fi
+        exit 1
+    fi
 
 
-########################################################################
-## Verify libtool version
-########################################################################
+    ########################################################################
+    ## Verify libtool version
+    ########################################################################
 
-echo_n "Checking for libtool version... "
-recreate_tmp
-ver=2.4.4
-cat <<EOF >.tmp/configure.ac
+    echo_n "Checking for libtool version... "
+    recreate_tmp
+    ver=2.4.4
+    cat <<EOF >.tmp/configure.ac
 AC_INIT(testver,1.0)
 AC_CONFIG_AUX_DIR([m4])
 AC_CONFIG_MACRO_DIR([m4])
@@ -525,27 +528,27 @@ LT_PREREQ($ver)
 LT_INIT()
 AC_MSG_RESULT([A message])
 EOF
-cat <<EOF >.tmp/Makefile.am
+    cat <<EOF >.tmp/Makefile.am
 ACLOCAL_AMFLAGS = -I m4
 EOF
-if [ ! -d .tmp/m4 ] ; then mkdir .tmp/m4 >/dev/null 2>&1 ; fi
-if (cd .tmp && $autoreconf $autoreconf_args >/dev/null 2>&1 ) ; then
-    echo ">= $ver"
-else
-    echo "bad libtool installation"
-    cat <<EOF
+    if [ ! -d .tmp/m4 ] ; then mkdir .tmp/m4 >/dev/null 2>&1 ; fi
+    if (cd .tmp && $autoreconf $autoreconf_args >/dev/null 2>&1 ) ; then
+        echo ">= $ver"
+    else
+        echo "bad libtool installation"
+        cat <<EOF
 You either do not have libtool in your path or it is too old
 (version $ver or higher required). You may be able to use
 
-     libtool --version
+    libtool --version
 
 Unfortunately, there is no standard format for the version output and
 it changes between autotools versions.  In addition, some versions of
 autoconf choose among many versions and provide incorrect output).
 EOF
-    exit 1
+        exit 1
+    fi
 fi
-
 
 ########################################################################
 ## Checking for bash

--- a/autogen.sh
+++ b/autogen.sh
@@ -106,8 +106,6 @@ do_ucx=yes
 do_json=yes
 do_yaksa=yes
 
-export do_build_configure
-
 # Allow MAKE to be set from the environment
 MAKE=${MAKE-make}
 

--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -1,0 +1,70 @@
+dnl ==== hwloc ====
+
+dnl internal routine, $1 is the extra cflags, hwloc_embedded_dir is m4 macro
+dnl defined to be the path to embedded hwloc.
+AC_DEFUN([PAC_CONFIG_HWLOC_EMBEDDED],[
+    PAC_PUSH_FLAG([CFLAGS])
+    CFLAGS="$1"
+    hwloc_config_args="--enable-embedded-mode --disable-visibility"
+    hwloc_config_args="$hwloc_config_args --disable-libxml2"
+    hwloc_config_args="$hwloc_config_args --disable-nvml"
+    hwloc_config_args="$hwloc_config_args --disable-cuda"
+    hwloc_config_args="$hwloc_config_args --disable-opencl"
+    hwloc_config_args="$hwloc_config_args --disable-rsmi"
+    PAC_CONFIG_SUBDIR_ARGS(hwloc_embedded_dir, [$hwloc_config_args],[], [AC_MSG_ERROR(embedded hwloc configure failed)])
+    PAC_POP_FLAG([CFLAGS])
+])
+
+AC_DEFUN([PAC_CONFIG_HWLOC],[
+    dnl minor difference from e.g. mpl and zm -- we'll prioritize system hwloc by default
+    PAC_CHECK_HEADER_LIB_OPTIONAL([hwloc],[hwloc.h],[hwloc],[hwloc_topology_set_pid])
+    if test "$pac_have_hwloc" = "yes" -a "$with_hwloc" != "embedded"; then
+        AC_MSG_CHECKING([if hwloc meets minimum version requirement])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <hwloc.h>], [
+                        #if HWLOC_API_VERSION < 0x00020000
+                        #error
+                        #endif
+                        return 0;])],[],[pac_have_hwloc=no])
+        AC_MSG_RESULT([$pac_have_hwloc])
+
+        # if an old hwloc was specified by the user, throw an error
+        if test "$pac_have_hwloc" = "no" -a -n "$with_hwloc" -a "$with_hwloc" != "yes" ; then
+            AC_MSG_ERROR([hwloc installation does not meet minimum version requirement (2.0). Please update your hwloc installation or use --with-hwloc=embedded.])
+        fi
+    fi
+    if test "$pac_have_hwloc" = "no" -a "$with_hwloc" != "no"; then
+        with_hwloc=embedded
+        pac_have_hwloc=yes
+    fi
+
+    if test "$with_hwloc" = "embedded" ; then
+        m4_if(hwloc_embedded_dir, [modules/hwloc], [
+            dnl ---- the main MPICH configure ----
+            PAC_CONFIG_HWLOC_EMBEDDED([$VISIBILITY_CFLAGS])
+            hwlocsrcdir="${main_top_builddir}/modules/hwloc"
+            hwloclib="${main_top_builddir}/modules/hwloc/hwloc/libhwloc_embedded.la"
+            PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/hwloc/include],[CPPFLAGS])
+            PAC_APPEND_FLAG([-I${main_top_builddir}/modules/hwloc/include],[CPPFLAGS])
+
+            # capture the line -- S["HWLOC_EMBEDDED_LIBS"]="-lm "
+            hwloc_embedded_libs=$(awk -F'"' '/^S."HWLOC_EMBEDDED_LIBS"/ {print $4}' modules/hwloc/config.status)
+            echo "hwloc_embedded_libs = $hwloc_embedded_libs"
+            if test -n "$hwloc_embedded_libs" ; then
+                dnl TODO: split and add individual lib
+                PAC_LIBS_ADD([$hwloc_embedded_libs])
+            fi
+        ], [
+            dnl ---- sub-configure (hydra) ----
+            if test "$FROM_MPICH" = "yes"; then
+                hwloc_includedir="-I${main_top_srcdir}/modules/hwloc/include -I${main_top_builddir}/modules/hwloc/include"
+                hwloc_lib="${main_top_builddir}/modules/hwloc/hwloc/libhwloc_embedded.la"
+            else
+                PAC_CONFIG_HWLOC_EMBEDDED()
+                dnl Note that single quote is intentional to pass the variable as is
+                hwloc_srcdir="hwloc_embedded_dir"
+                hwloc_includedir='-I${srcdir}/${hwloc_srcdir}/include -I${builddir}/${hwloc_srcdir}/include'
+                hwloc_lib='${builddir}/${hwloc_srcdir}/hwloc/libhwloc_embedded.la'
+            fi
+        ])
+    fi
+])

--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -1,3 +1,35 @@
+dnl ==== mpl ====
+
+dnl internal routine
+AC_DEFUN([PAC_CONFIG_MPL_EMBEDDED],[
+    mpl_subdir_args="--disable-versioning --enable-embedded"
+    PAC_CONFIG_SUBDIR_ARGS(mpl_embedded_dir,[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
+])
+
+AC_DEFUN([PAC_CONFIG_MPL],[
+    dnl NOTE: we only support embedded mpl
+    m4_if(mpl_embedded_dir, [src/mpl], [
+        dnl ---- the main MPICH configure ----
+        PAC_CONFIG_MPL_EMBEDDED
+        PAC_APPEND_FLAG([-I${main_top_builddir}/src/mpl/include], [CPPFLAGS])
+        PAC_APPEND_FLAG([-I${use_top_srcdir}/src/mpl/include], [CPPFLAGS])
+        mplsrcdir="src/mpl"
+        mpllib="src/mpl/libmpl.la"
+    ], [
+        dnl ---- sub-configure (e.g. hydra, romio) ----
+        if test "$FROM_MPICH" = "yes"; then
+            mpl_lib="$main_top_builddir/src/mpl/libmpl.la"
+            mpl_includedir='-I$(main_top_builddir)/src/mpl/include -I$(main_top_srcdir)/src/mpl/include'
+        else
+            PAC_CONFIG_MPL_EMBEDDED
+            mpl_srcdir="mpl_embedded_dir"
+            mpl_dist_srcdir="mpl_embedded_dir"
+            mpl_lib="mpl_embedded_dir/libmpl.la"
+            mpl_includedir='-I$(top_builddir)/mpl_embedded_dir/include -I$(top_srcdir)/mpl_embedded_dir/include'
+        fi
+    ])
+])
+
 dnl ==== hwloc ====
 
 dnl internal routine, $1 is the extra cflags, hwloc_embedded_dir is m4 macro

--- a/configure.ac
+++ b/configure.ac
@@ -1090,59 +1090,13 @@ hwloclib=""
 AC_SUBST([hwloclib])
 
 m4_define([hwloc_embedded_dir],[modules/hwloc])
-dnl minor difference from e.g. mpl and zm -- we'll prioritize system hwloc by default
-PAC_CHECK_HEADER_LIB_OPTIONAL([hwloc],[hwloc.h],[hwloc],[hwloc_topology_set_pid])
-PAC_CHECK_HEADER_LIB_OPTIONAL([netloc],[netloc.h],[netloc],[netloc_get_all_host_nodes])
-
-if test "$pac_have_hwloc" = "yes" -a "$with_hwloc" != "embedded"; then
-    AC_MSG_CHECKING([if hwloc meets minimum version requirement])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <hwloc.h>], [
-                       #if HWLOC_API_VERSION < 0x00020000
-                       #error
-                       #endif
-                       return 0;])],[],[pac_have_hwloc=no])
-    AC_MSG_RESULT([$pac_have_hwloc])
-
-    # if an old hwloc was specified by the user, throw an error
-    if test "$pac_have_hwloc" = "no" -a -n "$with_hwloc" -a "$with_hwloc" != "yes" ; then
-        AC_MSG_ERROR([hwloc installation does not meet minimum version requirement (2.0). Please update your hwloc installation or use --with-hwloc=embedded.])
-    fi
-fi
-
-if test "$pac_have_hwloc" = "no" -a "$with_hwloc" != "no"; then
-    with_hwloc=embedded
-    pac_have_hwloc=yes
-    dnl TODO: check and configure embedded netloc
-fi
-
-if test "$with_hwloc" = "embedded" ; then
-    PAC_PUSH_FLAG([CFLAGS])
-    CFLAGS="$VISIBILITY_CFLAGS"
-    hwloc_config_args="--enable-embedded-mode --disable-visibility"
-    hwloc_config_args="$hwloc_config_args --disable-libxml2"
-    hwloc_config_args="$hwloc_config_args --disable-nvml"
-    hwloc_config_args="$hwloc_config_args --disable-cuda"
-    hwloc_config_args="$hwloc_config_args --disable-opencl"
-    hwloc_config_args="$hwloc_config_args --disable-rsmi"
-    PAC_CONFIG_SUBDIR_ARGS([modules/hwloc], [$hwloc_config_args],[], [AC_MSG_ERROR(embedded hwloc configure failed)])
-    PAC_POP_FLAG([CFLAGS])
-    hwlocsrcdir="${main_top_builddir}/modules/hwloc"
-    hwloclib="${main_top_builddir}/modules/hwloc/hwloc/libhwloc_embedded.la"
-    PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/hwloc/include],[CPPFLAGS])
-    PAC_APPEND_FLAG([-I${main_top_builddir}/modules/hwloc/include],[CPPFLAGS])
-
-    # capture the line -- S["HWLOC_EMBEDDED_LIBS"]="-lm "
-    hwloc_embedded_libs=$(awk -F'"' '/^S."HWLOC_EMBEDDED_LIBS"/ {print $4}' modules/hwloc/config.status)
-    echo "hwloc_embedded_libs = $hwloc_embedded_libs"
-    if test -n "$hwloc_embedded_libs" ; then
-        dnl TODO: split and add individual lib
-        PAC_LIBS_ADD([$hwloc_embedded_libs])
-    fi
-fi
+PAC_CONFIG_HWLOC
 
 if test "$pac_have_hwloc" = "yes" ; then
     AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
 fi
+
+PAC_CHECK_HEADER_LIB_OPTIONAL([netloc],[netloc.h],[netloc],[netloc_get_all_host_nodes])
 if test "$pac_have_netloc" = "yes" ; then
     AC_DEFINE(HAVE_NETLOC,1,[Define if netloc is available])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -994,15 +994,8 @@ AC_SUBST([mpllibdir])
 mpllib=""
 AC_SUBST([mpllib])
 
-# NOTE: we only support embedded mpl now
-# no need for libtool versioning when embedding MPL
-mpl_subdir_args="--disable-versioning --enable-embedded"
-PAC_CONFIG_SUBDIR_ARGS([src/mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
-PAC_APPEND_FLAG([-I${main_top_builddir}/src/mpl/include], [CPPFLAGS])
-PAC_APPEND_FLAG([-I${use_top_srcdir}/src/mpl/include], [CPPFLAGS])
-
-mplsrcdir="src/mpl"
-mpllib="src/mpl/libmpl.la"
+m4_define([mpl_embedded_dir],[src/mpl])
+PAC_CONFIG_MPL
 
 # Izem
 

--- a/src/mpi/romio/autogen.sh
+++ b/src/mpi/romio/autogen.sh
@@ -6,5 +6,7 @@
 
 ${AUTORECONF:-autoreconf} ${autoreconf_args:-"-vif"} -I confdb
 
-echo "=== running autoreconf in 'mpl' ==="
-(cd mpl && ${AUTORECONF:-autoreconf} ${autoreconf_args:-"-vif"}) || exit 1
+if test -d mpl ; then
+    echo "=== running autoreconf in 'mpl' ==="
+    (cd mpl && ${AUTORECONF:-autoreconf} ${autoreconf_args:-"-vif"}) || exit 1
+fi

--- a/src/pm/hydra/autogen.sh
+++ b/src/pm/hydra/autogen.sh
@@ -6,11 +6,15 @@
 
 autoreconf=${AUTORECONF:-autoreconf}
 
-echo "=== running autoreconf in 'mpl' ==="
-(cd mpl && $autoreconf ${autoreconf_args:-"-vif"}) || exit 1
+if test -d "mpl" ; then
+    echo "=== running autoreconf in 'mpl' ==="
+    (cd mpl && $autoreconf ${autoreconf_args:-"-vif"}) || exit 1
+fi
 
-echo "=== running autoreconf in 'tools/topo/hwloc/hwloc' ==="
-(cd tools/topo/hwloc/hwloc && ./autogen.sh) || exit 1
+if test -d "tools/topo/hwloc/hwloc" ; then
+    echo "=== running autoreconf in 'tools/topo/hwloc/hwloc' ==="
+    (cd tools/topo/hwloc/hwloc && ./autogen.sh) || exit 1
+fi
 
 echo "=== running autoreconf in '.' ==="
 $autoreconf ${autoreconf_args:-"-vif"} || exit 1

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -402,44 +402,7 @@ for hydra_topolib in ${hydra_topolibs}; do
     case "$hydra_topolib" in
 	hwloc)
                 m4_define([hwloc_embedded_dir],[tools/topo/hwloc/hwloc])
-                PAC_CHECK_HEADER_LIB_OPTIONAL([hwloc],[hwloc.h],[hwloc],[hwloc_topology_set_pid])
-
-                if test "$pac_have_hwloc" = "yes" -a "$with_hwloc" != "embedded"; then
-                    AC_MSG_CHECKING([if hwloc meets minimum version requirement])
-                    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <hwloc.h>], [
-                                       #if HWLOC_API_VERSION < 0x00020000
-                                       #error
-                                       #endif
-                                       return 0;])],[],[pac_have_hwloc=no])
-                    AC_MSG_RESULT([$pac_have_hwloc])
-
-                    # if an old hwloc was specified by the user, throw an error
-                    if test "$pac_have_hwloc" = "no" -a -n "$with_hwloc" -a "$with_hwloc" != "yes" ; then
-                        AC_MSG_ERROR([hwloc installation does not meet minimum version requirement (2.0). Please update your hwloc installation or use --with-hwloc=embedded.])
-                    fi
-                fi
-
-                if test "$pac_have_hwloc" = "no" -a "$with_hwloc" != "no"; then
-                    with_hwloc=embedded
-                    pac_have_hwloc=yes
-                fi
-		if test "$with_hwloc" = "embedded" ; then
-                    hydra_use_embedded_hwloc=yes
-                    PAC_PUSH_FLAG([CFLAGS])
-                    CFLAGS=""
-                    hwloc_config_args="--enable-embedded-mode --disable-visibility"
-                    hwloc_config_args="$hwloc_config_args --disable-libxml2"
-                    hwloc_config_args="$hwloc_config_args --disable-nvml"
-                    hwloc_config_args="$hwloc_config_args --disable-cuda"
-                    hwloc_config_args="$hwloc_config_args --disable-opencl"
-                    hwloc_config_args="$hwloc_config_args --disable-rsmi"
-                    PAC_CONFIG_SUBDIR_ARGS([tools/topo/hwloc/hwloc], [$hwloc_config_args],[], [AC_MSG_ERROR(embedded hwloc configure failed)])
-                    PAC_POP_FLAG([CFLAGS])
-                    dnl Note that single quote is intentional to pass the variable as is
-                    hwloc_srcdir="tools/topo/hwloc/hwloc"
-                    hwloc_includedir='-I${srcdir}/${hwloc_srcdir}/include -I${builddir}/${hwloc_srcdir}/include'
-                    hwloc_lib='${builddir}/${hwloc_srcdir}/hwloc/libhwloc_embedded.la'
-                fi
+                PAC_CONFIG_HWLOC
 
 		if test "$pac_have_hwloc" = "yes" ; then
 		   AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -110,17 +110,6 @@ PAC_POP_ALL_FLAGS
 AC_DEFINE_UNQUOTED(HYDRA_CONFIGURE_ARGS_CLEAN,"`echo $ac_configure_args`",[Configure arguments])
 
 # MPL
-AC_ARG_VAR([MPLLIBNAME],[can be used to override the name of the MPL library (default: "mpl")])
-MPLLIBNAME=${MPLLIBNAME:-"mpl"}
-export MPLLIBNAME
-AC_SUBST(MPLLIBNAME)
-AC_ARG_WITH([mpl-prefix],
-            [AS_HELP_STRING([[--with-mpl-prefix[=DIR]]],
-                            [use the MPL library installed in DIR. Pass
-                             "embedded" to force usage of the MPL source
-                             distributed with Hydra.])],
-            [],dnl action-if-given
-            [with_mpl_prefix=embedded]) dnl action-if-not-given
 mpl_srcdir=""
 AC_SUBST([mpl_srcdir])
 # Controls whether we recurse into the MPL dir when running "dist" rules like
@@ -132,15 +121,7 @@ AC_SUBST([mpl_includedir])
 mpl_lib=""
 AC_SUBST([mpl_lib])
 m4_define([mpl_embedded_dir],[mpl])
-PAC_CHECK_HEADER_LIB_EXPLICIT([mpl],[mplconfig.h],[$MPLLIBNAME],[mpl_str_get_int_arg])
-if test "$with_mpl" = "embedded" ; then
-    mpl_srcdir="mpl"
-    mpl_dist_srcdir="mpl"
-    mpl_lib="mpl/lib${MPLLIBNAME}.la"
-    mpl_subdir_args="--disable-versioning --enable-embedded"
-    PAC_CONFIG_SUBDIR_ARGS([mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
-    mpl_includedir='-I$(top_builddir)/mpl/include -I$(top_srcdir)/mpl/include'
-fi
+PAC_CONFIG_MPL
 
 # Documentation
 AC_PATH_PROG([DOXYGEN],[doxygen],,$PATH)


### PR DESCRIPTION
## Pull Request Description

Avoid duplicated build of hwloc and mpl in hydra by reusing the libtool package build in the main mpich.

Also, add `-quick` option to autogen to skip many unneeded submodule initializations.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
