### PR TITLE
ch4/ofi: fix tx and rx ctx counts

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -509,6 +509,18 @@ static void host_free_registered(void *ptr)
     MPL_free(ptr);
 }
 
+static void set_sep_counters(int nic)
+{
+    if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
+        int num_ctx_per_nic = MPIDI_OFI_global.num_vnis;
+        int max_by_prov = MPL_MIN(MPIDI_OFI_global.prov_use[nic]->domain_attr->tx_ctx_cnt,
+                                  MPIDI_OFI_global.prov_use[nic]->domain_attr->rx_ctx_cnt);
+        num_ctx_per_nic = MPL_MIN(num_ctx_per_nic, max_by_prov);
+        MPIDI_OFI_global.prov_use[nic]->ep_attr->tx_ctx_cnt = num_ctx_per_nic;
+        MPIDI_OFI_global.prov_use[nic]->ep_attr->rx_ctx_cnt = num_ctx_per_nic;
+    }
+}
+
 int MPIDI_OFI_init_local(int *tag_bits)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -633,6 +645,9 @@ int MPIDI_OFI_init_local(int *tag_bits)
 
     MPIDI_OFI_global.num_vnis = num_vnis;
 
+    /* set rx_ctx_cnt and tx_ctx_cnt for nic 0 */
+    set_sep_counters(0);
+
     /* Creating the context for vni 0 and nic 0.
      * This code maybe moved to a later stage */
     mpi_errno = create_vni_context(0, 0);
@@ -708,6 +723,11 @@ int MPIDI_OFI_post_init(void)
     /* FIXME: It would also be helpful to check that all of the NICs can communicate so we can fall
      * back to other options if that is not the case (e.g., verbs are often configured with a
      * different subnet for each "set" of nics). It's unknown how to write a good check for that. */
+
+    /* set rx_ctx_cnt and tx_ctx_cnt for the remaining (non-0) nics */
+    for (int nic = 1; nic < MPIDI_OFI_global.num_nics; nic++) {
+        set_sep_counters(nic);
+    }
 
     for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
         for (int nic = 0; nic < MPIDI_OFI_global.num_nics; nic++) {


### PR DESCRIPTION
## Pull Request Description
`tx_ctx_cnt` and `rx_ctx_cnt` were not being set. As a result, ofi providers could limit
to an insufficient number of contexts when we use scalable endpoints with multiple VNIs.


Fixes: https://github.com/pmodels/mpich/issues/5551

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
