### PR TITLE
ch4/ofi: fix address exchange assertion

### DIFF
--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -160,7 +160,7 @@ int MPIDI_OFI_addr_exchange_root_ctx(void)
 /* Step 2 & 3: exchange non-root contexts */
 
 /* Macros to reduce clutter, so we can focus on the ordering logics.
- * Note: they are not perfectly-wraaped, but tolearable since only used here. */
+ * Note: they are not perfectly wrapped, but tolerable since only used here. */
 #define GET_AV_AND_ADDRNAMES(rank) \
     MPIDI_OFI_addr_t *av ATTRIBUTE((unused)) = &MPIDI_OFI_AV(&MPIDIU_get_av(0, rank)); \
     char *r_names = all_names + rank * num_vnis * num_nics * name_len;

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -60,7 +60,12 @@ static int get_av_table_index(int rank, int nic, int vni)
             return rank;
         }
     } else {
+#ifdef MPIDI_OFI_VNI_USE_DOMAIN
         int num_vnis = MPIDI_OFI_global.num_vnis;
+#else
+        /* with scalable endpoint as context, all vnis share the same address. */
+        int num_vnis = 1;
+#endif
         int num_nics = MPIDI_OFI_global.num_nics;
         int num_later_ranks = MPIR_Process.size - (rank + 1);
         return rank * num_nics * num_vnis + nic * num_vnis + vni + num_later_ranks;


### PR DESCRIPTION
## Pull Request Description
Fix get_av_table_index when SEP is used for vni contexts, when it is
equivalent to single vni for the purpose of address exchange.       

Fixes #5552

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
