### PR TITLE
ch3: suppress warnings under noerrorchecking

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
@@ -300,13 +300,13 @@ void MPIR_Typerep_commit(MPI_Datatype type)
                     }
                     MPI_Aint *disps = aints;
                     int err = MPIR_Dataloop_create_struct(n, blkls, disps, types, (void **) dlp_p);
-                    MPIR_Assert(0 == err);
+                    MPIR_Assertp(0 == err);
                     MPL_free(blkls);
                 } else {
                     MPI_Aint *blkls = counts + 1;
                     MPI_Aint *disps = counts + 1 + n;
                     int err = MPIR_Dataloop_create_struct(n, blkls, disps, types, (void **) dlp_p);
-                    MPIR_Assert(0 == err);
+                    MPIR_Assertp(0 == err);
                 }
             }
             break;

--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
@@ -89,13 +89,15 @@ int MPIDI_CH3_SHM_Win_free(MPIR_Win **win_ptr);
 #if !defined(HAVE_WINDOWS_H)
 #define MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr)                                              \
     do {                                                                                \
-        int pt_err = pthread_mutex_lock((win_ptr)->shm_mutex);                          \
+        MPIR_AssertDeclValue(int pt_err, 0);                                            \
+        pt_err = pthread_mutex_lock((win_ptr)->shm_mutex);                              \
         MPIR_Assert(pt_err == 0); \
     } while (0)
 
 #define MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr)                                            \
     do {                                                                                \
-        int pt_err = pthread_mutex_unlock((win_ptr)->shm_mutex);                        \
+        MPIR_AssertDeclValue(int pt_err, 0);                                            \
+        pt_err = pthread_mutex_unlock((win_ptr)->shm_mutex);                            \
         MPIR_Assert(pt_err == 0); \
     } while (0)
 

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
@@ -1775,14 +1775,14 @@ int MPID_nem_tcp_connpoll(int in_blocking_poll)
              * on many platforms, including modern Linux. */
             if (it_plfd->revents & POLLERR || it_plfd->revents & POLLNVAL) {
                 int req_errno = MPI_SUCCESS;
-                ssize_t rc;
-                char dummy;
 
                 /* See if we can get a specific error for this fd
                  * (Stevens Network Programming Vol 1, pg 184) */
-                rc = read(it_plfd->fd, &dummy, 1);
 #ifdef HAVE_ERROR_CHECKING
+                ssize_t rc;
+                char dummy;
                 const char *err_str = "UNKNOWN";
+                rc = read(it_plfd->fd, &dummy, 1);
                 if (rc < 0)
                     err_str = MPIR_Strerror(errno, strerrbuf, MPIR_STRERROR_BUF_SIZE);
 #endif

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
@@ -425,7 +425,9 @@ static int send_id_info(const sockconn_t * const sc)
     int buf_size, iov_cnt = 2;
     ssize_t offset;
     size_t pg_id_len = 0;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 
@@ -489,7 +491,9 @@ static int send_tmpvc_info(const sockconn_t * const sc)
     struct iovec iov[3];
     int buf_size, iov_cnt = 2;
     ssize_t offset;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 
@@ -544,7 +548,9 @@ static int recv_id_or_tmpvc_info(sockconn_t * const sc, int *got_sc_eof)
     int hdr_len = sizeof(MPIDI_nem_tcp_header_t);
     struct iovec iov[2];
     char *pg_id = NULL;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_CHKPMEM_DECL(1);
     MPIR_CHKLMEM_DECL(1);
@@ -692,7 +698,9 @@ static int send_cmd_pkt(int fd, MPIDI_nem_tcp_socksm_pkt_type_t pkt_type)
     ssize_t offset;
     MPIDI_nem_tcp_header_t pkt;
     int pkt_len = sizeof(MPIDI_nem_tcp_header_t);
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_Assert(pkt_type == MPIDI_NEM_TCP_SOCKSM_PKT_ID_ACK ||
                 pkt_type == MPIDI_NEM_TCP_SOCKSM_PKT_ID_NAK ||
@@ -730,7 +738,9 @@ static int recv_cmd_pkt(int fd, MPIDI_nem_tcp_socksm_pkt_type_t * pkt_type)
     ssize_t nread;
     MPIDI_nem_tcp_header_t pkt;
     int pkt_len = sizeof(MPIDI_nem_tcp_header_t);
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 
@@ -768,7 +778,9 @@ int MPID_nem_tcp_connect(struct MPIDI_VC *const vc)
     struct pollfd *plfd = NULL;
     int idx = -1;
     int mpi_errno = MPI_SUCCESS;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_CHKLMEM_DECL(1);
 
@@ -988,7 +1000,9 @@ int close_cleanup_and_free_sc_plfd(sockconn_t * const sc)
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno2 = MPI_SUCCESS;
     int rc;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 
@@ -1481,7 +1495,9 @@ static int MPID_nem_tcp_recv_handler(sockconn_t * const sc)
     MPIR_AssertDeclValue(MPID_nem_tcp_vc_area * const sc_vc_tcp, VC_TCP(sc_vc));
     int mpi_errno = MPI_SUCCESS;
     ssize_t bytes_recvd;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 
@@ -1727,7 +1743,9 @@ int MPID_nem_tcp_connpoll(int in_blocking_poll)
     /* num_polled is needed b/c the call to it_sc->handler() can change the
      * size of the table, which leads to iterating over invalid revents. */
     int num_polled = g_tbl_size;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     if (num_polled) {
         MPIR_Assert(MPID_nem_tcp_plfd_tbl != NULL);
@@ -1759,14 +1777,15 @@ int MPID_nem_tcp_connpoll(int in_blocking_poll)
                 int req_errno = MPI_SUCCESS;
                 ssize_t rc;
                 char dummy;
-                const char *err_str ATTRIBUTE((unused)) = "UNKNOWN";
 
                 /* See if we can get a specific error for this fd
                  * (Stevens Network Programming Vol 1, pg 184) */
                 rc = read(it_plfd->fd, &dummy, 1);
+#ifdef HAVE_ERROR_CHECKING
+                const char *err_str = "UNKNOWN";
                 if (rc < 0)
                     err_str = MPIR_Strerror(errno, strerrbuf, MPIR_STRERROR_BUF_SIZE);
-
+#endif
                 MPL_DBG_MSG(MPIDI_NEM_TCP_DBG_DET, VERBOSE, "error polling fd, closing sc");
                 if (it_sc->vc) {
                     MPIR_ERR_SET2(req_errno, MPIX_ERR_PROC_FAILED, "**comm_fail",
@@ -1833,7 +1852,9 @@ int MPID_nem_tcp_state_listening_handler(struct pollfd *const unused_1, sockconn
     socklen_t len;
     SA_IN rmt_addr;
     sockconn_t *l_sc;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_finalize.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_finalize.c
@@ -9,7 +9,9 @@ int MPID_nem_tcp_finalize(void)
 {
     int mpi_errno = MPI_SUCCESS;
     int ret;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_init.c
@@ -118,7 +118,9 @@ int MPID_nem_tcp_listen(int sockfd);
 static int set_up_listener(void)
 {
     int mpi_errno = MPI_SUCCESS;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 
@@ -149,7 +151,9 @@ static int set_up_listener(void)
 int MPID_nem_tcp_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_max_sz_p)
 {
     int mpi_errno = MPI_SUCCESS;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 
@@ -382,7 +386,9 @@ int MPID_nem_tcp_get_business_card(int my_rank, char **bc_val_p, int *val_max_sz
     int ret;
     MPL_sockaddr_t sock_id;
     socklen_t len;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 
@@ -572,7 +578,9 @@ int MPID_nem_tcp_listen(int sockfd)
     int mpi_errno = MPI_SUCCESS;
     int ret;
     unsigned short port;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
@@ -67,7 +67,9 @@ int MPID_nem_tcp_send_queued(MPIDI_VC_t * vc, MPIDI_nem_tcp_request_queue_t * se
     struct iovec *iov;
     int complete;
     MPID_nem_tcp_vc_area *vc_tcp = VC_TCP(vc);
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 
@@ -211,7 +213,9 @@ static inline int tcp_large_writev(MPIDI_VC_t * vc, const struct iovec * iov, in
 {
     int mpi_errno = MPI_SUCCESS;
     MPID_nem_tcp_vc_area *vc_tcp = VC_TCP(vc);
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     *offset_ptr = MPL_large_writev(vc_tcp->sc->fd, iov, iov_n);
     if (*offset_ptr == 0) {

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_utility.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_utility.c
@@ -57,7 +57,9 @@ int MPID_nem_tcp_set_sockopts(int fd)
     int option, flags;
     int ret;
     socklen_t len;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
 /*     fprintf(stdout, __func__ " Enter\n"); fflush(stdout); */
     /* I heard you have to read the options after setting them in some implementations */

--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -796,7 +796,9 @@ int MPID_nem_handle_pkt(MPIDI_VC_t *vc, char *buf, intptr_t buflen)
 int MPIDI_CH3I_Progress_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -117,7 +117,9 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     void *cells_p = NULL;
     MPID_nem_queue_t *recv_queues_p = NULL;
     MPID_nem_queue_t *free_queues_p = NULL;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     MPIR_CHKPMEM_DECL(8);
 

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -1111,7 +1111,9 @@ int MPIDI_CH3I_Sock_SetSockBufferSize(int fd, int firm)
 {
     int mpi_errno = MPI_SUCCESS;
     int rc;
+#ifdef HAVE_ERROR_CHECKING
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
+#endif
 
     /* Get the socket buffer size if we haven't yet acquired it */
     if (sockBufSize < 0) {

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -228,11 +228,11 @@ int MPIDI_CH3I_Comm_commit_pre_hook(MPIR_Comm *comm)
     /* do some sanity checks */
     LL_FOREACH(comm->mapper_head, mapper) {
         if (mapper->src_comm->comm_kind == MPIR_COMM_KIND__INTRACOMM)
-            MPIR_Assert(mapper->dir == MPIR_COMM_MAP_DIR__L2L ||
-                        mapper->dir == MPIR_COMM_MAP_DIR__L2R);
+            MPIR_Assertp(mapper->dir == MPIR_COMM_MAP_DIR__L2L ||
+                         mapper->dir == MPIR_COMM_MAP_DIR__L2R);
         if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM)
-            MPIR_Assert(mapper->dir == MPIR_COMM_MAP_DIR__L2L ||
-                        mapper->dir == MPIR_COMM_MAP_DIR__R2L);
+            MPIR_Assertp(mapper->dir == MPIR_COMM_MAP_DIR__L2L ||
+                         mapper->dir == MPIR_COMM_MAP_DIR__R2L);
     }
 
     /* First, handle all the mappers that contribute to the local part

--- a/src/mpid/ch3/src/ch3u_handle_op_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_op_req.c
@@ -11,7 +11,6 @@ int MPIDI_CH3_Req_handler_rma_op_complete(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *ureq = NULL;
-    MPIR_Win *win_ptr = NULL;
 
     MPIR_FUNC_ENTER;
 
@@ -20,6 +19,7 @@ int MPIDI_CH3_Req_handler_rma_op_complete(MPIR_Request * sreq)
     }
 
     /* get window, decrement active request cnt on window */
+    MPIR_AssertDeclValue(MPIR_Win *win_ptr, NULL);
     MPIR_Win_get_ptr(sreq->dev.source_win_handle, win_ptr);
     MPIR_Assert(win_ptr != NULL);
     MPIDI_CH3I_RMA_Active_req_cnt--;

--- a/src/mpid/ch3/src/ch3u_request.c
+++ b/src/mpid/ch3/src/ch3u_request.c
@@ -575,7 +575,8 @@ void MPID_Request_free_hook(MPIR_Request *req)
 
     /* trigger request_completed callback function */
     if (req->dev.request_completed_cb != NULL && MPIR_Request_is_complete(req)) {
-        int mpi_errno = req->dev.request_completed_cb(req);
+        MPIR_AssertDeclValue(int mpi_errno, MPI_SUCCESS);
+        mpi_errno = req->dev.request_completed_cb(req);
         MPIR_Assert(mpi_errno == MPI_SUCCESS);
 
         req->dev.request_completed_cb = NULL;


### PR DESCRIPTION
## Pull Request Description
Make the warnings test clean under `noerrorchecking`.

* Use `MPIR_Assertp` in the non-critical path and where the assertion checking is important.
* Use `MPIR_AssertDeclValue` to protect variables only used for assertions.
* Protect `strerrbuf` with `#ifdef HAVE_ERROR_CHECKING`

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
