### PR TITLE
romio/daos: add support for DAOS pool and container labels

### DIFF
--- a/src/mpi/romio/adio/ad_daos/ad_daos.h
+++ b/src/mpi/romio/adio/ad_daos/ad_daos.h
@@ -22,9 +22,20 @@
                 __FILE__, __LINE__, __func__, ##__VA_ARGS__);           \
     } while (0)
 
+#if defined(DAOS_API_VERSION_MAJOR) && defined(DAOS_API_VERSION_MINOR)
+#define CHECK_DAOS_API_VERSION(major, minor)                                            \
+        ((DAOS_API_VERSION_MAJOR > (major))                                             \
+        || (DAOS_API_VERSION_MAJOR == (major) && DAOS_API_VERSION_MINOR >= (minor)))
+#else
+#define CHECK_DAOS_API_VERSION(major, minor) 0
+#endif
+
+extern bool adio_daos_bypass_duns;
+extern const char *adio_daos_path_prefix;
+
 struct adio_daos_hdl {
     d_list_t entry;
-    uuid_t uuid;
+    char value[DAOS_PROP_LABEL_MAX_LEN + 1];
     daos_handle_t open_hdl;
     dfs_t *dfs;
     int ref;
@@ -76,13 +87,14 @@ void ADIOI_DAOS_Init(int *error_code);
 /** Container/Pool Handle Hash functions */
 int adio_daos_hash_init(void);
 void adio_daos_hash_finalize(void);
-struct adio_daos_hdl *adio_daos_poh_lookup(const uuid_t uuid);
-int adio_daos_poh_insert(uuid_t uuid, daos_handle_t poh, struct adio_daos_hdl **hdl);
-int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl);
+struct adio_daos_hdl *adio_daos_poh_lookup(struct duns_attr_t *attr);
+int adio_daos_poh_insert(struct duns_attr_t *attr, daos_handle_t poh, struct adio_daos_hdl **hdl);
+int adio_daos_poh_lookup_connect(struct duns_attr_t *attr, struct adio_daos_hdl **hdl);
 void adio_daos_poh_release(struct adio_daos_hdl *hdl);
-struct adio_daos_hdl *adio_daos_coh_lookup(const uuid_t uuid);
-int adio_daos_coh_insert(uuid_t uuid, daos_handle_t coh, struct adio_daos_hdl **hdl);
-int adio_daos_coh_lookup_create(daos_handle_t poh, uuid_t uuid, int amode,
+struct adio_daos_hdl *adio_daos_coh_lookup(struct duns_attr_t *attr);
+int adio_daos_coh_insert(struct duns_attr_t *attr, daos_handle_t coh, dfs_t * dfs,
+                         struct adio_daos_hdl **hdl);
+int adio_daos_coh_lookup_create(daos_handle_t poh, struct duns_attr_t *attr, int amode,
                                 bool create, struct adio_daos_hdl **hdl);
 void adio_daos_coh_release(struct adio_daos_hdl *hdl);
 

--- a/src/mpi/romio/adio/ad_daos/ad_daos_close.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_close.c
@@ -31,11 +31,16 @@ void ADIOI_DAOS_Close(ADIO_File fd, int *error_code)
     if (rank == 0) {
         ADIOI_Free(cont->obj_name);
         ADIOI_Free(cont->cont_name);
-        if (cont->attr.da_rel_path) {
-            MPL_direct_free(cont->attr.da_rel_path);
-            cont->attr.da_rel_path = NULL;
-        }
     }
+#if CHECK_DAOS_API_VERSION(1, 3)
+    duns_destroy_attr(&cont->attr);
+#else
+    if (cont->attr.da_rel_path) {
+        MPL_direct_free(cont->attr.da_rel_path);
+        cont->attr.da_rel_path = NULL;
+    }
+#endif
+
     ADIOI_Free(fd->fs_ptr);
     fd->fs_ptr = NULL;
 

--- a/src/mpi/romio/adio/ad_daos/ad_daos_common.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_common.c
@@ -4,8 +4,11 @@
  */
 
 #include "ad_daos.h"
+#include <gurt/common.h>
 #include <daos_errno.h>
 
+bool adio_daos_bypass_duns;
+const char *adio_daos_path_prefix = NULL;
 int ADIOI_DAOS_Initialized = MPI_KEYVAL_INVALID;
 
 static int ad_daos_end(MPI_Comm comm, int keyval, void *attribute_val, void *extra_state)
@@ -49,6 +52,9 @@ void ADIOI_DAOS_Init(int *error_code)
         fprintf(stderr, "Failed to init daos handle hash table\n");
         return;
     }
+
+    d_getenv_bool("DAOS_BYPASS_DUNS", &adio_daos_bypass_duns);
+    adio_daos_path_prefix = getenv("DAOS_UNS_PREFIX");
 
     /** attach to comm_self destroy to finalize DAOS */
     MPI_Keyval_create(MPI_NULL_COPY_FN, ad_daos_end, &ADIOI_DAOS_Initialized, (void *) 0);

--- a/src/mpi/romio/adio/ad_daos/ad_daos_hhash.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_hhash.c
@@ -25,7 +25,7 @@ key_cmp(struct d_hash_table *htable, d_list_t * rlink, const void *key, unsigned
 {
     struct adio_daos_hdl *hdl = hdl_obj(rlink);
 
-    return (uuid_compare(hdl->uuid, key) == 0);
+    return (strcmp(hdl->value, key) == 0);
 }
 
 static void rec_addref(struct d_hash_table *htable, d_list_t * rlink)
@@ -59,35 +59,69 @@ static void rec_free(struct d_hash_table *htable, d_list_t * rlink)
     ADIOI_Free(hdl);
 }
 
+static uint32_t rec_hash(struct d_hash_table *htable, d_list_t * rlink)
+{
+    struct adio_daos_hdl *hdl = hdl_obj(rlink);
+
+    return d_hash_string_u32(hdl->value, strlen(hdl->value));
+}
+
 static d_hash_table_ops_t hdl_hash_ops = {
     .hop_key_cmp = key_cmp,
     .hop_rec_addref = rec_addref,
     .hop_rec_decref = rec_decref,
-    .hop_rec_free = rec_free
+    .hop_rec_free = rec_free,
+    .hop_rec_hash = rec_hash
 };
 
 int adio_daos_hash_init(void)
 {
     int rc;
 
-    rc = d_hash_table_create(0, 16, NULL, &hdl_hash_ops, &poh_hash);
+    rc = d_hash_table_create(D_HASH_FT_EPHEMERAL | D_HASH_FT_LRU,
+                             4, NULL, &hdl_hash_ops, &poh_hash);
     if (rc)
         return rc;
 
-    return d_hash_table_create(0, 16, NULL, &hdl_hash_ops, &coh_hash);
+    return d_hash_table_create(D_HASH_FT_EPHEMERAL | D_HASH_FT_LRU,
+                               4, NULL, &hdl_hash_ops, &coh_hash);
 }
 
 void adio_daos_hash_finalize(void)
 {
-    d_hash_table_destroy(coh_hash, true /* force */);
-    d_hash_table_destroy(poh_hash, true /* force */);
+    d_list_t *rlink;
+
+    while (1) {
+        rlink = d_hash_rec_first(coh_hash);
+        if (rlink == NULL)
+            break;
+
+        d_hash_rec_decref(coh_hash, rlink);
+    }
+    d_hash_table_destroy(coh_hash, false);
+
+    while (1) {
+        rlink = d_hash_rec_first(poh_hash);
+        if (rlink == NULL)
+            break;
+
+        d_hash_rec_decref(poh_hash, rlink);
+    }
+    d_hash_table_destroy(poh_hash, false);
 }
 
-struct adio_daos_hdl *adio_daos_poh_lookup(const uuid_t uuid)
+struct adio_daos_hdl *adio_daos_poh_lookup(struct duns_attr_t *attr)
 {
     d_list_t *rlink;
 
-    rlink = d_hash_rec_find(poh_hash, uuid, sizeof(uuid_t));
+#if CHECK_DAOS_API_VERSION(1, 4)
+    rlink = d_hash_rec_find(poh_hash, attr->da_pool, strlen(attr->da_pool));
+#else
+    char str[37];
+
+    uuid_unparse(attr->da_puuid, str);
+    rlink = d_hash_rec_find(poh_hash, str, strlen(str));
+#endif
     if (rlink == NULL)
         return NULL;
 
@@ -99,7 +133,7 @@ void adio_daos_poh_release(struct adio_daos_hdl *hdl)
     d_hash_rec_decref(poh_hash, &hdl->entry);
 }
 
-int adio_daos_poh_insert(uuid_t uuid, daos_handle_t poh, struct adio_daos_hdl **hdl)
+int adio_daos_poh_insert(struct duns_attr_t *attr, daos_handle_t poh, struct adio_daos_hdl **hdl)
 {
     struct adio_daos_hdl *phdl;
     int rc;
@@ -109,16 +143,20 @@ int adio_daos_poh_insert(uuid_t uuid, daos_handle_t poh, struct adio_daos_hdl **
         return -1;
 
     phdl->type = DAOS_POOL;
-    uuid_copy(phdl->uuid, uuid);
     phdl->open_hdl.cookie = poh.cookie;
-
-    rc = d_hash_rec_insert(poh_hash, phdl->uuid, sizeof(uuid_t), &phdl->entry, true);
+    phdl->ref = 2;
+#if CHECK_DAOS_API_VERSION(1, 4)
+    strncpy(phdl->value, attr->da_pool, DAOS_PROP_LABEL_MAX_LEN + 1);
+    phdl->value[DAOS_PROP_LABEL_MAX_LEN] = 0;
+#else
+    uuid_unparse(attr->da_puuid, phdl->value);
+#endif
+    rc = d_hash_rec_insert(poh_hash, phdl->value, strlen(phdl->value) + 1, &phdl->entry, true);
     if (rc) {
-        PRINT_MSG(stderr, "Failed to add phdl to hashtable (%d)\n", rc);
+        PRINT_MSG(stderr, "Failed to add pool hdl to hashtable (%d)\n", rc);
         goto free_hdl;
     }
 
-    d_hash_rec_addref(poh_hash, &phdl->entry);
     *hdl = phdl;
 
     return 0;
@@ -128,61 +166,44 @@ int adio_daos_poh_insert(uuid_t uuid, daos_handle_t poh, struct adio_daos_hdl **
     return rc;
 }
 
-int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl)
+int adio_daos_poh_lookup_connect(struct duns_attr_t *attr, struct adio_daos_hdl **hdl)
 {
     struct adio_daos_hdl *phdl;
-    char *group = NULL;
-    daos_pool_info_t pool_info;
+    char *sys = NULL;
+    daos_handle_t poh;
     int rc;
 
-    phdl = adio_daos_poh_lookup(uuid);
+    phdl = adio_daos_poh_lookup(attr);
     if (phdl != NULL) {
         *hdl = phdl;
         return 0;
     }
 
-    phdl = (struct adio_daos_hdl *) ADIOI_Calloc(1, sizeof(struct adio_daos_hdl));
-    if (phdl == NULL)
-        return -1;
+    /** Get the DAOS system name from env variable */
+#if CHECK_DAOS_API_VERSION(1, 4)
+    if (attr->da_sys)
+        sys = attr->da_sys;
+#endif
 
-    phdl->type = DAOS_POOL;
-    uuid_copy(phdl->uuid, uuid);
+    if (sys == NULL)
+        sys = getenv("DAOS_SYSTEM");
 
-    /** Get the DAOS system name group from env variable */
-    group = getenv("DAOS_GROUP");
-
-#if !defined(DAOS_API_VERSION_MAJOR) || DAOS_API_VERSION_MAJOR < 1
-    /** Get the SVCL from env variable */
-    char *svcl_str = NULL;
-    d_rank_list_t *svcl = NULL;
-
-    svcl_str = getenv("DAOS_SVCL");
-    if (svcl_str != NULL) {
-        svcl = daos_rank_list_parse(svcl_str, ":");
-        if (svcl == NULL) {
-            PRINT_MSG(stderr, "Failed to parse SVC list env\n");
-            rc = -1;
-            goto free_hdl;
-        }
-    }
-
-    rc = daos_pool_connect(uuid, group, svcl, DAOS_PC_RW, &phdl->open_hdl, &pool_info, NULL);
-    d_rank_list_free(svcl);
+#if CHECK_DAOS_API_VERSION(1, 4)
+    rc = daos_pool_connect(attr->da_pool, sys, DAOS_PC_RW, &poh, NULL, NULL);
 #else
-    rc = daos_pool_connect(uuid, group, DAOS_PC_RW, &phdl->open_hdl, &pool_info, NULL);
+    rc = daos_pool_connect(attr->da_puuid, sys, DAOS_PC_RW, &poh, NULL, NULL);
 #endif
     if (rc < 0) {
         PRINT_MSG(stderr, "Failed to connect to pool (%d)\n", rc);
         goto free_hdl;
     }
 
-    rc = d_hash_rec_insert(poh_hash, phdl->uuid, sizeof(uuid_t), &phdl->entry, true);
+    rc = adio_daos_poh_insert(attr, poh, &phdl);
     if (rc) {
         PRINT_MSG(stderr, "Failed to add phdl to hashtable (%d)\n", rc);
         goto err_pool;
     }
 
-    d_hash_rec_addref(poh_hash, &phdl->entry);
     *hdl = phdl;
 
     return 0;
@@ -194,11 +215,18 @@ int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl)
     return rc;
 }
 
-struct adio_daos_hdl *adio_daos_coh_lookup(const uuid_t uuid)
+struct adio_daos_hdl *adio_daos_coh_lookup(struct duns_attr_t *attr)
 {
     d_list_t *rlink;
 
-    rlink = d_hash_rec_find(coh_hash, uuid, sizeof(uuid_t));
+#if CHECK_DAOS_API_VERSION(1, 4)
+    rlink = d_hash_rec_find(coh_hash, attr->da_cont, strlen(attr->da_cont));
+#else
+    char str[37];
+
+    uuid_unparse(attr->da_cuuid, str);
+    rlink = d_hash_rec_find(coh_hash, str, strlen(str));
+#endif
     if (rlink == NULL)
         return NULL;
 
@@ -210,7 +238,8 @@ void adio_daos_coh_release(struct adio_daos_hdl *hdl)
     d_hash_rec_decref(coh_hash, &hdl->entry);
 }
 
-int adio_daos_coh_insert(uuid_t uuid, daos_handle_t coh, struct adio_daos_hdl **hdl)
+int adio_daos_coh_insert(struct duns_attr_t *attr, daos_handle_t coh, dfs_t * dfs,
+                         struct adio_daos_hdl **hdl)
 {
     struct adio_daos_hdl *co_hdl;
     int rc;
@@ -220,16 +249,21 @@ int adio_daos_coh_insert(uuid_t uuid, daos_handle_t coh, struct adio_daos_hdl **
         return -1;
 
     co_hdl->type = DAOS_CONT;
-    uuid_copy(co_hdl->uuid, uuid);
+    co_hdl->dfs = dfs;
     co_hdl->open_hdl.cookie = coh.cookie;
-
-    rc = d_hash_rec_insert(coh_hash, co_hdl->uuid, sizeof(uuid_t), &co_hdl->entry, true);
+    co_hdl->ref = 2;
+#if CHECK_DAOS_API_VERSION(1, 4)
+    strncpy(co_hdl->value, attr->da_cont, DAOS_PROP_LABEL_MAX_LEN + 1);
+    co_hdl->value[DAOS_PROP_LABEL_MAX_LEN] = 0;
+#else
+    uuid_unparse(attr->da_cuuid, co_hdl->value);
+#endif
+    rc = d_hash_rec_insert(coh_hash, co_hdl->value, strlen(co_hdl->value), &co_hdl->entry, true);
     if (rc) {
-        PRINT_MSG(stderr, "Failed to add co_hdl to hashtable (%d)\n", rc);
+        PRINT_MSG(stderr, "Failed to add container hdl to hashtable (%d)\n", rc);
         goto err_coh;
     }
 
-    d_hash_rec_addref(coh_hash, &co_hdl->entry);
     *hdl = co_hdl;
 
     return 0;
@@ -240,38 +274,51 @@ int adio_daos_coh_insert(uuid_t uuid, daos_handle_t coh, struct adio_daos_hdl **
 }
 
 int
-adio_daos_coh_lookup_create(daos_handle_t poh, uuid_t uuid, int amode,
+adio_daos_coh_lookup_create(daos_handle_t poh, struct duns_attr_t *attr, int amode,
                             bool create, struct adio_daos_hdl **hdl)
 {
     struct adio_daos_hdl *co_hdl;
+    daos_handle_t coh;
+    dfs_t *dfs;
     int rc;
 
-    co_hdl = adio_daos_coh_lookup(uuid);
+    co_hdl = adio_daos_coh_lookup(attr);
     if (co_hdl != NULL) {
         *hdl = co_hdl;
         return 0;
     }
 
-    co_hdl = (struct adio_daos_hdl *) ADIOI_Calloc(1, sizeof(struct adio_daos_hdl));
-    if (co_hdl == NULL)
-        return -1;
-
-    co_hdl->type = DAOS_CONT;
-    uuid_copy(co_hdl->uuid, uuid);
-
-    /* Try to open the DAOS container first (the parent directory) */
-    rc = daos_cont_open(poh, uuid, DAOS_COO_RW, &co_hdl->open_hdl, NULL, NULL);
+    /* Try to open the DAOS container first */
+#if CHECK_DAOS_API_VERSION(1, 4)
+    rc = daos_cont_open(poh, attr->da_cont, DAOS_COO_RW, &coh, NULL, NULL);
+#else
+    rc = daos_cont_open(poh, attr->da_cuuid, DAOS_COO_RW, &coh, NULL, NULL);
+#endif
     /* If fails with NOEXIST we can create it then reopen if create mode */
     if (rc == -DER_NONEXIST && create) {
-        rc = dfs_cont_create(poh, uuid, NULL, &co_hdl->open_hdl, &co_hdl->dfs);
+#if CHECK_DAOS_API_VERSION(1, 4)
+        uuid_t cuuid;
+
+        if (uuid_parse(attr->da_cont, cuuid) != 0) {
+            rc = dfs_cont_create_with_label(poh, attr->da_cont, NULL, &cuuid, &coh, &dfs);
+        } else {
+            rc = dfs_cont_create(poh, cuuid, NULL, &coh, &dfs);
+        }
+#else
+        rc = dfs_cont_create(poh, attr->da_cuuid, NULL, &coh, &dfs);
+#endif
         /** if someone got there first, re-open*/
         if (rc == EEXIST) {
-            rc = daos_cont_open(poh, uuid, DAOS_COO_RW, &co_hdl->open_hdl, NULL, NULL);
+#if CHECK_DAOS_API_VERSION(1, 4)
+            rc = daos_cont_open(poh, attr->da_cont, DAOS_COO_RW, &coh, NULL, NULL);
+#else
+            rc = daos_cont_open(poh, attr->da_cuuid, DAOS_COO_RW, &coh, NULL, NULL);
+#endif
             if (rc) {
                 PRINT_MSG(stderr, "Failed to create DFS container (%d)\n", rc);
                 goto free_coh;
             }
-            rc = dfs_mount(poh, co_hdl->open_hdl, amode, &co_hdl->dfs);
+            rc = dfs_mount(poh, coh, amode, &dfs);
             if (rc) {
                 PRINT_MSG(stderr, "Failed to mount DFS namesapce (%d)\n", rc);
                 goto err_cont;
@@ -282,7 +329,7 @@ adio_daos_coh_lookup_create(daos_handle_t poh, uuid_t uuid, int amode,
         }
     } else if (rc == 0) {
         /* Mount a DFS namespace on the container */
-        rc = dfs_mount(poh, co_hdl->open_hdl, amode, &co_hdl->dfs);
+        rc = dfs_mount(poh, coh, amode, &dfs);
         if (rc) {
             PRINT_MSG(stderr, "Failed to mount DFS namespace (%d)\n", rc);
             goto err_cont;
@@ -291,21 +338,19 @@ adio_daos_coh_lookup_create(daos_handle_t poh, uuid_t uuid, int amode,
         goto free_coh;
     }
 
-    rc = d_hash_rec_insert(coh_hash, co_hdl->uuid, sizeof(uuid_t), &co_hdl->entry, true);
+    rc = adio_daos_coh_insert(attr, coh, dfs, &co_hdl);
     if (rc) {
-        PRINT_MSG(stderr, "Failed to add co_hdl to hashtable (%d)\n", rc);
+        PRINT_MSG(stderr, "Failed to add container hdl to hashtable (%d)\n", rc);
         goto err_dfs;
     }
 
-    d_hash_rec_addref(coh_hash, &co_hdl->entry);
     *hdl = co_hdl;
-
     return 0;
 
   err_dfs:
-    dfs_umount(co_hdl->dfs);
+    dfs_umount(dfs);
   err_cont:
-    daos_cont_close(co_hdl->open_hdl, NULL);
+    daos_cont_close(coh, NULL);
   free_coh:
     ADIOI_Free(co_hdl);
     return rc;

--- a/src/mpi/romio/adio/ad_daos/ad_daos_open.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_open.c
@@ -70,10 +70,10 @@ static int cache_handles(struct ADIO_DAOS_cont *cont)
 {
     int rc;
 
-    cont->c = adio_daos_coh_lookup(cont->attr.da_cuuid);
+    cont->c = adio_daos_coh_lookup(&cont->attr);
     if (cont->c == NULL) {
         /** insert handle into container hashtable */
-        rc = adio_daos_coh_insert(cont->attr.da_cuuid, cont->coh, &cont->c);
+        rc = adio_daos_coh_insert(&cont->attr, cont->coh, NULL, &cont->c);
     } else {
         /** g2l handle not needed, already cached */
         rc = daos_cont_close(cont->coh, NULL);
@@ -82,10 +82,10 @@ static int cache_handles(struct ADIO_DAOS_cont *cont)
     if (rc)
         return rc;
 
-    cont->p = adio_daos_poh_lookup(cont->attr.da_puuid);
+    cont->p = adio_daos_poh_lookup(&cont->attr);
     if (cont->p == NULL) {
         /** insert handle into pool hashtable */
-        rc = adio_daos_poh_insert(cont->attr.da_puuid, cont->poh, &cont->p);
+        rc = adio_daos_poh_insert(&cont->attr, cont->poh, &cont->p);
     } else {
         /** g2l handle not needed, already cached */
         rc = daos_pool_disconnect(cont->poh, NULL);
@@ -97,13 +97,18 @@ static int cache_handles(struct ADIO_DAOS_cont *cont)
 
 static int share_cont_info(struct ADIO_DAOS_cont *cont, int rank, MPI_Comm comm)
 {
-    char uuid_buf[74];
     d_iov_t pool_hdl = { NULL, 0, 0 };
     d_iov_t cont_hdl = { NULL, 0, 0 };
     d_iov_t dfs_hdl = { NULL, 0, 0 };
     d_iov_t file_hdl = { NULL, 0, 0 };
     char *buf = NULL;
-    uint64_t total_size = 0;
+    uint64_t total_size;
+    daos_size_t buf_size;
+#if CHECK_DAOS_API_VERSION(1, 4)
+    daos_size_t pool_len, cont_len;
+#else
+    daos_size_t pool_len = 37, cont_len = 37;
+#endif
     int rc = 0;
 
     if (rank == 0) {
@@ -120,7 +125,18 @@ static int share_cont_info(struct ADIO_DAOS_cont *cont, int rank, MPI_Comm comm)
         if (rc)
             return rc;
 
-        total_size = sizeof(uuid_buf) + pool_hdl.iov_buf_len + cont_hdl.iov_buf_len +
+        buf_size = 0;
+#if CHECK_DAOS_API_VERSION(1, 4)
+        pool_len = strlen(cont->attr.da_pool) + 1;
+#endif
+        buf_size += pool_len;
+
+#if CHECK_DAOS_API_VERSION(1, 4)
+        cont_len = strlen(cont->attr.da_cont) + 1;
+#endif
+        buf_size += cont_len;
+
+        total_size = buf_size + pool_hdl.iov_buf_len + cont_hdl.iov_buf_len +
             dfs_hdl.iov_buf_len + file_hdl.iov_buf_len + sizeof(daos_size_t) * 4;
     }
 
@@ -137,10 +153,19 @@ static int share_cont_info(struct ADIO_DAOS_cont *cont, int rank, MPI_Comm comm)
     if (rank == 0) {
         char *ptr = buf;
 
+#if CHECK_DAOS_API_VERSION(1, 4)
+        strcpy(ptr, cont->attr.da_pool);
+#else
         uuid_unparse(cont->attr.da_puuid, ptr);
-        ptr += 37;
+#endif
+        ptr += pool_len;
+
+#if CHECK_DAOS_API_VERSION(1, 4)
+        strcpy(ptr, cont->attr.da_cont);
+#else
         uuid_unparse(cont->attr.da_cuuid, ptr);
-        ptr += 37;
+#endif
+        ptr += cont_len;
 
         *((daos_size_t *) ptr) = pool_hdl.iov_buf_len;
         ptr += sizeof(daos_size_t);
@@ -185,15 +210,27 @@ static int share_cont_info(struct ADIO_DAOS_cont *cont, int rank, MPI_Comm comm)
     if (rank != 0) {
         char *ptr = buf;
 
+#if CHECK_DAOS_API_VERSION(1, 4)
+        strncpy(cont->attr.da_pool, ptr, DAOS_PROP_LABEL_MAX_LEN + 1);
+        cont->attr.da_pool[DAOS_PROP_LABEL_MAX_LEN] = 0;
+        pool_len = strlen(cont->attr.da_pool) + 1;
+#else
         rc = uuid_parse(ptr, cont->attr.da_puuid);
         if (rc)
             goto out;
-        ptr += 37;
+#endif
+        ptr += pool_len;
 
+#if CHECK_DAOS_API_VERSION(1, 4)
+        strncpy(cont->attr.da_cont, ptr, DAOS_PROP_LABEL_MAX_LEN + 1);
+        cont->attr.da_cont[DAOS_PROP_LABEL_MAX_LEN] = 0;
+        cont_len = strlen(cont->attr.da_cont) + 1;
+#else
         rc = uuid_parse(ptr, cont->attr.da_cuuid);
         if (rc)
             goto out;
-        ptr += 37;
+#endif
+        ptr += cont_len;
 
         pool_hdl.iov_buf_len = *((daos_size_t *) ptr);
         ptr += sizeof(daos_size_t);
@@ -251,40 +288,66 @@ static int share_cont_info(struct ADIO_DAOS_cont *cont, int rank, MPI_Comm comm)
 
 static int get_pool_cont_uuids(const char *path, struct duns_attr_t *attr)
 {
-    bool bypass_duns = false;
-    char *uuid_str;
+    char *str;
     int rc;
 
-    d_getenv_bool("DAOS_BYPASS_DUNS", &bypass_duns);
+    if (adio_daos_bypass_duns)
+        goto resolve_with_env;
 
-    if (!bypass_duns) {
+    if (adio_daos_path_prefix) {
+        char *new_path;
+
+        new_path = ADIOI_Malloc(strlen(path) + strlen(adio_daos_path_prefix) + 2);
+        if (new_path == NULL)
+            return ENOMEM;
+        snprintf(new_path, PATH_MAX, "%s/%s", adio_daos_path_prefix, path);
+        rc = duns_resolve_path(new_path, attr);
+        ADIOI_Free(new_path);
+    } else {
+#if CHECK_DAOS_API_VERSION(1, 4)
+        attr->da_flags = DUNS_NO_PREFIX;
+#else
         attr->da_no_prefix = true;
+#endif
         rc = duns_resolve_path(path, attr);
-        if (rc)
-            PRINT_MSG(stderr, "duns_resolve_path() failed on path %s (%d)\n", path, rc);
-        return rc;
     }
 
-    /* use the env variables to retrieve the pool and container */
-    uuid_str = getenv("DAOS_POOL");
-    if (uuid_str == NULL) {
-        PRINT_MSG(stderr, "Can't retrieve DAOS pool uuid\n");
+    if (rc)
+        PRINT_MSG(stderr, "duns_resolve_path() failed on path %s (%d)\n", path, rc);
+    return rc;
+
+  resolve_with_env:
+    /* use env variables to retrieve the pool and container */
+
+    str = getenv("DAOS_POOL");
+    if (str == NULL) {
+        PRINT_MSG(stderr, "Can't retrieve DAOS pool uuid/label\n");
         return EINVAL;
     }
-    if (uuid_parse(uuid_str, attr->da_puuid) < 0) {
+#if CHECK_DAOS_API_VERSION(1, 4)
+    strncpy(attr->da_pool, str, DAOS_PROP_LABEL_MAX_LEN + 1);
+    attr->da_pool[DAOS_PROP_LABEL_MAX_LEN] = 0;
+#else
+    if (uuid_parse(str, attr->da_puuid) < 0) {
         PRINT_MSG(stderr, "Failed to parse pool uuid\n");
         return EINVAL;
     }
+#endif
 
-    uuid_str = getenv("DAOS_CONT");
-    if (uuid_str == NULL) {
-        PRINT_MSG(stderr, "Can't retrieve DAOS cont uuid\n");
+    str = getenv("DAOS_CONT");
+    if (str == NULL) {
+        PRINT_MSG(stderr, "Can't retrieve DAOS cont uuid/label\n");
         return EINVAL;
     }
-    if (uuid_parse(uuid_str, attr->da_cuuid) < 0) {
-        PRINT_MSG(stderr, "Failed to parse container uuid\n");
+#if CHECK_DAOS_API_VERSION(1, 4)
+    strncpy(attr->da_cont, str, DAOS_PROP_LABEL_MAX_LEN + 1);
+    attr->da_cont[DAOS_PROP_LABEL_MAX_LEN] = 0;
+#else
+    if (uuid_parse(str, attr->da_cuuid) < 0) {
+        PRINT_MSG(stderr, "Failed to parse cont uuid\n");
         return EINVAL;
     }
+#endif
 
     attr->da_oclass_id = OC_UNKNOWN;
     attr->da_chunk_size = 0;
@@ -332,7 +395,7 @@ void ADIOI_DAOS_Open(ADIO_File fd, int *error_code)
     fprintf(stderr, "OCLASS  = %d\n", cont->attr.da_oclass_id);
 #endif
 
-    rc = adio_daos_poh_lookup_connect(cont->attr.da_puuid, &cont->p);
+    rc = adio_daos_poh_lookup_connect(&cont->attr, &cont->p);
     if (rc) {
         PRINT_MSG(stderr, "Failed to connect to DAOS Pool (%d)\n", rc);
         *error_code = ADIOI_DAOS_err(myname, cont->cont_name, __LINE__, rc);
@@ -341,7 +404,7 @@ void ADIOI_DAOS_Open(ADIO_File fd, int *error_code)
 
     cont->poh = cont->p->open_hdl;
 
-    rc = adio_daos_coh_lookup_create(cont->poh, cont->attr.da_cuuid, O_RDWR,
+    rc = adio_daos_coh_lookup_create(cont->poh, &cont->attr, O_RDWR,
                                      (fd->access_mode & ADIO_CREATE), &cont->c);
     if (rc) {
         *error_code = ADIOI_DAOS_err(myname, cont->cont_name, __LINE__, rc);
@@ -398,10 +461,6 @@ void ADIOI_DAOS_Open(ADIO_File fd, int *error_code)
 
   out:
     return;
-  err_obj:
-    dfs_release(cont->obj);
-    if (fd->access_mode & ADIO_CREATE)
-        dfs_remove(cont->dfs, NULL, cont->obj_name, false, NULL);
   err_cont:
     adio_daos_coh_release(cont->c);
     cont->c = NULL;
@@ -409,10 +468,14 @@ void ADIOI_DAOS_Open(ADIO_File fd, int *error_code)
     adio_daos_poh_release(cont->p);
     cont->p = NULL;
   err_free:
+#if CHECK_DAOS_API_VERSION(1, 4)
+    duns_destroy_attr(&cont->attr);
+#else
     if (cont->attr.da_rel_path) {
         MPL_direct_free(cont->attr.da_rel_path);
         cont->attr.da_rel_path = NULL;
     }
+#endif
     ADIOI_Free(cont->obj_name);
     ADIOI_Free(cont->cont_name);
     goto out;
@@ -531,14 +594,14 @@ void ADIOI_DAOS_Delete(const char *filename, int *error_code)
         goto out_free;
     }
 
-    rc = adio_daos_poh_lookup_connect(attr.da_puuid, &p);
+    rc = adio_daos_poh_lookup_connect(&attr, &p);
     if (rc || p == NULL) {
         PRINT_MSG(stderr, "Failed to connect to pool\n");
         *error_code = ADIOI_DAOS_err(myname, cont_name, __LINE__, rc);
         goto out_free;
     }
 
-    rc = adio_daos_coh_lookup_create(p->open_hdl, attr.da_cuuid, O_RDWR, false, &c);
+    rc = adio_daos_coh_lookup_create(p->open_hdl, &attr, O_RDWR, false, &c);
     if (rc || c == NULL) {
         *error_code = ADIOI_DAOS_err(myname, cont_name, __LINE__, rc);
         goto out_pool;
@@ -582,8 +645,12 @@ void ADIOI_DAOS_Delete(const char *filename, int *error_code)
   out_pool:
     adio_daos_poh_release(p);
   out_free:
+#if CHECK_DAOS_API_VERSION(1, 4)
+    duns_destroy_attr(&attr);
+#else
     if (attr.da_rel_path)
         MPL_direct_free(attr.da_rel_path);
+#endif
     ADIOI_Free(obj_name);
     ADIOI_Free(cont_name);
     return;


### PR DESCRIPTION
DAOS now supports labels in addition to uuids for pools and container.
Update the DAOS ADIO driver to work with both labels and uuids,
depending on the API version of DAOS being used and adjust the environment
variables to be able to set a prefix for the direct UNS path.

## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
