### PR TITLE
misc: warnings suppression for intel compiler

### DIFF
--- a/maint/clmake.in
+++ b/maint/clmake.in
@@ -90,6 +90,7 @@ $rootSrcDir = "";
     'copying python',
     'LOOP WAS VECTORIZED',
     'Using variables ',
+    'remark #\d+: .*', # intel compiler
 );
 # In the past, we also needed
 # WARNING 84.*not used for resolving any symbol

--- a/maint/gen_coll.py
+++ b/maint/gen_coll.py
@@ -288,7 +288,7 @@ def dump_mpir_impl_blocking(name):
     dump_close("}")
     dump_else()
     if re.match(r'(scan|exscan|neighbor_)', name):
-        G.out.append("MPIR_Assert(0 && \"Only intra-communicator allowed\");")
+        G.out.append("MPIR_Assert_error(\"Only intra-communicator allowed\");")
     else:
         dump_open("switch (MPIR_CVAR_%s_INTER_ALGORITHM) {" % NAME)
         dump_cases("inter")
@@ -371,7 +371,7 @@ def dump_sched_impl(name):
     dump_close("}")
     dump_else()
     if re.match(r'(scan|exscan|neighbor_)', name):
-        G.out.append("MPIR_Assert(0 && \"Only intra-communicator allowed\");")
+        G.out.append("MPIR_Assert_error(\"Only intra-communicator allowed\");")
     else:
         dump_open("switch (MPIR_CVAR_%s_INTER_ALGORITHM) {" % NAME)
         dump_cases("inter")

--- a/src/include/mpir_assert.h
+++ b/src/include/mpir_assert.h
@@ -20,6 +20,10 @@ int MPIR_Assert_fail(const char *cond, const char *file_name, int line_num);
 int MPIR_Assert_fail_fmt(const char *cond, const char *file_name, int line_num, const char *fmt,
                          ...);
 
+/* Instead of "MPIR_Assert(0)", use "MPIR_Assert_error(error_msg)" */
+#define MPIR_Assert_error(errmsg) \
+    MPIR_Assert_fail(errmsg, __FILE__, __LINE__)
+
 /*
  * MPIR_Assert()
  *

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -64,7 +64,7 @@ int MPII_Coll_finalize(void);
 #define MPII_SCHED_CREATE_SCHED_P() \
     do { \
         MPIR_Sched_t s = MPIR_SCHED_NULL; \
-        int sched_kind = MPIR_SCHED_KIND_REGULAR; \
+        enum MPIR_Sched_kind sched_kind = MPIR_SCHED_KIND_REGULAR; \
         if (is_persistent) { \
             sched_kind = MPIR_SCHED_KIND_PERSISTENT; \
         } \

--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -155,7 +155,7 @@ static int external32_basic_convert(char *dest_buf,
                      * range. It won't work if value overflow anyway. */
                     *(int64_t *) dest_ptr = (int32_t) tmp;
                 } else {
-                    MPIR_Assert(0 && "Unhandled conversion of unequal size");
+                    MPIR_Assert_error("Unhandled conversion of unequal size");
                 }
 
                 src_ptr += src_el_size;
@@ -169,14 +169,14 @@ static int external32_basic_convert(char *dest_buf,
                     tmp = (int32_t) (*(const int64_t *) src_ptr);
                     BASIC_convert32(tmp, *(uint32_t *) dest_ptr);
                 } else {
-                    MPIR_Assert(0 && "Unhandled conversion of unequal size");
+                    MPIR_Assert_error("Unhandled conversion of unequal size");
                 }
 
                 src_ptr += src_el_size;
                 dest_ptr += dest_el_size;
             }
         } else {
-            MPIR_Assert(0 && "Unhandled conversion of unequal size");
+            MPIR_Assert_error("Unhandled conversion of unequal size");
         }
     }
     return 0;

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
@@ -144,7 +144,7 @@ void MPIR_Typerep_commit(MPI_Datatype type)
         case MPI_COMBINER_HVECTOR_INTEGER:
         case MPI_COMBINER_HINDEXED_INTEGER:
         case MPI_COMBINER_STRUCT_INTEGER:
-            MPIR_Assert(0 && "wrong combiner");
+            MPIR_Assert_error("wrong combiner");
             break;
         default:
             break;

--- a/src/mpi/errhan/errhan_impl.c
+++ b/src/mpi/errhan/errhan_impl.c
@@ -300,7 +300,7 @@ static int call_errhandler(MPIR_Errhandler * errhandler, int errorcode, int hand
             } else if (kind == MPIR_WIN) {
                 cxx_kind = 2;
             } else {
-                MPIR_Assert(0 && "not supported");
+                MPIR_Assert_error("kind not supported");
             }
             MPIR_Process.cxx_call_errfn(cxx_kind, &handle, &errorcode,
                                         (void (*)(void)) errhandler->errfn.C_Comm_Handler_function);

--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -76,7 +76,7 @@ int MPIR_Cancel_impl(MPIR_Request * request_ptr)
         case MPIR_REQUEST_KIND__PREQUEST_COLL:
             {
                 if (request_ptr->u.persist_coll.real_request != NULL) {
-                    MPIR_Assert(0 && "Not supported");
+                    MPIR_Assert_error("Cancel persistent collective not supported");
                 } else {
                     MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_REQUEST, "**requestpersistactive");
                 }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1480,6 +1480,7 @@ static void dump_global_settings(void)
     fprintf(stdout, "MPIDI_OFI_MAX_AM_HDR_SIZE: %d\n", (int) MPIDI_OFI_MAX_AM_HDR_SIZE);
     fprintf(stdout, "sizeof(MPIDI_OFI_am_request_header_t): %d\n",
             (int) sizeof(MPIDI_OFI_am_request_header_t));
+    fprintf(stdout, "sizeof(MPIDI_OFI_per_vni_t): %d\n", (int) sizeof(MPIDI_OFI_per_vni_t));
     fprintf(stdout, "MPIDI_OFI_AM_HDR_POOL_CELL_SIZE: %d\n", (int) MPIDI_OFI_AM_HDR_POOL_CELL_SIZE);
     fprintf(stdout, "MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE: %d\n",
             (int) MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE);

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -174,7 +174,7 @@ static int setup_single_nic(void)
 static int setup_multi_nic(int nic_count)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_hwtopo_gid_t parents[MPIDI_OFI_MAX_NICS];
+    MPIR_hwtopo_gid_t parents[MPIDI_OFI_MAX_NICS] = { 0 };
     int num_parents = 0;
     int local_rank = MPIR_Process.local_rank;
     MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -243,7 +243,7 @@ typedef struct {
     int cq_buffered_static_tail;
     MPIDI_OFI_cq_list_t *cq_buffered_dynamic_head, *cq_buffered_dynamic_tail;
 
-    char pad[] MPL_ATTR_ALIGNED(MPL_CACHELINE_SIZE);
+    char pad MPL_ATTR_ALIGNED(MPL_CACHELINE_SIZE);
 } MPIDI_OFI_per_vni_t;
 
 typedef struct {

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -28,6 +28,7 @@ typedef struct {
     MPIDU_genq_private_pool_t am_hdr_buf_pool;
     MPIDI_POSIX_am_request_header_t *postponed_queue;
     MPIR_Request **active_rreq;
+    char pad MPL_ATTR_ALIGNED(MPL_CACHELINE_SIZE);
 } MPIDI_POSIX_per_vsi_t;
 
 typedef struct {

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -357,12 +357,13 @@ int MPID_Init(int requested, int *provided)
     if (mpi_errno != MPI_SUCCESS)
         return mpi_errno;
 
+    if (MPIR_CVAR_DEBUG_SUMMARY && MPIR_Process.rank == 0) {
 #ifdef MPIDI_CH4_USE_MT_RUNTIME
-    int rank = MPIR_Process.rank;
-    if (MPIR_CVAR_CH4_RUNTIME_CONF_DEBUG && rank == 0)
         print_runtime_configurations();
-#endif /* #ifdef MPIDI_CH4_USE_MT_RUNTIME */
-
+#endif
+        fprintf(stdout, "==== Various sizes and limits ====\n");
+        fprintf(stdout, "sizeof(MPIDI_per_vci_t): %d\n", (int) sizeof(MPIDI_per_vci_t));
+    }
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPIDI_workq_init(&MPIDI_global.workqueue);
 #endif /* #ifdef MPIDI_CH4_USE_WORK_QUEUES */

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -254,7 +254,7 @@ typedef struct MPIDI_per_vci {
     MPL_atomic_uint64_t exp_seq_no;
     MPL_atomic_uint64_t nxt_seq_no;
 
-    char pad[] MPL_ATTR_ALIGNED(MPL_CACHELINE_SIZE);
+    char pad MPL_ATTR_ALIGNED(MPL_CACHELINE_SIZE);
 } MPIDI_per_vci_t;
 
 #define MPIDI_VCI(i) MPIDI_global.per_vci[i]

--- a/src/mpid/common/genq/mpidu_genq_shmem_queue.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_queue.c
@@ -23,7 +23,7 @@ int MPIDU_genq_shmem_queue_init(MPIDU_genq_shmem_queue_t queue, int flags)
     } else if (flags == MPIDU_GENQ_SHMEM_QUEUE_TYPE__NEM_MPSC) {
         rc = MPIDU_genqi_nem_mpsc_init(queue_obj);
     } else {
-        MPIR_Assert(0 && "Invalid GenQ flag");
+        MPIR_Assert_error("Invalid GenQ flag");
     }
 
     MPIR_FUNC_EXIT;

--- a/src/mpid/common/genq/mpidu_genq_shmem_queue.h
+++ b/src/mpid/common/genq/mpidu_genq_shmem_queue.h
@@ -232,7 +232,7 @@ static inline int MPIDU_genq_shmem_queue_dequeue(MPIDU_genq_shmem_pool_t pool,
     } else if (flags == MPIDU_GENQ_SHMEM_QUEUE_TYPE__NEM_MPSC) {
         rc = MPIDU_genqi_nem_mpsc_dequeue(pool_obj, queue_obj, cell);
     } else {
-        MPIR_Assert(0 && "Invalid GenQ flag");
+        MPIR_Assert_error("Invalid GenQ flag");
     }
 
     MPIR_FUNC_EXIT;
@@ -255,7 +255,7 @@ static inline int MPIDU_genq_shmem_queue_enqueue(MPIDU_genq_shmem_pool_t pool,
     } else if (flags == MPIDU_GENQ_SHMEM_QUEUE_TYPE__NEM_MPSC) {
         rc = MPIDU_genqi_nem_mpsc_enqueue(pool_obj, queue_obj, cell);
     } else {
-        MPIR_Assert(0 && "Invalid GenQ flag");
+        MPIR_Assert_error("Invalid GenQ flag");
     }
 
     MPIR_FUNC_EXIT;

--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -135,7 +135,7 @@ static hwloc_obj_type_t get_hwloc_obj_type(MPIR_hwtopo_type_e type)
             hwloc_obj_type = HWLOC_OBJ_PCI_DEVICE;
             break;
         default:
-            hwloc_obj_type = -1;
+            hwloc_obj_type = (hwloc_obj_type_t) (-1);
     }
 
     return hwloc_obj_type;
@@ -517,7 +517,7 @@ int MPIR_hwtopo_mem_bind(void *baseaddr, size_t len, MPIR_hwtopo_gid_t gid)
     hwloc_bitmap_or(bitmap, bitmap, hwloc_obj->nodeset);
 
     if (hwloc_obj->type == HWLOC_OBJ_NUMANODE) {
-        flags |= HWLOC_MEMBIND_BYNODESET;
+        flags = (hwloc_membind_flags_t) ((int) flags | (int) HWLOC_MEMBIND_BYNODESET);
     } else {
 #ifdef HAVE_ERROR_CHECKING
         ret =


### PR DESCRIPTION
## Pull Request Description
Suppress amount of warnings with intel compilers.

* Use `MPIR_Assert_error` instead of `MPIR_Assert(0 && errmsg)`
* Use `char pad MPL_ATTR_ALIGNED(MPL_CACHELINE_SIZE)` instead of flexible array member
* Use cast to fix mix of enum with integer

This fixes following warnings:
```
In file included from ./src/mpid/common/genq/mpidu_genq_shmem_pool.h(11),
                 from ./src/mpid/common/genq/mpidu_genq.h(9),
                 from ./src/mpid/ch4/src/ch4_types.h(13),
                 from ./src/mpid/ch4/src/ch4_impl.h(9),
                 from ./src/mpid/ch4/src/ch4_request.h(9),
                 from ./src/mpid/ch4/include/mpidch4.h(329),
                 from ./src/mpid/ch4/include/mpidpost.h(10),
                 from ./src/include/mpiimpl.h(230),
                 from src/binding/fortran/use_mpi/create_f90_util.h(9),
                 from src/binding/fortran/use_mpi/create_f90_util.c(6):
./src/mpid/common/genq/mpidu_genq_shmem_queue.h(258): warning #279: controlling expression is constant
          MPIR_Assert(0 && "Invalid GenQ flag");
          ^

In file included from ./src/mpid/ch4/src/ch4_impl.h(9),
                 from ./src/mpid/ch4/src/ch4_request.h(9),
                 from ./src/mpid/ch4/include/mpidch4.h(329),
                 from ./src/mpid/ch4/include/mpidpost.h(10),
                 from ./src/include/mpiimpl.h(230),
                 from src/binding/fortran/use_mpi/create_f90_util.h(9),
                 from src/binding/fortran/use_mpi/create_f90_util.c(6):
./src/mpid/ch4/src/ch4_types.h(285): warning #2405: array of elements containing a flexible array member is nonstandard
      MPIDI_per_vci_t per_vci[MPIDI_CH4_MAX_VCIS];
                      ^

src/mpi/coll/mpir_coll.c(136): warning #188: enumerated type mixed with another type
              MPII_SCHED_CREATE_SCHED_P();

src/util/mpir_hwtopo.c(138): warning #188: enumerated type mixed with another type
              hwloc_obj_type = -1;
                             ^

src/util/mpir_hwtopo.c(520): warning #188: enumerated type mixed with another type
          flags |= HWLOC_MEMBIND_BYNODESET;
                ^

src/mpid/ch4/netmod/ofi/ofi_nic.c(216): warning #3656: variable "parents" may be used before its value is set
                  if (parents[j] == nics[i].parent) {
```

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
