### PR TITLE
test: lower the iterations for rma_contig test

### DIFF
--- a/test/mpi/rma/testlist.in
+++ b/test/mpi/rma/testlist.in
@@ -132,7 +132,7 @@ mutex_bench_shared 4
 mutex_bench_shm 4
 mutex_bench_shm_ordered 4
 rma_contig 2 arg=-iter=10
-rma_contig 2 arg=-iter=32768
+rma_contig 2 arg=-iter=10000
 badrma 2
 acc_loc 4
 acc_ordering 2


### PR DESCRIPTION
## Pull Request Description

This test used to have 720s time limit. The nightly tests on ch3 is having timeout on this test due to we removed the time limit in previous PR. Lowering the iteration count
serves the same testing purpose as increasing the time limit, and it is
cleaner to just lower the iteration count.

This fixes the current ch3 timeout failure on rma_contig.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
