### PR TITLE
build: fix parsing hwloc_embedded_libs

### DIFF
--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -79,7 +79,7 @@ AC_DEFUN([PAC_CONFIG_HWLOC],[
             PAC_APPEND_FLAG([-I${main_top_builddir}/modules/hwloc/include],[CPPFLAGS])
 
             # capture the line -- S["HWLOC_EMBEDDED_LIBS"]="-lm "
-            hwloc_embedded_libs=$(awk -F'"' '/^S."HWLOC_EMBEDDED_LIBS"/ {print $4}' modules/hwloc/config.status)
+            hwloc_embedded_libs=$(awk -F'"' '/^S."HWLOC_EMBEDDED_LIBS"/ {print $[]4}' modules/hwloc/config.status)
             echo "hwloc_embedded_libs = $hwloc_embedded_libs"
             if test -n "$hwloc_embedded_libs" ; then
                 dnl TODO: split and add individual lib


### PR DESCRIPTION

## Pull Request Description

The `$4` is eaten by M4 in autoconf. We need play some quoting trick to
pass it to shell.

This fixes the noshared build.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
