### PR TITLE
ch4/ipc: fix bug in ipc_send

### DIFF
--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -48,6 +48,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
             MPI_Datatype *types;
             MPIR_Datatype_access_contents(tmp_dtp->contents, &ints, &aints, &counts, &types);
             MPIR_Datatype_get_ptr(types[0], tmp_dtp);
+            if (!tmp_dtp || !tmp_dtp->contents) {
+                break;
+            }
             combiner = tmp_dtp->contents->combiner;
         }
         switch (combiner) {


### PR DESCRIPTION
## Pull Request Description
We can't recursively getting combiner once it hit a predefined datatype.

The bug was introduced in #5494.

It is surprising that the bug escapes the testsuite with `MPIR_CVAR_ODD_EVEN_CLIQUES`.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
