### PR TITLE
config: FFLAGS no longer used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1989,7 +1989,7 @@ if test "$enable_f77" = "yes" ; then
 	# that turns off checking for *everything* is not something that
 	# configure should do - if the user wants this, they can follow
 	# the instructions in the following error message.
-	AC_MSG_ERROR([The Fortran compiler $F77 does not accept programs that call the same routine with arguments of different types without the option $addarg.  Rerun configure with FFLAGS=$addarg])
+        AC_MSG_ERROR([The Fortran compiler $FC does not accept programs that call the same routine with arguments of different types without the option $addarg.  Rerun configure with FCFLAGS=$addarg])
     fi
 
     bindings="$bindings f77"


### PR DESCRIPTION
gcc-10 wants '-fallow-mismatched-args'.  Stop telling users to pass that
through an env variable MPICH will ignore.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
