### PR TITLE
mpif_h: always check MPIR_F_NeedInit

### DIFF
--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -96,16 +96,8 @@ our $prototype_file_b = "../../../include/mpi_proto.h";
 # Fortran runtime.  Thus, we must check whether the values are initialized
 # before any use in any routine.
 #
-# Having said the above, however, if the environment (specifically, the
-# C and Fortran compilers) makes it easy for the C init routines to initialize
-# the Fortran environment, then we should make that easy.  This is indicated
-# by the CPP name HAVE_MPI_F_INIT_WORKS_WITH_C.  If that is defined, then
-# there is no lazy initialization of these values.
 $specialInitAdded = 0;
-$specialInitString = "\
-#ifndef HAVE_MPI_F_INIT_WORKS_WITH_C
-    if (MPIR_F_NeedInit){ mpirinitf_(); MPIR_F_NeedInit = 0; }
-#endif";
+$specialInitString = "if (MPIR_F_NeedInit){ mpirinitf_(); MPIR_F_NeedInit = 0;}";
 
 # Process arguments
 #


### PR DESCRIPTION
## Pull Request Description
Since now we remove the mpirinitf_ symbol from libmpi.so -- it's in
libmpifort.so -- we need always check MPIR_F_NeedInit and do the lazy
init. This is because the application may call MPI_Init from the C side,
thus never call mpirinitf_() during init.

Fixes #5589

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
