### PR TITLE
romio: synchronized flush

### DIFF
--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_features.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_features.c
@@ -13,10 +13,12 @@ int ADIOI_NFS_Feature(ADIO_File fd, int flag)
         case ADIO_LOCKS:
         case ADIO_SEQUENTIAL:
         case ADIO_DATA_SIEVING_WRITES:
+        case ADIO_ATOMIC_MODE:
             return 1;
         case ADIO_SCALABLE_OPEN:
         case ADIO_UNLINK_AFTER_CLOSE:
         case ADIO_SCALABLE_RESIZE:
+        case ADIO_IMMEDIATELY_VISIBLE:
         default:
             return 0;
     }

--- a/src/mpi/romio/adio/common/ad_features.c
+++ b/src/mpi/romio/adio/common/ad_features.c
@@ -15,6 +15,7 @@ int ADIOI_GEN_Feature(ADIO_File fd, int flag)
         case ADIO_UNLINK_AFTER_CLOSE:
         case ADIO_TWO_PHASE:
         case ADIO_SCALABLE_RESIZE:
+        case ADIO_IMMEDIATELY_VISIBLE:
             return 1;
             break;
         case ADIO_SCALABLE_OPEN:

--- a/src/mpi/romio/adio/common/ad_hints.c
+++ b/src/mpi/romio/adio/common/ad_hints.c
@@ -128,6 +128,12 @@ void ADIOI_GEN_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
         fd->hints->min_fdomain_size = 0;
         fd->hints->striping_unit = 0;
 
+        /* temporally synchronizing flush: I think this is going to be a useful
+         * optimization for all users, but might have surprising hangs if
+         * client code incorrectly treats MPI_File_sync as independent */
+        ADIOI_Info_set(info, "romio_synchronized_flush", "disabled");
+        fd->hints->synchronizing_flush = 0;
+
         fd->hints->initialized = 1;
 
         /* ADIO_Open sets up collective buffering arrays.  If we are in this
@@ -249,6 +255,9 @@ void ADIOI_GEN_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
          * process hints for it. */
         ADIOI_Info_check_and_install_int(fd, users_info, "striping_unit",
                                          &(fd->hints->striping_unit), myname, error_code);
+
+        ADIOI_Info_check_and_install_enabled(fd, users_info, "romio_synchronized_flush",
+                                             &(fd->hints->synchronizing_flush), myname, error_code);
     }
 
     /* Begin hint post-processig: some hints take precedence over or conflict

--- a/src/mpi/romio/adio/common/ad_hints.c
+++ b/src/mpi/romio/adio/common/ad_hints.c
@@ -32,12 +32,10 @@ void ADIOI_GEN_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
     }
     ad_get_env_vars();
 
+    /* Interpreting MPI-4.0 to mean ROMIO should only return hints it knows
+     * about when user calls MPI_File_get_info */
     if (fd->info == MPI_INFO_NULL) {
-        if (users_info == MPI_INFO_NULL)
-            MPI_Info_create(&(fd->info));
-        else
-            /* duplicate users_info to preserve hints not used in ROMIO */
-            MPI_Info_dup(users_info, &(fd->info));
+        MPI_Info_create(&(fd->info));
     }
     info = fd->info;
 

--- a/src/mpi/romio/adio/common/ad_open.c
+++ b/src/mpi/romio/adio/common/ad_open.c
@@ -91,6 +91,11 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
     fd->hints->initialized = 0;
     fd->info = MPI_INFO_NULL;
 
+    /* Some ROMIO drivers will support "write tracking": omit an fsync() call
+     * if no writes happened.  Drivers supporting that feature will set the bit
+     * on write, and clear the bit on open, close, and sync. */
+    fd->dirty_write = 1;
+
     /* move system-wide hint processing *back* into open, but this time the
      * hintfile reader will do a scalable read-and-broadcast.  The global
      * ADIOI_syshints will get initialized at first open.  subsequent open

--- a/src/mpi/romio/adio/common/ad_opencoll.c
+++ b/src/mpi/romio/adio/common/ad_opencoll.c
@@ -179,4 +179,7 @@ void ADIOI_GEN_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code
      * not an aggregaor and we are doing deferred open, we returned earlier)*/
     fd->is_open = 1;
 
+    /* sync optimization: we can omit the fsync() call if we do no writes */
+    fd->dirty_write = 0;
+
 }

--- a/src/mpi/romio/adio/common/ad_write.c
+++ b/src/mpi/romio/adio/common/ad_write.c
@@ -89,6 +89,7 @@ void ADIOI_GEN_WriteContig(ADIO_File fd, const void *buf, int count,
         bytes_xfered += err;
         p += err;
     }
+    fd->dirty_write = 1;
 
 #ifdef ROMIO_GPFS
     if (gpfsmpio_timing)

--- a/src/mpi/romio/adio/common/hint_fns.c
+++ b/src/mpi/romio/adio/common/hint_fns.c
@@ -70,6 +70,12 @@ int ADIOI_Info_check_and_install_enabled(ADIO_File fd, MPI_Info info, const char
         } else if (!strcmp(value, "automatic") || !strcmp(value, "AUTOMATIC")) {
             ADIOI_Info_set(fd->info, key, value);
             *local_cache = ADIOI_HINT_AUTO;
+            /* treat the user-provided string like "enabled":  either it is a hint
+             * ROMIO knows about and can support it, or ROMIO will not return the
+             * hint at all in the MPI_File_get_info info object */
+        } else if (!strcmp(value, "requested") || !strcmp(value, "REQUESTED")) {
+            ADIOI_Info_set(fd->info, key, "enable");
+            *local_cache = ADIOI_HINT_ENABLE;
         }
 
         tmp_val = *local_cache;

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -239,6 +239,7 @@ typedef struct ADIOI_FileD {
 #ifdef ROMIO_QUOBYTEFS
     struct quobyte_fh *file_handle;     /* file handle for quobytefs */
 #endif
+    int dirty_write;            /* this client has written data */
 } ADIOI_FileD;
 
 typedef struct ADIOI_FileD *ADIO_File;

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -319,6 +319,9 @@ typedef struct {
 #define ADIO_SCALABLE_RESIZE     307    /* file system supports resizing from one
                                          * processor (nfs, e.g. does not) */
 
+#define ADIO_IMMEDIATELY_VISIBLE 308    /* a write from one client immediately
+                                         * visible on other clients (POSIX semantics) */
+
 /* for default file permissions */
 #define ADIO_PERM_NULL           -1
 

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -47,6 +47,7 @@ struct ADIOI_Hints_struct {
     int deferred_open;
     int start_iodevice;
     int min_fdomain_size;
+    int synchronizing_flush;    /* "romio_synchronized_flush" hint */
     char *cb_config_list;
     int *ranklist;
     union {

--- a/test/mpi/io/setinfo.c
+++ b/test/mpi/io/setinfo.c
@@ -86,13 +86,7 @@ int main(int argc, char *argv[])
     MPI_Info_get(infoout, (char *) "access_style", 1024, value, &flag);
     /* Note that an implementation is allowed to ignore the set_info,
      * so we'll accept either the original or the updated version */
-    if (!flag) {
-        ;
-        /*
-         * errs++;
-         * printf("Access style hint not saved\n");
-         */
-    } else {
+    if (flag) {
         if (strcmp(value, "read_once") != 0 && strcmp(value, "write_once,random") != 0) {
             errs++;
             printf("value for access_style unexpected; is %s\n", value);


### PR DESCRIPTION
Provide a way for users to request temporal synchronization from file
sync, making it a little less onerous to ensure write visibilty to all
other mpi processes

## Pull Request Description

Here's a fun observation:  the MPI standard spends a lot of time on how important the `sync/barrier/sync` sequence is, then rather offhandedly in `advice to users` says "oh by the way if your flush is temporally synchronizing you can just sync" 

OK, let's give ROMIO a temporally synchronizing sync.  Clients have to opt-in though since this is a change to longstanding behavior. 

Also novel here is the idea of a "handshake" via info hints:  clients set a key with the value "requested" and only if ROMIO responds with "enabled" is that hint going to take effect.   We don't have too many examples of ROMIO programmatically informing clients what it can and cannot do.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
