### PR TITLE
typerep/yaksa: suppress warnings on used variable

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -629,7 +629,7 @@ static int typerep_op_fallback(void *source_buf, MPI_Aint source_count, MPI_Data
         MPI_Aint vec_len;
         struct iovec *typerep_vec = NULL;
         {
-            MPIR_Datatype *dtp;
+            MPIR_Datatype *dtp ATTRIBUTE((unused));
             MPIR_Datatype_get_ptr(target_dtp, dtp);
             MPIR_Assert(dtp != NULL);
             MPIR_Assert(dtp->basic_type == source_dtp);


### PR DESCRIPTION
## Pull Request Description
The dtp variable is only used when error checking is enabled.




## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
