### PR TITLE
hydra: fix segfaults in argument parsing

### DIFF
--- a/src/pm/hydra/ui/mpich/utils.c
+++ b/src/pm/hydra/ui/mpich/utils.c
@@ -15,6 +15,14 @@ static char **config_argv = NULL;
 static int reading_config_file = 0;
 static struct HYD_arg_match_table match_table[];
 
+#define ASSERT_ARGV \
+    do { \
+        if (!**argv) { \
+            status = HYD_FAILURE; \
+            HYDU_ERR_POP(status, "missing command line argument, add -h for help\n"); \
+        }\
+    } while (0)
+
 static void init_ui_mpich_info(void)
 {
     HYD_ui_mpich_info.ppn = -1;
@@ -777,6 +785,7 @@ static HYD_status np_fn(char *arg, char ***argv)
     status = get_current_exec(&exec);
     HYDU_ERR_POP(status, "get_current_exec returned error\n");
 
+    ASSERT_ARGV;
     status = HYDU_set_int(arg, &exec->proc_count, atoi(**argv));
     HYDU_ERR_POP(status, "error getting executable process count\n");
 

--- a/src/pm/hydra/utils/alloc/alloc.c
+++ b/src/pm/hydra/utils/alloc/alloc.c
@@ -431,6 +431,10 @@ HYD_status HYDU_create_proxy_list(struct HYD_exec *exec_list, struct HYD_node *n
         pg->proxy_list->next = NULL;
         HYDU_free_proxy_list(pg->proxy_list);
         pg->proxy_list = tmp;
+        if (pg->proxy_list == NULL) {
+            status = HYD_FAILURE;
+            HYDU_ERR_POP(status, "Missing executable.\n");
+        }
     }
     for (proxy = pg->proxy_list; proxy->next;) {
         if (proxy->next->exec_list == NULL) {


### PR DESCRIPTION
## Pull Request Description
Add checks for missing argument. As a TODO, we should enhance the error
reporting to make it more user friendly. But we should prevent segfault
for now at least.

Fixes #5594


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
