### PR TITLE
binding/fortran: Fix MPI_Status_c2f/f2c binding generation

### DIFF
--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -4519,14 +4519,15 @@ sub build_specials {
 #include <stdio.h>
 
 /* -- Begin Profiling Symbol Block for routine MPI_Status_f2c */
-#if defined(USE_WEAK_SYMBOLS) && !defined(USE_ONLY_MPI_NAMES)
 #if defined(HAVE_PRAGMA_WEAK)
 #pragma weak MPI_Status_f2c = PMPI_Status_f2c
 #elif defined(HAVE_PRAGMA_HP_SEC_DEF)
 #pragma _HP_SECONDARY_DEF PMPI_Status_f2c  MPI_Status_f2c
 #elif defined(HAVE_PRAGMA_CRI_DUP)
 #pragma _CRI duplicate MPI_Status_f2c as PMPI_Status_f2c
-#endif
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_Status_f2c( const MPI_Fint *f_status, MPI_Status *c_status )
+     __attribute__ ((weak, alias(\"PMPI_Status_f2c\")));
 #endif
 /* -- End Profiling Symbol Block */
 
@@ -4535,8 +4536,7 @@ sub build_specials {
 #ifndef MPICH_MPI_FROM_PMPI
 #undef MPI_Status_f2c
 #define MPI_Status_f2c PMPI_Status_f2c
-#endif
-
+#endif /* MPICH_MPI_FROM_PMPI */
 
 int MPI_Status_f2c( const MPI_Fint *f_status, MPI_Status *c_status )
 {
@@ -4589,14 +4589,15 @@ print $OUTFD "\
 #include <stdio.h>
 
 /* -- Begin Profiling Symbol Block for routine MPI_Status_c2f */
-#if defined(USE_WEAK_SYMBOLS) && !defined(USE_ONLY_MPI_NAMES)
 #if defined(HAVE_PRAGMA_WEAK)
 #pragma weak MPI_Status_c2f = PMPI_Status_c2f
 #elif defined(HAVE_PRAGMA_HP_SEC_DEF)
 #pragma _HP_SECONDARY_DEF PMPI_Status_c2f MPI_Status_c2f
 #elif defined(HAVE_PRAGMA_CRI_DUP)
 #pragma _CRI duplicate MPI_Status_c2f as PMPI_Status_c2f
-#endif
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_Status_c2f( const MPI_Status *c_status, MPI_Fint *f_status )
+     __attribute__ ((weak, alias(\"PMPI_Status_c2f\")));
 #endif
 /* -- End Profiling Symbol Block */
 
@@ -4605,8 +4606,7 @@ print $OUTFD "\
 #ifndef MPICH_MPI_FROM_PMPI
 #undef MPI_Status_c2f
 #define MPI_Status_c2f PMPI_Status_c2f
-#endif
-
+#endif /* MPICH_MPI_FROM_PMPI */
 
 int MPI_Status_c2f( const MPI_Status *c_status, MPI_Fint *f_status )
 {


### PR DESCRIPTION
## Pull Request Description

The bindings for MPI_Status_c2f and MPI_Status_f2c do not have the latest version of the PMPI binding macros which means that on some compilers (including the new Intel C/C++ compiler), symbols like MPI_Status_c2f and MPI_Status_f2c don't exist, only the PMPI versions.

Though this doesn't come up often, apparently mpi4py hits this when using the new Intel C/C++ compiler. It's fine when using GCC or the classic Intel compilers.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
