### PR TITLE
bsend: Hardcode MPI_BSEND_OVERHEAD value

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4505,9 +4505,9 @@ if test "$ac_cv_sizeof_MPII_Bsend_data_t" = "0" ; then
     # argument, so code that depended on the prior defined behavior now
     # silently breaks.
 fi
-BSEND_OVERHEAD=$ac_cv_sizeof_MPII_Bsend_data_t
-export BSEND_OVERHEAD
-AC_SUBST(BSEND_OVERHEAD)
+if test $ac_cv_sizeof_MPII_Bsend_data_t -gt 96 ; then
+    AC_MSG_ERROR([MPI_BSEND_OVERHEAD exceeds current ABI value])
+fi
 
 dnl Configure any subdirectories.  Note that config.status will *not*
 dnl reexecute these!

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -378,7 +378,7 @@ typedef enum MPIR_Win_model {
 } MPIR_Win_model_t;
 
 /* Upper bound on the overhead in bsend for each message buffer */
-#define MPI_BSEND_OVERHEAD @BSEND_OVERHEAD@
+#define MPI_BSEND_OVERHEAD 96
 
 /* Topology types */
 typedef enum MPIR_Topo_type { MPI_GRAPH=1, MPI_CART=2, MPI_DIST_GRAPH=3 } MPIR_Topo_type;


### PR DESCRIPTION
## Pull Request Description

The MPICH ABI initially defined this value to 96, which was based on the
size of MPII_Bsend_data_t. However the value was accidentally changed
(96->88 on x86_64) when the MPII_Bsend_data_t structure was
modified. This could cause a one-way incompatibility where an
application using the new, lower value may crash if run with a library
using the old, higher value.

To address this, we hardcode the value to 96, which is an upper bound
for the user. As long as the size of MPII_Bsend_data_t stays at or below
96 bytes, then there will be no ABI compatibility issue. A check is
added in configure ensure the struct size meets the ABI requirement.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
