### PR TITLE
ch4/stub: remove including mpl.h which is already added in mpidimpl.h

### DIFF
--- a/maint/gen_ch4_api.py
+++ b/maint/gen_ch4_api.py
@@ -280,13 +280,11 @@ def dump_func_table_c(c_file, mod):
     print("  --> [%s]" % c_file)
     with open(c_file, "w") as Out:
         dump_copyright(Out)
-        print("#include \"mpl.h\"", file=Out)
-        print("", file=Out)
-        print("MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;", file=Out)
-        print("", file=Out)
         print("#ifndef NETMOD_INLINE", file=Out)
         print("#define NETMOD_DISABLE_INLINES", file=Out)
         print("#include <mpidimpl.h>", file=Out)
+        print("MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;", file=Out)
+        print("", file=Out)
         print("#include \"netmod_inline.h\"", file=Out)
         print("MPIDI_NM_funcs_t MPIDI_NM_%s_funcs = {" % mod, file=Out)
         for a in G.apis:


### PR DESCRIPTION
From mpiimpl.h:
pmix.h contains inline functions that calls malloc, calloc, and free,
and it will break with MPL's memory tracing when enabled.
So we need to make sure mpiimpl.h is included before mpl.h.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
