### PR TITLE
ch4/ofi: fix bug in get_huge_complete

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_huge.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_huge.c
@@ -149,6 +149,9 @@ static int get_huge_complete(MPIR_Request * rreq)
     int vni_remote = info->vni_src;
     int vni_local = info->vni_dst;
 
+    /* important: save comm_ptr because MPIDI_OFI_recv_event may free the request. */
+    MPIR_Comm *comm_ptr = rreq->comm;
+
     struct fi_cq_tagged_entry wc;
     wc.len = info->msgsize;
     wc.data = info->origin_rank;
@@ -158,7 +161,7 @@ static int get_huge_complete(MPIR_Request * rreq)
     MPIDI_OFI_send_control_t ctrl;
     ctrl.type = MPIDI_OFI_CTRL_HUGEACK;
     ctrl.u.huge_ack.ackreq = info->ackreq;
-    mpi_errno = MPIDI_NM_am_send_hdr(info->origin_rank, rreq->comm,
+    mpi_errno = MPIDI_NM_am_send_hdr(info->origin_rank, comm_ptr,
                                      MPIDI_OFI_INTERNAL_HANDLER_CONTROL,
                                      &ctrl, sizeof(ctrl), vni_local, vni_remote);
     MPIR_ERR_CHECK(mpi_errno);


### PR DESCRIPTION
## Pull Request Description

We need save the comm_ptr before calling MPIDI_OFI_recv_event because it
may free the request pointer and make rreq->comm inaccessible.

This is especially true when the receive is an any source receive, when
the user visible request is the shm request, and the netmod request will
get freed after copied over.

Fixes pmodels/mpich#5607.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
