### PR TITLE
coll: refactor TSP recursive exchange algorithms

### DIFF
--- a/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
+++ b/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
@@ -40,24 +40,42 @@ int MPII_Recexchalgo_comm_cleanup(MPIR_Comm * comm)
  * participating in Step 2. In Step 3, the ranks that participated in Step 2 send
  * the final data to non-partcipating ranks.
 */
-int MPII_Recexchalgo_get_neighbors(int rank, int nranks, int *k_,
-                                   int *step1_sendto, int **step1_recvfrom_, int *step1_nrecvs,
-                                   int ***step2_nbrs_, int *step2_nphases, int *p_of_k_, int *T_)
+int MPII_Recexchalgo_start(int rank, int nranks, int k, MPII_Recexchalgo_t * recexch)
 {
     int mpi_errno = MPI_SUCCESS;
-    int i, j, k;
-    int p_of_k = 1, log_p_of_k = 0, rem, T, newrank;
-    int **step2_nbrs;
-    int *step1_recvfrom;
-
     MPIR_FUNC_ENTER;
 
-    k = *k_;
-    if (nranks < k)     /* If size of the communicator is less than k, reduce the value of k */
-        k = (nranks > 2) ? nranks : 2;
-    *k_ = k;
+    memset(recexch, 0, sizeof(*recexch));
+    recexch->k = k;
+
+    if (nranks < k) {
+        /* trivial case, only step 1 and step 3 */
+        recexch->k = nranks;
+        recexch->in_step2 = 0;
+        recexch->step2_nphases = 0;
+
+        if (rank < nranks - 1) {
+            recexch->step1_sendto = nranks - 1;
+        } else {
+            int n = nranks - 1;
+            recexch->step1_sendto = -1;
+            recexch->step1_nrecvs = n;
+            if (n > 0) {
+                recexch->step1_recvfrom = (int *) MPL_malloc(sizeof(int) * n, MPL_MEM_COLL);
+                MPIR_ERR_CHKANDJUMP(!recexch->step1_recvfrom, mpi_errno, MPI_ERR_OTHER, "**nomem");
+                /* to accommodate immutable op, we need accumulate from right side */
+                for (int i = 0; i < n; i++) {
+                    recexch->step1_recvfrom[i] = i;
+                }
+            }
+        }
+
+        goto fn_exit;
+    }
 
     /* Calculate p_of_k, p_of_k is the largest power of k that is less than nranks */
+    int p_of_k = 1;
+    int log_p_of_k = 0;
     while (p_of_k <= nranks) {
         p_of_k *= k;
         log_p_of_k++;
@@ -65,20 +83,10 @@ int MPII_Recexchalgo_get_neighbors(int rank, int nranks, int *k_,
     p_of_k /= k;
     log_p_of_k--;
 
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                    (MPL_DBG_FDEST, "allocate memory for storing communication pattern"));
-    step1_recvfrom = *step1_recvfrom_ = (int *) MPL_malloc(sizeof(int) * (k - 1), MPL_MEM_COLL);
-    step2_nbrs = *step2_nbrs_ = (int **) MPL_malloc(sizeof(int *) * log_p_of_k, MPL_MEM_COLL);
-    MPIR_Assert(step1_recvfrom != NULL && *step1_recvfrom_ != NULL && step2_nbrs != NULL &&
-                *step2_nbrs_ != NULL);
+    recexch->p_of_k = p_of_k;
+    recexch->step2_nphases = log_p_of_k;
 
-    for (i = 0; i < log_p_of_k; i++) {
-        (*step2_nbrs_)[i] = (int *) MPL_malloc(sizeof(int) * (k - 1), MPL_MEM_COLL);
-    }
-
-    *step2_nphases = log_p_of_k;
-
-    rem = nranks - p_of_k;
+    int rem, T, newrank;
     /* rem is the number of ranks that do not particpate in Step 2
      * We need to identify these non-participating ranks. This is done in the following way.
      * The first T ranks are divided into sets of k consecutive ranks each.
@@ -87,49 +95,59 @@ int MPII_Recexchalgo_get_neighbors(int rank, int nranks, int *k_,
      * The non-participating ranks send their data to the participating rank
      * in their corresponding set.
      */
-    T = (rem * k) / (k - 1);
-    *T_ = T;
-    *p_of_k_ = p_of_k;
+    rem = nranks - p_of_k;
 
+    /* since we are adding 1 participating rank with every k - 1 non-participating ranks,
+     * we effectively expand rem by the ration of k / (k - 1).
+     * Note: the extra processes are accounted in T, rem % (k-1) * k / (k-1) == rem % (k-1).
+     * */
+    T = rem * k / (k - 1);
 
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                    (MPL_DBG_FDEST, "step 1 nbr calculation started. T is %d", T));
-    *step1_nrecvs = 0;
-    *step1_sendto = -1;
+    recexch->T = T;
 
     /* Step 1 */
+    recexch->step1_sendto = -1;
     if (rank < T) {
-        if (rank % k != (k - 1)) {      /* I am a non-participating rank */
-            *step1_sendto = rank + (k - 1 - rank % k);  /* partipating rank to send the data to */
-            /* if the corresponding participating rank is not in T,
-             * then send to the Tth rank to preserve non-commutativity */
-            if (*step1_sendto > T - 1)
-                *step1_sendto = T;
-            newrank = -1;       /* tag this rank as non-participating */
-        } else {        /* participating rank */
-            for (i = 0; i < k - 1; i++) {
-                step1_recvfrom[i] = rank - i - 1;
-            }
-            *step1_nrecvs = k - 1;
-            newrank = rank / k; /* this is the new rank amongst the set of participating ranks */
+        if (rank % k != (k - 1)) {
+            /* I am a non-participating rank */
+            recexch->step1_sendto = MPL_MIN(rank + (k - 1 - rank % k), T);
+            recexch->in_step2 = false;
+            newrank = -1;
+        } else {
+            recexch->step1_nrecvs = k - 1;
+            recexch->in_step2 = true;
+            newrank = rank / k;
         }
-    } else {    /* rank >= T */
+    } else if (rank == T) {
+        recexch->step1_nrecvs = T % k;
+        recexch->in_step2 = true;
         newrank = rank - rem;
+    } else {
+        recexch->in_step2 = true;
+        newrank = rank - rem;
+    }
 
-        if (rank == T && (T - 1) % k != k - 1 && T >= 1) {
-            int nsenders = (T - 1) % k + 1;     /* number of ranks sending their data to me in Step 1 */
+    if (recexch->step1_nrecvs > 0) {
+        int n = recexch->step1_nrecvs;
+        recexch->step1_recvfrom = (int *) MPL_malloc(n * sizeof(int), MPL_MEM_COLL);
+        MPIR_ERR_CHKANDJUMP(!recexch->step1_recvfrom, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
-            for (j = nsenders - 1; j >= 0; j--) {
-                step1_recvfrom[nsenders - 1 - j] = T - nsenders + j;
-            }
-            *step1_nrecvs = nsenders;
+        for (int i = 0; i < n; i++) {
+            recexch->step1_recvfrom[i] = rank - n + i;
         }
     }
 
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "step 1 nbr computation completed"));
-
     /* Step 2 */
-    if (*step1_sendto == -1) {  /* calculate step2_nbrs only for participating ranks */
+    if (recexch->in_step2) {
+        recexch->step2_nbrs = (int **) MPL_malloc(sizeof(int *) * log_p_of_k, MPL_MEM_COLL);
+        MPIR_ERR_CHKANDJUMP(!recexch->step2_nbrs, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+        for (int i = 0; i < log_p_of_k; i++) {
+            recexch->step2_nbrs[i] = (int *) MPL_malloc(sizeof(int) * (k - 1), MPL_MEM_COLL);
+            MPIR_ERR_CHKANDJUMP(!recexch->step2_nbrs[i], mpi_errno, MPI_ERR_OTHER, "**nomem");
+        }
+
+        /* calculate step2_nbrs only for participating ranks */
         int *digit = (int *) MPL_malloc(sizeof(int) * log_p_of_k, MPL_MEM_COLL);
         MPIR_Assert(digit != NULL);
         int temprank = newrank;
@@ -137,7 +155,7 @@ int MPII_Recexchalgo_get_neighbors(int rank, int nranks, int *k_,
         int phase = 0, cbit, cnt, nbr, power;
 
         /* calculate the digits in base k representation of newrank */
-        for (i = 0; i < log_p_of_k; i++)
+        for (int i = 0; i < log_p_of_k; i++)
             digit[i] = 0;
 
         int remainder, i_digit = 0;
@@ -151,24 +169,21 @@ int MPII_Recexchalgo_get_neighbors(int rank, int nranks, int *k_,
         while (mask < p_of_k) {
             cbit = digit[phase];        /* phase_th digit changes in this phase, obtain its original value */
             cnt = 0;
-            for (i = 0; i < k; i++) {   /* there are k-1 neighbors */
+            for (int i = 0; i < k; i++) {       /* there are k-1 neighbors */
                 if (i != cbit) {        /* do not generate yourself as your nieighbor */
                     digit[phase] = i;   /* this gets us the base k representation of the neighbor */
 
                     /* calculate the base 10 value of the neighbor rank */
                     nbr = 0;
                     power = 1;
-                    for (j = 0; j < log_p_of_k; j++) {
+                    for (int j = 0; j < log_p_of_k; j++) {
                         nbr += digit[j] * power;
                         power *= k;
                     }
 
                     /* calculate its real rank and store it */
-                    step2_nbrs[phase][cnt] =
+                    recexch->step2_nbrs[phase][cnt] =
                         (nbr < rem / (k - 1)) ? (nbr * k) + (k - 1) : nbr + rem;
-                    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                                    (MPL_DBG_FDEST, "step2_nbrs[%d][%d] is %d", phase, cnt,
-                                     step2_nbrs[phase][cnt]));
                     cnt++;
                 }
             }
@@ -182,11 +197,36 @@ int MPII_Recexchalgo_get_neighbors(int rank, int nranks, int *k_,
         MPL_free(digit);
     }
 
+  fn_exit:
     MPIR_FUNC_EXIT;
-
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
+void MPII_Recexchalgo_finish(MPII_Recexchalgo_t * recexch)
+{
+    if (recexch->step1_sendto == -1) {
+        if (recexch->step1_recvfrom) {
+            MPL_free(recexch->step1_recvfrom);
+        }
+    }
+
+    if (recexch->in_step2) {
+        for (int i = 0; i < recexch->step2_nphases; i++) {
+            MPL_free(recexch->step2_nbrs[i]);
+        }
+        MPL_free(recexch->step2_nbrs);
+
+        if (recexch->myidxes) {
+            MPL_free(recexch->myidxes);
+        }
+    }
+
+    if (recexch->nbr_bufs) {
+        MPL_free(recexch->nbr_bufs);
+    }
+}
 
 int MPII_Recexchalgo_origrank_to_step2rank(int rank, int rem, int T, int k)
 {

--- a/src/mpi/coll/algorithms/recexchalgo/recexchalgo.h
+++ b/src/mpi/coll/algorithms/recexchalgo/recexchalgo.h
@@ -6,12 +6,29 @@
 #ifndef RECEXCHALGO_H_INCLUDED
 #define RECEXCHALGO_H_INCLUDED
 
+typedef struct {
+    int k;
+    int p_of_k;
+    int T;
+    bool in_step2;
+    int step1_sendto;
+    int step1_nrecvs;
+    int *step1_recvfrom;
+    int step2_nphases;
+    int **step2_nbrs;
+
+    int per_nbr_buffer;         /* if false, use a single temporary buffer */
+    void **nbr_bufs;            /* temp buffer allocated with MPIR_TSP_sched_malloc */
+
+    int is_commutative;         /* if false, step2_nbrs are sorted and myidx is set */
+    int *myidxes;               /* for each phase, set to number of nbrs to the left */
+} MPII_Recexchalgo_t;
+
 int MPII_Recexchalgo_init(void);
 int MPII_Recexchalgo_comm_init(MPIR_Comm * comm);
 int MPII_Recexchalgo_comm_cleanup(MPIR_Comm * comm);
-int MPII_Recexchalgo_get_neighbors(int rank, int nranks, int *k_, int *step1_sendto,
-                                   int **step1_recvfrom_, int *step1_nrecvs,
-                                   int ***step2_nbrs_, int *step2_nphases, int *p_of_k_, int *T_);
+int MPII_Recexchalgo_start(int rank, int nranks, int k, MPII_Recexchalgo_t * recexch);
+void MPII_Recexchalgo_finish(MPII_Recexchalgo_t * recexch);
 /* Converts original rank to rank in step 2 of recursive exchange */
 int MPII_Recexchalgo_origrank_to_step2rank(int rank, int rem, int T, int k);
 /* Converts rank in step 2 of recursive exchange to original rank */
@@ -20,22 +37,21 @@ int MPII_Recexchalgo_get_count_and_offset(int rank, int phase, int k, int nranks
                                           int *offset);
 int MPII_Recexchalgo_reverse_digits_step2(int rank, int comm_size, int k);
 
-int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_nphases,
-                                                   int **step2_nbrs, int rank, int nranks, int k,
-                                                   int p_of_k, int log_pofk, int T, int *nrecvs_,
+int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int rank, int nranks, int *nrecvs_,
                                                    int **recv_id_, int tag, void *recvbuf,
                                                    size_t recv_extent, const MPI_Aint * recvcounts,
                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
                                                    int is_dist_halving, MPIR_Comm * comm,
+                                                   MPII_Recexchalgo_t * recexch,
                                                    MPIR_TSP_sched_t sched);
 int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *tmp_recvbuf,
                                                        const MPI_Aint * recvcounts,
                                                        MPI_Aint * displs, MPI_Datatype datatype,
                                                        MPI_Op op, size_t extent, int tag,
-                                                       MPIR_Comm * comm, int k, int is_dist_halving,
-                                                       int step2_nphases, int **step2_nbrs,
+                                                       MPIR_Comm * comm, int is_dist_halving,
                                                        int rank, int nranks, int sink_id,
                                                        int is_out_vtcs, int *reduce_id_,
+                                                       MPII_Recexchalgo_t * recexch,
                                                        MPIR_TSP_sched_t sched);
 
 #endif /* RECEXCHALGO_H_INCLUDED */

--- a/src/mpi/coll/coll_algorithms.txt
+++ b/src/mpi/coll/coll_algorithms.txt
@@ -320,21 +320,23 @@ iallreduce-intra:
         restrictions: size-ge-pof2, builtin-op
     tsp_recexch_single_buffer
         func_name: recexch
-        extra_const_params: recexch_type=MPIR_IALLREDUCE_RECEXCH_TYPE_SINGLE_BUFFER
+        extra_const_params: per_nbr_buffer=0, do_dtcopy=1
         extra_params: k
         cvar_params: RECEXCH_KVAL
     tsp_recexch_multiple_buffer
         func_name: recexch
-        extra_const_params: recexch_type=MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER
+        extra_const_params: per_nbr_buffer=1, do_dtcopy=1
         extra_params: k
         cvar_params: RECEXCH_KVAL
     tsp_recexch_single_buffer_without_dtcopy
-        func_name: single_buffer_without_dtcopy_recexch
+        func_name: recexch
+        extra_const_params: per_nbr_buffer=0, do_dtcopy=0
         extra_params: k
         cvar_params: RECEXCH_KVAL
         restrictions: commutative
     tsp_recexch_multiple_buffer_without_dtcopy
-        func_name: multiple_buffer_without_dtcopy_recexch
+        func_name: recexch
+        extra_const_params: per_nbr_buffer=1, do_dtcopy=0
         extra_params: k
         cvar_params: RECEXCH_KVAL
         restrictions: commutative

--- a/src/mpi/coll/coll_algorithms.txt
+++ b/src/mpi/coll/coll_algorithms.txt
@@ -328,6 +328,16 @@ iallreduce-intra:
         extra_const_params: recexch_type=MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER
         extra_params: k
         cvar_params: RECEXCH_KVAL
+    tsp_recexch_single_buffer_without_dtcopy
+        func_name: single_buffer_without_dtcopy_recexch
+        extra_params: k
+        cvar_params: RECEXCH_KVAL
+        restrictions: commutative
+    tsp_recexch_multiple_buffer_without_dtcopy
+        func_name: multiple_buffer_without_dtcopy_recexch
+        extra_params: k
+        cvar_params: RECEXCH_KVAL
+        restrictions: commutative
     tsp_tree
         extra_params: tree_type, k, chunk_size, buffer_per_child
         cvar_params: TREE_TYPE, TREE_KVAL, TREE_PIPELINE_CHUNK_SIZE, TREE_BUFFER_PER_CHILD

--- a/src/mpi/coll/cvars.txt
+++ b/src/mpi/coll/cvars.txt
@@ -1221,6 +1221,8 @@ cvars:
         sched_reduce_scatter_allgather   - Force reduce scatter allgather algorithm
         tsp_recexch_single_buffer    - Force generic transport recursive exchange with single buffer for receives
         tsp_recexch_multiple_buffer  - Force generic transport recursive exchange with multiple buffers for receives
+        tsp_recexch_single_buffer_without_dtcopy    - Force generic transport recursive exchange without data copy using single buffer for receives
+        tsp_recexch_multiple_buffer_without_dtcopy  - Force generic transport recursive exchange without data copy using multiple buffers for receives
         tsp_tree                     - Force generic transport tree algorithm
         tsp_ring                     - Force generic transport ring algorithm
         tsp_recexch_reduce_scatter_recexch_allgatherv  - Force generic transport recursive exchange with reduce scatter and allgatherv

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
@@ -242,7 +242,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, MPI_Aint sendc
                                              int is_dist_halving, int k, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int is_inplace, i;
+    int is_inplace;
     int nranks, rank;
     size_t recv_extent;
     MPI_Aint recv_lb, true_extent;

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
@@ -8,6 +8,547 @@
 #include "recexchalgo.h"
 #include "iallreduce_tsp_recursive_exchange_common.h"
 
+/* Allreduce single buffer and multiple buffer without dtcopy algorithms are an optimization to the existing
+ * allreduce recexch algorithms. These two algorithms are decoupled and written as separate algorithms
+ * for readability */
+
+/* Routine to schedule a recursive exchange based allreduce using single receive buffer without
+ * data copy in step2. Similar to other recursive exchange algorithms, this algorithm also involves "k"
+ * partners in every communication phase. Removing the data copy in step2 improves performance but at the cost
+ * of increased dependencies. */
+int MPIR_TSP_Iallreduce_sched_intra_single_buffer_without_dtcopy_recexch(const void *sendbuf,
+                                                                         void *recvbuf,
+                                                                         MPI_Aint count,
+                                                                         MPI_Datatype datatype,
+                                                                         MPI_Op op,
+                                                                         MPIR_Comm * comm, int k,
+                                                                         MPIR_TSP_sched_t sched)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    MPIR_Assert(k == 2);        /* This algorithm will deadlock if the exchange involves more than 2 partners */
+
+    int is_inplace, i;
+    int dtcopy_id = -1;
+    size_t extent;
+    MPI_Aint lb, true_extent;
+    int is_commutative;
+    int nranks, rank;
+    int step1_sendto = -1, step1_nrecvs, *step1_recvfrom;
+    int step2_nphases, **step2_nbrs;
+    int p_of_k, T;
+    int nvtcs, *vtcs;
+    int nbr, phase;
+    int send_id, reduce_id, recv_id;
+    bool in_step2;
+    void *step1_recvbuf = NULL;
+    void *nbr_buffer = NULL;
+    int tag;
+
+    MPIR_FUNC_ENTER;
+
+    is_inplace = (sendbuf == MPI_IN_PLACE);
+    nranks = MPIR_Comm_size(comm);
+    rank = MPIR_Comm_rank(comm);
+
+    MPIR_Datatype_get_extent_macro(datatype, extent);
+    MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
+    extent = MPL_MAX(extent, true_extent);
+    is_commutative = MPIR_Op_is_commutative(op);
+
+    /* For correctness, transport based collectives need to get the
+     * tag from the same pool as schedule based collectives */
+    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    /* if there is only 1 rank, copy data from sendbuf
+     * to recvbuf and exit */
+    if (nranks == 1) {
+        if (!is_inplace) {
+            int dummy_id;
+            mpi_errno =
+                MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype, sched,
+                                         0, NULL, &dummy_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        }
+        goto fn_exit;
+    }
+
+    /* get the neighbors, the function allocates the required memory */
+    MPII_Recexchalgo_get_neighbors(rank, nranks, &k, &step1_sendto,
+                                   &step1_recvfrom, &step1_nrecvs,
+                                   &step2_nbrs, &step2_nphases, &p_of_k, &T);
+
+    in_step2 = (step1_sendto == -1);    /* whether this rank participates in Step 2 */
+    vtcs = MPL_malloc(sizeof(int) * (step2_nphases) * 2, MPL_MEM_COLL); /* to store graph dependencies */
+    MPIR_Assert(vtcs != NULL);  /* If memory allocation for vtcs fails, MPI will abort. Else MPI would be inconsistent */
+
+
+    if (in_step2 && !is_inplace) {      /* copy the data to recvbuf but only if you are a rank participating in Step 2 */
+        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
+                                             recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After initial dt copy"));
+    }
+
+    /* Step 1 */
+    if (!in_step2) {
+        /* non-participating rank sends the data to a participating rank */
+        void *buf_to_send;
+        if (is_inplace)
+            buf_to_send = recvbuf;
+        else
+            buf_to_send = (void *) sendbuf;
+        int dummy_id;
+        mpi_errno =
+            MPIR_TSP_sched_isend(buf_to_send, count, datatype, step1_sendto, tag, comm, sched, 0,
+                                 NULL, &dummy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    } else {    /* Step 2 participating rank */
+        step1_recvbuf = MPIR_TSP_sched_malloc(count * extent, sched);
+        MPIR_Assert(step1_recvbuf != NULL);
+
+        for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
+            /* recv dependencies */
+            nvtcs = 0;
+            if (i != 0) {
+                vtcs[nvtcs++] = reduce_id;
+                MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                                (MPL_DBG_FDEST, "step1 recv depend on reduce_id %d", reduce_id));
+            }
+            mpi_errno = MPIR_TSP_sched_irecv(step1_recvbuf, count, datatype,
+                                             step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
+                                             &recv_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            /* setup reduce dependencies */
+            nvtcs = 1;
+            vtcs[0] = recv_id;
+            if (i == 0 && !is_inplace)
+                vtcs[nvtcs++] = dtcopy_id;
+            mpi_errno = MPIR_TSP_sched_reduce_local(step1_recvbuf, recvbuf, count,
+                                                    datatype, op, sched, nvtcs, vtcs, &reduce_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        }
+    }
+
+    /* Step 2 */
+    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Start Step2"));
+
+    /* allocate memory for receive buffers */
+    if (in_step2) {
+        nbr_buffer = step1_recvbuf;
+        MPIR_Assert(nbr_buffer != NULL);
+    }
+
+    for (phase = 0; phase < step2_nphases && step1_sendto == -1; phase++) {
+
+        nbr = step2_nbrs[phase][0];
+        /* send data to all the neighbors */
+        nvtcs = 0;
+        if ((phase == 0 && step1_nrecvs > 0) || phase != 0) {
+            vtcs[nvtcs++] = reduce_id;
+        } else if (phase == 0 && in_step2 && !is_inplace) {
+            vtcs[nvtcs++] = dtcopy_id;
+        }
+
+        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                        (MPL_DBG_FDEST, "sending data to %d. I'm dependent on nvtcs %d", nbr,
+                         nvtcs));
+        mpi_errno =
+            MPIR_TSP_sched_isend(recvbuf, count, datatype, nbr, tag, comm, sched, nvtcs, vtcs,
+                                 &send_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
+        /* receive and reduce data from the neighbors to the left */
+        nvtcs = 0;
+        if ((phase == 0 && step1_nrecvs > 0) || phase != 0) {
+            vtcs[nvtcs++] = reduce_id;
+        }
+        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                        (MPL_DBG_FDEST,
+                         "receiving data to %d. I'm dependent on nvtcs %d vtcs %d",
+                         nbr, nvtcs, vtcs[0]));
+        mpi_errno =
+            MPIR_TSP_sched_irecv(nbr_buffer, count, datatype, nbr, tag, comm, sched, nvtcs, vtcs,
+                                 &recv_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
+        nvtcs = 2;
+        vtcs[0] = recv_id;
+        vtcs[1] = send_id;
+
+        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                        (MPL_DBG_FDEST,
+                         "reducing data with count %ld dependent %d nvtcs", count, nvtcs));
+        if (is_commutative) {
+            mpi_errno =
+                MPIR_TSP_sched_reduce_local(nbr_buffer, recvbuf, count, datatype, op,
+                                            sched, nvtcs, vtcs, &reduce_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        } else {
+            mpi_errno =
+                MPIR_TSP_sched_reduce_local(recvbuf, nbr_buffer, count, datatype, op,
+                                            sched, nvtcs, vtcs, &reduce_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            mpi_errno =
+                MPIR_TSP_sched_localcopy(nbr_buffer, count, datatype, recvbuf, count,
+                                         datatype, sched, 1, &reduce_id, &reduce_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        }
+    }
+    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After Step 2"));
+
+    /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
+     * send the data to non-partcipating ranks */
+    if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
+        int dummy_id;
+        mpi_errno =
+            MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, sched, 0, NULL,
+                                 &dummy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    } else {
+        /* Wait for the last reduce to complete */
+        nvtcs = 1;
+        vtcs[0] = reduce_id;
+        for (i = 0; i < step1_nrecvs; i++) {
+            int dummy_id;
+            mpi_errno =
+                MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm, sched,
+                                     nvtcs, vtcs, &dummy_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        }
+    }
+
+    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Done Step 3"));
+
+    /* free all allocated memory for storing nbrs */
+    for (i = 0; i < step2_nphases; i++)
+        MPL_free(step2_nbrs[i]);
+    MPL_free(step2_nbrs);
+    MPL_free(step1_recvfrom);
+    MPL_free(vtcs);
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* Routine to schedule a recursive exchange based allreduce using separate receive buffer
+ * for each partner and in each phase and without data copy in step2.
+ * Removing the data copy improves performance but at the cost
+ * of increased dependencies. */
+int MPIR_TSP_Iallreduce_sched_intra_multiple_buffer_without_dtcopy_recexch(const void *sendbuf,
+                                                                           void *recvbuf,
+                                                                           MPI_Aint count,
+                                                                           MPI_Datatype datatype,
+                                                                           MPI_Op op,
+                                                                           MPIR_Comm * comm, int k,
+                                                                           MPIR_TSP_sched_t sched)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    int is_inplace, i, j;
+    int dtcopy_id = -1;
+    size_t extent;
+    MPI_Aint lb, true_extent;
+    int is_commutative;
+    int nranks, rank;
+    int step1_sendto = -1, step1_nrecvs, *step1_recvfrom;
+    int step2_nphases, **step2_nbrs;
+    int p_of_k, T;
+    int buf = 0;
+    int nvtcs, step1_id, *recv_id, *vtcs;
+    int myidx, nbr, phase;
+    int counter = 0;
+    int *reduce_id, imcast_id;
+    bool in_step2;
+    void **step1_recvbuf = NULL;
+    void **nbr_buffer = NULL;
+    int tag;
+
+    MPIR_FUNC_ENTER;
+
+    is_inplace = (sendbuf == MPI_IN_PLACE);
+    nranks = MPIR_Comm_size(comm);
+    rank = MPIR_Comm_rank(comm);
+
+    MPIR_Datatype_get_extent_macro(datatype, extent);
+    MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
+    extent = MPL_MAX(extent, true_extent);
+    is_commutative = MPIR_Op_is_commutative(op);
+
+    /* For correctness, transport based collectives need to get the
+     * tag from the same pool as schedule based collectives */
+    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    /* if there is only 1 rank, copy data from sendbuf
+     * to recvbuf and exit */
+    if (nranks == 1) {
+        if (!is_inplace) {
+            int dummy_id;
+            mpi_errno =
+                MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype, sched,
+                                         0, NULL, &dummy_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        }
+        goto fn_exit;
+    }
+
+    /* get the neighbors, the function allocates the required memory */
+    MPII_Recexchalgo_get_neighbors(rank, nranks, &k, &step1_sendto,
+                                   &step1_recvfrom, &step1_nrecvs,
+                                   &step2_nbrs, &step2_nphases, &p_of_k, &T);
+
+    in_step2 = (step1_sendto == -1);    /* whether this rank participates in Step 2 */
+    reduce_id = (int *) MPL_malloc(sizeof(int) * k, MPL_MEM_COLL);      /* to store reduce vertex ids */
+    recv_id = (int *) MPL_malloc(sizeof(int) * step2_nphases * (k - 1), MPL_MEM_COLL);  /* to store receive vertex ids */
+    vtcs = MPL_malloc(sizeof(int) * (step2_nphases) * k, MPL_MEM_COLL); /* to store graph dependencies */
+    /* If memory allocation fails here, MPI will abort. Else MPI would be inconsistent */
+    MPIR_Assert(reduce_id != NULL && recv_id != NULL && vtcs != NULL);
+
+
+    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Beforeinitial dt copy"));
+    if (in_step2 && !is_inplace) {      /* copy the data to recvbuf but only if you are a rank participating in Step 2 */
+        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
+                                             recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    }
+    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After initial dt copy"));
+
+    /* Step 1 */
+    if (!in_step2) {
+        /* non-participating rank sends the data to a participating rank */
+        void *buf_to_send;
+        if (is_inplace)
+            buf_to_send = recvbuf;
+        else
+            buf_to_send = (void *) sendbuf;
+        int dummy_id;
+        mpi_errno =
+            MPIR_TSP_sched_isend(buf_to_send, count, datatype, step1_sendto, tag, comm, sched,
+                                 0, NULL, &dummy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    } else {    /* Step 2 participating rank */
+        step1_recvbuf = (void **) MPL_malloc(sizeof(void *) * step1_nrecvs, MPL_MEM_COLL);
+        MPIR_Assert(step1_recvbuf != NULL);
+
+        for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
+            step1_recvbuf[i] = MPIR_TSP_sched_malloc(count * extent, sched);
+
+            /* recv dependencies */
+            nvtcs = 0;
+            mpi_errno = MPIR_TSP_sched_irecv(step1_recvbuf[i], count, datatype,
+                                             step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
+                                             &recv_id[i]);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            /* setup reduce dependencies */
+            nvtcs = 1;
+            vtcs[0] = recv_id[i];
+            if (is_commutative) {
+                if (!is_inplace) {      /* wait for the data to be copied to recvbuf */
+                    vtcs[nvtcs++] = dtcopy_id;
+                }
+            } else {    /* if not commutative */
+                /* wait for datacopy to complete if i==0 && !is_inplace else wait for previous reduce */
+                if (i == 0 && !is_inplace)
+                    vtcs[nvtcs++] = dtcopy_id;
+                else if (i != 0)
+                    vtcs[nvtcs++] = reduce_id[i - 1];
+            }
+            mpi_errno = MPIR_TSP_sched_reduce_local(step1_recvbuf[i], recvbuf, count,
+                                                    datatype, op, sched, nvtcs, vtcs,
+                                                    &reduce_id[i]);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        }
+    }
+
+    mpi_errno = MPIR_TSP_sched_sink(sched, &step1_id);  /* sink for all the tasks up to end of Step 1 */
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    /* Step 2 */
+    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Start Step2"));
+
+    /* allocate memory for receive buffers */
+    nbr_buffer = (void **) MPL_malloc(sizeof(void *) * step2_nphases * (k - 1), MPL_MEM_COLL);
+    MPIR_Assert(nbr_buffer != NULL);
+    buf = 0;
+    for (i = 0; i < step2_nphases; i++) {
+        for (j = 0; j < (k - 1); j++, buf++) {
+            nbr_buffer[buf] = MPIR_TSP_sched_malloc(count * extent, sched);
+        }
+    }
+
+    buf = 0;
+    for (phase = 0; phase < step2_nphases && step1_sendto == -1; phase++) {
+        if (!is_commutative) {
+            /* sort the neighbor list so that receives can be posted in order */
+#if defined(HAVE_QSORT)
+            qsort(step2_nbrs[phase], k - 1, sizeof(int), MPII_Algo_compare_int);
+#else
+            MPIR_insertion_sort(step2_nbrs[phase], k - 1);
+#endif
+        }
+        /* myidx is the index in the neighbors list such that
+         * all neighbors before myidx have ranks less than my rank
+         * and neighbors at and after myidx have rank greater than me.
+         * This is useful only in the non-commutative case. */
+        myidx = 0;
+        /* send data to all the neighbors */
+        if (phase == 0) {
+            nvtcs = 1;
+            vtcs[0] = step1_id;
+            MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "phase is 0"));
+        } else if (is_commutative) {    /* wait for all the previous receives to have completed */
+            nvtcs = 0;
+            for (j = 0; j < k - 1; j++)
+                vtcs[nvtcs++] = reduce_id[j];
+            MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                            (MPL_DBG_FDEST, "Depend on all reduces (%d)", nvtcs));
+        } else {        /* if it is not commutative or if there is only one recv buffer */
+            /*just wait for the last recv_reduce to complete as recv_reduce happen in order */
+            nvtcs = 1;
+            vtcs[0] = reduce_id[k - 2];
+        }
+
+        if (!is_commutative)
+            for (i = 0; i < k - 1; i++) {
+                nbr = step2_nbrs[phase][i];
+                if (rank > nbr) {
+                    myidx = i + 1;
+                }
+            }
+        mpi_errno =
+            MPIR_TSP_sched_imcast(recvbuf, count, datatype, step2_nbrs[phase], k - 1, tag, comm,
+                                  sched, nvtcs, vtcs, &imcast_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                        (MPL_DBG_FDEST, "sending imcast to %d brs. I'm dependent on nvtcs %d",
+                         k - 1, nvtcs));
+
+        /* receive and reduce data from the neighbors to the left */
+        for (i = myidx - 1, counter = 0; i >= 0; i--, counter++, buf++) {
+            nbr = step2_nbrs[phase][i];
+            nvtcs = 0;
+            mpi_errno =
+                MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
+                                     vtcs, &recv_id[buf]);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
+            nvtcs = 1;
+            vtcs[0] = recv_id[buf];
+            /*If no dtcopy, reduce should wait on all previous phase sends to complete */
+            if (counter == 0 || is_commutative) {
+                vtcs[nvtcs++] = imcast_id;
+            } else {
+                vtcs[nvtcs++] = reduce_id[counter - 1];
+            }
+            MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                            (MPL_DBG_FDEST,
+                             "reducing data with count %ld dependent %d nvtcs counter %d",
+                             count, nvtcs, counter));
+            mpi_errno =
+                MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
+                                            sched, nvtcs, vtcs, &reduce_id[counter]);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
+        }
+
+        /* receive and reduce data from the neighbors to the right */
+        for (i = myidx; i < k - 1; i++, counter++, buf++) {
+            nbr = step2_nbrs[phase][i];
+            nvtcs = 0;
+            mpi_errno =
+                MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
+                                     vtcs, &recv_id[buf]);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+
+            nvtcs = 1;
+            vtcs[0] = recv_id[buf];
+            /*If no dtcopy, reduce should wait on all previous phase sends to complete */
+            if (counter == 0 || is_commutative) {
+                vtcs[nvtcs++] = imcast_id;
+            } else {
+                vtcs[nvtcs++] = reduce_id[counter - 1];
+            }
+            MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                            (MPL_DBG_FDEST,
+                             "reducing data with count %ld dependent %d nvtcs counter %d right neighbor",
+                             count, nvtcs, counter));
+            if (is_commutative) {
+                mpi_errno =
+                    MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
+                                                sched, nvtcs, vtcs, &reduce_id[counter]);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            } else {
+                mpi_errno =
+                    MPIR_TSP_sched_reduce_local(recvbuf, nbr_buffer[buf], count, datatype, op,
+                                                sched, nvtcs, vtcs, &reduce_id[counter]);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                mpi_errno =
+                    MPIR_TSP_sched_localcopy(nbr_buffer[buf], count, datatype, recvbuf, count,
+                                             datatype, sched, 1, &reduce_id[counter],
+                                             &reduce_id[counter]);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            }
+        }
+    }
+    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After Step 2"));
+
+    /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
+     * send the data to non-partcipating ranks */
+    if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
+        int dummy_id;
+        mpi_errno =
+            MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, sched, 0, NULL,
+                                 &dummy_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    } else {
+        for (i = 0; i < step1_nrecvs; i++) {
+            if (is_commutative) {
+                /* If commutative, wait for all the prev reduce calls to complete
+                 * since they can happen in any order */
+                nvtcs = k - 1;
+                MPIR_Localcopy(reduce_id, k - 1, MPI_INT, vtcs, k - 1, MPI_INT);
+            } else {
+                /* If non commutative, wait for the last reduce to complete, as they happen in sequential order */
+                nvtcs = 1;
+                vtcs[0] = reduce_id[k - 2];
+            }
+            int dummy_id;
+            mpi_errno =
+                MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm, sched,
+                                     nvtcs, vtcs, &dummy_id);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        }
+    }
+
+    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Done Step 3"));
+
+    /* free all allocated memory for storing nbrs */
+    for (i = 0; i < step2_nphases; i++)
+        MPL_free(step2_nbrs[i]);
+    MPL_free(step2_nbrs);
+    MPL_free(step1_recvfrom);
+    MPL_free(reduce_id);
+    MPL_free(recv_id);
+    MPL_free(vtcs);
+    MPL_free(nbr_buffer);
+    if (in_step2)
+        MPL_free(step1_recvbuf);
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 /* Routine to schedule a recursive exchange based allreduce */
 int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                             MPI_Datatype datatype, MPI_Op op,
@@ -29,7 +570,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     int nvtcs, step1_id, *recv_id, *vtcs;
     int myidx, nbr, phase;
     int counter = 0;
-    int *send_id, *reduce_id;
+    int *reduce_id, imcast_id;
     bool in_step2;
     void *tmp_buf;
     void **step1_recvbuf = NULL;
@@ -59,11 +600,10 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                                    &step1_recvfrom, &step1_nrecvs,
                                    &step2_nbrs, &step2_nphases, &p_of_k, &T);
     in_step2 = (step1_sendto == -1);    /* whether this rank participates in Step 2 */
-    send_id = (int *) MPL_malloc(sizeof(int) * k, MPL_MEM_COLL);        /* to store send vertex ids */
     reduce_id = (int *) MPL_malloc(sizeof(int) * k, MPL_MEM_COLL);      /* to store reduce vertex ids */
     recv_id = (int *) MPL_malloc(sizeof(int) * step2_nphases * (k - 1), MPL_MEM_COLL);  /* to store receive vertex ids */
     vtcs = MPL_malloc(sizeof(int) * (step2_nphases) * k, MPL_MEM_COLL); /* to store graph dependencies */
-    MPIR_Assert(send_id != NULL && reduce_id != NULL && recv_id != NULL && vtcs != NULL);
+    MPIR_Assert(reduce_id != NULL && recv_id != NULL && vtcs != NULL);
 
     if (in_step2 && !is_inplace && count > 0) { /* copy the data to recvbuf but only if you are a rank participating in Step 2 */
         mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
@@ -113,8 +653,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                 vtcs[0] = step1_id;
             } else {
                 /* wait for the previous sends to complete */
-                MPIR_Localcopy(send_id, k - 1, MPI_INT, vtcs, k - 1, MPI_INT);
-                nvtcs = k - 1;
+                vtcs[0] = imcast_id;
+                nvtcs = 1;
                 if (is_commutative && per_nbr_buffer == 1) {
                     /* wait for all the previous reductions to complete */
                     MPIR_Localcopy(reduce_id, k - 1, MPI_INT, vtcs + nvtcs, k - 1, MPI_INT);
@@ -136,30 +676,38 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
          * This is useful only in the non-commutative case. */
         myidx = 0;
         /* send data to all the neighbors */
-        for (i = 0; i < k - 1; i++) {
-            if (count == 0) {
-                if (phase == 0) {
-                    nvtcs = 1;
-                    vtcs[0] = step1_id;
-                } else {        /* wait for all the previous receives to have completed */
-                    MPIR_Localcopy(recv_id, phase * (k - 1), MPI_INT, vtcs, phase * (k - 1),
-                                   MPI_INT);
-                    nvtcs = phase * (k - 1);
-                }
-            } else {
+        if (count == 0) {
+            if (phase == 0) {
                 nvtcs = 1;
-                vtcs[0] = dtcopy_id;
+                vtcs[0] = step1_id;
+                MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "count and phase are 0"));
+            } else {    /* wait for all the previous receives to have completed */
+                MPIR_Localcopy(recv_id, phase * (k - 1), MPI_INT, vtcs, phase * (k - 1), MPI_INT);
+                nvtcs = phase * (k - 1);
+                MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                                (MPL_DBG_FDEST, "count 0. Depend on all previous %d recvs.",
+                                 nvtcs));
             }
+        } else {
+            nvtcs = 1;
+            vtcs[0] = dtcopy_id;
+        }
 
-            nbr = step2_nbrs[phase][i];
-            mpi_errno =
-                MPIR_TSP_sched_isend(tmp_buf, count, datatype, nbr, tag, comm, sched, nvtcs, vtcs,
-                                     &send_id[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-            if (rank > nbr) {
-                myidx = i + 1;
+        if (!is_commutative) {
+            for (i = 0; i < k - 1; i++) {
+                nbr = step2_nbrs[phase][i];
+                if (rank > nbr) {
+                    myidx = i + 1;
+                }
             }
         }
+        mpi_errno =
+            MPIR_TSP_sched_imcast(tmp_buf, count, datatype, step2_nbrs[phase], k - 1, tag, comm,
+                                  sched, nvtcs, vtcs, &imcast_id);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                        (MPL_DBG_FDEST, "sending imcast to %d brs. I'm dependent on nvtcs %d",
+                         k - 1, nvtcs));
 
         /* receive and reduce data from the neighbors to the left */
         for (i = myidx - 1, counter = 0; i >= 0; i--, counter++, buf++) {
@@ -265,7 +813,6 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
         MPL_free(step2_nbrs[i]);
     MPL_free(step2_nbrs);
     MPL_free(step1_recvfrom);
-    MPL_free(send_id);
     MPL_free(reduce_id);
     MPL_free(recv_id);
     MPL_free(vtcs);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
@@ -8,573 +8,56 @@
 #include "recexchalgo.h"
 #include "iallreduce_tsp_recursive_exchange_common.h"
 
-/* Allreduce single buffer and multiple buffer without dtcopy algorithms are an optimization to the existing
- * allreduce recexch algorithms. These two algorithms are decoupled and written as separate algorithms
- * for readability */
-
-/* Routine to schedule a recursive exchange based allreduce using single receive buffer without
- * data copy in step2. Similar to other recursive exchange algorithms, this algorithm also involves "k"
- * partners in every communication phase. Removing the data copy in step2 improves performance but at the cost
- * of increased dependencies. */
-static int single_buffer_without_dtcopy_recexch(const void *sendbuf, void *recvbuf,
-                                                MPI_Aint count, MPI_Datatype datatype,
-                                                MPI_Op op, MPIR_Comm * comm, int k,
-                                                MPIR_TSP_sched_t sched)
-{
-    int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-    MPIR_Assert(k == 2);        /* This algorithm will deadlock if the exchange involves more than 2 partners */
-
-    int is_inplace, i;
-    int dtcopy_id = -1;
-    size_t extent;
-    MPI_Aint lb, true_extent;
-    int is_commutative;
-    int nranks, rank;
-    int p_of_k, T;
-    int nvtcs, *vtcs;
-    int nbr, phase;
-    int send_id, reduce_id, recv_id;
-    void *step1_recvbuf = NULL;
-    void *nbr_buffer = NULL;
-    int tag;
-
-    MPIR_FUNC_ENTER;
-
-    is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
-
-    MPIR_Datatype_get_extent_macro(datatype, extent);
-    MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
-    extent = MPL_MAX(extent, true_extent);
-    is_commutative = MPIR_Op_is_commutative(op);
-
-    /* For correctness, transport based collectives need to get the
-     * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
-
-    /* if there is only 1 rank, copy data from sendbuf
-     * to recvbuf and exit */
-    if (nranks == 1) {
-        if (!is_inplace) {
-            int dummy_id;
-            mpi_errno =
-                MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype, sched,
-                                         0, NULL, &dummy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
-        goto fn_exit;
-    }
-
-    MPII_Recexchalgo_t recexch;
-    MPII_Recexchalgo_start(rank, nranks, k, &recexch);
-
-    vtcs = MPL_malloc(sizeof(int) * (recexch.step2_nphases) * 2, MPL_MEM_COLL); /* to store graph dependencies */
-    MPIR_Assert(vtcs != NULL);  /* If memory allocation for vtcs fails, MPI will abort. Else MPI would be inconsistent */
-
-
-    if (recexch.in_step2 && !is_inplace) {      /* copy the data to recvbuf but only if you are a rank participating in Step 2 */
-        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
-                                             recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After initial dt copy"));
-    }
-
-    /* Step 1 */
-    if (!recexch.in_step2) {
-        /* non-participating rank sends the data to a participating rank */
-        void *buf_to_send;
-        if (is_inplace)
-            buf_to_send = recvbuf;
-        else
-            buf_to_send = (void *) sendbuf;
-        int dummy_id;
-        mpi_errno =
-            MPIR_TSP_sched_isend(buf_to_send, count, datatype, recexch.step1_sendto, tag, comm,
-                                 sched, 0, NULL, &dummy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-    } else {    /* Step 2 participating rank */
-        step1_recvbuf = MPIR_TSP_sched_malloc(count * extent, sched);
-        MPIR_Assert(step1_recvbuf != NULL);
-
-        for (i = 0; i < recexch.step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
-            /* recv dependencies */
-            nvtcs = 0;
-            if (i != 0) {
-                vtcs[nvtcs++] = reduce_id;
-                MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                                (MPL_DBG_FDEST, "step1 recv depend on reduce_id %d", reduce_id));
-            }
-            mpi_errno = MPIR_TSP_sched_irecv(step1_recvbuf, count, datatype,
-                                             recexch.step1_recvfrom[i], tag, comm, sched, nvtcs,
-                                             vtcs, &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-            /* setup reduce dependencies */
-            nvtcs = 1;
-            vtcs[0] = recv_id;
-            if (i == 0 && !is_inplace)
-                vtcs[nvtcs++] = dtcopy_id;
-            mpi_errno = MPIR_TSP_sched_reduce_local(step1_recvbuf, recvbuf, count,
-                                                    datatype, op, sched, nvtcs, vtcs, &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
-    }
-
-    /* Step 2 */
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Start Step2"));
-
-    /* allocate memory for receive buffers */
-    if (recexch.in_step2) {
-        nbr_buffer = step1_recvbuf;
-        MPIR_Assert(nbr_buffer != NULL);
-    }
-
-    for (phase = 0; phase < recexch.step2_nphases && recexch.step1_sendto == -1; phase++) {
-
-        nbr = recexch.step2_nbrs[phase][0];
-        /* send data to all the neighbors */
-        nvtcs = 0;
-        if ((phase == 0 && recexch.step1_nrecvs > 0) || phase != 0) {
-            vtcs[nvtcs++] = reduce_id;
-        } else if (phase == 0 && recexch.in_step2 && !is_inplace) {
-            vtcs[nvtcs++] = dtcopy_id;
-        }
-
-        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                        (MPL_DBG_FDEST, "sending data to %d. I'm dependent on nvtcs %d", nbr,
-                         nvtcs));
-        mpi_errno =
-            MPIR_TSP_sched_isend(recvbuf, count, datatype, nbr, tag, comm, sched, nvtcs, vtcs,
-                                 &send_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-
-        /* receive and reduce data from the neighbors to the left */
-        nvtcs = 0;
-        if ((phase == 0 && recexch.step1_nrecvs > 0) || phase != 0) {
-            vtcs[nvtcs++] = reduce_id;
-        }
-        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                        (MPL_DBG_FDEST,
-                         "receiving data to %d. I'm dependent on nvtcs %d vtcs %d",
-                         nbr, nvtcs, vtcs[0]));
-        mpi_errno =
-            MPIR_TSP_sched_irecv(nbr_buffer, count, datatype, nbr, tag, comm, sched, nvtcs, vtcs,
-                                 &recv_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-
-        nvtcs = 2;
-        vtcs[0] = recv_id;
-        vtcs[1] = send_id;
-
-        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                        (MPL_DBG_FDEST,
-                         "reducing data with count %ld dependent %d nvtcs", count, nvtcs));
-        if (is_commutative) {
-            mpi_errno =
-                MPIR_TSP_sched_reduce_local(nbr_buffer, recvbuf, count, datatype, op,
-                                            sched, nvtcs, vtcs, &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        } else {
-            mpi_errno =
-                MPIR_TSP_sched_reduce_local(recvbuf, nbr_buffer, count, datatype, op,
-                                            sched, nvtcs, vtcs, &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-            mpi_errno =
-                MPIR_TSP_sched_localcopy(nbr_buffer, count, datatype, recvbuf, count,
-                                         datatype, sched, 1, &reduce_id, &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
-    }
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After Step 2"));
-
-    /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
-     * send the data to non-partcipating ranks */
-    if (recexch.step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
-        int dummy_id;
-        mpi_errno =
-            MPIR_TSP_sched_irecv(recvbuf, count, datatype, recexch.step1_sendto, tag, comm, sched,
-                                 0, NULL, &dummy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-    } else {
-        /* Wait for the last reduce to complete */
-        nvtcs = 1;
-        vtcs[0] = reduce_id;
-        for (i = 0; i < recexch.step1_nrecvs; i++) {
-            int dummy_id;
-            mpi_errno =
-                MPIR_TSP_sched_isend(recvbuf, count, datatype, recexch.step1_recvfrom[i], tag, comm,
-                                     sched, nvtcs, vtcs, &dummy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
-    }
-
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Done Step 3"));
-
-    MPII_Recexchalgo_finish(&recexch);
-    MPL_free(vtcs);
-  fn_exit:
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-/* Routine to schedule a recursive exchange based allreduce using separate receive buffer
- * for each partner and in each phase and without data copy in step2.
- * Removing the data copy improves performance but at the cost
- * of increased dependencies. */
-static int multiple_buffer_without_dtcopy_recexch(const void *sendbuf, void *recvbuf,
-                                                  MPI_Aint count, MPI_Datatype datatype,
-                                                  MPI_Op op, MPIR_Comm * comm, int k,
-                                                  MPIR_TSP_sched_t sched)
-{
-    int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret = MPI_SUCCESS;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-    int is_inplace, i, j;
-    int dtcopy_id = -1;
-    size_t extent;
-    MPI_Aint lb, true_extent;
-    int is_commutative;
-    int nranks, rank;
-    int p_of_k, T;
-    int buf = 0;
-    int nvtcs, step1_id, *recv_id, *vtcs;
-    int myidx, nbr, phase;
-    int counter = 0;
-    int *reduce_id, imcast_id;
-    void **step1_recvbuf = NULL;
-    void **nbr_buffer = NULL;
-    int tag;
-
-    MPIR_FUNC_ENTER;
-
-    is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
-
-    MPIR_Datatype_get_extent_macro(datatype, extent);
-    MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
-    extent = MPL_MAX(extent, true_extent);
-    is_commutative = MPIR_Op_is_commutative(op);
-
-    /* For correctness, transport based collectives need to get the
-     * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
-
-    /* if there is only 1 rank, copy data from sendbuf
-     * to recvbuf and exit */
-    if (nranks == 1) {
-        if (!is_inplace) {
-            int dummy_id;
-            mpi_errno =
-                MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype, sched,
-                                         0, NULL, &dummy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
-        goto fn_exit;
-    }
-
-    MPII_Recexchalgo_t recexch;
-    MPII_Recexchalgo_start(rank, nranks, k, &recexch);
-
-    reduce_id = (int *) MPL_malloc(sizeof(int) * k, MPL_MEM_COLL);      /* to store reduce vertex ids */
-    recv_id = (int *) MPL_malloc(sizeof(int) * recexch.step2_nphases * (k - 1), MPL_MEM_COLL);  /* to store receive vertex ids */
-    vtcs = MPL_malloc(sizeof(int) * (recexch.step2_nphases) * k, MPL_MEM_COLL); /* to store graph dependencies */
-    /* If memory allocation fails here, MPI will abort. Else MPI would be inconsistent */
-    MPIR_Assert(reduce_id != NULL && recv_id != NULL && vtcs != NULL);
-
-
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Beforeinitial dt copy"));
-    if (recexch.in_step2 && !is_inplace) {      /* copy the data to recvbuf but only if you are a rank participating in Step 2 */
-        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
-                                             recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-    }
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After initial dt copy"));
-
-    /* Step 1 */
-    if (!recexch.in_step2) {
-        /* non-participating rank sends the data to a participating rank */
-        void *buf_to_send;
-        if (is_inplace)
-            buf_to_send = recvbuf;
-        else
-            buf_to_send = (void *) sendbuf;
-        int dummy_id;
-        mpi_errno =
-            MPIR_TSP_sched_isend(buf_to_send, count, datatype, recexch.step1_sendto, tag, comm,
-                                 sched, 0, NULL, &dummy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-    } else {    /* Step 2 participating rank */
-        step1_recvbuf = (void **) MPL_malloc(sizeof(void *) * recexch.step1_nrecvs, MPL_MEM_COLL);
-        MPIR_Assert(step1_recvbuf != NULL);
-
-        for (i = 0; i < recexch.step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
-            step1_recvbuf[i] = MPIR_TSP_sched_malloc(count * extent, sched);
-
-            /* recv dependencies */
-            nvtcs = 0;
-            mpi_errno = MPIR_TSP_sched_irecv(step1_recvbuf[i], count, datatype,
-                                             recexch.step1_recvfrom[i], tag, comm, sched, nvtcs,
-                                             vtcs, &recv_id[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-            /* setup reduce dependencies */
-            nvtcs = 1;
-            vtcs[0] = recv_id[i];
-            if (is_commutative) {
-                if (!is_inplace) {      /* wait for the data to be copied to recvbuf */
-                    vtcs[nvtcs++] = dtcopy_id;
-                }
-            } else {    /* if not commutative */
-                /* wait for datacopy to complete if i==0 && !is_inplace else wait for previous reduce */
-                if (i == 0 && !is_inplace)
-                    vtcs[nvtcs++] = dtcopy_id;
-                else if (i != 0)
-                    vtcs[nvtcs++] = reduce_id[i - 1];
-            }
-            mpi_errno = MPIR_TSP_sched_reduce_local(step1_recvbuf[i], recvbuf, count,
-                                                    datatype, op, sched, nvtcs, vtcs,
-                                                    &reduce_id[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
-    }
-
-    mpi_errno = MPIR_TSP_sched_sink(sched, &step1_id);  /* sink for all the tasks up to end of Step 1 */
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
-
-    /* Step 2 */
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Start Step2"));
-
-    /* allocate memory for receive buffers */
-    nbr_buffer =
-        (void **) MPL_malloc(sizeof(void *) * recexch.step2_nphases * (k - 1), MPL_MEM_COLL);
-    MPIR_Assert(nbr_buffer != NULL);
-    buf = 0;
-    for (i = 0; i < recexch.step2_nphases; i++) {
-        for (j = 0; j < (k - 1); j++, buf++) {
-            nbr_buffer[buf] = MPIR_TSP_sched_malloc(count * extent, sched);
-        }
-    }
-
-    buf = 0;
-    for (phase = 0; phase < recexch.step2_nphases && recexch.step1_sendto == -1; phase++) {
-        if (!is_commutative) {
-            /* sort the neighbor list so that receives can be posted in order */
-#if defined(HAVE_QSORT)
-            qsort(recexch.step2_nbrs[phase], k - 1, sizeof(int), MPII_Algo_compare_int);
-#else
-            MPIR_insertion_sort(recexch.step2_nbrs[phase], k - 1);
-#endif
-        }
-        /* myidx is the index in the neighbors list such that
-         * all neighbors before myidx have ranks less than my rank
-         * and neighbors at and after myidx have rank greater than me.
-         * This is useful only in the non-commutative case. */
-        myidx = 0;
-        /* send data to all the neighbors */
-        if (phase == 0) {
-            nvtcs = 1;
-            vtcs[0] = step1_id;
-            MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "phase is 0"));
-        } else if (is_commutative) {    /* wait for all the previous receives to have completed */
-            nvtcs = 0;
-            for (j = 0; j < k - 1; j++)
-                vtcs[nvtcs++] = reduce_id[j];
-            MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                            (MPL_DBG_FDEST, "Depend on all reduces (%d)", nvtcs));
-        } else {        /* if it is not commutative or if there is only one recv buffer */
-            /*just wait for the last recv_reduce to complete as recv_reduce happen in order */
-            nvtcs = 1;
-            vtcs[0] = reduce_id[k - 2];
-        }
-
-        if (!is_commutative)
-            for (i = 0; i < k - 1; i++) {
-                nbr = recexch.step2_nbrs[phase][i];
-                if (rank > nbr) {
-                    myidx = i + 1;
-                }
-            }
-        mpi_errno =
-            MPIR_TSP_sched_imcast(recvbuf, count, datatype, recexch.step2_nbrs[phase], k - 1, tag,
-                                  comm, sched, nvtcs, vtcs, &imcast_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                        (MPL_DBG_FDEST, "sending imcast to %d brs. I'm dependent on nvtcs %d",
-                         k - 1, nvtcs));
-
-        /* receive and reduce data from the neighbors to the left */
-        for (i = myidx - 1, counter = 0; i >= 0; i--, counter++, buf++) {
-            nbr = recexch.step2_nbrs[phase][i];
-            nvtcs = 0;
-            mpi_errno =
-                MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
-                                     vtcs, &recv_id[buf]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-
-            nvtcs = 1;
-            vtcs[0] = recv_id[buf];
-            /*If no dtcopy, reduce should wait on all previous phase sends to complete */
-            if (counter == 0 || is_commutative) {
-                vtcs[nvtcs++] = imcast_id;
-            } else {
-                vtcs[nvtcs++] = reduce_id[counter - 1];
-            }
-            MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                            (MPL_DBG_FDEST,
-                             "reducing data with count %ld dependent %d nvtcs counter %d",
-                             count, nvtcs, counter));
-            mpi_errno =
-                MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
-                                            sched, nvtcs, vtcs, &reduce_id[counter]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-
-        }
-
-        /* receive and reduce data from the neighbors to the right */
-        for (i = myidx; i < k - 1; i++, counter++, buf++) {
-            nbr = recexch.step2_nbrs[phase][i];
-            nvtcs = 0;
-            mpi_errno =
-                MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
-                                     vtcs, &recv_id[buf]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-
-            nvtcs = 1;
-            vtcs[0] = recv_id[buf];
-            /*If no dtcopy, reduce should wait on all previous phase sends to complete */
-            if (counter == 0 || is_commutative) {
-                vtcs[nvtcs++] = imcast_id;
-            } else {
-                vtcs[nvtcs++] = reduce_id[counter - 1];
-            }
-            MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                            (MPL_DBG_FDEST,
-                             "reducing data with count %ld dependent %d nvtcs counter %d right neighbor",
-                             count, nvtcs, counter));
-            if (is_commutative) {
-                mpi_errno =
-                    MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
-                                                sched, nvtcs, vtcs, &reduce_id[counter]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-            } else {
-                mpi_errno =
-                    MPIR_TSP_sched_reduce_local(recvbuf, nbr_buffer[buf], count, datatype, op,
-                                                sched, nvtcs, vtcs, &reduce_id[counter]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-                mpi_errno =
-                    MPIR_TSP_sched_localcopy(nbr_buffer[buf], count, datatype, recvbuf, count,
-                                             datatype, sched, 1, &reduce_id[counter],
-                                             &reduce_id[counter]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-            }
-        }
-    }
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After Step 2"));
-
-    /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
-     * send the data to non-partcipating ranks */
-    if (recexch.step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
-        int dummy_id;
-        mpi_errno =
-            MPIR_TSP_sched_irecv(recvbuf, count, datatype, recexch.step1_sendto, tag, comm, sched,
-                                 0, NULL, &dummy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-    } else {
-        for (i = 0; i < recexch.step1_nrecvs; i++) {
-            if (is_commutative) {
-                /* If commutative, wait for all the prev reduce calls to complete
-                 * since they can happen in any order */
-                nvtcs = k - 1;
-                MPIR_Localcopy(reduce_id, k - 1, MPI_INT, vtcs, k - 1, MPI_INT);
-            } else {
-                /* If non commutative, wait for the last reduce to complete, as they happen in sequential order */
-                nvtcs = 1;
-                vtcs[0] = reduce_id[k - 2];
-            }
-            int dummy_id;
-            mpi_errno =
-                MPIR_TSP_sched_isend(recvbuf, count, datatype, recexch.step1_recvfrom[i], tag, comm,
-                                     sched, nvtcs, vtcs, &dummy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
-    }
-
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Done Step 3"));
-
-    MPII_Recexchalgo_finish(&recexch);
-    MPL_free(reduce_id);
-    MPL_free(recv_id);
-    MPL_free(vtcs);
-    MPL_free(nbr_buffer);
-    if (recexch.in_step2)
-        MPL_free(step1_recvbuf);
-  fn_exit:
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
+static int do_step2_recv_and_reduce(void *recvbuf,
+                                    MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
+                                    int tag, MPIR_Comm * comm, MPIR_TSP_sched_t sched,
+                                    MPII_Recexchalgo_t * recexch, int phase, int i,
+                                    int recvbuf_ready, int nbr_buf_ready, int *vtx_out);
+static int do_step2(void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
+                    MPI_Op op, int tag, MPIR_Comm * comm, MPI_Aint dt_size,
+                    MPIR_TSP_sched_t sched, MPII_Recexchalgo_t * recexch,
+                    int pre_reduce_id, int do_dtcopy);
+static int iallreduce_sched_intra_recexch_zero(MPIR_Comm * comm, int k, MPIR_TSP_sched_t sched);
+static int iallreduce_sched_intra_recexch_single_proc(const void *sendbuf, void *recvbuf,
+                                                      MPI_Aint count, MPI_Datatype datatype,
+                                                      MPI_Op op, MPIR_Comm * comm,
+                                                      MPIR_TSP_sched_t sched);
 
 /* Routine to schedule a recursive exchange based allreduce */
 int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, MPI_Aint count,
-                                            MPI_Datatype datatype, MPI_Op op,
-                                            MPIR_Comm * comm, int per_nbr_buffer, int do_dtcopy,
-                                            int k, MPIR_TSP_sched_t sched)
+                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                            int per_nbr_buffer, int do_dtcopy, int k,
+                                            MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
-    int is_inplace, i, j;
-    int dtcopy_id = -1;
-    size_t extent;
-    MPI_Aint lb, true_extent;
-    int is_commutative;
-    int nranks, rank;
-    int p_of_k, T;
-    int buf = 0;
-    int nvtcs, step1_id, *recv_id, *vtcs;
-    int myidx, nbr, phase;
-    int counter = 0;
-    int *reduce_id, imcast_id;
-    void *tmp_buf;
-    void **nbr_buffer;
-    int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
-
     MPIR_FUNC_ENTER;
 
-    if (!do_dtcopy) {
-        if (!per_nbr_buffer) {
-            mpi_errno = single_buffer_without_dtcopy_recexch(sendbuf, recvbuf, count, datatype,
-                                                             op, comm, k, sched);
-        } else {
-            mpi_errno = multiple_buffer_without_dtcopy_recexch(sendbuf, recvbuf, count, datatype,
-                                                               op, comm, k, sched);
-        }
+    int is_inplace = (sendbuf == MPI_IN_PLACE);
+    int is_commutative = MPIR_Op_is_commutative(op);
+    int nranks = MPIR_Comm_size(comm);
+    int rank = MPIR_Comm_rank(comm);
+
+    if (count == 0) {
+        mpi_errno = iallreduce_sched_intra_recexch_zero(comm, k, sched);
         goto fn_exit;
     }
 
-    is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    if (nranks == 1) {
+        mpi_errno = iallreduce_sched_intra_recexch_single_proc(sendbuf, recvbuf, count,
+                                                               datatype, op, comm, sched);
+        goto fn_exit;
+    }
 
+    MPI_Aint lb, extent, true_extent, dt_size;
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
     extent = MPL_MAX(extent, true_extent);
-    is_commutative = MPIR_Op_is_commutative(op);
+    dt_size = count * extent;
 
-    tmp_buf = MPIR_TSP_sched_malloc(count * extent, sched);
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
+    int tag;
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
 
     MPII_Recexchalgo_t recexch;
@@ -582,210 +65,276 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     recexch.per_nbr_buffer = per_nbr_buffer;
     recexch.is_commutative = is_commutative;
 
-    mpi_errno = MPIR_TSP_Iallreduce_recexch_alloc_nbr_bufs(recexch.step2_nphases * (k - 1),
-                                                           count * extent, &recexch, sched);
+    /* allocate memory for receive buffers */
+    mpi_errno = MPIR_TSP_Iallreduce_recexch_alloc_nbr_bufs(dt_size, &recexch, sched);
     MPIR_ERR_CHECK(mpi_errno);
-    nbr_buffer = recexch.nbr_bufs;
 
-    reduce_id = (int *) MPL_malloc(sizeof(int) * k, MPL_MEM_COLL);      /* to store reduce vertex ids */
-    recv_id = (int *) MPL_malloc(sizeof(int) * recexch.step2_nphases * (k - 1), MPL_MEM_COLL);  /* to store receive vertex ids */
-    vtcs = MPL_malloc(sizeof(int) * (recexch.step2_nphases) * k, MPL_MEM_COLL); /* to store graph dependencies */
-    MPIR_Assert(reduce_id != NULL && recv_id != NULL && vtcs != NULL);
+    mpi_errno = MPIR_TSP_Iallreduce_recexch_check_commutative(&recexch, rank);
+    MPIR_ERR_CHECK(mpi_errno);
 
-    if (recexch.in_step2 && !is_inplace && count > 0) { /* copy the data to recvbuf but only if you are a rank participating in Step 2 */
+    int dtcopy_id = -1;
+    if (recexch.step1_sendto == -1 && !is_inplace) {
         mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
                                              recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
-    /* Step 1 */
-    MPIR_TSP_Iallreduce_sched_intra_recexch_step1(sendbuf, recvbuf, count,
-                                                  datatype, op, comm,
-                                                  tag, count * extent, dtcopy_id, &recexch, sched);
+    /* Step 1 - non-participating ranks send data to participating ranks */
+    mpi_errno = MPIR_TSP_Iallreduce_sched_intra_recexch_step1(sendbuf, recvbuf, count,
+                                                              datatype, op, comm,
+                                                              tag, dt_size, dtcopy_id,
+                                                              &recexch, sched);
 
-    mpi_errno = MPIR_TSP_sched_sink(sched, &step1_id);  /* sink for all the tasks up to end of Step 1 */
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
-    /* Step 2 */
-    buf = 0;
-    for (phase = 0; phase < recexch.step2_nphases && recexch.step1_sendto == -1; phase++) {
-        if (!is_commutative) {
-            /* sort the neighbor list so that receives can be posted in order */
-            MPL_sort_int_array(recexch.step2_nbrs[phase], k - 1);
-        }
-        /* copy the data to a temporary buffer so that sends ands recvs
-         * can be posted simultaneously */
-        if (count != 0) {
-            if (phase == 0) {   /* wait for Step 1 to complete */
-                nvtcs = 1;
-                vtcs[0] = step1_id;
-            } else {
-                /* wait for the previous sends to complete */
-                vtcs[0] = imcast_id;
-                nvtcs = 1;
-                if (is_commutative && per_nbr_buffer == 1) {
-                    /* wait for all the previous reductions to complete */
-                    MPIR_Localcopy(reduce_id, k - 1, MPI_INT, vtcs + nvtcs, k - 1, MPI_INT);
-                    nvtcs += k - 1;
-                } else {        /* if it is not commutative or if there is only one recv buffer */
-                    /* just wait for the last reduce to complete as reductions happen in sequential order */
-                    vtcs[nvtcs++] = reduce_id[k - 2];
-                }
-            }
-            mpi_errno =
-                MPIR_TSP_sched_localcopy(recvbuf, count, datatype, tmp_buf, count, datatype, sched,
-                                         nvtcs, vtcs, &dtcopy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    mpi_errno = MPIR_TSP_sched_fence(sched);
+    MPIR_ERR_CHECK(mpi_errno);
 
-        }
-        /* myidx is the index in the neighbors list such that
-         * all neighbors before myidx have ranks less than my rank
-         * and neighbors at and after myidx have rank greater than me.
-         * This is useful only in the non-commutative case. */
-        myidx = 0;
-        /* send data to all the neighbors */
-        if (count == 0) {
-            if (phase == 0) {
-                nvtcs = 1;
-                vtcs[0] = step1_id;
-                MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "count and phase are 0"));
-            } else {    /* wait for all the previous receives to have completed */
-                MPIR_Localcopy(recv_id, phase * (k - 1), MPI_INT, vtcs, phase * (k - 1), MPI_INT);
-                nvtcs = phase * (k - 1);
-                MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                                (MPL_DBG_FDEST, "count 0. Depend on all previous %d recvs.",
-                                 nvtcs));
-            }
-        } else {
-            nvtcs = 1;
-            vtcs[0] = dtcopy_id;
-        }
-
-        if (!is_commutative) {
-            for (i = 0; i < k - 1; i++) {
-                nbr = recexch.step2_nbrs[phase][i];
-                if (rank > nbr) {
-                    myidx = i + 1;
-                }
-            }
-        }
-        mpi_errno =
-            MPIR_TSP_sched_imcast(tmp_buf, count, datatype, recexch.step2_nbrs[phase], k - 1, tag,
-                                  comm, sched, nvtcs, vtcs, &imcast_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                        (MPL_DBG_FDEST, "sending imcast to %d brs. I'm dependent on nvtcs %d",
-                         k - 1, nvtcs));
-
-        /* receive and reduce data from the neighbors to the left */
-        for (i = myidx - 1, counter = 0; i >= 0; i--, counter++, buf++) {
-            nbr = recexch.step2_nbrs[phase][i];
-            nvtcs = 0;
-            if (count != 0 && per_nbr_buffer == 0 && (phase != 0 || counter != 0)) {
-                vtcs[nvtcs++] = (counter == 0) ? reduce_id[k - 2] : reduce_id[counter - 1];
-            }
-            mpi_errno =
-                MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
-                                     vtcs, &recv_id[buf]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-
-            if (count != 0) {
-                nvtcs = 1;
-                vtcs[0] = recv_id[buf];
-                if (counter == 0 || is_commutative) {
-                    vtcs[nvtcs++] = dtcopy_id;
-                } else {
-                    vtcs[nvtcs++] = reduce_id[counter - 1];
-                }
-                mpi_errno =
-                    MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
-                                                sched, nvtcs, vtcs, &reduce_id[counter]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-            }
-
-        }
-
-        /* receive and reduce data from the neighbors to the right */
-        for (i = myidx; i < k - 1; i++, counter++, buf++) {
-            nbr = recexch.step2_nbrs[phase][i];
-            nvtcs = 0;
-            if (count != 0 && per_nbr_buffer == 0 && (phase != 0 || counter != 0)) {
-                vtcs[nvtcs++] = (counter == 0) ? reduce_id[k - 2] : reduce_id[counter - 1];
-            }
-            mpi_errno =
-                MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
-                                     vtcs, &recv_id[buf]);
-
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-
-            if (count != 0) {
-                nvtcs = 1;
-                vtcs[0] = recv_id[buf];
-                if (counter == 0 || is_commutative) {
-                    vtcs[nvtcs++] = dtcopy_id;
-                } else {
-                    vtcs[nvtcs++] = reduce_id[counter - 1];
-                }
-                if (is_commutative) {
-                    mpi_errno =
-                        MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
-                                                    sched, nvtcs, vtcs, &reduce_id[counter]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-                } else {
-                    mpi_errno =
-                        MPIR_TSP_sched_reduce_local(recvbuf, nbr_buffer[buf], count, datatype, op,
-                                                    sched, nvtcs, vtcs, &reduce_id[counter]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-                    mpi_errno =
-                        MPIR_TSP_sched_localcopy(nbr_buffer[buf], count, datatype, recvbuf, count,
-                                                 datatype, sched, 1, &reduce_id[counter], &vtx_id);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-                    reduce_id[counter] = vtx_id;
-                }
-            }
-        }
+    /* Step 2 - recursive exchange on power-of-k processes */
+    if (recexch.in_step2) {
+        mpi_errno = do_step2(recvbuf, count, datatype, op, tag, comm, dt_size,
+                             sched, &recexch, dtcopy_id, do_dtcopy);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
-    /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
-     * send the data to non-partcipating ranks */
-    if (recexch.step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
-        mpi_errno =
-            MPIR_TSP_sched_irecv(recvbuf, count, datatype, recexch.step1_sendto, tag, comm, sched,
-                                 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-    } else {
-        for (i = 0; i < recexch.step1_nrecvs; i++) {
-            if (count == 0) {
-                nvtcs = recexch.step2_nphases * (k - 1);
-                MPIR_Localcopy(recv_id, recexch.step2_nphases * (k - 1), MPI_INT, vtcs,
-                               recexch.step2_nphases * (k - 1), MPI_INT);
-            } else if (is_commutative && per_nbr_buffer == 1) {
-                /* If commutative, wait for all the prev reduce calls to complete
-                 * since they can happen in any order */
-                nvtcs = k - 1;
-                MPIR_Localcopy(reduce_id, k - 1, MPI_INT, vtcs, k - 1, MPI_INT);
-            } else {
-                /* If non commutative, wait for the last reduce to complete, as they happen in sequential order */
-                nvtcs = 1;
-                vtcs[0] = reduce_id[k - 2];
-            }
-            mpi_errno =
-                MPIR_TSP_sched_isend(recvbuf, count, datatype, recexch.step1_recvfrom[i], tag, comm,
-                                     sched, nvtcs, vtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
-    }
+    /* Step 3: participating ranks send reduced data to non-participating ranks */
+    mpi_errno = MPIR_TSP_Iallreduce_sched_intra_recexch_step3(recvbuf, count, datatype,
+                                                              comm, tag, &recexch, sched);
+    MPIR_ERR_CHECK(mpi_errno);
 
-    /* free all allocated memory for storing nbrs */
     MPII_Recexchalgo_finish(&recexch);
-    MPL_free(reduce_id);
-    MPL_free(recv_id);
-    MPL_free(vtcs);
 
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
     goto fn_exit;
+}
+
+/* A single step in step2 -- receive from one of the neighbor into nbr_buf, then
+ * reduce into recvbuf. recvbuf_ready and nbr_buf_ready are vertex dependency that
+ * indicate the dependency on recvbuf and nbr_buf correspondingly.
+ */
+static int do_step2_recv_and_reduce(void *recvbuf,
+                                    MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
+                                    int tag, MPIR_Comm * comm, MPIR_TSP_sched_t sched,
+                                    MPII_Recexchalgo_t * recexch, int phase, int i,
+                                    int recvbuf_ready, int nbr_buf_ready, int *vtx_out)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int is_commutative = recexch->is_commutative;
+    int nbr = recexch->step2_nbrs[phase][i];
+    void *nbr_buf = MPIR_TSP_Iallreduce_recexch_get_nbr_buf(recexch, phase, i);
+
+    /* -- recv from nbr -- */
+    int recv_id;
+    mpi_errno = MPIR_TSP_sched_irecv(nbr_buf, count, datatype,
+                                     nbr, tag, comm, sched, 1, &nbr_buf_ready, &recv_id);
+    MPIR_ERR_CHECK(mpi_errno);
+    nbr_buf_ready = recv_id;
+
+    /* -- reduce_local -- */
+    int vtcs[2];
+    vtcs[0] = nbr_buf_ready;
+    vtcs[1] = recvbuf_ready;
+    if (is_commutative) {
+        mpi_errno = MPIR_TSP_sched_reduce_local(nbr_buf, recvbuf, count, datatype, op,
+                                                sched, 2, vtcs, vtx_out);
+        MPIR_ERR_CHECK(mpi_errno);
+    } else {
+        if (i < recexch->myidxes[phase]) {
+            /* nbr_buf + recvbuf */
+            mpi_errno = MPIR_TSP_sched_reduce_local(nbr_buf, recvbuf, count, datatype, op,
+                                                    sched, 2, vtcs, vtx_out);
+        } else {
+            /* recvbuf + nbr_buf */
+            int temp_id;
+            /* TODO: instead of reduce and copy, can we just amend reduce_local? */
+            mpi_errno = MPIR_TSP_sched_reduce_local(recvbuf, nbr_buf, count, datatype, op,
+                                                    sched, 2, vtcs, &temp_id);
+            MPIR_ERR_CHECK(mpi_errno);
+
+            mpi_errno = MPIR_TSP_sched_localcopy(nbr_buf, count, datatype,
+                                                 recvbuf, count, datatype, sched,
+                                                 1, &temp_id, vtx_out);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int do_step2(void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
+                    MPI_Op op, int tag, MPIR_Comm * comm, MPI_Aint dt_size,
+                    MPIR_TSP_sched_t sched, MPII_Recexchalgo_t * recexch,
+                    int pre_reduce_id, int do_dtcopy)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_ENTER;
+
+    int per_nbr_buffer = recexch->per_nbr_buffer;
+    int is_commutative = recexch->is_commutative;
+    int k = recexch->k;
+    int nphases = recexch->step2_nphases;
+
+    int *reduce_ids = MPL_malloc((k - 1) * sizeof(int), MPL_MEM_OTHER);
+    MPIR_ERR_CHKANDJUMP(!reduce_ids, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+    void *tmp_buf;
+    if (do_dtcopy) {
+        tmp_buf = MPIR_TSP_sched_malloc(dt_size, sched);
+        MPIR_ERR_CHKANDJUMP(!tmp_buf, mpi_errno, MPI_ERR_OTHER, "**nomem");
+    } else {
+        /* directly send from recvbuf */
+        tmp_buf = recvbuf;
+    }
+
+    int recvbuf_ready = pre_reduce_id;
+    int tmp_buf_ready = -1;     /* only used if do_dtcopy */
+    int nbr_buf_ready = -1;
+
+    for (int phase = 0; phase < nphases; phase++) {
+        int imcast_depend;
+        /* -- dtcopy -- */
+        if (do_dtcopy) {
+            int vtcs[2];
+            vtcs[0] = recvbuf_ready;
+            vtcs[1] = tmp_buf_ready;
+            int dtcopy_id;
+            mpi_errno = MPIR_TSP_sched_localcopy(recvbuf, count, datatype,
+                                                 tmp_buf, count, datatype, sched,
+                                                 2, vtcs, &dtcopy_id);
+            MPIR_ERR_CHECK(mpi_errno);
+            recvbuf_ready = dtcopy_id;
+            tmp_buf_ready = dtcopy_id;
+            imcast_depend = tmp_buf_ready;
+        } else {
+            imcast_depend = recvbuf_ready;
+        }
+        /* -- send data to all the neighbors -- */
+        int imcast_id;
+        mpi_errno = MPIR_TSP_sched_imcast(tmp_buf, count, datatype,
+                                          recexch->step2_nbrs[phase], k - 1, tag, comm,
+                                          sched, 1, &imcast_depend, &imcast_id);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        if (do_dtcopy) {
+            tmp_buf_ready = imcast_id;
+        } else {
+            recvbuf_ready = imcast_id;
+        }
+
+        /* -- recv data and reduce_local -- */
+        for (int i = 0; i < k - 1; i++) {
+            mpi_errno = do_step2_recv_and_reduce(recvbuf, count, datatype, op, tag, comm,
+                                                 sched, recexch, phase, i,
+                                                 recvbuf_ready, nbr_buf_ready, &reduce_ids[i]);
+            MPIR_ERR_CHECK(mpi_errno);
+            if (!per_nbr_buffer) {
+                nbr_buf_ready = reduce_ids[i];
+            }
+            if (!is_commutative) {
+                recvbuf_ready = reduce_ids[i];
+            }
+        }
+
+        if (is_commutative) {
+            /* get a sink dependency on all reduces for this phase */
+            int sink_id;
+            mpi_errno = MPIR_TSP_sched_selective_sink(sched, k - 1, reduce_ids, &sink_id);
+            MPIR_ERR_CHECK(mpi_errno);
+            recvbuf_ready = sink_id;
+        }
+    }
+
+  fn_exit:
+    MPL_free(reduce_ids);
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int iallreduce_sched_intra_recexch_zero(MPIR_Comm * comm, int k, MPIR_TSP_sched_t sched)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_ENTER;
+
+    int nranks = MPIR_Comm_size(comm);
+    int rank = MPIR_Comm_rank(comm);
+
+    /* For correctness, transport based collectives need to get the
+     * tag from the same pool as schedule based collectives */
+    int tag;
+    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+
+    MPII_Recexchalgo_t recexch;
+    MPII_Recexchalgo_start(rank, nranks, k, &recexch);
+
+    /* Step 1 - non-participating ranks send data to participating ranks */
+    mpi_errno = MPIR_TSP_Iallreduce_sched_intra_recexch_step1_zero(comm, tag, &recexch, sched);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIR_TSP_sched_fence(sched);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* Step 2 */
+    if (recexch.in_step2) {
+        int imcast_id = -1;
+        int *recv_id = MPL_malloc(recexch.step2_nphases * (k - 1) * sizeof(int), MPL_MEM_OTHER);
+
+        for (int phase = 0; phase < recexch.step2_nphases; phase++) {
+            /* depend on all previous recv */
+            mpi_errno = MPIR_TSP_sched_imcast(NULL, 0, MPI_DATATYPE_NULL,
+                                              recexch.step2_nbrs[phase], k - 1,
+                                              tag, comm, sched,
+                                              phase * (k - 1), recv_id, &imcast_id);
+            MPIR_ERR_CHECK(mpi_errno);
+
+            for (int i = 0; i < k - 1; i++) {
+                mpi_errno = MPIR_TSP_sched_irecv(NULL, 0, MPI_DATATYPE_NULL,
+                                                 recexch.step2_nbrs[phase][i],
+                                                 tag, comm, sched, 0, NULL, &recv_id[i]);
+                MPIR_ERR_CHECK(mpi_errno);
+            }
+        }
+        MPL_free(recv_id);
+    }
+
+    mpi_errno = MPIR_TSP_sched_fence(sched);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
+     * send the data to non-partcipating ranks */
+    mpi_errno = MPIR_TSP_Iallreduce_sched_intra_recexch_step3_zero(comm, tag, &recexch, sched);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPII_Recexchalgo_finish(&recexch);
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int iallreduce_sched_intra_recexch_single_proc(const void *sendbuf, void *recvbuf,
+                                                      MPI_Aint count, MPI_Datatype datatype,
+                                                      MPI_Op op, MPIR_Comm * comm,
+                                                      MPIR_TSP_sched_t sched)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    if (sendbuf == MPI_IN_PLACE) {
+        MPIR_TSP_sched_fence(sched);
+    } else {
+        int dummy_id;
+        mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
+                                             recvbuf, count, datatype, sched, 0, NULL, &dummy_id);
+    }
+
+    return mpi_errno;
 }

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
@@ -103,7 +103,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     for (phase = 0; phase < step2_nphases && step1_sendto == -1; phase++) {
         if (!is_commutative) {
             /* sort the neighbor list so that receives can be posted in order */
-            qsort(step2_nbrs[phase], k - 1, sizeof(int), MPII_Algo_compare_int);
+            MPL_sort_int_array(step2_nbrs[phase], k - 1);
         }
         /* copy the data to a temporary buffer so that sends ands recvs
          * can be posted simultaneously */

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.c
@@ -6,121 +6,299 @@
 #include "mpiimpl.h"
 #include "iallreduce_tsp_recursive_exchange_common.h"
 
-/* Routine to schedule a recursive exchange based allreduce */
-/*
-    MPIR_TSP_Iallreduce_sched_intra_recexch_step1 - non participating ranks
-    send their data to participating ranks for allreduce in step2.
-
-Input Parameters:
-+ sendbuf - initial address of send buffer (choice)
-. recvbuf - initial address of recv buffer (choice)
-. count - number of elements in send buffer/recv buffer (if sendbuf is MPI_INPLACE) (nonnegative integer)
-. datatype - datatype of each buffer element (handle)
-. op - Type of allreduce operation (handle)
-. tag - message tag (integer)
-. extent - extent of datatype (integer)
-. dtcopy_id - id of previous data copy from scheduler (integer)
-. recv_id - array to store ids of the receives from the scheduler (integer array)
-. reduce_id - array to store ids of the reduces from the scheduler (integer array)
-. vtcs - array to specify dependencies of a call to the scheduler (integer array)
-. step1_sendto - partner to send my data in step1 (integer)
-. in_step2 - variable to check if I participate in step2 or not (bool)
-. step1_nrecvs - number of partners to receive data from in step1 (integer)
-. step1_recvfrom - partners to receive data from in step1 (integer array)
-. per_nbr_buffer - variable to denote whether different receive buffers are
-                    used for each partner and in each phase (integer)
-. step1_recvbuf - address of array of receive buffers used in step1 to receive data from partners.
-                  to receive data from in step1. Memory is allocated in this function and
-                  address is returned (address of array of buffers)
-. comm - communicator (handle)
-- sched - scheduler (handle)
-
+/* MPIR_TSP_Iallreduce_sched_intra_recexch_step1 - non participating ranks
+   send their data to participating ranks for allreduce in step2.
 */
-int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
-                                                  void *recvbuf,
-                                                  MPI_Aint count,
-                                                  MPI_Datatype datatype,
-                                                  MPI_Op op, int is_commutative, int tag,
-                                                  int extent, int dtcopy_id, int *recv_id,
-                                                  int *reduce_id, int *vtcs, int is_inplace,
-                                                  int step1_sendto, bool in_step2, int step1_nrecvs,
-                                                  int *step1_recvfrom, int per_nbr_buffer,
-                                                  void ***step1_recvbuf_, MPIR_Comm * comm,
+int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype,
+                                                  MPI_Op op, MPIR_Comm * comm,
+                                                  int tag,
+                                                  MPI_Aint dt_size, int recvbuf_ready,
+                                                  MPII_Recexchalgo_t * recexch,
                                                   MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int i, nvtcs, vtx_id;
-    int mpi_errno_ret = MPI_SUCCESS;
-    void **step1_recvbuf;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-
     MPIR_FUNC_ENTER;
-    /* Step 1 */
-    if (!in_step2) {
+
+    /* FIXME: replace the trivial cases with MPIR_Assert */
+    if (count == 0) {
+        mpi_errno = MPIR_TSP_Iallreduce_sched_intra_recexch_step1_zero(comm, tag, recexch, sched);
+        goto fn_exit;
+    }
+
+    if (recexch->k == 1) {
+        /* this is the case when nprocs is 1 */
+        goto fn_exit;
+    }
+
+    if (recexch->step1_sendto >= 0) {
         /* non-participating rank sends the data to a participating rank */
-        const void *buf_to_send;
-        if (is_inplace)
-            buf_to_send = (const void *) recvbuf;
-        else
-            buf_to_send = sendbuf;
-        mpi_errno =
-            MPIR_TSP_sched_isend(buf_to_send, count, datatype, step1_sendto, tag, comm, sched, 0,
-                                 NULL, &vtx_id);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            errflag = MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
-    } else {    /* Step 2 participating rank */
-        step1_recvbuf = *step1_recvbuf_ =
-            (void **) MPL_malloc(sizeof(void *) * step1_nrecvs, MPL_MEM_COLL);
-        if (per_nbr_buffer != 1 && step1_nrecvs > 0) {
-            step1_recvbuf[0] = (*step1_recvbuf_)[0] = MPIR_TSP_sched_malloc(count * extent, sched);
-            MPIR_Assert(step1_recvbuf != NULL);
-        }
+        const void *buf_to_send = (sendbuf == MPI_IN_PLACE) ? (const void *) recvbuf : sendbuf;
+        int dummy_id;
+        mpi_errno = MPIR_TSP_sched_isend(buf_to_send, count, datatype,
+                                         recexch->step1_sendto, tag, comm,
+                                         sched, 0, NULL, &dummy_id);
+        MPIR_ERR_CHECK(mpi_errno);
+    } else {
+        /* require MPIR_TSP_Iallreduce_recexch_alloc_nbr_bufs */
+        MPIR_Assert(recexch->nbr_bufs);
 
-        for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
-            if (per_nbr_buffer == 1)
-                step1_recvbuf[i] = (*step1_recvbuf_)[i] =
-                    MPIR_TSP_sched_malloc(count * extent, sched);
-            else
-                step1_recvbuf[i] = (*step1_recvbuf_)[i] = (*step1_recvbuf_)[0];
+        /* participating rank */
+        int nbr_buf_ready = -1;
+        for (int i = 0; i < recexch->step1_nrecvs; i++) {
+            int nbr = recexch->step1_recvfrom[i];
+            void *nbr_buf = MPIR_TSP_Iallreduce_recexch_get_nbr_buf(recexch, 0, i);
 
-            /* recv dependencies */
-            nvtcs = 0;
-            if (i != 0 && per_nbr_buffer == 0 && count != 0) {
-                vtcs[nvtcs++] = reduce_id[i - 1];
-                MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                                (MPL_DBG_FDEST, "step1 recv depend on reduce_id[%d] %d", i - 1,
-                                 reduce_id[i - 1]));
+            /* -- irecv -- */
+            int recv_id;
+            mpi_errno = MPIR_TSP_sched_irecv(nbr_buf, count, datatype,
+                                             nbr, tag, comm, sched, 1, &nbr_buf_ready, &recv_id);
+            MPIR_ERR_CHECK(mpi_errno);
+
+            /* -- reduce -- */
+            int vtcs[2];
+            vtcs[0] = recv_id;
+            vtcs[1] = recvbuf_ready;
+
+            int reduce_id;
+            mpi_errno = MPIR_TSP_sched_reduce_local(nbr_buf, recvbuf, count,
+                                                    datatype, op, sched, 2, vtcs, &reduce_id);
+            MPIR_ERR_CHECK(mpi_errno);
+
+            if (!recexch->per_nbr_buffer) {
+                nbr_buf_ready = reduce_id;
             }
-            mpi_errno = MPIR_TSP_sched_irecv(step1_recvbuf[i], count, datatype,
-                                             step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
-                                             &recv_id[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-            if (count != 0) {   /* Reduce only if data is present */
-                /* setup reduce dependencies */
-                nvtcs = 1;
-                vtcs[0] = recv_id[i];
-                if (is_commutative) {
-                    if (!is_inplace) {  /* wait for the data to be copied to recvbuf */
-                        vtcs[nvtcs++] = dtcopy_id;
-                    }
-                } else {        /* if not commutative */
-                    /* wait for datacopy to complete if i==0 && !is_inplace else wait for previous reduce */
-                    if (i == 0 && !is_inplace)
-                        vtcs[nvtcs++] = dtcopy_id;
-                    else if (i != 0)
-                        vtcs[nvtcs++] = reduce_id[i - 1];
-                }
-                mpi_errno = MPIR_TSP_sched_reduce_local(step1_recvbuf[i], recvbuf, count,
-                                                        datatype, op, sched, nvtcs, vtcs,
-                                                        &reduce_id[i]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            if (!recexch->is_commutative) {
+                recvbuf_ready = reduce_id;
             }
         }
     }
+
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* MPIR_TSP_Iallreduce_sched_intra_recexch_step3 - reverse of step1. Participating ranks
+   send final data to non-participating ranks.
+*/
+int MPIR_TSP_Iallreduce_sched_intra_recexch_step3(void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype,
+                                                  MPIR_Comm * comm, int tag,
+                                                  MPII_Recexchalgo_t * recexch,
+                                                  MPIR_TSP_sched_t sched)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_ENTER;
+
+    int dummy_id;
+    if (recexch->step1_sendto >= 0) {
+        mpi_errno = MPIR_TSP_sched_irecv(recvbuf, count, datatype, recexch->step1_sendto,
+                                         tag, comm, sched, 0, NULL, &dummy_id);
+        MPIR_ERR_CHECK(mpi_errno);
+    } else {
+        /* wait for all previous operations */
+        mpi_errno = MPIR_TSP_sched_fence(sched);
+        MPIR_ERR_CHECK(mpi_errno);
+        for (int i = 0; i < recexch->step1_nrecvs; i++) {
+            mpi_errno = MPIR_TSP_sched_isend(recvbuf, count, datatype,
+                                             recexch->step1_recvfrom[i], tag, comm, sched,
+                                             0, NULL, &dummy_id);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+    }
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* special case when count == 0 */
+
+int MPIR_TSP_Iallreduce_sched_intra_recexch_step1_zero(MPIR_Comm * comm, int tag,
+                                                       MPII_Recexchalgo_t * recexch,
+                                                       MPIR_TSP_sched_t sched)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_ENTER;
+
+    int dummy_id;
+    if (recexch->step1_sendto >= 0) {
+        /* non-participating rank sends the data to a participating rank */
+        mpi_errno = MPIR_TSP_sched_isend(NULL, 0, MPI_DATATYPE_NULL,
+                                         recexch->step1_sendto, tag, comm,
+                                         sched, 0, NULL, &dummy_id);
+        MPIR_ERR_CHECK(mpi_errno);
+    } else {
+        /* participating rank */
+        for (int i = 0; i < recexch->step1_nrecvs; i++) {
+            mpi_errno = MPIR_TSP_sched_irecv(NULL, 0, MPI_DATATYPE_NULL,
+                                             recexch->step1_recvfrom[i],
+                                             tag, comm, sched, 0, NULL, &dummy_id);
+        }
+    }
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_TSP_Iallreduce_sched_intra_recexch_step3_zero(MPIR_Comm * comm, int tag,
+                                                       MPII_Recexchalgo_t * recexch,
+                                                       MPIR_TSP_sched_t sched)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_ENTER;
+
+    int dummy_id;
+    if (recexch->step1_sendto >= 0) {
+        mpi_errno = MPIR_TSP_sched_irecv(NULL, 0, MPI_DATATYPE_NULL, recexch->step1_sendto,
+                                         tag, comm, sched, 0, NULL, &dummy_id);
+        MPIR_ERR_CHECK(mpi_errno);
+    } else {
+        /* wait for all previous operations */
+        mpi_errno = MPIR_TSP_sched_fence(sched);
+        MPIR_ERR_CHECK(mpi_errno);
+        for (int i = 0; i < recexch->step1_nrecvs; i++) {
+            mpi_errno = MPIR_TSP_sched_isend(NULL, 0, MPI_DATATYPE_NULL,
+                                             recexch->step1_recvfrom[i], tag, comm, sched,
+                                             0, NULL, &dummy_id);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+    }
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_TSP_Iallreduce_recexch_alloc_nbr_bufs(MPI_Aint dt_size,
+                                               MPII_Recexchalgo_t * recexch, MPIR_TSP_sched_t sched)
+{
+    int mpi_errno = MPI_SUCCESS;
+    void **bufs = NULL;
+
+    /* FIXME: replace the trivial cases with MPIR_Assert */
+    if (recexch->k == 1) {
+        /* this is the case when number of procs is 1 */
+        goto fn_exit;
+    }
+
+    int n;
+    if (recexch->per_nbr_buffer) {
+        if (recexch->step2_nphases > 0) {
+            n = recexch->step2_nphases * (recexch->k - 1);
+        } else {
+            n = recexch->k - 1;
+        }
+    } else {
+        /* single buffer */
+        n = 1;
+    }
+
+    if (recexch->step1_sendto == -1) {
+        bufs = (void **) MPL_malloc(n * sizeof(void *), MPL_MEM_COLL);
+        MPIR_ERR_CHKANDJUMP(!bufs, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+        if (!recexch->per_nbr_buffer) {
+            /* single buffer */
+            bufs[0] = MPIR_TSP_sched_malloc(dt_size, sched);
+            MPIR_ERR_CHKANDJUMP(!bufs[0], mpi_errno, MPI_ERR_OTHER, "**nomem");
+            for (int i = 1; i < n; i++) {
+                bufs[i] = (char *) bufs[0];
+            }
+        } else {
+            /* multiple buffer */
+            bufs[0] = MPIR_TSP_sched_malloc(dt_size * n, sched);
+            MPIR_ERR_CHKANDJUMP(!bufs[0], mpi_errno, MPI_ERR_OTHER, "**nomem");
+            for (int i = 1; i < n; i++) {
+                bufs[i] = (char *) bufs[0] + dt_size * i;
+            }
+        }
+    }
+
+  fn_exit:
+    recexch->nbr_bufs = bufs;
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    if (bufs) {
+        MPL_free(bufs);
+        bufs = NULL;
+    }
+    goto fn_exit;
+}
+
+void *MPIR_TSP_Iallreduce_recexch_get_nbr_buf(MPII_Recexchalgo_t * recexch, int phase, int i)
+{
+    if (recexch->per_nbr_buffer) {
+        int k = recexch->k;
+        return recexch->nbr_bufs[phase * (k - 1) + i];
+    } else {
+        return recexch->nbr_bufs[0];
+    }
+}
+
+/* For non-commutative op, re-order the rank list and fill myidxes. The algorithms following
+ * the reduction order will ensure correctness */
+int MPIR_TSP_Iallreduce_recexch_check_commutative(MPII_Recexchalgo_t * recexch, int myrank)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int k = recexch->k;
+    int nphases = recexch->step2_nphases;
+    int *myidxes = NULL;
+
+    if (recexch->is_commutative) {
+        goto fn_exit;
+    }
+
+    if (recexch->step1_recvfrom) {
+        /* assuming step1_recvfrom is ordered. Or we may add a MPL_sort_int_array */
+        MPL_reverse_int_array(recexch->step1_recvfrom, recexch->step1_nrecvs);
+    }
+
+    if (recexch->in_step2 && nphases > 0) {
+        myidxes = (int *) MPL_malloc(nphases * sizeof(int), MPL_MEM_COLL);
+        MPIR_ERR_CHKANDJUMP(!myidxes, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+        for (int phase = 0; phase < nphases; phase++) {
+            int *nbrs = recexch->step2_nbrs[phase];
+            MPL_sort_int_array(nbrs, k - 1);
+
+            /* myidx is the index in the neighbors list such that
+             * all neighbors before myidx have ranks less than my rank
+             * and neighbors at and after myidx have rank greater than me.
+             * This is useful only in the non-commutative case. */
+            int myidx = 0;
+            for (int i = 0; i < k - 1; i++) {
+                if (myrank > nbrs[i]) {
+                    myidx = i + 1;
+                }
+            }
+            myidxes[phase] = myidx;
+
+            /* NOTE: since we are accumulating into recvbuf, in order to
+             * preserve operation order, we need follow the reduction sequence:
+             *     myidx-1, myidx-2, ..., 0, myidx, myidx+1, ..., k-1
+             * Rather than use spearate for-loops, rearrange the list here so
+             * a single for i=0:k-1 loop will work.
+             */
+            MPL_reverse_int_array(nbrs, myidx);
+        }
+        recexch->myidxes = myidxes;
+    }
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.h
@@ -6,15 +6,33 @@
 #ifndef IALLREDUCE_TSP_RECURSIVE_EXCHANGE_COMMON_H_INCLUDED
 #define IALLREDUCE_TSP_RECURSIVE_EXCHANGE_COMMON_H_INCLUDED
 
-int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
-                                                  void *recvbuf,
-                                                  MPI_Aint count,
-                                                  MPI_Datatype datatype,
-                                                  MPI_Op op, int is_commutative, int tag,
-                                                  int extent, int dtcopy_id, int *recv_id,
-                                                  int *reduce_id, int *vtcs, int is_inplace,
-                                                  int step1_sendto, bool in_step2, int step1_nrecvs,
-                                                  int *step1_recvfrom, int per_nbr_buffer,
-                                                  void ***step1_recvbuf_, MPIR_Comm * comm,
+int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf, void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype,
+                                                  MPI_Op op, MPIR_Comm * comm,
+                                                  int tag,
+                                                  MPI_Aint dt_size, int recvbuf_ready,
+                                                  MPII_Recexchalgo_t * recexch,
                                                   MPIR_TSP_sched_t sched);
+
+int MPIR_TSP_Iallreduce_sched_intra_recexch_step3(void *recvbuf,
+                                                  MPI_Aint count, MPI_Datatype datatype,
+                                                  MPIR_Comm * comm, int tag,
+                                                  MPII_Recexchalgo_t * recexch,
+                                                  MPIR_TSP_sched_t sched);
+
+int MPIR_TSP_Iallreduce_sched_intra_recexch_step1_zero(MPIR_Comm * comm, int tag,
+                                                       MPII_Recexchalgo_t * recexch,
+                                                       MPIR_TSP_sched_t sched);
+
+int MPIR_TSP_Iallreduce_sched_intra_recexch_step3_zero(MPIR_Comm * comm, int tag,
+                                                       MPII_Recexchalgo_t * recexch,
+                                                       MPIR_TSP_sched_t sched);
+
+int MPIR_TSP_Iallreduce_recexch_alloc_nbr_bufs(MPI_Aint dt_size,
+                                               MPII_Recexchalgo_t * recexch,
+                                               MPIR_TSP_sched_t sched);
+
+void *MPIR_TSP_Iallreduce_recexch_get_nbr_buf(MPII_Recexchalgo_t * recexch, int phase, int i);
+
+int MPIR_TSP_Iallreduce_recexch_check_commutative(MPII_Recexchalgo_t * recexch, int myrank);
 #endif /* IALLREDUCE_TSP_RECURSIVE_EXCHANGE_COMMON_H_INCLUDED */

--- a/src/mpi/coll/include/coll_types.h
+++ b/src/mpi/coll/include/coll_types.h
@@ -28,6 +28,12 @@ enum {
 
 /* enumerator for different recexch types */
 enum {
+    MPIR_IALLREDUCE_RECEXCH_TYPE_WITH_DTCOPY = 0,
+    MPIR_IALLREDUCE_RECEXCH_TYPE_WITHOUT_DTCOPY
+};
+
+/* enumerator for different recexch types */
+enum {
     MPIR_IALLGATHER_RECEXCH_TYPE_DISTANCE_DOUBLING = 0,
     MPIR_IALLGATHER_RECEXCH_TYPE_DISTANCE_HALVING
 };

--- a/src/mpi/coll/include/csel_container.h
+++ b/src/mpi/coll/include/csel_container.h
@@ -79,6 +79,8 @@ typedef enum {
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_sched_reduce_scatter_allgather,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_recexch_single_buffer,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_recexch_multiple_buffer,
+    MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_recexch_single_buffer_without_dtcopy,
+    MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_recexch_multiple_buffer_without_dtcopy,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_tree,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_ring,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_recexch_reduce_scatter_recexch_allgatherv,
@@ -225,6 +227,12 @@ typedef struct {
             struct {
                 int k;
             } intra_tsp_recexch_multiple_buffer;
+            struct {
+                int k;
+            } intra_tsp_recexch_single_buffer_without_dtcopy;
+            struct {
+                int k;
+            } intra_tsp_recexch_multiple_buffer_without_dtcopy;
             struct {
                 int tree_type;
                 int k;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
@@ -41,10 +41,10 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                                                        const MPI_Aint * recvcounts,
                                                        MPI_Aint * displs, MPI_Datatype datatype,
                                                        MPI_Op op, size_t extent, int tag,
-                                                       MPIR_Comm * comm, int k, int is_dist_halving,
-                                                       int step2_nphases, int **step2_nbrs,
+                                                       MPIR_Comm * comm, int is_dist_halving,
                                                        int rank, int nranks, int sink_id,
                                                        int is_out_vtcs, int *reduce_id_,
+                                                       MPII_Recexchalgo_t * recexch,
                                                        MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -54,19 +54,20 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
     int send_cnt, recv_cnt, send_offset, recv_offset, nvtcs, vtcs[2];
     int send_id, recv_id, reduce_id = -1;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int k = recexch->k;
 
     MPIR_FUNC_ENTER;
 
-    for (x = 0, phase = step2_nphases - 1; phase >= 0; phase--, x++) {
+    for (x = 0, phase = recexch->step2_nphases - 1; phase >= 0; phase--, x++) {
         for (i = 0; i < k - 1; i++) {
             if (is_dist_halving)
-                dst = step2_nbrs[x][i];
+                dst = recexch->step2_nbrs[x][i];
             else
-                dst = step2_nbrs[phase][i];
+                dst = recexch->step2_nbrs[phase][i];
 
             /* Both send and recv have similar dependencies */
             nvtcs = 1;
-            if (phase == step2_nphases - 1 && i == 0) {
+            if (phase == recexch->step2_nphases - 1 && i == 0) {
                 vtcs[0] = sink_id;
             } else {
                 vtcs[0] = reduce_id;
@@ -138,11 +139,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
     int is_inplace;
     size_t extent;
     MPI_Aint lb, true_extent;
-    int step1_sendto = -1, step2_nphases = 0, step1_nrecvs = 0;
-    int in_step2;
-    int *step1_recvfrom = NULL;
-    int **step2_nbrs = NULL;
-    int nranks, rank, p_of_k, T;
+    int nranks, rank;
     int total_count, i;
     int dtcopy_id = -1, recv_id = -1, reduce_id = -1, sink_id = -1;
     int nvtcs, vtcs[2];
@@ -183,17 +180,15 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         displs[i] = displs[i - 1] + recvcounts[i - 1];
     }
 
-    /* get the neighbors, the function allocates the required memory */
-    MPII_Recexchalgo_get_neighbors(rank, nranks, &k, &step1_sendto,
-                                   &step1_recvfrom, &step1_nrecvs,
-                                   &step2_nbrs, &step2_nphases, &p_of_k, &T);
-    in_step2 = (step1_sendto == -1);    /* whether this rank participates in Step 2 */
+    MPII_Recexchalgo_t recexch;
+    MPII_Recexchalgo_start(rank, nranks, k, &recexch);
+
     tmp_results = MPIR_TSP_sched_malloc(total_count * extent, sched);
     tmp_recvbuf = MPIR_TSP_sched_malloc(total_count * extent, sched);
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Beforeinitial dt copy"));
 
-    if (in_step2) {
+    if (recexch.in_step2) {
         if (!is_inplace)
             mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, total_count, datatype,
                                                  tmp_results, total_count, datatype, sched, 0,
@@ -207,7 +202,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After initial dt copy"));
 
     /* Step 1 */
-    if (!in_step2) {
+    if (!recexch.in_step2) {
         /* non-participating rank sends the data to a participating rank */
         void *buf_to_send;
         if (is_inplace)
@@ -215,18 +210,18 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         else
             buf_to_send = (void *) sendbuf;
         mpi_errno =
-            MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, step1_sendto, tag, comm, sched,
-                                 0, NULL, &vtx_id);
+            MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, recexch.step1_sendto, tag,
+                                 comm, sched, 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
     } else {    /* Step 2 participating rank */
-        for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
+        for (i = 0; i < recexch.step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
             /* recv dependencies */
             nvtcs = 1;
             vtcs[0] = (i == 0) ? dtcopy_id : reduce_id;
             mpi_errno = MPIR_TSP_sched_irecv(tmp_recvbuf, total_count, datatype,
-                                             step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
-                                             &recv_id);
+                                             recexch.step1_recvfrom[i], tag, comm, sched, nvtcs,
+                                             vtcs, &recv_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             nvtcs++;
             vtcs[1] = recv_id;
@@ -242,12 +237,12 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
 
     /* Step 2 */
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Start Step2"));
-    if (in_step2) {
+    if (recexch.in_step2) {
         MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(tmp_results, tmp_recvbuf,
                                                            recvcounts, displs, datatype, op, extent,
-                                                           tag, comm, k, is_dist_halving,
-                                                           step2_nphases, step2_nbrs, rank, nranks,
-                                                           sink_id, 1, &reduce_id, sched);
+                                                           tag, comm, is_dist_halving,
+                                                           rank, nranks,
+                                                           sink_id, 1, &reduce_id, &recexch, sched);
         /* copy data from tmp_results buffer correct position into recvbuf for all participating ranks */
         nvtcs = 1;
         vtcs[0] = reduce_id;    /* This assignment will also be used in step3 sends */
@@ -261,28 +256,26 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
 
     /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
      * send the data to non-partcipating ranks */
-    if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
+    if (recexch.step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno =
-            MPIR_TSP_sched_irecv(recvbuf, recvcounts[rank], datatype, step1_sendto, tag, comm,
-                                 sched, 1, &sink_id, &vtx_id);
+            MPIR_TSP_sched_irecv(recvbuf, recvcounts[rank], datatype, recexch.step1_sendto, tag,
+                                 comm, sched, 1, &sink_id, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
-    for (i = 0; i < step1_nrecvs; i++) {
+    for (i = 0; i < recexch.step1_nrecvs; i++) {
         nvtcs = 1;
         /* vtcs will be assigned to last reduce_id in step2 function */
-        mpi_errno = MPIR_TSP_sched_isend((char *) tmp_results + displs[step1_recvfrom[i]] * extent,
-                                         recvcounts[step1_recvfrom[i]], datatype, step1_recvfrom[i],
-                                         tag, comm, sched, nvtcs, vtcs, &vtx_id);
+        mpi_errno =
+            MPIR_TSP_sched_isend((char *) tmp_results + displs[recexch.step1_recvfrom[i]] * extent,
+                                 recvcounts[recexch.step1_recvfrom[i]], datatype,
+                                 recexch.step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Done Step 3"));
 
   fn_exit:
-    for (i = 0; i < step2_nphases; i++)
-        MPL_free(step2_nbrs[i]);
-    MPL_free(step2_nbrs);
-    MPL_free(step1_recvfrom);
+    MPII_Recexchalgo_finish(&recexch);
     MPIR_CHKLMEM_FREEALL();
 
     MPIR_FUNC_EXIT;

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
@@ -18,11 +18,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
     int is_inplace;
     size_t extent;
     MPI_Aint lb, true_extent;
-    int step1_sendto = -1, step2_nphases = 0, step1_nrecvs = 0;
-    int in_step2;
-    int *step1_recvfrom = NULL;
-    int **step2_nbrs = NULL;
-    int nranks, rank, p_of_k, T, dst;
+    int nranks, rank, dst;
     int total_count, send_cnt, recv_cnt;
     int i, phase, offset, send_offset, recv_offset;
     int dtcopy_id = -1, send_id = -1, recv_id = -1, reduce_id = -1, step1_id = -1;
@@ -48,15 +44,13 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
 
     total_count = nranks * recvcount;
 
-    /* get the neighbors, the function allocates the required memory */
-    MPII_Recexchalgo_get_neighbors(rank, nranks, &k, &step1_sendto,
-                                   &step1_recvfrom, &step1_nrecvs,
-                                   &step2_nbrs, &step2_nphases, &p_of_k, &T);
-    in_step2 = (step1_sendto == -1);    /* whether this rank participates in Step 2 */
+    MPII_Recexchalgo_t recexch;
+    MPII_Recexchalgo_start(rank, nranks, k, &recexch);
+
     tmp_results = MPIR_TSP_sched_malloc(total_count * extent, sched);
     tmp_recvbuf = MPIR_TSP_sched_malloc(total_count * extent, sched);
 
-    if (in_step2) {
+    if (recexch.in_step2) {
         if (!is_inplace)
             mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, total_count, datatype,
                                                  tmp_results, total_count, datatype, sched, 0,
@@ -69,7 +63,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
     }
 
     /* Step 1 */
-    if (!in_step2) {
+    if (!recexch.in_step2) {
         /* non-participating rank sends the data to a participating rank */
         void *buf_to_send;
         if (is_inplace)
@@ -77,17 +71,17 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
         else
             buf_to_send = (void *) sendbuf;
         mpi_errno =
-            MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, step1_sendto, tag, comm, sched,
-                                 0, NULL, &vtx_id);
+            MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, recexch.step1_sendto, tag,
+                                 comm, sched, 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     } else {    /* Step 2 participating rank */
-        for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
+        for (i = 0; i < recexch.step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
             /* recv dependencies */
             nvtcs = 1;
             vtcs[0] = (i == 0) ? dtcopy_id : reduce_id;
             mpi_errno = MPIR_TSP_sched_irecv(tmp_recvbuf, total_count, datatype,
-                                             step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
-                                             &recv_id);
+                                             recexch.step1_recvfrom[i], tag, comm, sched, nvtcs,
+                                             vtcs, &recv_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
             nvtcs++;
             vtcs[1] = recv_id;
@@ -102,14 +96,14 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
         MPIR_ERR_POP(mpi_errno);
 
     /* Step 2 */
-    for (phase = step2_nphases - 1; phase >= 0 && step1_sendto == -1; phase--) {
+    for (phase = recexch.step2_nphases - 1; phase >= 0 && recexch.step1_sendto == -1; phase--) {
         for (i = 0; i < k - 1; i++) {
-            dst = step2_nbrs[phase][i];
+            dst = recexch.step2_nbrs[phase][i];
             send_cnt = recv_cnt = 0;
 
             /* Both send and recv have similar dependencies */
             nvtcs = 1;
-            if (phase == step2_nphases - 1 && i == 0) {
+            if (phase == recexch.step2_nphases - 1 && i == 0) {
                 vtcs[0] = step1_id;
             } else {
                 vtcs[0] = reduce_id;
@@ -142,7 +136,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         }
     }
-    if (in_step2) {
+    if (recexch.in_step2) {
         nvtcs = 1;
         vtcs[0] = reduce_id;
         /* copy data from tmp_results buffer correct position into recvbuf for all participating ranks */
@@ -155,28 +149,25 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
 
     /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
      * send the data to non-partcipating ranks */
-    if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
+    if (recexch.step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno =
-            MPIR_TSP_sched_irecv(recvbuf, recvcount, datatype, step1_sendto, tag, comm, sched, 1,
-                                 &step1_id, &vtx_id);
+            MPIR_TSP_sched_irecv(recvbuf, recvcount, datatype, recexch.step1_sendto, tag, comm,
+                                 sched, 1, &step1_id, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
-    for (i = 0; i < step1_nrecvs; i++) {
+    for (i = 0; i < recexch.step1_nrecvs; i++) {
         nvtcs = 1;
         vtcs[0] = reduce_id;
         mpi_errno =
-            MPIR_TSP_sched_isend((char *) tmp_results + recvcount * step1_recvfrom[i] * extent,
-                                 recvcount, datatype, step1_recvfrom[i], tag, comm, sched, nvtcs,
-                                 vtcs, &vtx_id);
+            MPIR_TSP_sched_isend((char *) tmp_results +
+                                 recvcount * recexch.step1_recvfrom[i] * extent, recvcount,
+                                 datatype, recexch.step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
+                                 &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
   fn_exit:
-    /* free all allocated memory for storing nbrs */
-    for (i = 0; i < step2_nphases; i++)
-        MPL_free(step2_nbrs[i]);
-    MPL_free(step2_nbrs);
-    MPL_free(step1_recvfrom);
+    MPII_Recexchalgo_finish(&recexch);
 
     MPIR_FUNC_EXIT;
 

--- a/src/mpi/coll/src/csel_container.c
+++ b/src/mpi/coll/src/csel_container.c
@@ -135,6 +135,30 @@ static void parse_container_params(struct json_object *obj, MPII_Csel_container_
             }
             break;
 
+        case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_recexch_single_buffer_without_dtcopy:
+            {
+                json_object_object_foreach(obj, key, val) {
+                    ckey = MPL_strdup_no_spaces(key);
+                    if (!strncmp(ckey, "k=", strlen("k=")))
+                        cnt->u.iallreduce.intra_tsp_recexch_single_buffer_without_dtcopy.k =
+                            atoi(ckey + strlen("k="));
+                    MPL_free(ckey);
+                }
+            }
+            break;
+
+        case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_recexch_multiple_buffer_without_dtcopy:
+            {
+                json_object_object_foreach(obj, key, val) {
+                    ckey = MPL_strdup_no_spaces(key);
+                    if (!strncmp(ckey, "k=", strlen("k=")))
+                        cnt->u.iallreduce.intra_tsp_recexch_multiple_buffer_without_dtcopy.k =
+                            atoi(ckey + strlen("k="));
+                    MPL_free(ckey);
+                }
+            }
+            break;
+
         case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_recexch_reduce_scatter_recexch_allgatherv:
             {
                 json_object_object_foreach(obj, key, val) {

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -447,7 +447,7 @@ void MPII_Genutil_vtx_add_dependencies(MPII_Genutil_sched_t * sched, int vtx_id,
     /* check if there was any fence operation and add appropriate dependencies.
      * The application will never explicitly specify a dependency on it,
      * the transport has to make sure that the dependency on the fence operation is met */
-    if (sched->last_fence != -1 && sched->last_fence != vtx_id && n_in_vtcs == 0) {
+    if (sched->last_fence != -1 && sched->last_fence != vtx_id) {
         /* add vtx as outgoing vtx of last_fence */
         vtx_t *sched_fence = (vtx_t *) utarray_eltptr(&sched->vtcs, sched->last_fence);
         MPIR_Assert(sched_fence != NULL);

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -427,6 +427,9 @@ void MPII_Genutil_vtx_add_dependencies(MPII_Genutil_sched_t * sched, int vtx_id,
     /* update the list of outgoing vertices of the incoming
      * vertices */
     for (i = 0; i < n_in_vtcs; i++) {
+        if (in_vtcs[i] == -1) {
+            continue;
+        }
         vtx_t *in_vtx = (vtx_t *) utarray_eltptr(&sched->vtcs, in_vtcs[i]);
         MPIR_Assert(in_vtx != NULL);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "invtx: %d", in_vtcs[i]));

--- a/src/mpl/include/mpl.h
+++ b/src/mpl/include/mpl.h
@@ -32,5 +32,6 @@
 #include "mpl_gavl.h"
 #include "mpl_initlock.h"
 #include "mpl_misc.h"
+#include "mpl_sort.h"
 
 #endif /* MPL_H_INCLUDED */

--- a/src/mpl/include/mpl_sort.h
+++ b/src/mpl/include/mpl_sort.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPL_SORT_H_INCLUDED
+#define MPL_SORT_H_INCLUDED
+
+#include "mplconfig.h"
+
+/* *INDENT-ON* */
+#if defined(__cplusplus)
+extern "C" {
+#endif
+/* *INDENT-OFF* */
+
+/* Define routines for integer sort */
+void MPL_sort_int_array(int *arr, int n);
+
+/* *INDENT-ON* */
+#if defined(__cplusplus)
+}
+#endif
+/* *INDENT-OFF* */
+
+#endif /* MPL_SORT_H_INCLUDED */

--- a/src/mpl/include/mpl_sort.h
+++ b/src/mpl/include/mpl_sort.h
@@ -16,6 +16,7 @@ extern "C" {
 
 /* Define routines for integer sort */
 void MPL_sort_int_array(int *arr, int n);
+void MPL_reverse_int_array(int *arr, int n);
 
 /* *INDENT-ON* */
 #if defined(__cplusplus)

--- a/src/mpl/src/misc/Makefile.mk
+++ b/src/mpl/src/misc/Makefile.mk
@@ -4,4 +4,5 @@
 #     See COPYRIGHT in top-level directory.
 #
 
-lib@MPLLIBNAME@_la_SOURCES += src/misc/mpl_misc.c
+lib@MPLLIBNAME@_la_SOURCES += src/misc/mpl_misc.c    \
+                              src/misc/mpl_sort.c

--- a/src/mpl/src/misc/mpl_sort.c
+++ b/src/mpl/src/misc/mpl_sort.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpl.h"
+
+/* This is a simple function to compare two integers. */
+#if defined(HAVE_QSORT)
+static int compare_int(const void *a, const void *b)
+{
+    return (*(int *) a - *(int *) b);
+}
+#endif
+
+void MPL_sort_int_array(int *arr, int n)
+{
+#if defined(HAVE_QSORT)
+    qsort(arr, n, sizeof(int), compare_int);
+#else
+    int i, j, value;
+    for (i = 0; i < n; i++) {
+        value = arr[i];
+        j = i;
+        while (j > 0 && arr[j - 1] > value) {
+            arr[j] = arr[j - 1];
+            j = j - 1;
+        }
+        arr[j] = value;
+    }
+#endif
+}

--- a/src/mpl/src/misc/mpl_sort.c
+++ b/src/mpl/src/misc/mpl_sort.c
@@ -30,3 +30,13 @@ void MPL_sort_int_array(int *arr, int n)
     }
 #endif
 }
+
+void MPL_reverse_int_array(int *arr, int n)
+{
+    for (int i = 0; i < n / 2; i++) {
+        int j = n - 1 - i;
+        int tmp = arr[i];
+        arr[i] = arr[j];
+        arr[j] = tmp;
+    }
+}

--- a/test/mpi/maint/coll_cvars.txt
+++ b/test/mpi/maint/coll_cvars.txt
@@ -233,6 +233,8 @@ algorithms:
             sched_reduce_scatter_allgather
             tsp_recexch_single_buffer
             tsp_recexch_multiple_buffer
+            tsp_recexch_single_buffer_without_dtcopy
+            tsp_recexch_multiple_buffer_without_dtcopy
             tsp_tree
                 .MPIR_CVAR_IALLREDUCE_TREE_TYPE=kary,knomial_1,knomial_2
                 .MPIR_CVAR_IALLREDUCE_TREE_KVAL=2,3,4


### PR DESCRIPTION
## Pull Request Description
This is a revamp based on #5457. It refactors the existing algorithms and merges related iallreduce algorithms into a single algorithm with options.

## Notes
The most complex part of these TSP algorithms is figuring out the exact dependency of each operation. The current code assigns each operation with a vertex id variable, and each operation needs to populate a dependency list referring to the previous operations vertexes. The is **very hard**, since each operation references other parts. It is extremely complex if there are option branches and loop dependencies.

However, it is easy to figure each operation on **why** it has some dependency. For example, an `irecv` will need to wait for the `recvbuf` ready and it is also easy to see that any later operations that use `recvbuf` will depend on this `irecv` operation. Thus, instead of tracking operation vertexes, we should have a variable refer to e.g. buffer readiness. For example, if we have a `recvbuf_ready` variable, an `irecv` will depend on this variable and right after its schedule, it should set its own vertex to `irecv_ready`.

This way, all the logic is contained by the logic of the individual operation only, thus greatly simplifying the complexity.

In addition, TSP utilities should allow "NULL dependency" (using `-1`) and also a universal `fence`. The former simplifies option branches. The latter ensures component orthogonality.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
