### PR TITLE
topo: fix copying dist_graph when it is unweighted

### DIFF
--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -165,10 +165,16 @@ static int MPIR_Topology_copy_fn(MPI_Comm comm ATTRIBUTE((unused)),
     } else if (old_topology->kind == MPI_DIST_GRAPH) {
         copy_topology->topo.dist_graph.indegree = old_topology->topo.dist_graph.indegree;
         copy_topology->topo.dist_graph.outdegree = old_topology->topo.dist_graph.outdegree;
+        copy_topology->topo.dist_graph.is_weighted = old_topology->topo.dist_graph.is_weighted;
         MPIR_ARRAY_COPY_HELPER(dist_graph, in, indegree);
-        MPIR_ARRAY_COPY_HELPER(dist_graph, in_weights, indegree);
         MPIR_ARRAY_COPY_HELPER(dist_graph, out, outdegree);
-        MPIR_ARRAY_COPY_HELPER(dist_graph, out_weights, outdegree);
+        if (old_topology->topo.dist_graph.is_weighted) {
+            MPIR_ARRAY_COPY_HELPER(dist_graph, in_weights, indegree);
+            MPIR_ARRAY_COPY_HELPER(dist_graph, out_weights, outdegree);
+        } else {
+            copy_topology->topo.dist_graph.in_weights = NULL;
+            copy_topology->topo.dist_graph.out_weights = NULL;
+        }
     }
     /* --BEGIN ERROR HANDLING-- */
     else {


### PR DESCRIPTION
## Pull Request Description

When it is unweighted, the weights pointer is NULL.


Fixes #5628

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
