### PR TITLE
spawn: set socket to nonblocking use fcntl

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -39,6 +39,8 @@ cvars:
 #include "posix_csel_container.h"
 #include "mpidu_genq.h"
 
+#include <strings.h>    /* for strncasecmp */
+
 extern MPL_atomic_uint64_t *MPIDI_POSIX_shm_limit_counter;
 
 static int choose_posix_eager(void);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -664,9 +664,12 @@ void *MPID_Alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
              * process is bound to the corresponding device; allocate
              * memory and bind it to device. */
             assert(mem_gid != MPIR_HWTOPO_GID_ROOT);
-            real_buf =
-                MPL_mmap(NULL, size + alignment, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1,
-                         0, MPL_MEM_USER);
+#ifdef MAP_ANON
+            real_buf = MPL_mmap(NULL, size + alignment, PROT_READ | PROT_WRITE,
+                                MAP_ANON | MAP_PRIVATE, -1, 0, MPL_MEM_USER);
+#else
+            real_buf = MPL_malloc(size + alignment, MPL_MEM_USER);
+#endif
             MPIR_hwtopo_mem_bind(real_buf, size + alignment, mem_gid);
             break;
 

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -8,6 +8,7 @@
 #include "datatype.h"
 #include "mpidu_init_shm.h"
 
+#include <strings.h>    /* for strncasecmp */
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif


### PR DESCRIPTION
## Pull Request Description
The previous commit (PR #5586) uses per-call flag MSG_DONTWAIT to set
nonblocking recv. On FreeBSD under _POSIX_SOURCE, defined with
--enable-strict, MSG_DONTWAIT is hidden. To work around, use fnctl
instead.

Because `fnctl` affects the socket globally, we apply it to the send
call and handle the EAGAIN error as well to make the code more
symmetric.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
