### PR TITLE
ch4/ofi: move am inflight trackers into per_vni

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.c
@@ -19,12 +19,13 @@ int MPIDI_OFI_am_rdma_read_ack_handler(void *am_hdr, void *data,
     ack_msg = (MPIDI_OFI_am_rdma_read_ack_msg_t *) am_hdr;
     sreq = ack_msg->sreq_ptr;
 
+    int vni_local = MPIDIG_AM_ATTR_DST_VCI(attr);
     if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
         uint64_t mr_key = fi_mr_key(MPIDI_OFI_AM_SREQ_HDR(sreq, lmt_mr));
         MPIDI_OFI_mr_key_free(MPIDI_OFI_LOCAL_MR_KEY, mr_key);
     }
     MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_AM_SREQ_HDR(sreq, lmt_mr)->fid), mr_unreg);
-    MPL_atomic_fetch_sub_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs, 1);
+    MPIDI_OFI_global.per_vni[vni_local].am_inflight_rma_send_mrs -= 1;
 
     MPIR_gpu_free_host(MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer));
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -203,7 +203,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_rdma_read(MPIDI_OFI_am_header_t * 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_rdma_read_ack(int rank, MPIR_Comm * comm,
-                                                           MPIR_Request * sreq_ptr)
+                                                           MPIR_Request * sreq_ptr,
+                                                           int local_vci, int remote_vci)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_rdma_read_ack_msg_t ack_msg;
@@ -212,7 +213,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_rdma_read_ack(int rank, MPIR_Comm *
 
     ack_msg.sreq_ptr = sreq_ptr;
     mpi_errno = MPIDI_NM_am_send_hdr_reply(comm, rank, MPIDI_OFI_AM_RDMA_READ_ACK,
-                                           &ack_msg, (MPI_Aint) sizeof(ack_msg), 0, 0);
+                                           &ack_msg, (MPI_Aint) sizeof(ack_msg),
+                                           local_vci, remote_vci);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -281,7 +281,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
                              0ULL,
                              lmt_info->rma_key,
                              0ULL, &MPIDI_OFI_AM_SREQ_HDR(sreq, lmt_mr), NULL), mr_reg);
-    MPL_atomic_fetch_add_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs, 1);
+    MPIDI_OFI_global.per_vni[vni_src].am_inflight_rma_send_mrs += 1;
 
     if (MPIDI_OFI_ENABLE_MR_PROV_KEY) {
         /* MR_BASIC */
@@ -546,7 +546,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(MPIR_Comm * comm, fi_a
 
     MPIDI_OFI_REQUEST(sreq, event_id) = MPIDI_OFI_EVENT_INJECT_EMU;
     MPIDI_OFI_REQUEST(sreq, util.inject_buf) = ibuf;
-    MPL_atomic_fetch_add_int(&MPIDI_OFI_global.am_inflight_inject_emus, 1);
+    MPIDI_OFI_global.per_vni[vni_src].am_inflight_inject_emus += 1;
 
     MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[ctx_idx].tx, ibuf, len,
                                     NULL /* desc */ , addr, &(MPIDI_OFI_REQUEST(sreq, context))),

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -421,7 +421,10 @@ static int am_read_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * 
         comm = rreq->comm;
     }
     MPIDI_OFI_lmt_msg_payload_t *lmt_info = (void *) MPIDI_OFI_AM_RREQ_HDR(rreq, am_hdr_buf);
-    mpi_errno = MPIDI_OFI_do_am_rdma_read_ack(lmt_info->src_rank, comm, lmt_info->sreq_ptr);
+    int local_vci = MPIDIG_REQUEST(rreq, req->local_vci);
+    int remote_vci = MPIDIG_REQUEST(rreq, req->remote_vci);
+    mpi_errno = MPIDI_OFI_do_am_rdma_read_ack(lmt_info->src_rank, comm, lmt_info->sreq_ptr,
+                                              local_vci, remote_vci);
 
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -164,7 +164,7 @@ static int inject_emu_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request
     if (!incomplete) {
         MPL_free(MPIDI_OFI_REQUEST(req, util.inject_buf));
         MPIDI_CH4_REQUEST_FREE(req);
-        MPL_atomic_fetch_sub_int(&MPIDI_OFI_global.am_inflight_inject_emus, 1);
+        MPIDI_OFI_global.per_vni[vni].am_inflight_inject_emus -= 1;
     }
 
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -856,8 +856,11 @@ int MPIDI_OFI_mpi_finalize_hook(void)
 
     /* Progress until we drain all inflight RMA send long buffers */
     /* NOTE: am currently only use vni 0. Need update once that changes */
-    while (MPL_atomic_load_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs) > 0)
-        MPIDI_OFI_PROGRESS(0);
+    for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
+        while (MPIDI_OFI_global.per_vni[vni].am_inflight_rma_send_mrs > 0) {
+            MPIDI_OFI_PROGRESS(vni);
+        }
+    }
 
     /* Destroy RMA key allocator */
     MPIDI_OFI_mr_key_allocator_destroy();
@@ -877,9 +880,12 @@ int MPIDI_OFI_mpi_finalize_hook(void)
 
     /* Progress until we drain all inflight injection emulation requests */
     /* NOTE: am currently only use vni 0. Need update once that changes */
-    while (MPL_atomic_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) > 0)
-        MPIDI_OFI_PROGRESS(0);
-    MPIR_Assert(MPL_atomic_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) == 0);
+    for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
+        while (MPIDI_OFI_global.per_vni[vni].am_inflight_inject_emus > 0) {
+            MPIDI_OFI_PROGRESS(vni);
+        }
+        MPIR_Assert(MPIDI_OFI_global.per_vni[vni].am_inflight_inject_emus == 0);
+    }
 
     /* Tearing down endpoints in reverse order they were created */
     for (int nic = MPIDI_OFI_global.num_nics - 1; nic >= 0; nic--) {
@@ -1520,12 +1526,13 @@ int ofi_am_init(void)
             MPIDI_OFI_global.per_vni[vni].am_unordered_msgs = NULL;
 
             MPIDI_OFI_global.per_vni[vni].deferred_am_isend_q = NULL;
+
+            MPIDI_OFI_global.per_vni[vni].am_inflight_inject_emus = 0;
+            MPIDI_OFI_global.per_vni[vni].am_inflight_rma_send_mrs = 0;
         }
         MPIDIG_am_reg_cb(MPIDI_OFI_INTERNAL_HANDLER_CONTROL, NULL, &MPIDI_OFI_control_handler);
         MPIDIG_am_reg_cb(MPIDI_OFI_AM_RDMA_READ_ACK, NULL, &MPIDI_OFI_am_rdma_read_ack_handler);
     }
-    MPL_atomic_store_int(&MPIDI_OFI_global.am_inflight_inject_emus, 0);
-    MPL_atomic_store_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs, 0);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -235,6 +235,10 @@ typedef struct {
     void *am_send_seq_tracker;
     void *am_recv_seq_tracker;
 
+    /* active message trackers */
+    int am_inflight_inject_emus;
+    int am_inflight_rma_send_mrs;
+
     /* Queue (utlist) to store early-arrival active messages */
     MPIDI_OFI_am_unordered_msg_t *am_unordered_msgs;
 
@@ -365,10 +369,6 @@ typedef struct {
     /* OFI atomics limitation of each pair of <dtype, op> returned by the
      * OFI provider at MPI initialization.*/
     MPIDI_OFI_atomic_valid_t win_op_table[MPIR_DATATYPE_N_PREDEFINED][MPIDIG_ACCU_NUM_OP];
-
-    /* Active Message Globals */
-    MPL_atomic_int_t am_inflight_inject_emus;
-    MPL_atomic_int_t am_inflight_rma_send_mrs;
 
     /* Process management and PMI globals */
     int pname_set;


### PR DESCRIPTION
## Pull Request Description
We need track and progress individual vni's am inflight trackers,
especially during finalize.

Fixes pmodels/mpich#5627


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
