### PR TITLE
ch4/am: Extended request structure cleanup

### DIFF
--- a/src/mpi/debugger/dbgstub.c
+++ b/src/mpi/debugger/dbgstub.c
@@ -199,11 +199,11 @@ int dbgrI_field_offset(mqs_type * type, char *name)
                 } else if (strcmp(name, "count") == 0) {
                     off = ((char *) &c.count - (char *) &c);
                 } else if (strcmp(name, "rank") == 0) {
-                    off = ((char *) &c.rank - (char *) &c);
+                    off = ((char *) &c.u.recv.source - (char *) &c);
                 } else if (strcmp(name, "tag") == 0) {
-                    off = ((char *) &c.tag - (char *) &c);
+                    off = ((char *) &c.u.recv.tag - (char *) &c);
                 } else if (strcmp(name, "context_id") == 0) {
-                    off = ((char *) &c.context_id - (char *) &c);
+                    off = ((char *) &c.u.recv.context_id - (char *) &c);
                 } else if (strcmp(name, "datatype") == 0) {
                     off = ((char *) &c.datatype - (char *) &c);
                 } else {

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -90,7 +90,6 @@ typedef struct MPIDIG_part_am_req_t {
 typedef struct MPIDIG_put_req_t {
     MPIR_Request *preq_ptr;
     void *flattened_dt;
-    MPIR_Datatype *dt;
     MPI_Datatype target_datatype;
     MPI_Aint origin_data_sz;
 } MPIDIG_put_req_t;
@@ -98,7 +97,6 @@ typedef struct MPIDIG_put_req_t {
 typedef struct MPIDIG_get_req_t {
     MPIR_Request *greq_ptr;
     void *flattened_dt;
-    MPIR_Datatype *dt;
     MPI_Datatype target_datatype;
 } MPIDIG_get_req_t;
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -102,10 +102,7 @@ typedef struct MPIDIG_get_req_t {
 
 typedef struct MPIDIG_cswap_req_t {
     MPIR_Request *creq_ptr;
-    void *addr;
-    MPI_Datatype datatype;
     void *data;
-    void *result_addr;
 } MPIDIG_cswap_req_t;
 
 typedef struct MPIDIG_acc_req_t {

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -200,6 +200,12 @@ typedef struct MPIDIG_req_t {
             MPIR_Context_id_t context_id;
             int tag;
         } recv;
+        struct {
+            int target_rank;
+        } origin;
+        struct {
+            int origin_rank;
+        } target;
     } u;
 } MPIDIG_req_t;
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -91,10 +91,6 @@ typedef struct MPIDIG_put_req_t {
     MPIR_Request *preq_ptr;
     void *flattened_dt;
     MPIR_Datatype *dt;
-    void *origin_addr;
-    int origin_count;
-    MPI_Datatype origin_datatype;
-    void *target_addr;
     MPI_Datatype target_datatype;
     MPI_Aint origin_data_sz;
 } MPIDIG_put_req_t;

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -90,14 +90,12 @@ typedef struct MPIDIG_part_am_req_t {
 typedef struct MPIDIG_put_req_t {
     MPIR_Request *preq_ptr;
     void *flattened_dt;
-    MPI_Datatype target_datatype;
     MPI_Aint origin_data_sz;
 } MPIDIG_put_req_t;
 
 typedef struct MPIDIG_get_req_t {
     MPIR_Request *greq_ptr;
     void *flattened_dt;
-    MPI_Datatype target_datatype;
 } MPIDIG_get_req_t;
 
 typedef struct MPIDIG_cswap_req_t {
@@ -202,6 +200,7 @@ typedef struct MPIDIG_req_t {
         } recv;
         struct {
             int target_rank;
+            MPI_Datatype target_datatype;
         } origin;
         struct {
             int origin_rank;

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -209,13 +209,20 @@ typedef struct MPIDIG_req_t {
     MPIDI_SHM_REQUEST_AM_DECL} shm_am;
 #endif
     MPIDIG_req_ext_t *req;
-    void *buffer;
     void *rndv_hdr;
+    void *buffer;
     MPI_Aint count;
-    int rank;
-    int tag;
-    MPIR_Context_id_t context_id;
     MPI_Datatype datatype;
+    union {
+        struct {
+            int dest;
+        } send;
+        struct {
+            int source;
+            MPIR_Context_id_t context_id;
+            int tag;
+        } recv;
+    } u;
 } MPIDIG_req_t;
 
 /* Structure to capture arguments for pt2pt persistent communications */
@@ -251,13 +258,18 @@ typedef struct MPIDI_part_request {
 
     /* partitioned attributes */
     void *buffer;
-    MPI_Aint count;             /* count per partition */
-    int rank;
-    int tag;
-    MPIR_Context_id_t context_id;       /* temporarily store send context_id in unexp_rreq.
-                                         * Valid also in posted_rreq so that single dequeue
-                                         * routine can be used. */
+    MPI_Aint count;
     MPI_Datatype datatype;
+    union {
+        struct {
+            int dest;
+        } send;
+        struct {
+            int source;
+            MPIR_Context_id_t context_id;
+            int tag;
+        } recv;
+    } u;
     union {
     MPIDI_NM_PART_DECL} netmod;
 } MPIDI_part_request_t;

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -73,15 +73,6 @@ typedef enum {
 #define MPIDI_PARENT_PORT_KVSKEY "PARENT_ROOT_PORT_NAME"
 #define MPIDI_MAX_KVS_VALUE_LEN  4096
 
-typedef struct MPIDIG_sreq_t {
-    /* persistent send fields */
-    const void *src_buf;
-    MPI_Aint count;
-    MPI_Datatype datatype;
-    int rank;
-    MPIR_Context_id_t context_id;
-} MPIDIG_sreq_t;
-
 typedef struct MPIDIG_rreq_t {
     /* mrecv fields */
     void *mrcv_buffer;
@@ -179,7 +170,6 @@ typedef struct MPIDIG_sreq_async {
 
 typedef struct MPIDIG_req_ext_t {
     union {
-        MPIDIG_sreq_t sreq;
         MPIDIG_rreq_t rreq;
         MPIDIG_put_req_t preq;
         MPIDIG_get_req_t greq;

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -97,9 +97,6 @@ typedef struct MPIDIG_put_req_t {
 
 typedef struct MPIDIG_get_req_t {
     MPIR_Request *greq_ptr;
-    void *addr;
-    MPI_Datatype datatype;
-    int count;
     void *flattened_dt;
     MPIR_Datatype *dt;
     MPI_Datatype target_datatype;

--- a/src/mpid/ch4/src/mpidig_part.c
+++ b/src/mpid/ch4/src/mpidig_part.c
@@ -24,13 +24,17 @@ static int part_req_create(void *buf, int partitions, MPI_Aint count,
     req->comm = comm;
 
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDI_PART_REQUEST(req, datatype) = datatype;
 
-    MPIDI_PART_REQUEST(req, rank) = rank;
-    MPIDI_PART_REQUEST(req, tag) = tag;
     MPIDI_PART_REQUEST(req, buffer) = buf;
     MPIDI_PART_REQUEST(req, count) = count;
-    MPIDI_PART_REQUEST(req, context_id) = comm->context_id;
+    MPIDI_PART_REQUEST(req, datatype) = datatype;
+    if (kind == MPIR_REQUEST_KIND__PART_SEND) {
+        MPIDI_PART_REQUEST(req, u.send.dest) = rank;
+    } else {
+        MPIDI_PART_REQUEST(req, u.recv.source) = rank;
+        MPIDI_PART_REQUEST(req, u.recv.tag) = tag;
+        MPIDI_PART_REQUEST(req, u.recv.context_id) = comm->context_id;
+    }
 
     req->u.part.partitions = partitions;
     MPIR_Part_request_inactivate(req);
@@ -69,8 +73,8 @@ void MPIDIG_precv_matched(MPIR_Request * part_req)
 
     /* Set status for partitioned req */
     MPIR_STATUS_SET_COUNT(part_req->status, sdata_size);
-    part_req->status.MPI_SOURCE = MPIDI_PART_REQUEST(part_req, rank);
-    part_req->status.MPI_TAG = MPIDI_PART_REQUEST(part_req, tag);
+    part_req->status.MPI_SOURCE = MPIDI_PART_REQUEST(part_req, u.recv.source);
+    part_req->status.MPI_TAG = MPIDI_PART_REQUEST(part_req, u.recv.tag);
     part_req->status.MPI_ERROR = MPI_SUCCESS;
 
     /* Additional check for partitioned pt2pt: require identical buffer size */

--- a/src/mpid/ch4/src/mpidig_part_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_part_callbacks.c
@@ -76,9 +76,9 @@ int MPIDIG_part_send_init_target_msg_cb(void *am_hdr, void *data,
         MPIR_ERR_CHKANDSTMT(unexp_req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
                             "**nomemreq");
 
-        MPIDI_PART_REQUEST(unexp_req, rank) = msg_hdr->src_rank;
-        MPIDI_PART_REQUEST(unexp_req, tag) = msg_hdr->tag;
-        MPIDI_PART_REQUEST(unexp_req, context_id) = msg_hdr->context_id;
+        MPIDI_PART_REQUEST(unexp_req, u.recv.source) = msg_hdr->src_rank;
+        MPIDI_PART_REQUEST(unexp_req, u.recv.tag) = msg_hdr->tag;
+        MPIDI_PART_REQUEST(unexp_req, u.recv.context_id) = msg_hdr->context_id;
         part_rreq_update_sinfo(unexp_req, msg_hdr);
 
         MPIDIG_enqueue_request(unexp_req, &MPIDI_global.part_unexp_list, MPIDIG_PART);

--- a/src/mpid/ch4/src/mpidig_part_utils.h
+++ b/src/mpid/ch4/src/mpidig_part_utils.h
@@ -18,7 +18,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_issue_cts(MPIR_Request * rreq_ptr)
     am_hdr.sreq_ptr = MPIDIG_PART_REQUEST(rreq_ptr, peer_req_ptr);
     am_hdr.rreq_ptr = rreq_ptr;
 
-    int source = MPIDI_PART_REQUEST(rreq_ptr, rank);
+    int source = MPIDI_PART_REQUEST(rreq_ptr, u.recv.source);
     CH4_CALL(am_send_hdr_reply(rreq_ptr->comm, source, MPIDIG_PART_CTS, &am_hdr, sizeof(am_hdr),
                                0, 0), MPIDI_REQUEST(rreq_ptr, is_local), mpi_errno);
 
@@ -60,13 +60,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_issue_data(MPIR_Request * part_sreq,
                 MPIR_AINT_MAX);
 
     if (mode == MPIDIG_PART_REGULAR) {
-        CH4_CALL(am_isend(MPIDI_PART_REQUEST(part_sreq, rank), part_sreq->comm,
+        CH4_CALL(am_isend(MPIDI_PART_REQUEST(part_sreq, u.send.dest), part_sreq->comm,
                           MPIDIG_PART_SEND_DATA,
-                          &am_hdr, sizeof(am_hdr), MPIDI_PART_REQUEST(part_sreq, buffer), count,
-                          MPIDI_PART_REQUEST(part_sreq, datatype), 0, 0, sreq),
+                          &am_hdr, sizeof(am_hdr), MPIDI_PART_REQUEST(part_sreq, buffer),
+                          count, MPIDI_PART_REQUEST(part_sreq, datatype), 0, 0, sreq),
                  MPIDI_REQUEST(part_sreq, is_local), mpi_errno);
     } else {    /* MPIDIG_PART_REPLY */
-        CH4_CALL(am_isend_reply(part_sreq->comm, MPIDI_PART_REQUEST(part_sreq, rank),
+        CH4_CALL(am_isend_reply(part_sreq->comm, MPIDI_PART_REQUEST(part_sreq, u.send.dest),
                                 MPIDIG_PART_SEND_DATA,
                                 &am_hdr, sizeof(am_hdr),
                                 MPIDI_PART_REQUEST(part_sreq, buffer), count,

--- a/src/mpid/ch4/src/mpidig_probe.h
+++ b/src/mpid/ch4/src/mpidig_probe.h
@@ -26,8 +26,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
     if (unexp_req) {
         *flag = 1;
         unexp_req->status.MPI_ERROR = MPI_SUCCESS;
-        unexp_req->status.MPI_SOURCE = MPIDIG_REQUEST(unexp_req, rank);
-        unexp_req->status.MPI_TAG = MPIDIG_REQUEST(unexp_req, tag);
+        unexp_req->status.MPI_SOURCE = MPIDIG_REQUEST(unexp_req, u.recv.source);
+        unexp_req->status.MPI_TAG = MPIDIG_REQUEST(unexp_req, u.recv.tag);
         MPIR_STATUS_SET_COUNT(unexp_req->status, MPIDIG_REQUEST(unexp_req, count));
 
         MPIR_Request_extract_status(unexp_req, status);
@@ -65,8 +65,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
         MPIR_Comm_add_ref(comm);
 
         unexp_req->status.MPI_ERROR = MPI_SUCCESS;
-        unexp_req->status.MPI_SOURCE = MPIDIG_REQUEST(unexp_req, rank);
-        unexp_req->status.MPI_TAG = MPIDIG_REQUEST(unexp_req, tag);
+        unexp_req->status.MPI_SOURCE = MPIDIG_REQUEST(unexp_req, u.recv.source);
+        unexp_req->status.MPI_TAG = MPIDIG_REQUEST(unexp_req, u.recv.tag);
         MPIR_STATUS_SET_COUNT(unexp_req->status, MPIDIG_REQUEST(unexp_req, count));
         MPIDIG_REQUEST(unexp_req, req->status) |= MPIDIG_REQ_UNEXP_DQUED;
 

--- a/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
@@ -166,7 +166,7 @@ int MPIDIG_send_data_origin_cb(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, req->sreq).datatype);
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, datatype));
     MPID_Request_complete(sreq);
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -487,9 +487,9 @@ int MPIDIG_send_cts_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     CH4_CALL(am_isend_reply(sreq->comm,
                             MPIDIG_REQUEST(sreq, u.send.dest), MPIDIG_SEND_DATA,
                             &send_hdr, sizeof(send_hdr),
-                            MPIDIG_REQUEST(sreq, req->sreq).src_buf,
-                            MPIDIG_REQUEST(sreq, req->sreq).count,
-                            MPIDIG_REQUEST(sreq, req->sreq).datatype, local_vci, remote_vci, sreq),
+                            MPIDIG_REQUEST(sreq, buffer),
+                            MPIDIG_REQUEST(sreq, count),
+                            MPIDIG_REQUEST(sreq, datatype), local_vci, remote_vci, sreq),
              MPIDI_REQUEST(sreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
@@ -24,7 +24,7 @@ int MPIDIG_do_cts(MPIR_Request * rreq)
 
     int local_vci = MPIDIG_REQUEST(rreq, req->local_vci);
     int remote_vci = MPIDIG_REQUEST(rreq, req->remote_vci);
-    CH4_CALL(am_send_hdr_reply(rreq->comm, MPIDIG_REQUEST(rreq, rank), MPIDIG_SEND_CTS,
+    CH4_CALL(am_send_hdr_reply(rreq->comm, MPIDIG_REQUEST(rreq, u.recv.source), MPIDIG_SEND_CTS,
                                &am_hdr, sizeof(am_hdr), local_vci, remote_vci),
              MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
@@ -120,8 +120,8 @@ static int recv_target_cmpl_cb(MPIR_Request * rreq)
         goto fn_exit;
     }
 
-    rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, rank);
-    rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, tag);
+    rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, u.recv.source);
+    rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, u.recv.tag);
 
     if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_PEER_SSEND) {
         mpi_errno = MPIDIG_reply_ssend(rreq);
@@ -235,9 +235,9 @@ static int create_unexp_rreq(int rank, int tag, MPIR_Context_id_t context_id,
     MPIDIG_REQUEST(rreq, datatype) = MPI_BYTE;
     MPIDIG_REQUEST(rreq, count) = data_sz;
     MPIDIG_REQUEST(rreq, buffer) = NULL;        /* default */
-    MPIDIG_REQUEST(rreq, rank) = rank;
-    MPIDIG_REQUEST(rreq, tag) = tag;
-    MPIDIG_REQUEST(rreq, context_id) = context_id;
+    MPIDIG_REQUEST(rreq, u.recv.source) = rank;
+    MPIDIG_REQUEST(rreq, u.recv.tag) = tag;
+    MPIDIG_REQUEST(rreq, u.recv.context_id) = context_id;
 
     MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_UNEXPECTED;
     MPIDIG_REQUEST(rreq, req->rreq.match_req) = NULL;
@@ -304,9 +304,9 @@ static void set_matched_rreq_fields(MPIR_Request * rreq, int rank, int tag,
                                     MPIR_Context_id_t context_id, int error_bits, int is_local)
 {
     MPIR_FUNC_ENTER;
-    MPIDIG_REQUEST(rreq, rank) = rank;
-    MPIDIG_REQUEST(rreq, tag) = tag;
-    MPIDIG_REQUEST(rreq, context_id) = context_id;
+    MPIDIG_REQUEST(rreq, u.recv.source) = rank;
+    MPIDIG_REQUEST(rreq, u.recv.tag) = tag;
+    MPIDIG_REQUEST(rreq, u.recv.context_id) = context_id;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
@@ -485,7 +485,7 @@ int MPIDIG_send_cts_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     /* Start the main data transfer */
     send_hdr.rreq_ptr = msg_hdr->rreq_ptr;
     CH4_CALL(am_isend_reply(sreq->comm,
-                            MPIDIG_REQUEST(sreq, rank), MPIDIG_SEND_DATA,
+                            MPIDIG_REQUEST(sreq, u.send.dest), MPIDIG_SEND_DATA,
                             &send_hdr, sizeof(send_hdr),
                             MPIDIG_REQUEST(sreq, req->sreq).src_buf,
                             MPIDIG_REQUEST(sreq, req->sreq).count,

--- a/src/mpid/ch4/src/mpidig_recv_utils.h
+++ b/src/mpid/ch4/src/mpidig_recv_utils.h
@@ -148,8 +148,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_get_recv_iov_count(MPIR_Request * rreq)
     MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->recv_async));
     if (p->recv_type == MPIDIG_RECV_DATATYPE) {
         MPI_Aint num_iov;
-        MPIR_Typerep_iov_len(MPIDIG_REQUEST(rreq, count), MPIDIG_REQUEST(rreq, datatype),
-                             p->in_data_sz, &num_iov);
+        MPIR_Typerep_iov_len(MPIDIG_REQUEST(rreq, count),
+                             MPIDIG_REQUEST(rreq, datatype), p->in_data_sz, &num_iov);
         return num_iov;
     } else if (p->recv_type == MPIDIG_RECV_CONTIG) {
         return 1;
@@ -343,8 +343,8 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_convert_datatype(MPIR_Request * rreq)
     MPI_Aint data_sz;
     MPIR_Datatype *dt_ptr;
     MPI_Aint dt_true_lb;
-    MPIDI_Datatype_get_info(MPIDIG_REQUEST(rreq, count), MPIDIG_REQUEST(rreq, datatype),
-                            dt_contig, data_sz, dt_ptr, dt_true_lb);
+    MPIDI_Datatype_get_info(MPIDIG_REQUEST(rreq, count),
+                            MPIDIG_REQUEST(rreq, datatype), dt_contig, data_sz, dt_ptr, dt_true_lb);
 
     MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->recv_async));
     if (dt_contig) {
@@ -354,8 +354,8 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_convert_datatype(MPIR_Request * rreq)
     } else {
         struct iovec *iov;
         MPI_Aint num_iov;
-        MPIR_Typerep_iov_len(MPIDIG_REQUEST(rreq, count), MPIDIG_REQUEST(rreq, datatype),
-                             data_sz, &num_iov);
+        MPIR_Typerep_iov_len(MPIDIG_REQUEST(rreq, count),
+                             MPIDIG_REQUEST(rreq, datatype), data_sz, &num_iov);
         MPIR_Assert(num_iov > 0);
 
         iov = MPL_malloc(num_iov * sizeof(struct iovec), MPL_MEM_OTHER);

--- a/src/mpid/ch4/src/mpidig_recvq.h
+++ b/src/mpid/ch4/src/mpidig_recvq.h
@@ -79,7 +79,7 @@ enum MPIDIG_queue_type {
         if (qtype_ == MPIDIG_PT2PT_UNEXP) {                  \
             MPIR_T_DO_EVENT(unexp_message_indices[0],        \
                             MPI_T_CB_REQUIRE_MPI_RESTRICTED, \
-                            &MPIDIG_REQUEST(req, rank));     \
+                            &MPIDIG_REQUEST(req, u.recv.source));     \
         }                                                    \
     } while (0)
 
@@ -88,7 +88,7 @@ enum MPIDIG_queue_type {
         if (qtype_ == MPIDIG_PT2PT_UNEXP) {                  \
             MPIR_T_DO_EVENT(unexp_message_indices[1],        \
                             MPI_T_CB_REQUIRE_MPI_RESTRICTED, \
-                            &MPIDIG_REQUEST(req, rank));     \
+                            &MPIDIG_REQUEST(req, u.recv.source));     \
         }                                                    \
     } while (0)
 
@@ -98,18 +98,19 @@ MPL_STATIC_INLINE_PREFIX bool MPIDIG_match_request(int rank, int tag,
                                                    enum MPIDIG_queue_type qtype)
 {
     if (qtype == MPIDIG_PT2PT_POSTED) {
-        return (rank == MPIDIG_REQUEST(req, rank) || MPIDIG_REQUEST(req, rank) == MPI_ANY_SOURCE) &&
-            (tag == MPIR_TAG_MASK_ERROR_BITS(MPIDIG_REQUEST(req, tag)) ||
-             MPIDIG_REQUEST(req, tag) == MPI_ANY_TAG) &&
-            context_id == MPIDIG_REQUEST(req, context_id);
+        return (rank == MPIDIG_REQUEST(req, u.recv.source) ||
+                MPIDIG_REQUEST(req, u.recv.source) == MPI_ANY_SOURCE) &&
+            (tag == MPIR_TAG_MASK_ERROR_BITS(MPIDIG_REQUEST(req, u.recv.tag)) ||
+             MPIDIG_REQUEST(req, u.recv.tag) == MPI_ANY_TAG) &&
+            context_id == MPIDIG_REQUEST(req, u.recv.context_id);
     } else if (qtype == MPIDIG_PT2PT_UNEXP) {
-        return (rank == MPIDIG_REQUEST(req, rank) || rank == MPI_ANY_SOURCE) &&
-            (tag == MPIR_TAG_MASK_ERROR_BITS(MPIDIG_REQUEST(req, tag)) ||
-             tag == MPI_ANY_TAG) && context_id == MPIDIG_REQUEST(req, context_id);
+        return (rank == MPIDIG_REQUEST(req, u.recv.source) || rank == MPI_ANY_SOURCE) &&
+            (tag == MPIR_TAG_MASK_ERROR_BITS(MPIDIG_REQUEST(req, u.recv.tag)) ||
+             tag == MPI_ANY_TAG) && context_id == MPIDIG_REQUEST(req, u.recv.context_id);
     } else if (qtype == MPIDIG_PART) {
-        return rank == MPIDI_PART_REQUEST(req, rank) &&
-            tag == MPIR_TAG_MASK_ERROR_BITS(MPIDI_PART_REQUEST(req, tag)) &&
-            context_id == MPIDI_PART_REQUEST(req, context_id);
+        return rank == MPIDI_PART_REQUEST(req, u.recv.source) &&
+            tag == MPIR_TAG_MASK_ERROR_BITS(MPIDI_PART_REQUEST(req, u.recv.tag)) &&
+            context_id == MPIDI_PART_REQUEST(req, u.recv.context_id);
     } else {
         /* unknown queue type */
         MPIR_Assert(0);

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -57,8 +57,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
     sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 2, vci, vci);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     sreq->u.rma.win = win;
-    MPIDIG_REQUEST(sreq, req->preq.target_datatype) = target_datatype;
-    MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
     MPIR_cc_inc(sreq->cc_ptr);
     MPIR_T_PVAR_TIMER_START(RMA, rma_amhdr_set);
@@ -130,6 +128,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
         MPIDIG_REQUEST(sreq, req->preq.origin_count) = origin_count;
         MPIDIG_REQUEST(sreq, req->preq.origin_datatype) = origin_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
+        /* add reference to ensure the flattened_dt buffer does not get freed */
+        MPIDIG_REQUEST(sreq, req->preq.target_datatype) = target_datatype;
+        MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
         CH4_CALL(am_isend(target_rank, win->comm_ptr, MPIDIG_PUT_DT_REQ, &am_hdr, sizeof(am_hdr),
                           flattened_dt, flattened_sz, MPI_BYTE, vci, vci, sreq), is_local,
@@ -291,8 +292,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
     sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 2, vci, vci);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     sreq->u.rma.win = win;
-    MPIDIG_REQUEST(sreq, req->areq.target_datatype) = target_datatype;
-    MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
     MPIR_cc_inc(sreq->cc_ptr);
 
@@ -364,6 +363,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
         MPIDIG_REQUEST(sreq, req->areq.origin_count) = origin_count;
         MPIDIG_REQUEST(sreq, req->areq.origin_datatype) = origin_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
+        /* add reference to ensure the flattened_dt buffer does not get freed */
+        MPIDIG_REQUEST(sreq, req->areq.target_datatype) = target_datatype;
+        MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
         CH4_CALL(am_isend(target_rank, win->comm_ptr, MPIDIG_ACC_DT_REQ, &am_hdr, sizeof(am_hdr),
                           flattened_dt, flattened_sz, MPI_BYTE, vci, vci, sreq), is_local,
@@ -441,8 +443,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
     MPIDIG_REQUEST(sreq, req->areq.result_count) = result_count;
     MPIDIG_REQUEST(sreq, req->areq.result_datatype) = result_datatype;
     MPIR_Datatype_add_ref_if_not_builtin(result_datatype);
-    MPIDIG_REQUEST(sreq, req->areq.target_datatype) = target_datatype;
-    MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
     MPIR_cc_inc(sreq->cc_ptr);
 
     /* TODO: have common routine for accumulate/get_accumulate */
@@ -516,6 +516,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
         MPIDIG_REQUEST(sreq, req->areq.origin_count) = origin_count;
         MPIDIG_REQUEST(sreq, req->areq.origin_datatype) = origin_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
+        /* add reference to ensure the flattened_dt buffer does not get freed */
+        MPIDIG_REQUEST(sreq, req->areq.target_datatype) = target_datatype;
+        MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
+
         CH4_CALL(am_isend(target_rank, win->comm_ptr, MPIDIG_GET_ACC_DT_REQ,
                           &am_hdr, sizeof(am_hdr), flattened_dt, flattened_sz, MPI_BYTE,
                           vci, vci, sreq), is_local, mpi_errno);

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -129,7 +129,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
         MPIDIG_REQUEST(sreq, datatype) = origin_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
         /* add reference to ensure the flattened_dt buffer does not get freed */
-        MPIDIG_REQUEST(sreq, req->preq.target_datatype) = target_datatype;
+        MPIDIG_REQUEST(sreq, u.origin.target_datatype) = target_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
         CH4_CALL(am_isend(target_rank, win->comm_ptr, MPIDIG_PUT_DT_REQ, &am_hdr, sizeof(am_hdr),
@@ -195,7 +195,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
     MPIDIG_REQUEST(sreq, buffer) = origin_addr;
     MPIDIG_REQUEST(sreq, count) = origin_count;
     MPIDIG_REQUEST(sreq, datatype) = origin_datatype;
-    MPIDIG_REQUEST(sreq, req->greq.target_datatype) = target_datatype;
+    MPIDIG_REQUEST(sreq, u.origin.target_datatype) = target_datatype;
     MPIDIG_REQUEST(sreq, u.origin.target_rank) = target_rank;
     MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
     MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
@@ -364,7 +364,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
         MPIDIG_REQUEST(sreq, datatype) = origin_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
         /* add reference to ensure the flattened_dt buffer does not get freed */
-        MPIDIG_REQUEST(sreq, req->areq.target_datatype) = target_datatype;
+        MPIDIG_REQUEST(sreq, u.origin.target_datatype) = target_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
         CH4_CALL(am_isend(target_rank, win->comm_ptr, MPIDIG_ACC_DT_REQ, &am_hdr, sizeof(am_hdr),
@@ -517,7 +517,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
         MPIDIG_REQUEST(sreq, datatype) = origin_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
         /* add reference to ensure the flattened_dt buffer does not get freed */
-        MPIDIG_REQUEST(sreq, req->areq.target_datatype) = target_datatype;
+        MPIDIG_REQUEST(sreq, u.origin.target_datatype) = target_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
         CH4_CALL(am_isend(target_rank, win->comm_ptr, MPIDIG_GET_ACC_DT_REQ,

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -192,9 +192,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
     sreq->u.rma.win = win;
-    MPIDIG_REQUEST(sreq, req->greq.addr) = origin_addr;
-    MPIDIG_REQUEST(sreq, req->greq.count) = origin_count;
-    MPIDIG_REQUEST(sreq, req->greq.datatype) = origin_datatype;
+    MPIDIG_REQUEST(sreq, buffer) = origin_addr;
+    MPIDIG_REQUEST(sreq, count) = origin_count;
+    MPIDIG_REQUEST(sreq, datatype) = origin_datatype;
     MPIDIG_REQUEST(sreq, req->greq.target_datatype) = target_datatype;
     MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
     MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -71,7 +71,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
     /* Increase local and remote completion counters and set the local completion
      * counter in request, thus it can be decreased at request completion. */
     MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
-    MPIDIG_REQUEST(sreq, rank) = target_rank;
+    MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
 
     int is_contig;
     MPIR_Datatype_is_contig(target_datatype, &is_contig);
@@ -195,7 +195,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
     MPIDIG_REQUEST(sreq, req->greq.count) = origin_count;
     MPIDIG_REQUEST(sreq, req->greq.datatype) = origin_datatype;
     MPIDIG_REQUEST(sreq, req->greq.target_datatype) = target_datatype;
-    MPIDIG_REQUEST(sreq, rank) = target_rank;
+    MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
     MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
     MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
@@ -321,7 +321,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
     /* Increase remote completion counter for acc. */
     MPIDIG_win_remote_acc_cmpl_cnt_incr(win, target_rank);
 
-    MPIDIG_REQUEST(sreq, rank) = target_rank;
+    MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
     if (MPIR_DATATYPE_IS_PREDEFINED(target_datatype)) {
         am_hdr.flattened_sz = 0;
         MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
@@ -473,7 +473,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
     /* Increase remote completion counter for acc. */
     MPIDIG_win_remote_acc_cmpl_cnt_incr(win, target_rank);
 
-    MPIDIG_REQUEST(sreq, rank) = target_rank;
+    MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
     if (MPIR_DATATYPE_IS_PREDEFINED(target_datatype)) {
         am_hdr.flattened_sz = 0;
         MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
@@ -783,7 +783,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
     MPIDIG_REQUEST(sreq, req->creq.datatype) = datatype;
     MPIDIG_REQUEST(sreq, req->creq.result_addr) = result_addr;
     MPIDIG_REQUEST(sreq, req->creq.data) = p_data;
-    MPIDIG_REQUEST(sreq, rank) = target_rank;
+    MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
     MPIR_cc_inc(sreq->cc_ptr);
 
     MPIR_T_PVAR_TIMER_START(RMA, rma_amhdr_set);

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -124,9 +124,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
                  is_local, mpi_errno);
         MPL_free(header);
     } else {
-        MPIDIG_REQUEST(sreq, req->preq.origin_addr) = (void *) origin_addr;
-        MPIDIG_REQUEST(sreq, req->preq.origin_count) = origin_count;
-        MPIDIG_REQUEST(sreq, req->preq.origin_datatype) = origin_datatype;
+        MPIDIG_REQUEST(sreq, buffer) = (void *) origin_addr;
+        MPIDIG_REQUEST(sreq, count) = origin_count;
+        MPIDIG_REQUEST(sreq, datatype) = origin_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
         /* add reference to ensure the flattened_dt buffer does not get freed */
         MPIDIG_REQUEST(sreq, req->preq.target_datatype) = target_datatype;
@@ -359,9 +359,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
                           vci, vci, sreq), is_local, mpi_errno);
         MPL_free(header);
     } else {
-        MPIDIG_REQUEST(sreq, req->areq.origin_addr) = (void *) origin_addr;
-        MPIDIG_REQUEST(sreq, req->areq.origin_count) = origin_count;
-        MPIDIG_REQUEST(sreq, req->areq.origin_datatype) = origin_datatype;
+        MPIDIG_REQUEST(sreq, buffer) = (void *) origin_addr;
+        MPIDIG_REQUEST(sreq, count) = origin_count;
+        MPIDIG_REQUEST(sreq, datatype) = origin_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
         /* add reference to ensure the flattened_dt buffer does not get freed */
         MPIDIG_REQUEST(sreq, req->areq.target_datatype) = target_datatype;

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -512,9 +512,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
                           vci, vci, sreq), is_local, mpi_errno);
         MPL_free(header);
     } else {
-        MPIDIG_REQUEST(sreq, req->areq.origin_addr) = (void *) origin_addr;
-        MPIDIG_REQUEST(sreq, req->areq.origin_count) = origin_count;
-        MPIDIG_REQUEST(sreq, req->areq.origin_datatype) = origin_datatype;
+        MPIDIG_REQUEST(sreq, buffer) = (void *) origin_addr;
+        MPIDIG_REQUEST(sreq, count) = origin_count;
+        MPIDIG_REQUEST(sreq, datatype) = origin_datatype;
         MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
         /* add reference to ensure the flattened_dt buffer does not get freed */
         MPIDIG_REQUEST(sreq, req->areq.target_datatype) = target_datatype;

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -69,7 +69,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
     /* Increase local and remote completion counters and set the local completion
      * counter in request, thus it can be decreased at request completion. */
     MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
-    MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
+    MPIDIG_REQUEST(sreq, u.origin.target_rank) = target_rank;
 
     int is_contig;
     MPIR_Datatype_is_contig(target_datatype, &is_contig);
@@ -196,7 +196,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
     MPIDIG_REQUEST(sreq, count) = origin_count;
     MPIDIG_REQUEST(sreq, datatype) = origin_datatype;
     MPIDIG_REQUEST(sreq, req->greq.target_datatype) = target_datatype;
-    MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
+    MPIDIG_REQUEST(sreq, u.origin.target_rank) = target_rank;
     MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
     MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
@@ -320,7 +320,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
     /* Increase remote completion counter for acc. */
     MPIDIG_win_remote_acc_cmpl_cnt_incr(win, target_rank);
 
-    MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
+    MPIDIG_REQUEST(sreq, u.origin.target_rank) = target_rank;
     if (MPIR_DATATYPE_IS_PREDEFINED(target_datatype)) {
         am_hdr.flattened_sz = 0;
         MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
@@ -473,7 +473,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
     /* Increase remote completion counter for acc. */
     MPIDIG_win_remote_acc_cmpl_cnt_incr(win, target_rank);
 
-    MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
+    MPIDIG_REQUEST(sreq, u.origin.target_rank) = target_rank;
     if (MPIR_DATATYPE_IS_PREDEFINED(target_datatype)) {
         am_hdr.flattened_sz = 0;
         MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
@@ -786,7 +786,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
     MPIDIG_REQUEST(sreq, buffer) = result_addr;
     MPIDIG_REQUEST(sreq, datatype) = datatype;
     MPIDIG_REQUEST(sreq, req->creq.data) = p_data;
-    MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
+    MPIDIG_REQUEST(sreq, u.origin.target_rank) = target_rank;
     MPIR_cc_inc(sreq->cc_ptr);
 
     MPIR_T_PVAR_TIMER_START(RMA, rma_amhdr_set);

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -783,9 +783,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
     sreq->u.rma.win = win;
-    MPIDIG_REQUEST(sreq, req->creq.addr) = result_addr;
-    MPIDIG_REQUEST(sreq, req->creq.datatype) = datatype;
-    MPIDIG_REQUEST(sreq, req->creq.result_addr) = result_addr;
+    MPIDIG_REQUEST(sreq, buffer) = result_addr;
+    MPIDIG_REQUEST(sreq, datatype) = datatype;
     MPIDIG_REQUEST(sreq, req->creq.data) = p_data;
     MPIDIG_REQUEST(sreq, u.send.dest) = target_rank;
     MPIR_cc_inc(sreq->cc_ptr);

--- a/src/mpid/ch4/src/mpidig_rma_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_rma_callbacks.c
@@ -464,7 +464,7 @@ static int ack_put(MPIR_Request * rreq)
     int local_vci = MPIDIG_REQUEST(rreq, req->local_vci);
     int remote_vci = MPIDIG_REQUEST(rreq, req->remote_vci);
     ack_msg.preq_ptr = MPIDIG_REQUEST(rreq, req->preq.preq_ptr);
-    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, u.recv.source),
                                MPIDIG_PUT_ACK, &ack_msg, sizeof(ack_msg), local_vci, remote_vci),
              MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
@@ -492,7 +492,7 @@ static int ack_cswap(MPIR_Request * rreq)
 
     int local_vci = MPIDIG_REQUEST(rreq, req->local_vci);
     int remote_vci = MPIDIG_REQUEST(rreq, req->remote_vci);
-    CH4_CALL(am_isend_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+    CH4_CALL(am_isend_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, u.recv.source),
                             MPIDIG_CSWAP_ACK, &ack_msg, sizeof(ack_msg), result_addr, 1,
                             MPIDIG_REQUEST(rreq, req->creq.datatype), local_vci, remote_vci, rreq),
              MPIDI_REQUEST(rreq, is_local), mpi_errno);
@@ -514,7 +514,7 @@ static int ack_acc(MPIR_Request * rreq)
     int local_vci = MPIDIG_REQUEST(rreq, req->local_vci);
     int remote_vci = MPIDIG_REQUEST(rreq, req->remote_vci);
     ack_msg.req_ptr = MPIDIG_REQUEST(rreq, req->areq.req_ptr);
-    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, u.recv.source),
                                MPIDIG_ACC_ACK, &ack_msg, sizeof(ack_msg), local_vci, remote_vci),
              MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
@@ -537,7 +537,7 @@ static int ack_get_acc(MPIR_Request * rreq)
 
     int local_vci = MPIDIG_REQUEST(rreq, req->local_vci);
     int remote_vci = MPIDIG_REQUEST(rreq, req->remote_vci);
-    CH4_CALL(am_isend_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+    CH4_CALL(am_isend_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, u.recv.source),
                             MPIDIG_GET_ACC_ACK, &ack_msg, sizeof(ack_msg),
                             MPIDIG_REQUEST(rreq, req->areq.data),
                             MPIDIG_REQUEST(rreq, req->areq.result_data_sz), MPI_BYTE, local_vci,
@@ -890,7 +890,7 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
     if (MPIDIG_REQUEST(rreq, req->greq.flattened_dt) == NULL) {
         MPIDI_Datatype_check_size(MPIDIG_REQUEST(rreq, req->greq.datatype),
                                   MPIDIG_REQUEST(rreq, req->greq.count), get_ack.target_data_sz);
-        CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+        CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, u.recv.source),
                                 MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
                                 (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
                                 MPIDIG_REQUEST(rreq, req->greq.count),
@@ -914,7 +914,7 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
     get_ack.target_data_sz = MPIDIG_REQUEST(rreq, req->greq.count);
     MPIDIG_REQUEST(rreq, req->greq.count) /= dt->size;
 
-    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(rreq, u.recv.source),
                             MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
                             MPIDIG_REQUEST(rreq, req->greq.addr),
                             MPIDIG_REQUEST(rreq, req->greq.count), dt->handle, local_vci,
@@ -958,13 +958,13 @@ static int put_dt_target_cmpl_cb(MPIR_Request * rreq)
 
     MPIR_FUNC_ENTER;
 
-    ack_msg.src_rank = MPIDIG_REQUEST(rreq, rank);
+    ack_msg.src_rank = MPIDIG_REQUEST(rreq, u.recv.source);
     ack_msg.origin_preq_ptr = MPIDIG_REQUEST(rreq, req->preq.preq_ptr);
     ack_msg.target_preq_ptr = rreq;
 
     int local_vci = MPIDIG_REQUEST(rreq, req->local_vci);
     int remote_vci = MPIDIG_REQUEST(rreq, req->remote_vci);
-    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, u.recv.source),
                                MPIDIG_PUT_DT_ACK, &ack_msg, sizeof(ack_msg), local_vci, remote_vci),
              MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
@@ -988,7 +988,7 @@ static int acc_dt_target_cmpl_cb(MPIR_Request * rreq)
 
     int local_vci = MPIDIG_REQUEST(rreq, req->local_vci);
     int remote_vci = MPIDIG_REQUEST(rreq, req->remote_vci);
-    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, u.recv.source),
                                MPIDIG_ACC_DT_ACK, &ack_msg, sizeof(ack_msg), local_vci, remote_vci),
              MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
@@ -1012,7 +1012,7 @@ static int get_acc_dt_target_cmpl_cb(MPIR_Request * rreq)
 
     int local_vci = MPIDIG_REQUEST(rreq, req->local_vci);
     int remote_vci = MPIDIG_REQUEST(rreq, req->remote_vci);
-    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, rank),
+    CH4_CALL(am_send_hdr_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, u.recv.source),
                                MPIDIG_GET_ACC_DT_ACK, &ack_msg, sizeof(ack_msg), local_vci,
                                remote_vci), MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
@@ -1128,7 +1128,7 @@ static int get_ack_target_cmpl_cb(MPIR_Request * rreq)
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->greq.target_datatype));
 
     win = rreq->u.rma.win;
-    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
+    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, u.send.dest));
 
     MPIDIG_recv_finish(rreq);
 
@@ -1149,8 +1149,8 @@ static int get_acc_ack_target_cmpl_cb(MPIR_Request * rreq)
     MPIDIG_recv_finish(rreq);
 
     win = rreq->u.rma.win;
-    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
-    MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
+    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, u.send.dest));
+    MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, u.send.dest));
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->areq.result_datatype));
     MPID_Request_complete(rreq);
@@ -1167,8 +1167,8 @@ static int cswap_ack_target_cmpl_cb(MPIR_Request * rreq)
     MPIR_FUNC_ENTER;
 
     win = rreq->u.rma.win;
-    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
-    MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
+    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, u.send.dest));
+    MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, u.send.dest));
 
     MPL_free(MPIDIG_REQUEST(rreq, req->creq.data));
     MPID_Request_complete(rreq);
@@ -1193,7 +1193,7 @@ int MPIDIG_put_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(preq, req->preq.target_datatype));
 
-    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(preq, rank));
+    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(preq, u.send.dest));
 
     MPID_Request_complete(preq);
 
@@ -1223,8 +1223,8 @@ int MPIDIG_acc_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->areq.target_datatype));
 
-    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
-    MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
+    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, u.send.dest));
+    MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, u.send.dest));
 
     MPID_Request_complete(rreq);
 
@@ -1254,6 +1254,7 @@ int MPIDIG_get_acc_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_
 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = get_acc_ack_target_cmpl_cb;
 
+    /* setup recv fields for result data */
     MPIDIG_REQUEST(rreq, buffer) = MPIDIG_REQUEST(rreq, req->areq.result_addr);
     MPIDIG_REQUEST(rreq, count) = MPIDIG_REQUEST(rreq, req->areq.result_count);
     MPIDIG_REQUEST(rreq, datatype) = MPIDIG_REQUEST(rreq, req->areq.result_datatype);
@@ -1445,7 +1446,7 @@ int MPIDIG_put_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
     MPIDIG_REQUEST(rreq, req->preq.preq_ptr) = msg_hdr->preq_ptr;
-    MPIDIG_REQUEST(rreq, rank) = msg_hdr->src_rank;
+    MPIDIG_REQUEST(rreq, u.recv.source) = msg_hdr->src_rank;
 
     win = (MPIR_Win *) MPIDIU_map_lookup(MPIDI_global.win_map, msg_hdr->win_id);
     MPIR_Assert(win);
@@ -1521,7 +1522,7 @@ int MPIDIG_put_dt_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
     MPIDIG_REQUEST(rreq, req->preq.preq_ptr) = msg_hdr->preq_ptr;
-    MPIDIG_REQUEST(rreq, rank) = msg_hdr->src_rank;
+    MPIDIG_REQUEST(rreq, u.recv.source) = msg_hdr->src_rank;
 
     win = (MPIR_Win *) MPIDIU_map_lookup(MPIDI_global.win_map, msg_hdr->win_id);
     MPIR_Assert(win);
@@ -1580,7 +1581,7 @@ int MPIDIG_put_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_s
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
     win = origin_req->u.rma.win;
 
-    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, rank),
+    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, u.send.dest),
                             MPIDIG_PUT_DAT_REQ, &dat_msg, sizeof(dat_msg),
                             MPIDIG_REQUEST(origin_req, req->preq.origin_addr),
                             MPIDIG_REQUEST(origin_req, req->preq.origin_count),
@@ -1624,7 +1625,7 @@ int MPIDIG_acc_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_s
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
     win = origin_req->u.rma.win;
 
-    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, rank),
+    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, u.send.dest),
                             MPIDIG_ACC_DAT_REQ, &dat_msg, sizeof(dat_msg),
                             MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                             MPIDIG_REQUEST(origin_req, req->areq.origin_count),
@@ -1668,7 +1669,7 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(void *am_hdr, void *data,
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
     win = origin_req->u.rma.win;
 
-    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, rank),
+    CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, u.send.dest),
                             MPIDIG_GET_ACC_DAT_REQ, &dat_msg, sizeof(dat_msg),
                             MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                             MPIDIG_REQUEST(origin_req, req->areq.origin_count),
@@ -1830,7 +1831,7 @@ int MPIDIG_cswap_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     MPIDIG_REQUEST(rreq, req->creq.creq_ptr) = msg_hdr->req_ptr;
     MPIDIG_REQUEST(rreq, req->creq.datatype) = msg_hdr->datatype;
     MPIDIG_REQUEST(rreq, req->creq.addr) = (char *) base + offset;
-    MPIDIG_REQUEST(rreq, rank) = msg_hdr->src_rank;
+    MPIDIG_REQUEST(rreq, u.recv.source) = msg_hdr->src_rank;
 
     MPIR_Assert(dt_contig == 1);
     p_data = MPL_malloc(data_sz * 2, MPL_MEM_RMA);
@@ -1908,7 +1909,7 @@ int MPIDIG_acc_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     MPIDIG_REQUEST(rreq, req->areq.data) = p_data;
     MPIDIG_REQUEST(rreq, req->areq.flattened_dt) = NULL;
     MPIDIG_REQUEST(rreq, req->areq.result_data_sz) = msg_hdr->result_data_sz;
-    MPIDIG_REQUEST(rreq, rank) = msg_hdr->src_rank;
+    MPIDIG_REQUEST(rreq, u.recv.source) = msg_hdr->src_rank;
 
     if (msg_hdr->flattened_sz) {
         /* FIXME: MPIR_Typerep_unflatten should allocate the new object */
@@ -2001,7 +2002,7 @@ int MPIDIG_acc_dt_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     MPIDIG_REQUEST(rreq, req->areq.target_addr) = (void *) (offset + base);
     MPIDIG_REQUEST(rreq, req->areq.op) = msg_hdr->op;
     MPIDIG_REQUEST(rreq, req->areq.result_data_sz) = msg_hdr->result_data_sz;
-    MPIDIG_REQUEST(rreq, rank) = msg_hdr->src_rank;
+    MPIDIG_REQUEST(rreq, u.recv.source) = msg_hdr->src_rank;
 
     void *flattened_dt = MPL_malloc(msg_hdr->flattened_sz, MPL_MEM_RMA);
     MPIR_Assert(flattened_dt);
@@ -2093,7 +2094,7 @@ int MPIDIG_get_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     MPIDIG_REQUEST(rreq, req->greq.flattened_dt) = NULL;
     MPIDIG_REQUEST(rreq, req->greq.dt) = NULL;
     MPIDIG_REQUEST(rreq, req->greq.greq_ptr) = msg_hdr->greq_ptr;
-    MPIDIG_REQUEST(rreq, rank) = msg_hdr->src_rank;
+    MPIDIG_REQUEST(rreq, u.recv.source) = msg_hdr->src_rank;
 
     if (msg_hdr->flattened_sz) {
         void *flattened_dt = MPL_malloc(msg_hdr->flattened_sz, MPL_MEM_BUFFER);
@@ -2141,6 +2142,7 @@ int MPIDIG_get_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     MPIDI_REQUEST(rreq, is_local) = (attr & MPIDIG_AM_ATTR__IS_LOCAL) ? 1 : 0;
 #endif
 
+    /* setup recv fields for get data */
     MPIDIG_REQUEST(rreq, buffer) = MPIDIG_REQUEST(rreq, req->greq.addr);
     MPIDIG_REQUEST(rreq, count) = MPIDIG_REQUEST(rreq, req->greq.count);
     MPIDIG_REQUEST(rreq, datatype) = MPIDIG_REQUEST(rreq, req->greq.datatype);

--- a/src/mpid/ch4/src/mpidig_rma_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_rma_callbacks.c
@@ -1580,13 +1580,13 @@ int MPIDIG_put_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_s
 
     CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, u.send.dest),
                             MPIDIG_PUT_DAT_REQ, &dat_msg, sizeof(dat_msg),
-                            MPIDIG_REQUEST(origin_req, req->preq.origin_addr),
-                            MPIDIG_REQUEST(origin_req, req->preq.origin_count),
-                            MPIDIG_REQUEST(origin_req, req->preq.origin_datatype),
+                            MPIDIG_REQUEST(origin_req, buffer),
+                            MPIDIG_REQUEST(origin_req, count),
+                            MPIDIG_REQUEST(origin_req, datatype),
                             local_vci, remote_vci, rreq),
              (attr & MPIDIG_AM_ATTR__IS_LOCAL), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->preq.origin_datatype));
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, datatype));
 
     if (attr & MPIDIG_AM_ATTR__IS_ASYNC) {
         *req = NULL;
@@ -1624,13 +1624,13 @@ int MPIDIG_acc_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_s
 
     CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, u.send.dest),
                             MPIDIG_ACC_DAT_REQ, &dat_msg, sizeof(dat_msg),
-                            MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
-                            MPIDIG_REQUEST(origin_req, req->areq.origin_count),
-                            MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
+                            MPIDIG_REQUEST(origin_req, buffer),
+                            MPIDIG_REQUEST(origin_req, count),
+                            MPIDIG_REQUEST(origin_req, datatype),
                             local_vci, remote_vci, rreq),
              (attr & MPIDIG_AM_ATTR__IS_LOCAL), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->areq.origin_datatype));
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, datatype));
 
     if (attr & MPIDIG_AM_ATTR__IS_ASYNC) {
         *req = NULL;

--- a/src/mpid/ch4/src/mpidig_rma_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_rma_callbacks.c
@@ -208,6 +208,7 @@ int MPIDIG_put_dt_origin_cb(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, req->preq.target_datatype));
     MPID_Request_complete(sreq);
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -217,6 +218,7 @@ int MPIDIG_acc_dt_origin_cb(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, req->areq.target_datatype));
     MPID_Request_complete(sreq);
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -226,6 +228,7 @@ int MPIDIG_get_acc_dt_origin_cb(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, req->areq.target_datatype));
     MPID_Request_complete(sreq);
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -1191,8 +1194,6 @@ int MPIDIG_put_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     preq = (MPIR_Request *) msg_hdr->preq_ptr;
     win = preq->u.rma.win;
 
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(preq, req->preq.target_datatype));
-
     MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(preq, u.send.dest));
 
     MPID_Request_complete(preq);
@@ -1221,8 +1222,6 @@ int MPIDIG_acc_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     rreq = (MPIR_Request *) msg_hdr->req_ptr;
     win = rreq->u.rma.win;
 
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->areq.target_datatype));
-
     MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, u.send.dest));
     MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, u.send.dest));
 
@@ -1249,8 +1248,6 @@ int MPIDIG_get_acc_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_
     MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_acc_ack);
 
     rreq = (MPIR_Request *) msg_hdr->req_ptr;
-
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->areq.target_datatype));
 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = get_acc_ack_target_cmpl_cb;
 

--- a/src/mpid/ch4/src/mpidig_rma_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_rma_callbacks.c
@@ -210,7 +210,7 @@ int MPIDIG_put_dt_origin_cb(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, req->preq.target_datatype));
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, u.origin.target_datatype));
     MPID_Request_complete(sreq);
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -220,7 +220,7 @@ int MPIDIG_acc_dt_origin_cb(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, req->areq.target_datatype));
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, u.origin.target_datatype));
     MPID_Request_complete(sreq);
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -230,7 +230,7 @@ int MPIDIG_get_acc_dt_origin_cb(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, req->areq.target_datatype));
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, u.origin.target_datatype));
     MPID_Request_complete(sreq);
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -1134,7 +1134,7 @@ static int get_ack_target_cmpl_cb(MPIR_Request * rreq)
 
     MPIR_FUNC_ENTER;
 
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->greq.target_datatype));
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, u.origin.target_datatype));
 
     win = rreq->u.rma.win;
     MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, u.origin.target_rank));

--- a/src/mpid/ch4/src/mpidig_rma_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_rma_callbacks.c
@@ -1672,13 +1672,13 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(void *am_hdr, void *data,
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
     win = origin_req->u.rma.win;
     /* origin datatype to be released in MPIDIG_get_acc_data_origin_cb */
-    MPIDIG_REQUEST(rreq, datatype) = MPIDIG_REQUEST(origin_req, req->areq.origin_datatype);
+    MPIDIG_REQUEST(rreq, datatype) = MPIDIG_REQUEST(origin_req, datatype);
 
     CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, u.origin.target_rank),
                             MPIDIG_GET_ACC_DAT_REQ, &dat_msg, sizeof(dat_msg),
-                            MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
-                            MPIDIG_REQUEST(origin_req, req->areq.origin_count),
-                            MPIDIG_REQUEST(origin_req, req->areq.origin_datatype), local_vci,
+                            MPIDIG_REQUEST(origin_req, buffer),
+                            MPIDIG_REQUEST(origin_req, count),
+                            MPIDIG_REQUEST(origin_req, datatype), local_vci,
                             remote_vci, rreq), (attr & MPIDIG_AM_ATTR__IS_LOCAL), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/src/mpidig_rma_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_rma_callbacks.c
@@ -181,6 +181,7 @@ int MPIDIG_put_data_origin_cb(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, datatype));
     MPID_Request_complete(sreq);
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -190,6 +191,7 @@ int MPIDIG_acc_data_origin_cb(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, datatype));
     MPID_Request_complete(sreq);
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -199,6 +201,7 @@ int MPIDIG_get_acc_data_origin_cb(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, datatype));
     MPID_Request_complete(sreq);
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -1577,6 +1580,8 @@ int MPIDIG_put_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_s
     origin_req = (MPIR_Request *) msg_hdr->origin_preq_ptr;
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
     win = origin_req->u.rma.win;
+    /* origin datatype to be released in MPIDIG_put_data_origin_cb */
+    MPIDIG_REQUEST(rreq, datatype) = MPIDIG_REQUEST(origin_req, datatype);
 
     CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, u.send.dest),
                             MPIDIG_PUT_DAT_REQ, &dat_msg, sizeof(dat_msg),
@@ -1586,7 +1591,6 @@ int MPIDIG_put_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_s
                             local_vci, remote_vci, rreq),
              (attr & MPIDIG_AM_ATTR__IS_LOCAL), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, datatype));
 
     if (attr & MPIDIG_AM_ATTR__IS_ASYNC) {
         *req = NULL;
@@ -1621,6 +1625,8 @@ int MPIDIG_acc_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_s
     origin_req = (MPIR_Request *) msg_hdr->origin_preq_ptr;
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
     win = origin_req->u.rma.win;
+    /* origin datatype to be released in MPIDIG_acc_data_origin_cb */
+    MPIDIG_REQUEST(rreq, datatype) = MPIDIG_REQUEST(origin_req, datatype);
 
     CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, u.send.dest),
                             MPIDIG_ACC_DAT_REQ, &dat_msg, sizeof(dat_msg),
@@ -1630,7 +1636,6 @@ int MPIDIG_acc_dt_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_s
                             local_vci, remote_vci, rreq),
              (attr & MPIDIG_AM_ATTR__IS_LOCAL), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, datatype));
 
     if (attr & MPIDIG_AM_ATTR__IS_ASYNC) {
         *req = NULL;
@@ -1665,6 +1670,8 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(void *am_hdr, void *data,
     origin_req = (MPIR_Request *) msg_hdr->origin_preq_ptr;
     dat_msg.preq_ptr = msg_hdr->target_preq_ptr;
     win = origin_req->u.rma.win;
+    /* origin datatype to be released in MPIDIG_get_acc_data_origin_cb */
+    MPIDIG_REQUEST(rreq, datatype) = MPIDIG_REQUEST(origin_req, req->areq.origin_datatype);
 
     CH4_CALL(am_isend_reply(win->comm_ptr, MPIDIG_REQUEST(origin_req, u.send.dest),
                             MPIDIG_GET_ACC_DAT_REQ, &dat_msg, sizeof(dat_msg),
@@ -1673,7 +1680,6 @@ int MPIDIG_get_acc_dt_ack_target_msg_cb(void *am_hdr, void *data,
                             MPIDIG_REQUEST(origin_req, req->areq.origin_datatype), local_vci,
                             remote_vci, rreq), (attr & MPIDIG_AM_ATTR__IS_LOCAL), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->areq.origin_datatype));
 
     if (attr & MPIDIG_AM_ATTR__IS_ASYNC) {
         *req = NULL;

--- a/src/mpid/ch4/src/mpidig_send.h
+++ b/src/mpid/ch4/src/mpidig_send.h
@@ -93,11 +93,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
                           src_vci, dst_vci, sreq), is_local, mpi_errno);
     } else {
         /* RNDV send */
-        MPIDIG_REQUEST(sreq, req->sreq).src_buf = buf;
-        MPIDIG_REQUEST(sreq, req->sreq).count = count;
-        MPIDIG_REQUEST(sreq, req->sreq).datatype = datatype;
-        MPIDIG_REQUEST(sreq, req->sreq).rank = am_hdr.src_rank;
-        MPIDIG_REQUEST(sreq, req->sreq).context_id = am_hdr.context_id;
+        MPIDIG_REQUEST(sreq, buffer) = (void *) buf;
+        MPIDIG_REQUEST(sreq, count) = count;
+        MPIDIG_REQUEST(sreq, datatype) = datatype;
         MPIDIG_REQUEST(sreq, u.send.dest) = rank;
         MPIR_Datatype_add_ref_if_not_builtin(datatype);
         MPIDIG_AM_SEND_SET_RNDV(am_hdr.flags, MPIDIG_RNDV_GENERIC);

--- a/src/mpid/ch4/src/mpidig_send.h
+++ b/src/mpid/ch4/src/mpidig_send.h
@@ -81,7 +81,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
 
 #ifdef HAVE_DEBUGGER_SUPPORT
     MPIDIG_REQUEST(sreq, datatype) = datatype;
-    MPIDIG_REQUEST(sreq, buffer) = (char *) buf;
+    MPIDIG_REQUEST(sreq, buffer) = (void *) buf;
     MPIDIG_REQUEST(sreq, count) = count;
 #endif
 
@@ -98,7 +98,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
         MPIDIG_REQUEST(sreq, req->sreq).datatype = datatype;
         MPIDIG_REQUEST(sreq, req->sreq).rank = am_hdr.src_rank;
         MPIDIG_REQUEST(sreq, req->sreq).context_id = am_hdr.context_id;
-        MPIDIG_REQUEST(sreq, rank) = rank;
+        MPIDIG_REQUEST(sreq, u.send.dest) = rank;
         MPIR_Datatype_add_ref_if_not_builtin(datatype);
         MPIDIG_AM_SEND_SET_RNDV(am_hdr.flags, MPIDIG_RNDV_GENERIC);
 


### PR DESCRIPTION
## Pull Request Description

The "extended" request structures for ch4 active messages contain many redundant or unnecessary fields. This PR is an attempt to clean up the definitions, and ultimately improve memory access patterns when processing these types of messages.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
