### PR TITLE
test: add barrier in errors/pt2pt/truncmsg1.c

### DIFF
--- a/test/mpi/errors/pt2pt/truncmsg1.c
+++ b/test/mpi/errors/pt2pt/truncmsg1.c
@@ -93,6 +93,8 @@ int main(int argc, char *argv[])
         }
     }
 
+    MPI_Barrier(MPI_COMM_WORLD);
+
     free(buf);
     MTest_Finalize(errs);
 


### PR DESCRIPTION
## Pull Request Description

In this test the sender sends a huge message while the receiver posts a
tiny buffer. The receiver will quickly complete on receiving the first
packet, acknowledge and exit, while the send may still be sending the
remaining packets. The sender may fail due to disconnection. The
behavior is system-dependent. On linux, the send is often able to
complete before detecting the disconnect. On FreeBSD, this test nearly
always fails with I/O error at the libfabric sockets layer.

Because the purpose of test is not about disconnection error, and the
disconnection error can be legitimate. Therefore, we are adding a barrier
to prevent the disconnect error. The test still tests the
implementations handling of truncation error.

Fixes #5592
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
