### PR TITLE
config: fix clang failures due to config revamp

### DIFF
--- a/confdb/aclocal_datatype.m4
+++ b/confdb/aclocal_datatype.m4
@@ -177,7 +177,7 @@ AC_DEFUN([PAC_F77_CHECK_FIXED_INTEGER], [
         eval pac_cv_f77_sizeof_integer$1=0
     else
         eval pac_cv_f77_sizeof_integer$1=$1
-        AC_DEFINE_UNQUOTED(MPIR_REAL$1_CTYPE,$pac_retval,[C type to use for MPI_INTEGER$1])
+        AC_DEFINE_UNQUOTED(MPIR_INTEGER$1_CTYPE,$pac_retval,[C type to use for MPI_INTEGER$1])
     fi
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -2735,8 +2735,6 @@ AC_CHECK_SIZEOF(wchar_t, 0, [
 #endif
 ])
 
-AC_CHECK_SIZEOF(_BOOL, 0)
-
 AC_CHECK_SIZEOF(__float128, 0)
 if test "$ac_cv_sizeof___float128" = "16" ; then
     AC_DEFINE(HAVE_FLOAT128, 1, [Define if __float128 is supported])


### PR DESCRIPTION
## Pull Request Description

The previous datatype configure revamp resulted in Clang failures. The cause is quite accidental. We had an extra `AC_CHECK_SIZEOF(_BOOL)` in the configure, which clang recognizes, resulting in double definition of `SIZEOF__BOOL` in config tests. Some config tests need `-Werror` but the double definition prevented the flag , resulting in false positives. In particular, `NO_TAGS_WITH_MODIFIERS` is not defined when it should. 

However, the failures: 
```
In file included from mpi-io/get_view.c:6:
In file included from ./mpi-io/mpioimpl.h:13:
In file included from ./adio/include/adio.h:65:
In file included from /var/lib/jenkins-slave/workspace/mpich-main-ch4-ofi/compiler/clang/fabric_prov/sockets/jenkins_configure/default/label/centos64/mpich-main/src/include/mpi.h:977:
/var/lib/jenkins-slave/workspace/mpich-main-ch4-ofi/compiler/clang/fabric_prov/sockets/jenkins_configure/default/label/centos64/mpich-main/src/include/mpi_proto.h:3065:58: error: 'pointer_with_type_tag' attribute only applies to pointer arguments
                   MPICH_ATTR_POINTER_WITH_TYPE_TAG(1,3) MPICH_ATTR_POINTER_WITH_TYPE_TAG(4,6) MPICH_API_PUBLIC;
                                                         ^
/var/lib/jenkins-slave/workspace/mpich-main-ch4-ofi/compiler/clang/fabric_prov/sockets/jenkins_configure/default/label/centos64/mpich-main/src/include/mpi.h:31:84: note: expanded from macro 'MPICH_ATTR_POINTER_WITH_TYPE_TAG'
#    define MPICH_ATTR_POINTER_WITH_TYPE_TAG(buffer_idx, type_idx)  __attribute__((pointer_with_type_tag(MPI,buffer_idx,type_idx)))
```

is really showing the error that we didn't adjust the `idx` for QMPI functions, which have `2` extra parameters. It escaped our tests previously only because the attributes were disabled.


[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
