### PR TITLE
request: Remove volatile qualifier from MPIR_cc_t

### DIFF
--- a/src/include/mpir_refcount_global.h
+++ b/src/include/mpir_refcount_global.h
@@ -9,7 +9,7 @@
 /* define a type for the completion counter */
 /* memory barriers aren't needed in this impl, because all access to completion
  * counters is done while holding the GLOBAL critical section */
-typedef volatile int MPIR_cc_t;
+typedef int MPIR_cc_t;
 #define MPIR_cc_get(cc_) (cc_)
 #define MPIR_cc_set(cc_ptr_, val_) (*(cc_ptr_)) = (val_)
 #define MPIR_cc_is_complete(cc_ptr_) (0 == *(cc_ptr_))


### PR DESCRIPTION
## Pull Request Description

In the global critical section, completion counters are regular integers
because they are always read or written under lock by any thread. The
volatile qualifier offers no additional protection in this scenario, and
can be removed.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
