### PR TITLE
ch4/part: Fix reference counting for unstarted requests

### DIFF
--- a/src/mpid/ch4/src/mpidig_part.c
+++ b/src/mpid/ch4/src/mpidig_part.c
@@ -162,6 +162,9 @@ int MPIDIG_mpi_precv_init(void *buf, int partitions, int count,
 
         MPIDIG_precv_matched(*request);
     } else {
+        /* add a reference for handshake */
+        MPIR_Request_add_ref(*request);
+
         MPIDIG_enqueue_request(*request, &MPIDI_global.part_posted_list, MPIDIG_PART);
     }
 

--- a/src/mpid/ch4/src/mpidig_part_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_part_callbacks.c
@@ -68,6 +68,9 @@ int MPIDIG_part_send_init_target_msg_cb(void *am_hdr, void *data,
         if (MPIR_Part_request_is_active(posted_req)) {
             mpi_errno = MPIDIG_part_issue_cts(posted_req);
         }
+
+        /* release handshake reference */
+        MPIR_Request_free_unsafe(posted_req);
     } else {
         MPIR_Request *unexp_req = NULL;
 

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1231,6 +1231,7 @@
 /mpi_t/mpit_vars
 /mpi_t/qmpi_test
 /part/multipart
+/part/no_start
 /part/nonblocking_pready
 /part/parrived
 /part/parrived_pready_out_of_order

--- a/test/mpi/part/Makefile.am
+++ b/test/mpi/part/Makefile.am
@@ -21,7 +21,8 @@ noinst_PROGRAMS =  \
     parrived_pready_out_of_order   \
     pingping                       \
     multipart                      \
-    nonblocking_pready
+    nonblocking_pready             \
+    no_start
 
 
 start_pready_wait_CPPFLAGS = -DTEST_WAIT $(AM_CPPFLAGS)

--- a/test/mpi/part/no_start.c
+++ b/test/mpi/part/no_start.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include "mpitest.h"
+
+/*
+static char MTEST_Descrip[] = "Test for a partitioned request that is never started";
+*/
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    MTest_Init(&argc, &argv);
+
+    int size;
+    int rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (size < 2) {
+        fprintf(stderr, "This test requires at least two processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    int a;
+    MPI_Request request;
+    if (rank == 0) {
+        MPI_Psend_init(&a, 1, 1, MPI_INT, 1, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &request);
+    } else if (rank == 1) {
+        MPI_Precv_init(&a, 1, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &request);
+    }
+
+    if (rank < 2) {
+        MPI_Request_free(&request);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/part/testlist
+++ b/test/mpi/part/testlist
@@ -40,4 +40,4 @@ parrived_pready_out_of_order 2 arg=-spart=16 arg=-rpart=32 arg=-tot_count=512 ar
 
 multipart 2
 nonblocking_pready 2
-
+no_start 2


### PR DESCRIPTION
## Pull Request Description

If a partitioned request is freed without ever being started, then the handshake packet handlers may try to access an already freed request. Solve the issue by adding a request reference for the handshake protocol.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
