### PR TITLE
build: accelerate CI build by prebuild modules

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -79,6 +79,12 @@ for arg in "$@" ; do
         do_hydra=yes
         do_hydra2=no
         do_romio=no
+
+        if test -e 'modules.tar.gz' -a ! -e 'modules/PREBUILT' ; then
+            echo_n "Untaring modules.tar.gz... "
+            tar xf modules.tar.gz
+            echo "done"
+        fi
     fi
 done
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -71,6 +71,8 @@ do_quick=no
 for arg in "$@" ; do
     if test $arg = "-quick"; then
         do_quick=yes
+        do_hwloc=no
+        do_json=no
         do_izem=no
         do_ofi=no
         do_ucx=no

--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -84,9 +84,13 @@ AC_DEFUN([PAC_CONFIG_HWLOC],[
     if test "$with_hwloc" = "embedded" ; then
         m4_if(hwloc_embedded_dir, [modules/hwloc], [
             dnl ---- the main MPICH configure ----
-            PAC_CONFIG_HWLOC_EMBEDDED([$VISIBILITY_CFLAGS])
-            hwlocsrcdir="${main_top_builddir}/modules/hwloc"
-            hwloclib="${main_top_builddir}/modules/hwloc/hwloc/libhwloc_embedded.la"
+            hwloclib="modules/hwloc/hwloc/libhwloc_embedded.la"
+            if test -e "${use_top_srcdir}/modules/PREBUILT" -a -e "$hwloclib"; then
+                hwlocsrcdir=""
+            else
+                hwlocsrcdir="${main_top_builddir}/modules/hwloc"
+                PAC_CONFIG_HWLOC_EMBEDDED([$VISIBILITY_CFLAGS])
+            fi
             PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/hwloc/include],[CPPFLAGS])
             PAC_APPEND_FLAG([-I${main_top_builddir}/modules/hwloc/include],[CPPFLAGS])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1083,10 +1083,14 @@ PAC_CHECK_HEADER_LIB_EXPLICIT([zm],[lock/zm_ticket.h],[$ZMLIBNAME],[zm_ticket_in
 if test "$enable_izem_queue" != "no" && test "$enable_izem_queue" != "none"; then
     if test "$with_zm" = "embedded" ; then
         if test -e "${use_top_srcdir}/modules/izem" ; then
-            zm_subdir_args="--enable-embedded"
-            PAC_CONFIG_SUBDIR_ARGS([modules/izem],[$zm_subdir_args],[],[AC_MSG_ERROR(Izem configure failed)])
-            zmsrcdir="${main_top_builddir}/modules/izem"
-            zmlib="${main_top_builddir}/modules/izem/src/lib${ZMLIBNAME}.la"
+            zmlib="modules/izem/src/lib${ZMLIBNAME}.la"
+            if test -e "${use_top_srcdir}/modules/PREBUILT" -a -e "$zmlib"; then
+                zmsrcdir=""
+            else
+                zm_subdir_args="--enable-embedded"
+                PAC_CONFIG_SUBDIR_ARGS([modules/izem],[$zm_subdir_args],[],[AC_MSG_ERROR(Izem configure failed)])
+                zmsrcdir="${main_top_builddir}/modules/izem"
+            fi
             PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/izem/src/include],[CPPFLAGS])
             PAC_APPEND_FLAG([-I${main_top_builddir}/modules/izem/src/include],[CPPFLAGS])
         else
@@ -1103,12 +1107,16 @@ AC_SUBST([jsonsrcdir])
 jsonlib=""
 AC_SUBST([jsonlib])
 
-PAC_PUSH_ALL_FLAGS()
-PAC_RESET_ALL_FLAGS()
-PAC_CONFIG_SUBDIR_ARGS([modules/json-c],[--enable-embedded --disable-werror],[],[AC_MSG_ERROR(json-c configure failed)])
-PAC_POP_ALL_FLAGS()
-jsonsrcdir="${main_top_builddir}/modules/json-c"
-jsonlib="${main_top_builddir}/modules/json-c/libjson-c.la"
+jsonlib="modules/json-c/libjson-c.la"
+if test -e "${use_top_srcdir}/modules/PREBUILT" -a -e "$jsonlib"; then
+    jsonsrcdir=""
+else
+    PAC_PUSH_ALL_FLAGS()
+    PAC_RESET_ALL_FLAGS()
+    PAC_CONFIG_SUBDIR_ARGS([modules/json-c],[--enable-embedded --disable-werror],[],[AC_MSG_ERROR(json-c configure failed)])
+    PAC_POP_ALL_FLAGS()
+    jsonsrcdir="${main_top_builddir}/modules/json-c"
+fi
 PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/json-c],[CPPFLAGS])
 PAC_APPEND_FLAG([-I${main_top_builddir}/modules/json-c],[CPPFLAGS])
 

--- a/maint/prebuild_modules.sh
+++ b/maint/prebuild_modules.sh
@@ -1,0 +1,74 @@
+#! /usr/bin/env bash
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+# Prebuild modules into modules.tar.gz. Copy the tarball to a fresh git cloned repository,
+# both autogen.sh and configure will skip them in the build process.
+#
+# This is to accelerate repeated CI testing.
+#
+
+git submodule update --init
+
+make_it_lean () {
+    rm -rf .git
+    find . -name '*.o' | xargs rm -f
+}
+
+pushd modules/hwloc
+./autogen.sh
+./configure CFLAGS=-fvisibility=hidden \
+    --enable-embedded-mode --enable-visibility=no \
+    --disable-libxml2 --disable-nvml --disable-cuda --disable-opencl --disable-rsmi
+make
+make_it_lean
+popd
+
+pushd modules/json-c
+./autogen.sh
+./configure --enable-embedded --disable-werror
+make
+make_it_lean
+popd
+
+pushd modules/yaksa
+extra_option=
+if test -d "$CUDA_DIR" ; then
+    extra_option=--with-cuda=$CUDA_DIR
+fi
+./autogen.sh
+./configure --enable-embedded $extra_option
+make
+make_it_lean
+popd
+
+pushd modules/libfabric
+extra_option=
+if test $(uname) = "FreeBSD" ; then
+    extra_option='--disable-verbs'
+fi
+./autogen.sh
+./configure --enable-embedded $extra_option
+make
+make_it_lean
+popd
+
+# ucx need make install to work, which need replace all hardcoded paths to work
+pushd modules/ucx
+./autogen.sh
+if false ; then
+    # skip for now
+    ./configure --prefix=/MODPREFIX --disable-static
+    make
+    find . -name '*.la' | xargs --verbose sed -i "s,$PWD,MODDIR,g"
+fi
+make_it_lean
+popd
+
+# Add a flag to mark modules as pre-built. Remove the flag file to allow configure
+# reconfigure and rebuild modules.
+touch modules/PREBUILT
+
+tar czf modules.tar.gz modules

--- a/src/mpi/datatype/typerep/src/subconfigure.m4
+++ b/src/mpi/datatype/typerep/src/subconfigure.m4
@@ -46,17 +46,18 @@ AM_COND_IF([BUILD_YAKSA_ENGINE], [
 m4_define([yaksa_embedded_dir],[modules/yaksa])
 PAC_CHECK_HEADER_LIB_EXPLICIT([yaksa],[yaksa.h],[$YAKSALIBNAME],[yaksa_init])
 if test "$with_yaksa" = "embedded" ; then
-    PAC_PUSH_ALL_FLAGS()
-    PAC_RESET_ALL_FLAGS()
-    # no need for libtool versioning when embedding YAKSA
-    yaksa_subdir_args="--enable-embedded"
-    PAC_CONFIG_SUBDIR_ARGS([modules/yaksa],[$yaksa_subdir_args],[],[AC_MSG_ERROR(YAKSA configure failed)])
-    PAC_POP_ALL_FLAGS()
+    yaksalib="modules/yaksa/lib${YAKSALIBNAME}.la"
+    if test ! -e "$yaksalib" ; then
+        PAC_PUSH_ALL_FLAGS()
+        PAC_RESET_ALL_FLAGS()
+        # no need for libtool versioning when embedding YAKSA
+        yaksa_subdir_args="--enable-embedded"
+        PAC_CONFIG_SUBDIR_ARGS([modules/yaksa],[$yaksa_subdir_args],[],[AC_MSG_ERROR(YAKSA configure failed)])
+        PAC_POP_ALL_FLAGS()
+        yaksasrcdir="modules/yaksa"
+    fi
     PAC_APPEND_FLAG([-I${main_top_builddir}/modules/yaksa/src/frontend/include], [CPPFLAGS])
     PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/yaksa/src/frontend/include], [CPPFLAGS])
-
-    yaksasrcdir="modules/yaksa"
-    yaksalib="modules/yaksa/lib${YAKSALIBNAME}.la"
 fi
 ])
 

--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -303,14 +303,19 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
             AC_MSG_NOTICE([Enabling direct embedded provider: ${ofi_direct_provider}])
         fi
 
-        ofi_subdir_args="$ofi_subdir_args $prov_config"
-
-        dnl Unset all of these env vars so they don't pollute the libfabric configuration
-        PAC_PUSH_ALL_FLAGS()
-        PAC_RESET_ALL_FLAGS()
-        CFLAGS="$CFLAGS $VISIBILITY_CFLAGS"
-        PAC_CONFIG_SUBDIR_ARGS([modules/libfabric],[$ofi_subdir_args],[],[AC_MSG_ERROR(libfabric configure failed)])
-        PAC_POP_ALL_FLAGS()
+        ofilib="modules/libfabric/src/libfabric.la"
+        if test -e "${use_top_srcdir}/modules/PREBUILT" -a -e "$ofilib"; then
+            ofisrcdir=""
+        else
+            ofi_subdir_args="$ofi_subdir_args $prov_config"
+            dnl Unset all of these env vars so they don't pollute the libfabric configuration
+            PAC_PUSH_ALL_FLAGS()
+            PAC_RESET_ALL_FLAGS()
+            CFLAGS="$CFLAGS $VISIBILITY_CFLAGS"
+            PAC_CONFIG_SUBDIR_ARGS([modules/libfabric],[$ofi_subdir_args],[],[AC_MSG_ERROR(libfabric configure failed)])
+            PAC_POP_ALL_FLAGS()
+            ofisrcdir="${main_top_builddir}/modules/libfabric"
+        fi
         PAC_APPEND_FLAG([-I${main_top_builddir}/modules/libfabric/include], [CPPFLAGS])
         PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/libfabric/include], [CPPFLAGS])
 
@@ -319,9 +324,6 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
             PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/libfabric/prov/${ofi_direct_provider}/include], [CPPFLAGS])
             PAC_APPEND_FLAG([-DFABRIC_DIRECT],[CPPFLAGS])
         fi
-
-        ofisrcdir="${main_top_builddir}/modules/libfabric"
-        ofilib="modules/libfabric/src/libfabric.la"
     else
         AC_MSG_NOTICE([CH4 OFI Netmod:  Using an external libfabric])
         PAC_LIBS_ADD([-lfabric])

--- a/src/mpid/ch4/netmod/ucx/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ucx/subconfigure.m4
@@ -39,21 +39,25 @@ AM_COND_IF([BUILD_CH4_NETMOD_UCX],[
         with_ucx=embedded
     fi
     if test "$with_ucx" = "embedded" ; then
-        PAC_PUSH_ALL_FLAGS()
-        PAC_RESET_ALL_FLAGS()
-        if test "$enable_fast" = "yes" -o "$enable_fast" = "all" ; then
-            # add flags from contrib/configure-release and contrib/configure-opt scripts in the ucx source
-            ucx_opt_flags="--disable-logging --disable-debug --disable-assertions --disable-params-check --enable-optimizations"
+        ucxlib="modules/ucx/src/ucp/libucp.la"
+        if test -e "${use_top_srcdir}/modules/PREBUILT" -a -e "$ucxlib"; then
+            ucxdir=""
         else
-            ucx_opt_flags=""
+            PAC_PUSH_ALL_FLAGS()
+            PAC_RESET_ALL_FLAGS()
+            if test "$enable_fast" = "yes" -o "$enable_fast" = "all" ; then
+                # add flags from contrib/configure-release and contrib/configure-opt scripts in the ucx source
+                ucx_opt_flags="--disable-logging --disable-debug --disable-assertions --disable-params-check --enable-optimizations"
+            else
+                ucx_opt_flags=""
+            fi
+            PAC_CONFIG_SUBDIR_ARGS([modules/ucx],[--disable-static --enable-embedded --with-java=no $ucx_opt_flags],[],[AC_MSG_ERROR(ucx configure failed)])
+            PAC_POP_ALL_FLAGS()
+            ucxdir="modules/ucx"
         fi
-        PAC_CONFIG_SUBDIR_ARGS([modules/ucx],[--disable-static --enable-embedded --with-java=no $ucx_opt_flags],[],[AC_MSG_ERROR(ucx configure failed)])
-        PAC_POP_ALL_FLAGS()
         PAC_APPEND_FLAG([-I${main_top_builddir}/modules/ucx/src], [CPPFLAGS])
         PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/ucx/src], [CPPFLAGS])
 
-        ucxdir="modules/ucx"
-        ucxlib="modules/ucx/src/ucp/libucp.la"
     else
         dnl PAC_PROBE_HEADER_LIB must've been successful
         AC_MSG_NOTICE([CH4 UCX Netmod:  Using an external ucx])


### PR DESCRIPTION
## Pull Request Description

Every CI build will spend several minutes `autoconf`, `configure`, and `make` in submodules. These are dependencies and stable across various pull requests and testing jobs. Avoiding rebuild them can significantly save time in CI jobs, especially those simple ones such as warnings tests. For review tests, it can shorten the developer feedback time. For nightly tests, consider that we run hundreds of CI tests, they save quite some energy as well.

* add `maint/prebuild_modules.sh` that can be used to pre-build modules, create `modules.tar.gz`
* If `moldules.tar.gz` exist and run `autogen.sh -quick`, both autogen and configure will skip pre-built modules

## Why not use external libs
That's one way to avoid rebuilding modules. Potential points --
* Maintaining external install paths can be a hassle.
* We'd like for our CI tests to test the embedded module versions. It is difficult to ensure the external installations are always up-to-date.
* Other than avoiding rebuilding, the rest of the build is *exactly* like an embedded build. Linking externally may have different behavior from an embedded build.
* We have separate "external" tests already.

## Further ideas:
* split configure of `test/mpi` -- https://github.com/pmodels/mpich/pull/5067
   Not all jobs need to run the full test suite.
* create separate `Fortran and `io` tests and skip both for most review jobs
* Add options to do "amalgamation" -- [ref](https://www.sqlite.org/amalgamation.html)
   It will cut significant make time considering that we have so many repeated inline headers

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
