### PR TITLE
f08: avoid using MPL memory functions in f08

### DIFF
--- a/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_c.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_c.c
@@ -26,7 +26,7 @@ int MPIR_Comm_spawn_c(const char *command, char *argv_f, int maxprocs, MPI_Info 
         PMPI_Comm_spawn(command, argv_c, maxprocs, info, root, comm, intercomm, array_of_errcodes);
 
     if (argv_c != MPI_ARGV_NULL) {
-        MPL_free(argv_c);
+        free(argv_c);
     }
 
   fn_exit:

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_c.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_c.c
@@ -3,7 +3,6 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include "mpiimpl.h"
 #include "cdesc.h"
 
 int MPIR_Comm_spawn_c(const char *command, char *argv_f, int maxprocs, MPI_Info info, int root,

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
@@ -52,13 +52,13 @@ int MPIR_Comm_spawn_multiple_c(int count, char *array_of_commands_f,
     if ((char ***) array_of_argv_f == MPI_ARGVS_NULL) {
         array_of_argv_c = MPI_ARGVS_NULL;
     } else {
-        array_of_argv_c = (char ***) MPL_malloc(sizeof(char **) * count, MPL_MEM_BUFFER);
+        array_of_argv_c = (char ***) malloc(sizeof(char **) * count);
         if (!array_of_argv_c)
             MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         /* Allocate a temp buf to put args of a command */
         len = 256;      /* length of buf. Initialized with an arbitrary value */
-        buf = (char *) MPL_malloc(sizeof(char) * len, MPL_MEM_BUFFER);
+        buf = (char *) malloc(sizeof(char) * len);
         if (!buf)
             MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
 
@@ -70,9 +70,9 @@ int MPIR_Comm_spawn_multiple_c(int count, char *array_of_commands_f,
             do {
                 if (offset + argv_elem_len > len) {     /* Make sure buf is big enough */
                     len = offset + argv_elem_len;
-                    newbuf = (char *) MPL_realloc(buf, len, MPL_MEM_BUFFER);
+                    newbuf = (char *) realloc(buf, len);
                     if (!newbuf) {
-                        MPL_free(buf);
+                        free(buf);
                         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
                     }
                     buf = newbuf;
@@ -96,25 +96,25 @@ int MPIR_Comm_spawn_multiple_c(int count, char *array_of_commands_f,
                 MPIR_Fortran_array_of_string_f2c(buf, &(array_of_argv_c[i]), argv_elem_len, 0, 0);
             if (mpi_errno != MPI_SUCCESS) {
                 for (j = i - 1; j >= 0; j--)
-                    MPL_free(array_of_argv_c[j]);
-                MPL_free(buf);
+                    free(array_of_argv_c[j]);
+                free(buf);
                 goto fn_fail;
             }
         }
 
-        MPL_free(buf);
+        free(buf);
     }
 
     mpi_errno = PMPI_Comm_spawn_multiple(count, array_of_commands_c, array_of_argv_c,
                                          array_of_maxprocs, array_of_info, root, comm, intercomm,
                                          array_of_errcodes);
 
-    MPL_free(array_of_commands_c);
+    free(array_of_commands_c);
 
     if (array_of_argv_c != MPI_ARGVS_NULL) {
         for (i = 0; i < count; i++)
-            MPL_free(array_of_argv_c[i]);
-        MPL_free(array_of_argv_c);
+            free(array_of_argv_c[i]);
+        free(array_of_argv_c);
     }
 
   fn_exit:

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
@@ -52,14 +52,18 @@ int MPIR_Comm_spawn_multiple_c(int count, char *array_of_commands_f,
         array_of_argv_c = MPI_ARGVS_NULL;
     } else {
         array_of_argv_c = (char ***) malloc(sizeof(char **) * count);
-        if (!array_of_argv_c)
-            MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
+        if (!array_of_argv_c) {
+            mpi_errno = MPI_ERR_OTHER;
+            goto fn_fail;
+        }
 
         /* Allocate a temp buf to put args of a command */
         len = 256;      /* length of buf. Initialized with an arbitrary value */
         buf = (char *) malloc(sizeof(char) * len);
-        if (!buf)
-            MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
+        if (!buf) {
+            mpi_errno = MPI_ERR_OTHER;
+            goto fn_fail;
+        }
 
         for (i = 0; i < count; i++) {
             /* Extract args of command i, and put them in buf */
@@ -72,7 +76,8 @@ int MPIR_Comm_spawn_multiple_c(int count, char *array_of_commands_f,
                     newbuf = (char *) realloc(buf, len);
                     if (!newbuf) {
                         free(buf);
-                        MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
+                        mpi_errno = MPI_ERR_OTHER;
+                        goto fn_fail;
                     }
                     buf = newbuf;
                 }

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
@@ -3,7 +3,6 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include "mpiimpl.h"
 #include "cdesc.h"
 
 int MPIR_Comm_spawn_multiple_c(int count, char *array_of_commands_f,

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
@@ -54,7 +54,7 @@ extern int MPIR_Fortran_array_of_string_f2c(const char *strs_f, char ***strs_c, 
     }
 
     /* Allocate memory for pointers to strings and the strings themself */
-    buf = (char *) MPL_malloc(sizeof(char *) * num_strs + sizeof(char) * (num_chars + num_strs), MPL_MEM_STRINGS);      /* Add \0 for each string */
+    buf = (char *) malloc(sizeof(char *) * num_strs + sizeof(char) * (num_chars + num_strs));   /* Add \0 for each string */
     if (buf == NULL) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
     }

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
@@ -55,7 +55,8 @@ extern int MPIR_Fortran_array_of_string_f2c(const char *strs_f, char ***strs_c, 
     /* Allocate memory for pointers to strings and the strings themself */
     buf = (char *) malloc(sizeof(char *) * num_strs + sizeof(char) * (num_chars + num_strs));   /* Add \0 for each string */
     if (buf == NULL) {
-        MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
+        mpi_errno = MPI_ERR_OTHER;
+        goto fn_fail;
     }
 
     *strs_c = (char **) buf;

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
@@ -3,7 +3,6 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include "mpiimpl.h"
 #include "cdesc.h"
 
 /*


### PR DESCRIPTION
## Pull Request Description

When compiled with debug options, MPL_malloc refers to MPL_trmalloc,
which now is hidden inside libmpi.so and cannot be accessed from
libmpifort.so.

This fixes nightly `debug` tests on FreeBSD. The bug is not new, but only manifested due to recent fix that hides MPL symbols in `libmpi.so`, and only when the build builds `f08`, and trying to link tests that uses the few functions that the PR fixes.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
