### PR TITLE
configure: fix typo in defining HAVE_FINT_IS_INT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3001,7 +3001,7 @@ if test "$enable_f77" = yes ; then
     fi
 
     # Include a defined value for Fint is int
-    if test "$SIZEOF_F77_INTEGER" != "$ac_cv_sizeof_int" ; then
+    if test "$SIZEOF_F77_INTEGER" == "$ac_cv_sizeof_int" ; then
         AC_DEFINE(HAVE_FINT_IS_INT,1,[Define if Fortran integer are the same size as C ints])
     else
         AC_MSG_WARN([Fortran integers and C ints are not the same size.  Support for this case is experimental; use at your own risk])


### PR DESCRIPTION
## Pull Request Description

The typo defined the opposite. When FINT actually is INT, it still
worked. But it breaks when we configure FINT to be different than INT.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
