### PR TITLE
f08: add missing string.h

### DIFF
--- a/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
@@ -4,6 +4,7 @@
  */
 
 #include "cdesc.h"
+#include <string.h>
 
 int MPIR_Comm_spawn_multiple_c(int count, char *array_of_commands_f,
                                char *array_of_argv_f, const int *array_of_maxprocs,

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
@@ -4,6 +4,7 @@
  */
 
 #include "cdesc.h"
+#include <string.h>
 
 /*
   Convert an array of strings in Fortran Format to an array of strings in C format (i.e., char* a[]).


### PR DESCRIPTION
## Pull Request Description
Need include string.h for strncpy.

```
src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c:91:17: error: implicit declaration of function 'strncpy' [-Werror=implicit-function-declaration]
   91 |                 strncpy(buf + offset, arg, argv_elem_len);      /* Copy it even it is all blank */
      |                 ^~~~~~~
src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c:91:17: warning: incompatible implicit declaration of built-in function 'strncpy'
src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c:7:1: note: include '<string.h>' or provide a declaration of 'strncpy'
    6 | #include "cdesc.h"
  +++ |+#include <string.h>
    7 | 
```
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
