### PR TITLE
maint: remove autotools version check in release.pl

### DIFF
--- a/maint/release.pl
+++ b/maint/release.pl
@@ -151,13 +151,9 @@ check_package("autoconf");
 check_package("automake");
 print("\n");
 
-## IMPORTANT: Changing the autotools versions can result in ABI
-## breakage. So make sure the ABI string in the release tarball is
-## updated when you do that.
-check_autotools_version("autoconf", "2.69");
-check_autotools_version("automake", "1.15");
-check_autotools_version("libtool", "2.4.6");
-print("\n");
+## NOTE: Different autotools versions may result in accidental ABI chanages.
+## For flexibility, we no longer enforce the check for specific versions.
+## Always double check using the ABI compatibility tool before the final release.
 
 
 my $tdir = tempdir(CLEANUP => 1);


### PR DESCRIPTION

## Pull Request Description

It is not clear that autotools version change will always result in ABI
breakage. It is likely some autotool bugs in older versions. Remove the
check and add a note to advise to check ABI compatibility instead.

Fixes #5564 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
