### PR TITLE
binding/c: check userbuffer with displacement

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2034,7 +2034,9 @@ def dump_validate_userbuffer_neighbor_vw(func, kind, buf, ct, dt, disp):
         dt += '[i]'
         dump_validate_datatype(func, dt)
     G.out.append("MPIR_ERRTEST_COUNT(%s, mpi_errno);" % ct)
-    G.out.append("MPIR_ERRTEST_USERBUFFER(%s, %s, %s, mpi_errno);" % (buf, ct, dt))
+    G.out.append("if (%s[i] == 0) {" % disp)
+    G.out.append("    MPIR_ERRTEST_USERBUFFER(%s, %s, %s, mpi_errno);" % (buf, ct, dt))
+    G.out.append("}")
     dump_for_close()
 
 def dump_validate_userbuffer_reduce(func, sbuf, rbuf, ct, dt, op):
@@ -2164,7 +2166,11 @@ def dump_validate_userbuffer_coll(func, kind, buf, ct, dt, disp):
 
     # -- check count && buffer
     G.out.append("MPIR_ERRTEST_COUNT(%s, mpi_errno);" % ct)
+    if disp:
+        dump_if_open("%s[i] == 0" % disp)
     G.out.append("MPIR_ERRTEST_USERBUFFER(%s, %s, %s, mpi_errno);" % (buf, ct, dt))
+    if disp:
+        dump_if_close()
 
     if with_vw:
         dump_for_close() # i = 0:comm_size


### PR DESCRIPTION
## Pull Request Description
We need consider the case when displacement is set to the address and
the buffer is MPI_BOTTOM.

Fixes #5661 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
