### PR TITLE
xfail: fix typos

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -94,11 +94,11 @@
 * * * ch3:tcp *         /^mt_iprobe_isendrecv/          xfail=issue4258         test/mpi/threads/pt2pt/testlist
 * * * ch3:tcp *         /^mt_improbe_isendrecv/         xfail=issue4258         test/mpi/threads/pt2pt/testlist
 # pingping tests with large testsize currently fails async tests due to netmod handling of large message queue
-* * async * *           /^pingpingtestsize=32.*/         xfail=issue4474        test/mpi/pt2pt/testlist.dtp
+* * async * *           /^pingping .*testsize=32/        xfail=issue4474        test/mpi/pt2pt/testlist.dtp
 # dup_leak_test suffers from mutex unfairness issue under load for ch4:ofi
-* * * ch4:ofi *         /^dup_leak_testiter=12345.*/     xfail=issue4595        test/mpi/threads/comm/testlist
+* * * ch4:ofi *         /^dup_leak_test .*iter=12345.*/  xfail=issue4595        test/mpi/threads/comm/testlist
 # more mutex unfairness on freebsd64. note: check these after upgrading freebsd64 hardware
-* * * ch4:ofi freebsd64 /^dup_leak_testiter=1234.*/      xfail=issue4595        test/mpi/threads/comm/testlist
+* * * ch4:ofi freebsd64 /^dup_leak_test .*iter=1234.*/   xfail=issue4595        test/mpi/threads/comm/testlist
 * * * ch4:ofi freebsd64 /^alltoall/                      xfail=issue4595        test/mpi/threads/pt2pt/testlist
 # release-gather algorithm won't work with multithread
 * * async * *           /^.*_ALGORITHM=release_gather.*/ xfail=ticket0          test/mpi/coll/testlist.cvar


### PR DESCRIPTION
## Pull Request Description
The .* was accidentally omitted during previous commit
01dc636df7b378132125141f7f6ad4208323e2a5.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
