### PR TITLE
test: make xfail script work from test/mpi

### DIFF
--- a/test/mpi/maint/jenkins/set_xfail.py
+++ b/test/mpi/maint/jenkins/set_xfail.py
@@ -19,6 +19,8 @@ class RE:
 def main():
     parse_args()
     load_xfail_conf()
+    if os.path.exists('test/mpi'):
+        os.chdir('test/mpi')
     apply_xfails()
 
 # ---- subroutines --------------------------------------------
@@ -76,6 +78,7 @@ def load_xfail_conf():
             elif RE.match(r'\s*(.*?)\s*\/(.*)\/\s*xfail=(\w*)\s*(\S+)\s*$', line):
                 # -- new direct pattern
                 cond, pat, reason, testlist = RE.m.group(1, 2, 3, 4)
+                testlist = re.sub(r'^test\/mpi\/', '', testlist)
                 if match_states(cond, G.states):
                     cond = re.sub(r'\s\s+', ' ', cond)
                     if testlist not in G.xfails:

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -31,85 +31,85 @@
 ################################################################################
 
 # xfail ch4 bugs
-* * * ch4:ofi *         /^idup_comm_gen/ xfail=ticket3794        test/mpi/threads/comm/testlist
-* * * ch4:ofi *         /^idup_nb/       xfail=ticket3794        test/mpi/threads/comm/testlist
-* * * ch4:ucx *         /^idup_comm_gen/ xfail=ticket3794        test/mpi/threads/comm/testlist
-* * * ch4:ucx *         /^idup_nb/       xfail=ticket3794        test/mpi/threads/comm/testlist
+* * * ch4:ofi *         /^idup_comm_gen/ xfail=ticket3794        threads/comm/testlist
+* * * ch4:ofi *         /^idup_nb/       xfail=ticket3794        threads/comm/testlist
+* * * ch4:ucx *         /^idup_comm_gen/ xfail=ticket3794        threads/comm/testlist
+* * * ch4:ucx *         /^idup_nb/       xfail=ticket3794        threads/comm/testlist
 ################################################################################
 # misc special build
-* * nofast * *          /^large_acc_flush_local/ xfail=issue4663 test/mpi/rma/testlist
+* * nofast * *          /^large_acc_flush_local/ xfail=issue4663 rma/testlist
 #ch3:ofi
-* * * ch3:ofi *         /^manyget/               xfail=ticket0   test/mpi/rma/testlist
-* * * ch3:ofi *         /^manyrma2/              xfail=ticket0   test/mpi/rma/testlist
-* * * ch3:ofi *         /^manyrma2_shm/          xfail=ticket0   test/mpi/rma/testlist
+* * * ch3:ofi *         /^manyget/               xfail=ticket0   rma/testlist
+* * * ch3:ofi *         /^manyrma2/              xfail=ticket0   rma/testlist
+* * * ch3:ofi *         /^manyrma2_shm/          xfail=ticket0   rma/testlist
 ################################################################################
-* * * * osx             /^throwtest/            xfail=ticket0   test/mpi/errors/cxx/errhan/testlist
-* * * * osx             /^commerrx/             xfail=ticket0   test/mpi/errors/cxx/errhan/testlist
-* * * * osx             /^fileerrretx/          xfail=ticket0   test/mpi/errors/cxx/io/testlist
-* * * * osx             /^throwtestfilex/       xfail=ticket0   test/mpi/errors/cxx/io/testlist
-* gnu debug ch3:tcp osx /^namepubx/             xfail=issue3506 test/mpi/cxx/spawn/testlist
-* intel * * osx         /^statusesf08/          xfail=issue4374 test/mpi/f08/pt2pt/testlist
-* intel * * osx         /^vw_inplacef08/        xfail=issue4374 test/mpi/f08/coll/testlist
-* intel * * osx         /^red_scat_blockf08/    xfail=issue4374 test/mpi/f08/coll/testlist
-* intel * * osx         /^nonblocking_inpf08/   xfail=issue4374 test/mpi/f08/coll/testlist
-* intel * * osx         /^structf/              xfail=issue4374 test/mpi/f08/datatype/testlist
-* intel * * osx         /^aintf08/              xfail=issue4374 test/mpi/f08/rma/testlist
-* intel * * osx         /^dgraph_unwgtf90/      xfail=issue4374 test/mpi/f08/topo/testlist
+* * * * osx             /^throwtest/            xfail=ticket0   errors/cxx/errhan/testlist
+* * * * osx             /^commerrx/             xfail=ticket0   errors/cxx/errhan/testlist
+* * * * osx             /^fileerrretx/          xfail=ticket0   errors/cxx/io/testlist
+* * * * osx             /^throwtestfilex/       xfail=ticket0   errors/cxx/io/testlist
+* gnu debug ch3:tcp osx /^namepubx/             xfail=issue3506 cxx/spawn/testlist
+* intel * * osx         /^statusesf08/          xfail=issue4374 f08/pt2pt/testlist
+* intel * * osx         /^vw_inplacef08/        xfail=issue4374 f08/coll/testlist
+* intel * * osx         /^red_scat_blockf08/    xfail=issue4374 f08/coll/testlist
+* intel * * osx         /^nonblocking_inpf08/   xfail=issue4374 f08/coll/testlist
+* intel * * osx         /^structf/              xfail=issue4374 f08/datatype/testlist
+* intel * * osx         /^aintf08/              xfail=issue4374 f08/rma/testlist
+* intel * * osx         /^dgraph_unwgtf90/      xfail=issue4374 f08/topo/testlist
 ################################################################################
 # xfail large count tests on 32 bit architectures (cannot allocate such large memory)
-* * * * freebsd32       /^getfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   test/mpi/rma/testlist.dtp
-* * * * freebsd32       /^putfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   test/mpi/rma/testlist.dtp
-* * * * ubuntu32        /^getfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   test/mpi/rma/testlist.dtp
-* * * * ubuntu32        /^putfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   test/mpi/rma/testlist.dtp
+* * * * freebsd32       /^getfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   rma/testlist.dtp
+* * * * freebsd32       /^putfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   rma/testlist.dtp
+* * * * ubuntu32        /^getfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   rma/testlist.dtp
+* * * * ubuntu32        /^putfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   rma/testlist.dtp
 # intercomm abort test are expected to fail since MPI_Finalize will try to perform Allreduce on all process (includeing the aborted ones)
-* * * * *               /^intercomm_abort/       xfail=ticket0   test/mpi/errors/comm/testlist
+* * * * *               /^intercomm_abort/       xfail=ticket0   errors/comm/testlist
 # asan glitches with ucx for large buffer (when greater than ~1GB)
-* * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   test/mpi/coll/testlist.dtp
-* * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   test/mpi/pt2pt/testlist.dtp
-* * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   test/mpi/rma/testlist.dtp
+* * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   coll/testlist.dtp
+* * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   pt2pt/testlist.dtp
+* * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   rma/testlist.dtp
 # Bug - Github Issue https://github.com/pmodels/mpich/issues/3618
-* * * ch4:ucx *         /^darray_pack/   xfail=ticket0   test/mpi/datatype/testlist
+* * * ch4:ucx *         /^darray_pack/   xfail=ticket0   datatype/testlist
 # Collectivess other than bcast don't currently detect mismatched datatype lengths
-* * * * *               /^reducelength/         xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^ireducelength/        xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^allreducelength/      xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^iallreducelength/     xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^reduceop/             xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^ireduceop/            xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^gatherlength/         xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^igatherlength/        xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^allgatherlength/      xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^iallgatherlength/     xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^alltoalllength/       xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^ialltoalllength/      xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^scatterlength/        xfail=ticket3655        test/mpi/errors/coll/testlist
-* * * * *               /^iscatterlength/       xfail=ticket3655        test/mpi/errors/coll/testlist
+* * * * *               /^reducelength/         xfail=ticket3655        errors/coll/testlist
+* * * * *               /^ireducelength/        xfail=ticket3655        errors/coll/testlist
+* * * * *               /^allreducelength/      xfail=ticket3655        errors/coll/testlist
+* * * * *               /^iallreducelength/     xfail=ticket3655        errors/coll/testlist
+* * * * *               /^reduceop/             xfail=ticket3655        errors/coll/testlist
+* * * * *               /^ireduceop/            xfail=ticket3655        errors/coll/testlist
+* * * * *               /^gatherlength/         xfail=ticket3655        errors/coll/testlist
+* * * * *               /^igatherlength/        xfail=ticket3655        errors/coll/testlist
+* * * * *               /^allgatherlength/      xfail=ticket3655        errors/coll/testlist
+* * * * *               /^iallgatherlength/     xfail=ticket3655        errors/coll/testlist
+* * * * *               /^alltoalllength/       xfail=ticket3655        errors/coll/testlist
+* * * * *               /^ialltoalllength/      xfail=ticket3655        errors/coll/testlist
+* * * * *               /^scatterlength/        xfail=ticket3655        errors/coll/testlist
+* * * * *               /^iscatterlength/       xfail=ticket3655        errors/coll/testlist
 # some of the bcastlength test that is still failing
-* * * ch3:ofi *         /^ibcastlength/         xfail=issue3775         test/mpi/errors/coll/testlist
-* * * ch3:ofi *         /^bcastlength/          xfail=issue4373         test/mpi/errors/coll/testlist
+* * * ch3:ofi *         /^ibcastlength/         xfail=issue3775         errors/coll/testlist
+* * * ch3:ofi *         /^bcastlength/          xfail=issue4373         errors/coll/testlist
 # hwloc is unable to detect topology info on FreeBSD in strict mode with GCC
-* gnu strict * freebsd64        /^cmsplit_type/         xfail=ticket3972        test/mpi/comm/testlist
-* gnu strict * freebsd32        /^cmsplit_type/         xfail=ticket3972        test/mpi/comm/testlist
+* gnu strict * freebsd64        /^cmsplit_type/         xfail=ticket3972        comm/testlist
+* gnu strict * freebsd32        /^cmsplit_type/         xfail=ticket3972        comm/testlist
 # multi-threading tests failing for ch3 freebsd64
-* * * ch3:tcp *         /^mt_iprobe_isendrecv/          xfail=issue4258         test/mpi/threads/pt2pt/testlist
-* * * ch3:tcp *         /^mt_improbe_isendrecv/         xfail=issue4258         test/mpi/threads/pt2pt/testlist
+* * * ch3:tcp *         /^mt_iprobe_isendrecv/          xfail=issue4258         threads/pt2pt/testlist
+* * * ch3:tcp *         /^mt_improbe_isendrecv/         xfail=issue4258         threads/pt2pt/testlist
 # pingping tests with large testsize currently fails async tests due to netmod handling of large message queue
-* * async * *           /^pingping .*testsize=32/        xfail=issue4474        test/mpi/pt2pt/testlist.dtp
+* * async * *           /^pingping .*testsize=32/        xfail=issue4474        pt2pt/testlist.dtp
 # dup_leak_test suffers from mutex unfairness issue under load for ch4:ofi
-* * * ch4:ofi *         /^dup_leak_test .*iter=12345.*/  xfail=issue4595        test/mpi/threads/comm/testlist
+* * * ch4:ofi *         /^dup_leak_test .*iter=12345.*/  xfail=issue4595        threads/comm/testlist
 # more mutex unfairness on freebsd64. note: check these after upgrading freebsd64 hardware
-* * * ch4:ofi freebsd64 /^dup_leak_test .*iter=1234.*/   xfail=issue4595        test/mpi/threads/comm/testlist
-* * * ch4:ofi freebsd64 /^alltoall/                      xfail=issue4595        test/mpi/threads/pt2pt/testlist
+* * * ch4:ofi freebsd64 /^dup_leak_test .*iter=1234.*/   xfail=issue4595        threads/comm/testlist
+* * * ch4:ofi freebsd64 /^alltoall/                      xfail=issue4595        threads/pt2pt/testlist
 # release-gather algorithm won't work with multithread
-* * async * *           /^.*_ALGORITHM=release_gather.*/ xfail=ticket0          test/mpi/coll/testlist.cvar
+* * async * *           /^.*_ALGORITHM=release_gather.*/ xfail=ticket0          coll/testlist.cvar
 # freebsd failures
-* * debug ch3:tcp freebsd64     /^comm_create_group_threads/     xfail=issue4372        test/mpi/threads/comm/testlist
+* * debug ch3:tcp freebsd64     /^comm_create_group_threads/     xfail=issue4372        threads/comm/testlist
 
 # timeout due to lack of passive progress
-* * vci ch4:ofi *       /^rma_contig.*iter=10000/        xfail=issue5565        test/mpi/rma/testlist
+* * vci ch4:ofi *       /^rma_contig.*iter=10000/        xfail=issue5565        rma/testlist
 
 # Job-sepecific xfails
 # Our Arm servers are too slow for some tests
-mpich-main-arm.* * * * * /^sendflood /          xfail=ticket0       test/mpi/pt2pt/testlist
-mpich-main-arm.* * * * * /^nonblocking3 /       xfail=ticket0       test/mpi/coll/testlist
-mpich-main-arm.* * * * * /^alltoall /           xfail=ticket0       test/mpi/threads/pt2pt/testlist
+mpich-main-arm.* * * * * /^sendflood /          xfail=ticket0       pt2pt/testlist
+mpich-main-arm.* * * * * /^nonblocking3 /       xfail=ticket0       coll/testlist
+mpich-main-arm.* * * * * /^alltoall /           xfail=ticket0       threads/pt2pt/testlist


### PR DESCRIPTION
## Pull Request Description
Currently we autoconf test/mpi from mpich top directory. Make the xfail
scripts also work inside test/mpi/ so that we can autoconf and apply
xfail from test/mpi as well.

This commit is picked from #5067. It makes xfail scripts more flexible and can be applied either from `test/mpi/` or mpich top directory.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
