### PR TITLE
config: do not probe fortran compiler if --disable-fortran

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -697,10 +697,6 @@ AS_IF([test "x$enable_fc"  = "xno"],[FC=no])
 : ${CXXFLAGS=""}
 AC_PROG_CXX
 
-# suppress default "-g -O2" from AC_PROG_FC
-: ${FCFLAGS=""}
-AC_PROG_FC
-
 enable_f77=no
 enable_fc=no
 case "$enable_fortran" in
@@ -715,22 +711,29 @@ case "$enable_fortran" in
             ;;
 esac
 
-# HACK, use $FC as F77. We should remove all the F77 usages.
-if test "$enable_fc" = "yes" ; then
-    F77=$FC
-   if test ! -z "$FCFLAGS" ; then
-      FFLAGS=$FCFLAGS
-   fi
+if test "$enable_fortran" != "no" ; then
+    # suppress default "-g -O2" from AC_PROG_FC
+    : ${FCFLAGS=""}
+    AC_PROG_FC
+
+    # HACK, use $FC as F77. We should remove all the F77 usages.
+    if test "$enable_fc" = "yes" ; then
+        F77=$FC
+        if test ! -z "$FCFLAGS" ; then
+            FFLAGS=$FCFLAGS
+        fi
+    fi
+
+    # This needs to come after we've potentially set F77=$FC. Otherwise, we could
+    # override the user's Fortran compiler selection when only specifying FC at configure
+    # time, as is allowed.
+    # suppress default "-g -O2" from AC_PROG_F77
+    : ${FFLAGS=""}
+    AC_PROG_F77
+
 fi
 
-AM_CONDITIONAL([INSTALL_MPIF77],[test "$F77" != "$FC" -a "$FFLAGS" != "$FCFLAGS"])
-
-# This needs to come after we've potentially set F77=$FC. Otherwise, we could
-# override the user's Fortran compiler selection when only specifying FC at configure
-# time, as is allowed.
-# suppress default "-g -O2" from AC_PROG_F77
-: ${FFLAGS=""}
-AC_PROG_F77
+AM_CONDITIONAL([INSTALL_MPIF77],[test "$enable_fc" = "yes" -a "$F77" != "$FC" -a "$FFLAGS" != "$FCFLAGS"])
 
 # compute canonical system types
 AC_CANONICAL_BUILD


### PR DESCRIPTION
## Pull Request Description
Some build system, e.g. spack, uses fake fortran compiler and even
probing it with AC_PROG_FC may end up turning off the shared library
option from libtool. Both spack and libtool can do something to fix this
behavior, but let's see if we can simply clean it here.

Fixes #5674


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
