### PR TITLE
binding/f08: fix a few bugs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3004,7 +3004,7 @@ if test "$enable_f77" = yes ; then
     fi
 
     # Include a defined value for Fint is int
-    if test "$SIZEOF_F77_INTEGER" == "$ac_cv_sizeof_int" ; then
+    if test "$pac_cv_f77_sizeof_integer" == "$ac_cv_sizeof_int" ; then
         AC_DEFINE(HAVE_FINT_IS_INT,1,[Define if Fortran integer are the same size as C ints])
     else
         AC_MSG_WARN([Fortran integers and C ints are not the same size.  Support for this case is experimental; use at your own risk])
@@ -4207,7 +4207,7 @@ if test "$f08_works" = "yes" ; then
     if test "$enable_romio" = "no" ; then
         cmd="$cmd -no-mpiio"
     fi
-    cmd="$cmd -fint-size=$SIZEOF_F77_INTEGER -aint-size=$MPI_SIZEOF_AINT -count-size=$MPI_SIZEOF_COUNT -cint-size=$ac_cv_sizeof_int"
+    cmd="$cmd -fint-size=$pac_cv_f77_sizeof_integer -aint-size=$MPI_SIZEOF_AINT -count-size=$MPI_SIZEOF_COUNT -cint-size=$ac_cv_sizeof_int"
     AC_CONFIG_COMMANDS([gen_binding_f08], [$cmd_gen_binding_f08], [cmd_gen_binding_f08="$cmd"])
 fi
 

--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -1575,16 +1575,19 @@ def get_real_POLY_kinds():
         elif "MPI_COUNT_KIND" in fortran_type:
             return "count"
         else:
-            raise Exception("Unrecognized POLY type")
+            raise Exception("Unrecognized POLY int type: %s" % fortran_type)
 
     small_map = G.MAPS['SMALL_F08_KIND_MAP']
     large_map = G.MAPS['BIG_F08_KIND_MAP']
     for kind in small_map:
-        if small_map[kind].startswith('POLY'):
+        if kind == 'POLYFUNCTION':
+            # TODO: potentially tricky. Might be easier to treat individual function case by case.
+            G.real_poly_kinds[kind] = 1
+        elif kind.startswith('POLY'):
             a = get_int_type(small_map[kind]) + "-size"
             b = get_int_type(large_map[kind]) + "-size"
             if G.opts[a] != G.opts[b]:
-                G.real_poly_kinds['kind'] = 1
+                G.real_poly_kinds[kind] = 1
 
 def function_has_real_POLY_parameters(func):
     for p in func['parameters']:

--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -173,7 +173,7 @@ def dump_f08_wrappers_f(func, is_large):
     has_comm_size = False  # arrays of length = comm_size
     status_var = ""
     status_count = ""
-    is_alltoallw = False
+    is_alltoallvw = False
 
     if need_cdesc(func):
         f08ts_name = get_f08ts_name(func, is_large)
@@ -189,28 +189,33 @@ def dump_f08_wrappers_f(func, is_large):
         arg_list_2.append("c_null_ptr")
         arg_list_2.append("c_null_ptr")
         uses['c_null_ptr'] = 1
-    elif RE.match(r'mpi_i?alltoallw', func['name'], re.IGNORECASE):
-        # Need check MPI_IN_PLACE in order to skip sendtypes array
-        is_alltoallw = True
+    elif RE.match(r'mpi_i?alltoall[vw]', func['name'], re.IGNORECASE):
+        # Need check MPI_IN_PLACE in order to skip accessing sender arrays
+        is_alltoallvw = True
         uses['c_loc'] = 1
         uses['c_associated'] = 1
         uses['MPI_IN_PLACE'] = 1
 
     # alltoallw inplace hack (since it is a corner case)
-    def dump_alltoallw_inplace(arg_list_1, arg_list_2, convert_list_2):
+    def dump_alltoallvw_inplace(arg_list_1, arg_list_2, convert_list_2):
         # cannot use like sendcounts(1:length)
         if G.opts['fint-size'] == G.opts['cint-size']:
-            send_args = "sendbuf, sendcounts, sdispls, sendtypes(1:1)%MPI_VAL"
-            args1 = send_args + ", " + ', '.join(arg_list_1[4:])
+            if re.match(r'mpi_i?alltoallw', func['name'], re.IGNORECASE):
+                send_args = "sendbuf, sendcounts, sdispls, sendtypes(1:1)%MPI_VAL"
+                args1 = send_args + ", " + ', '.join(arg_list_1[4:])
+            else:
+                # alltoallv is fine
+                args1 = ', '.join(arg_list_1)
             dump_fortran_line("ierror_c = %s(%s)" % (c_func_name, args1))
         else:
             args2 = ', '.join(arg_list_2)
             G.out.append("sendcounts_c = sendcounts(1:1)")
-            G.out.append("sdispls_c = sdispls_c(1:1)")
-            G.out.append("sendtypes_c = sendtypes(1:1)%MPI_VAL")
+            G.out.append("sdispls_c = sdispls(1:1)")
             G.out.append("recvcounts_c = recvcounts(1:length)")
-            G.out.append("rdispls_c = rdispls_c(1:length)")
-            G.out.append("recvtypes_c = recvtypes(1:length)%MPI_VAL")
+            G.out.append("rdispls_c = rdispls(1:length)")
+            if re.match(r'mpi_i?alltoallw', func['name'], re.IGNORECASE):
+                G.out.append("sendtypes_c = sendtypes(1:1)%MPI_VAL")
+                G.out.append("recvtypes_c = recvtypes(1:length)%MPI_VAL")
             dump_fortran_line("ierror_c = %s(%s)" % (c_func_name, args2))
             G.out.extend(convert_list_2)
 
@@ -590,7 +595,7 @@ def dump_f08_wrappers_f(func, is_large):
             has_attribute_val = True
         f_param_list.append(p['name'])
         f_decl = get_F_decl(p, f08_mapping)
-        if is_alltoallw and p['name'] == 'sendbuf':
+        if is_alltoallvw and p['name'] == 'sendbuf':
             f_decl = re.sub(r' ::', ', TARGET ::', f_decl)
         f_decl_list.append(f_decl)
         check_decl_uses(f_decl, uses)
@@ -703,9 +708,9 @@ def dump_f08_wrappers_f(func, is_large):
     else:
         ret = 'res'
 
-    if is_alltoallw:
+    if is_alltoallvw:
         dump_F_if_open("c_associated(c_loc(sendbuf), c_loc(MPI_IN_PLACE))")
-        dump_alltoallw_inplace(arg_list_1, arg_list_2, convert_list_2)
+        dump_alltoallvw_inplace(arg_list_1, arg_list_2, convert_list_2)
         dump_F_else()
     if need_check_int_kind and G.opts['fint-size'] == G.opts['cint-size']:
         dump_call("%s = %s(%s)" % (ret, c_func_name, ', '.join(arg_list_1)), False)
@@ -714,7 +719,7 @@ def dump_f08_wrappers_f(func, is_large):
         dump_call("%s = %s(%s)" % (ret, c_func_name, ', '.join(arg_list_2)), True)
         G.out.extend(convert_list_2)
 
-    if is_alltoallw:
+    if is_alltoallvw:
         dump_F_if_close()
     G.out.append("")
 

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -99,11 +99,8 @@ AC_ARG_ENABLE(echo,
 AC_ARG_ENABLE(fortran,
 [  --enable-fortran=option - Control the level of Fortran support in the MPICH implementation.
         yes|all   - Enable all available Fortran implementations (F77, F90, F08)
-        f77       - Enable Fortran 77 support
-        f90       - Enable Fortran 90 support
-        f08       - Enable Fortran 2008 support
         no|none   - No Fortran support
-],,[enable_fortran=f77,f90])
+],,[enable_fortran=all])
 
 save_IFS="$IFS"
 IFS=","
@@ -121,15 +118,6 @@ for option in $enable_fortran ; do
                 enable_f77=no
                 enable_fc=no
                 enable_f08=no
-                ;;
-        f77)
-                enable_f77=yes
-                ;;
-        f90)
-                enable_fc=yes
-                ;;
-        f08)
-                enable_f08=yes
                 ;;
         *)
                 IFS="$save_IFS"

--- a/test/mpi/f08/init/baseenvf90.f90
+++ b/test/mpi/f08/init/baseenvf90.f90
@@ -44,7 +44,7 @@
       &              MPI_SUBVERSION
           print *, 'Version in get_version is ', iv, '.', isubv
        endif
-       if (iv .lt. 1 .or. iv .gt. 3) then
+       if (iv .lt. 1 .or. iv .gt. 4) then
           errs = errs + 1
           print *, 'Version of MPI is invalid (=', iv, ')'
        endif


### PR DESCRIPTION
## Pull Request Description
Fix a few bugs revealed in PR #5067 
* baseenvf90 test need account for MPI version 4 now
* `SIZEOF_F77_INTEGER` is no longer defined in configure
* `MPI_Alltoallv` need the same have as in `MPI_Alltoallw` when `fint_size != cint_size`

It fixes following test failures (they are previously xfailed via `intel` on `osx` and now it shows up via `gcc-9`):
```
summary_junit_xml. - ./f08/pt2pt/mprobef08 2 | 36 ms | 1
summary_junit_xml. - ./f08/pt2pt/pt2pt_largef08 | 0 ms | 1
summary_junit_xml. - ./f08/coll/vw_inplacef08 4 | 63 ms | 1
summary_junit_xml. - ./f08/coll/nonblocking_inpf08 4 | 43 ms | 1
summary_junit_xml. - ./f08/topo/dgraph_wgtf90 4 | 42 ms | 1
summary_junit_xml. - ./f08/init/baseenvf90 1 | 34 ms | 1
```
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
