### PR TITLE
binding/c: fix missing check in MPI_Type_create_struct

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1983,7 +1983,12 @@ def dump_validation(func, t):
         dump_if_open("%s > 0" % t['length'])
         G.out.append("MPIR_ERRTEST_ARGNULL(%s, \"%s\", mpi_errno);" % (name, name))
         dump_for_open('i', t['length'])
-        dump_if_open("%s[i] != MPI_DATATYPE_NULL && !HANDLE_IS_BUILTIN(%s[i])" % (name, name))
+        if re.match(r'mpi_type_create_struct', func_name, re.IGNORECASE):
+            # MPI_DATATYPE_NULL not allowed
+            cond = "!HANDLE_IS_BUILTIN(%s[i])" % name
+        else:
+            cond = "%s[i] != MPI_DATATYPE_NULL && !HANDLE_IS_BUILTIN(%s[i])" % (name, name)
+        dump_if_open(cond)
         G.out.append("MPIR_Datatype *datatype_ptr;")
         G.out.append("MPIR_Datatype_get_ptr(%s[i], datatype_ptr);" % name)
         G.out.append("MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);")


### PR DESCRIPTION
## Pull Request Description
We should not allow MPI_DATATYPE_NULL in MPI_Type_create_struct.

Fixes #5680 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
