### PR TITLE
romio: warning fix of unused variable

### DIFF
--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -968,9 +968,7 @@ static void ADIOI_R_Iexchange_data_recv(ADIOI_NBC_Request * nbc_req, int *error_
     int *start_pos = vars->start_pos;
     int *partial_send = vars->partial_send;
     int nprocs = vars->nprocs;
-    int myrank = vars->myrank;
     ADIOI_Access *others_req = vars->others_req;
-    int iter = vars->iter;
     MPI_Aint *buf_idx = vars->buf_idx;
 
     int i, j, k = 0, tmp = 0, nprocs_recv, nprocs_send;
@@ -1005,7 +1003,7 @@ static void ADIOI_R_Iexchange_data_recv(ADIOI_NBC_Request * nbc_req, int *error_
         for (i = 0; i < nprocs; i++)
             if (recv_size[i]) {
                 MPI_Irecv(((char *) vars->buf) + buf_idx[i], recv_size[i],
-                          MPI_BYTE, i, ADIOI_COLL_TAG(i, iter), fd->comm, vars->req2 + j);
+                          MPI_BYTE, i, ADIOI_COLL_TAG(i, vars->iter), fd->comm, vars->req2 + j);
                 j++;
                 buf_idx[i] += recv_size[i];
             }
@@ -1021,11 +1019,11 @@ static void ADIOI_R_Iexchange_data_recv(ADIOI_NBC_Request * nbc_req, int *error_
         for (i = 0; i < nprocs; i++)
             if (recv_size[i]) {
                 MPI_Irecv(recv_buf[i], recv_size[i], MPI_BYTE, i,
-                          ADIOI_COLL_TAG(i, iter), fd->comm, vars->req2 + j);
+                          ADIOI_COLL_TAG(i, vars->iter), fd->comm, vars->req2 + j);
                 j++;
 #ifdef RDCOLL_DEBUG
                 DBG_FPRINTF(stderr, "node %d, recv_size %d, tag %d \n",
-                            myrank, recv_size[i], ADIOI_COLL_TAG(i, iter));
+                            vars->myrank, recv_size[i], ADIOI_COLL_TAG(i, vars->iter));
 #endif
             }
     }
@@ -1047,7 +1045,7 @@ static void ADIOI_R_Iexchange_data_recv(ADIOI_NBC_Request * nbc_req, int *error_
                                          MPI_BYTE, &send_type);
             /* absolute displacement; use MPI_BOTTOM in send */
             MPI_Type_commit(&send_type);
-            MPI_Isend(MPI_BOTTOM, 1, send_type, i, ADIOI_COLL_TAG(i, iter),
+            MPI_Isend(MPI_BOTTOM, 1, send_type, i, ADIOI_COLL_TAG(i, vars->iter),
                       fd->comm, vars->req2 + nprocs_recv + j);
             MPI_Type_free(&send_type);
             if (partial_send[i])


### PR DESCRIPTION

## Pull Request Description

PR #5660 left warnings of a couple unused variables.



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
