### PR TITLE
f08: fix generation of POLYFUNCTION

### DIFF
--- a/maint/gen_binding_f08.py
+++ b/maint/gen_binding_f08.py
@@ -28,9 +28,6 @@ def main():
     func_list.extend(get_type_create_f90_func_list())
 
     skip_large_list = []
-    # skip large variations because MPI_ADDRESS_KIND == MPI_COUNT_KIND
-    if G.opts['aint-size'] == G.opts['count-size']:
-        skip_large_list.extend(["MPI_Op_create", "MPI_Register_datarep", "MPI_Type_create_resized", "MPI_Type_get_extent", "MPI_Type_get_true_extent", "MPI_File_get_type_extent", "MPI_Win_allocate", "MPI_Win_allocate_shared", "MPI_Win_create", "MPI_Win_shared_query"])
     # skip File large count functions because it is not implemented yet
     for func in func_list:
         if func['name'].startswith('MPI_File_') or func['name'] == 'MPI_Register_datarep':

--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -1581,8 +1581,11 @@ def get_real_POLY_kinds():
     large_map = G.MAPS['BIG_F08_KIND_MAP']
     for kind in small_map:
         if kind == 'POLYFUNCTION':
-            # TODO: potentially tricky. Might be easier to treat individual function case by case.
-            G.real_poly_kinds[kind] = 1
+            # Currently there are only two: MPI_User_function, MPI_Datarep_conversion_function,
+            # both contains parameter POLYXFER_NUM_ELEM. However, Fortran is not able to
+            # differentiate generic interface based on different function signature. Disable
+            # for now.
+            pass
         elif kind.startswith('POLY'):
             a = get_int_type(small_map[kind]) + "-size"
             b = get_int_type(large_map[kind]) + "-size"

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -44,13 +44,7 @@
 * * * * osx             /^fileerrretx/          xfail=ticket0   errors/cxx/io/testlist
 * * * * osx             /^throwtestfilex/       xfail=ticket0   errors/cxx/io/testlist
 * gnu debug ch3:tcp osx /^namepubx/             xfail=issue3506 cxx/spawn/testlist
-* intel * * osx         /^statusesf08/          xfail=issue4374 f08/pt2pt/testlist
-* intel * * osx         /^vw_inplacef08/        xfail=issue4374 f08/coll/testlist
-* intel * * osx         /^red_scat_blockf08/    xfail=issue4374 f08/coll/testlist
-* intel * * osx         /^nonblocking_inpf08/   xfail=issue4374 f08/coll/testlist
-* intel * * osx         /^structf/              xfail=issue4374 f08/datatype/testlist
-* intel * * osx         /^aintf08/              xfail=issue4374 f08/rma/testlist
-* intel * * osx         /^dgraph_unwgtf90/      xfail=issue4374 f08/topo/testlist
+* * * * osx             /^dgraph_unwgtf90/      xfail=issue4374 f08/topo/testlist
 ################################################################################
 # xfail large count tests on 32 bit architectures (cannot allocate such large memory)
 * * * * freebsd32       /^getfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   rma/testlist.dtp


### PR DESCRIPTION
## Pull Request Description
We can't assume POLYFUNCTION types are always different between
big/small. Because currently we only have two actual functions types and
both just concern with POLYXFER_NUM_ELEM, we can simply check on that
instead.

[skip warnings]
## Background

The reason for https://github.com/pmodels/mpich/pull/5676/commits/8bda3e650b11ab55fc2bf413536f48188b3c7432 (I believe, revert and confirm first) is there is no `get_int_type` for `POLYFUNCTION`. However, it appears that Fortran can't really support generic interfaces that are only different by function prototypes, showed up in nightly tests on `freebsd32`:
```
src/binding/fortran/use_mpi_f08/pmpi_f08.f90:4192:38:

 4192 |         SUBROUTINE PMPIR_Op_create_f08(user_fn, commute, op, ierror)
      |                                      1
......
 4202 |         SUBROUTINE PMPIR_Op_create_f08_large(user_fn, commute, op, ierror)
      |                                            2
Error: Ambiguous interfaces in generic interface 'pmpi_op_create' for 'pmpir_op_create_f08' at (1) and 'pmpir_op_create_f08_large' at (2)
*** [src/binding/fortran/use_mpi_f08/pmpi_f08.stamp] Error code 1
```

This is not shown up earlier because, on 64bit, we have another code logic in `gen_binding_f08.py` that excludes those functions for large type - https://github.com/pmodels/mpich/blob/6f609c046bae4c8271f65a1822a6684a70e45aa5/maint/gen_binding_f08.py#L31-L33
This is an early hack that we need to be removed since we check actual type differences now.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
