### PR TITLE
github: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# The Intel MPICH team is primarily responsible for the collective TSP
+# and algorithm frameworks.
+/src/mpi/coll/algorithms/ @pmodels/mpich-intel
+/src/mpi/coll/transports/ @pmodels/mpich-intel


### PR DESCRIPTION
## Pull Request Description

Add initial CODEOWNERS file that sets the @pmodels/mpich-intel as owner
for collective frameworks initially contributed by them. The idea is
that pull requests to this code automatically request a review from the
owner.

The intention is for code owners to have the authority to accept or
reject changes based on whatever criteria they like, with some
exceptions. For example, security or licensing issues may result in
changes to the code by the core MPICH team without involvement of the
code owner.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
