### PR TITLE
ch4: Only unmap memory allocated with mmap

### DIFF
--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -726,7 +726,11 @@ int MPID_Free_mem(void *user_buf)
     switch (container->buf_type) {
         case ALLOC_MEM_BUF_TYPE__HBM:
         case ALLOC_MEM_BUF_TYPE__DDR:
+#ifdef MAP_ANON
             MPL_munmap(container->real_buf, container->size, MPL_MEM_USER);
+#else
+            MPL_free(container->real_buf, MPL_MEM_USER);
+#endif
             break;
 
         case ALLOC_MEM_BUF_TYPE__NETMOD:


### PR DESCRIPTION
## Pull Request Description

In the allocation path, we may use either MPL_mmap or MPL_malloc, but
the free path always used MPL_munmap. Add a similar branch in the free
logic to call MPL_free when appropriate.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
