### PR TITLE
configure: pass USER_CFLAGS to hwloc

### DIFF
--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -41,7 +41,7 @@ dnl internal routine, $1 is the extra cflags, hwloc_embedded_dir is m4 macro
 dnl defined to be the path to embedded hwloc.
 AC_DEFUN([PAC_CONFIG_HWLOC_EMBEDDED],[
     PAC_PUSH_FLAG([CFLAGS])
-    CFLAGS="$1"
+    CFLAGS="$USER_CFLAGS $1"
     hwloc_config_args="--enable-embedded-mode --disable-visibility"
     hwloc_config_args="$hwloc_config_args --disable-libxml2"
     hwloc_config_args="$hwloc_config_args --disable-nvml"

--- a/confdb/aclocal_subcfg.m4
+++ b/confdb/aclocal_subcfg.m4
@@ -1,24 +1,3 @@
-dnl PAC_RESET_ALL_FLAGS - Reset precious flags to those set by the user
-AC_DEFUN([PAC_RESET_ALL_FLAGS],[
-	if test "$FROM_MPICH" = "yes" ; then
-	   CFLAGS="$USER_CFLAGS"
-	   CPPFLAGS="$USER_CPPFLAGS"
-	   CXXFLAGS="$USER_CXXFLAGS"
-	   FFLAGS="$USER_FFLAGS"
-	   FCFLAGS="$USER_FCFLAGS"
-	   LDFLAGS="$USER_LDFLAGS"
-	   LIBS="$USER_LIBS"
-	fi
-])
-
-dnl PAC_RESET_LINK_FLAGS - Reset precious link flags to those set by the user
-AC_DEFUN([PAC_RESET_LINK_FLAGS],[
-	if test "$FROM_MPICH" = "yes" ; then
-	   LDFLAGS="$USER_LDFLAGS"
-	   LIBS="$USER_LIBS"
-	fi
-])
-
 dnl Sandbox configure with additional arguments
 dnl Usage: PAC_CONFIG_SUBDIR_ARGS(subdir,configure-args,action-if-success,action-if-failure)
 dnl

--- a/confdb/aclocal_util.m4
+++ b/confdb/aclocal_util.m4
@@ -58,6 +58,27 @@ AC_DEFUN([PAC_PREFIX_ALL_FLAGS],[
 	PAC_PREFIX_FLAG($1, EXTRA_LIBS)
 ])
 
+dnl PAC_RESET_ALL_FLAGS - Reset precious flags to those set by the user
+AC_DEFUN([PAC_RESET_ALL_FLAGS],[
+	if test "$FROM_MPICH" = "yes" ; then
+	   CFLAGS="$USER_CFLAGS"
+	   CPPFLAGS="$USER_CPPFLAGS"
+	   CXXFLAGS="$USER_CXXFLAGS"
+	   FFLAGS="$USER_FFLAGS"
+	   FCFLAGS="$USER_FCFLAGS"
+	   LDFLAGS="$USER_LDFLAGS"
+	   LIBS="$USER_LIBS"
+	fi
+])
+
+dnl PAC_RESET_LINK_FLAGS - Reset precious link flags to those set by the user
+AC_DEFUN([PAC_RESET_LINK_FLAGS],[
+	if test "$FROM_MPICH" = "yes" ; then
+	   LDFLAGS="$USER_LDFLAGS"
+	   LIBS="$USER_LIBS"
+	fi
+])
+
 AC_DEFUN([PAC_CHECK_FGREP_WORD],[
     AC_PROG_FGREP
     AC_MSG_CHECKING([if fgrep support -w option])

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -11,6 +11,10 @@ AC_INIT([Hydra], MPICH_VERSION_m4)
 AC_CONFIG_AUX_DIR(confdb)
 AC_CONFIG_MACRO_DIR(confdb)
 
+if test "$FROM_MPICH" != "yes" ; then
+    PAC_PREFIX_ALL_FLAGS(USER)
+fi
+
 AC_ARG_PROGRAM
 
 dnl must come before LT_INIT, which AC_REQUIREs AC_PROG_CC


### PR DESCRIPTION
## Pull Request Description
When we reset flags, we need make sure to pass along user flags.

Fixes #5688 


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
