### PR TITLE
mpl: remove AI_V4MAPPED from sockaddr

### DIFF
--- a/src/mpl/src/sock/mpl_sockaddr.c
+++ b/src/mpl/src/sock/mpl_sockaddr.c
@@ -98,7 +98,6 @@ int MPL_get_sockaddr(const char *s_hostname, MPL_sockaddr_t * p_addr)
     ai_hint.ai_family = af_type;
     ai_hint.ai_socktype = SOCK_STREAM;
     ai_hint.ai_protocol = IPPROTO_TCP;
-    ai_hint.ai_flags = AI_V4MAPPED;
     ret = getaddrinfo(s_hostname, NULL, &ai_hint, &ai_list);
     if (ret) {
         return ret;


### PR DESCRIPTION

## Pull Request Description
The purpose of AI_V4MAPPED flag is to be able to use IPv6 when hosts are
only configured with IPv4 addresses. Unfortunately, AI_V4MAPPED is not
widely supported, e.g. on OpenBSD. And since the use scenario is not
common -- currently we default to IPv4 -- it is safe to remove this
hint.

Fixes #5697
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
