### PR TITLE
ch3: use MPL_proc_mutex abstraction

### DIFF
--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
@@ -104,20 +104,8 @@ int MPIDI_CH3_SHM_Win_free(MPIR_Win **win_ptr);
 #define MPIDI_CH3I_SHM_MUTEX_INIT(win_ptr)                                              \
     do {                                                                                \
         int pt_err;                                                                     \
-        pthread_mutexattr_t attr;                                                       \
-                                                                                        \
-        pt_err = pthread_mutexattr_init(&attr);                                         \
-        MPIR_ERR_CHKANDJUMP1(pt_err, mpi_errno, MPI_ERR_OTHER, "**pthread_mutex",       \
-                             "**pthread_mutex %s", strerror(pt_err));                   \
-        pt_err = pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);           \
-        MPIR_ERR_CHKANDJUMP1(pt_err, mpi_errno, MPI_ERR_OTHER, "**pthread_mutex",       \
-                             "**pthread_mutex %s", strerror(pt_err));                   \
-        pt_err = pthread_mutex_init((win_ptr)->shm_mutex, &attr);                       \
-        MPIR_ERR_CHKANDJUMP1(pt_err, mpi_errno, MPI_ERR_OTHER, "**pthread_mutex",       \
-                             "**pthread_mutex %s", strerror(pt_err));                   \
-        pt_err = pthread_mutexattr_destroy(&attr);                                      \
-        MPIR_ERR_CHKANDJUMP1(pt_err, mpi_errno, MPI_ERR_OTHER, "**pthread_mutex",       \
-                             "**pthread_mutex %s", strerror(pt_err));                   \
+        MPL_proc_mutex_create((win_ptr)->shm_mutex, &pt_err);                           \
+        MPIR_ERR_CHECK(pt_err);                                                         \
     } while (0);
 
 #define MPIDI_CH3I_SHM_MUTEX_DESTROY(win_ptr)                                           \

--- a/src/mpid/ch3/channels/nemesis/src/ch3_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_init.c
@@ -62,17 +62,7 @@ static int split_type(MPIR_Comm * user_comm_ptr, int stype, int key,
 
 int MPIDI_CH3I_Shm_supported(void)
 {
-    int mutex_err;
-    pthread_mutexattr_t attr;
-
-    /* Test for PTHREAD_PROCESS_SHARED support.  Some platforms do not support
-     * this capability even though it is a part of the pthreads core API (e.g.,
-     * FreeBSD does not support this as of version 9.1) */
-    pthread_mutexattr_init(&attr);
-    mutex_err = pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
-    pthread_mutexattr_destroy(&attr);
-
-    return !mutex_err;
+    return MPL_proc_mutex_enabled();
 }
 
 static MPIR_Commops comm_fns = {


### PR DESCRIPTION

## Pull Request Description
We have abstracted the processs shared mutex creation utilities into MPL
but failed to convert some of the usages in ch3. The MPL abstraction
takes care of the case when shared mutex isn't available or even when the
pthread API isn't available.

Fixes #5698 

Reference: https://github.com/pmodels/mpich/pull/3149
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
