### PR TITLE
github: Use intel-reviewers team instead of mpich-intel

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # The Intel MPICH team is primarily responsible for the collective TSP
 # and algorithm frameworks.
-/src/mpi/coll/algorithms/ @pmodels/mpich-intel
-/src/mpi/coll/transports/ @pmodels/mpich-intel
+/src/mpi/coll/algorithms/ @pmodels/intel-reviewers
+/src/mpi/coll/transports/ @pmodels/intel-reviewers


### PR DESCRIPTION
## Pull Request Description

It seems CODEOWNERS need write permissions in order to function
correctly. We have created a sub team of the mpich-intel team
specifically for use in CODEOWNERS.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
