### PR TITLE
test/mpi/f08: Fix tests that did not finalize

### DIFF
--- a/test/mpi/f08/attr/fandcattrf08.f90
+++ b/test/mpi/f08/attr/fandcattrf08.f90
@@ -23,7 +23,7 @@
       delcount  = 0
 
       errs      = 0
-      call mpi_init(ierr)
+      call mtest_init(ierr)
       commextra = 1001
       call mpi_comm_create_keyval( mycopyfn, mydelfn,                     &
      &                             fcomm2_keyval, commextra, ierr )
@@ -48,11 +48,7 @@
       call mpi_type_free_keyval( ctype2_keyval, ierr )
       call mpi_win_free_keyval( cwin2_keyval, ierr )
 
-      if (errs .eq. 0) then
-         print *, ' No Errors'
-      else
-         print *, ' Found ', errs, ' errors'
-      endif
+      call mtest_finalize( errs )
 
       end
 !

--- a/test/mpi/f08/ext/c2f2cf90.f90
+++ b/test/mpi/f08/ext/c2f2cf90.f90
@@ -27,7 +27,7 @@
       logical   flag
       errs = 0
 
-      call mpi_init( ierr )
+      call mtest_init( ierr )
 
 !
 ! Test passing a Fortran MPI object to C

--- a/test/mpi/f08/io/c2f2ciof90.f90
+++ b/test/mpi/f08/io/c2f2ciof90.f90
@@ -6,7 +6,7 @@
 ! Test just the MPI-IO FILE object
       program main
       use mpi_f08
-      integer errs, toterrs, ierr
+      integer errs, ierr
       integer wrank
       type(MPI_Group) wgroup
       integer fsize, frank
@@ -18,7 +18,7 @@
 
       errs = 0
 
-      call mpi_init( ierr )
+      call mtest_init( ierr )
 
       call mpi_comm_rank( MPI_COMM_WORLD, wrank, ierr )
       call  mpi_comm_group( MPI_COMM_WORLD, wgroup, ierr )
@@ -44,18 +44,8 @@
       call mpi_group_free( group, ierr )
       call mpi_group_free( wgroup, ierr )
       call mpi_file_close( file, ierr )
-!
-! Summarize the errors
-!
-      call mpi_allreduce( errs, toterrs, 1, MPI_INTEGER, MPI_SUM, &
-      &     MPI_COMM_WORLD, ierr )
-      if (wrank .eq. 0) then
-         if (toterrs .eq. 0) then
-            print *, ' No Errors'
-         else
-            print *, ' Found ', toterrs, ' errors'
-         endif
-      endif
+
+      call mtest_finalize( errs )
 
       end
 

--- a/test/mpi/f08/misc/sizeof2.f90
+++ b/test/mpi/f08/misc/sizeof2.f90
@@ -13,7 +13,7 @@
           complex c
 
           errs = 0
-          call mpi_init(ierr)
+          call mtest_init(ierr)
           size1 = storage_size(errs) / 8
           call mpi_type_size( MPI_INTEGER, size2, ierr )
           if (size1 .ne. size2) then
@@ -49,10 +49,6 @@
              print *, "real array size is ", size2, " storage_size claims ", size1
           endif
 
-          if (errs .gt. 0) then
-             print *, ' Found ', errs, ' errors'
-          else
-             print *, ' No Errors'
-          endif
+          call mtest_finalize( errs )
 
         end program main

--- a/test/mpi/f08/rma/c2f2cwinf08.f90
+++ b/test/mpi/f08/rma/c2f2cwinf08.f90
@@ -9,7 +9,7 @@
 !
       program main
       use mpi_f08
-      integer errs, toterrs, ierr
+      integer errs, ierr
       integer wrank, wsize
       integer wgroup, info, req
       TYPE(MPI_Win) win
@@ -20,7 +20,7 @@
 
       errs = 0
 
-      call mpi_init( ierr )
+      call mtest_init( ierr )
 
 !
 ! Test passing a Fortran MPI object to C
@@ -38,18 +38,7 @@
 !     displacement unit 1
       call mpi_win_free( win, ierr )
 
-!
-! Summarize the errors
-!
-      call mpi_allreduce( errs, toterrs, 1, MPI_INTEGER, MPI_SUM, &
-      &     MPI_COMM_WORLD, ierr )
-      if (wrank .eq. 0) then
-         if (toterrs .eq. 0) then
-            print *, ' No Errors'
-         else
-            print *, ' Found ', toterrs, ' errors'
-         endif
-      endif
+      call mtest_finalize( errs )
 
       end
 

--- a/test/mpi/f08/timer/wtimef90.f90
+++ b/test/mpi/f08/timer/wtimef90.f90
@@ -13,7 +13,7 @@
           integer err
           double precision time1
 
-          call mpi_init(err)
+          call mtest_init(err)
 
           time1 = mpi_wtime()
           time1 = time1 + mpi_wtick()
@@ -24,9 +24,9 @@
 ! including these operations ensures that a buggy compiler doesn't
 ! pass this test by mistake).
           if (time1 .lt. 0.0d0) then
-             print *, ' Negative time result'
-          else
-                print *, ' No Errors'
+             err = 1
           endif
+
+          call mtest_finalize(err)
 
         end

--- a/test/mpi/f77/attr/commattr4f.f
+++ b/test/mpi/f77/attr/commattr4f.f
@@ -18,7 +18,7 @@ C
 C
 C  initialize the mpi environment
 C
-      call mpi_init(ierr)
+      call mtest_init(ierr)
 
       call mpi_comm_create_keyval(MPI_COMM_DUP_FN,
      $     MPI_NULL_DELETE_FN,

--- a/test/mpi/f77/ext/c2f2cf.f
+++ b/test/mpi/f77/ext/c2f2cf.f
@@ -17,7 +17,7 @@ C
       logical   flag
       errs = 0
 
-      call mpi_init( ierr )
+      call mtest_init( ierr )
 
 C
 C Test passing a Fortran MPI object to C

--- a/test/mpi/f77/io/c2f2ciof.f
+++ b/test/mpi/f77/io/c2f2ciof.f
@@ -16,7 +16,7 @@ C Test just the MPI-IO FILE object
 
       errs = 0
 
-      call mpi_init( ierr )
+      call mtest_init( ierr )
 
       call mpi_comm_rank( MPI_COMM_WORLD, wrank, ierr )
       call  mpi_comm_group( MPI_COMM_WORLD, wgroup, ierr )

--- a/test/mpi/f77/rma/c2f2cwinf.f
+++ b/test/mpi/f77/rma/c2f2cwinf.f
@@ -15,7 +15,7 @@ C The integer asize must be of ADDRESS_KIND size
       include 'addsize.h'
       errs = 0
 
-      call mpi_init( ierr )
+      call mtest_init( ierr )
 
 C
 C Test passing a Fortran MPI object to C

--- a/test/mpi/f90/attr/fandcattrf90.f90
+++ b/test/mpi/f90/attr/fandcattrf90.f90
@@ -22,7 +22,7 @@
       delcount  = 0
 
       errs      = 0
-      call mpi_init(ierr)
+      call mtest_init(ierr)
       commextra = 1001
       call mpi_comm_create_keyval( mycopyfn, mydelfn,                     &
      &                             fcomm2_keyval, commextra, ierr )

--- a/test/mpi/f90/misc/sizeof2.f90
+++ b/test/mpi/f90/misc/sizeof2.f90
@@ -13,7 +13,7 @@
           complex c
 
           errs = 0
-          call mpi_init(ierr)
+          call mtest_init(ierr)
           call mpi_sizeof( errs, size1, ierr )
           call mpi_type_size( MPI_INTEGER, size2, ierr )
           if (size1 .ne. size2) then

--- a/test/mpi/f90/timer/wtimef90.f90
+++ b/test/mpi/f90/timer/wtimef90.f90
@@ -13,7 +13,7 @@
           integer err
           double precision time1
 
-          call mpi_init(err)
+          call mtest_init(err)
 
           time1 = mpi_wtime()
           time1 = time1 + mpi_wtick()


### PR DESCRIPTION
## Pull Request Description

The AddressSanitizer complained that these tests leaked memory because
MPI was not properly finalized. Use mtest utilities where appropriate to
avoid open coding the error reporting logic at the end of the test.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
