### PR TITLE
ch4/posix: force a 16-byte alignment

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
@@ -10,6 +10,20 @@
 
 #define MPIDI_MAX_POSIX_EAGER_STRING_LEN 64
 
+/* We need try prevent breaking basic datatype in segments, for example, split double
+ * in half. This can easily happen on 32-bit systems where max alignment is 4 and am
+ * header size for MPIDIG_send_data_msg_t is 4. Currently, yaksa cannot handle packing
+ * or unpacking fragments of basic datatype.
+ * Enforcing a bigger payload alignment prevents most of the issues. But it is not
+ * fail-proof. For example, long double may be 12 bytes thus can't fill at even 16-byte
+ * boundary. Similarly, if there is mixed int and double, it still can break the double
+ * in half.
+ * For a complete fix, we need yaksa to add a fallback path to handle fragments of basic
+ * types.
+ * FIXME: once yaksa is fixed, redefine MPIDI_POSIX_MIN_ALIGNMENT to MAX_ALIGNMENT.
+ */
+#define MPIDI_POSIX_MIN_ALIGNMENT 16
+
 typedef int (*MPIDI_POSIX_eager_init_t) (int rank, int size);
 typedef int (*MPIDI_POSIX_eager_finalize_t) (void);
 

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -43,8 +43,8 @@ int MPIDI_POSIX_iqueue_init(int rank, int size)
     MPIR_FUNC_ENTER;
 
     /* ensure max alignment for payload */
-    MPIR_Assert((MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE & (MAX_ALIGNMENT - 1)) == 0);
-    MPIR_Assert((sizeof(MPIDI_POSIX_eager_iqueue_cell_t) & (MAX_ALIGNMENT - 1)) == 0);
+    MPIR_Assert((MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE & (MPIDI_POSIX_MIN_ALIGNMENT - 1)) == 0);
+    MPIR_Assert((sizeof(MPIDI_POSIX_eager_iqueue_cell_t) & (MPIDI_POSIX_MIN_ALIGNMENT - 1)) == 0);
 
     size_t size_of_terminals;
     /* Create one terminal for each process with which we will be able to communicate. */

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -79,12 +79,12 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
      * tail. */
     cell->payload_size = 0;
     if (am_hdr) {
-        MPI_Aint resized_am_hdr_sz = MPL_ROUND_UP_ALIGN(am_hdr_sz, MAX_ALIGNMENT);
+        MPI_Aint resized_am_hdr_sz = MPL_ROUND_UP_ALIGN(am_hdr_sz, MPIDI_POSIX_MIN_ALIGNMENT);
         cell->am_header = *msg_hdr;
         cell->type = MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_HDR;
         /* send am_hdr if this is the first segment */
         MPIR_Typerep_copy(payload, am_hdr, am_hdr_sz);
-        /* make sure the data region starts at the boundary of MAX_ALIGNMENT */
+        /* make sure the data region starts at the boundary of MPIDI_POSIX_MIN_ALIGNMENT */
         payload = payload + resized_am_hdr_sz;
         cell->payload_size += resized_am_hdr_sz;
         cell->am_header.am_hdr_sz = resized_am_hdr_sz;

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -13,7 +13,7 @@
 
 MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_POSIX_am_eager_limit(void)
 {
-    return MPIDI_POSIX_eager_payload_limit() - MAX_ALIGNMENT;
+    return MPIDI_POSIX_eager_payload_limit() - MPIDI_POSIX_MIN_ALIGNMENT;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_am_send_hdr(int grank,


### PR DESCRIPTION

## Pull Request Description
On 32-bit systems, the `MAX_ALIGNMENT` is 4. Breaking the segments at
the boundary of 4 may end up chopping a `double` in half. Currently, yaksa
cannot handle packing or unpacking fragments of basic types.

This patch forces a 16-byte minimum payload alignment. It will prevent
most fail cases but it is not fail-proof. For example, if we are packing
`int+double`, neither alignment of `4` or `16` can prevent splitting a
`double`. Yaksa need to handle the fragments for a complete fix.

## Background
Current failures on `ch4-ofi-32`:
```
summary_junit_xml. - ./rma/epochtest 4 -type=MPI_INT:4+MPI_DOUBLE:8 -count=1018 -seed=150 -testsize=16 | 1 sec | 37
summary_junit_xml. - ./rma/putpscw1 4 -type=MPI_INT:4+MPI_DOUBLE:8 -count=1018 -seed=298 -testsize=16 | 0.77 sec | 37
summary_junit_xml. - ./pt2pt/sendself 2 -type=MPI_C_DOUBLE_COMPLEX -sendcnt=8192 -recvcnt=8192 -seed=47 -testsize=100 | 1.5 sec | 79
summary_junit_xml. - ./rma/epochtest 4 -type=MPI_INT:4+MPI_DOUBLE:8 -count=262144 -seed=154 -testsize=16 | 1 min 6 sec | 95
summary_junit_xml. - ./coll/bcast 4 -type=MPI_INT:4+MPI_DOUBLE:8 -count=262144 -seed=8 -testsize=16 | 7 min 1 sec | 139
summary_junit_xml. - ./rma/epochtest 4 -type=MPI_INT:4+MPI_DOUBLE:8 -count=65530 -seed=153 -testsize=16 | 18 sec | 139
summary_junit_xml. - ./rma/putpscw1 4 -type=MPI_INT:4+MPI_DOUBLE:8 -count=65530 -seed=301 -testsize=16 | 18 sec | 139
summary_junit_xml. - ./rma/putpscw1 4 -type=MPI_INT:4+MPI_DOUBLE:8 -count=262144 -seed=302 -testsize=16 | 48 sec | 139
summary_junit_xml. - ./datatype/concurrent_irecv 3
```

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
