### PR TITLE
modules: use --disable-gl to configure embedded hwloc

### DIFF
--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -43,6 +43,7 @@ AC_DEFUN([PAC_CONFIG_HWLOC_EMBEDDED],[
     PAC_PUSH_FLAG([CFLAGS])
     CFLAGS="$USER_CFLAGS $1"
     hwloc_config_args="--enable-embedded-mode --disable-visibility"
+    hwloc_config_args="$hwloc_config_args --disable-gl"
     hwloc_config_args="$hwloc_config_args --disable-libxml2"
     hwloc_config_args="$hwloc_config_args --disable-nvml"
     hwloc_config_args="$hwloc_config_args --disable-cuda"


### PR DESCRIPTION
## Pull Request Description

The extra graphics layer dependency is undesirable.

A user commented in discuss mailing list:

> This is bringing in a shared library that is causing havoc.  No matter
> how I configure, I get
>
> $ grep -i wrapper_libs= config.log
> WRAPPER_LIBS='-lm  -ludev -L/usr/lib64 -lpciaccess -lXNVCtrl -lXext 
> -lX11 -L/usr/lib64 -lxml2  -lpthread  -lrt '
>



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
