### PR TITLE
ch3/win: Stash and ignore optimized MR hint

### DIFF
--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -293,6 +293,7 @@ struct MPIDI_Win_info_args {
     int same_disp_unit;
     int alloc_shared_noncontig;
     int alloc_shm;
+    int optimized_mr;
 };
 
 struct MPIDI_RMA_op;            /* forward decl from mpidrma.h */

--- a/src/mpid/ch3/src/ch3u_win_fns.c
+++ b/src/mpid/ch3/src/ch3u_win_fns.c
@@ -356,6 +356,18 @@ int MPID_Win_set_info(MPIR_Win * win, MPIR_Info * info)
             if (!strncmp(info_value, "false", sizeof("false")))
                 win->info_args.same_disp_unit = FALSE;
         }
+
+        /********************************************************/
+        /******* accept (but ignore) a CH4-specific hint ********/
+        /********************************************************/
+        info_flag = 0;
+        MPIR_Info_get_impl(info, "optimized_mr", MPI_MAX_INFO_VAL, info_value, &info_flag);
+        if (info_flag) {
+            if (!strncmp(info_value, "true", sizeof("true")))
+                win->info_args.optimized_mr = TRUE;
+            if (!strncmp(info_value, "false", sizeof("false")))
+                win->info_args.optimized_mr = FALSE;
+        }
     }
 
 
@@ -440,6 +452,12 @@ int MPID_Win_get_info(MPIR_Win * win, MPIR_Info ** info_used)
         mpi_errno = MPIR_Info_set_impl(*info_used, "same_disp_unit", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_used, "same_disp_unit", "false");
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (win->info_args.optimized_mr)
+        mpi_errno = MPIR_Info_set_impl(*info_used, "optimized_mr", "true");
+    else
+        mpi_errno = MPIR_Info_set_impl(*info_used, "optimized_mr", "false");
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch3/src/mpid_rma.c
+++ b/src/mpid/ch3/src/mpid_rma.c
@@ -266,6 +266,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
     (*win_ptr)->info_args.same_disp_unit = FALSE;
     (*win_ptr)->info_args.alloc_shared_noncontig = 0;
     (*win_ptr)->info_args.alloc_shm = FALSE;
+    (*win_ptr)->info_args.optimized_mr = FALSE;
     if ((*win_ptr)->create_flavor == MPI_WIN_FLAVOR_ALLOCATE ||
         (*win_ptr)->create_flavor == MPI_WIN_FLAVOR_SHARED) {
         (*win_ptr)->info_args.alloc_shm = TRUE;


### PR DESCRIPTION
## Pull Request Description

A new info hint was added in 3cbc32e9ba285c29d2063ff8b65778597d14b1ee to support optimized memory regions in CH4, but not putting it in CH3 caused problems with tests that look for it.

This patch adds that hint to CH3 (even though it is never used) to allow the test to pass.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
