### PR TITLE
modules: config hwloc consistently between mpich and hydra

### DIFF
--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -24,7 +24,7 @@ AC_DEFUN([PAC_CONFIG_MPL],[
         dnl ---- sub-configure (e.g. hydra, romio) ----
         if test "$FROM_MPICH" = "yes"; then
             mpl_lib="$main_top_builddir/src/mpl/libmpl.la"
-            mpl_includedir='-I$(main_top_builddir)/src/mpl/include -I$(main_top_srcdir)/src/mpl/include'
+            mpl_includedir="-I$main_top_builddir/src/mpl/include -I$main_top_srcdir/src/mpl/include"
         else
             PAC_CONFIG_MPL_EMBEDDED
             mpl_srcdir="mpl_embedded_dir"

--- a/configure.ac
+++ b/configure.ac
@@ -3874,9 +3874,12 @@ m4_map([PAC_SUBCFG_CONFIGURE_SUBSYS], [PAC_SUBCFG_MODULE_LIST])
 
 # now configure any actual recursively configures subsystems, such as ROMIO and
 # hydra, or older components that haven't been updated to a subconfigure.m4 yet
+PAC_PUSH_ALL_FLAGS()
+PAC_RESET_ALL_FLAGS()
 for subsys in $devsubsystems $subsystems ; do
     PAC_CONFIG_SUBDIR([$subsys],[],[AC_MSG_ERROR([$subsys configure failed])])
 done
+PAC_POP_ALL_FLAGS()
 if test "$DEBUG_SUBDIR_CACHE" = yes -a "$enable_echo" != yes ; then
     set +x
 fi

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -147,6 +147,9 @@ else
     mpl_libdir="-L${with_mpl_prefix}/lib"
     mpl_lib="-l${MPLLIBNAME}"
 fi
+else
+    # we are configuring romio inside mpich, just set mpl_includedir
+    mpl_includedir="-I$main_top_builddir/src/mpl/include -I$main_top_srcdir/src/mpl/include"
 fi
 
 CFLAGS=${CFLAGS:-""}


### PR DESCRIPTION

## Pull Request Description
When there is an old version hwloc installed, mpich configure will
choose embedded hwloc due to version check. Hydra inherits the CPPFLAGS
from mpich, resulting in probing hwloc using embedded headers. The version
checks only checks for headers, thus resulting in hydra using embedded
headers but linking with incompatible external hwloc.

Fix this issue by checking and force the embedded option in hydra.

Thank Matt Thompson for reporting this issue on discuss mailinglist.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
