### PR TITLE
mtest: Fix thread barrier implementation

### DIFF
--- a/test/mpi/util/mtest_thread.c
+++ b/test/mpi/util/mtest_thread.c
@@ -99,18 +99,9 @@ int MTest_thread_barrier(int nt)
         return err;
     }
     cntP = &c[phase];
-    err = MTest_thread_unlock(&barrierLock);
-    if (err) {
-        fprintf(stderr, "Unlock failed in barrier!\n");
-        return err;
-    }
 
     /* printf("[%d] cnt = %d, phase = %d\n", pthread_self(), *cntP, phase); */
-    err = MTest_thread_lock(&barrierLock);
-    if (err) {
-        fprintf(stderr, "Lock failed in barrier!\n");
-        return err;
-    }
+
     /* The first thread to enter will reset the counter */
     if (*cntP < 0)
         *cntP = nt;

--- a/test/mpi/util/mtest_thread.c
+++ b/test/mpi/util/mtest_thread.c
@@ -82,6 +82,12 @@ int MTest_thread_barrier_free(void)
     return MTest_thread_lock_free(&barrierLock);
 }
 
+#define LOCK_ERR_CHECK(err_)                            \
+    if (err_) {                                         \
+        fprintf(stderr, "Lock failed in barrier!\n");   \
+        return err_;                                    \
+    }
+
 /* This is a generic barrier implementation.  To ensure that tests don't
    silently fail, this both prints an error message and returns an error
    result on any failure. */
@@ -94,10 +100,7 @@ int MTest_thread_barrier(int nt)
         nt = nthreads;
     /* Force a write barrier by using lock/unlock */
     err = MTest_thread_lock(&barrierLock);
-    if (err) {
-        fprintf(stderr, "Lock failed in barrier!\n");
-        return err;
-    }
+    LOCK_ERR_CHECK(err);
     cntP = &c[phase];
 
     /* printf("[%d] cnt = %d, phase = %d\n", pthread_self(), *cntP, phase); */
@@ -116,10 +119,7 @@ int MTest_thread_barrier(int nt)
     /* Really need a write barrier here */
     *cntP = *cntP - 1;
     err = MTest_thread_unlock(&barrierLock);
-    if (err) {
-        fprintf(stderr, "Unlock failed in barrier!\n");
-        return err;
-    }
+    LOCK_ERR_CHECK(err);
     while (*cntP > 0);
 
     return err;


### PR DESCRIPTION
## Pull Request Description

Fix a data race in MTest_thread_barrier. Found when investigating some Jenkins failures with help from ThreadSanitizer.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
