### PR TITLE
configure: Fix when MPL require additional CPPFLAGS

### DIFF
--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -23,8 +23,14 @@ AC_DEFUN([PAC_CONFIG_MPL],[
     ], [
         dnl ---- sub-configure (e.g. hydra, romio) ----
         if test "$FROM_MPICH" = "yes"; then
-            mpl_lib="$main_top_builddir/src/mpl/libmpl.la"
+            dnl skip ROMIO since mpich already links libmpl.la
+            m4_if(AC_PACKAGE_NAME, [ROMIO], [], [
+                mpl_lib="$main_top_builddir/src/mpl/libmpl.la"
+            ])
             mpl_includedir="-I$main_top_builddir/src/mpl/include -I$main_top_srcdir/src/mpl/include"
+            # source variables that are configured by MPL
+            AC_MSG_NOTICE([sourcing $main_top_srcdir/src/mpl/localdefs])
+            . $main_top_builddir/src/mpl/localdefs
         else
             PAC_CONFIG_MPL_EMBEDDED
             mpl_srcdir="mpl_embedded_dir"

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -131,22 +131,22 @@ AC_SUBST([mpl_libdir])
 mpl_lib=""
 AC_SUBST([mpl_lib])
 if test "$FROM_MPICH" = "no" ; then
-if test "$with_mpl_prefix" = "embedded" ; then
-    mpl_srcdir="mpl"
-    mpl_dist_srcdir="mpl"
-    mpl_subdir_args="--disable-versioning --enable-embedded"
-    PAC_CONFIG_SUBDIR_ARGS([mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
-    mpl_includedir='-I$(top_builddir)/mpl/include -I$(top_srcdir)/mpl/include'
-    mpl_lib="mpl/lib${MPLLIBNAME}.la"
-else
-    # The user specified an already-installed MPL; just sanity check, don't
-    # subconfigure it
-    AS_IF([test -s "${with_mpl_prefix}/include/mplconfig.h"],
-          [:],[AC_MSG_ERROR([the MPL installation in "${with_mpl_prefix}" appears broken])])
-    mpl_includedir="-I${with_mpl_prefix}/include"
-    mpl_libdir="-L${with_mpl_prefix}/lib"
-    mpl_lib="-l${MPLLIBNAME}"
-fi
+    if test "$with_mpl_prefix" = "embedded" ; then
+        mpl_srcdir="mpl"
+        mpl_dist_srcdir="mpl"
+        mpl_subdir_args="--disable-versioning --enable-embedded"
+        PAC_CONFIG_SUBDIR_ARGS([mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
+        mpl_includedir='-I$(top_builddir)/mpl/include -I$(top_srcdir)/mpl/include'
+        mpl_lib="mpl/lib${MPLLIBNAME}.la"
+    else
+        # The user specified an already-installed MPL; just sanity check, don't
+        # subconfigure it
+        AS_IF([test -s "${with_mpl_prefix}/include/mplconfig.h"],
+            [:],[AC_MSG_ERROR([the MPL installation in "${with_mpl_prefix}" appears broken])])
+        mpl_includedir="-I${with_mpl_prefix}/include"
+        mpl_libdir="-L${with_mpl_prefix}/lib"
+        mpl_lib="-l${MPLLIBNAME}"
+    fi
 else
     # we are configuring romio inside mpich. MPICH should configured MPL already, following
     # macro will just set mpl_includedir and source mpl/localdefs if any.

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -148,8 +148,9 @@ else
     mpl_lib="-l${MPLLIBNAME}"
 fi
 else
-    # we are configuring romio inside mpich, just set mpl_includedir
-    mpl_includedir="-I$main_top_builddir/src/mpl/include -I$main_top_srcdir/src/mpl/include"
+    # we are configuring romio inside mpich. MPICH should configured MPL already, following
+    # macro will just set mpl_includedir and source mpl/localdefs if any.
+    PAC_CONFIG_MPL
 fi
 
 CFLAGS=${CFLAGS:-""}


### PR DESCRIPTION
## Pull Request Description

Now that we only configure MPL once and in addition we sanitize flags before configuring "subsystems", we need make sure sub-packages, e.g. hydra and romio, source `mpl/localdefs` to get additional `CPPFLAGS`. Currently, `--with-cuda` flags is lost because of this.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
