### PR TITLE
ch4: fix use of builtin_element_size in pack/unpack

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -142,7 +142,10 @@ static int typerep_do_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype dat
         MPIR_Datatype *dtp;
         MPIR_Datatype_get_ptr(datatype, dtp);
         is_contig = dtp->is_contig;
-        element_size = dtp->builtin_element_size;
+        /* NOTE: dtp->element_size may not be set if dtp is from a flattened type */
+        if (dtp->basic_type != MPI_DATATYPE_NULL) {
+            element_size = MPIR_Datatype_get_basic_size(datatype);
+        }
         inbuf_ptr = MPIR_get_contig_ptr(inbuf, dtp->true_lb);
         total_size = incount * dtp->size;
     }

--- a/src/mpid/ch4/src/mpidig_rma_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_rma_callbacks.c
@@ -806,6 +806,7 @@ static int handle_get_acc_cmpl(MPIR_Request * rreq)
                                                                                    req->
                                                                                    areq.target_datatype),
                       0, original, result_data_sz, &actual_pack_bytes);
+    MPIR_Assert(actual_pack_bytes == result_data_sz);
 
     mpi_errno = MPIDIG_compute_acc_op(MPIDIG_REQUEST(rreq, req->areq.data),
                                       MPIDIG_REQUEST(rreq, req->areq.origin_count),


### PR DESCRIPTION
## Pull Request Description
If the datatype is from a flatted type, builtin_element_size can be
garbage because the field is not copied in struct flatten_hdr.

Obtain the builtin_element_size from the basic type instead.

Background: 
This bug was not detected in our testsuite because the current (get_acc) tests do not cover the case when a flattened datatype object reuses the previously freed handle memory with non-zero conflicting values of `builtin_element_size`. It was caught in #5725 when we test multiple tests within a single `MPI_Init/Finalize` window.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
