### PR TITLE
ch4/ofi: Handle multiple buffered cq entries at a time

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -706,26 +706,28 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_progress_do_queue(int vni)
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_buffered(int vni, struct fi_cq_tagged_entry *wc)
 {
-    int rc = 0;
+    int num = 0;
 
-    if (1) {
+    while (num < MPIDI_OFI_NUM_CQ_ENTRIES) {
         /* If the static list isn't empty, do so first */
         if (CQ_S_HEAD != CQ_S_TAIL) {
-            wc[0] = CQ_S_LIST[CQ_S_TAIL];
+            wc[num] = CQ_S_LIST[CQ_S_TAIL];
             CQ_S_TAIL = (CQ_S_TAIL + 1) % MPIDI_OFI_NUM_CQ_BUFFERED;
         }
         /* If there's anything in the dynamic list, it goes second. */
         else if (CQ_D_HEAD != NULL) {
             MPIDI_OFI_cq_list_t *cq_list_entry = CQ_D_HEAD;
             LL_DELETE(CQ_D_HEAD, CQ_D_TAIL, cq_list_entry);
-            wc[0] = cq_list_entry->cq_entry;
+            wc[num] = cq_list_entry->cq_entry;
             MPL_free(cq_list_entry);
+        } else {
+            break;
         }
 
-        rc = 1;
+        num++;
     }
 
-    return rc;
+    return num;
 }
 
 #undef CQ_S_LIST

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -87,8 +87,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
     }
 
     if (unlikely(MPIDI_OFI_has_cq_buffered(vni))) {
-        ret = MPIDI_OFI_get_buffered(vni, wc);
-        mpi_errno = MPIDI_OFI_handle_cq_entries(vni, wc, 1);
+        int num = MPIDI_OFI_get_buffered(vni, wc);
+        mpi_errno = MPIDI_OFI_handle_cq_entries(vni, wc, num);
     } else if (likely(1)) {
         for (int nic = 0; nic < MPIDI_OFI_global.num_nics; nic++) {
             int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);


### PR DESCRIPTION
## Pull Request Description

Return as many buffered cq entries as possible in a single call to
MPIDI_OFI_get_buffered, rather than doing them one by one.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
