### PR TITLE
mpi: use pointers for array_of_statuses

### DIFF
--- a/maint/local_python/binding_common.py
+++ b/maint/local_python/binding_common.py
@@ -139,6 +139,10 @@ def get_C_param(param, func, mapping):
         else:
             # MPI_Init, MPI_Init_thread -> char ***argv
             want_star = 3
+    elif kind == "STATUS" and param['length'] is not None:
+        # MPI_{Wait,Test}{all,some}
+        # gcc-11 warns when we pass MPI_STATUSES_IGNORE to MPI_Status statues[]
+        want_star = 1
     elif not want_star:
         if is_pointer_type(param):
             if kind == "STRING_ARRAY":


### PR DESCRIPTION
## Pull Request Description

Apparently some compilers -- gcc-11.2 -- will differentiate between
    MPI_Status array_of_statuses[]
and
    MPI_Status *array_of_statuses
and warns if we pass MPI_STATUSES_IGNORE to the former.

Note: the standard uses the *former* form.

Fixes #5687

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
