### PR TITLE
ch3/nemesis: fix issues with inter-process mutex on FreeBSD

### DIFF
--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
@@ -83,6 +83,8 @@ int MPID_nem_handle_pkt(MPIDI_VC_t *vc, char *buf, intptr_t buflen);
 /* Nemesis-provided RMA implementation */
 int MPIDI_CH3_SHM_Win_shared_query(MPIR_Win *win_ptr, int target_rank, MPI_Aint *size, int *disp_unit, void *baseptr);
 int MPIDI_CH3_SHM_Win_free(MPIR_Win **win_ptr);
+int MPIDI_CH3_SHM_Init(void);
+int MPIDI_CH3_SHM_Finalize(void);
 
 /* Shared memory window atomic/accumulate mutex implementation */
 
@@ -111,6 +113,13 @@ int MPIDI_CH3_SHM_Win_free(MPIR_Win **win_ptr);
 #define MPIDI_CH3I_SHM_MUTEX_DESTROY(win_ptr)                                           \
     do {                                                                                \
         int pt_err = pthread_mutex_destroy((win_ptr)->shm_mutex);                       \
+        MPIR_ERR_CHKANDJUMP1(pt_err, mpi_errno, MPI_ERR_OTHER, "**pthread_mutex",       \
+                             "**pthread_mutex %s", strerror(pt_err));                   \
+    } while (0);
+
+#define MPIDI_CH3I_SHM_MUTEX_DESTROY_DIRECT(shm_mutex)                                  \
+    do {                                                                                \
+        int pt_err = pthread_mutex_destroy(shm_mutex);                       \
         MPIR_ERR_CHKANDJUMP1(pt_err, mpi_errno, MPI_ERR_OTHER, "**pthread_mutex",       \
                              "**pthread_mutex %s", strerror(pt_err));                   \
     } while (0);
@@ -167,6 +176,14 @@ int MPIDI_CH3_SHM_Win_free(MPIR_Win **win_ptr);
 #define MPIDI_CH3I_SHM_MUTEX_DESTROY(win_ptr)                                           \
     do {                                                                                \
         BOOL result = CloseHandle(*((win_ptr)->shm_mutex));                             \
+        if (!result) {                                                                  \
+            HANDLE_WIN_MUTEX_ERROR();                                                   \
+        }                                                                               \
+    } while (0);
+
+#define MPIDI_CH3I_SHM_MUTEX_DESTROY_DIRECT(shm_mutex)                                  \
+    do {                                                                                \
+        BOOL result = CloseHandle(*(shm_mutex));                             \
         if (!result) {                                                                  \
             HANDLE_WIN_MUTEX_ERROR();                                                   \
         }                                                                               \

--- a/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
@@ -105,7 +105,7 @@ int MPIDI_CH3_SHM_Finalize(void)
 
 static int delay_shm_mutex_destroy(int rank, MPIR_Win *win_ptr)
 {
-#if 0
+#ifdef DELAY_SHM_MUTEX_DESTROY
     /* On FreeBSD (tested on ver 12.2) destroying the mutex and recreate the mutex,
      * which may result in the same address, the new mutex will not work for inter-
      * process. To work around, we delay the destroy of mutex until finalize. */

--- a/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
@@ -5,7 +5,7 @@
 
 #include "mpidi_ch3_impl.h"
 #include "mpidrma.h"
-
+#include <utarray.h>
 
 int MPIDI_CH3_SHM_Win_shared_query(MPIR_Win * win_ptr, int target_rank, MPI_Aint * size,
                                    int *disp_unit, void *baseptr)
@@ -62,6 +62,79 @@ int MPIDI_CH3_SHM_Win_shared_query(MPIR_Win * win_ptr, int target_rank, MPI_Aint
     goto fn_exit;
 }
 
+struct shm_mutex_entry {
+    int rank;
+    MPL_shm_hnd_t shm_hnd;
+    MPIDI_CH3I_SHM_MUTEX *shm_mutex;
+};
+
+static UT_icd shm_mutex_icd = {sizeof(struct shm_mutex_entry), NULL, NULL, NULL};
+static UT_array *shm_mutex_free_list;
+
+int MPIDI_CH3_SHM_Init(void)
+{
+    utarray_new(shm_mutex_free_list, &shm_mutex_icd, MPL_MEM_OTHER);
+    return 0;
+}
+
+int MPIDI_CH3_SHM_Finalize(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    struct shm_mutex_entry *p;
+
+    for (p = (struct shm_mutex_entry *) utarray_front(shm_mutex_free_list); p != NULL;
+         p = (struct shm_mutex_entry *) utarray_next(shm_mutex_free_list, p)) {
+        if (p->rank == 0) {
+            MPIDI_CH3I_SHM_MUTEX_DESTROY_DIRECT(p->shm_mutex);
+        }
+
+        /* detach from shared memory segment */
+        mpi_errno = MPL_shm_seg_detach(p->shm_hnd, (void **) &p->shm_mutex,
+                                       sizeof(MPIDI_CH3I_SHM_MUTEX));
+        MPIR_ERR_CHECK(mpi_errno);
+
+        MPL_shm_hnd_finalize(&p->shm_hnd);
+    }
+    utarray_free(shm_mutex_free_list);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int delay_shm_mutex_destroy(int rank, MPIR_Win *win_ptr)
+{
+#if 0
+    /* On FreeBSD (tested on ver 12.2) destroying the mutex and recreate the mutex,
+     * which may result in the same address, the new mutex will not work for inter-
+     * process. To work around, we delay the destroy of mutex until finalize. */
+    struct shm_mutex_entry entry;
+    entry.rank = rank;
+    entry.shm_hnd = win_ptr->shm_mutex_segment_handle;
+    entry.shm_mutex = win_ptr->shm_mutex;
+    utarray_push_back(shm_mutex_free_list, &entry, MPL_MEM_OTHER);
+    return 0;
+#else
+    int mpi_errno = MPI_SUCCESS;
+
+    if (rank == 0) {
+        MPIDI_CH3I_SHM_MUTEX_DESTROY_DIRECT(win_ptr->shm_mutex);
+    }
+
+    /* detach from shared memory segment */
+    mpi_errno = MPL_shm_seg_detach(win_ptr->shm_mutex_segment_handle, (void **) &win_ptr->shm_mutex,
+                                    sizeof(MPIDI_CH3I_SHM_MUTEX));
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPL_shm_hnd_finalize(&win_ptr->shm_mutex_segment_handle);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+#endif
+}
 
 int MPIDI_CH3_SHM_Win_free(MPIR_Win ** win_ptr)
 {
@@ -108,17 +181,7 @@ int MPIDI_CH3_SHM_Win_free(MPIR_Win ** win_ptr)
         node_comm_ptr = (*win_ptr)->comm_ptr->node_comm;
         MPIR_Assert(node_comm_ptr != NULL);
 
-        if (node_comm_ptr->rank == 0) {
-            MPIDI_CH3I_SHM_MUTEX_DESTROY(*win_ptr);
-        }
-
-        /* detach from shared memory segment */
-        mpi_errno =
-            MPL_shm_seg_detach((*win_ptr)->shm_mutex_segment_handle,
-                                 (void **) &(*win_ptr)->shm_mutex, sizeof(MPIDI_CH3I_SHM_MUTEX));
-        MPIR_ERR_CHECK(mpi_errno);
-
-        MPL_shm_hnd_finalize(&(*win_ptr)->shm_mutex_segment_handle);
+        delay_shm_mutex_destroy(node_comm_ptr->rank, *win_ptr);
     }
 
     /* Free shared memory region for window info */

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_finalize.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_finalize.c
@@ -11,12 +11,16 @@
 
 #include "mpidi_nem_statistics.h"
 #include "mpidu_init_shm.h"
+#include "mpidi_ch3_impl.h"
 
 int MPID_nem_finalize(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
+
+    mpi_errno = MPIDI_CH3_SHM_Finalize();
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* this test is not the right one */
 /*     MPIR_Assert(MPID_nem_queue_empty( MPID_nem_mem_region.RecvQ[MPID_nem_mem_region.rank])); */

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -10,6 +10,7 @@
 #include "mpidi_nem_statistics.h"
 #include "mpit.h"
 #include "mpidu_init_shm.h"
+#include "mpidi_ch3_impl.h"
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
@@ -405,6 +406,9 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     mpi_errno = MPIDI_nem_ckpt_init();
     MPIR_ERR_CHECK(mpi_errno);
 #endif
+
+    mpi_errno = MPIDI_CH3_SHM_Init();
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifdef PAPI_MONITOR
     my_papi_start( pg_rank );

--- a/src/mpid/ch3/channels/nemesis/subconfigure.m4
+++ b/src/mpid/ch3/channels/nemesis/subconfigure.m4
@@ -98,6 +98,12 @@ This turns off error checking and timing collection],,enable_fast=no)
 AC_CHECK_HEADERS(signal.h)
 AC_CHECK_FUNCS(signal)
 
+case "$host_os" in
+    freebsd*)
+        AC_DEFINE(DELAY_SHM_MUTEX_DESTROY, 1, [Define to workaround interprocess mutex issue on FreeBSD])
+        ;;
+esac
+
 nemesis_nets_dirs=""
 nemesis_nets_strings=""
 nemesis_nets_array=""   

--- a/test/mpi/rma/atomic_rmw_cas.c
+++ b/test/mpi/rma/atomic_rmw_cas.c
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
 
         MPI_Barrier(MPI_COMM_WORLD);
 
-        /* perform FOP */
+        /* perform CAS */
         MPI_Win_lock_all(0, win);
         if (rank != dest) {
             MPI_Compare_and_swap(orig_buf, compare_buf, result_buf, MPI_INT, dest, 0, win);

--- a/test/mpi/rma/atomic_rmw_gacc.c
+++ b/test/mpi/rma/atomic_rmw_gacc.c
@@ -74,20 +74,19 @@ static void checkResults(int loop_k, int *errors)
     }
 }
 
-int main(int argc, char *argv[])
+static int test_atomic_rmw_gacc(void)
 {
     int i, k;
     int errors = 0;
     int my_buf_num = 0;         /* to suppress warning */
     MPI_Datatype origin_dtp, target_dtp;
 
-    MTest_Init(&argc, &argv);
-
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     if (size != 3) {
         /* run this test with three processes */
-        goto exit_test;
+        printf("Run this test with three processes.\n");
+        return 1;
     }
 
     MPI_Type_contiguous(OP_COUNT, MPI_INT, &origin_dtp);
@@ -258,7 +257,17 @@ int main(int argc, char *argv[])
     MPI_Type_free(&origin_dtp);
     MPI_Type_free(&target_dtp);
 
-  exit_test:
+    return errors;
+}
+
+int main(int argc, char *argv[])
+{
+    int errors = 0;
+
+    MTest_Init(&argc, &argv);
+
+    errors += test_atomic_rmw_gacc();
+
     MTest_Finalize(errors);
     return MTestReturnValue(errors);
 }

--- a/test/mpi/rma/atomic_rmw_gacc.c
+++ b/test/mpi/rma/atomic_rmw_gacc.c
@@ -267,6 +267,7 @@ int main(int argc, char *argv[])
     MTest_Init(&argc, &argv);
 
     errors += test_atomic_rmw_gacc();
+    errors += test_atomic_rmw_gacc();
 
     MTest_Finalize(errors);
     return MTestReturnValue(errors);

--- a/test/mpi/rma/atomic_rmw_gacc.c
+++ b/test/mpi/rma/atomic_rmw_gacc.c
@@ -50,7 +50,7 @@ static void checkResults(int loop_k, int *errors)
                     for (m = 0; m < OP_COUNT; m++) {
                         if (check_buf[i * OP_COUNT + m] == result_buf[j * OP_COUNT + m]) {
                             printf
-                                ("LOOP=%d, rank=%d, FOP, both check_buf[%d] and result_buf[%d] equal to %d, expected to be different. \n",
+                                ("LOOP=%d, rank=%d, GACC, both check_buf[%d] and result_buf[%d] equal to %d, expected to be different. \n",
                                  loop_k, rank, i * OP_COUNT + m, j * OP_COUNT + m,
                                  check_buf[i * OP_COUNT + m]);
                             (*errors)++;
@@ -65,7 +65,7 @@ static void checkResults(int loop_k, int *errors)
         /* check results on P1 */
         for (i = 0; i < OP_COUNT; i++) {
             if (target_buf[i] != AM_BUF_NUM + SHM_BUF_NUM) {
-                printf("LOOP=%d, rank=%d, FOP, target_buf[%d] = %d, expected %d. \n",
+                printf("LOOP=%d, rank=%d, GACC, target_buf[%d] = %d, expected %d. \n",
                        loop_k, rank, i, target_buf[i], AM_BUF_NUM + SHM_BUF_NUM);
                 (*errors)++;
             }


### PR DESCRIPTION
## Pull Request Description
On FreeBSD (at lease for ver 12.2), destroying the mutex and recreate
the mutex, the new mutex will not work for inter-process. As workaround,
delay destroying window mutex until finalize.

Fixes #5750 

* [x] confirm the issue
* [x] fix the issue

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
