### PR TITLE
Use Streaming Store For Cross-Socket Memory Copies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -889,6 +889,9 @@ for option in $enable_fast ; do
         ;;
         alwaysinline) # No op in MPICH. See mpl/configure.ac
         ;;
+        avx)
+        enable_fast_avx_instr=yes
+        ;;
         all|yes)
         enable_fast_ndebug=yes
         enable_fast_opts=O2
@@ -896,6 +899,7 @@ for option in $enable_fast ; do
         none|no)
         enable_fast_ndebug=no
         enable_fast_opts=O0
+        enable_fast_avx_instr=no
         ;;
         *)
 	IFS="$save_IFS"
@@ -930,6 +934,37 @@ fi
 if test -z "$enable_fast_no_strict_alignment" ; then
     # we need observe strict alignment to pass ubsan check
     AC_DEFINE(NEEDS_STRICT_ALIGNMENT,1,[Define if strict alignment memory access is required])
+fi
+
+if test "$enable_fast_avx_instr" = "yes" ; then
+    AC_CACHE_CHECK([whether -mavx is supported], pac_cv_found_avx,
+                   [PAC_C_CHECK_COMPILER_OPTION([-mavx],pac_cv_found_avx=yes,pac_cv_found_avx=no)],
+                   pac_cv_found_avx=no,pac_cv_found_avx=yes)
+    if test "$pac_cv_found_avx" = "yes" ; then
+        PAC_APPEND_FLAG([-mavx],[CFLAGS])
+
+        AC_CACHE_CHECK([whether _mm256_stream_si256 is supported], pac_cv_found__mm256_stream_si256,[
+                        AC_RUN_IFELSE([AC_LANG_SOURCE([[
+                                       #include <immintrin.h>
+
+                                       int main(int argc, char **argv) {
+                                           char source[1024], dest[1024];
+                                           for (int i = 0; i < 1024; i++) source[i] = 'a';
+
+                                           __m256i ymm0 = _mm256_loadu_si256((__m256i const *) source);
+                                           _mm256_stream_si256((__m256i *) dest, ymm0);
+
+                                           if (dest[0] == source[0]) return 0;
+                                           else return 1;
+                                       }
+                                       ]])], pac_cv_found__mm256_stream_si256="yes",
+                                       pac_cv_found__mm256_stream_si256="no",
+                                       pac_cv_found__mm256_stream_si256="unknown")
+                        ])
+    fi
+    if test "$pac_cv_found__mm256_stream_si256" = "yes" ; then
+        AC_DEFINE(HAVE_MM256_STREAM_SI256,1,[Define if 256 bit streaming memcpy is available])
+    fi
 fi
 
 # error-checking

--- a/src/include/mpir_mem.h
+++ b/src/include/mpir_mem.h
@@ -84,6 +84,12 @@ extern "C" {
         memcpy((dst), (src), (len));            \
     } while (0)
 
+#define MPIR_Memcpy_stream(dst, src, len)       \
+    do {                                        \
+        CHECK_MEMCPY((dst),(src),(len));        \
+        MPL_Memcpy_stream((dst), (src), (len)); \
+    } while (0)
+
 /* Memory allocation macros. See document. */
 
 /* Standard macro for generating error codes.  We set the error to be

--- a/src/include/mpir_typerep.h
+++ b/src/include/mpir_typerep.h
@@ -56,21 +56,25 @@ int MPIR_Typerep_to_iov_offset(const void *buf, MPI_Aint count, MPI_Datatype typ
 int MPIR_Typerep_iov_len(MPI_Aint count, MPI_Datatype type, MPI_Aint max_iov_bytes,
                          MPI_Aint * iov_len);
 
-int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes);
+#define MPIR_TYPEREP_FLAG_NONE          0x0UL
+#define MPIR_TYPEREP_FLAG_STREAM        0x1UL
+
+int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes, uint32_t flags);
 int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                       MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
-                      MPI_Aint * actual_pack_bytes);
+                      MPI_Aint * actual_pack_bytes, uint32_t flags);
 int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize,
                         void *outbuf, MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
-                        MPI_Aint * actual_unpack_bytes);
+                        MPI_Aint * actual_unpack_bytes, uint32_t flags);
 int MPIR_Typerep_icopy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
-                       MPIR_Typerep_req * typereq_req);
+                       MPIR_Typerep_req * typereq_req, uint32_t flags);
 int MPIR_Typerep_ipack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                        MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
-                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typereq_req);
-int MPIR_Typerep_iunpack(const void *inbuf, MPI_Aint insize,
-                         void *outbuf, MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
-                         MPI_Aint * actual_unpack_bytes, MPIR_Typerep_req * typereq_req);
+                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typereq_req,
+                       uint32_t flags);
+int MPIR_Typerep_iunpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_Aint outcount,
+                         MPI_Datatype datatype, MPI_Aint outoffset, MPI_Aint * actual_unpack_bytes,
+                         MPIR_Typerep_req * typereq_req, uint32_t flags);
 int MPIR_Typerep_wait(MPIR_Typerep_req typereq_req);
 
 int MPIR_Typerep_size_external32(MPI_Datatype type);

--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -59,7 +59,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
         MPIR_CHKLMEM_MALLOC(sendbuf, void *, nbytes, mpi_errno, "sendbuf", MPL_MEM_BUFFER);
         if (rank == root) {
             mpi_errno = MPIR_Typerep_pack(buffer, count, datatype, 0, sendbuf, nbytes,
-                                          &actual_packed_unpacked_bytes);
+                                          &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }
@@ -225,7 +225,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
     if (!is_contig) {
         if (rank != root) {
             mpi_errno = MPIR_Typerep_unpack(sendbuf, nbytes, buffer, count, datatype, 0,
-                                            &actual_packed_unpacked_bytes);
+                                            &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -57,7 +57,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {
             mpi_errno = MPIR_Typerep_pack(buffer, count, datatype, 0, send_buf, nbytes,
-                                          &actual_packed_unpacked_bytes);
+                                          &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
             MPIR_ERR_CHECK(mpi_errno);
         }
         count = count * type_size;
@@ -148,7 +148,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
     if (!is_contig) {
         if (rank != root) {
             mpi_errno = MPIR_Typerep_unpack(send_buf, nbytes, buffer, saved_count, datatype, 0,
-                                            &actual_packed_unpacked_bytes);
+                                            &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -403,7 +403,8 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
                             MPL_MEM_BUFFER);
 
         mpi_errno =
-            MPIR_Typerep_pack(buf, count, datatype, 0, tmpbuf, tmpbuf_size, &actual_pack_bytes);
+            MPIR_Typerep_pack(buf, count, datatype, 0, tmpbuf, tmpbuf_size, &actual_pack_bytes,
+                              MPIR_TYPEREP_FLAG_NONE);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/datatype/datatype_impl.c
+++ b/src/mpi/datatype/datatype_impl.c
@@ -68,7 +68,8 @@ int MPIR_Pack_impl(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint actual_pack_bytes;
     void *buf = (void *) ((char *) outbuf + *position);
-    mpi_errno = MPIR_Typerep_pack(inbuf, incount, datatype, 0, buf, outsize, &actual_pack_bytes);
+    mpi_errno = MPIR_Typerep_pack(inbuf, incount, datatype, 0, buf, outsize, &actual_pack_bytes,
+                                  MPIR_TYPEREP_FLAG_NONE);
     MPIR_ERR_CHECK(mpi_errno);
     *position += actual_pack_bytes;
 
@@ -102,7 +103,8 @@ int MPIR_Unpack_impl(const void *inbuf, MPI_Aint insize, MPI_Aint * position,
     MPI_Aint actual_unpack_bytes;
     void *buf = (void *) ((char *) inbuf + *position);
     mpi_errno =
-        MPIR_Typerep_unpack(buf, insize, outbuf, outcount, datatype, 0, &actual_unpack_bytes);
+        MPIR_Typerep_unpack(buf, insize, outbuf, outcount, datatype, 0, &actual_unpack_bytes,
+                            MPIR_TYPEREP_FLAG_NONE);
     MPIR_ERR_CHECK(mpi_errno);
     *position += actual_unpack_bytes;
 

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
@@ -13,7 +13,11 @@ int MPIR_Typerep_icopy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
 {
     MPIR_FUNC_ENTER;
 
-    MPIR_Memcpy(outbuf, inbuf, num_bytes);
+    if (flags & MPIR_TYPEREP_FLAG_STREAM) {
+        MPIR_Memcpy_stream(outbuf, inbuf, num_bytes);
+    } else {
+        MPIR_Memcpy(outbuf, inbuf, num_bytes);
+    }
 
     MPIR_FUNC_EXIT;
     return MPI_SUCCESS;

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
@@ -9,7 +9,7 @@
 #include "typerep_internal.h"
 
 int MPIR_Typerep_icopy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
-                       MPIR_Typerep_req * typereq_req)
+                       MPIR_Typerep_req * typereq_req, uint32_t flags)
 {
     MPIR_FUNC_ENTER;
 
@@ -19,14 +19,14 @@ int MPIR_Typerep_icopy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
     return MPI_SUCCESS;
 }
 
-int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
+int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes, uint32_t flags)
 {
-    return MPIR_Typerep_icopy(outbuf, inbuf, num_bytes, NULL);
+    return MPIR_Typerep_icopy(outbuf, inbuf, num_bytes, NULL, flags);
 }
 
 int MPIR_Typerep_ipack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                        MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
-                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typereq_req)
+                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typereq_req, uint32_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Segment *segp;
@@ -83,16 +83,17 @@ int MPIR_Typerep_ipack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatyp
 
 int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                       MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
-                      MPI_Aint * actual_pack_bytes)
+                      MPI_Aint * actual_pack_bytes, uint32_t flags)
 {
     return MPIR_Typerep_ipack(inbuf, incount, datatype, inoffset, outbuf, max_pack_bytes,
-                              actual_pack_bytes, NULL);
+                              actual_pack_bytes, NULL, flags);
 }
 
 
 int MPIR_Typerep_iunpack(const void *inbuf, MPI_Aint insize,
                          void *outbuf, MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
-                         MPI_Aint * actual_unpack_bytes, MPIR_Typerep_req * typereq_req)
+                         MPI_Aint * actual_unpack_bytes, MPIR_Typerep_req * typereq_req,
+                         uint32_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Segment *segp;
@@ -150,10 +151,10 @@ int MPIR_Typerep_iunpack(const void *inbuf, MPI_Aint insize,
 
 int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize,
                         void *outbuf, MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
-                        MPI_Aint * actual_unpack_bytes)
+                        MPI_Aint * actual_unpack_bytes, uint32_t flags)
 {
     return MPIR_Typerep_iunpack(inbuf, insize, outbuf, outcount, datatype, outoffset,
-                                actual_unpack_bytes, NULL);
+                                actual_unpack_bytes, NULL, flags);
 }
 
 int MPIR_Typerep_wait(MPIR_Typerep_req typereq_req)

--- a/src/mpi/datatype/typerep/src/typerep_op.c
+++ b/src/mpi/datatype/typerep/src/typerep_op.c
@@ -37,7 +37,7 @@ int MPII_Typerep_op_fallback(void *source_buf, MPI_Aint source_count, MPI_Dataty
             void *src_ptr = MPL_malloc(source_dtp_extent * source_count, MPL_MEM_OTHER);
             MPI_Aint unpack_size;
             MPIR_Typerep_unpack(source_buf, source_dtp_size * source_count, src_ptr,
-                                source_count, source_dtp, 0, &unpack_size);
+                                source_count, source_dtp, 0, &unpack_size, MPIR_TYPEREP_REQ_NULL);
             source_buf = src_ptr;
             source_unpacked = true;
         }

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -60,7 +60,7 @@ cvars:
 /* When a returned typerep_req is expected, using the nonblocking yaksa routine and
  * return the request; otherwise use the blocking yaksa routine. */
 static int typerep_do_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
-                           MPIR_Typerep_req * typerep_req)
+                           MPIR_Typerep_req * typerep_req, uint32_t flags)
 {
     MPIR_FUNC_ENTER;
 
@@ -111,7 +111,8 @@ static int typerep_do_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
  * return the request; otherwise use the blocking yaksa routine. */
 static int typerep_do_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                            MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
-                           MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typerep_req)
+                           MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typerep_req,
+                           uint32_t flags)
 {
     MPIR_FUNC_ENTER;
 
@@ -239,7 +240,8 @@ int MPIR_Typerep_reduce_is_supported(MPI_Op op, MPI_Datatype datatype)
  * return the request; otherwise use the blocking yaksa routine. */
 static int typerep_do_unpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_Aint outcount,
                              MPI_Datatype datatype, MPI_Aint outoffset,
-                             MPI_Aint * actual_unpack_bytes, MPIR_Typerep_req * typerep_req)
+                             MPI_Aint * actual_unpack_bytes, MPIR_Typerep_req * typerep_req,
+                             uint32_t flags)
 {
     MPIR_FUNC_ENTER;
 
@@ -316,23 +318,23 @@ static int typerep_do_unpack(const void *inbuf, MPI_Aint insize, void *outbuf, M
 }
 
 int MPIR_Typerep_icopy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
-                       MPIR_Typerep_req * typerep_req)
+                       MPIR_Typerep_req * typerep_req, uint32_t flags)
 {
     MPIR_FUNC_ENTER;
 
     int mpi_errno = MPI_SUCCESS;
-    mpi_errno = typerep_do_copy(outbuf, inbuf, num_bytes, typerep_req);
+    mpi_errno = typerep_do_copy(outbuf, inbuf, num_bytes, typerep_req, flags);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }
 
-int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
+int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes, uint32_t flags)
 {
     MPIR_FUNC_ENTER;
 
     int mpi_errno = MPI_SUCCESS;
-    mpi_errno = typerep_do_copy(outbuf, inbuf, num_bytes, NULL);
+    mpi_errno = typerep_do_copy(outbuf, inbuf, num_bytes, NULL, flags);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -340,13 +342,13 @@ int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes)
 
 int MPIR_Typerep_ipack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                        MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
-                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typerep_req)
+                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typerep_req, uint32_t flags)
 {
     MPIR_FUNC_ENTER;
 
     int mpi_errno = MPI_SUCCESS;
     mpi_errno = typerep_do_pack(inbuf, incount, datatype, inoffset, outbuf, max_pack_bytes,
-                                actual_pack_bytes, typerep_req);
+                                actual_pack_bytes, typerep_req, flags);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -354,13 +356,13 @@ int MPIR_Typerep_ipack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatyp
 
 int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                       MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
-                      MPI_Aint * actual_pack_bytes)
+                      MPI_Aint * actual_pack_bytes, uint32_t flags)
 {
     MPIR_FUNC_ENTER;
 
     int mpi_errno = MPI_SUCCESS;
     mpi_errno = typerep_do_pack(inbuf, incount, datatype, inoffset, outbuf, max_pack_bytes,
-                                actual_pack_bytes, NULL);
+                                actual_pack_bytes, NULL, flags);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -368,26 +370,27 @@ int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype
 
 int MPIR_Typerep_iunpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_Aint outcount,
                          MPI_Datatype datatype, MPI_Aint outoffset, MPI_Aint * actual_unpack_bytes,
-                         MPIR_Typerep_req * typerep_req)
+                         MPIR_Typerep_req * typerep_req, uint32_t flags)
 {
     MPIR_FUNC_ENTER;
 
     int mpi_errno = MPI_SUCCESS;
     mpi_errno = typerep_do_unpack(inbuf, insize, outbuf, outcount, datatype, outoffset,
-                                  actual_unpack_bytes, typerep_req);
+                                  actual_unpack_bytes, typerep_req, flags);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }
 
 int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_Aint outcount,
-                        MPI_Datatype datatype, MPI_Aint outoffset, MPI_Aint * actual_unpack_bytes)
+                        MPI_Datatype datatype, MPI_Aint outoffset, MPI_Aint * actual_unpack_bytes,
+                        uint32_t flags)
 {
     MPIR_FUNC_ENTER;
 
     int mpi_errno = MPI_SUCCESS;
     mpi_errno = typerep_do_unpack(inbuf, insize, outbuf, outcount, datatype, outoffset,
-                                  actual_unpack_bytes, NULL);
+                                  actual_unpack_bytes, NULL, flags);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -485,7 +488,7 @@ int MPIR_Typerep_op(void *source_buf, MPI_Aint source_count, MPI_Datatype source
             void *src_ptr = MPL_malloc(data_sz, MPL_MEM_OTHER);
             MPI_Aint pack_size;
             MPIR_Typerep_pack(source_buf, source_count, source_dtp, 0, src_ptr, data_sz,
-                              &pack_size);
+                              &pack_size, MPIR_TYPEREP_REQ_NULL);
             MPIR_Assert(pack_size == data_sz);
             mpi_errno = typerep_op_unpack(src_ptr, target_buf, target_count, target_dtp,
                                           op, mapped_device);

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -159,7 +159,11 @@ static int typerep_do_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype dat
         MPI_Aint real_bytes = MPL_MIN(total_size - inoffset, max_pack_bytes);
         /* Make sure we never pack partial element */
         real_bytes -= real_bytes % element_size;
-        MPIR_Memcpy(outbuf, MPIR_get_contig_ptr(inbuf_ptr, inoffset), real_bytes);
+        if (flags & MPIR_TYPEREP_FLAG_STREAM) {
+            MPIR_Memcpy_stream(outbuf, MPIR_get_contig_ptr(inbuf_ptr, inoffset), real_bytes);
+        } else {
+            MPIR_Memcpy(outbuf, MPIR_get_contig_ptr(inbuf_ptr, inoffset), real_bytes);
+        }
         *actual_pack_bytes = real_bytes;
         goto fn_exit;
     }

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -59,10 +59,12 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
         MPI_Aint actual_unpack_bytes;
         if (typereq_req) {
             MPIR_Typerep_iunpack(MPIR_get_contig_ptr(sendbuf, sendtype_true_lb), copy_sz, recvbuf,
-                                 recvcount, recvtype, 0, &actual_unpack_bytes, typereq_req);
+                                 recvcount, recvtype, 0, &actual_unpack_bytes, typereq_req,
+                                 MPIR_TYPEREP_FLAG_NONE);
         } else {
             MPIR_Typerep_unpack(MPIR_get_contig_ptr(sendbuf, sendtype_true_lb), copy_sz, recvbuf,
-                                recvcount, recvtype, 0, &actual_unpack_bytes);
+                                recvcount, recvtype, 0, &actual_unpack_bytes,
+                                MPIR_TYPEREP_FLAG_NONE);
         }
         MPIR_ERR_CHKANDJUMP(actual_unpack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
                             "**dtypemismatch");
@@ -71,11 +73,11 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
         if (typereq_req) {
             MPIR_Typerep_ipack(sendbuf, sendcount, sendtype, 0,
                                MPIR_get_contig_ptr(recvbuf, recvtype_true_lb), copy_sz,
-                               &actual_pack_bytes, typereq_req);
+                               &actual_pack_bytes, typereq_req, MPIR_TYPEREP_FLAG_NONE);
         } else {
             MPIR_Typerep_pack(sendbuf, sendcount, sendtype, 0,
                               MPIR_get_contig_ptr(recvbuf, recvtype_true_lb), copy_sz,
-                              &actual_pack_bytes);
+                              &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
         }
         MPIR_ERR_CHKANDJUMP(actual_pack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
                             "**dtypemismatch");
@@ -109,14 +111,14 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
 
             MPI_Aint actual_pack_bytes;
             MPIR_Typerep_pack(sendbuf, sendcount, sendtype, sfirst, buf,
-                              max_pack_bytes, &actual_pack_bytes);
+                              max_pack_bytes, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
             MPIR_Assert(actual_pack_bytes > 0);
 
             sfirst += actual_pack_bytes;
 
             MPI_Aint actual_unpack_bytes;
             MPIR_Typerep_unpack(buf, actual_pack_bytes, recvbuf, recvcount, recvtype,
-                                rfirst, &actual_unpack_bytes);
+                                rfirst, &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
             MPIR_Assert(actual_unpack_bytes > 0);
 
             rfirst += actual_unpack_bytes;

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -258,7 +258,8 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
                 MPI_Aint actual_pack_bytes;
                 void *pbuf = (void *) ((char *) p->msg.msgbuf + p->msg.count);
                 mpi_errno =
-                    MPIR_Typerep_pack(buf, count, dtype, 0, pbuf, packsize, &actual_pack_bytes);
+                    MPIR_Typerep_pack(buf, count, dtype, 0, pbuf, packsize, &actual_pack_bytes,
+                                      MPIR_TYPEREP_FLAG_NONE);
                 MPIR_ERR_CHECK(mpi_errno);
                 p->msg.count += actual_pack_bytes;
             } else {

--- a/src/mpi/pt2pt/sendrecv.c
+++ b/src/mpi/pt2pt/sendrecv.c
@@ -111,7 +111,8 @@ int MPIR_Sendrecv_replace_impl(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                    "temporary send buffer", MPL_MEM_BUFFER);
 
         mpi_errno =
-            MPIR_Typerep_pack(buf, count, datatype, 0, tmpbuf, tmpbuf_size, &actual_pack_bytes);
+            MPIR_Typerep_pack(buf, count, datatype, 0, tmpbuf, tmpbuf_size, &actual_pack_bytes,
+                              MPIR_TYPEREP_FLAG_NONE);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -254,7 +255,7 @@ int MPIR_Isendrecv_replace_impl(void *buf, MPI_Aint count, MPI_Datatype datatype
         }
 
         mpi_errno = MPIR_Typerep_pack(buf, count, datatype, 0, tmpbuf, tmpbuf_size,
-                                      &actual_pack_bytes);
+                                      &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(tmpbuf_size == actual_pack_bytes);
     }

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
@@ -505,7 +505,7 @@ MPID_nem_mpich_send_seg_header (void *buf, MPI_Aint count, MPI_Datatype datatype
             MPI_Aint actual_pack_bytes;
             MPIR_Typerep_pack(buf, count, datatype, *msg_offset,
                            (char *)cell_ptr->payload + sizeof(MPIDI_CH3_Pkt_t),
-                           msgsize - *msg_offset, &actual_pack_bytes);
+                           msgsize - *msg_offset, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
             MPIR_Assert(actual_pack_bytes == msgsize - *msg_offset);
 
             MPL_atomic_release_store_int(&pbox->flag, 1);
@@ -560,7 +560,7 @@ MPID_nem_mpich_send_seg_header (void *buf, MPI_Aint count, MPI_Datatype datatype
 
     MPI_Aint actual_pack_bytes;
     MPIR_Typerep_pack(buf, count, datatype, *msg_offset, (char *)el->payload + buf_offset,
-                   max_pack_bytes, &actual_pack_bytes);
+                   max_pack_bytes, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
     datalen = buf_offset + actual_pack_bytes;
     *msg_offset += actual_pack_bytes;
 
@@ -645,7 +645,7 @@ MPID_nem_mpich_send_seg (void *buf, MPI_Aint count, MPI_Datatype datatype,
 
     MPI_Aint actual_pack_bytes;
     MPIR_Typerep_pack(buf, count, datatype, *msg_offset, (char *)el->payload,
-                   max_pack_bytes, &actual_pack_bytes);
+                   max_pack_bytes, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
     datalen = actual_pack_bytes;
     *msg_offset += actual_pack_bytes;
     

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
@@ -326,7 +326,8 @@ int MPID_nem_ofi_SendNoncontig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr, 
     MPI_Aint actual_pack_bytes;
     MPIR_Typerep_pack(sreq->dev.user_buf, sreq->dev.user_count, sreq->dev.datatype,
                       sreq->dev.msg_offset, pack_buffer + buf_offset,
-                      sreq->dev.msgsize - sreq->dev.msg_offset, &actual_pack_bytes);
+                      sreq->dev.msgsize - sreq->dev.msg_offset, &actual_pack_bytes,
+                      MPIR_TYPEREP_FLAG_NONE);
     MPIR_Assert(actual_pack_bytes == sreq->dev.msgsize - sreq->dev.msg_offset);
 
     START_COMM();

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_shm.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_shm.c
@@ -456,7 +456,8 @@ static int lmt_shm_send_progress(MPIDI_VC_t *vc, MPIR_Request *req, int *done)
 
         MPI_Aint actual_pack_bytes;
         MPIR_Typerep_pack(req->dev.user_buf, req->dev.user_count, req->dev.datatype, first,
-                       (void *)copy_buf->buf[buf_num], max_pack_bytes, &actual_pack_bytes);
+                       (void *)copy_buf->buf[buf_num], max_pack_bytes, &actual_pack_bytes,
+                       MPIR_TYPEREP_FLAG_NONE);
 
         MPL_atomic_write_barrier();
         MPIR_Assign_trunc(copy_buf->len[buf_num].val, actual_pack_bytes, int);
@@ -545,7 +546,7 @@ static int lmt_shm_recv_progress(MPIDI_VC_t *vc, MPIR_Request *req, int *done)
         MPI_Aint actual_unpack_bytes;
         MPIR_Typerep_unpack(src_buf, last - first,
                          req->dev.user_buf, req->dev.user_count, req->dev.datatype,
-                         first, &actual_unpack_bytes);
+                         first, &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
         last = first + actual_unpack_bytes;
 
         MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_CHANNEL, VERBOSE, (MPL_DBG_FDEST, "recvd data.  last=%" PRIdPTR " data_sz=%" PRIdPTR, last, data_sz));

--- a/src/mpid/ch3/include/mpid_rma_shm.h
+++ b/src/mpid/ch3/include/mpid_rma_shm.h
@@ -353,7 +353,8 @@ static inline int MPIDI_CH3I_Shm_acc_op(const void *origin_addr, int origin_coun
 
         MPI_Aint actual_pack_bytes;
         MPIR_Typerep_pack(origin_addr, origin_count, origin_datatype,
-                       stream_offset, packed_buf, stream_size, &actual_pack_bytes);
+                       stream_offset, packed_buf, stream_size, &actual_pack_bytes,
+                       MPIR_TYPEREP_FLAG_NONE);
         MPIR_Assert(actual_pack_bytes == stream_size);
 
         if (shm_op) {
@@ -473,7 +474,8 @@ static inline int MPIDI_CH3I_Shm_get_acc_op(const void *origin_addr, int origin_
 
         MPI_Aint actual_pack_bytes;
         MPIR_Typerep_pack(origin_addr, origin_count, origin_datatype,
-                       stream_offset, packed_buf, stream_size, &actual_pack_bytes);
+                       stream_offset, packed_buf, stream_size, &actual_pack_bytes,
+                       MPIR_TYPEREP_FLAG_NONE);
         MPIR_Assert(actual_pack_bytes == stream_size);
 
         MPIR_Assert(stream_count == (int) stream_count);

--- a/src/mpid/ch3/src/ch3u_buffer.c
+++ b/src/mpid/ch3/src/ch3u_buffer.c
@@ -72,7 +72,8 @@ void MPIDI_CH3U_Buffer_copy(
     else if (sdt_contig)
     {
         MPI_Aint actual_unpack_bytes;
-        MPIR_Typerep_unpack(MPIR_get_contig_ptr(sbuf, sdt_true_lb), sdata_sz, rbuf, rcount, rdt, 0, &actual_unpack_bytes);
+        MPIR_Typerep_unpack(MPIR_get_contig_ptr(sbuf, sdt_true_lb), sdata_sz, rbuf, rcount, rdt, 0,
+                            &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
         /* --BEGIN ERROR HANDLING-- */
         if (actual_unpack_bytes != sdata_sz)
         {
@@ -84,7 +85,8 @@ void MPIDI_CH3U_Buffer_copy(
     else if (rdt_contig)
     {
 	MPI_Aint actual_pack_bytes;
-	MPIR_Typerep_pack(sbuf, scount, sdt, 0, MPIR_get_contig_ptr(rbuf, rdt_true_lb), sdata_sz, &actual_pack_bytes);
+    MPIR_Typerep_pack(sbuf, scount, sdt, 0, MPIR_get_contig_ptr(rbuf, rdt_true_lb), sdata_sz,
+                      &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
 	/* --BEGIN ERROR HANDLING-- */
 	if (actual_pack_bytes != sdata_sz)
 	{
@@ -134,8 +136,10 @@ void MPIDI_CH3U_Buffer_copy(
 	    if (max_pack_bytes == 0)
 		break;
 
-	    MPIR_Typerep_pack(sbuf, scount, sdt, sfirst, buf, max_pack_bytes, &actual_pack_bytes);
-	    MPIR_Typerep_unpack(buf, actual_pack_bytes, rbuf, rcount, rdt, rfirst, &actual_unpack_bytes);
+        MPIR_Typerep_pack(sbuf, scount, sdt, sfirst, buf, max_pack_bytes, &actual_pack_bytes,
+                          MPIR_TYPEREP_FLAG_NONE);
+        MPIR_Typerep_unpack(buf, actual_pack_bytes, rbuf, rcount, rdt, rfirst, &actual_unpack_bytes,
+                            MPIR_TYPEREP_FLAG_NONE);
 	    MPIR_Assert(actual_pack_bytes == actual_unpack_bytes);
 
 	    sfirst += actual_pack_bytes;

--- a/src/mpid/ch3/src/ch3u_eager.c
+++ b/src/mpid/ch3/src/ch3u_eager.c
@@ -394,8 +394,9 @@ int MPIDI_CH3_PktHandler_EagerShortSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, v
 		recv_data_sz = rreq->dev.recv_data_sz;
 
 		MPI_Aint actual_unpack_bytes;
-		MPIR_Typerep_unpack(eagershort_pkt->data, recv_data_sz, rreq->dev.user_buf,
-				 rreq->dev.user_count, rreq->dev.datatype, 0, &actual_unpack_bytes);
+        MPIR_Typerep_unpack(eagershort_pkt->data, recv_data_sz, rreq->dev.user_buf,
+                 rreq->dev.user_count, rreq->dev.datatype, 0, &actual_unpack_bytes,
+                 MPIR_TYPEREP_FLAG_NONE);
 
 		if (actual_unpack_bytes != recv_data_sz) {
 		    /* --BEGIN ERROR HANDLING-- */

--- a/src/mpid/ch3/src/ch3u_handle_recv_pkt.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_pkt.c
@@ -172,7 +172,8 @@ int MPIDI_CH3U_Receive_data_found(MPIR_Request *rreq, void *buf, intptr_t *bufle
 
             MPI_Aint actual_unpack_bytes;
             MPIR_Typerep_unpack(buf, data_sz, rreq->dev.user_buf, rreq->dev.user_count,
-                             rreq->dev.datatype, rreq->dev.msg_offset, &actual_unpack_bytes);
+                             rreq->dev.datatype, rreq->dev.msg_offset, &actual_unpack_bytes,
+                             MPIR_TYPEREP_FLAG_NONE);
 
             /* --BEGIN ERROR HANDLING-- */
             if (actual_unpack_bytes != data_sz)

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -308,7 +308,8 @@ int MPIDI_CH3_ReqHandler_GaccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
     else {
         MPI_Aint actual_pack_bytes;
         MPIR_Typerep_pack(rreq->dev.real_user_buf, rreq->dev.user_count, rreq->dev.datatype,
-                       stream_offset, resp_req->dev.user_buf, stream_data_len, &actual_pack_bytes);
+                       stream_offset, resp_req->dev.user_buf, stream_data_len, &actual_pack_bytes,
+                       MPIR_TYPEREP_FLAG_NONE);
         MPIR_Assert(actual_pack_bytes == stream_data_len);
     }
 
@@ -433,7 +434,7 @@ int MPIDI_CH3_ReqHandler_FOPRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
     else {
         MPI_Aint actual_pack_bytes;
         MPIR_Typerep_pack(rreq->dev.real_user_buf, 1, rreq->dev.datatype, 0, resp_req->dev.user_buf,
-                       type_size, &actual_pack_bytes);
+                       type_size, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
         MPIR_Assert(actual_pack_bytes == type_size);
     }
 
@@ -1283,7 +1284,8 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
     else {
         MPI_Aint actual_pack_bytes;
         MPIR_Typerep_pack(get_accum_pkt->addr, get_accum_pkt->count, get_accum_pkt->datatype,
-                       0, sreq->dev.user_buf, type_size * recv_count, &actual_pack_bytes);
+                       0, sreq->dev.user_buf, type_size * recv_count, &actual_pack_bytes,
+                       MPIR_TYPEREP_FLAG_NONE);
         MPIR_Assert(actual_pack_bytes == type_size * recv_count);
     }
 
@@ -1422,7 +1424,7 @@ static inline int perform_fop_in_lock_queue(MPIR_Win * win_ptr,
     else {
         MPI_Aint actual_pack_bytes;
         MPIR_Typerep_pack(fop_pkt->addr, 1, fop_pkt->datatype, 0, resp_req->dev.user_buf,
-                       type_size, &actual_pack_bytes);
+                       type_size, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
         MPIR_Assert(actual_pack_bytes == type_size);
     }
 

--- a/src/mpid/ch3/src/ch3u_request.c
+++ b/src/mpid/ch3/src/ch3u_request.c
@@ -159,7 +159,7 @@ int MPIDI_CH3U_Request_load_send_iov(MPIR_Request * const sreq,
 
         MPIR_Typerep_pack(sreq->dev.user_buf, sreq->dev.user_count, sreq->dev.datatype,
                        sreq->dev.msg_offset, (char*) sreq->dev.tmpbuf + iov_data_copied,
-                       max_pack_bytes, &actual_pack_bytes);
+                       max_pack_bytes, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
         last = sreq->dev.msg_offset + actual_pack_bytes;
 
 	iov[0].iov_base = (void *)sreq->dev.tmpbuf;
@@ -418,7 +418,7 @@ int MPIDI_CH3U_Request_unpack_srbuf(MPIR_Request * rreq)
     MPI_Aint actual_unpack_bytes;
     MPIR_Typerep_unpack(rreq->dev.tmpbuf, tmpbuf_last - rreq->dev.msg_offset,
                      rreq->dev.user_buf, rreq->dev.user_count, rreq->dev.datatype,
-                     rreq->dev.msg_offset, &actual_unpack_bytes);
+                     rreq->dev.msg_offset, &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
     last = rreq->dev.msg_offset + actual_unpack_bytes;
 
     if (last == 0 || last == rreq->dev.msg_offset)
@@ -528,7 +528,7 @@ int MPIDI_CH3U_Request_unpack_uebuf(MPIR_Request * rreq)
 	    MPI_Aint actual_unpack_bytes;
 	    MPIR_Typerep_unpack(rreq->dev.tmpbuf, unpack_sz,
 			     rreq->dev.user_buf, rreq->dev.user_count,
-			     rreq->dev.datatype, 0, &actual_unpack_bytes);
+			     rreq->dev.datatype, 0, &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
 
 	    if (actual_unpack_bytes != unpack_sz)
 	    {

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -352,7 +352,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm
     }
 
     MPI_Aint packed_size;
-    mpi_errno = MPIR_Typerep_pack(buf, count, datatype, 0, p_am_data, data_sz, &packed_size);
+    mpi_errno = MPIR_Typerep_pack(buf, count, datatype, 0, p_am_data, data_sz, &packed_size,
+                                  MPIR_TYPEREP_FLAG_NONE);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(packed_size == data_sz);
 
@@ -411,7 +412,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
     MPIR_Memcpy(send_req->am_hdr, MPIDI_OFI_AM_SREQ_HDR(sreq, am_hdr), am_hdr_sz);
     MPI_Aint packed_size;
     mpi_errno = MPIR_Typerep_pack(buf, count, datatype, offset,
-                                  send_req->am_data, seg_sz, &packed_size);
+                                  send_req->am_data, seg_sz, &packed_size, MPIR_TYPEREP_FLAG_NONE);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(packed_size == seg_sz);
 
@@ -763,7 +764,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_rdma_read(int rank, MPIR_Comm
          * step when we work on ZCOPY protocol support. Basically, if the src buf and datatype needs
          * packing, we should not be doing RDMA read. */
         MPIR_gpu_malloc_host((void **) &send_buf, data_sz);
-        mpi_errno = MPIR_Typerep_pack(buf, count, datatype, 0, send_buf, data_sz, &last);
+        mpi_errno = MPIR_Typerep_pack(buf, count, datatype, 0, send_buf, data_sz, &last,
+                                      MPIR_TYPEREP_FLAG_NONE);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(data_sz == last);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -85,7 +85,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vni, struct fi_cq_tagged_e
                             MPIDI_OFI_REQUEST(rreq, noncontig.pack.buf),
                             MPIDI_OFI_REQUEST(rreq, noncontig.pack.count),
                             MPIDI_OFI_REQUEST(rreq, noncontig.pack.datatype), 0,
-                            &actual_unpack_bytes);
+                            &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
         MPIR_gpu_free_host(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer));
         if (actual_unpack_bytes != (MPI_Aint) count) {
             rreq->status.MPI_ERROR =

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -37,7 +37,7 @@ void MPIDI_OFI_complete_chunks(MPIDI_OFI_win_request_t * winreq)
                                 chunk->unpack_size, winreq->noncontig.get.origin.addr,
                                 winreq->noncontig.get.origin.count,
                                 winreq->noncontig.get.origin.datatype, chunk->unpack_offset,
-                                &actual_unpack_bytes);
+                                &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
             MPIR_Assert(chunk->unpack_size == actual_unpack_bytes);
         }
 
@@ -223,7 +223,7 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         MPIR_Typerep_pack(req->noncontig.put.origin.addr, req->noncontig.put.origin.count,
                           req->noncontig.put.origin.datatype,
                           req->noncontig.put.origin.pack_offset, pack_buffer,
-                          msg_len, &actual_pack_bytes);
+                          msg_len, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
         MPIR_Assert(msg_len == actual_pack_bytes);
 
         MPIDI_OFI_pack_chunk *chunk = create_chunk(pack_buffer, 0, 0, req);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -262,7 +262,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPI_Aint actual_pack_bytes;
         MPIR_Typerep_pack(buf, count, datatype, 0,
                           MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer), data_sz,
-                          &actual_pack_bytes);
+                          &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
         send_buf = MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer);
     } else {
         MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer) = NULL;
@@ -416,7 +416,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
                 /* Force pack for GPU buffer. */
                 void *host_buf = NULL;
                 MPIR_gpu_malloc_host(&host_buf, data_sz);
-                MPIR_Typerep_pack(buf, count, datatype, 0, host_buf, data_sz, &actual_pack_bytes);
+                MPIR_Typerep_pack(buf, count, datatype, 0, host_buf, data_sz, &actual_pack_bytes,
+                                  MPIR_TYPEREP_FLAG_NONE);
                 MPIR_Assert(actual_pack_bytes == data_sz);
                 send_buf = host_buf;
             }

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -103,7 +103,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
         MPI_Aint actual_pack_bytes;
         mpi_errno =
             MPIR_Typerep_pack(data, count, datatype, 0, send_buf + am_hdr_sz + sizeof(ucx_hdr),
-                              data_sz, &actual_pack_bytes);
+                              data_sz, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(actual_pack_bytes == data_sz);
 

--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.c
@@ -69,7 +69,7 @@ static size_t pack(void *state, size_t offset, void *dest, size_t max_length)
     MPI_Aint actual_pack_bytes;
 
     MPIR_Typerep_pack(pack_state->buffer, pack_state->count, pack_state->datatype, offset,
-                      dest, max_length, &actual_pack_bytes);
+                      dest, max_length, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
 
     return actual_pack_bytes;
 }
@@ -85,7 +85,7 @@ static ucs_status_t unpack(void *state, size_t offset, const void *src, size_t c
     max_unpack_bytes = MPL_MIN(packsize, count);
 
     MPIR_Typerep_unpack(src, max_unpack_bytes, pack_state->buffer, pack_state->count,
-                        pack_state->datatype, offset, &actual_unpack_bytes);
+                        pack_state->datatype, offset, &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
     if (unlikely(actual_unpack_bytes != max_unpack_bytes)) {
         return UCS_ERR_MESSAGE_TRUNCATED;
     }

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -105,7 +105,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_noncontig_put(const void *origin_addr,
 
     MPI_Aint actual_pack_bytes;
     mpi_errno = MPIR_Typerep_pack(origin_addr, origin_count, origin_datatype, 0, buffer, size,
-                                  &actual_pack_bytes);
+                                  &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(actual_pack_bytes == size);
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -133,7 +133,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_copy_data(MPIDI_IPC_hdr * ipc_hdr, MPIR_
         mpi_errno = MPIR_Typerep_unpack(src_buf, src_data_sz,
                                         MPIDIG_REQUEST(rreq, buffer), MPIDIG_REQUEST(rreq,
                                                                                      count),
-                                        MPIDIG_REQUEST(rreq, datatype), 0, &actual_unpack_bytes);
+                                        MPIDIG_REQUEST(rreq, datatype), 0, &actual_unpack_bytes,
+                                        MPIR_TYPEREP_FLAG_NONE);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(actual_unpack_bytes == src_data_sz);
     } else {

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX void
 MPIDI_POSIX_eager_recv_memcpy(MPIDI_POSIX_eager_recv_transaction_t * transaction,
                               void *dst, const void *src, size_t size)
 {
-    MPIR_Typerep_copy(dst, src, size);
+    MPIR_Typerep_copy(dst, src, size, MPIR_TYPEREP_FLAG_NONE);
 }
 
 MPL_STATIC_INLINE_PREFIX void

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -83,7 +83,7 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
         cell->am_header = *msg_hdr;
         cell->type = MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_HDR;
         /* send am_hdr if this is the first segment */
-        MPIR_Typerep_copy(payload, am_hdr, am_hdr_sz);
+        MPIR_Typerep_copy(payload, am_hdr, am_hdr_sz, MPIR_TYPEREP_FLAG_STREAM);
         /* make sure the data region starts at the boundary of MAX_ALIGNMENT */
         payload = payload + resized_am_hdr_sz;
         cell->payload_size += resized_am_hdr_sz;
@@ -99,7 +99,8 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
      * not reliable because the derived datatype could have zero block size which contains no
      * data. */
     if (bytes_sent) {
-        MPIR_Typerep_pack(buf, count, datatype, offset, payload, available, &packed_size);
+        MPIR_Typerep_pack(buf, count, datatype, offset, payload, available, &packed_size,
+                          MPIR_TYPEREP_FLAG_STREAM);
         cell->payload_size += packed_size;
         *bytes_sent = packed_size;
     }

--- a/src/mpid/ch4/shm/posix/posix_am_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_am_impl.h
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_init_req_hdr(const void *am_hdr,
     }
 
     if (am_hdr) {
-        MPIR_Typerep_copy(req_hdr->am_hdr, am_hdr, am_hdr_sz);
+        MPIR_Typerep_copy(req_hdr->am_hdr, am_hdr, am_hdr_sz, MPIR_TYPEREP_FLAG_NONE);
     }
 
     *req_hdr_ptr = req_hdr;

--- a/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
@@ -99,7 +99,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
                 /* Root packs the data before sending, for non contiguous datatypes */
                 mpi_errno =
                     MPIR_Typerep_pack(ori_buffer, ori_count, ori_datatype, 0, buffer, count,
-                                      &actual_packed_unpacked_bytes);
+                                      &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
             }
         }
@@ -151,7 +151,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
             /* Non-root unpack the data if expecting non-contiguous datatypes */
             mpi_errno =
                 MPIR_Typerep_unpack(buffer, count, ori_buffer, ori_count, ori_datatype, 0,
-                                    &actual_packed_unpacked_bytes);
+                                    &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
         }
         MPL_free(buffer);

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -63,8 +63,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_compute_accumulate(void *origin_addr,
     MPIR_ERR_CHKANDJUMP(packed_buf == NULL, mpi_errno, MPI_ERR_NO_MEM, "**nomem");
 
     MPI_Aint actual_pack_bytes;
-    mpi_errno = MPIR_Typerep_pack(origin_addr, origin_count, origin_datatype, 0,
-                                  packed_buf, total_len, &actual_pack_bytes);
+    mpi_errno = MPIR_Typerep_pack(origin_addr, origin_count, origin_datatype, 0, packed_buf,
+                                  total_len, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(actual_pack_bytes == total_len);
 
@@ -479,9 +479,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_compare_and_swap(const void *origin
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
     }
 
-    MPIR_Typerep_copy(result_addr, target_addr, dtype_sz);
+    MPIR_Typerep_copy(result_addr, target_addr, dtype_sz, MPIR_TYPEREP_FLAG_NONE);
     if (MPIR_Compare_equal(compare_addr, target_addr, datatype)) {
-        MPIR_Typerep_copy(target_addr, origin_addr, dtype_sz);
+        MPIR_Typerep_copy(target_addr, origin_addr, dtype_sz, MPIR_TYPEREP_FLAG_NONE);
     }
 
     if (winattr & MPIDI_WINATTR_SHM_ALLOCATED) {
@@ -649,7 +649,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_fetch_and_op(const void *origin_add
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
     }
 
-    MPIR_Typerep_copy(result_addr, target_addr, dtype_sz);
+    MPIR_Typerep_copy(result_addr, target_addr, dtype_sz, MPIR_TYPEREP_FLAG_NONE);
 
     if (op != MPI_NO_OP) {
         /* We need to make sure op is valid here.

--- a/src/mpid/ch4/src/mpidig_recv.h
+++ b/src/mpid/ch4/src/mpidig_recv.h
@@ -72,7 +72,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_copy_from_unexp_req(MPIR_Request * req, void
         if (!dt_contig) {
             MPI_Aint actual_unpack_bytes;
             MPIR_Typerep_unpack(MPIDIG_REQUEST(req, buffer), nbytes, user_buf, user_count,
-                                user_datatype, 0, &actual_unpack_bytes);
+                                user_datatype, 0, &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
             if (actual_unpack_bytes != nbytes) {
                 mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
                                                  __FUNCTION__, __LINE__,
@@ -85,7 +85,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_copy_from_unexp_req(MPIR_Request * req, void
              * the absolute address of the buffer (e.g. buf == MPI_BOTTOM).
              */
             char *addr = MPIR_get_contig_ptr(user_buf, dt_true_lb);
-            MPIR_Typerep_copy(addr, MPIDIG_REQUEST(req, buffer), nbytes);
+            MPIR_Typerep_copy(addr, MPIDIG_REQUEST(req, buffer), nbytes, MPIR_TYPEREP_FLAG_NONE);
         }
     }
 

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -776,8 +776,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
 
     p_data = MPL_malloc(data_sz * 2, MPL_MEM_BUFFER);
     MPIR_Assert(p_data);
-    MPIR_Typerep_copy(p_data, (char *) origin_addr, data_sz);
-    MPIR_Typerep_copy((char *) p_data + data_sz, (char *) compare_addr, data_sz);
+    MPIR_Typerep_copy(p_data, (char *) origin_addr, data_sz, MPIR_TYPEREP_FLAG_NONE);
+    MPIR_Typerep_copy((char *) p_data + data_sz, (char *) compare_addr, data_sz,
+                      MPIR_TYPEREP_FLAG_NONE);
 
     sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 1, vci, vci);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");

--- a/src/mpid/ch4/src/mpidig_rma_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_rma_callbacks.c
@@ -805,7 +805,7 @@ static int handle_get_acc_cmpl(MPIR_Request * rreq)
                       MPIDIG_REQUEST(rreq, req->areq.target_count), MPIDIG_REQUEST(rreq,
                                                                                    req->
                                                                                    areq.target_datatype),
-                      0, original, result_data_sz, &actual_pack_bytes);
+                      0, original, result_data_sz, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
     MPIR_Assert(actual_pack_bytes == result_data_sz);
 
     mpi_errno = MPIDIG_compute_acc_op(MPIDIG_REQUEST(rreq, req->areq.data),
@@ -1062,10 +1062,13 @@ static int cswap_target_cmpl_cb(MPIR_Request * rreq)
 
     if (MPIR_Compare_equal((void *) MPIDIG_REQUEST(rreq, buffer), compare_addr,
                            MPIDIG_REQUEST(rreq, datatype))) {
-        MPIR_Typerep_copy(compare_addr, (void *) MPIDIG_REQUEST(rreq, buffer), data_sz);
-        MPIR_Typerep_copy((void *) MPIDIG_REQUEST(rreq, buffer), origin_addr, data_sz);
+        MPIR_Typerep_copy(compare_addr, (void *) MPIDIG_REQUEST(rreq, buffer), data_sz,
+                          MPIR_TYPEREP_FLAG_NONE);
+        MPIR_Typerep_copy((void *) MPIDIG_REQUEST(rreq, buffer), origin_addr, data_sz,
+                          MPIR_TYPEREP_FLAG_NONE);
     } else {
-        MPIR_Typerep_copy(compare_addr, (void *) MPIDIG_REQUEST(rreq, buffer), data_sz);
+        MPIR_Typerep_copy(compare_addr, (void *) MPIDIG_REQUEST(rreq, buffer), data_sz,
+                          MPIR_TYPEREP_FLAG_NONE);
     }
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -230,6 +230,99 @@ typedef struct {
   Utility
   M*/
 
+#include "string.h"
+
+#ifdef HAVE_MM256_STREAM_SI256
+#include <immintrin.h>
+
+static inline void MPL_Memcpy_stream(void *dest, const void *src, size_t n)
+{
+    /* Anything less than 256 bytes is not worth optimizing */
+    if (n <= 256) {
+        memcpy(dest, src, n);
+        return;
+    }
+
+    char *d = (char *) dest;
+    const char *s = (const char *) src;
+
+    /* Copy the first 63 bytes or less (if the address isn't 64-byte aligned) using a regular memcpy
+     * to make the rest faster */
+    if (((uintptr_t) d) & 63) {
+        const uintptr_t t = 64 - (((uintptr_t) d) & 63);
+        memcpy(d, s, t);
+        d += t;
+        s += t;
+        n -= t;
+    }
+
+    /* Copy 256 bytes at a time by unrolling a series of 32-byte streaming copies. */
+    while (n >= 256) {
+        __m256i ymm0 = _mm256_loadu_si256((__m256i const *) (s + (32 * 0)));
+        __m256i ymm1 = _mm256_loadu_si256((__m256i const *) (s + (32 * 1)));
+        __m256i ymm2 = _mm256_loadu_si256((__m256i const *) (s + (32 * 2)));
+        __m256i ymm3 = _mm256_loadu_si256((__m256i const *) (s + (32 * 3)));
+        __m256i ymm4 = _mm256_loadu_si256((__m256i const *) (s + (32 * 4)));
+        __m256i ymm5 = _mm256_loadu_si256((__m256i const *) (s + (32 * 5)));
+        __m256i ymm6 = _mm256_loadu_si256((__m256i const *) (s + (32 * 6)));
+        __m256i ymm7 = _mm256_loadu_si256((__m256i const *) (s + (32 * 7)));
+        _mm256_stream_si256((__m256i *) (d + (32 * 0)), ymm0);
+        _mm256_stream_si256((__m256i *) (d + (32 * 1)), ymm1);
+        _mm256_stream_si256((__m256i *) (d + (32 * 2)), ymm2);
+        _mm256_stream_si256((__m256i *) (d + (32 * 3)), ymm3);
+        _mm256_stream_si256((__m256i *) (d + (32 * 4)), ymm4);
+        _mm256_stream_si256((__m256i *) (d + (32 * 5)), ymm5);
+        _mm256_stream_si256((__m256i *) (d + (32 * 6)), ymm6);
+        _mm256_stream_si256((__m256i *) (d + (32 * 7)), ymm7);
+        d += 256;
+        s += 256;
+        n -= 256;
+    }
+
+    /* Once there are fewer than 256 bytes left to be copied, copy a chunk of 128 and 64 bytes (if
+     * applicable). */
+    if (n >= 128) {
+        __m256i ymm0 = _mm256_loadu_si256((__m256i const *) (s + (32 * 0)));
+        __m256i ymm1 = _mm256_loadu_si256((__m256i const *) (s + (32 * 1)));
+        __m256i ymm2 = _mm256_loadu_si256((__m256i const *) (s + (32 * 2)));
+        __m256i ymm3 = _mm256_loadu_si256((__m256i const *) (s + (32 * 3)));
+        _mm256_stream_si256((__m256i *) (d + (32 * 0)), ymm0);
+        _mm256_stream_si256((__m256i *) (d + (32 * 1)), ymm1);
+        _mm256_stream_si256((__m256i *) (d + (32 * 2)), ymm2);
+        _mm256_stream_si256((__m256i *) (d + (32 * 3)), ymm3);
+        d += 128;
+        s += 128;
+        n -= 128;
+    }
+
+    if (n >= 64) {
+        __m256i ymm0 = _mm256_loadu_si256((__m256i const *) (s + (32 * 0)));
+        __m256i ymm1 = _mm256_loadu_si256((__m256i const *) (s + (32 * 1)));
+        _mm256_stream_si256((__m256i *) (d + (32 * 0)), ymm0);
+        _mm256_stream_si256((__m256i *) (d + (32 * 1)), ymm1);
+        d += 64;
+        s += 64;
+        n -= 64;
+    }
+
+    /* If there is any data left, copy it using a regular memcpy */
+    if (n > 0) {
+        memcpy(d, s, (n & 63));
+    }
+
+    /* A memory fence is required after the streaming stores above. */
+    _mm_sfence();
+}
+
+#else
+
+static inline void MPL_Memcpy_stream(void *dest, const void *src, size_t n)
+{
+    memcpy(dest, src, n);
+}
+
+#endif
+
 #ifdef MPL_USE_MEMORY_TRACING
 
 /* Define these as invalid C to catch their use in the code.


### PR DESCRIPTION
## Pull Request Description

Adds a new type of `memcpy` that uses the AVX instruction `_mm256_stream_si256` to perform a streaming copy that writes data without bringing it into the cache of the writing process. This is used with the iqueue send code to avoid extra latency, especially when writing data from a process located on one socket to a process located on another socket.

**Update** - Originally, there were changes in this PR related to the genq/iqueue code. Those were moved out to https://github.com/pmodels/mpich/pull/5759 to separate the topics. Related discussions should move to that PR.

**Note** - This PR includes an updated Yaksa module. I've not created a PR for it, but this PR points to a patch in my fork. The code in that change is very similar to what is changed in this PR and I can make a PR for that when we agree that it's worth doing.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
