### PR TITLE
shm: change posix genq to grab cells from receiver freelist

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -53,7 +53,11 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
     transport = MPIDI_POSIX_eager_iqueue_get_transport(src_vsi, dst_vsi);
 
     /* Try to get a new cell to hold the message */
-    MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell, grank);
+    /* Select the appropriate pool depending on whether we are using sender-side or receiver-side
+     * queuing. */
+    MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell,
+                                     MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE ?
+                                     MPIR_Process.local_rank : grank);
 
     /* If a cell wasn't available, let the caller know that we weren't able to send the message
      * immediately. */

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -53,7 +53,8 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
     transport = MPIDI_POSIX_eager_iqueue_get_transport(src_vsi, dst_vsi);
 
     /* Try to get a new cell to hold the message */
-    MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell);
+    MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell,
+                                     MPIR_Process.local_rank);
 
     /* If a cell wasn't available, let the caller know that we weren't able to send the message
      * immediately. */

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -53,8 +53,7 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
     transport = MPIDI_POSIX_eager_iqueue_get_transport(src_vsi, dst_vsi);
 
     /* Try to get a new cell to hold the message */
-    MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell,
-                                     MPIR_Process.local_rank);
+    MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell, grank);
 
     /* If a cell wasn't available, let the caller know that we weren't able to send the message
      * immediately. */

--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.c
@@ -12,6 +12,38 @@
 #include <stdint.h>
 #include <string.h>
 
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE
+      category    : CH4
+      type        : boolean
+      default     : true
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        The genq shmem code allocates pools of cells on each process and, when needed, a cell is
+        removed from the pool and passed to another process. This can happen by either removing a
+        cell from the pool of the sending process or from the pool of the receiving process. This
+        CVAR determines which pool to use. If true, the cell will come from the sender-side. If
+        false, the cell will com from the receiver-side.
+
+        There are specific advantages of using receiver-side cells when combined with the "avx" fast
+        configure option, which allows MPICH to use AVX streaming copy intrintrinsics, when
+        available, to avoid polluting the cache of the sender with the data being copied to the
+        receiver. Using receiver-side cells does have the trade-off of requiring an MPMC lock for
+        the free queue rather than an MPSC lock, which is used for sender-side cells. Initial
+        performance analysis shows that using the MPMC lock in this case had no significant
+        performance loss.
+
+        By default, the queue will continue to use sender-side queues until the performance impact
+        is verified.
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
 #define RESIZE_TO_MAX_ALIGN(x) \
     ((((x) / MAX_ALIGNMENT) + !!((x) % MAX_ALIGNMENT)) * MAX_ALIGNMENT)
 
@@ -91,7 +123,11 @@ int MPIDU_genq_shmem_pool_create_unsafe(uintptr_t cell_size, uintptr_t cells_per
     pool_obj->free_queues =
         (MPIDU_genq_shmem_queue_u *) ((char *) pool_obj->slab + total_cells_size);
 
+    /* If using sender-side queuing, use an MPSC lock. If using recevier-side queuing, an MPMC lock
+     * is needed. */
     rc = MPIDU_genq_shmem_queue_init(&pool_obj->free_queues[rank],
+                                     MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE ?
+                                     MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC :
                                      MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPMC);
     MPIR_ERR_CHECK(rc);
 

--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.c
@@ -31,6 +31,11 @@ static int cell_block_alloc(MPIDU_genqi_shmem_pool_s * pool, int block_idx)
     /* init cell headers */
     int idx = block_idx * pool->cells_per_proc;
     for (int i = 0; i < pool->cells_per_proc; i++) {
+        /* Have the "host" process for each cell zero-out the cell contents to force the first-touch
+         * policy to make the pages resident to that process. */
+        memset((char *) pool->cell_header_base + (idx + i) * pool->cell_alloc_size, 0,
+               pool->cell_alloc_size);
+
         pool->cell_headers[i] =
             (MPIDU_genqi_shmem_cell_header_s *) ((char *) pool->cell_header_base
                                                  + (idx + i) * pool->cell_alloc_size);

--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.c
@@ -87,7 +87,7 @@ int MPIDU_genq_shmem_pool_create_unsafe(uintptr_t cell_size, uintptr_t cells_per
         (MPIDU_genq_shmem_queue_u *) ((char *) pool_obj->slab + total_cells_size);
 
     rc = MPIDU_genq_shmem_queue_init(&pool_obj->free_queues[rank],
-                                     MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC);
+                                     MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPMC);
     MPIR_ERR_CHECK(rc);
 
     rc = cell_block_alloc(pool_obj, rank);

--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.h
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.h
@@ -19,7 +19,8 @@ int MPIDU_genq_shmem_pool_create_unsafe(uintptr_t cell_size, uintptr_t cells_per
                                         MPIDU_genq_shmem_pool_t * pool);
 int MPIDU_genq_shmem_pool_destroy_unsafe(MPIDU_genq_shmem_pool_t pool);
 
-static inline int MPIDU_genq_shmem_pool_cell_alloc(MPIDU_genq_shmem_pool_t pool, void **cell)
+static inline int MPIDU_genq_shmem_pool_cell_alloc(MPIDU_genq_shmem_pool_t pool, void **cell,
+                                                   int block_idx)
 {
     int rc = MPI_SUCCESS;
     MPIDU_genqi_shmem_pool_s *pool_obj = (MPIDU_genqi_shmem_pool_s *) pool;
@@ -28,7 +29,7 @@ static inline int MPIDU_genq_shmem_pool_cell_alloc(MPIDU_genq_shmem_pool_t pool,
 
     MPIR_FUNC_ENTER;
 
-    rc = MPIDU_genq_shmem_queue_dequeue(pool, &pool_obj->free_queues[pool_obj->rank], cell);
+    rc = MPIDU_genq_shmem_queue_dequeue(pool, &pool_obj->free_queues[block_idx], cell);
     MPIR_ERR_CHECK(rc);
 
   fn_exit:

--- a/src/mpid/common/genq/mpidu_genq_shmem_queue.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_queue.c
@@ -22,6 +22,8 @@ int MPIDU_genq_shmem_queue_init(MPIDU_genq_shmem_queue_t queue, int flags)
         rc = MPIDU_genqi_inv_mpsc_init(queue_obj);
     } else if (flags == MPIDU_GENQ_SHMEM_QUEUE_TYPE__NEM_MPSC) {
         rc = MPIDU_genqi_nem_mpsc_init(queue_obj);
+    } else if (flags == MPIDU_GENQ_SHMEM_QUEUE_TYPE__NEM_MPMC) {
+        rc = MPIDU_genqi_nem_mpmc_init(queue_obj);
     } else {
         MPIR_Assert_error("Invalid GenQ flag");
     }


### PR DESCRIPTION
## Pull Request Description

As a follow-on for https://github.com/pmodels/mpich/pull/5758, there are some design things in the genq code that needed to be modified. Specifically, the cell being used for the data transfer should now come from the pool of the receiving process rather than the sending process. We also need to touch the memory in each cell during initialization to make sure that the first-touch policy will map that memory to physical memory near the process.

In order to support this, the free queue used by the genq code needed to change from an MPSC queue to an MPMC queue to support either receiver-side or sender-side queuing. In theory, receiver-side queuing could have been accomplished with an SPMC queue, but I decided not to do that because 1) the implementation of SPMC and MPMC ended up being pretty similar (at least in the way I was doing it), and 2) having an MPMC queue means that the queue can be used with either sender or receiver-side queuing without additional changes (if that is ever desired).

The image below gives a visual representation of what's happening with the new version of the iqueue code. The copy across sockets is the part that is being accelerated. The rest of the code remains the same (i.e., there are not fewer copies than there were before, just that the existing copies are more efficient).

<img width="952" alt="Screen Shot 2022-01-11 at 10 09 34 AM" src="https://user-images.githubusercontent.com/1561207/148978977-88c3d4ef-ce97-49eb-af76-1bd10658f7c8.png">

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
