### PR TITLE
op: replace predefined datatype on input

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2287,6 +2287,14 @@ def dump_validate_op(op, dt, is_coll):
     if dt:
         G.out.append("} else {")
         G.out.append("    mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(%s)) (%s);" % (op, dt))
+        # check predefined datatype and replace with basic_type if necessary
+        G.out.append("    if (mpi_errno != MPI_SUCCESS) {")
+        G.out.append("        MPI_Datatype alt_dt = MPIR_Op_get_alt_datatype(%s, %s);" % (op, dt))
+        G.out.append("        if (alt_dt != MPI_DATATYPE_NULL) {")
+        G.out.append("            %s = alt_dt;" % dt)
+        G.out.append("            mpi_errno = MPI_SUCCESS;")
+        G.out.append("        }")
+        G.out.append("    }")
     G.out.append("}")
     dump_error_check("")
 

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -220,4 +220,8 @@ extern MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[];
 
 int MPIR_Op_is_commutative(MPI_Op);
 
+/* for some predefined datatypes, e.g. from MPI_Type_create_f90_xxx, we need
+ * use its basic type for operations */
+MPI_Datatype MPIR_Op_get_alt_datatype(MPI_Op op, MPI_Datatype datatype);
+
 #endif /* MPIR_OP_H_INCLUDED */

--- a/src/mpi/coll/op/oputil.c
+++ b/src/mpi/coll/op/oputil.c
@@ -86,3 +86,25 @@ const char *MPIR_Op_builtin_get_shortname(MPI_Op op)
     }
     return "";
 }
+
+/* for some predefined datatypes, e.g. from MPI_Type_create_f90_xxx, we need
+ * use its basic type for operations */
+MPI_Datatype MPIR_Op_get_alt_datatype(MPI_Op op, MPI_Datatype datatype)
+{
+    MPI_Datatype alt_dt = MPI_DATATYPE_NULL;
+    if (!HANDLE_IS_BUILTIN(datatype)) {
+        MPIR_Datatype *dt_ptr;
+        MPIR_Datatype_get_ptr(datatype, dt_ptr);
+
+        if (dt_ptr && dt_ptr->contents) {
+            int combiner = dt_ptr->contents->combiner;
+            if (combiner == MPI_COMBINER_F90_REAL ||
+                combiner == MPI_COMBINER_F90_COMPLEX || combiner == MPI_COMBINER_F90_INTEGER) {
+                if (MPI_SUCCESS == (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (dt_ptr->basic_type)) {
+                    alt_dt = dt_ptr->basic_type;
+                }
+            }
+        }
+    }
+    return alt_dt;
+}


### PR DESCRIPTION

## Pull Request Description

We are supposed to support operations on some predefined datatype, such
as those from MPI_Type_create_f90_xxx. However, those types are in fact
derived types wraps around a basic type. Check and replace the input
datatype with the basic type if that is the case so the reduction can
work. Since the datatype in these case are all input only parameters,
there shouldn't be any side effects replacing them.

Fixes #1769 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
