### PR TITLE
coll: fix additional neighbor_alltoall algorithms

### DIFF
--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_sched_linear.c
@@ -42,11 +42,19 @@ int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, MPI_Aint s
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    /* receive needs to happen in the opposite order of sends.  This
-     * is to cover the case of Cartesian graphs where the same process
-     * might be both the left and right neighbor.  In this case, we
-     * need to make sure the first message (which is from the right
-     * neighbor) is received in the last buffer. */
+    /* Cartesian graph may result in multiple edges going to the same process when it is
+     * periodic and dim is 1 or 2, in which case, both left and right neighbor (in a circular sense) points to
+     * self or the other process. When that occurs, we are sending two messages to the
+     * same receiver and receiving two messages from the same sender. Both messages are using
+     * the same tag, thus we need reverse the order of recvs to ensure correct matching.
+     * In the example of 1-dim cartesian graph, if we send in the order of left and right,
+     * the target need receive in the order of right and left to receive the correct messages.
+     *
+     * Note: duplicate graph edges can only result from MPI_Cart_create when certain
+     * dimension is periodic and size is 1 or 2. And the resulting graph edges will be
+     * in fixed orders, which the code here takes advantage of. A general graph will not
+     * contain duplicated edges, and the order of send and recv should not matter.
+     */
     for (l = indegree - 1; l >= 0; l--) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
         mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
@@ -52,11 +52,9 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Ai
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
-    /* receive needs to happen in the opposite order of sends.  This
-     * is to cover the case of Cartesian graphs where the same process
-     * might be both the left and right neighbor.  In this case, we
-     * need to make sure the first message (which is from the right
-     * neighbor) is received in the last buffer. */
+    /* need reverse the order to ensure matching when the graph is from MPI_Cart_create and
+     * the n-th dimension is periodic and the size is 1 or 2.
+     * ref. ineighbor_alltoall_allcomm_sched_linear.c */
     for (l = indegree - 1; l >= 0; l--) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
         mpi_errno =

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_sched_linear.c
@@ -43,7 +43,10 @@ int MPIR_Ineighbor_alltoallv_allcomm_sched_linear(const void *sendbuf, const MPI
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    for (l = 0; l < indegree; ++l) {
+    /* need reverse the order to ensure matching when the graph is from MPI_Cart_create and
+     * the n-th dimension is periodic and the size is 1 or 2.
+     * ref. ineighbor_alltoall_allcomm_sched_linear.c */
+    for (l = indegree - 1; l >= 0; l--) {
         char *rb = ((char *) recvbuf) + rdispls[l] * recvtype_extent;
         mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
@@ -55,7 +55,10 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
-    for (l = 0; l < indegree; ++l) {
+    /* need reverse the order to ensure matching when the graph is from MPI_Cart_create and
+     * the n-th dimension is periodic and the size is 1 or 2.
+     * ref. ineighbor_alltoall_allcomm_sched_linear.c */
+    for (l = indegree - 1; l >= 0; l--) {
         char *rb = ((char *) recvbuf) + rdispls[l] * recvtype_extent;
         mpi_errno =
             MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, sched, 0,

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_sched_linear.c
@@ -43,7 +43,10 @@ int MPIR_Ineighbor_alltoallw_allcomm_sched_linear(const void *sendbuf, const MPI
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    for (l = 0; l < indegree; ++l) {
+    /* need reverse the order to ensure matching when the graph is from MPI_Cart_create and
+     * the n-th dimension is periodic and the size is 1 or 2.
+     * ref. ineighbor_alltoall_allcomm_sched_linear.c */
+    for (l = indegree - 1; l >= 0; l--) {
         char *rb;
 
         rb = ((char *) recvbuf) + rdispls[l];

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
@@ -53,7 +53,10 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
-    for (l = 0; l < indegree; ++l) {
+    /* need reverse the order to ensure matching when the graph is from MPI_Cart_create and
+     * the n-th dimension is periodic and the size is 1 or 2.
+     * ref. ineighbor_alltoall_allcomm_sched_linear.c */
+    for (l = indegree - 1; l >= 0; l--) {
         char *rb;
 
         rb = ((char *) recvbuf) + rdispls[l];


### PR DESCRIPTION
## Pull Request Description

The fix is for peioridic cartetian graph when dimension is 1 or 2. In
both case we have two edges points to the same process and vice versa.
If we send in the order of left and right, we need receive in the order
of right and left since left and right are reversed between in and out.

Previously we only fixed ineighbor_alltoall. This patch extends the same
fix to ineighbor_alltoallv and ineighbor_alltoallw.

I also updated the comment because the previous comments is still
confusing to me. In particular, it fails to high light the key points --
First it only matters for the periodic cartesian dimension of 1 or 2.
Second that results in multiple message with the same datatype and tag.
Lastly, the matching need reverse because left and right is reversed
between in and out.

Personally, I think allowing graphs to have duplicated edges pointing to
the same rank shouldn't be allowed. Because a general graph may not
guarantee ordering the edges and thus there is no way of ensuring the
correct matching order. In the general light, this fix is merely a hack.

Fixes #2194 

Reference: previous PR #4902, previous issue #4061, mpi forum issue https://github.com/mpi-forum/mpi-issues/issues/153

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
