### PR TITLE
romio: fix buggy file system detection

### DIFF
--- a/src/mpi/romio/adio/common/ad_fstype.c
+++ b/src/mpi/romio/adio/common/ad_fstype.c
@@ -421,28 +421,42 @@ static void ADIO_FileSysType_fncall(const char *filename, int *fstype, int *erro
     /* --END ERROR HANDLING-- */
 
     switch (file_id) {
+#ifdef ROMIO_NFS
         case NFS_SUPER_MAGIC:
             *fstype = ADIO_NFS;
             return;
+#endif
+#ifdef ROMIO_XFS
         case XFS_SUPER_MAGIC:
         case EXFS_SUPER_MAGIC:
             *fstype = ADIO_XFS;
             return;
+#endif
+#ifdef ROMIO_GPFS
         case GPFS_SUPER_MAGIC:
             *fstype = ADIO_GPFS;
             return;
+#endif
+#ifdef ROMIO_LUSTRE
         case LL_SUPER_MAGIC:
             *fstype = ADIO_LUSTRE;
             return;
+#endif
+#ifdef ROMIO_DAOS
         case DAOS_SUPER_MAGIC:
             *fstype = ADIO_DAOS;
             return;
+#endif
+#ifdef ROMIO_PANFS
         case PAN_KERNEL_FS_CLIENT_SUPER_MAGIC:
             *fstype = ADIO_PANFS;
             return;
+#endif
+#ifdef ROMIO_PVFS2
         case PVFS2_SUPER_MAGIC:
             *fstype = ADIO_PVFS2;
             return;
+#endif
         default:
             /* UFS support if we don't know what else to use */
             *fstype = ADIO_UFS;


### PR DESCRIPTION
After the file system detection rework, ROMIO was finding file systems
it had heard about (e.g. xfs) but then reporting "UNSUPPORTED" if the
support for that file system was not requested at cofigure time.

Relax file system detection to pick UFS (generic unix-like file system)
in more cases if ROMIO does not know how to use anything more optimized.

Fixes: pmodels/mpich#5772

## Pull Request Description


## Author Checklist
* [x ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
