### PR TITLE
mpl: Use CPU affinity functions with standard names

### DIFF
--- a/src/mpl/src/thread/mpl_thread_posix.c
+++ b/src/mpl/src/thread/mpl_thread_posix.c
@@ -90,10 +90,10 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
     int err = MPL_SUCCESS;
     int proc_idx, set_size = 0;
     cpu_set_t cpuset;
-    __CPU_ZERO_S(sizeof(cpu_set_t), &cpuset);
+    CPU_ZERO_S(sizeof(cpu_set_t), &cpuset);
 
     for (proc_idx = 0; proc_idx < affinity_size; proc_idx++)
-        __CPU_SET_S(affinity_arr[proc_idx], sizeof(cpu_set_t), &cpuset);
+        CPU_SET_S(affinity_arr[proc_idx], sizeof(cpu_set_t), &cpuset);
 
     if (pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpuset) != 0) {
         err = MPL_ERR_THREAD;
@@ -106,7 +106,7 @@ void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affi
     }
 
     for (proc_idx = 0; proc_idx < affinity_size; proc_idx++) {
-        if (__CPU_ISSET_S(affinity_arr[proc_idx], sizeof(cpu_set_t), &cpuset))
+        if (CPU_ISSET_S(affinity_arr[proc_idx], sizeof(cpu_set_t), &cpuset))
             set_size++;
     }
     if (set_size != affinity_size) {


### PR DESCRIPTION
## Pull Request Description

The functions with leading underscores are internally used in some systems, but
the user-facing ones are without underscores:
https://linux.die.net/man/3/cpu_set.  The underscore-prefixed names are not
available on Musl systems, leading to a linking error:

```
[01:19:03] libtool: link: cc -fvisibility=hidden -DNDEBUG -DNVALGRIND -O3 -o src/env/.libs/mpichversion src/env/mpichversion.o  lib/.libs/libmpi.so -lpthread -lm -Wl,-rpath -Wl,/workspace/destdir/lib
[01:19:03] /opt/x86_64-linux-musl/bin/../lib/gcc/x86_64-linux-musl/8.1.0/../../../../x86_64-linux-musl/bin/ld: lib/.libs/libmpi.so: undefined reference to `__CPU_ISSET_S'
[01:19:03] /opt/x86_64-linux-musl/bin/../lib/gcc/x86_64-linux-musl/8.1.0/../../../../x86_64-linux-musl/bin/ld: lib/.libs/libmpi.so: undefined reference to `__CPU_SET_S'
[01:19:03] /opt/x86_64-linux-musl/bin/../lib/gcc/x86_64-linux-musl/8.1.0/../../../../x86_64-linux-musl/bin/ld: lib/.libs/libmpi.so: undefined reference to `__CPU_ZERO_S'
[01:19:03] /opt/x86_64-linux-musl/bin/../lib/gcc/x86_64-linux-musl/8.1.0/../../../../x86_64-linux-musl/bin/ld: lib/.libs/libmpi.so: undefined reference to collect2: error: ld returned 1 exit status
[01:19:03] `__CPU_ISSET_S'
[01:19:03] /opt/x86_64-linux-musl/bin/../lib/gcc/x86_64-linux-musl/8.1.0/../../../../x86_64-linux-musl/bin/ld: lib/.libs/libmpi.so: undefined reference to `__CPU_SET_S'
[01:19:03] /opt/x86_64-linux-musl/bin/../lib/gcc/x86_64-linux-musl/8.1.0/../../../../x86_64-linux-musl/bin/ld: lib/.libs/libmpi.so: undefined reference to `__CPU_ZERO_S'
[01:19:03] collect2: error: ld returned 1 exit status
[01:19:03] make[2]: *** [Makefile:14129: src/env/mpichversion] Error 1
[01:19:03] make[2]: *** Waiting for unfinished jobs....
[01:19:03] make[2]: *** [Makefile:14135: src/env/mpivars] Error 1
```

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
