### PR TITLE
build: optionally generate single c binding source

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1011,7 +1011,11 @@ done
 ## Check for the location of autotools
 ########################################################################
 
-fn_check_autotools
+if test "$do_quick" = "no" ; then
+    fn_check_autotools
+else
+    set_autotools
+fi
 fn_check_bash_find_patch_xargs
 check_python3
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -530,7 +530,11 @@ fn_gen_coll() {
 fn_gen_binding_c() {
     set_PYTHON
     echo_n "generating MPI C functions..."
-    $PYTHON maint/gen_binding_c.py
+    if test "$do_quick" = "no" ; then
+        $PYTHON maint/gen_binding_c.py
+    else
+        $PYTHON maint/gen_binding_c.py -single-source
+    fi
     echo "done"
 }
 


### PR DESCRIPTION
## Pull Request Description
By default, we generate individual C source file for each MPI function. With `-single-source` option, we can generate the entire C binding in a single `c_binding.c`. This avoid duplicated compilations of internal headers and can result in a significant acceleration in build.

The option is switched on with autogen `-quick` mode. 

Also added a commit to skip autotools version check with `-quick`.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
