### PR TITLE
mpl: fix double duplicate definition of PATH_MAX

### DIFF
--- a/src/mpl/include/mpl_base.h
+++ b/src/mpl/include/mpl_base.h
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include <limits.h>
 
 #if defined MPL_HAVE_CTYPE_H
 #include <ctype.h>


### PR DESCRIPTION

## Pull Request Description

We define PATH_MAX if PATH_MAX is not defined. Sometimes limits.h
defines it but we didn't include limits.h first. This results in we
defining PATH_MAX first and limits.h included later and defines it
again, resulting in duplcated define warnings.

Fix this by include <limits.h> first.

This warning was seen during testing on OSX  during troubleshooting #5795

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
