### PR TITLE
ch4: invoke infrequent progress in send

### DIFF
--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -336,4 +336,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_wait(MPID_Progress_state * state)
     goto fn_exit;
 }
 
+/* Call this function in places where we normally skip progress, such as MPID_Isend */
+MPL_STATIC_INLINE_PREFIX void MPIDI_check_global_progress(void)
+{
+    global_vci_poll_count++;
+    if ((global_vci_poll_count & MPIDI_CH4_PROG_POLL_MASK) == 0) {
+        MPID_Progress_test(NULL);
+    }
+}
+
 #endif /* CH4_PROGRESS_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -9,6 +9,8 @@
 #include "ch4_impl.h"
 #include "ch4_proc.h"
 
+MPL_STATIC_INLINE_PREFIX void MPIDI_check_global_progress(void);
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_isend(const void *buf,
                                          MPI_Aint count,
                                          MPI_Datatype datatype,
@@ -47,6 +49,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend(const void *buf,
 #endif
     MPIR_ERR_CHECK(mpi_errno);
 #endif
+
+    MPIDI_check_global_progress();
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -98,6 +102,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll(const void *buf,
 #endif
     MPIR_ERR_CHECK(mpi_errno);
 #endif
+
+    MPIDI_check_global_progress();
 
   fn_exit:
     MPIR_FUNC_EXIT;


### PR DESCRIPTION
## Pull Request Description
Process only call send repeatedly may never invoke progress. Check and
call global progress every now and then can be beneficial. For example,
it may help checkpoint if checkpoint mechanism is attached to the
progress. It also can help operations that rely on passive progress, as
well as lightweight sends that cache local messages.

Since we only invoke global progress infrequently, we expect a negligible
impact on normal applications. Specific micro-benchmark applications can
use CVARs to disable or further tune the progress frequency.

Fixes #1102
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
