### PR TITLE
ch3/nemesis: fix usage in MPIR_Typerep_to_iov

### DIFF
--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
@@ -700,6 +700,8 @@ int MPID_nem_tcp_SendNoncontig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *heade
 
     iov_offset = iov_n;
 
+    /* Set iov_n to remaining capacity. It will be set to actual num of iovs loaded on output. */
+    iov_n = MPL_IOV_LIMIT - iov_offset;
     mpi_errno = MPIDI_CH3U_Request_load_send_iov(sreq, &iov[iov_offset], &iov_n);
     MPIR_ERR_CHKANDJUMP(mpi_errno, mpi_errno, MPI_ERR_OTHER, "**ch3|loadsendiov");
 

--- a/src/mpid/ch3/src/ch3u_request.c
+++ b/src/mpid/ch3/src/ch3u_request.c
@@ -120,7 +120,6 @@ int MPIDI_CH3U_Request_load_send_iov(MPIR_Request * const sreq,
     else
     {
 	intptr_t data_sz;
-	int i, iov_data_copied;
 	
 	MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL,VERBOSE,"low density.  using SRBuf.");
 	    
@@ -141,29 +140,21 @@ int MPIDI_CH3U_Request_load_send_iov(MPIR_Request * const sreq,
 	    /* --END ERROR HANDLING-- */
 	}
 
-	iov_data_copied = 0;
-	for (i = 0; i < *iov_n; i++) {
-	    MPIR_Memcpy((char*) sreq->dev.tmpbuf + iov_data_copied,
-		   iov[i].iov_base, iov[i].iov_len);
-	    iov_data_copied += iov[i].iov_len;
-	}
-	sreq->dev.msg_offset = last;
-
         MPI_Aint max_pack_bytes;
         MPI_Aint actual_pack_bytes;
 
-        if (data_sz > sreq->dev.tmpbuf_sz - iov_data_copied)
-            max_pack_bytes = sreq->dev.tmpbuf_sz - iov_data_copied;
+        if (data_sz > sreq->dev.tmpbuf_sz)
+            max_pack_bytes = sreq->dev.tmpbuf_sz;
         else
-            max_pack_bytes = sreq->dev.msgsize - sreq->dev.msg_offset;
+            max_pack_bytes = data_sz;
 
         MPIR_Typerep_pack(sreq->dev.user_buf, sreq->dev.user_count, sreq->dev.datatype,
-                       sreq->dev.msg_offset, (char*) sreq->dev.tmpbuf + iov_data_copied,
+                       sreq->dev.msg_offset, (char*) sreq->dev.tmpbuf,
                        max_pack_bytes, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
         last = sreq->dev.msg_offset + actual_pack_bytes;
 
 	iov[0].iov_base = (void *)sreq->dev.tmpbuf;
-	iov[0].iov_len = actual_pack_bytes + iov_data_copied;
+	iov[0].iov_len = actual_pack_bytes;
 	*iov_n = 1;
 	if (last == sreq->dev.msgsize)
 	{

--- a/src/mpid/ch3/src/ch3u_request.c
+++ b/src/mpid/ch3/src/ch3u_request.c
@@ -80,46 +80,44 @@ void MPID_Request_create_hook(MPIR_Request *req)
 int MPIDI_CH3U_Request_load_send_iov(MPIR_Request * const sreq,
 				     struct iovec * const iov, int * const iov_n)
 {
-    MPI_Aint last;
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    last = sreq->dev.msgsize;
-    MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_CHANNEL,VERBOSE,(MPL_DBG_FDEST,
-     "pre-pv: first=%" PRIdPTR ", last=%" PRIdPTR ", iov_n=%d",
-		      sreq->dev.msg_offset, last, *iov_n));
-    MPIR_Assert(sreq->dev.msg_offset < last);
-    MPIR_Assert(last > 0);
-    MPIR_Assert(*iov_n > 0 && *iov_n <= MPL_IOV_LIMIT);
+    MPI_Aint density;
+    MPIR_Datatype_get_density(sreq->dev.datatype, density);
+    if (density >= MPIDI_IOV_DENSITY_MIN) {
+        MPI_Aint last = sreq->dev.msgsize;
+        MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_CHANNEL,VERBOSE,(MPL_DBG_FDEST,
+        "pre-pv: first=%" PRIdPTR ", last=%" PRIdPTR ", iov_n=%d",
+                        sreq->dev.msg_offset, last, *iov_n));
+        MPIR_Assert(sreq->dev.msg_offset < last);
+        MPIR_Assert(last > 0);
+        MPIR_Assert(*iov_n > 0 && *iov_n <= MPL_IOV_LIMIT);
 
-    int max_iov_len = *iov_n;
-    MPI_Aint actual_iov_bytes, actual_iov_len;
-    MPIR_Typerep_to_iov(sreq->dev.user_buf, sreq->dev.user_count, sreq->dev.datatype,
-                     sreq->dev.msg_offset, iov, (MPI_Aint) max_iov_len,
-                     sreq->dev.msgsize - sreq->dev.msg_offset, &actual_iov_len, &actual_iov_bytes);
-    *iov_n = (int) actual_iov_len;
-    last = sreq->dev.msg_offset + actual_iov_bytes;
+        int max_iov_len = *iov_n;
+        MPI_Aint actual_iov_bytes, actual_iov_len;
+        MPIR_Typerep_to_iov(sreq->dev.user_buf, sreq->dev.user_count, sreq->dev.datatype,
+                        sreq->dev.msg_offset, iov, (MPI_Aint) max_iov_len,
+                        sreq->dev.msgsize - sreq->dev.msg_offset, &actual_iov_len, &actual_iov_bytes);
+        *iov_n = (int) actual_iov_len;
+        last = sreq->dev.msg_offset + actual_iov_bytes;
 
-    MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_CHANNEL,VERBOSE,(MPL_DBG_FDEST,
-    "post-pv: first=%" PRIdPTR ", last=%" PRIdPTR ", iov_n=%d",
-		      sreq->dev.msg_offset, last, *iov_n));
-    MPIR_Assert(*iov_n > 0 && *iov_n <= MPL_IOV_LIMIT);
-    
-    if (last == sreq->dev.msgsize)
-    {
-	MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL,VERBOSE,"remaining data loaded into IOV");
-	sreq->dev.OnDataAvail = sreq->dev.OnFinal;
-    }
-    else if ((last - sreq->dev.msg_offset) / *iov_n >= MPIDI_IOV_DENSITY_MIN)
-    {
-	MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL,VERBOSE,"more data loaded into IOV");
-	sreq->dev.msg_offset = last;
-	sreq->dev.OnDataAvail = MPIDI_CH3_ReqHandler_SendReloadIOV;
-    }
-    else
-    {
-	intptr_t data_sz;
+        MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_CHANNEL,VERBOSE,(MPL_DBG_FDEST,
+        "post-pv: first=%" PRIdPTR ", last=%" PRIdPTR ", iov_n=%d",
+                        sreq->dev.msg_offset, last, *iov_n));
+        MPIR_Assert(*iov_n > 0 && *iov_n <= MPL_IOV_LIMIT);
+        
+        if (last == sreq->dev.msgsize) {
+            MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL,VERBOSE,"remaining data loaded into IOV");
+            sreq->dev.OnDataAvail = sreq->dev.OnFinal;
+        } else {
+            MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL,VERBOSE,"more data loaded into IOV");
+            sreq->dev.msg_offset = last;
+            sreq->dev.OnDataAvail = MPIDI_CH3_ReqHandler_SendReloadIOV;
+        }
+    } else {
+	MPI_Aint data_sz;
 	
 	MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL,VERBOSE,"low density.  using SRBuf.");
 	    
@@ -151,7 +149,7 @@ int MPIDI_CH3U_Request_load_send_iov(MPIR_Request * const sreq,
         MPIR_Typerep_pack(sreq->dev.user_buf, sreq->dev.user_count, sreq->dev.datatype,
                        sreq->dev.msg_offset, (char*) sreq->dev.tmpbuf,
                        max_pack_bytes, &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
-        last = sreq->dev.msg_offset + actual_pack_bytes;
+        MPI_Aint last = sreq->dev.msg_offset + actual_pack_bytes;
 
 	iov[0].iov_base = (void *)sreq->dev.tmpbuf;
 	iov[0].iov_len = actual_pack_bytes;


### PR DESCRIPTION
## Pull Request Description
The old code didn't set max_iov_len properly on calling
MPIR_Typerep_to_iov. This bug is revealed when we test ch3 with yaksa.
It is curious why dataloop didn't fail.

TODO: investigate dataloop.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
