### PR TITLE
test/mpi: Add back collalgo testing switch

### DIFF
--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -178,6 +178,7 @@
 /coll/scattern
 /coll/scatterv
 /coll/testlist
+/coll/testlist.collalgo
 /coll/testlist.dtp
 /coll/uop_equal
 /coll/uoplong

--- a/test/mpi/Makefile_common.mtest
+++ b/test/mpi/Makefile_common.mtest
@@ -21,16 +21,8 @@ LDADD = $(top_builddir)/dtpools/src/libdtpools.la
 $(top_builddir)/dtpools/src/libdtpools.la:
 	(cd $(top_builddir)/dtpools && $(MAKE))
 
-if HAVE_GPU
-if GPU_ONLY
-TESTDIRS ?= coll,pt2pt,rma
-TESTLIST ?= testlist.gpu
-else
-TESTLIST ?= testlist,testlist.dtp,testlist.cvar,testlist.gpu
-endif
-else
-TESTLIST ?= testlist,testlist.dtp,testlist.cvar
-endif
+TESTDIRS ?= @TESTDIRS@
+TESTLIST ?= @TESTLIST@
 SUMMARY_BASENAME ?= summary
 
 testing:

--- a/test/mpi/autogen.sh
+++ b/test/mpi/autogen.sh
@@ -4,6 +4,35 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
+echo_n() {
+    # "echo -n" isn't portable, must portably implement with printf
+    printf "%s" "$*"
+}
+
+PYTHON=
+check_python3() {
+    echo_n "Checking for Python 3... "
+    PYTHON=
+    if test 3 = `python -c 'import sys; print(sys.version_info[0])'`; then
+        PYTHON=python
+    fi
+
+    if test -z "$PYTHON" -a 3 = `python3 -c 'import sys; print(sys.version_info[0])'`; then
+        PYTHON=python3
+    fi
+
+    if test -z "$PYTHON" ; then
+        echo "not found"
+        exit 1
+    else
+        echo "$PYTHON"
+    fi
+}
+
+check_python3
+echo "Generating collective cvar tests"
+$PYTHON maint/gen_coll_cvar.py
+
 check_copy() {
     name=$1
     orig=$2

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -252,13 +252,6 @@ AC_ARG_WITH(dtpools-datatypes,
 dtp_args="--with-dtpools-datatypes=${with_dtpools_datatypes}"
 AC_CONFIG_COMMANDS([gentests],[$srcdir/maint/gentests_dtp.sh $dtp_args],[dtp_args="$dtp_args"])
 
-if test $enable_collalgo_tests = "yes" ; then
-    PAC_CHECK_PYTHON
-    #Test collectives algorithms with CVARs
-    cmd="$PYTHON $srcdir/maint/gen_coll_cvar.py"
-    AC_CONFIG_COMMANDS([collcvartests],[$cmd_gen_coll],[cmd_gen_coll="$cmd"])
-fi
-
 AC_ARG_WITH(mpi,
         [AC_HELP_STRING([--with-mpi=dir],
                 [Use the selected MPI; compilation scripts for mpicc,
@@ -739,13 +732,16 @@ PAC_POP_FLAG([LDFLAGS])
 PAC_POP_FLAG([LIBS])
 
 # setup which tests "make testing" will run
-TESTLIST=testlist,testlist.cvar
+TESTLIST=testlist
 TESTDIRS=
 if test $have_gpu = "yes" ; then
     TESTLIST="${TESTLIST},testlist.gpu"
 fi
 if test $enable_dtpools = "yes" ; then
     TESTLIST="${TESTLIST},testlist.dtp"
+fi
+if test $enable_collalgo_tests = "yes" ; then
+    TESTLIST="${TESTLIST},testlist.cvar"
 fi
 # handle --enable-gpu-tests-only
 if test $have_gpu = "no" -a $enable_gpu_tests_only = "yes" ; then

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -238,6 +238,11 @@ AC_ARG_ENABLE(xfail,
                 [Run tests marked for expected failure])],,
         [enable_xfail=no])
 
+AC_ARG_ENABLE(collalgo-tests,
+        [AS_HELP_STRING([--enable-collalgo-tests],
+                [Run extended collective algorithm tests])],,
+        [enable_collalgo_tests=yes])
+
 AC_ARG_ENABLE(gpu-tests-only,
         [AS_HELP_STRING([--enable-gpu-tests-only],
                 [Run only GPU tests])],,
@@ -253,12 +258,14 @@ AC_ARG_WITH(dtpools-datatypes,
 
 # parse args for typegen.sh script
 dtp_args="--with-dtpools-datatypes=${with_dtpools_datatypes}"
-
-PAC_CHECK_PYTHON
 AC_CONFIG_COMMANDS([gentests],[$srcdir/maint/gentests_dtp.sh $dtp_args],[dtp_args="$dtp_args"])
-#Test collectives algorithms with CVARs
-cmd="$PYTHON $srcdir/maint/gen_coll_cvar.py"
-AC_CONFIG_COMMANDS([collcvartests],[$cmd_gen_coll],[cmd_gen_coll="$cmd"])
+
+if test $enable_collalgo_tests = "yes" ; then
+    PAC_CHECK_PYTHON
+    #Test collectives algorithms with CVARs
+    cmd="$PYTHON $srcdir/maint/gen_coll_cvar.py"
+    AC_CONFIG_COMMANDS([collcvartests],[$cmd_gen_coll],[cmd_gen_coll="$cmd"])
+fi
 
 AC_ARG_WITH(mpi,
         [AC_HELP_STRING([--with-mpi=dir],

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -133,14 +133,6 @@ AC_ARG_ENABLE([dtpools],
               [AS_HELP_STRING([--disable-dtpools],[Disable dtpools tests])],,
               [enable_dtpools=yes])
 
-if test "x${enable_dtpools}" = "xyes"; then
-    DTP_SWITCH="ON"
-else
-    DTP_SWITCH="OFF"
-fi
-
-AC_SUBST(DTP_SWITCH)
-
 # runtests options
 RUNTESTS_OPTS=
 AC_SUBST(RUNTESTS_OPTS)
@@ -746,13 +738,24 @@ PAC_POP_FLAG([CPPFLAGS])
 PAC_POP_FLAG([LDFLAGS])
 PAC_POP_FLAG([LIBS])
 
-AM_CONDITIONAL([HAVE_GPU], [test $have_gpu = "yes"])
-# GPU only tests
+# setup which tests "make testing" will run
+TESTLIST=testlist,testlist.cvar
+TESTDIRS=
+if test $have_gpu = "yes" ; then
+    TESTLIST="${TESTLIST},testlist.gpu"
+fi
+if test $enable_dtpools = "yes" ; then
+    TESTLIST="${TESTLIST},testlist.dtp"
+fi
+# handle --enable-gpu-tests-only
 if test $have_gpu = "no" -a $enable_gpu_tests_only = "yes" ; then
     AC_MSG_ERROR([GPU only test configuration requires GPU library (CUDA or LevelZero)])
+elif test $enable_gpu_tests_only = "yes" ; then
+    TESTDIRS=coll,pt2pt,rma
+    TESTLIST=testlist.gpu
 fi
-AM_CONDITIONAL([GPU_ONLY], [test $enable_gpu_tests_only = "yes"])
-# End of GPU libs Check
+AC_SUBST([TESTDIRS])
+AC_SUBST([TESTLIST])
 
 # for tests that require large mem
 largetest="#"

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -741,7 +741,7 @@ if test $enable_dtpools = "yes" ; then
     TESTLIST="${TESTLIST},testlist.dtp"
 fi
 if test $enable_collalgo_tests = "yes" ; then
-    TESTLIST="${TESTLIST},testlist.cvar"
+    TESTLIST="${TESTLIST},testlist.collalgo"
 fi
 # handle --enable-gpu-tests-only
 if test $have_gpu = "no" -a $enable_gpu_tests_only = "yes" ; then

--- a/test/mpi/maint/gen_coll_cvar.py
+++ b/test/mpi/maint/gen_coll_cvar.py
@@ -20,7 +20,7 @@ class RE:
 
 def main():
     (tests, algos, algo_params) = load_config("coll_cvars.txt")
-    testlist_cvar = "coll/testlist.cvar"
+    testlist_cvar = "coll/testlist.collalgo"
     print("  --> [%s]" % testlist_cvar)
     with open(testlist_cvar, "w") as Out:
         for (key, testlist) in tests.items():


### PR DESCRIPTION
## Pull Request Description

Collective algorithm testing requires Python 3 at configure time. Give
users who do not have Python 3 an option to disable those tests, and
skip the testlist generation.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
