### PR TITLE
init: fix missing initialization when init after session_init

### DIFF
--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -276,6 +276,16 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
 
   fn_exit:
     if (is_world_model) {
+        if (!MPIR_Process.comm_world) {
+            mpi_errno = MPIR_init_comm_world();
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+
+        if (!MPIR_Process.comm_self) {
+            mpi_errno = MPIR_init_comm_self();
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+
         MPII_world_set_initilized();
 
         mpi_errno = MPII_init_async();


### PR DESCRIPTION
## Pull Request Description
Some initialization steps are only carried out during world MPI_Init.
When we run MPI_Init after MPI_Session_init, some of these world-only
steps was mistakenly skipped. Make sure we check and run these steps.

Fixes #5805 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
