### PR TITLE
config: do not add flat_namespace option by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -559,17 +559,15 @@ fi
 AC_SUBST(ENABLE_QMPI)
 
 AC_ARG_ENABLE([two-level-namespace],
-              [AS_HELP_STRING([--enable-two-level-namespace],
-                              [(Darwin only) Build shared libraries and programs
-                               built with the mpicc/mpifort/etc. compiler
-                               wrappers with '-Wl,-commons,use_dylibs' and
-                               without '-Wl,-flat_namespace'.  This may make the
-                               MPICH installation and MPI programs more
-                               compatible with other libraries.  Only enable
-                               this option if you really know what these linker
-                               options imply.])],
+              [AS_HELP_STRING([--disable-two-level-namespace],
+                              [(Darwin only) Add `-Wl,-flat_namespace` to
+                               mpicc/mpifort/etc. compiler wrappers.
+                               This may fix some issues due to not resolving
+                               MPI constants, such as MPI_IN_PLACE.
+                               Try disable this option if you encounter these issues
+                               on Mac OS.])],
               [],
-              [enable_two_level_namespace=no])
+              [enable_two_level_namespace=yes])
 
 AC_ARG_ENABLE(multi-aliases,
 	AS_HELP_STRING([--enable-multi-aliases],


### PR DESCRIPTION
## Pull Request Description
We added -Wl,-flat_namespace when we used to depend on common symbols
to be shared across libmpifort.so and libmpi.so. This is no longer the
case. This flag is added to the mpicxx wrapper scripts and have side
effects on all dynamic libraries users may use. It is better we do not
add it by default.

I imagine if user use another Fortran library that built with MPI may
still need this option to make the constants, e.g. MPI_IN_PLACE, to
work.

NOTE: the better option name should be `--enable-flat-namespace`. But some user scripts may already use `--enable-two-level-namespace`. We are keeping the name to reduce impact.

Reference to comment: https://github.com/pmodels/mpich/commit/2999a0ab3abc7a113d35d6117a9d1db8fa0ffa44#commitcomment-31131644

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
