### PR TITLE
config: amend error messages for -fallow-argument-mismatch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1992,7 +1992,7 @@ if test "$enable_f77" = "yes" ; then
 	# that turns off checking for *everything* is not something that
 	# configure should do - if the user wants this, they can follow
 	# the instructions in the following error message.
-        AC_MSG_ERROR([The Fortran compiler $FC does not accept programs that call the same routine with arguments of different types without the option $addarg.  Rerun configure with FCFLAGS=$addarg])
+        AC_MSG_ERROR([The Fortran compiler $FC does not accept programs that call the same routine with arguments of different types without the option $addarg.  Rerun configure with FFLAGS=$addarg and FCFLAGS=$addarg])
     fi
 
     bindings="$bindings f77"


### PR DESCRIPTION

## Pull Request Description

While the main mpich configure only need FC and FCFLAGS, the configure
in test/mpi still need FFLAGS because there are tests in F77. Because
the test/mpi is a subdir within mpich configure, we need direct user to
supply both flags. This is not an issue in the main branch since we have
detached test/mpi from the mpich configure.

Fixes #5811

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
