### PR TITLE
test: fix missing MPIEXEC

### DIFF
--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -349,6 +349,7 @@ PAC_GET_EXENAME("mpicc", MPICC_NAME)
 PAC_GET_EXENAME("mpif77", MPIF77_NAME)
 PAC_GET_EXENAME("mpifort", MPIFORT_NAME)
 PAC_GET_EXENAME("mpicxx", MPICXX_NAME)
+PAC_GET_EXENAME("mpiexec", MPIEXEC_NAME)
 
 if test -n "$with_mpi" ; then
     if test -z "$MPICC" ; then
@@ -370,6 +371,9 @@ if test -n "$with_mpi" ; then
         CXX=$with_mpi/bin/$MPICXX_NAME
     else
         CXX=$MPICXX
+    fi
+    if test -z "$MPIEXEC" ; then
+        MPIEXEC=$with_mpi/bin/$MPIEXEC_NAME
     fi
 else
     # Try to use mpicc etc names
@@ -399,7 +403,12 @@ else
     if test "x$MPICXX" != "x" ; then
         CXX=$MPICXX
     fi
+    if test -z "$MPIEXEC" ; then
+        AC_PATH_PROG(MPIEXEC,$MPIEXEC_NAME mpiexec)
+    fi
 fi
+dnl MPIEXEC is used in the Makefile testing target.
+AC_SUBST([MPIEXEC])
 
 # Make sure we export CC before configuring DTPools, since MPI is
 # needed to build the library.

--- a/test/mpi/runtests
+++ b/test/mpi/runtests
@@ -281,6 +281,10 @@ foreach $_ (@ARGV) {
     }
 }
 
+if (!$g_opt{mpiexec}) {
+    die "Missing mpiexec. Did you supplied empty MPIEXEC environment or empty --mpiexec= option?\n";
+}
+
 # Perform any post argument processing
 
 $g_opt{srcdir} = Cwd::abs_path($g_opt{srcdir});


### PR DESCRIPTION
## Pull Request Description
We accidentally removed the checking of MPIEXEC in test/mpi/configure, this resulted in empty `--mpiexec=` option in the `make testing` target when user didn't set `MPIEXEC` environment. This PR fixes it.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
