### PR TITLE
configure: Fix prebuilt yaksa configuration

### DIFF
--- a/src/mpi/datatype/typerep/src/subconfigure.m4
+++ b/src/mpi/datatype/typerep/src/subconfigure.m4
@@ -47,7 +47,7 @@ m4_define([yaksa_embedded_dir],[modules/yaksa])
 PAC_CHECK_HEADER_LIB_EXPLICIT([yaksa],[yaksa.h],[$YAKSALIBNAME],[yaksa_init])
 if test "$with_yaksa" = "embedded" ; then
     yaksalib="modules/yaksa/lib${YAKSALIBNAME}.la"
-    if test ! -e "$yaksalib" ; then
+    if test ! -e "${use_top_srcdir}/modules/PREBUILT" -o ! -e "$yaksalib"; then
         PAC_PUSH_ALL_FLAGS()
         PAC_RESET_ALL_FLAGS()
         # no need for libtool versioning when embedding YAKSA


### PR DESCRIPTION
## Pull Request Description

configure was skipping yaksa reconfiguration even when prebuilt modules
were not in use.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
