### PR TITLE
pmi: Add support for Slurm PMI2 library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -483,7 +483,16 @@ AC_ARG_WITH(device,
 	with_device=ch4)
 
 AC_ARG_WITH(pmi,
-	AS_HELP_STRING([--with-pmi=name], [Specify the pmi interface for MPICH]),,
+	AS_HELP_STRING([--with-pmi=name], [Specify the pmi interface for MPICH. The following options are supported. By default, MPICH will select the PMI supported by the configured process manager.])
+        Internal
+            simple      - Simple PMI 1
+            pmi2/simple - Simple PMI 2
+        External
+            cray        - Cray PMI 2
+            slurm       - Slurm PMI 1
+            slurm/pmi2  - Slurm PMI 2
+            pmix        - PMIx
+        ,,
 	with_pmi=default)
 
 AC_ARG_WITH(pm,

--- a/src/pmi/cray/subconfigure.m4
+++ b/src/pmi/cray/subconfigure.m4
@@ -5,20 +5,17 @@ AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
 
 AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
 
-AM_CONDITIONAL([BUILD_PMI_CRAY],[test "x$pmi_name" = "xcray"])
-AM_COND_IF([BUILD_PMI_CRAY],[
+if test "x$pmi_name" = "xcray" ; then
+    # set CPPFLAGS and LDFLAGS
+    PAC_PREPEND_FLAG([$CRAY_PMI_INCLUDE_OPTS], [CPPFLAGS])
+    PAC_PREPEND_FLAG([$CRAY_PMI_POST_LINK_OPTS], [LDFLAGS])
 
-# set CPPFLAGS and LDFLAGS
-PAC_PREPEND_FLAG([$CRAY_PMI_INCLUDE_OPTS], [CPPFLAGS])
-PAC_PREPEND_FLAG([$CRAY_PMI_POST_LINK_OPTS], [LDFLAGS])
+    AC_CHECK_HEADER([pmi.h], [], [AC_MSG_ERROR([could not find pmi.h.  Configure aborted])])
+    AC_CHECK_LIB([pmi], [PMI_Init], [], [AC_MSG_ERROR([could not find the cray libpmi.  Configure aborted])])
 
-AC_CHECK_HEADER([pmi.h], [], [AC_MSG_ERROR([could not find pmi.h.  Configure aborted])])
-AC_CHECK_LIB([pmi], [PMI_Init], [], [AC_MSG_ERROR([could not find the cray libpmi.  Configure aborted])])
-
-AC_DEFINE(USE_PMI2_API, 1, [Define if Cray PMI API must be used])
-PAC_APPEND_FLAG([-lpmi], [WRAPPER_LIBS])
-
-])dnl end COND_IF
+    AC_DEFINE(USE_PMI2_API, 1, [Define if Cray PMI API must be used])
+    PAC_APPEND_FLAG([-lpmi], [WRAPPER_LIBS])
+fi
 
 ])dnl end BODY macro
 

--- a/src/pmi/slurm/subconfigure.m4
+++ b/src/pmi/slurm/subconfigure.m4
@@ -14,6 +14,18 @@ if test "x$pmi_name" = "xslurm" ; then
                   PAC_PREPEND_FLAG([-lpmi], [WRAPPER_LIBS])],
                  [AC_MSG_ERROR([could not find the Slurm libpmi.  Configure aborted])])
 fi
+
+if test "x$pmi_name" = "xslurm/pmi2" ; then
+    # sets CPPFLAGS and LDFLAGS
+    PAC_SET_HEADER_LIB_PATH([slurm])
+
+    AC_CHECK_HEADER([slurm/pmi2.h], [], [AC_MSG_ERROR([could not find slurm/pmi2.h.  Configure aborted])])
+    AC_CHECK_LIB([pmi2], [PMI2_Init],
+                 [PAC_PREPEND_FLAG([-lpmi2],[LIBS])
+                  PAC_PREPEND_FLAG([-lpmi2], [WRAPPER_LIBS])],
+                 [AC_MSG_ERROR([could not find the Slurm libpmi2.  Configure aborted])])
+    AC_DEFINE(USE_PMI2_API, 1, [Define if PMI2 API must be used])
+fi
 ])dnl end BODY macro
 
 [#] end of __file__

--- a/src/pmi/slurm/subconfigure.m4
+++ b/src/pmi/slurm/subconfigure.m4
@@ -4,21 +4,16 @@ AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
 ])
 
 AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
+if test "x$pmi_name" = "xslurm" ; then
+    # sets CPPFLAGS and LDFLAGS
+    PAC_SET_HEADER_LIB_PATH([slurm])
 
-AM_CONDITIONAL([BUILD_PMI_SLURM],[test "x$pmi_name" = "xslurm"])
-AM_COND_IF([BUILD_PMI_SLURM],[
-
-# sets CPPFLAGS and LDFLAGS
-PAC_SET_HEADER_LIB_PATH([slurm])
-
-AC_CHECK_HEADER([slurm/pmi.h], [], [AC_MSG_ERROR([could not find slurm/pmi.h.  Configure aborted])])
-AC_CHECK_LIB([pmi], [PMI_Init],
-             [PAC_PREPEND_FLAG([-lpmi],[LIBS])
-              PAC_PREPEND_FLAG([-lpmi], [WRAPPER_LIBS])],
-             [AC_MSG_ERROR([could not find the Slurm libpmi.  Configure aborted])])
-
-])dnl end COND_IF
-
+    AC_CHECK_HEADER([slurm/pmi.h], [], [AC_MSG_ERROR([could not find slurm/pmi.h.  Configure aborted])])
+    AC_CHECK_LIB([pmi], [PMI_Init],
+                 [PAC_PREPEND_FLAG([-lpmi],[LIBS])
+                  PAC_PREPEND_FLAG([-lpmi], [WRAPPER_LIBS])],
+                 [AC_MSG_ERROR([could not find the Slurm libpmi.  Configure aborted])])
+fi
 ])dnl end BODY macro
 
 [#] end of __file__


### PR DESCRIPTION
## Pull Request Description

Slurm ships both PMI-1 and PMI-2 libraries. Gives users the choice to use either --with-pmi=slurm or --with-pmi=slurm/pmi2.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
