### PR TITLE
test: proper substitution for f90 profile tests

### DIFF
--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1249,6 +1249,8 @@ if test "$enable_fc" = yes ; then
     AC_LANG_POP([Fortran])
 fi
 
+f90profile=
+AC_SUBST(f90profile)
 if test "$f90dir" = "f90" ; then
     AC_MSG_CHECKING([that mpi module contains choice buffer routines])
     AC_LANG_PUSH([Fortran])
@@ -1260,10 +1262,9 @@ if test "$f90dir" = "f90" ; then
         ])
     ],[
         AC_MSG_RESULT(yes)
+        f90profile="profile"
     ],[
         AC_MSG_RESULT(no)
-        # patch f90/profile tests
-        find "$srcdir/f90/profile" -name "*.f90" -exec sed -i "s/use mpi, skip_.*/use mpi/" {} \;
     ])
     AC_LANG_POP([Fortran])
 fi

--- a/test/mpi/f90/Makefile.am
+++ b/test/mpi/f90/Makefile.am
@@ -8,6 +8,6 @@ include $(top_srcdir)/Makefile_f90.mtest
 EXTRA_DIST = testlist.in
 
 static_subdirs = timer attr coll datatype pt2pt info comm topo ext init \
-		 misc f90types profile
-SUBDIRS = $(static_subdirs) $(rmadir) $(spawndir) $(iodir)
+		 misc f90types
+SUBDIRS = $(static_subdirs) $(rmadir) $(spawndir) $(iodir) $(f90profile)
 DIST_SUBDIRS = $(static_subdirs) rma spawn io

--- a/test/mpi/f90/testlist.in
+++ b/test/mpi/f90/testlist.in
@@ -13,4 +13,4 @@ f90types
 @spawndir@
 timer
 topo
-profile
+@f90profile@


### PR DESCRIPTION
## Pull Request Description
The f90 profiles tests previously were substituted in configure on the
distributed source directly. This patch uses separate `.in` files for
substitution. It will allow repeated configure to work.


Fixes #5827 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
