### PR TITLE
qmpi: chop MPICH_API_PUBLIC from the definition

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -159,7 +159,7 @@ def dump_mpir_impl_h(f):
         print("", file=Out)
         print("#endif /* MPIR_IMPL_H_INCLUDED */", file=Out)
 
-def get_qmpi_decl_from_func_decl(func_decl):
+def get_qmpi_decl_from_func_decl(func_decl, kind=""):
     if RE.match(r'(.*) (MPIX?_\w+)\((.*?)\)(.*)', func_decl):
         T, name, args, tail = RE.m.group(1,2,3,4)
     else:
@@ -170,11 +170,12 @@ def get_qmpi_decl_from_func_decl(func_decl):
     else:
         t = "%s Q%s(QMPI_Context context, int tool_id, %s)" % (T, name, args)
 
-    while RE.search(r'MPICH_ATTR_POINTER_WITH_TYPE_TAG\((\d+),(\d+)\)(.*)', tail):
-        i1, i2, tail = RE.m.group(1, 2, 3)
-        t += " MPICH_ATTR_POINTER_WITH_TYPE_TAG(%d,%d)" % (int(i1) + 2, int(i2) + 2)
+    if kind == 'proto':
+        while RE.search(r'MPICH_ATTR_POINTER_WITH_TYPE_TAG\((\d+),(\d+)\)(.*)', tail):
+            i1, i2, tail = RE.m.group(1, 2, 3)
+            t += " MPICH_ATTR_POINTER_WITH_TYPE_TAG(%d,%d)" % (int(i1) + 2, int(i2) + 2)
 
-    t += " MPICH_API_PUBLIC"
+        t += " MPICH_API_PUBLIC"
 
     return t
 
@@ -292,7 +293,7 @@ def dump_mpi_proto_h(f):
             m = re.match(r'[a-zA-Z0-9_]* ([a-zA-Z0-9_]*)\(.*', func_decl);
             if need_skip_qmpi(m.group(1)):
                 continue
-            func_decl = get_qmpi_decl_from_func_decl(func_decl)
+            func_decl = get_qmpi_decl_from_func_decl(func_decl, 'proto')
             dump_proto_line(func_decl, Out)
 
         print("", file=Out)


### PR DESCRIPTION
## Pull Request Description
MPICH_API_PUBLIC is accidentally leaked into definitions, which isn't
allowed.

Fixes #5829

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
