### PR TITLE
mpi/coll: add TSP-based scatter/ring-based-allgather algorithm for Ibcast

### DIFF
--- a/src/mpi/coll/coll_algorithms.txt
+++ b/src/mpi/coll/coll_algorithms.txt
@@ -81,8 +81,11 @@ ibcast-intra:
         cvar_params: TREE_TYPE, TREE_KVAL, TREE_PIPELINE_CHUNK_SIZE
     tsp_scatterv_recexch_allgatherv
         func_name: scatterv_allgatherv
-        extra_params: scatterv_k, allgatherv_k
-        cvar_params: SCATTERV_KVAL, ALLGATHERV_RECEXCH_KVAL
+        extra_params: allgatherv_algo=MPIR_CVAR_IALLGATHERV_INTRA_ALGORITHM_tsp_recexch_doubling, scatterv_k, allgatherv_k
+        cvar_params: -, SCATTERV_KVAL, ALLGATHERV_RECEXCH_KVAL
+    tsp_scatterv_ring_allgatherv
+        extra_params: scatterv_k
+        cvar_params:  SCATTERV_KVAL
     tsp_ring
         func_name: tree
         extra_params: tree_type=MPIR_TREE_TYPE_KARY, k=1, chunk_size

--- a/src/mpi/coll/cvars.txt
+++ b/src/mpi/coll/cvars.txt
@@ -299,6 +299,7 @@ cvars:
         sched_scatter_ring_allgather               - Force Scatter Ring Allgather algorithm
         tsp_tree                               - Force Generic Transport Tree algorithm
         tsp_scatterv_recexch_allgatherv        - Force Generic Transport Scatterv followed by Recursive Exchange Allgatherv algorithm
+        tsp_scatterv_ring_allgatherv           - Force Generic Transport Scatterv followed by Ring Allgatherv algorithm
         tsp_ring                               - Force Generic Transport Ring algorithm
 
     - name        : MPIR_CVAR_IBCAST_SCATTERV_KVAL

--- a/src/mpi/coll/ibcast/Makefile.mk
+++ b/src/mpi/coll/ibcast/Makefile.mk
@@ -14,6 +14,7 @@ mpi_core_sources += \
     src/mpi/coll/ibcast/ibcast_intra_sched_smp.c                                  \
     src/mpi/coll/ibcast/ibcast_inter_sched_flat.c                                 \
     src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c \
+    src/mpi/coll/ibcast/ibcast_tsp_scatterv_ring_allgatherv.c \
     src/mpi/coll/ibcast/ibcast_tsp_tree.c 					  \
     src/mpi/coll/ibcast/ibcast_utils.c
 

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_ring_allgatherv.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_ring_allgatherv.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+#include "algo_common.h"
+
+/* Routine to schedule a scatter followed by ring based broadcast */
+int MPIR_TSP_Ibcast_sched_intra_scatterv_ring_allgatherv(void *buffer, MPI_Aint count,
+                                                         MPI_Datatype datatype, int root,
+                                                         MPIR_Comm * comm, int scatterv_k,
+                                                         MPIR_TSP_sched_t sched)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_ENTER;
+
+    mpi_errno = MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(buffer, count, datatype, root,
+                                                                comm,
+                                                                MPIR_CVAR_IALLGATHERV_INTRA_ALGORITHM_tsp_ring,
+                                                                scatterv_k, 0, sched);
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+
+}

--- a/src/mpi/coll/include/csel_container.h
+++ b/src/mpi/coll/include/csel_container.h
@@ -115,6 +115,7 @@ typedef enum {
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibarrier_inter_sched_bcast,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_tsp_tree,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_tsp_scatterv_recexch_allgatherv,
+    MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_tsp_scatterv_ring_allgatherv,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_tsp_ring,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_sched_binomial,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather,
@@ -287,6 +288,9 @@ typedef struct {
                 int scatterv_k;
                 int allgatherv_k;
             } intra_tsp_scatterv_recexch_allgatherv;
+            struct {
+                int scatterv_k;
+            } intra_tsp_scatterv_ring_allgatherv;
         } ibcast;
         struct {
             struct {

--- a/test/mpi/maint/coll_cvars.txt
+++ b/test/mpi/maint/coll_cvars.txt
@@ -350,6 +350,8 @@ algorithms:
             tsp_scatterv_recexch_allgatherv
                 .MPIR_CVAR_IBCAST_SCATTERV_KVAL=3
                 .MPIR_CVAR_IBCAST_ALLGATHER_RECEXCH=3
+            tsp_scatterv_ring_allgatherv
+                .MPIR_CVAR_IBCAST_SCATTERV_KVAL=3
             tsp_ring
                 .MPIR_CVAR_IBCAST_RING_CHUNK_SIZE=4096
     exscan:


### PR DESCRIPTION
This algorithm is similar to the existing scatter followed by recursive exchange-based allgather Ibcast algorithm. 
This ring-based algorithm is similar to the idea used in Baidu's ring allreduce (https://www.tomshardware.com/news/baidu-svail-ring-allreduce-library,33691.html)

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
