### PR TITLE
hydra: Fix spawn when specifying launch hosts

### DIFF
--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -520,7 +520,7 @@ for option in $enable_g ; do
         mem)
 		AC_DEFINE(USE_MEMORY_TRACING,1,[Define if memory tracing is enabled])
 		;;
-        all)
+        yes|all)
 		PAC_APPEND_FLAG(-g, CFLAGS)
 		AC_DEFINE(USE_MEMORY_TRACING,1,[Define if memory tracing is enabled])
 		AC_DEFINE(PMI_KEY_CHECK,1,[Define if we should check for PMI key collisions])

--- a/src/pm/hydra/pm/pmiserv/pmiserv_utils.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_utils.c
@@ -279,8 +279,8 @@ HYD_status HYD_pmcd_pmi_fill_in_exec_launch_info(struct HYD_pg *pg)
     }
 
     total_core_count = 0;
-    for (node = HYD_server_info.node_list; node; node = node->next)
-        total_core_count += node->core_count;
+    for (proxy = pg->proxy_list; proxy; proxy = proxy->next)
+        total_core_count += proxy->node->core_count;
 
     HYDU_MALLOC_OR_JUMP(filler_pmi_ids, int *, proxy_count * sizeof(int), status);
     HYDU_MALLOC_OR_JUMP(nonfiller_pmi_ids, int *, proxy_count * sizeof(int), status);


### PR DESCRIPTION
## Pull Request Description

Address MPICH + Hydra + PMI 1 configuration in #5835. Hydra was incorrectly calculating process ranks, causing a crash. The issue is an incorrect "global core map" that was using all nodes known to `mpiexec` at spawn time (default), instead of only the nodes being used by the spawn command (info key `"host"="<hostname>"`).

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
