### PR TITLE
test: permanently xfail collective length checks

### DIFF
--- a/test/mpi/errors/coll/testlist
+++ b/test/mpi/errors/coll/testlist
@@ -7,17 +7,17 @@ nb_rerr 2
 reduce_local 1
 bcastlength 4
 ibcastlength 4
-reducelength 4
-ireducelength 4
-allreducelength 4
-iallreducelength 4
-reduceop 4
-ireduceop 4
-gatherlength 4
-igatherlength 4
-scatterlength 4
-iscatterlength 4
-allgatherlength 4
-iallgatherlength 4
-alltoalllength 4
+reducelength 4 xfail=ticket3655
+ireducelength 4 xfail=ticket3655
+allreducelength 4 xfail=ticket3655
+iallreducelength 4 xfail=ticket3655
+reduceop 4 xfail=ticket3655
+ireduceop 4 xfail=ticket3655
+gatherlength 4 xfail=ticket3655
+igatherlength 4 xfail=ticket3655
+scatterlength 4 xfail=ticket3655
+iscatterlength 4 xfail=ticket3655
+allgatherlength 4 xfail=ticket3655
+iallgatherlength 4 xfail=ticket3655
+alltoalllength 4 xfail=ticket3655
 

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -58,21 +58,6 @@
 * * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   rma/testlist.dtp
 # Bug - Github Issue https://github.com/pmodels/mpich/issues/3618
 * * * ch4:ucx *         /^darray_pack/   xfail=ticket0   datatype/testlist
-# Collectivess other than bcast don't currently detect mismatched datatype lengths
-* * * * *               /^reducelength/         xfail=ticket3655        errors/coll/testlist
-* * * * *               /^ireducelength/        xfail=ticket3655        errors/coll/testlist
-* * * * *               /^allreducelength/      xfail=ticket3655        errors/coll/testlist
-* * * * *               /^iallreducelength/     xfail=ticket3655        errors/coll/testlist
-* * * * *               /^reduceop/             xfail=ticket3655        errors/coll/testlist
-* * * * *               /^ireduceop/            xfail=ticket3655        errors/coll/testlist
-* * * * *               /^gatherlength/         xfail=ticket3655        errors/coll/testlist
-* * * * *               /^igatherlength/        xfail=ticket3655        errors/coll/testlist
-* * * * *               /^allgatherlength/      xfail=ticket3655        errors/coll/testlist
-* * * * *               /^iallgatherlength/     xfail=ticket3655        errors/coll/testlist
-* * * * *               /^alltoalllength/       xfail=ticket3655        errors/coll/testlist
-* * * * *               /^ialltoalllength/      xfail=ticket3655        errors/coll/testlist
-* * * * *               /^scatterlength/        xfail=ticket3655        errors/coll/testlist
-* * * * *               /^iscatterlength/       xfail=ticket3655        errors/coll/testlist
 # some of the bcastlength test that is still failing
 * * * ch3:ofi *         /^ibcastlength/         xfail=issue3775         errors/coll/testlist
 * * * ch3:ofi *         /^bcastlength/          xfail=issue4373         errors/coll/testlist


### PR DESCRIPTION
## Pull Request Description
Since we have no plan of supporting collective length checks in general,
hard code the xfail in the testlist. This avoids making general users
alarmed that not tests are passing.

We can easily revert this commit once our plan changes.

ref. https://github.com/pmodels/mpich/issues/5836
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
