### PR TITLE
config: do not reset flags config subsystems

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -471,12 +471,7 @@ dnl had trouble with gcc 2.95.3 accepting -std=c89 but then trying to
 dnl compile program with a invalid set of options 
 dnl (-D __STRICT_ANSI__-trigraphs)
 AC_DEFUN([PAC_CC_STRICT],[
-PAC_CC_VENDOR()
-export enable_strict_done
-if test "$enable_strict_done" != "yes" ; then
-    # make sure we don't add the below flags multiple times
-    enable_strict_done=yes
-
+    PAC_CC_VENDOR()
     # Some comments on strict warning options.
     # These were added to improve portability
     #   -Wstack-usage=262144 -- 32 bit FreeBSD did not like the mprobe test
@@ -682,7 +677,6 @@ if test "$enable_strict_done" != "yes" ; then
         PAC_POP_FLAG([CFLAGS])
     done
     pac_cc_strict_flags=$accepted_flags
-fi
 ])
 
 dnl/*D

--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -79,6 +79,8 @@ AC_DEFUN([PAC_CONFIG_HWLOC],[
     if test "$pac_have_hwloc" = "no" -a "$with_hwloc" != "no"; then
         with_hwloc=embedded
         pac_have_hwloc=yes
+        # make sure subsystems such as hydra will use embedded hwloc consistently
+        subsys_config_args="$subsys_config_args --with-hwloc=embedded"
     fi
 
     if test "$with_hwloc" = "embedded" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -3848,12 +3848,9 @@ m4_map([PAC_SUBCFG_CONFIGURE_SUBSYS], [PAC_SUBCFG_MODULE_LIST])
 
 # now configure any actual recursively configures subsystems, such as ROMIO and
 # hydra, or older components that haven't been updated to a subconfigure.m4 yet
-PAC_PUSH_ALL_FLAGS()
-PAC_RESET_ALL_FLAGS()
 for subsys in $devsubsystems $subsystems ; do
     PAC_CONFIG_SUBDIR([$subsys],[],[AC_MSG_ERROR([$subsys configure failed])])
 done
-PAC_POP_ALL_FLAGS()
 if test "$DEBUG_SUBDIR_CACHE" = yes -a "$enable_echo" != yes ; then
     set +x
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -3849,7 +3849,7 @@ m4_map([PAC_SUBCFG_CONFIGURE_SUBSYS], [PAC_SUBCFG_MODULE_LIST])
 # now configure any actual recursively configures subsystems, such as ROMIO and
 # hydra, or older components that haven't been updated to a subconfigure.m4 yet
 for subsys in $devsubsystems $subsystems ; do
-    PAC_CONFIG_SUBDIR([$subsys],[],[AC_MSG_ERROR([$subsys configure failed])])
+    PAC_CONFIG_SUBDIR_ARGS([$subsys],[$subsys_config_args],[],[AC_MSG_ERROR([$subsys configure failed])])
 done
 if test "$DEBUG_SUBDIR_CACHE" = yes -a "$enable_echo" != yes ; then
     set +x

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -46,8 +46,6 @@ AC_SUBST(WRAPPER_LIBS)
 # let confdb macro know that we are using WRAPPER FLAGS
 m4_define([use_wrapper_flags], [1])
 
-PAC_ARG_STRICT
-
 # Look for perl.  The absolute path of perl is required in hydra-doxygen.cfg.
 AC_PATH_PROG(PERL,perl)
 


### PR DESCRIPTION
## Pull Request Description
Subsystems include romio and hydra, and we need at least the strict
CFLAGS to be applied. This commit removes the reset. We can reset
particular flags or add customization once we understand what is needed.




## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
