### PR TITLE
binding/c: Ignore MPI_INFO_NULL in comm spawn interfaces

### DIFF
--- a/src/binding/c/spawn_api.txt
+++ b/src/binding/c/spawn_api.txt
@@ -41,7 +41,7 @@ MPI_Comm_spawn:
 }
 { -- handle_ptr -- info
     MPIR_Info *info_ptr = NULL;
-    if (comm_ptr->rank == root) {
+    if (comm_ptr->rank == root && info != MPI_INFO_NULL) {
         MPIR_Info_get_ptr(info, info_ptr);
     }
 }
@@ -59,7 +59,11 @@ MPI_Comm_spawn_multiple:
     if (comm_ptr->rank == root) {
         array_of_info_ptrs = MPL_malloc(count * sizeof(MPIR_Info *), MPL_MEM_OTHER);
         for (int i = 0; i < count; i++) {
-            MPIR_Info_get_ptr(array_of_info[i], array_of_info_ptrs[i]);
+            if (array_of_info[i] != MPI_INFO_NULL) {
+                MPIR_Info_get_ptr(array_of_info[i], array_of_info_ptrs[i]);
+            } else {
+                array_of_info_ptrs[i] = NULL;
+            }
         }
     }
 }


### PR DESCRIPTION
## Pull Request Description

The MPI_INFO_NULL handle does not work with MPIR_Info_get_ptr, so we
need to check it first and ignore it.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
