### PR TITLE
spawn: Avoid passing pointer to NULL info array

### DIFF
--- a/src/mpi/spawn/spawn_impl.c
+++ b/src/mpi/spawn/spawn_impl.c
@@ -173,8 +173,9 @@ int MPIR_Comm_spawn_impl(const char *command, char *argv[], int maxprocs, MPIR_I
                          int root, MPIR_Comm * comm_ptr, MPIR_Comm ** p_intercomm_ptr,
                          int array_of_errcodes[])
 {
-    return MPID_Comm_spawn_multiple(1, (char **) &command, &argv, &maxprocs, &info_ptr, root,
-                                    comm_ptr, p_intercomm_ptr, array_of_errcodes);
+    return MPID_Comm_spawn_multiple(1, (char **) &command, &argv, &maxprocs,
+                                    info_ptr ? &info_ptr : NULL, root, comm_ptr, p_intercomm_ptr,
+                                    array_of_errcodes);
 }
 
 int MPIR_Comm_spawn_multiple_impl(int count, char *array_of_commands[], char **array_of_argv[],


### PR DESCRIPTION
## Pull Request Description

MPID_Comm_spawn_multiple takes an array of info ptrs or NULL as
argument. MPID_Comm_spawn calls MPID_Comm_spawn_multiple with count=1
and always passed an array of info pointers, even when the underlying
array did not exist. Check if there is an array, and pass NULL
otherwise.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
