### PR TITLE
Fix spawn functionality with pmi2

### DIFF
--- a/src/mpid/ch3/channels/sock/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_progress.c
@@ -4,7 +4,6 @@
  */
 
 #include "mpidi_ch3_impl.h"
-#include "pmi.h"
 #include "mpidu_sock.h"
 #include "utlist.h"
 

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -1006,6 +1006,7 @@ int MPIDI_CH3I_Port_destroy(int port_name_tag);
   --------------------------*/
 
 #define MPIDI_MAX_KVS_VALUE_LEN    4096
+#define MPIDI_MAX_JOBID_LEN        1024
 
 /* ------------------------------------------------------------------------- */
 /* mpirma.h (in src/mpi/rma?) */

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -5,8 +5,6 @@
 
 #include "mpidimpl.h"
 
-#define MAX_JOBID_LEN 1024
-
 #if defined(HAVE_LIMITS_H)
 #include <limits.h>
 #endif

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -10,8 +10,6 @@
 #include "pmi.h"
 #endif
 
-#define MAX_JOBID_LEN 1024
-
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
 
@@ -739,12 +737,12 @@ int MPIDI_PG_InitConnKVS( MPIDI_PG_t *pg )
 #ifdef USE_PMI2_API
     int mpi_errno = MPI_SUCCESS;
     
-    pg->connData = (char *)MPL_malloc(MAX_JOBID_LEN, MPL_MEM_STRINGS);
+    pg->connData = (char *)MPL_malloc(MPIDI_MAX_JOBID_LEN, MPL_MEM_STRINGS);
     if (pg->connData == NULL) {
 	MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER, "**nomem");
     }
     
-    mpi_errno = PMI2_Job_GetId(pg->connData, MAX_JOBID_LEN);
+    mpi_errno = PMI2_Job_GetId(pg->connData, MPIDI_MAX_JOBID_LEN);
     MPIR_ERR_CHECK(mpi_errno);
 #else
     int pmi_errno, kvs_name_sz;

--- a/src/mpid/ch3/util/sock/ch3u_connect_sock.c
+++ b/src/mpid/ch3/util/sock/ch3u_connect_sock.c
@@ -163,7 +163,7 @@ int MPIDI_CH3I_Connection_alloc(MPIDI_CH3I_Connection_t ** connp)
        we might prefer for connections to simply point at the single process
        group to which the remote process belong */
 #ifdef USE_PMI2_API
-    id_sz = MPID_MAX_JOBID_LEN;
+    id_sz = MPIDI_MAX_JOBID_LEN;
 #else
     pmi_errno = PMI_KVS_Get_name_length_max(&id_sz);
     MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno,MPI_ERR_OTHER, 

--- a/src/pm/hydra/pm/pmiserv/pmip_pmi_v2.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_pmi_v2.c
@@ -172,7 +172,17 @@ static HYD_status fn_fullinit(int fd, char *args[])
             break;
         }
     }
+    int idx = i;
     HYDU_ASSERT(i < HYD_pmcd_pmip.local.proxy_process_count, status);
+
+    /* find executable information */
+    i = 0;
+    struct HYD_exec *exec;
+    for (exec = HYD_pmcd_pmip.exec_list; exec; exec = exec->next) {
+        i += exec->proc_count;
+        if (idx < i)
+            break;
+    }
 
     HYD_STRING_STASH_INIT(stash);
     HYD_STRING_STASH(stash,
@@ -183,7 +193,8 @@ static HYD_status fn_fullinit(int fd, char *args[])
     HYD_STRING_STASH(stash, MPL_strdup(";size="), status);
     HYD_STRING_STASH(stash, HYDU_int_to_str(HYD_pmcd_pmip.system_global.global_process_count),
                      status);
-    HYD_STRING_STASH(stash, MPL_strdup(";appnum=0"), status);
+    HYD_STRING_STASH(stash, MPL_strdup(";appnum="), status);
+    HYD_STRING_STASH(stash, HYDU_int_to_str(exec->appnum), status);
     if (HYD_pmcd_pmip.local.spawner_kvsname) {
         HYD_STRING_STASH(stash, MPL_strdup(";spawner-jobid="), status);
         HYD_STRING_STASH(stash, MPL_strdup(HYD_pmcd_pmip.local.spawner_kvsname), status);

--- a/src/pmi/pmi2/simple/simple2pmi.c
+++ b/src/pmi/pmi2/simple/simple2pmi.c
@@ -1034,7 +1034,7 @@ int PMI2_Nameserv_lookup(const char service_name[], const PMI2U_Info * info_ptr,
     PMI2U_ERR_CHKANDJUMP1(rc, pmi2_errno, PMI2_ERR_OTHER, "**pmi2_nameservlookup",
                           "**pmi2_nameservlookup %s", errmsg ? errmsg : "unknown");
 
-    found = getval(cmd.pairs, cmd.nPairs, VALUE_KEY, &found_port, &plen);
+    found = getval(cmd.pairs, cmd.nPairs, PORT_KEY, &found_port, &plen);
     PMI2U_ERR_CHKANDJUMP1(!found, pmi2_errno, PMI2_ERR_OTHER, "**pmi2_nameservlookup",
                           "**pmi2_nameservlookup %s", "not found");
     MPL_strncpy(port, found_port, portLen);


### PR DESCRIPTION
## Pull Request Description

Fixes in ch3, hydra, and simple pmi2. `test/mpi/spawn` should now pass in the `--with-pmi=pmi2/simple` configuration.

~TODO: add support for PMI2_Job_Spawn in `src/util/mpir_pmi.c`.~

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
