### PR TITLE
binding/c: check when alltoallw count is 0

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2079,7 +2079,9 @@ def dump_validate_userbuffer_neighbor_vw(func, kind, buf, ct, dt, disp):
     ct += '[i]'
     if RE.search(r'-w$', kind):
         dt += '[i]'
+        dump_if_open("%s > 0" % ct)
         dump_validate_datatype(func, dt)
+        dump_if_close()
     G.out.append("MPIR_ERRTEST_COUNT(%s, mpi_errno);" % ct)
     G.out.append("if (%s[i] == 0) {" % disp)
     G.out.append("    MPIR_ERRTEST_USERBUFFER(%s, %s, %s, mpi_errno);" % (buf, ct, dt))
@@ -2198,7 +2200,9 @@ def dump_validate_userbuffer_coll(func, kind, buf, ct, dt, disp):
         ct += '[i]'
         if RE.search(r'-w$', kind):
             dt += '[i]'
+            dump_if_open("%s > 0" % ct)
             dump_validate_datatype(func, dt)
+            dump_if_close()
 
     #  -- test wrong MPI_IN_PLACE
     SEND = "SEND"


### PR DESCRIPTION
## Pull Request Description
When the `counts` array in MPI_Alltoallw contains `0`, we need to skip the
corresponding datatype check.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
