### PR TITLE
ch4: Workaround Intel compiler TLS bug on macOS

### DIFF
--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -36,6 +36,17 @@ MPL_COMPILER_TLS int global_vci_poll_count;
 int global_vci_poll_count = 0;
 #endif
 
+/* ** HACK **
+ * Hack to workaround an Intel compiler bug on macOS. Touching
+ * global_vci_poll_count in this file forces the compiler to allocate
+ * it as TLS. See https://github.com/pmodels/mpich/issues/3437.
+ */
+int _dummy_touch_tls(void);
+int _dummy_touch_tls(void)
+{
+    return global_vci_poll_count;
+}
+
 /* PVAR */
 unsigned PVAR_LEVEL_posted_recvq_length ATTRIBUTE((unused));
 unsigned PVAR_LEVEL_unexpected_recvq_length ATTRIBUTE((unused));


### PR DESCRIPTION
## Pull Request Description

Same problem as previously fixed in [2925988a]. global_vci_poll_count
was not being allocated as TLS by the Intel compiler on macOS. Add a
dummy function to touch it and force the correct allocation.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
