### PR TITLE
pmi: Fix Slurm PMI support

### DIFF
--- a/src/pmi/Makefile.mk
+++ b/src/pmi/Makefile.mk
@@ -6,5 +6,6 @@
 include $(top_srcdir)/src/pmi/pmi2/Makefile.mk
 include $(top_srcdir)/src/pmi/simple/Makefile.mk
 include $(top_srcdir)/src/pmi/bgq/Makefile.mk
+include $(top_srcdir)/src/pmi/slurm/Makefile.mk
 
 errnames_txt_files += src/pmi/errnames.txt

--- a/src/pmi/slurm/Makefile.mk
+++ b/src/pmi/slurm/Makefile.mk
@@ -1,0 +1,12 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+if BUILD_PMI_SLURM
+
+noinst_HEADERS += src/pmi/slurm/pmi.h
+
+AM_CPPFLAGS += -I$(top_srcdir)/src/pmi/slurm
+
+endif BUILD_PMI_SLURM

--- a/src/pmi/slurm/pmi.h
+++ b/src/pmi/slurm/pmi.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef SLURM_PMI_H_INCLUDED
+#define SLURM_PMI_H_INCLUDED
+
+/* Slurm puts PMI headers in a subdirectory. Include it once
+ * here so that other parts of MPICH do not have to change from
+ * using "#include <pmi.h>" */
+#include <slurm/pmi.h>
+
+#endif /* SLURM_PMI_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

Slurm PMI headers are in a "slurm" subdirectory. Rather than adapting
the code to #include <slurm/pmi.h> in various places, add a dummy pmi.h
header to include the Slurm file and make it available to the rest of
MPICH.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
