### PR TITLE
hydra: GPU visibility control revamp

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -1060,6 +1060,7 @@ PAC_CHECK_HEADER_LIB_OPTIONAL([cuda],[cuda_runtime_api.h],[cudart],[cudaStreamSy
 if test "$pac_have_cuda" = "yes" ; then
     # also require -lcuda (in addition to -lcudart)
     PAC_CHECK_HEADER_LIB([cuda.h],[cuda],[cuMemGetAddressRange], pac_have_cuda=yes, pac_have_cuda=no)
+    AC_CHECK_LIB(dl, dlopen, [], AC_MSG_ERROR([dlopen not found.  MPL CUDA support requires libdl.]))
 fi
 if test "$pac_have_cuda" = "yes" ; then
     if test -z "$NVCC"; then

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -80,6 +80,8 @@ int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len);
 
 int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr));
 int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id);
+int MPL_gpu_get_dev_list(int *dev_count, char ***dev_list, bool is_subdev);
+int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env);
 
 typedef void (*MPL_gpu_hostfn) (void *data);
 int MPL_gpu_launch_hostfn(MPL_gpu_stream_t stream, MPL_gpu_hostfn fn, void *data);

--- a/src/mpl/include/mpl_gpu_cuda.h
+++ b/src/mpl/include/mpl_gpu_cuda.h
@@ -20,4 +20,6 @@ typedef volatile int MPL_gpu_event_t;
 #define MPL_GPU_STREAM_DEFAULT 0
 #define MPL_GPU_DEVICE_INVALID -1
 
+#define MPL_GPU_DEV_AFFINITY_ENV "CUDA_VISIBLE_DEVICES"
+
 #endif /* ifndef MPL_GPU_CUDA_H_INCLUDED */

--- a/src/mpl/include/mpl_gpu_fallback.h
+++ b/src/mpl/include/mpl_gpu_fallback.h
@@ -16,4 +16,6 @@ typedef volatile int MPL_gpu_event_t;
 #define MPL_GPU_STREAM_DEFAULT 0
 #define MPL_GPU_DEVICE_INVALID -1
 
+#define MPL_GPU_DEV_AFFINITY_ENV NULL
+
 #endif /* ifndef MPL_GPU_CUDA_H_INCLUDED */

--- a/src/mpl/include/mpl_gpu_hip.h
+++ b/src/mpl/include/mpl_gpu_hip.h
@@ -23,4 +23,6 @@ typedef volatile int MPL_gpu_event_t;
 #define MPL_GPU_STREAM_DEFAULT 0
 #define MPL_GPU_DEVICE_INVALID -1
 
+#define MPL_GPU_DEV_AFFINITY_ENV "HIP_VISIBLE_DEVICES"
+
 #endif /* ifndef MPL_GPU_HIP_H_INCLUDED */

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -24,4 +24,6 @@ typedef volatile int MPL_gpu_event_t;
 #define MPL_GPU_STREAM_DEFAULT 0
 #define MPL_GPU_DEVICE_INVALID NULL
 
+#define MPL_GPU_DEV_AFFINITY_ENV "ZE_AFFINITY_MASK"
+
 #endif /* ifndef MPL_GPU_ZE_H_INCLUDED */

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -4,6 +4,7 @@
  */
 
 #include "mpl.h"
+#include "mpl_str.h"
 #include <dlfcn.h>
 #include <assert.h>
 
@@ -18,6 +19,9 @@ typedef struct gpu_free_hook {
 static int gpu_initialized = 0;
 static int device_count = -1;
 static int max_dev_id = -1;
+static char **device_list = NULL;
+#define MAX_GPU_STR_LEN 256
+static char affinity_env[MAX_GPU_STR_LEN] = { 0 };
 
 static int *local_to_global_map;        /* [device_count] */
 static int *global_to_local_map;        /* [max_dev_id + 1]   */
@@ -44,15 +48,42 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 int MPL_gpu_get_dev_list(int *dev_count, char ***dev_list, bool is_subdev)
 {
     int ret = MPL_SUCCESS;
-    *dev_count = 0;
-    *dev_list = NULL;
+    if (!gpu_initialized) {
+        ret = MPL_gpu_init(0);
+    }
+
+    device_list = (char **) MPL_malloc(device_count * sizeof(char *), MPL_MEM_OTHER);
+    assert(device_list != NULL);
+
+    for (int i = 0; i < device_count; ++i) {
+        int str_len = snprintf(NULL, 0, "%d", i);
+        device_list[i] = (char *) MPL_malloc((str_len + 1) * sizeof(char *), MPL_MEM_OTHER);
+        sprintf(device_list[i], "%d", i);
+    }
+
+    *dev_count = device_count;
+    *dev_list = device_list;
     return ret;
 }
 
 int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
 {
     int ret = MPL_SUCCESS;
-    *env = NULL;
+    memset(affinity_env, 0, MAX_GPU_STR_LEN);
+    if (dev_count == 0) {
+        MPL_snprintf(affinity_env, 3, "-1");
+    } else {
+        int str_offset = 0;
+        for (int i = 0; i < dev_count; ++i) {
+            if (i) {
+                MPL_strncpy(affinity_env + str_offset, ",", MAX_GPU_STR_LEN - str_offset);
+                str_offset++;
+            }
+            MPL_strncpy(affinity_env + str_offset, dev_list[i], MAX_GPU_STR_LEN - str_offset);
+            str_offset += strlen(dev_list[i]);
+        }
+    }
+    *env = affinity_env;
     return ret;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -41,6 +41,21 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
     return ret;
 }
 
+int MPL_gpu_get_dev_list(int *dev_count, char ***dev_list, bool is_subdev)
+{
+    int ret = MPL_SUCCESS;
+    *dev_count = 0;
+    *dev_list = NULL;
+    return ret;
+}
+
+int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
+{
+    int ret = MPL_SUCCESS;
+    *env = NULL;
+    return ret;
+}
+
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -12,6 +12,20 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
     return MPL_SUCCESS;
 }
 
+int MPL_gpu_get_dev_list(int *dev_count, char ***dev_list, bool is_subdev)
+{
+    int ret = MPL_SUCCESS;
+    *dev_list = NULL;
+    return ret;
+}
+
+int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
+{
+    int ret = MPL_SUCCESS;
+    *env = NULL;
+    return ret;
+}
+
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     abort();

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -4,6 +4,7 @@
  */
 
 #include "mpl.h"
+#include "mpl_str.h"
 #include <dlfcn.h>
 #include <assert.h>
 #ifdef MPL_HAVE_HIP
@@ -18,6 +19,9 @@ typedef struct gpu_free_hook {
 static int gpu_initialized = 0;
 static int device_count = -1;
 static int max_dev_id = -1;
+static char **device_list = NULL;
+#define MAX_GPU_STR_LEN 256
+static char affinity_env[MAX_GPU_STR_LEN] = { 0 };
 
 static int *local_to_global_map;        /* [device_count] */
 static int *global_to_local_map;        /* [max_dev_id + 1]   */
@@ -43,14 +47,40 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 int MPL_gpu_get_dev_list(int *dev_count, char ***dev_list, bool is_subdev)
 {
     int ret = MPL_SUCCESS;
-    *dev_list = NULL;
+    if (!gpu_initialized) {
+        ret = MPL_gpu_init(0);
+    }
+
+    device_list = (char **) MPL_malloc(device_count * sizeof(char *), MPL_MEM_OTHER);
+    assert(device_list);
+
+    for (int i = 0; i < device_count; ++i) {
+        int str_len = snprintf(NULL, 0, "%d", i);
+        device_list[i] = (char *) MPL_malloc((str_len + 1) * sizeof(char *), MPL_MEM_OTHER);
+        sprintf(device_list[i], "%d", i);
+    }
+
+    *dev_list = device_list;
     return ret;
 }
 
 int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
 {
     int ret = MPL_SUCCESS;
-    *env = NULL;
+    if (dev_count == 0) {
+        MPL_snprintf(affinity_env, 3, "-1");
+    } else {
+        int str_offset = 0;
+        for (int i = 0; i < dev_count; ++i) {
+            if (i) {
+                MPL_strncpy(affinity_env + str_offset, ",", MAX_GPU_STR_LEN - str_offset);
+                str_offset++;
+            }
+            MPL_strncpy(affinity_env + str_offset, dev_list[i], MAX_GPU_STR_LEN - str_offset);
+            str_offset += strlen(dev_list[i]);
+        }
+    }
+    *env = affinity_env;
     return ret;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -40,6 +40,20 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
     return ret;
 }
 
+int MPL_gpu_get_dev_list(int *dev_count, char ***dev_list, bool is_subdev)
+{
+    int ret = MPL_SUCCESS;
+    *dev_list = NULL;
+    return ret;
+}
+
+int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
+{
+    int ret = MPL_SUCCESS;
+    *env = NULL;
+    return ret;
+}
+
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -44,6 +44,21 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
     return ret;
 }
 
+int MPL_gpu_get_dev_list(int *dev_count, char **dev_list, bool is_subdev)
+{
+    int ret = MPL_SUCCESS;
+    *dev_count = 0;
+    *dev_list = NULL;
+    return ret;
+}
+
+int MPL_gpu_dev_affinity_to_env(int dev_count, char ***dev_list, char **env)
+{
+    int ret = MPL_SUCCESS;
+    *env = NULL;
+    return ret;
+}
+
 int MPL_gpu_init(int debug_summary)
 {
     int mpl_err;

--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -404,6 +404,7 @@ struct HYD_user_global {
     int pmi_port;
     int skip_launch_node;
     int gpus_per_proc;
+    int gpu_subdevs_per_proc;
     int singleton_port;
     int singleton_pid;
 

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -26,6 +26,7 @@ void HYDU_init_user_global(struct HYD_user_global *user_global)
     user_global->pmi_port = -1;
     user_global->skip_launch_node = -1;
     user_global->gpus_per_proc = HYD_GPUS_PER_PROC_UNSET;
+    user_global->gpu_subdevs_per_proc = HYD_GPUS_PER_PROC_UNSET;
     user_global->singleton_port = 0;
     user_global->singleton_pid = 0;
 

--- a/src/pm/hydra/mpiexec/get_parameters.c
+++ b/src/pm/hydra/mpiexec/get_parameters.c
@@ -204,6 +204,9 @@ static void set_default_values(void)
 
     if (HYD_server_info.user_global.gpus_per_proc == HYD_GPUS_PER_PROC_UNSET)
         HYD_server_info.user_global.gpus_per_proc = HYD_GPUS_PER_PROC_AUTO;
+
+    if (HYD_server_info.user_global.gpu_subdevs_per_proc == HYD_GPUS_PER_PROC_UNSET)
+        HYD_server_info.user_global.gpu_subdevs_per_proc = HYD_GPUS_PER_PROC_AUTO;
 }
 
 /* In case a boolean environment value is unparsable (not 1|0|yes|no|true|false|on|off),

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -107,6 +107,10 @@ HYD_status HYD_pmcd_pmi_fill_in_proxy_args(struct HYD_string_stash *proxy_stash,
     HYD_STRING_STASH(*proxy_stash, HYDU_int_to_str(HYD_server_info.user_global.gpus_per_proc),
                      status);
 
+    HYD_STRING_STASH(*proxy_stash, MPL_strdup("--gpu-subdevs-per-proc"), status);
+    HYD_STRING_STASH(*proxy_stash,
+                     HYDU_int_to_str(HYD_server_info.user_global.gpu_subdevs_per_proc), status);
+
     if (pgid == 0 && HYD_server_info.singleton_port > 0) {
         HYD_STRING_STASH(*proxy_stash, MPL_strdup("--singleton-port"), status);
         HYD_STRING_STASH(*proxy_stash, HYDU_int_to_str(HYD_server_info.singleton_port), status);

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -116,6 +116,17 @@ static HYD_status gpus_per_proc_fn(char *arg, char ***argv)
     return status;
 }
 
+static HYD_status gpu_subdevs_per_proc_fn(char *arg, char ***argv)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    HYD_pmcd_pmip.user_global.gpu_subdevs_per_proc = atoi(**argv);
+
+    (*argv)++;
+
+    return status;
+}
+
 static HYD_status singleton_port_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
@@ -613,6 +624,7 @@ struct HYD_arg_match_table HYD_pmcd_pmip_match_table[] = {
     {"usize", usize_fn, NULL},
     {"pmi-port", pmi_port_fn, NULL},
     {"gpus-per-proc", gpus_per_proc_fn, NULL},
+    {"gpu-subdevs-per-proc", gpu_subdevs_per_proc_fn, NULL},
     {"singleton-port", singleton_port_fn, NULL},
     {"singleton-pid", singleton_pid_fn, NULL},
     {"rmk", rmk_fn, NULL},


### PR DESCRIPTION
## Pull Request Description

1. Add interface for querying GPU device list and subdevice list in MPL. The MPL returns array of integers that represents individual GPU device or subdevice.
2. Implementation of these interface for ZE, CUDA and HIP.
3. Add hydra option `-gpu-subdevs-per-proc` for allowing GPU visibility controlled at subdevice level.
4. Update hydra's round-robin GPU assignment algorithm for visibility control.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
