### PR TITLE
test: add generation of composition cvar tests

### DIFF
--- a/test/mpi/maint/gen_coll_cvar.py
+++ b/test/mpi/maint/gen_coll_cvar.py
@@ -51,6 +51,8 @@ def dump_tests(Out, key, testlist, algos, algo_params, special=None):
                     segs.append("env=MPIR_CVAR_%s_%s_ALGORITHM=nb" % (NAME, INTRA))
                     segs.append("env=MPIR_CVAR_I%s_DEVICE_COLLECTIVE=0" % NAME)
                     segs.append("env=MPIR_CVAR_I%s_%s_ALGORITHM=%s" % (NAME, INTRA, algo))
+                elif RE.match(r'composition:(\w+)', algo):
+                    segs.append("env=MPIR_CVAR_%s_COMPOSITION=%s" % (NAME, RE.m.group(1)))
                 elif RE.match(r'(\w+):(\w+)', algo):
                     DEVICE = RE.m.group(1).upper()
                     segs.append("env=MPIR_CVAR_%s_%s_%s_ALGORITHM=%s" % (NAME, DEVICE, INTRA, RE.m.group(2)))


### PR DESCRIPTION
## Pull Request Description

Add special syntax "composition:x" to generate tests with setting CVAR
to e.g. MPIR_CVAR_BCAST_COMPOSITION=x.



[skip warnings]
## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
