### PR TITLE
test/coll: add tests for collective compositions

### DIFF
--- a/test/mpi/maint/coll_cvars.txt
+++ b/test/mpi/maint/coll_cvars.txt
@@ -179,6 +179,8 @@ algorithms:
         inter-nonblocking:
             sched_local_gather_remote_bcast
         intra-blocking:
+            composition:1
+            composition:2
             brucks
             k_brucks
                 .MPIR_CVAR_ALLGATHER_BRUCKS_KVAL=2,3,4
@@ -221,6 +223,9 @@ algorithms:
         inter-nonblocking:
             sched_remote_reduce_local_bcast
         intra-blocking:
+            composition:1
+            composition:2
+            composition:3
             smp
             recursive_doubling
             reduce_scatter_allgather
@@ -255,6 +260,8 @@ algorithms:
         inter-nonblocking:
             sched_pairwise_exchange
         intra-blocking:
+            composition:1
+            composition:2
             brucks
             k_brucks
                 .MPIR_CVAR_ALLTOALL_BRUCKS_KVAL=2,3,4
@@ -308,6 +315,8 @@ algorithms:
         inter-nonblocking:
             sched_bcast
         intra-blocking:
+            composition:1
+            composition:2
             k_dissemination
                 .MPIR_CVAR_BARRIER_DISSEM_KVAL=2,3,4,8
             recexch
@@ -325,6 +334,9 @@ algorithms:
         inter-nonblocking:
             sched_flat
         intra-blocking:
+            composition:1
+            composition:2
+            composition:3
             binomial
             smp
             scatter_recursive_doubling_allgather
@@ -427,6 +439,9 @@ algorithms:
         inter-nonblocking:
             sched_local_reduce_remote_send
         intra-blocking:
+            composition:1
+            composition:2
+            composition:3
             binomial
             smp
             reduce_scatter_gather

--- a/test/mpi/maint/gen_coll_cvar.py
+++ b/test/mpi/maint/gen_coll_cvar.py
@@ -51,6 +51,8 @@ def dump_tests(Out, key, testlist, algos, algo_params, special=None):
                     segs.append("env=MPIR_CVAR_%s_%s_ALGORITHM=nb" % (NAME, INTRA))
                     segs.append("env=MPIR_CVAR_I%s_DEVICE_COLLECTIVE=0" % NAME)
                     segs.append("env=MPIR_CVAR_I%s_%s_ALGORITHM=%s" % (NAME, INTRA, algo))
+                elif RE.match(r'composition:(\w+)', algo):
+                    segs.append("env=MPIR_CVAR_%s_COMPOSITION=%s" % (NAME, RE.m.group(1)))
                 elif RE.match(r'(\w+):(\w+)', algo):
                     DEVICE = RE.m.group(1).upper()
                     segs.append("env=MPIR_CVAR_%s_%s_%s_ALGORITHM=%s" % (NAME, DEVICE, INTRA, RE.m.group(2)))


### PR DESCRIPTION
## Pull Request Description
This PR adds tests for some collectives by setting ch4-layer composition CVARs. For example, with blocking bcast, we want to test by setting `MPIR_CVAR_BCAST_COMPOSITION` (taking value of 0, 1, 2, and 3).

We use the special syntax `composition:xxx` in `test/mpi/maint/coll_cvars.txt` to generate these tests.
 
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
