### PR TITLE
f08: add elemental to eq/neq operator functions

### DIFF
--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -1143,7 +1143,7 @@ def dump_mpi_f08_types():
             for a in G.handle_list:
                 # e.g. MPI_Comm_eq
                 G.out.append("")
-                G.out.append("FUNCTION MPI_%s_%s(x, y) result(res)" % (a, op))
+                G.out.append("elemental FUNCTION MPI_%s_%s(x, y) result(res)" % (a, op))
                 G.out.append("    TYPE(MPI_%s), INTENT(in) :: x, y" % a)
                 G.out.append("    LOGICAL :: res")
                 if op == "eq":
@@ -1156,7 +1156,7 @@ def dump_mpi_f08_types():
                 for p in [("f08", "f"), ("f", "f08")]:
                     func_name = "MPI_%s_%s_%s_%s" % (a, p[0], op, p[1])
                     G.out.append("")
-                    G.out.append("FUNCTION %s(%s, %s) result(res)" % (func_name, p[0], p[1]))
+                    G.out.append("elemental FUNCTION %s(%s, %s) result(res)" % (func_name, p[0], p[1]))
                     G.out.append("    TYPE(MPI_%s), INTENT(in) :: f08" % a)
                     G.out.append("    INTEGER, INTENT(in) :: f")
                     G.out.append("    LOGICAL :: res")


### PR DESCRIPTION
## Pull Request Description
Adding elemental allows user to apply the operator to scalar/array
comparisons.


Fixes #5875 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
