### PR TITLE
pmi2: remove mpich internal references

### DIFF
--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -40,6 +40,7 @@ typedef struct MPIR_PMI_KEYVAL {
 int MPIR_pmi_init(void);
 void MPIR_pmi_finalize(void);
 void MPIR_pmi_abort(int exit_code, const char *error_msg);
+int MPIR_pmi_set_threaded(int is_threaded);
 
 /* PMI getters for private fields */
 int MPIR_pmi_max_key_size(void);

--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -14,8 +14,11 @@
 
 #ifdef USE_PMI1_API
 #include <pmi.h>
+
 #elif defined(USE_PMI2_API)
 #include <pmi2.h>
+#define PMI_keyval_t PMI2_keyval_t
+
 #elif defined(USE_PMIX_API)
 #include <pmix.h>
 #endif

--- a/src/nameserv/pmi/pmi_nameserv.c
+++ b/src/nameserv/pmi/pmi_nameserv.c
@@ -40,7 +40,7 @@ int MPID_NS_Publish(MPID_NS_Handle handle, const MPIR_Info * info_ptr,
 #ifdef USE_PMI2_API
     /* release the global CS for PMI calls */
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-    rc = PMI2_Nameserv_publish(service_name, info_ptr, port);
+    rc = PMI2_Nameserv_publish(service_name, NULL, port);
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
 #elif defined(USE_PMIX_API)
     MPIR_Assert(0);
@@ -65,7 +65,7 @@ int MPID_NS_Lookup(MPID_NS_Handle handle, const MPIR_Info * info_ptr,
 #ifdef USE_PMI2_API
     /* release the global CS for PMI calls */
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-    rc = PMI2_Nameserv_lookup(service_name, info_ptr, port, MPI_MAX_PORT_NAME);
+    rc = PMI2_Nameserv_lookup(service_name, NULL, port, MPI_MAX_PORT_NAME);
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
 #elif defined(USE_PMIX_API)
     MPIR_Assert(0);
@@ -89,7 +89,7 @@ int MPID_NS_Unpublish(MPID_NS_Handle handle, const MPIR_Info * info_ptr, const c
 #ifdef USE_PMI2_API
     /* release the global CS for PMI calls */
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-    rc = PMI2_Nameserv_unpublish(service_name, info_ptr);
+    rc = PMI2_Nameserv_unpublish(service_name, NULL);
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
 #elif defined(USE_PMIX_API)
     MPIR_Assert(0);

--- a/src/pmi/pmi2/include/pmi2.h
+++ b/src/pmi/pmi2/include/pmi2.h
@@ -137,6 +137,19 @@ S*/
     int PMI2_Finalize(void);
 
 /*@
+  PMI2_Set_threaded - set whether the PMI will be called from multiple threads
+
+  Return values:
+  Returns 'MPI_SUCCESS' on success and an MPI error code on failure.
+
+  Notes:
+  The default is to assume all PMI is issued from a single thread. Use this
+  function to set is_threaded to TRUE before calling PMI from multiple threads.
+
+@*/
+    int PMI2_Set_threaded(int is_threaded);
+
+/*@
   PMI2_Initialized - check if PMI has been initialized
 
   Return values:

--- a/src/pmi/pmi2/include/pmi2.h
+++ b/src/pmi/pmi2/include/pmi2.h
@@ -58,13 +58,18 @@ D*/
 #define PMI2_ERR_INVALID_SIZE       13
 #define PMI2_ERR_OTHER              14
 
-/* This is here to allow spawn multiple functions to compile.  This
-   needs to be removed once those functions are fixed for pmi2 */
-    typedef struct PMI_keyval_t {
+/*S
+PMI2_keyval_t - keyval structure used by PMI2_Spawn_multiple
+
+Fields:
++ key - name of the key
+- val - value of the key
+
+S*/
+    typedef struct PMI2_keyval_t {
         char *key;
         char *val;
-    } PMI_keyval_t;
-
+    } PMI2_keyval_t;
 
 /*@
   PMI2_Connect_comm_t - connection structure used when connecting to other jobs
@@ -98,8 +103,6 @@ D*/
         void *ctx;
         int isMain;
     } PMI2_Connect_comm_t;
-
-    struct MPIR_Info;
 
 /*@
   PMI2_Init - initialize the Process Manager Interface
@@ -197,9 +200,9 @@ D*/
                        int argcs[], const char **argvs[],
                        const int maxprocs[],
                        const int info_keyval_sizes[],
-                       const struct MPIR_Info *info_keyval_vectors[],
+                       const PMI2_keyval_t * info_keyval_vectors[],
                        int preput_keyval_size,
-                       const struct MPIR_Info *preput_keyval_vector[],
+                       const PMI2_keyval_t preput_keyval_vector[],
                        char jobId[], int jobIdSize, int errors[]);
 
 
@@ -508,7 +511,7 @@ D*/
   Returns 'MPI_SUCCESS' on success and an MPI error code on failure.
 
 @*/
-    int PMI2_Nameserv_publish(const char service_name[], const struct MPIR_Info *info_ptr,
+    int PMI2_Nameserv_publish(const char service_name[], const PMI2_keyval_t * info_ptr,
                               const char port[]);
 
 /*@
@@ -526,7 +529,7 @@ D*/
   Returns 'MPI_SUCCESS' on success and an MPI error code on failure.
 
 @*/
-    int PMI2_Nameserv_lookup(const char service_name[], const struct MPIR_Info *info_ptr,
+    int PMI2_Nameserv_lookup(const char service_name[], const PMI2_keyval_t * info_ptr,
                              char port[], int portLen);
 /*@
   PMI2_Nameserv_unpublish - unpublish a name
@@ -539,7 +542,7 @@ D*/
   Returns 'MPI_SUCCESS' on success and an MPI error code on failure.
 
 @*/
-    int PMI2_Nameserv_unpublish(const char service_name[], const struct MPIR_Info *info_ptr);
+    int PMI2_Nameserv_unpublish(const char service_name[], const PMI2_keyval_t * info_ptr);
 
 
 

--- a/src/pmi/pmi2/simple/pmi2compat.h
+++ b/src/pmi/pmi2/simple/pmi2compat.h
@@ -6,15 +6,15 @@
 #ifndef PMI2COMPAT_H_INCLUDED
 #define PMI2COMPAT_H_INCLUDED
 
-#include "mpiimpl.h"
+#include <stdlib.h>
+#include <assert.h>
 
 #define PMI2U_Malloc(size_) MPL_malloc(size_, MPL_MEM_PM)
 #define PMI2U_Free MPL_free
 #define PMI2U_Strdup MPL_strdup
 #define PMI2U_Strnapp MPL_strnapp
-#define PMI2U_Assert MPIR_Assert
+#define PMI2U_Assert assert
 #define PMI2U_Exit MPL_exit
-#define PMI2U_Info MPIR_Info
-#define PMI2U_Memcpy MPIR_Memcpy
+#define PMI2U_Memcpy memcpy
 
 #endif /* PMI2COMPAT_H_INCLUDED */

--- a/src/pmi/pmi2/simple/simple2pmi.c
+++ b/src/pmi/pmi2/simple/simple2pmi.c
@@ -421,9 +421,9 @@ int PMI2_Job_Spawn(int count, const char *cmds[],
                    int argcs[], const char **argvs[],
                    const int maxprocs[],
                    const int info_keyval_sizes[],
-                   const struct MPIR_Info *info_keyval_vectors[],
+                   const PMI2_keyval_t * info_keyval_vectors[],
                    int preput_keyval_size,
-                   const struct MPIR_Info *preput_keyval_vector[],
+                   const PMI2_keyval_t preput_keyval_vector[],
                    char jobId[], int jobIdSize, int errors[])
 {
     int i, rc, spawncnt, total_num_processes, num_errcodes_found;
@@ -486,8 +486,8 @@ cmd=spawn;thrid=string;ncmds=count;preputcount=n;ppkey0=name;ppval0=string;...;\
 
     init_kv_strdup_int(pairs_p[npairs++], "preputcount", preput_keyval_size);
     for (i = 0; i < preput_keyval_size; ++i) {
-        init_kv_strdup_intsuffix(pairs_p[npairs++], "ppkey", i, preput_keyval_vector[i]->key);
-        init_kv_strdup_intsuffix(pairs_p[npairs++], "ppval", i, preput_keyval_vector[i]->value);
+        init_kv_strdup_intsuffix(pairs_p[npairs++], "ppkey", i, preput_keyval_vector[i].key);
+        init_kv_strdup_intsuffix(pairs_p[npairs++], "ppval", i, preput_keyval_vector[i].val);
     }
 
     for (spawncnt = 0; spawncnt < count; ++spawncnt) {
@@ -507,7 +507,7 @@ cmd=spawn;thrid=string;ncmds=count;preputcount=n;ppkey0=name;ppval0=string;...;\
                 init_kv_strdup_intsuffix(pairs_p[npairs++], "infokey", i,
                                          info_keyval_vectors[spawncnt][i].key);
                 init_kv_strdup_intsuffix(pairs_p[npairs++], "infoval", i,
-                                         info_keyval_vectors[spawncnt][i].value);
+                                         info_keyval_vectors[spawncnt][i].val);
             }
         }
     }
@@ -983,7 +983,8 @@ int PMI2_Info_GetJobAttrIntArray(const char name[], int array[], int arraylen, i
     goto fn_exit;
 }
 
-int PMI2_Nameserv_publish(const char service_name[], const PMI2U_Info * info_ptr, const char port[])
+int PMI2_Nameserv_publish(const char service_name[], const PMI2_keyval_t * info_ptr,
+                          const char port[])
 {
     int pmi2_errno = PMI2_SUCCESS;
     PMI2_Command cmd = { 0 };
@@ -1012,7 +1013,7 @@ int PMI2_Nameserv_publish(const char service_name[], const PMI2U_Info * info_ptr
 }
 
 
-int PMI2_Nameserv_lookup(const char service_name[], const PMI2U_Info * info_ptr,
+int PMI2_Nameserv_lookup(const char service_name[], const PMI2_keyval_t * info_ptr,
                          char port[], int portLen)
 {
     int pmi2_errno = PMI2_SUCCESS;
@@ -1047,7 +1048,7 @@ int PMI2_Nameserv_lookup(const char service_name[], const PMI2U_Info * info_ptr,
     goto fn_exit;
 }
 
-int PMI2_Nameserv_unpublish(const char service_name[], const PMI2U_Info * info_ptr)
+int PMI2_Nameserv_unpublish(const char service_name[], const PMI2_keyval_t * info_ptr)
 {
     int pmi2_errno = PMI2_SUCCESS;
     int found;

--- a/src/pmi/pmi2/simple/simple_pmiutil.c
+++ b/src/pmi/pmi2/simple/simple_pmiutil.c
@@ -11,8 +11,8 @@
    key=value messages
 */
 #include "mpichconf.h"
-
 #include "pmi2compat.h"
+#include "mpl.h"
 
 #include <stdio.h>
 #ifdef HAVE_STDLIB_H

--- a/src/pmi/simple/simple_pmi.c
+++ b/src/pmi/simple/simple_pmi.c
@@ -45,8 +45,6 @@
 #endif
 
 #include "mpl.h"        /* Get ATTRIBUTE, some base functions */
-/* mpimem includes the definitions for MPL_malloc and MPL_free */
-#include "mpir_mem.h"
 
 /* Temporary debug definitions */
 /* #define DBG_PRINTF(args) printf args ; fflush(stdout) */

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -217,6 +217,17 @@ void MPIR_pmi_abort(int exit_code, const char *error_msg)
 #endif
 }
 
+/* This function is currently unused in MPICH because we always call
+ * PMI functions from a single thread or within a critical section.
+ */
+int MPIR_pmi_set_threaded(int is_threaded)
+{
+#if defined(USE_PMI2_API)
+    PMI2_Set_threaded(is_threaded);
+#endif
+    return MPI_SUCCESS;
+}
+
 /* getters for internal constants */
 int MPIR_pmi_max_key_size(void)
 {

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -852,7 +852,7 @@ int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
 
-#ifdef USE_PMI1_API
+#if defined(USE_PMI1_API) || defined(USE_PMI2_API)
     int *info_keyval_sizes = NULL;
     PMI_keyval_t **info_keyval_vectors = NULL;
 
@@ -875,7 +875,9 @@ int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
             MPIR_ERR_CHECK(mpi_errno);
         }
     }
+#endif
 
+#ifdef USE_PMI1_API
     pmi_errno = PMI_Spawn_multiple(count, (const char **) commands, (const char ***) argvs,
                                    maxprocs,
                                    info_keyval_sizes,
@@ -886,12 +888,8 @@ int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                          "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
 #elif defined(USE_PMI2_API)
-    struct MPIR_Info preput;
-    struct MPIR_Info *preput_p[1] = { &preput };
     int *argcs = MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
-    int *info_keyval_sizes = MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
     MPIR_Assert(argcs);
-    MPIR_Assert(info_keyval_sizes);
 
     /* compute argcs array */
     for (int i = 0; i < count; ++i) {
@@ -903,45 +901,23 @@ int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
         }
     }
 
-    /* FIXME cheating on constness */
-    preput.key = (char *) preput_keyvals->key;
-    preput.value = preput_keyvals->val;
-    preput.next = NULL;
-
-    /* determine info sizes */
-    if (!info_ptrs) {
-        for (int i = 0; i < count; i++) {
-            info_keyval_sizes[i] = 0;
-        }
-    } else {
-        for (int i = 0; i < count; i++) {
-            if (info_ptrs[i] != NULL) {
-                MPIR_Info_get_nkeys_impl(info_ptrs[i], &info_keyval_sizes[i]);
-                info_ptrs[i] = info_ptrs[i]->next;      /* skip empty MPIR_Info struct */
-            } else {
-                info_keyval_sizes[i] = 0;
-            }
-        }
-    }
-
     pmi_errno = PMI2_Job_Spawn(count, (const char **) commands,
                                argcs, (const char ***) argvs,
                                maxprocs,
-                               info_keyval_sizes, (const MPIR_Info **) info_ptrs,
-                               1, (const struct MPIR_Info **) preput_p, NULL, 0, pmi_errcodes);
+                               info_keyval_sizes,
+                               (const PMI_keyval_t **) info_keyval_vectors,
+                               num_preput_keyval, (const PMI_keyval_t *) preput_keyvals,
+                               NULL, 0, pmi_errcodes);
     MPL_free(argcs);
-    MPL_free(info_keyval_sizes);
-    if (pmi_errno != PMI2_SUCCESS) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER,
-                             "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
-    }
+    MPIR_ERR_CHKANDJUMP1(mpi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
 #elif defined(USE_PMIX_API)
     /* not supported yet */
     MPIR_Assert(0);
 #endif
 
   fn_exit:
-#ifdef USE_PMI1_API
+#if defined(USE_PMI1_API) || defined(USE_PMI2_API)
     if (info_keyval_vectors) {
         free_pmi_keyvals(info_keyval_vectors, count, info_keyval_sizes);
         MPL_free(info_keyval_vectors);


### PR DESCRIPTION
## Pull Request Description
The current pmi2 implementation references several MPICH internal types, thus cannot be build or used outside MPICH. This PR cleans up all these references so that it is ready to be exposed as an independent package to be used even without MPI. However, the current PMI2 APIs has to be slightly modified:

* `MPIR_Info` is redefined as `PMI2_keyval_t`. This affects the following functions due to its argument using MPIR_Info
     * `PMI2_Nameserv_publish`
     * `PMI2_Nameserv_lookup`
     * `PMI2_Nameserv_unpublish`
     * `PMI2_Job_Spawn`
     The change is backward compatible for code that only uses `NULL` info pointers. Since before this change, no code outside MPICH can properly use info argument anyway, we believe there is no backward impact.

* Add `PMI2_Set_threaded`
    The old code directly references MPICH internal global to determine whether thread safety needs to be added. For code outside MPICH, we need an API to inform the implementation of the thread-level requirement. By default, thread safety is not turned on. Because code outside MPICH can't enable thread-safety before this change anyway, we again believe there will be no backward impact adding this API.
     
After this PR, our pmi implementation may be build and used outside MPICH. There is one additional caveat:
* PMI1 implementation requires symbol `MPI_MAX_PORT_NAME`
As now, `simple_pmi.c` requires `mpi.h`. If the code need be built without MPI, one can simply provide a stand-in `mpi.h` that defines `MPI_MAX_PORT_NAME`. This is only needed since `PMI_Lookup_name(const char service_name[], char port[])` has no size input for `port` and assumes `MPI_MAX_PORT_NAME`.

## TODO
Add configure logic and work around so it can work with current Slurm release. (separate PR).
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
