### PR TITLE
romio_synchronized_sync: move barrier after fsync

### DIFF
--- a/src/mpi/romio/adio/common/ad_flush.c
+++ b/src/mpi/romio/adio/common/ad_flush.c
@@ -14,11 +14,8 @@ void ADIOI_GEN_Flush(ADIO_File fd, int *error_code)
     int err;
     static char myname[] = "ADIOI_GEN_FLUSH";
 
-    /* If MPI_File_sync is a temporally synchronizing sync, the caller can
-     * avoid the 'sync/barrier/sync' process to ensure visibility and just call
-     * 'sync' */
-    if (fd->hints->synchronizing_flush > 0)
-        MPI_Barrier(fd->comm);
+    *error_code = MPI_SUCCESS;
+
     /* the deferred-open optimization may mean that a file has not been opened
      * on this processor */
     /* additionally, if this process did no writes, there is no work to be done */
@@ -29,11 +26,15 @@ void ADIOI_GEN_Flush(ADIO_File fd, int *error_code)
             *error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
                                                myname, __LINE__, MPI_ERR_IO,
                                                "**io", "**io %s", strerror(errno));
-            return;
+        } else {
+            fd->dirty_write = 0;
         }
         /* --END ERROR HANDLING-- */
     }
-    fd->dirty_write = 0;
 
-    *error_code = MPI_SUCCESS;
+    /* If MPI_File_sync is a temporally synchronizing sync, the caller can
+     * avoid the 'sync/barrier/sync' process to ensure visibility and just call
+     * 'sync' */
+    if (fd->hints->synchronizing_flush > 0)
+        MPI_Barrier(fd->comm);
 }


### PR DESCRIPTION
## Pull Request Description
This is a proposed fix for the issue in https://github.com/pmodels/mpich/issues/5883.

For correctness, I think it may be necessary to move the barrier to follow the fsync.  This ensures that all ranks have completed their call to ``fsync`` before any process can return from ``MPI_File_sync``.

This change makes things equivalent to the longer sequence when not using the hint:
```
MPI_File_sync() // fsync, if dirty
MPI_Barrier()   // wait for fsync on all ranks
MPI_File_sync() // NOP, since dirty bit was cleared in above MPI_File_sync
```

In case the call to fsync fails on some process but not all, I dropped the early return to avoid deadlock on the barrier.  I then had to move clearing the dirty bit inside of the outer if branch so that it doesn't get cleared if the call to fsync failed.

One remaining question is whether the dirty bit should be cleared if the file was not open, i.e.,
```
fd->is_open <= 0
```

This change assumes that the dirty bit can only be set if the file is open.

Fixes #5883
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
