### PR TITLE
mpl: fix level zero properties initialization

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -112,6 +112,8 @@ static int gpu_ze_init_driver(void)
         /* Check if the driver supports a gpu */
         for (d = 0; d < global_ze_device_count; ++d) {
             ze_device_properties_t device_properties;
+            device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+            device_properties.pNext = NULL;
             ret = zeDeviceGetProperties(global_ze_devices_handle[d], &device_properties);
             ZE_ERR_CHECK(ret);
 

--- a/test/mpi/util/mtest_common.c
+++ b/test/mpi/util/mtest_common.c
@@ -386,6 +386,8 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
 
             for (int j = 0; j < num_devices; j++) {
                 ze_device_properties_t device_properties;
+                device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+                device_properties.pNext = NULL;
                 zerr = zeDeviceGetProperties(all_devices[j], &device_properties);
                 assert(zerr == ZE_RESULT_SUCCESS);
 
@@ -429,6 +431,10 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
         ze_command_queue_group_properties_t *queueProperties =
             (ze_command_queue_group_properties_t *)
             malloc(sizeof(ze_command_queue_group_properties_t) * numQueueGroups);
+        for (int i = 0; i < numQueueGroups; i++) {
+            queueProperties[i].stype = ZE_STRUCTURE_TYPE_COMMAND_QUEUE_GROUP_PROPERTIES;
+            queueProperties[i].pNext = NULL;
+        }
         zerr = zeDeviceGetCommandQueueGroupProperties(device[0], &numQueueGroups, queueProperties);
         descriptor.ordinal = -1;
         for (int i = 0; i < numQueueGroups; i++) {
@@ -640,8 +646,10 @@ void MTestCopyContent(const void *sbuf, void *dbuf, size_t size, mtest_mem_type_
             ze_memory_allocation_properties_t prop;
             ze_device_handle_t device;
         } s_attr, d_attr;
-        memset(&s_attr.prop, 0, sizeof(ze_memory_allocation_properties_t));
-        memset(&d_attr.prop, 0, sizeof(ze_memory_allocation_properties_t));
+        s_attr.prop.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
+        s_attr.prop.pNext = NULL;
+        d_attr.prop.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
+        d_attr.prop.pNext = NULL;
         zerr = zeMemGetAllocProperties(context, sbuf, &s_attr.prop, &s_attr.device);
         assert(zerr == ZE_RESULT_SUCCESS);
         if (s_attr.device) {


### PR DESCRIPTION

## Pull Request Description

This PR fixes https://github.com/pmodels/mpich/issues/5890. If properties are incorrectly initialized, future runtimes could be unable to determine which version of the struct is required, or could try to de-reference pNext if it happens not to be NULL.

## Author Checklist
* [X] **Provide Description** 
* [x] **Commits Follow Good Practice**
    commit title is not correct. I am not familiar with mpich architecture
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [X] **Contribution Agreement**
      Argonne author. 
