### PR TITLE
test: xfail allocmemf90 test for solstudio

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -83,6 +83,9 @@
 # timeout due to lack of passive progress
 * * vci ch4:ofi *       /^rma_contig.*iter=10000/        xfail=issue5565        rma/testlist
 
+# Sunf90 forbid passing cray pointer as integer
+* solstudio * * *       /^allocmemf90/          xfail=ticket0      f90/ext/testlist
+
 # Job-sepecific xfails
 # Our Arm servers are too slow for some tests
 mpich-main-arm.* * * * * /^sendflood /          xfail=ticket0       pt2pt/testlist


### PR DESCRIPTION
## Pull Request Description

The nightly tests now fails this one after we now generates the full mpi f90 module.

Solstudio's fortran compiler forbid passing cray pointer as integer
in MPI_Alloc_mem. Since cray pointer is non-standard feature, it is not
a priority to work around. Xfail for now.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
