### PR TITLE
ch4/posix: workaround for inter-process mutex on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4183,6 +4183,12 @@ if test "$enable_f08" = "yes" ; then
     fi
 fi
 
+case "$host_os" in
+    freebsd*)
+        AC_DEFINE(DELAY_SHM_MUTEX_DESTROY, 1, [Define to workaround interprocess mutex issue on FreeBSD])
+        ;;
+esac
+
 dnl This includes an experimental pkgconfig file for ch3 in the src/pkgconfig
 dnl directory
 AC_CONFIG_FILES([Makefile \

--- a/src/mpid/ch3/channels/nemesis/subconfigure.m4
+++ b/src/mpid/ch3/channels/nemesis/subconfigure.m4
@@ -98,12 +98,6 @@ This turns off error checking and timing collection],,enable_fast=no)
 AC_CHECK_HEADERS(signal.h)
 AC_CHECK_FUNCS(signal)
 
-case "$host_os" in
-    freebsd*)
-        AC_DEFINE(DELAY_SHM_MUTEX_DESTROY, 1, [Define to workaround interprocess mutex issue on FreeBSD])
-        ;;
-esac
-
 nemesis_nets_dirs=""
 nemesis_nets_strings=""
 nemesis_nets_array=""   

--- a/src/mpid/ch4/shm/posix/posix_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_impl.h
@@ -14,6 +14,8 @@
 #include "posix_eager_impl.h"
 #include "posix_progress.h"
 
+void MPIDI_POSIX_delay_shm_mutex_destroy(int rank, MPL_proc_mutex_t * shm_mutex_ptr);
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_get_vsi(int flag, MPIR_Comm * comm_ptr,
                                                  int src_rank, int dst_rank, int tag)
 {


### PR DESCRIPTION

## Pull Request Description
On FreeBSD (at lease for ver 12.2), destroying the mutex and recreate
the mutex, the new mutex will not work for inter-process. As workaround,
delay destroying window mutex until finalize.

This applies the same fix as #5753 that we did for ch3.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
