### PR TITLE
hydra: fix parsing HYDRA_LAUNCHER_EXTRA_ARGS

### DIFF
--- a/src/pm/hydra/lib/tools/bootstrap/external/external_common_launch.c
+++ b/src/pm/hydra/lib/tools/bootstrap/external/external_common_launch.c
@@ -150,11 +150,13 @@ HYD_status HYDT_bscd_common_launch_procs(char **args, struct HYD_proxy *proxy_li
     }
 
     if (MPL_env2str("HYDRA_LAUNCHER_EXTRA_ARGS", (const char **) &extra_arg_list)) {
-        extra_arg = strtok(extra_arg_list, " ");
+        char *s = MPL_strdup(extra_arg_list);
+        extra_arg = strtok(s, " ");
         while (extra_arg) {
             targs[idx++] = MPL_strdup(extra_arg);
             extra_arg = strtok(NULL, " ");
         }
+        MPL_free(s);
     }
 
     host_idx = idx++;   /* Hostname will come here */


### PR DESCRIPTION
## Pull Request Description
The parsing routine using strtok will modify the environment string,
resulting errors when the environment is parsed a second time, for
example, when spawn is launch additional processes.

This patch fixes it by make a strdup before parsing.

The bug is reported by a user setting `HYDRA_LAUNCHER_EXTRA_ARGS` that contains spaces and when the process is launching again in serving a `spawn`.

## Discuss

* We should centralize parsing of environment variables at init time
rather than scattering it ad-hoc.

* The proxy should have the ability to handle multiple pg (process-group), so that we only need one proxy on each node. Additional spawns do not need to launch additional proxies. This should make the dynamic spawn path less complicated and more robust.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
