### PR TITLE
init: add explicit MPIR_pmi_barrier in init

### DIFF
--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -207,6 +207,21 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     mpi_errno = MPID_Init(required, &MPIR_ThreadInfo.thread_provided);
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* The current default mechanism of MPIR Process Acquisition Interface is to
+     * break on MPIR_Breakpoint in mpiexec.hydra. Adding a PMI call that need
+     * response from mpiexec will hold the MPI process to provide opportunity for
+     * debugger to attach. Currently, the only effective call is PMI_Barrier.
+     */
+    /* NOTE: potentially we already calls PMI barrier during device business
+     * card exchange. But there may be optimizations that make it not true.
+     * We are adding a separate PMI barrier call here to ensure the debugger
+     * mechanism. And it is also cleaner. If init latency is a concern, we may
+     * add a config option to skip it. But focus on optimize PMI Barrier may
+     * be a better effort.
+     */
+    mpi_errno = MPIR_pmi_barrier();
+    MPIR_ERR_CHECK(mpi_errno);
+
     bool need_init_builtin_comms = true;
 #ifdef ENABLE_LOCAL_SESSION_INIT
     need_init_builtin_comms = is_world_model;


### PR DESCRIPTION
## Pull Request Description
Add explicit MPIR_pmi_barrier to hold the process to give debugger an
opportunity to attach. There are other mechanism, e.g. using
MPIR_CVAR_DEBUG_HOLD. But this is the default mechanism and conforms to
the MPIR Process Acquisition Interface spec.


Fixes #5877 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
