### PR TITLE
configure: check and fail when AC_CHECK_SIZEOF fails

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2719,6 +2719,14 @@ AC_CHECK_SIZEOF(double)
 AC_CHECK_SIZEOF(long double)
 AC_CHECK_SIZEOF(void *)
 
+# Let's not continue if we cannot detect these basic types
+for type in char int void_p ; do
+    eval len=\$ac_cv_sizeof_$type
+    if test "$len" = "0" ; then
+        AC_MSG_ERROR([Could not get size of "$type".])
+    fi
+done
+
 AC_CHECK_HEADERS([stddef.h])
 AC_CHECK_SIZEOF(wchar_t, 0, [
 #ifdef HAVE_STDDEF_H


### PR DESCRIPTION
## Pull Request Description
When AC_CHECK_SIZEOF fails, resulting in type size of 0, fail rather
than propagating the error into mysterious places.

Fixes #3910
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
