### PR TITLE
hydra: enhance proxy initial handshake

### DIFF
--- a/src/pm/hydra/lib/pmiserv_common.h
+++ b/src/pm/hydra/lib/pmiserv_common.h
@@ -28,6 +28,12 @@ struct HYD_pmcd_pmi_kvs {
     struct HYD_pmcd_pmi_kvs_pair *tail;
 };
 
+/* init header proxy send to server upon connection */
+struct HYD_pmcd_init_hdr {
+    char signature[4]; /* HYD\0 */ ;
+    int proxy_id;
+};
+
 struct HYD_pmcd_hdr {
     /* The set of commands supported */
     enum HYD_pmcd_cmd {

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -151,9 +151,11 @@ int main(int argc, char **argv)
                      HYD_pmcd_pmip.upstream.server_name, HYD_pmcd_pmip.upstream.server_port);
     }
 
+    struct HYD_pmcd_init_hdr init_hdr;
+    strncpy(init_hdr.signature, "HYD", 4);
+    init_hdr.proxy_id = HYD_pmcd_pmip.local.id;
     status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control,
-                             &HYD_pmcd_pmip.local.id, sizeof(HYD_pmcd_pmip.local.id), &sent,
-                             &closed, HYDU_SOCK_COMM_MSGWAIT);
+                             &init_hdr, sizeof(init_hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
     HYDU_ERR_POP(status, "unable to send the proxy ID to the server\n");
     if (closed)
         goto fn_fail;


### PR DESCRIPTION
## Pull Request Description

Add a signaure to the first packet when proxy first connect to server.
This guards against random connection and port scans.

Fixes #2106 
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
