### PR TITLE
pt2pt: add MPID_Allocate_vci

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -950,6 +950,11 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **set_thread_affinity:Failed to set the async thread affinity
 **set_thread_affinity %d:Failed to set the async thread affinity to the logical processor [%d]
 
+## MPIX_Stream
+**ch3nostream:Stream is not supported in ch3.
+**ch4nostream:No streams available. Configure --enable-thread-cs=per-vci and --with-ch4-max-vcis=# to enable streams.
+**outofstream:No streams available. Use MPIR_CVAR_CH4_RESERVE_VCIS to reserve the number of streams can be allocated.
+
 # -----------------------------------------------------------------------------
 # The following names are defined but not used (see the -careful option 
 # for extracterrmsgs) (still to do: move the undefined names here)

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -532,6 +532,9 @@ int MPID_Init(int required, int *provided);
 
 int MPID_InitCompleted( void );
 
+int MPID_Allocate_vci(int *vci);
+int MPID_Deallocate_vci(int vci);
+
 int MPID_Finalize(void);
 
 int MPID_Abort( MPIR_Comm *comm, int mpi_errno, int exit_code, const char *error_msg );

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -265,6 +265,19 @@ int MPID_InitCompleted( void )
     /* --END ERROR HANDLING-- */
 }
 
+int MPID_Allocate_vci(int *vci)
+{
+    int mpi_errno = MPI_SUCCESS;
+    *vci = 0;
+    MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**ch3nostream");
+    return mpi_errno;
+}
+
+int MPID_Deallocate_vci(int vci)
+{
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
+}
 /*
  * Initialize the process group structure by using PMI calls.
  * This routine initializes PMI and uses PMI calls to setup the 

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -14,6 +14,8 @@
 
 int MPID_Init(int, int *);
 int MPID_InitCompleted(void);
+int MPID_Allocate_vci(int *vci);
+int MPID_Deallocate_vci(int vci);
 MPL_STATIC_INLINE_PREFIX int MPID_Cancel_recv(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Cancel_send(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Comm_disconnect(MPIR_Comm *);

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -50,7 +50,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_vni(int flag, MPIR_Comm * comm_ptr,
 #if MPIDI_CH4_MAX_VCIS == 1
     return 0;
 #else
-    return MPIDI_get_vci(flag, comm_ptr, src_rank, dst_rank, tag) % MPIDI_OFI_global.num_vnis;
+    int vni = MPIDI_get_vci(flag, comm_ptr, src_rank, dst_rank, tag);
+    MPIR_Assert(vni < MPIDI_OFI_global.num_vnis);
+    return vni;
 #endif
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -242,18 +242,6 @@ cvars:
         minor version of the OFI library used with MPICH. If using this CVAR,
         it is recommended that the user also specifies a specific OFI provider.
 
-    - name        : MPIR_CVAR_CH4_OFI_MAX_VNIS
-      category    : CH4_OFI
-      type        : int
-      default     : 0
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_LOCAL
-      description : >-
-        If set to positive, this CVAR specifies the maximum number of CH4 VNIs
-        that OFI netmod exposes. If set to 0 (the default) or bigger than
-        MPIR_CVAR_CH4_NUM_VCIS, the number of exposed VNIs is set to MPIR_CVAR_CH4_NUM_VCIS.
-
     - name        : MPIR_CVAR_CH4_OFI_MAX_RMA_SEP_CTX
       category    : CH4_OFI
       type        : int
@@ -613,22 +601,10 @@ int MPIDI_OFI_init_local(int *tag_bits)
     /* Create transport level communication contexts.                           */
     /* ------------------------------------------------------------------------ */
 
-    int num_vnis = 1;
-    if (MPIR_CVAR_CH4_OFI_MAX_VNIS == 0 || MPIR_CVAR_CH4_OFI_MAX_VNIS > MPIDI_global.n_vcis) {
-        num_vnis = MPIDI_global.n_vcis;
-    } else {
-        num_vnis = MPIR_CVAR_CH4_OFI_MAX_VNIS;
-    }
-
-    /* TODO: update num_vnis according to provider capabilities, such as
-     * prov_use->domain_attr->{tx,rx}_ctx_cnt
+    /* TODO: check provider capabilities, such as prov_use->domain_attr->{tx,rx}_ctx_cnt,
+     *       abort if we can't support the requested number of vnis.
      */
-    if (num_vnis > MPIDI_OFI_MAX_VNIS) {
-        num_vnis = MPIDI_OFI_MAX_VNIS;
-    }
-    /* for best performance, we ensure 1-to-1 vci/vni mapping. ref: MPIDI_OFI_vci_to_vni */
-    /* TODO: allow less num_vnis. Option 1. runtime MOD; 2. override MPIDI_global.n_vcis */
-    MPIR_Assert(num_vnis == MPIDI_global.n_vcis);
+    int num_vnis = MPIDI_global.n_total_vcis;
 
     /* Multiple vni without using domain require MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS */
 #ifndef MPIDI_OFI_VNI_USE_DOMAIN

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -310,7 +310,7 @@ static int win_set_per_win_sync(MPIR_Win * win)
 
 static void win_init_am(MPIR_Win * win)
 {
-    MPIDI_WIN(win, am_vci) %= MPIDI_OFI_global.num_vnis;
+    MPIR_Assert(MPIDI_WIN(win, am_vci) < MPIDI_OFI_global.num_vnis);
 }
 
 /*

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -54,8 +54,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
 
     MPIR_FUNC_ENTER;
 
-    int src_vni = src_vci % MPIDI_UCX_global.num_vnis;
-    int dst_vni = dst_vci % MPIDI_UCX_global.num_vnis;
+    int src_vni = src_vci;
+    int dst_vni = dst_vci;
+    MPIR_Assert(src_vni < MPIDI_UCX_global.num_vnis);
+    MPIR_Assert(dst_vni < MPIDI_UCX_global.num_vnis);
     ep = MPIDI_UCX_COMM_TO_EP(comm, rank, src_vni, dst_vni);
 
     int dt_contig;
@@ -186,8 +188,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
 
     MPIR_FUNC_ENTER;
 
-    int src_vni = src_vci % MPIDI_UCX_global.num_vnis;
-    int dst_vni = dst_vci % MPIDI_UCX_global.num_vnis;
+    int src_vni = src_vci;
+    int dst_vni = dst_vci;
+    MPIR_Assert(src_vni < MPIDI_UCX_global.num_vnis);
+    MPIR_Assert(dst_vni < MPIDI_UCX_global.num_vnis);
     ep = MPIDI_UCX_COMM_TO_EP(comm, rank, src_vni, dst_vni);
 
     /* initialize our portion of the hdr */

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -120,7 +120,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_vci_to_vni(int vci)
 MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_get_vni(int flag, MPIR_Comm * comm_ptr,
                                                int src_rank, int dst_rank, int tag)
 {
-    return MPIDI_get_vci(flag, comm_ptr, src_rank, dst_rank, tag) % MPIDI_UCX_global.num_vnis;
+    int vni;
+    return MPIDI_get_vci(flag, comm_ptr, src_rank, dst_rank, tag);
+    MPIR_Assert(vni < MPIDI_UCX_global.num_vnis);
+    return vni;
 }
 
 /* for rma, we need ensure rkey is consistent with the per-vni ep,

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -8,29 +8,6 @@
 #include "mpidu_bc.h"
 #include <ucp/api/ucp.h>
 
-/*
-=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
-
-categories :
-    - name : CH4_UCX
-      description : A category for CH4 UCX netmod variables
-
-cvars:
-    - name        : MPIR_CVAR_CH4_UCX_MAX_VNIS
-      category    : CH4_UCX
-      type        : int
-      default     : 0
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_LOCAL
-      description : >-
-        If set to positive, this CVAR specifies the maximum number of CH4 VNIs
-        that UCX netmod exposes. If set to 0 (the default) or bigger than
-        MPIR_CVAR_CH4_NUM_VCIS, the number of exposed VNIs is set to MPIR_CVAR_CH4_NUM_VCIS.
-
-=== END_MPI_T_CVAR_INFO_BLOCK ===
-*/
-
 static void request_init_callback(void *request);
 
 static void request_init_callback(void *request)
@@ -43,18 +20,8 @@ static void request_init_callback(void *request)
 
 static void init_num_vnis(void)
 {
-    int num_vnis = 1;
-    if (MPIR_CVAR_CH4_UCX_MAX_VNIS == 0 || MPIR_CVAR_CH4_UCX_MAX_VNIS > MPIDI_global.n_vcis) {
-        num_vnis = MPIDI_global.n_vcis;
-    } else {
-        num_vnis = MPIR_CVAR_CH4_UCX_MAX_VNIS;
-    }
-
-    /* for best performance, we ensure 1-to-1 vci/vni mapping. ref: MPIDI_OFI_vci_to_vni */
-    /* TODO: allow less num_vnis. Option 1. runtime MOD; 2. override MPIDI_global.n_vcis */
-    MPIR_Assert(num_vnis == MPIDI_global.n_vcis);
-
-    MPIDI_UCX_global.num_vnis = num_vnis;
+    /* TODO: check capabilities, abort if we can't support the requested number of vnis. */
+    MPIDI_UCX_global.num_vnis = MPIDI_global.n_total_vcis;
 }
 
 static int init_worker(int vni)

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -176,7 +176,7 @@ static int win_init(MPIR_Win * win)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPIDI_WIN(win, am_vci) %= MPIDI_UCX_global.num_vnis;
+    MPIR_Assert(MPIDI_WIN(win, am_vci) < MPIDI_UCX_global.num_vnis);
 
     memset(&MPIDI_UCX_WIN(win), 0, sizeof(MPIDI_UCX_win_t));
 

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -150,7 +150,7 @@ int MPIDI_POSIX_init_local(int *tag_bits /* unused */)
 
     MPIDI_POSIX_global.local_rank_0 = local_rank_0;
 
-    MPIDI_POSIX_global.num_vsis = MPIDI_global.n_vcis;
+    MPIDI_POSIX_global.num_vsis = MPIDI_global.n_total_vcis;
     /* This is used to track messages that the eager submodule was not ready to send. */
     for (int vsi = 0; vsi < MPIDI_CH4_MAX_VCIS; vsi++) {
         mpi_errno = MPIDU_genq_private_pool_create_unsafe(MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE,

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -82,7 +82,17 @@ cvars:
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_LOCAL
       description : >-
-        Sets the number of VCIs that user needs (should be a subset of MPIDI_CH4_MAX_VCIS).
+        Sets the number of VCIs to be implicitly used (should be a subset of MPIDI_CH4_MAX_VCIS).
+
+    - name        : MPIR_CVAR_CH4_RESERVE_VCIS
+      category    : CH4
+      type        : int
+      default     : 0
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Sets the number of VCIs that user can explicitly allocate (should be a subset of MPIDI_CH4_MAX_VCIS).
 
     - name        : MPIR_CVAR_CH4_COLL_SELECTION_TUNING_JSON_FILE
       category    : COLLECTIVE

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -47,7 +47,8 @@ extern int global_vci_poll_count;
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_do_global_progress(void)
 {
-    if (MPIDI_global.n_vcis == 1 || !MPIDI_global.is_initialized || !MPIR_CVAR_CH4_GLOBAL_PROGRESS) {
+    if (MPIDI_global.n_total_vcis == 1 || !MPIDI_global.is_initialized ||
+        !MPIR_CVAR_CH4_GLOBAL_PROGRESS) {
         return 0;
     } else {
         global_vci_poll_count++;
@@ -153,7 +154,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_progress_test(MPID_Progress_state * state, in
 #else
     /* multiple vci */
     if (MPIDI_do_global_progress()) {
-        for (int vci = 0; vci < MPIDI_global.n_vcis; vci++) {
+        for (int vci = 0; vci < MPIDI_global.n_total_vcis; vci++) {
             MPIDI_PROGRESS(vci);
             if (wait) {
                 MPIDI_check_progress_made_vci(state, vci);
@@ -201,10 +202,10 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_progress_state_init(MPID_Progress_state * st
         state->vci_count = 1;
     } else {
         /* global progress by default */
-        for (int i = 0; i < MPIDI_global.n_vcis; i++) {
+        for (int i = 0; i < MPIDI_global.n_total_vcis; i++) {
             state->vci[i] = i;
         }
-        state->vci_count = MPIDI_global.n_vcis;
+        state->vci_count = MPIDI_global.n_total_vcis;
     }
 }
 
@@ -215,8 +216,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_progress_state_init_count(MPID_Progress_stat
 #if MPIDI_CH4_MAX_VCIS == 1
     state->progress_counts[0] = MPL_atomic_relaxed_load_int(&MPIDI_VCI(0).progress_count);
 #else
-    for (int i = 0; i < MPIDI_global.n_vcis; i++) {
-        state->progress_counts[i] = MPL_atomic_relaxed_load_int(&MPIDI_VCI(i).progress_count);
+    for (int i = 0; i < state->vci_count; i++) {
+        state->progress_counts[i] =
+            MPL_atomic_relaxed_load_int(&MPIDI_VCI(state->vci[i]).progress_count);
     }
 #endif
 }

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -254,6 +254,7 @@ typedef struct MPIDI_per_vci {
     MPL_atomic_uint64_t exp_seq_no;
     MPL_atomic_uint64_t nxt_seq_no;
 
+    bool allocated;
     char pad MPL_ATTR_ALIGNED(MPL_CACHELINE_SIZE);
 } MPIDI_per_vci_t;
 

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -279,7 +279,9 @@ typedef struct MPIDI_CH4_Global_t {
     int my_sigusr1_count;
 #endif
 
-    int n_vcis;
+    int n_vcis;                 /* num of vcis used for implicit hashing */
+    int n_reserved_vcis;        /* num of reserved vcis */
+    int n_total_vcis;           /* total num of vcis, must > n_vcis + n_reserved_vcis */
     MPIDI_per_vci_t per_vci[MPIDI_CH4_MAX_VCIS];
 
 #if defined(MPIDI_CH4_USE_WORK_QUEUES)

--- a/src/mpid/ch4/src/ch4_wait.h
+++ b/src/mpid/ch4/src/ch4_wait.h
@@ -68,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci_n(int n, MPIR_Request ** re
         }
         if (!found) {
             state->vci[idx++] = vci;
-            MPIR_Assert(vci < MPIDI_global.n_vcis);
+            MPIR_Assert(vci < MPIDI_global.n_total_vcis);
         }
     }
     state->vci_count = idx;

--- a/src/mpid/ch4/src/mpidig_init.c
+++ b/src/mpid/ch4/src/mpidig_init.c
@@ -132,7 +132,7 @@ int MPIDIG_am_init(void)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    for (int vci = 0; vci < MPIDI_global.n_vcis; vci++) {
+    for (int vci = 0; vci < MPIDI_global.n_total_vcis; vci++) {
         MPIDI_global.per_vci[vci].posted_list = NULL;
         MPIDI_global.per_vci[vci].unexp_list = NULL;
 
@@ -236,7 +236,7 @@ void MPIDIG_am_finalize(void)
     MPIR_FUNC_ENTER;
 
     MPIDIU_map_destroy(MPIDI_global.win_map);
-    for (int vci = 0; vci < MPIDI_global.n_vcis; vci++) {
+    for (int vci = 0; vci < MPIDI_global.n_total_vcis; vci++) {
         MPIDU_genq_private_pool_destroy_unsafe(MPIDI_global.per_vci[vci].request_pool);
         MPIDU_genq_private_pool_destroy_unsafe(MPIDI_global.per_vci[vci].unexp_pack_buf_pool);
     }


### PR DESCRIPTION
## Pull Request Description
Reserved vci can be used to isolate communications. For example, stream-based progress should not involve GPU path. Using a reserved vci that normal GPU traffic won't touch can ensure that. Similarly, we can use a reserved vci for dynamic process connections.

Since users always know exactly their thread mapping, it may be simpler and more reliable to let user directly specify vci, rather than we simplicity do hashing. To allow such explicit vci extensions, we need a way to pass down the vci information to device layer. Extending the `attr` parameter can achieve that.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
