### PR TITLE
mpix: gpu stream aware extensions

### DIFF
--- a/maint/local_python/binding_common.py
+++ b/maint/local_python/binding_common.py
@@ -187,6 +187,8 @@ def is_pointer_type(param):
         return 1
     elif RE.match(r'(ATTRIBUTE_VAL\w*|(C_)?BUFFER\d?|EXTRA_STATE\d*|TOOL_MPI_OBJ|(POLY)?FUNCTION\w*)$', param['kind']):
         return 1
+    elif RE.match(r'(GPU_STREAM)$', param['kind']):
+        return 1
     elif param['param_direction'] != 'in':
         return 1
     elif param['length']:

--- a/maint/local_python/binding_f77.py
+++ b/maint/local_python/binding_f77.py
@@ -1120,6 +1120,8 @@ def check_func_directives(func):
         func['_skip_fortran'] = 1
     elif RE.match(r'mpix_grequest_', func['name'], re.IGNORECASE):
         func['_skip_fortran'] = 1
+    elif RE.match(r'mpix_(Send|Recv)_enqueue', func['name'], re.IGNORECASE):
+        func['_skip_fortran'] = 1
     elif RE.match(r'mpi_\w+_(f|f08|c)2(f|f08|c)$', func['name'], re.IGNORECASE):
         # implemented in mpi_f08_types.f90
         func['_skip_fortran'] = 1

--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -548,3 +548,24 @@ MPI_Isendrecv:
 
 MPI_Isendrecv_replace:
     .desc: Starts a nonblocking send and receive with a single buffer
+
+MPIX_Send_enqueue:
+    .desc: Enqueue a send operation on a gpu stream
+    buf: BUFFER, constant=True, [initial address of send buffer]
+    count: POLYXFER_NUM_ELEM_NNI, [number of elements in send buffer]
+    datatype: DATATYPE, [datatype of each send buffer element]
+    dest: RANK, [rank of destination]
+    tag: TAG, [message tag]
+    comm: COMMUNICATOR
+    stream: GPU_STREAM, [gpu stream to enqueue on]
+
+MPIX_Recv_enqueue:
+    .desc: Enqueue a send operation on a gpu stream
+    buf: BUFFER, direction=out, [initial address of receive buffer]
+    count: POLYXFER_NUM_ELEM_NNI, [number of elements in receive buffer]
+    datatype: DATATYPE, [datatype of each receive buffer element]
+    source: RANK, [rank of source or MPI_ANY_SOURCE]
+    tag: TAG, [message tag or MPI_ANY_TAG]
+    comm: COMMUNICATOR
+    status: STATUS, direction=out
+    stream: GPU_STREAM, [gpu stream to enqueue on]

--- a/src/binding/custom_mapping.txt
+++ b/src/binding/custom_mapping.txt
@@ -3,28 +3,35 @@
 
 LIS_KIND_MAP:
     GPU_TYPE: integer
+    GPU_STREAM: integer(kind=cuda_stream_kind)
     GREQUEST_CLASS: None
 
 SMALL_F90_KIND_MAP:
     GPU_TYPE: INTEGER
+    GPU_STREAM: integer(kind=cuda_stream_kind)
     GREQUEST_CLASS: INTEGER
 
 BIG_F90_KIND_MAP:
     GPU_TYPE: INTEGER
+    GPU_STREAM: integer(kind=cuda_stream_kind)
     GREQUEST_CLASS: INTEGER
 
 SMALL_F08_KIND_MAP:
     GPU_TYPE: INTEGER
+    GPU_STREAM: integer(kind=cuda_stream_kind)
     GREQUEST_CLASS: INTEGER
 
 BIG_F08_KIND_MAP:
     GPU_TYPE: INTEGER
+    GPU_STREAM: integer(kind=cuda_stream_kind)
     GREQUEST_CLASS: INTEGER
 
 SMALL_C_KIND_MAP:
     GPU_TYPE: int
+    GPU_STREAM: void
     GREQUEST_CLASS: MPIX_Grequest_class
 
 BIG_C_KIND_MAP:
     GPU_TYPE: int
+    GPU_STREAM: void
     GREQUEST_CLASS: MPIX_Grequest_class

--- a/src/include/mpir_typerep.h
+++ b/src/include/mpir_typerep.h
@@ -91,4 +91,11 @@ int MPIR_Typerep_op(void *source_buf, MPI_Aint source_count, MPI_Datatype source
                     bool source_is_packed, int mapped_device);
 int MPIR_Typerep_reduce(const void *in_buf, void *out_buf, MPI_Aint count, MPI_Datatype datatype,
                         MPI_Op op);
+
+int MPIR_Typerep_pack_stream(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
+                             MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
+                             MPI_Aint * actual_pack_bytes, void *stream);
+int MPIR_Typerep_unpack_stream(const void *inbuf, MPI_Aint insize,
+                               void *outbuf, MPI_Aint outcount, MPI_Datatype datatype,
+                               MPI_Aint outoffset, MPI_Aint * actual_unpack_bytes, void *stream);
 #endif /* MPIR_TYPEREP_H_INCLUDED */

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
@@ -210,3 +210,25 @@ int MPIR_Typerep_reduce(const void *in_buf, void *out_buf, MPI_Aint count, MPI_D
 
     return mpi_errno;
 }
+
+int MPIR_Typerep_pack_stream(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
+                             MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
+                             MPI_Aint * actual_pack_bytes, void *stream)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(0);
+
+    return mpi_errno;
+}
+
+int MPIR_Typerep_unpack_stream(const void *inbuf, MPI_Aint insize, void *outbuf,
+                               MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
+                               MPI_Aint * actual_unpack_bytes, void *stream)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(0);
+
+    return mpi_errno;
+}

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -579,3 +579,49 @@ static int typerep_op_pack(void *source_buf, void *target_buf, MPI_Aint count,
   fn_fail:
     goto fn_exit;
 }
+
+int MPIR_Typerep_pack_stream(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
+                             MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
+                             MPI_Aint * actual_pack_bytes, void *stream)
+{
+    MPIR_FUNC_ENTER;
+
+    int mpi_errno = MPI_SUCCESS;
+    int rc;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(datatype);
+    uintptr_t packed_bytes;;
+    rc = yaksa_pack_stream(inbuf, incount, type, inoffset, outbuf, max_pack_bytes,
+                           &packed_bytes, NULL, YAKSA_OP__REPLACE, stream);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    *actual_pack_bytes = packed_bytes;
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Typerep_unpack_stream(const void *inbuf, MPI_Aint insize, void *outbuf,
+                               MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
+                               MPI_Aint * actual_unpack_bytes, void *stream)
+{
+    MPIR_FUNC_ENTER;
+
+    int mpi_errno = MPI_SUCCESS;
+    int rc;
+
+    yaksa_type_t type = MPII_Typerep_get_yaksa_type(datatype);
+    uintptr_t unpacked_bytes;;
+    rc = yaksa_unpack_stream(inbuf, insize, outbuf, outcount, type, outoffset,
+                             &unpacked_bytes, NULL, YAKSA_OP__REPLACE, stream);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");
+    *actual_unpack_bytes = unpacked_bytes;
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpi/pt2pt/Makefile.mk
+++ b/src/mpi/pt2pt/Makefile.mk
@@ -5,4 +5,5 @@
 
 mpi_core_sources += \
     src/mpi/pt2pt/sendrecv.c \
+    src/mpi/pt2pt/stream.c \
     src/mpi/pt2pt/bsendutil.c

--- a/src/mpi/pt2pt/stream.c
+++ b/src/mpi/pt2pt/stream.c
@@ -7,12 +7,12 @@
 
 /* ---- Send stream ---- */
 struct send_data {
-    const void *buf;
-    MPI_Aint count;
-    MPI_Datatype datatype;
     int dest;
     int tag;
     MPIR_Comm *comm_ptr;
+    void *host_buf;
+    MPI_Aint data_sz;
+    MPI_Aint actual_pack_bytes;
 };
 
 static void send_stream_cb(void *data)
@@ -21,7 +21,9 @@ static void send_stream_cb(void *data)
     MPIR_Request *request_ptr = NULL;
 
     struct send_data *p = data;
-    mpi_errno = MPID_Send(p->buf, p->count, p->datatype, p->dest, p->tag, p->comm_ptr,
+    assert(p->actual_pack_bytes == p->data_sz);
+
+    mpi_errno = MPID_Send(p->host_buf, p->data_sz, MPI_BYTE, p->dest, p->tag, p->comm_ptr,
                           MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     assert(mpi_errno == MPI_SUCCESS);
     assert(request_ptr != NULL);
@@ -31,6 +33,7 @@ static void send_stream_cb(void *data)
 
     MPIR_Request_free(request_ptr);
 
+    MPIR_gpu_free_host(p->host_buf);
     MPL_free(data);
 }
 
@@ -43,9 +46,16 @@ int MPIR_Send_enqueue_impl(const void *buf, MPI_Aint count, MPI_Datatype datatyp
     p = MPL_malloc(sizeof(struct send_data), MPL_MEM_OTHER);
     MPIR_ERR_CHKANDJUMP(!p, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
-    p->buf = buf;
-    p->count = count;
-    p->datatype = datatype;
+    MPI_Aint dt_size;
+    MPIR_Datatype_get_size_macro(datatype, dt_size);
+    p->data_sz = dt_size * count;
+
+    MPIR_gpu_malloc_host(&p->host_buf, p->data_sz);
+
+    mpi_errno = MPIR_Typerep_pack_stream(buf, count, datatype, 0, p->host_buf, p->data_sz,
+                                         &p->actual_pack_bytes, stream);
+    MPIR_ERR_CHECK(mpi_errno);
+
     p->dest = dest;
     p->tag = tag;
     p->comm_ptr = comm_ptr;
@@ -60,13 +70,13 @@ int MPIR_Send_enqueue_impl(const void *buf, MPI_Aint count, MPI_Datatype datatyp
 
 /* ---- Recv stream ---- */
 struct recv_data {
-    void *buf;
-    MPI_Aint count;
-    MPI_Datatype datatype;
     int source;
     int tag;
     MPIR_Comm *comm_ptr;
     MPI_Status *status;
+    void *host_buf;
+    MPI_Aint data_sz;
+    MPI_Aint actual_unpack_bytes;
 };
 
 static void recv_stream_cb(void *data)
@@ -75,7 +85,7 @@ static void recv_stream_cb(void *data)
     MPIR_Request *request_ptr = NULL;
 
     struct recv_data *p = data;
-    mpi_errno = MPID_Recv(p->buf, p->count, p->datatype, p->source, p->tag, p->comm_ptr,
+    mpi_errno = MPID_Recv(p->host_buf, p->data_sz, MPI_BYTE, p->source, p->tag, p->comm_ptr,
                           MPIR_CONTEXT_INTRA_PT2PT, p->status, &request_ptr);
     assert(mpi_errno == MPI_SUCCESS);
     assert(request_ptr != NULL);
@@ -85,7 +95,14 @@ static void recv_stream_cb(void *data)
 
     MPIR_Request_extract_status(request_ptr, p->status);
     MPIR_Request_free(request_ptr);
+}
 
+static void recv_stream_cleanup_cb(void *data)
+{
+    struct recv_data *p = data;
+    assert(p->actual_unpack_bytes == p->data_sz);
+
+    MPIR_gpu_free_host(p->host_buf);
     MPL_free(data);
 }
 
@@ -99,15 +116,24 @@ int MPIR_Recv_enqueue_impl(void *buf, MPI_Aint count, MPI_Datatype datatype,
     p = MPL_malloc(sizeof(struct recv_data), MPL_MEM_OTHER);
     MPIR_ERR_CHKANDJUMP(!p, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
-    p->buf = buf;
-    p->count = count;
-    p->datatype = datatype;
+    MPI_Aint dt_size;
+    MPIR_Datatype_get_size_macro(datatype, dt_size);
+    p->data_sz = dt_size * count;
+
+    MPIR_gpu_malloc_host(&p->host_buf, p->data_sz);
+
     p->source = source;
     p->tag = tag;
     p->comm_ptr = comm_ptr;
     p->status = status;
 
     MPL_gpu_launch_hostfn(stream, recv_stream_cb, p);
+
+    mpi_errno = MPIR_Typerep_unpack_stream(p->host_buf, p->data_sz, buf, count, datatype, 0,
+                                           &p->actual_unpack_bytes, stream);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPL_gpu_launch_hostfn(stream, recv_stream_cleanup_cb, p);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/pt2pt/stream.c
+++ b/src/mpi/pt2pt/stream.c
@@ -5,17 +5,112 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Send_stream_impl(const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                          int dest, int tag, MPIR_Comm * comm_ptr, void *stream)
+/* ---- Send stream ---- */
+struct send_data {
+    const void *buf;
+    MPI_Aint count;
+    MPI_Datatype datatype;
+    int dest;
+    int tag;
+    MPIR_Comm *comm_ptr;
+};
+
+static void send_stream_cb(void *data)
 {
-    int mpi_errno = MPI_SUCCESS;
-    return mpi_errno;
+    int mpi_errno;
+    MPIR_Request *request_ptr = NULL;
+
+    struct send_data *p = data;
+    mpi_errno = MPID_Send(p->buf, p->count, p->datatype, p->dest, p->tag, p->comm_ptr,
+                          MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    assert(mpi_errno == MPI_SUCCESS);
+    assert(request_ptr != NULL);
+
+    mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
+    assert(mpi_errno == MPI_SUCCESS);
+
+    MPIR_Request_free(request_ptr);
+
+    MPL_free(data);
 }
 
-int MPIR_Recv_stream_impl(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                          int source, int tag, MPIR_Comm * comm_ptr, MPI_Status * status,
-                          void *stream)
+int MPIR_Send_enqueue_impl(const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                           int dest, int tag, MPIR_Comm * comm_ptr, void *stream)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    struct send_data *p;
+    p = MPL_malloc(sizeof(struct send_data), MPL_MEM_OTHER);
+    MPIR_ERR_CHKANDJUMP(!p, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+    p->buf = buf;
+    p->count = count;
+    p->datatype = datatype;
+    p->dest = dest;
+    p->tag = tag;
+    p->comm_ptr = comm_ptr;
+
+    MPL_gpu_launch_hostfn(stream, send_stream_cb, p);
+
+  fn_exit:
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* ---- Recv stream ---- */
+struct recv_data {
+    void *buf;
+    MPI_Aint count;
+    MPI_Datatype datatype;
+    int source;
+    int tag;
+    MPIR_Comm *comm_ptr;
+    MPI_Status *status;
+};
+
+static void recv_stream_cb(void *data)
+{
+    int mpi_errno;
+    MPIR_Request *request_ptr = NULL;
+
+    struct recv_data *p = data;
+    mpi_errno = MPID_Recv(p->buf, p->count, p->datatype, p->source, p->tag, p->comm_ptr,
+                          MPIR_CONTEXT_INTRA_PT2PT, p->status, &request_ptr);
+    assert(mpi_errno == MPI_SUCCESS);
+    assert(request_ptr != NULL);
+
+    mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
+    assert(mpi_errno == MPI_SUCCESS);
+
+    MPIR_Request_extract_status(request_ptr, p->status);
+    MPIR_Request_free(request_ptr);
+
+    MPL_free(data);
+}
+
+int MPIR_Recv_enqueue_impl(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                           int source, int tag, MPIR_Comm * comm_ptr, MPI_Status * status,
+                           void *stream)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    struct recv_data *p;
+    p = MPL_malloc(sizeof(struct recv_data), MPL_MEM_OTHER);
+    MPIR_ERR_CHKANDJUMP(!p, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+    p->buf = buf;
+    p->count = count;
+    p->datatype = datatype;
+    p->source = source;
+    p->tag = tag;
+    p->comm_ptr = comm_ptr;
+    p->status = status;
+
+    MPL_gpu_launch_hostfn(stream, recv_stream_cb, p);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/mpi/pt2pt/stream.c
+++ b/src/mpi/pt2pt/stream.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+int MPIR_Send_stream_impl(const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                          int dest, int tag, MPIR_Comm * comm_ptr, void *stream)
+{
+    int mpi_errno = MPI_SUCCESS;
+    return mpi_errno;
+}
+
+int MPIR_Recv_stream_impl(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                          int source, int tag, MPIR_Comm * comm_ptr, MPI_Status * status,
+                          void *stream)
+{
+    int mpi_errno = MPI_SUCCESS;
+    return mpi_errno;
+}

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -81,4 +81,7 @@ int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len);
 int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr));
 int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id);
 
+typedef void (*MPL_gpu_hostfn) (void *data);
+int MPL_gpu_launch_hostfn(void *stream, MPL_gpu_hostfn fn, void *data);
+
 #endif /* ifndef MPL_GPU_H_INCLUDED */

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -409,3 +409,10 @@ cudaError_t CUDARTAPI cudaFree(void *dptr)
     result = sys_cudaFree(dptr);
     return result;
 }
+
+int MPL_gpu_launch_hostfn(void *stream, MPL_gpu_hostfn fn, void *data)
+{
+    cudaError_t result;
+    result = cudaLaunchHostFunc(*(cudaStream_t *) stream, fn, data);
+    return result;
+}

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -97,3 +97,8 @@ int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr))
 {
     return MPL_SUCCESS;
 }
+
+int MPL_gpu_launch_hostfn(void *stream, MPL_gpu_hostfn fn, void *data)
+{
+    return -1;
+}

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -367,4 +367,10 @@ hipError_t hipFree(void *dptr)
     result = sys_hipFree(dptr);
     return result;
 }
+
+int MPL_gpu_launch_hostfn(void *stream, MPL_gpu_hostfn fn, void *data)
+{
+    return -1;
+}
+
 #endif /* MPL_HAVE_HIP */

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -367,4 +367,9 @@ int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr))
     return MPL_SUCCESS;
 }
 
+int MPL_gpu_launch_hostfn(void *stream, MPL_gpu_hostfn fn, void *data)
+{
+    return -1;
+}
+
 #endif /* MPL_HAVE_ZE */

--- a/test/mpi/impls/mpich/cuda/Makefile.am
+++ b/test/mpi/impls/mpich/cuda/Makefile.am
@@ -8,4 +8,5 @@ include $(top_srcdir)/Makefile_cuda.mtest
 LDADD += -lm
 
 noinst_PROGRAMS = \
-    saxpy
+    saxpy \
+    stream

--- a/test/mpi/impls/mpich/cuda/stream.cu
+++ b/test/mpi/impls/mpich/cuda/stream.cu
@@ -1,0 +1,93 @@
+/* CC: nvcc -g */
+/* lib_list: -lmpi */
+/* run: mpirun -l -n 2 */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <assert.h>
+
+__global__
+void saxpy(int n, float a, float *x, float *y)
+{
+  int i = blockIdx.x*blockDim.x + threadIdx.x;
+  if (i < n) y[i] = a*x[i] + y[i];
+}
+
+int main(void)
+{
+    int mpi_errno;
+    int rank, size;
+    MPI_Init(NULL, NULL);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    int N = 1000000;
+    float *x, *y, *d_x, *d_y;
+    x = (float*)malloc(N*sizeof(float));
+    y = (float*)malloc(N*sizeof(float));
+
+    cudaMalloc(&d_x, N*sizeof(float)); 
+    cudaMalloc(&d_y, N*sizeof(float));
+
+    if (rank == 0) {
+        for (int i = 0; i < N; i++) {
+            x[i] = 1.0f;
+        }
+    } else if (rank == 1) {
+        for (int i = 0; i < N; i++) {
+            y[i] = 2.0f;
+        }
+    }
+
+    if (rank == 0) {
+      #if 0  
+        cudaMemcpyAsync(d_x, x, N*sizeof(float), cudaMemcpyHostToDevice, stream);
+
+        mpi_errno = MPIX_Send_enqueue(d_x, N, MPI_FLOAT, 1, 0, MPI_COMM_WORLD, &stream);
+      #else  
+        mpi_errno = MPIX_Send_enqueue(x, N, MPI_FLOAT, 1, 0, MPI_COMM_WORLD, &stream);
+      #endif  
+        assert(mpi_errno == MPI_SUCCESS);
+
+        cudaStreamSynchronize(stream);
+    } else if (rank == 1) {
+        cudaMemcpyAsync(d_y, y, N*sizeof(float), cudaMemcpyHostToDevice, stream);
+
+        mpi_errno = MPIX_Recv_enqueue(d_x, N, MPI_FLOAT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE, &stream);
+        assert(mpi_errno == MPI_SUCCESS);
+
+        // Perform SAXPY on 1M elements
+        saxpy<<<(N+255)/256, 256, 0, stream>>>(N, 2.0f, d_x, d_y);
+
+        cudaMemcpyAsync(y, d_y, N*sizeof(float), cudaMemcpyDeviceToHost, stream);
+
+        cudaStreamSynchronize(stream);
+    }
+
+    if (rank == 1) {
+        float maxError = 0.0f;
+        int errs = 0;
+        for (int i = 0; i < N; i++) {
+            if (abs(y[i] - 4.0f) > 0.01) {
+                errs++;
+                maxError = max(maxError, abs(y[i]-4.0f));
+            }
+        }
+        if (errs > 0) {
+            printf("%d errors, Max error: %f\n", errs, maxError);
+        } else {
+            printf("No Errors\n");
+        }
+    }
+
+    cudaFree(d_x);
+    cudaFree(d_y);
+    free(x);
+    free(y);
+
+    cudaStreamDestroy(stream);
+    MPI_Finalize();
+}

--- a/test/mpi/impls/mpich/cuda/testlist
+++ b/test/mpi/impls/mpich/cuda/testlist
@@ -1,1 +1,2 @@
 saxpy 2
+stream 2


### PR DESCRIPTION
## Pull Request Description
Add ~~MPIX_Send_stream~~MPIX_Send_enqueue and ~~MPIX_Recv_stream~~MPIX_Recv_enqueue.

*NOTE*: This PR works for the attached test code. But it will not work in general because it doesn't separate traffic. When we invoke progress from an enqueued stream, the progress my invoke operations from non-stream traffic, which may use the GPU, and, e.g. CUDA, will error out.

Reference discussions on `MPIX_Stream`: https://github.com/pmodels/mpich/discussions/5908

[skip warnings]
## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
