### PR TITLE
autogen: add message when submodule is missing

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -125,7 +125,10 @@ ProgHomeDir() {
 # checking and patching submodules
 check_submodule_presence() {
     if test ! -f "$SRCROOTDIR/$1/configure.ac"; then
-        error "Submodule $1 is not checked out"
+        error "Submodule $1 is not checked out."
+        error "if you just git cloned this repository, run"
+        error "    git submodule update --init"
+        error "to checkout the submodules."
         exit 1
     fi
 }
@@ -190,9 +193,6 @@ externals=
 set_externals() {
     if test -z "$externals" ; then
         #TODO: if necessary, run: git submodule update --init
-
-        # hwloc is always required
-        check_submodule_presence modules/hwloc
 
         # external packages that require autogen.sh to be run for each of them
         externals="test/mpi"


### PR DESCRIPTION
## Pull Request Description

Add a message to advise users to run git submodule checkout when they just
cloned the repository.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
