### PR TITLE
mtest: Add GPU flags to libmtest_cxx.la library

### DIFF
--- a/test/mpi/util/Makefile.am
+++ b/test/mpi/util/Makefile.am
@@ -24,6 +24,9 @@ if HAS_CXX
 ## to emit a rule for building mtest_cxx.o from mtest_cxx.cxx
 noinst_LTLIBRARIES += libmtest_cxx.la
 libmtest_cxx_la_SOURCES = mtest_cxx.cxx mtest_common.c
+libmtest_cxx_la_LIBADD = @cuda_LIBS@ @ze_LIBS@ @hip_LIBS@
+libmtest_cxx_la_LDFLAGS = @cuda_LDFLAGS@ @ze_LDFLAGS@ @hip_LDFLAGS@
+libmtest_cxx_la_CPPFLAGS = $(AM_CPPFLAGS) @cuda_CPPFLAGS@ @ze_CPPFLAGS@ @hip_CPPFLAGS@
 
 endif
 


### PR DESCRIPTION
## Pull Request Description

This library includes mtest_common.c which contains GPU
dependencies. Make sure GPU flags are added in order to build it
correctly.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
