### PR TITLE
coll: Add multileader allreduce composition

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -374,6 +374,7 @@ extern struct MPIR_Commops *MPIR_Comm_fns;      /* Communicator creation functio
 int MPII_Comm_init(MPIR_Comm *);
 
 int MPII_Comm_is_node_consecutive(MPIR_Comm *);
+int MPII_Comm_is_node_balanced(MPIR_Comm *, int *, bool *);
 
 int MPII_Comm_copy(MPIR_Comm * comm_ptr, int size, MPIR_Info * info, MPIR_Comm ** outcomm_ptr);
 int MPII_Comm_copy_data(MPIR_Comm * comm_ptr, MPIR_Info * info, MPIR_Comm ** outcomm_ptr);

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -1190,3 +1190,50 @@ int MPII_compare_info_hint(const char *hint_str, MPIR_Comm * comm_ptr, int *info
   fn_fail:
     goto fn_exit;
 }
+
+/* Returns true if the communicator is node-aware and the number of processes in all the nodes are
+ * same */
+int MPII_Comm_is_node_balanced(MPIR_Comm * comm, int *num_nodes, bool * node_balanced)
+{
+    int i = 0;
+    int mpi_errno = MPI_SUCCESS;
+    int *ranks_per_node;
+    *num_nodes = 0;
+
+    MPIR_CHKPMEM_DECL(1);
+
+    if (!MPIR_Comm_is_parent_comm(comm)) {
+        *node_balanced = false;
+        goto fn_exit;
+    }
+
+    /* Find maximum value in the internode_table */
+    for (i = 0; i < comm->local_size; i++) {
+        if (comm->internode_table[i] > *num_nodes) {
+            *num_nodes = comm->internode_table[i];
+        }
+    }
+    /* number of nodes is max_node_id + 1 */
+    (*num_nodes)++;
+
+    MPIR_CHKPMEM_CALLOC(ranks_per_node, int *,
+                        *num_nodes * sizeof(int), mpi_errno, "ranks per node", MPL_MEM_OTHER);
+
+    for (i = 0; i < comm->local_size; i++) {
+        ranks_per_node[comm->internode_table[i]]++;
+    }
+
+    for (i = 1; i < *num_nodes; i++) {
+        if (ranks_per_node[i - 1] != ranks_per_node[i]) {
+            *node_balanced = false;
+            goto fn_exit;
+        }
+    }
+
+    *node_balanced = true;
+  fn_exit:
+    MPIR_CHKPMEM_REAP();
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -609,11 +609,27 @@ typedef struct MPIDI_Devcomm_t {
 
         MPIDI_rank_map_t map;
         MPIDI_rank_map_t local_map;
+        struct MPIR_Comm *multi_leads_comm;
+        /* sub communicators related for multi-leaders based implementation */
+        struct MPIR_Comm *inter_node_leads_comm, *sub_node_comm, *intra_node_leads_comm;
+        int spanned_num_nodes;  /* comm spans over these number of nodes */
+        /* Pointers to store info of multi-leaders based compositions */
+        struct MPIDI_Multileads_comp_info_t *allreduce_comp_info;
+        int shm_size_per_lead;
+
         void *csel_comm;        /* collective selection handle */
     } ch4;
 } MPIDI_Devcomm_t;
+
+typedef struct MPIDI_Multileads_comp_info_t {
+    int use_multi_leads;        /* if multi-leaders based composition can be used for comm */
+    void *shm_addr;
+} MPIDI_Multileads_comp_info_t;
+
 #define MPIDIG_COMM(comm,field) ((comm)->dev.ch4.am).field
 #define MPIDI_COMM(comm,field) ((comm)->dev.ch4).field
+#define MPIDI_COMM_ALLREDUCE(comm,field) ((comm)->dev.ch4.allreduce_comp_info)->field
+
 
 typedef struct {
     union {

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -54,6 +54,7 @@ cvars:
         1 NM + SHM with reduce + bcast
         2 NM only composition
         3 SHM only composition
+        4 Multi leaders based inter node + intra node composition
 
     - name        : MPIR_CVAR_ALLGATHER_COMPOSITION
       category    : COLLECTIVE

--- a/src/mpid/ch4/src/ch4_comm.h
+++ b/src/mpid/ch4/src/ch4_comm.h
@@ -15,6 +15,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_set_comm_hint_sender_vci(MPIR_Comm * comm, in
 MPL_STATIC_INLINE_PREFIX int MPIDI_set_comm_hint_receiver_vci(MPIR_Comm * comm, int type,
                                                               int value);
 MPL_STATIC_INLINE_PREFIX int MPIDI_set_comm_hint_vci(MPIR_Comm * comm, int type, int value);
+int MPIDI_Comm_create_multi_leader_subcomms(MPIR_Comm * comm, int num_leads);
 
 MPL_STATIC_INLINE_PREFIX int MPID_Comm_AS_enabled(MPIR_Comm * comm)
 {

--- a/src/mpid/ch4/src/ch4_csel_container.h
+++ b/src/mpid/ch4/src/ch4_csel_container.h
@@ -19,6 +19,7 @@ typedef struct {
         MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allreduce_intra_composition_alpha,
         MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allreduce_intra_composition_beta,
         MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allreduce_intra_composition_gamma,
+        MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allreduce_intra_composition_delta,
         MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Alltoall_intra_composition_alpha,
         MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Alltoall_intra_composition_beta,
         MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Alltoallv_intra_composition_alpha,

--- a/src/mpl/include/mpl_math.h
+++ b/src/mpl/include/mpl_math.h
@@ -112,6 +112,35 @@ static inline int MPL_mirror_permutation(unsigned int x, int bits)
     return retval;
 }
 
+/* Round denominator to the closest integer to divide numerator completely. Rounded value lies
+ * within +/- range of denominator*/
+static inline int MPL_round_closest_multiple(int numerator, int denominator, int range)
+{
+    /* increase and decrease denominator until it divides numerator completely. Break if it takes
+     * more than range iterations and return numerator */
+    int iter = 1;
+    int increased_val = denominator, decreased_val = denominator;
+
+    if (numerator % denominator == 0)
+        return denominator;
+
+    while (true) {
+        increased_val += 1;
+        if (decreased_val > 1)
+            decreased_val -= 1;
+
+        if (numerator % decreased_val == 0)
+            return decreased_val;
+        else if (numerator % increased_val == 0)
+            return increased_val;
+        else if (iter >= range)
+            return numerator;
+
+        iter += 1;
+    }
+}
+
+
 /* *INDENT-ON* */
 #if defined(__cplusplus)
 }

--- a/test/mpi/maint/coll_cvars.txt
+++ b/test/mpi/maint/coll_cvars.txt
@@ -226,6 +226,7 @@ algorithms:
             composition:1
             composition:2
             composition:3
+            composition:4
             smp
             recursive_doubling
             reduce_scatter_allgather


### PR DESCRIPTION
## Pull Request Description

Multi-leaders based composition: It has `num_leaders` per node, which reduce the data within sub-node_comm. It is followed by intra_node reduce and inter_node allreduce on the piece of data the leader is responsible for. A shared memory buffer is allocated per leader. If size of message exceeds this shm buffer, the message is chunked.
Constraints: For a comm, all nodes should have same number of ranks per node, op should be commutative.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
