### PR TITLE
info: use dynamic array in MPIR_Info

### DIFF
--- a/src/include/mpir_info.h
+++ b/src/include/mpir_info.h
@@ -93,5 +93,6 @@ extern MPIR_Info MPIR_Info_direct[];
 
 int MPIR_Info_alloc(MPIR_Info ** info_p_p);
 void MPIR_Info_setup_env(MPIR_Info * info_ptr);
+const char *MPIR_Info_lookup(MPIR_Info * info_ptr, const char *key);
 
 #endif /* MPIR_INFO_H_INCLUDED */

--- a/src/include/mpir_info.h
+++ b/src/include/mpir_info.h
@@ -47,6 +47,12 @@
   'MPI_Info_free' on any particular 'MPI_Info' value.
 
   T*/
+
+struct info_entry {
+    char *key;
+    char *value;
+};
+
 /*S
   MPIR_Info - Structure of an MPIR info
 
@@ -81,10 +87,12 @@
   S*/
 struct MPIR_Info {
     MPIR_OBJECT_HEADER;         /* adds handle and ref_count fields */
-    struct MPIR_Info *next;
-    char *key;
-    char *value;
+    /* a dynamic array */
+    struct info_entry *entries;
+    int capacity;
+    int size;
 };
+
 extern MPIR_Object_alloc_t MPIR_Info_mem;
 /* Preallocated info objects */
 #define MPIR_INFO_N_BUILTIN 2
@@ -93,6 +101,7 @@ extern MPIR_Info MPIR_Info_direct[];
 
 int MPIR_Info_alloc(MPIR_Info ** info_p_p);
 void MPIR_Info_setup_env(MPIR_Info * info_ptr);
+int MPIR_Info_push(MPIR_Info * info_ptr, const char *key, const char *val);
 const char *MPIR_Info_lookup(MPIR_Info * info_ptr, const char *key);
 
 #endif /* MPIR_INFO_H_INCLUDED */

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -95,18 +95,6 @@ int MPIR_Comm_split_type_self(MPIR_Comm * comm_ptr, int key, MPIR_Comm ** newcom
     goto fn_exit;
 }
 
-static const char *info_get_key(MPIR_Info * info_ptr, const char *key)
-{
-    MPIR_Info *curr_ptr = info_ptr->next;
-    while (curr_ptr) {
-        if (strcmp(curr_ptr->key, key) == 0) {
-            return curr_ptr->value;
-        }
-        curr_ptr = curr_ptr->next;
-    }
-    return NULL;
-}
-
 int MPIR_Comm_split_type_hw_guided(MPIR_Comm * comm_ptr, int key, MPIR_Info * info_ptr,
                                    MPIR_Comm ** newcomm_ptr)
 {
@@ -115,7 +103,7 @@ int MPIR_Comm_split_type_hw_guided(MPIR_Comm * comm_ptr, int key, MPIR_Info * in
     const char *resource_type = NULL;
 
     if (info_ptr != NULL) {
-        resource_type = info_get_key(info_ptr, "mpi_hw_resource_type");
+        resource_type = MPIR_Info_lookup(info_ptr, "mpi_hw_resource_type");
     }
 
     if (!resource_type) {

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -110,21 +110,21 @@ int MPII_Comm_set_hints(MPIR_Comm * comm_ptr, MPIR_Info * info, bool in_comm_cre
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_Info *curr_info;
-    LL_FOREACH(info, curr_info) {
-        if (curr_info->key == NULL)
+    for (int i = 0; i < next_comm_hint_index; i++) {
+        if (!MPIR_comm_hint_list[i].key) {
             continue;
-        for (int i = 0; i < next_comm_hint_index; i++) {
-            if (MPIR_comm_hint_list[i].key &&
-                strcmp(curr_info->key, MPIR_comm_hint_list[i].key) == 0) {
-                int val;
-                int ret = parse_string_value(curr_info->value, MPIR_comm_hint_list[i].type, &val);
-                if (ret == 0) {
-                    if (MPIR_comm_hint_list[i].fn) {
-                        MPIR_comm_hint_list[i].fn(comm_ptr, i, val);
-                    } else {
-                        comm_ptr->hints[i] = val;
-                    }
+        }
+
+        const char *str_val;
+        str_val = MPIR_Info_lookup(info, MPIR_comm_hint_list[i].key);
+        if (str_val) {
+            int val;
+            int rc = parse_string_value(str_val, MPIR_comm_hint_list[i].type, &val);
+            if (rc == 0) {
+                if (MPIR_comm_hint_list[i].fn) {
+                    MPIR_comm_hint_list[i].fn(comm_ptr, i, val);
+                } else {
+                    comm_ptr->hints[i] = val;
                 }
             }
         }

--- a/src/mpi/info/info_impl.c
+++ b/src/mpi/info/info_impl.c
@@ -5,6 +5,18 @@
 
 #include "mpiimpl.h"
 
+const char *MPIR_Info_lookup(MPIR_Info * info_ptr, const char *key)
+{
+    MPIR_Info *curr_ptr = info_ptr->next;
+    while (curr_ptr) {
+        if (strncmp(curr_ptr->key, key, MPI_MAX_INFO_KEY) == 0) {
+            return curr_ptr->value;
+        }
+        curr_ptr = curr_ptr->next;
+    }
+    return NULL;
+}
+
 /* All the MPIR_Info routines may be called before initialization or after finalization of MPI. */
 int MPIR_Info_delete_impl(MPIR_Info * info_ptr, const char *key)
 {

--- a/src/mpi/info/info_impl.c
+++ b/src/mpi/info/info_impl.c
@@ -5,14 +5,26 @@
 
 #include "mpiimpl.h"
 
+static int info_find_key(MPIR_Info * info_ptr, const char *key)
+{
+    for (int i = 0; i < info_ptr->size; i++) {
+        if (strncmp(info_ptr->entries[i].key, key, MPI_MAX_INFO_KEY) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
 const char *MPIR_Info_lookup(MPIR_Info * info_ptr, const char *key)
 {
-    MPIR_Info *curr_ptr = info_ptr->next;
-    while (curr_ptr) {
-        if (strncmp(curr_ptr->key, key, MPI_MAX_INFO_KEY) == 0) {
-            return curr_ptr->value;
+    if (!info_ptr) {
+        return NULL;
+    }
+
+    for (int i = 0; i < info_ptr->size; i++) {
+        if (strncmp(info_ptr->entries[i].key, key, MPI_MAX_INFO_KEY) == 0) {
+            return info_ptr->entries[i].value;
         }
-        curr_ptr = curr_ptr->next;
     }
     return NULL;
 }
@@ -21,28 +33,21 @@ const char *MPIR_Info_lookup(MPIR_Info * info_ptr, const char *key)
 int MPIR_Info_delete_impl(MPIR_Info * info_ptr, const char *key)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Info *prev_ptr, *curr_ptr;
 
-    prev_ptr = info_ptr;
-    curr_ptr = info_ptr->next;
-
-    while (curr_ptr) {
-        if (!strncmp(curr_ptr->key, key, MPI_MAX_INFO_KEY)) {
-            /* MPI_Info objects are allocated by MPL_direct_malloc(), so they need to be
-             * freed by MPL_direct_free(), not MPL_free(). */
-            MPL_direct_free(curr_ptr->key);
-            MPL_direct_free(curr_ptr->value);
-            prev_ptr->next = curr_ptr->next;
-            MPIR_Info_handle_obj_free(&MPIR_Info_mem, curr_ptr);
-            break;
-        }
-        prev_ptr = curr_ptr;
-        curr_ptr = curr_ptr->next;
-    }
-
-    /* If curr_ptr is not defined, we never found the key */
-    MPIR_ERR_CHKANDJUMP1((!curr_ptr), mpi_errno, MPI_ERR_INFO_NOKEY, "**infonokey",
+    int found_index = info_find_key(info_ptr, key);
+    MPIR_ERR_CHKANDJUMP1((found_index < 0), mpi_errno, MPI_ERR_INFO_NOKEY, "**infonokey",
                          "**infonokey %s", key);
+
+    /* MPI_Info objects are allocated by MPL_direct_malloc(), so they need to be
+     * freed by MPL_direct_free(), not MPL_free(). */
+    MPL_direct_free(info_ptr->entries[found_index].key);
+    MPL_direct_free(info_ptr->entries[found_index].value);
+
+    /* move up the later entries */
+    for (int i = found_index + 1; i < info_ptr->size; i++) {
+        info_ptr->entries[i - 1] = info_ptr->entries[i];
+    }
+    info_ptr->size--;
 
   fn_exit:
     return mpi_errno;
@@ -53,36 +58,18 @@ int MPIR_Info_delete_impl(MPIR_Info * info_ptr, const char *key)
 int MPIR_Info_dup_impl(MPIR_Info * info_ptr, MPIR_Info ** new_info_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Info *curr_old, *curr_new;
 
     *new_info_ptr = NULL;
     if (!info_ptr)
         goto fn_exit;
 
-    /* Note that this routine allocates info elements one at a time.
-     * In the multithreaded case, each allocation may need to acquire
-     * and release the allocation lock.  If that is ever a problem, we
-     * may want to add an "allocate n elements" routine and execute this
-     * it two steps: count and then allocate */
-    /* FIXME : multithreaded */
-    mpi_errno = MPIR_Info_alloc(&curr_new);
+    MPIR_Info *info_new;
+    mpi_errno = MPIR_Info_alloc(&info_new);
     MPIR_ERR_CHECK(mpi_errno);
-    *new_info_ptr = curr_new;
+    *new_info_ptr = info_new;
 
-    curr_old = info_ptr->next;
-    while (curr_old) {
-        mpi_errno = MPIR_Info_alloc(&curr_new->next);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        curr_new = curr_new->next;
-        /* MPI_Info objects may not be allocated by MPL_strdup() since MPL_strdup() may not be
-         * called before MPI_Init() and the allocated memory must have been freed before
-         * MPI_Finalize() while MPI-4 allows calling MPI_Info routines before MPI_Init() and
-         * after MPI_Finalize(). */
-        curr_new->key = MPL_direct_strdup(curr_old->key);
-        curr_new->value = MPL_direct_strdup(curr_old->value);
-
-        curr_old = curr_old->next;
+    for (int i = 0; i < info_ptr->size; i++) {
+        MPIR_Info_push(info_new, info_ptr->entries[i].key, info_ptr->entries[i].value);
     }
 
   fn_exit:
@@ -93,48 +80,30 @@ int MPIR_Info_dup_impl(MPIR_Info * info_ptr, MPIR_Info ** new_info_ptr)
 
 int MPIR_Info_get_impl(MPIR_Info * info_ptr, const char *key, int valuelen, char *value, int *flag)
 {
-    MPIR_Info *curr_ptr;
-    int err = 0, mpi_errno = 0;
+    int mpi_errno = MPI_SUCCESS;
 
-    curr_ptr = info_ptr->next;
-    *flag = 0;
-
-    while (curr_ptr) {
-        if (!strncmp(curr_ptr->key, key, MPI_MAX_INFO_KEY)) {
-            err = MPL_strncpy(value, curr_ptr->value, valuelen + 1);
-            /* +1 because the MPI Standard says "In C, valuelen
-             * (passed to MPI_Info_get) should be one less than the
-             * amount of allocated space to allow for the null
-             * terminator*/
-            *flag = 1;
-            break;
+    const char *v = MPIR_Info_lookup(info_ptr, key);
+    if (!v) {
+        *flag = 0;
+    } else {
+        *flag = 1;
+        /* +1 because the MPI Standard says "In C, valuelen
+         * (passed to MPI_Info_get) should be one less than the
+         * amount of allocated space to allow for the null
+         * terminator*/
+        int err = MPL_strncpy(value, v, valuelen + 1);
+        if (err != 0) {
+            mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                             MPI_ERR_INFO_VALUE, "**infovallong", NULL);
         }
-        curr_ptr = curr_ptr->next;
     }
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (err != 0) {
-        mpi_errno =
-            MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                 MPI_ERR_INFO_VALUE, "**infovallong", NULL);
-    }
-    /* --END ERROR HANDLING-- */
 
     return mpi_errno;
 }
 
 int MPIR_Info_get_nkeys_impl(MPIR_Info * info_ptr, int *nkeys)
 {
-    int n;
-
-    info_ptr = info_ptr->next;
-    n = 0;
-
-    while (info_ptr) {
-        info_ptr = info_ptr->next;
-        n++;
-    }
-    *nkeys = n;
+    *nkeys = info_ptr->size;
 
     return MPI_SUCCESS;
 }
@@ -142,23 +111,14 @@ int MPIR_Info_get_nkeys_impl(MPIR_Info * info_ptr, int *nkeys)
 int MPIR_Info_get_nthkey_impl(MPIR_Info * info_ptr, int n, char *key)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Info *curr_ptr;
-    int nkeys;
-
-    curr_ptr = info_ptr->next;
-    nkeys = 0;
-    while (curr_ptr && nkeys != n) {
-        curr_ptr = curr_ptr->next;
-        nkeys++;
-    }
 
     /* verify that n is valid */
-    MPIR_ERR_CHKANDJUMP2((!curr_ptr), mpi_errno, MPI_ERR_ARG, "**infonkey", "**infonkey %d %d", n,
-                         nkeys);
+    MPIR_ERR_CHKANDJUMP2((n >= info_ptr->size), mpi_errno, MPI_ERR_ARG, "**infonkey",
+                         "**infonkey %d %d", n, info_ptr->size);
 
     /* if key is MPI_MAX_INFO_KEY long, MPL_strncpy will null-terminate it for
      * us */
-    MPL_strncpy(key, curr_ptr->key, MPI_MAX_INFO_KEY);
+    MPL_strncpy(key, info_ptr->entries[n].key, MPI_MAX_INFO_KEY);
     /* Eventually, we could remember the location of this key in
      * the head using the key/value locations (and a union datatype?) */
 
@@ -170,18 +130,13 @@ int MPIR_Info_get_nthkey_impl(MPIR_Info * info_ptr, int n, char *key)
 
 int MPIR_Info_get_valuelen_impl(MPIR_Info * info_ptr, const char *key, int *valuelen, int *flag)
 {
-    MPIR_Info *curr_ptr;
+    const char *v = MPIR_Info_lookup(info_ptr, key);
 
-    curr_ptr = info_ptr->next;
-    *flag = 0;
-
-    while (curr_ptr) {
-        if (!strncmp(curr_ptr->key, key, MPI_MAX_INFO_KEY)) {
-            *valuelen = (int) strlen(curr_ptr->value);
-            *flag = 1;
-            break;
-        }
-        curr_ptr = curr_ptr->next;
+    if (!v) {
+        *flag = 0;
+    } else {
+        *valuelen = (int) strlen(v);
+        *flag = 1;
     }
 
     return MPI_SUCCESS;
@@ -190,40 +145,17 @@ int MPIR_Info_get_valuelen_impl(MPIR_Info * info_ptr, const char *key, int *valu
 int MPIR_Info_set_impl(MPIR_Info * info_ptr, const char *key, const char *value)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Info *curr_ptr, *prev_ptr;
-
     MPIR_FUNC_ENTER;
 
-    prev_ptr = info_ptr;
-    curr_ptr = info_ptr->next;
-
-    while (curr_ptr) {
-        if (!strncmp(curr_ptr->key, key, MPI_MAX_INFO_KEY)) {
-            /* Key already present; replace value */
-
-            /* MPI_Info objects may not be allocated by MPL_strdup() since MPL_strdup() may not be
-             * called before MPI_Init() and the allocated memory must have been freed before
-             * MPI_Finalize() while MPI-4 allows calling MPI_Info routines before MPI_Init() and
-             * after MPI_Finalize().  For the same reason, we need to use free, not MPL_free(). */
-            MPL_direct_free(curr_ptr->value);
-            curr_ptr->value = MPL_direct_strdup(value);
-            break;
-        }
-        prev_ptr = curr_ptr;
-        curr_ptr = curr_ptr->next;
-    }
-
-    if (!curr_ptr) {
+    int found_index = info_find_key(info_ptr, key);
+    if (found_index < 0) {
         /* Key not present, insert value */
-        mpi_errno = MPIR_Info_alloc(&curr_ptr);
+        mpi_errno = MPIR_Info_push(info_ptr, key, value);
         MPIR_ERR_CHECK(mpi_errno);
-
-        /*printf("Inserting new elm %x at %x\n", curr_ptr->id, prev_ptr->id); */
-        prev_ptr->next = curr_ptr;
-        /* MPI_Info objects must be allocated by MPL_direct_strdup(), not MPL_strdup() because
-         * this function may be called before MPI_Init() and after MPI_Finalize(). */
-        curr_ptr->key = MPL_direct_strdup(key);
-        curr_ptr->value = MPL_direct_strdup(value);
+    } else {
+        /* Key already present; replace value */
+        MPL_direct_free(info_ptr->entries[found_index].value);
+        info_ptr->entries[found_index].value = MPL_direct_strdup(value);
     }
 
   fn_exit:
@@ -237,28 +169,22 @@ int MPIR_Info_set_impl(MPIR_Info * info_ptr, const char *key, const char *value)
 int MPIR_Info_get_string_impl(MPIR_Info * info_ptr, const char *key, int *buflen, char *value,
                               int *flag)
 {
-    MPIR_Info *curr_ptr;
+    const char *v = MPIR_Info_lookup(info_ptr, key);
+    if (!v) {
+        *flag = 0;
+    } else {
+        *flag = 1;
 
-    curr_ptr = info_ptr->next;
-    *flag = 0;
-
-    while (curr_ptr) {
-        if (!strncmp(curr_ptr->key, key, MPI_MAX_INFO_KEY)) {
-            int old_buflen = *buflen;
-            /* It needs to include a terminator. */
-            int new_buflen = (int) (strlen(curr_ptr->value) + 1);
-            if (old_buflen > 0) {
-                /* Copy the value. */
-                MPL_strncpy(value, curr_ptr->value, old_buflen);
-                /* No matter whether MPL_strncpy() returns an error or not
-                 * (i.e., whether curr_ptr->value fits value or not),
-                 * it is not an error. */
-            }
-            *buflen = new_buflen;
-            *flag = 1;
-            break;
+        int old_buflen = *buflen;
+        /* It needs to include a terminator. */
+        int new_buflen = (int) (strlen(v) + 1);
+        if (old_buflen > 0) {
+            /* Copy the value. */
+            MPL_strncpy(value, v, old_buflen);
+            /* No matter whether MPL_strncpy() returns an error or not
+             * (i.e., whether value fits or not), it is not an error. */
         }
-        curr_ptr = curr_ptr->next;
+        *buflen = new_buflen;
     }
 
     return MPI_SUCCESS;

--- a/src/mpi/info/infoutil.c
+++ b/src/mpi/info/infoutil.c
@@ -48,9 +48,15 @@ int MPIR_Info_free_impl(MPIR_Info * info_ptr)
     return MPI_SUCCESS;
 }
 
-/* Allocate and initialize an MPIR_Info object.
- *
- * Returns MPICH error codes */
+/* Allocate and initialize an MPIR_Info object. */
+
+static void info_init(MPIR_Info * info_ptr)
+{
+    info_ptr->next = NULL;
+    info_ptr->key = NULL;
+    info_ptr->value = NULL;
+}
+
 int MPIR_Info_alloc(MPIR_Info ** info_p_p)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -58,9 +64,7 @@ int MPIR_Info_alloc(MPIR_Info ** info_p_p)
     MPIR_ERR_CHKANDJUMP1(!*info_p_p, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s", "MPI_Info");
 
     MPIR_Object_set_ref(*info_p_p, 0);
-    (*info_p_p)->next = NULL;
-    (*info_p_p)->key = NULL;
-    (*info_p_p)->value = NULL;
+    info_init(*info_p_p);
 
   fn_fail:
     return mpi_errno;
@@ -70,6 +74,7 @@ int MPIR_Info_alloc(MPIR_Info ** info_p_p)
  * finalization by MPI_Info_create_env().  This routine must be thread-safe. */
 void MPIR_Info_setup_env(MPIR_Info * info_ptr)
 {
+    info_init(info_ptr);
     /* FIXME: Currently this info object is left empty, we need to add data to
      * this as defined by the standard. */
     (void) info_ptr;

--- a/src/mpi/info/infoutil.c
+++ b/src/mpi/info/infoutil.c
@@ -27,24 +27,15 @@ MPIR_Object_alloc_t MPIR_Info_mem = { 0, 0, 0, 0, 0, 0, MPIR_INFO,
    relies on the SINGLE_CS in the info routines (particularly MPI_Info_free) */
 int MPIR_Info_free_impl(MPIR_Info * info_ptr)
 {
-    MPIR_Info *curr_ptr, *last_ptr;
-
-    curr_ptr = info_ptr->next;
-    last_ptr = NULL;
-
-    MPIR_Info_handle_obj_free(&MPIR_Info_mem, info_ptr);
-
-    /* printf("Returning info %x\n", info_ptr->id); */
-    /* First, free the string storage */
-    while (curr_ptr) {
+    for (int i = 0; i < info_ptr->size; i++) {
         /* MPI_Info objects are allocated by normal MPL_direct_xxx() functions, so
          * they need to be freed by MPL_direct_free(), not MPL_free(). */
-        MPL_direct_free(curr_ptr->key);
-        MPL_direct_free(curr_ptr->value);
-        last_ptr = curr_ptr;
-        curr_ptr = curr_ptr->next;
-        MPIR_Info_handle_obj_free(&MPIR_Info_mem, last_ptr);
+        MPL_direct_free(info_ptr->entries[i].key);
+        MPL_direct_free(info_ptr->entries[i].value);
     }
+    MPL_direct_free(info_ptr->entries);
+    MPIR_Info_handle_obj_free(&MPIR_Info_mem, info_ptr);
+
     return MPI_SUCCESS;
 }
 
@@ -52,9 +43,9 @@ int MPIR_Info_free_impl(MPIR_Info * info_ptr)
 
 static void info_init(MPIR_Info * info_ptr)
 {
-    info_ptr->next = NULL;
-    info_ptr->key = NULL;
-    info_ptr->value = NULL;
+    info_ptr->capacity = 0;
+    info_ptr->size = 0;
+    info_ptr->entries = NULL;
 }
 
 int MPIR_Info_alloc(MPIR_Info ** info_p_p)
@@ -78,4 +69,30 @@ void MPIR_Info_setup_env(MPIR_Info * info_ptr)
     /* FIXME: Currently this info object is left empty, we need to add data to
      * this as defined by the standard. */
     (void) info_ptr;
+}
+
+#define INFO_INITIAL_SIZE 10
+int MPIR_Info_push(MPIR_Info * info_ptr, const char *key, const char *val)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    /* potentially grow the copacity */
+    if (info_ptr->capacity == 0) {
+        info_ptr->entries = MPL_direct_malloc(sizeof(*(info_ptr->entries)) * INFO_INITIAL_SIZE);
+        info_ptr->capacity = INFO_INITIAL_SIZE;
+    } else if (info_ptr->size == info_ptr->capacity) {
+        int n = info_ptr->capacity * 5 / 3;     /* arbitrary grow ratio */
+        info_ptr->entries = MPL_direct_realloc(info_ptr->entries, sizeof(*(info_ptr->entries)) * n);
+        info_ptr->capacity = n;
+
+    }
+
+    /* add new entry */
+    int i = info_ptr->size;
+    info_ptr->entries[i].key = MPL_direct_strdup(key);
+    info_ptr->entries[i].value = MPL_direct_strdup(val);
+
+    info_ptr->size++;
+
+    return mpi_errno;
 }

--- a/src/mpi/init/local_proc_attrs.c
+++ b/src/mpi/init/local_proc_attrs.c
@@ -83,9 +83,6 @@ int MPII_init_local_proc_attrs(int *p_thread_required)
     MPIR_Object_set_ref(info_ptr, 1);
     /* Add data to MPI_INFO_ENV. */
     MPIR_Info_setup_env(info_ptr);
-    info_ptr->next = NULL;
-    info_ptr->key = NULL;
-    info_ptr->value = NULL;
 
     /* Set the number of tag bits. The device may override this value. */
     MPIR_Process.tag_bits = MPIR_TAG_BITS_DEFAULT;


### PR DESCRIPTION
## Pull Request Description
The current code implements MPIR_Info as a linked list. It has a weird
property of keeping the first entry NULL that is not obvious and easy to
make mistake. Besides the code to iterate linked list is not as clean as
if we simply use a dynamic array.

The commit re-implements MPIR_Info using dynamic array.

## NOTES
After refactoring and adding `MPIR_Info_lookup` routine, the first NULL entry in `MPIR_Info` is a lesser issue. Thus the last commit can be optional. Nevertheless, the dynamic array implementation is more efficient than linked list (less memory allocation and faster iteration) -- and the implementation code is simpler (+122 -174). 

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
