### PR TITLE
configure ROMIO before checking MPI_OFFSET_TYPE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1423,7 +1423,6 @@ fi
 # This goes here because we need the top_srcdir
 if test "$enable_romio" = "yes" ; then
    if test -d $use_top_srcdir/src/mpi/romio ; then
-       subsystems="$subsystems src/mpi/romio"
        AC_DEFINE(HAVE_ROMIO,1,[Define if ROMIO is enabled])
 
        # make it possible to "#include" mpio.h at build time
@@ -1443,6 +1442,7 @@ if test "$enable_romio" = "yes" ; then
        if test ! -d lib ; then mkdir lib ; fi
        # tell mpi.h to include mpio.h
        PAC_HAVE_ROMIO
+       PAC_CONFIG_SUBDIR_ARGS([src/mpi/romio],[$subsys_config_args],[],[AC_MSG_ERROR([src/mpi/romio configure failed])])
    else
        AC_MSG_WARN([ROMIO src directory is not available])
    fi

--- a/configure.ac
+++ b/configure.ac
@@ -1442,7 +1442,7 @@ if test "$enable_romio" = "yes" ; then
        if test ! -d lib ; then mkdir lib ; fi
        # tell mpi.h to include mpio.h
        PAC_HAVE_ROMIO
-       PAC_CONFIG_SUBDIR_ARGS([src/mpi/romio],[$subsys_config_args],[],[AC_MSG_ERROR([src/mpi/romio configure failed])])
+       PAC_CONFIG_SUBDIR_ARGS([src/mpi/romio],[],[],[AC_MSG_ERROR([src/mpi/romio configure failed])])
    else
        AC_MSG_WARN([ROMIO src directory is not available])
    fi


### PR DESCRIPTION
Data type MPI_Offset is checked and set in ROMIO, but if ROMIO is
configured after MPI_OFFSET_TYPE is checked, then MPI_Offset
will be set to inconsistent data types, e.g. `long` in src/mpi.h v.s.
`long long` in src/mpi/romio/include/mpio.h

MPI_OFFSET_TYPE is checked at line 3439.
https://github.com/pmodels/mpich/blob/e763458ea520458f08e689d3b0861dd72dac6c91/configure.ac#L3439

ROMIO is configured at line 3960.
https://github.com/pmodels/mpich/blob/e763458ea520458f08e689d3b0861dd72dac6c91/configure.ac#L3960