### PR TITLE
PMI make failed: mpi.h: No such file or directory

### DIFF
--- a/src/pmi/configure.ac
+++ b/src/pmi/configure.ac
@@ -69,6 +69,7 @@ PAC_CONFIG_MPL
 # check "mpi.h" for MPI_MAX_PORT_NAME
 if test "$FROM_MPICH" = "yes" ; then
     PAC_APPEND_FLAG([-I${main_top_srcdir}/src/include], [CPPFLAGS])
+    PAC_APPEND_FLAG([-I${main_top_builddir}/src/include], [CPPFLAGS])
     AC_DEFINE([HAVE_MPI_H], 1, [define if we have mpi.h])
 else
     AC_CHECK_HEADER([mpi.h])


### PR DESCRIPTION
Add the include path that contains `mpi.h`, otherwise make failed with
the error message below.
```
../../../mpich/src/pmi/simple/simple_pmi.c:54:10: fatal error: mpi.h: No such file or directory
 #include "mpi.h"        /* to get MPI_MAX_PORT_NAME */
          ^~~~~~~
compilation terminated.
```
