### PR TITLE
pmi: fix warnings - unused variables in pmi_v2.c

### DIFF
--- a/src/pmi/src/pmi_v2.c
+++ b/src/pmi/src/pmi_v2.c
@@ -475,12 +475,10 @@ PMI_API_PUBLIC
                        const PMI2_keyval_t preput_keyval_vector[],
                        char jobId[], int jobIdSize, int errors[])
 {
-    int i, rc, spawncnt, total_num_processes, num_errcodes_found;
+    int i, rc, spawncnt, total_num_processes;
     int found;
     const char *jid;
     int jidlen;
-    char tempbuf[PMIU_MAXLINE];
-    char *lead, *lag;
     int spawn_rc;
     const char *errmsg = NULL;
     PMI2_Command resp_cmd = { 0 };


### PR DESCRIPTION
## Pull Request Description

Some warnings leaked through PR #5887
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
