### PR TITLE
retrieve and load hwloc topology file from hydra/pmi

### DIFF
--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -55,6 +55,7 @@ int MPIR_pmi_set_threaded(int is_threaded);
 int MPIR_pmi_max_key_size(void);
 int MPIR_pmi_max_val_size(void);
 const char *MPIR_pmi_job_id(void);
+char *MPIR_pmi_get_hwloc_xmlfile(void);
 
 /* PMI wrapper utilities */
 

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -155,6 +155,7 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     MPIR_Typerep_init();
     MPII_thread_mutex_create();
     MPII_init_request();
+    MPIR_pmi_init();
     MPII_hwtopo_init();
     MPII_nettopo_init();
     MPII_init_windows();

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -318,13 +318,8 @@ static int init_pg(int *has_parent, int *pg_rank_p, MPIDI_PG_t **pg_p)
        return errors if the routines are in fact used */
     if (usePMI) {
 	/*
-	 * Initialize the process management interface (PMI), 
-	 * and get rank and size information about our process group
+	 * rank and size information about our process group
 	 */
-
-        mpi_errno = MPIR_pmi_init();
-        MPIR_ERR_CHECK(mpi_errno);
-
         *has_parent = MPIR_Process.has_parent;
         pg_rank = MPIR_Process.rank;
         pg_size = MPIR_Process.size;

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -370,9 +370,6 @@ int MPID_Init(int requested, int *provided)
 
     choose_netmod();
 
-    mpi_errno = MPIR_pmi_init();
-    MPIR_ERR_CHECK(mpi_errno);
-
     /* Create all ch4-layer granular locks.
      * Note: some locks (e.g. MPIDIU_THREAD_HCOLL_MUTEX) may be unused due to configuration.
      * It is harmless to create them anyway rather than adding #ifdefs.

--- a/src/pm/hydra/lib/tools/topo/hwloc/topo_hwloc.h
+++ b/src/pm/hydra/lib/tools/topo/hwloc/topo_hwloc.h
@@ -15,6 +15,7 @@ struct HYDT_topo_hwloc_info {
     hwloc_membind_policy_t membind;
     int user_binding;
     int total_num_pus;
+    char *xml_topology_file;
 };
 extern struct HYDT_topo_hwloc_info HYDT_topo_hwloc_info;
 

--- a/src/pm/hydra/proxy/Makefile.mk
+++ b/src/pm/hydra/proxy/Makefile.mk
@@ -16,3 +16,7 @@ hydra_pmi_proxy_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/proxy
 hydra_pmi_proxy_LDFLAGS = $(external_ldflags) -L$(top_builddir)
 hydra_pmi_proxy_LDADD = -lhydra $(external_libs)
 hydra_pmi_proxy_DEPENDENCIES = libhydra.la
+
+if HYDRA_HAVE_HWLOC
+hydra_pmi_proxy_CPPFLAGS += -I$(top_srcdir)/lib/tools/topo/hwloc
+endif

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -90,5 +90,7 @@ HYD_status HYD_pmcd_pmip_get_params(char **t_argv);
 void HYD_pmcd_pmip_send_signal(int sig);
 
 HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp);
+HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v1(char **response);
+HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v2(char *thrid, char **response);
 
 #endif /* PMIP_H_INCLUDED */

--- a/src/pm/hydra/proxy/pmip_pmi_v1.c
+++ b/src/pm/hydra/proxy/pmip_pmi_v1.c
@@ -407,6 +407,12 @@ static HYD_status fn_get(int fd, char *args[])
         status = send_cmd_downstream(fd, cmd);
         HYDU_ERR_POP(status, "error sending PMI response\n");
         MPL_free(cmd);
+    } else if (!strcmp(key, "PMI_hwloc_xmlfile")) {
+        status = HYD_pmip_get_hwloc_xmlfile_resp_v1(&cmd);
+        HYDU_ERR_POP(status, "error getting topology info\n");
+        status = send_cmd_downstream(fd, cmd);
+        HYDU_ERR_POP(status, "error sending PMI response\n");
+        MPL_free(cmd);
     } else {
         HASH_FIND_STR(hash_get, key, found);
         if (found) {

--- a/src/pm/hydra/proxy/pmip_pmi_v2.c
+++ b/src/pm/hydra/proxy/pmip_pmi_v2.c
@@ -438,6 +438,11 @@ static HYD_status fn_info_getjobattr(int fd, char *args[])
 
         send_cmd_downstream(fd, cmd);
         MPL_free(cmd);
+    } else if (!strcmp(key, "PMI_hwloc_xmlfile")) {
+        status = HYD_pmip_get_hwloc_xmlfile_resp_v2(thrid, &cmd);
+        HYDU_ERR_POP(status, "error getting topology info\n");
+        send_cmd_downstream(fd, cmd);
+        MPL_free(cmd);
     } else {
         status = send_cmd_upstream("cmd=info-getjobattr;", fd, args);
         HYDU_ERR_POP(status, "error sending command upstream\n");

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -719,3 +719,119 @@ HYD_status HYD_pmcd_pmip_get_params(char **t_argv)
   fn_fail:
     goto fn_exit;
 }
+
+#ifdef HAVE_HWLOC
+#include "topo_hwloc.h"
+
+HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v1(char **response)
+{
+    HYD_status status = HYD_SUCCESS;
+    char *xmlfile;
+
+    HYDU_FUNC_ENTER();
+
+    *response = NULL;
+
+    /* lazy init */
+    status = HYDT_topo_hwloc_init(NULL, NULL, NULL);
+    HYDU_ERR_POP(status, "unable to initialize hwloc\n");
+    xmlfile = HYDT_topo_hwloc_info.xml_topology_file;
+    if (xmlfile != NULL) {
+        int strlen = MPL_snprintf(NULL, 0, "cmd=get_result rc=0 msg=success value=%s\n", xmlfile);
+        ++strlen;       /* for null char */
+        HYDU_MALLOC_OR_JUMP(*response, char *, strlen, status);
+        MPL_snprintf(*response, strlen, "cmd=get_result rc=0 msg=success value=%s\n", xmlfile);
+    } else {
+        /* we know about the key but no file is available */
+        *response = MPL_strdup("cmd=get_result rc=0 msg=success value=unavailable\n");
+    }
+
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    MPL_free(*response);
+    *response = NULL;
+    goto fn_exit;
+}
+
+HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v2(char *thrid, char **response)
+{
+    HYD_status status = HYD_SUCCESS;
+    char *xmlfile;
+    struct HYD_string_stash stash;
+
+    HYDU_FUNC_ENTER();
+
+    *response = NULL;
+
+    /* lazy init */
+    status = HYDT_topo_hwloc_init(NULL, NULL, NULL);
+    HYDU_ERR_POP(status, "unable to initialize hwloc\n");
+    xmlfile = HYDT_topo_hwloc_info.xml_topology_file;
+
+    HYD_STRING_STASH_INIT(stash);
+    HYD_STRING_STASH(stash, MPL_strdup("cmd=info-getjobattr-response;"), status);
+    if (thrid) {
+        HYD_STRING_STASH(stash, MPL_strdup("thrid="), status);
+        HYD_STRING_STASH(stash, MPL_strdup(thrid), status);
+        HYD_STRING_STASH(stash, MPL_strdup(";"), status);
+    }
+
+    if (xmlfile != NULL) {
+        HYD_STRING_STASH(stash, MPL_strdup("found=TRUE;value="), status);
+        HYD_STRING_STASH(stash, MPL_strdup(HYDT_topo_hwloc_info.xml_topology_file), status);
+        HYD_STRING_STASH(stash, MPL_strdup(";rc=0;"), status);
+    } else {
+        HYD_STRING_STASH(stash, MPL_strdup("found=FALSE;rc=0;"), status);
+    }
+
+    HYD_STRING_SPIT(stash, *response, status);
+
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    MPL_free(*response);
+    *response = NULL;
+    goto fn_exit;
+}
+#else
+HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v1(char **response)
+{
+    HYDU_FUNC_ENTER();
+
+    *response = MPL_strdup("cmd=get_result rc=0 msg=success value=unavailable\n");
+
+    HYDU_FUNC_EXIT();
+    return HYD_SUCCESS;
+}
+
+HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v2(char *thrid, char **response)
+{
+    HYD_status status = HYD_SUCCESS;
+    struct HYD_string_stash stash;
+
+    HYDU_FUNC_ENTER();
+
+    *response = NULL;
+
+    HYD_STRING_STASH_INIT(stash);
+    HYD_STRING_STASH(stash, MPL_strdup("cmd=info-getjobattr-response;"), status);
+    if (thrid) {
+        HYD_STRING_STASH(stash, MPL_strdup("thrid="), status);
+        HYD_STRING_STASH(stash, MPL_strdup(thrid), status);
+        HYD_STRING_STASH(stash, MPL_strdup(";"), status);
+    }
+    HYD_STRING_STASH(stash, MPL_strdup("found=FALSE;rc=0;"), status);
+    HYD_STRING_SPIT(stash, *response, status);
+
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+#endif

--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -200,6 +200,18 @@ int MPII_hwtopo_init(void)
 #ifdef HAVE_HWLOC
     bindset = hwloc_bitmap_alloc();
     hwloc_topology_init(&hwloc_topology);
+    char *xmlfile = MPIR_pmi_get_hwloc_xmlfile();
+    if (xmlfile != NULL) {
+        int rc;
+        rc = hwloc_topology_set_xml(hwloc_topology, xmlfile);
+        if (rc == 0) {
+            /* To have hwloc still actually call OS-specific hooks, the
+             * HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM has to be set to assert that the loaded
+             * file is really the underlying system. */
+            hwloc_topology_set_flags(hwloc_topology, HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM);
+        }
+    }
+
     hwloc_topology_set_io_types_filter(hwloc_topology, HWLOC_TYPE_FILTER_KEEP_ALL);
     if (!hwloc_topology_load(hwloc_topology))
         bindset_is_valid =


### PR DESCRIPTION
## Pull Request Description

Add capabilities in Hydra and MPIR layer to retrieve and load an hwloc topology file. This helps to avoid many processes on the same node discovering the same information from the OS, and ultimately faster `MPI_Init` times.

See #1650.

~Also included are a couple of singleton init bug fixes discovered when testing this feature.~ these were split out to #5944.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
