### PR TITLE
hydra: remove forced_cleanup in proxy

### DIFF
--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -39,7 +39,6 @@ static HYD_status init_params(void)
     HYD_pmcd_pmip.downstream.exit_status = NULL;
     HYD_pmcd_pmip.downstream.pmi_rank = NULL;
     HYD_pmcd_pmip.downstream.pmi_fd = NULL;
-    HYD_pmcd_pmip.downstream.forced_cleanup = 0;
 
     HYD_pmcd_pmip.local.id = -1;
     HYD_pmcd_pmip.local.pgid = -1;
@@ -209,18 +208,7 @@ int main(int argc, char **argv)
         if (pid > 0)
             for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++)
                 if (HYD_pmcd_pmip.downstream.pid[i] == pid) {
-                    if (HYD_pmcd_pmip.downstream.forced_cleanup) {
-                        /* If it is a forced cleanup, the exit status
-                         * is either already set or we have to ignore
-                         * it */
-                        if (HYD_pmcd_pmip.downstream.exit_status[i] == -1)
-                            HYD_pmcd_pmip.downstream.exit_status[i] = 0;
-                        else
-                            HYD_pmcd_pmip.downstream.exit_status[i] = ret_status;
-                    } else {
-                        HYD_pmcd_pmip.downstream.exit_status[i] = ret_status;
-                    }
-
+                    HYD_pmcd_pmip.downstream.exit_status[i] = ret_status;
                     done++;
                 }
 

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -205,12 +205,16 @@ int main(int argc, char **argv)
         pid = waitpid(-1, &ret_status, 0);
 
         /* Find the pid and mark it as complete. */
-        if (pid > 0)
-            for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++)
+        if (pid > 0) {
+            for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
                 if (HYD_pmcd_pmip.downstream.pid[i] == pid) {
-                    HYD_pmcd_pmip.downstream.exit_status[i] = ret_status;
+                    if (HYD_pmcd_pmip.downstream.exit_status[i] == PMIP_EXIT_STATUS_UNSET) {
+                        HYD_pmcd_pmip.downstream.exit_status[i] = ret_status;
+                    }
                     done++;
                 }
+            }
+        }
 
         /* If no more processes are pending, break out */
         if (done == HYD_pmcd_pmip.local.proxy_process_count)

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -59,8 +59,6 @@ struct HYD_pmcd_pmip_s {
         int *pmi_rank;
         int *pmi_fd;
         int *pmi_fd_active;
-
-        int forced_cleanup;
     } downstream;
 
     /* Proxy details */

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -85,7 +85,10 @@ extern struct HYD_pmcd_pmip_s HYD_pmcd_pmip;
 extern struct HYD_arg_match_table HYD_pmcd_pmip_match_table[];
 
 HYD_status HYD_pmcd_pmip_get_params(char **t_argv);
+
+#define PMIP_EXIT_STATUS_UNSET -1
 void HYD_pmcd_pmip_send_signal(int sig);
+
 HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp);
 
 #endif /* PMIP_H_INCLUDED */

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -305,12 +305,6 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
          * active" (which means that this is an MPI application).
          */
         if (pid != -1 && HYD_pmcd_pmip.downstream.pmi_fd_active[pid]) {
-            /* If this is not a forced cleanup, store a temporary
-             * erroneous exit status. In case the application does not
-             * return a non-zero exit status, we will use this. */
-            if (HYD_pmcd_pmip.downstream.forced_cleanup == 0)
-                HYD_pmcd_pmip.downstream.exit_status[pid] = 1;
-
             /* Deregister failed socket */
             status = HYDT_dmx_deregister_fd(fd);
             HYDU_ERR_POP(status, "unable to deregister fd\n");

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -266,7 +266,7 @@ static HYD_status check_pmi_cmd(char **buf, int *pmi_version, int *repeat)
 static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
 {
     char *buf = NULL;
-    int closed, repeat, sent, i = -1, linelen, pid = -1;
+    int closed, repeat, sent, linelen, pid = -1;
     struct HYD_pmcd_hdr hdr;
     HYD_status status = HYD_SUCCESS;
 
@@ -275,7 +275,7 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
     HYD_pmcd_init_header(&hdr);
 
     /* Try to find the PMI FD */
-    for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
+    for (int i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
         if (HYD_pmcd_pmip.downstream.pmi_fd[i] == fd) {
             pid = i;
             break;
@@ -312,6 +312,13 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
 
             if (HYD_pmcd_pmip.user_global.auto_cleanup) {
                 /* kill all processes */
+                /* preset all exit_status except for the closed pid */
+                for (int i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
+                    if (i != pid &&
+                        HYD_pmcd_pmip.downstream.exit_status[i] == PMIP_EXIT_STATUS_UNSET) {
+                        HYD_pmcd_pmip.downstream.exit_status[i] = 0;
+                    }
+                }
                 HYD_pmcd_pmip_send_signal(SIGKILL);
             } else {
                 /* If the user doesn't want to automatically cleanup,
@@ -486,7 +493,7 @@ static HYD_status singleton_init(void)
     HYD_pmcd_pmip.downstream.out[0] = 0;
     HYD_pmcd_pmip.downstream.err[0] = 0;
     HYD_pmcd_pmip.downstream.pid[0] = HYD_pmcd_pmip.user_global.singleton_pid;
-    HYD_pmcd_pmip.downstream.exit_status[0] = -1;
+    HYD_pmcd_pmip.downstream.exit_status[0] = PMIP_EXIT_STATUS_UNSET;
     HYD_pmcd_pmip.downstream.pmi_rank[0] = 0;
     HYD_pmcd_pmip.downstream.pmi_fd[0] = HYD_FD_UNSET;
     HYD_pmcd_pmip.downstream.pmi_fd_active[0] = 1;
@@ -574,7 +581,7 @@ static HYD_status launch_procs(void)
     /* Initialize the PMI_FD and PMI FD active state, and exit status */
     for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
         /* The exit status is populated when the processes terminate */
-        HYD_pmcd_pmip.downstream.exit_status[i] = -1;
+        HYD_pmcd_pmip.downstream.exit_status[i] = PMIP_EXIT_STATUS_UNSET;
 
         /* If we use PMI_FD, the pmi_fd and pmi_fd_active arrays will
          * be filled out in this function. But if we are using

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -27,8 +27,6 @@ void HYD_pmcd_pmip_send_signal(int sig)
             kill(HYD_pmcd_pmip.downstream.pid[i], sig);
 #endif
         }
-
-    HYD_pmcd_pmip.downstream.forced_cleanup = 1;
 }
 
 static HYD_status control_port_fn(char *arg, char ***argv)


### PR DESCRIPTION
## Pull Request Description
`forced_cleanup` is used to reset the exit status of force killed
processes to 0. For example, when one process dies and auto_cleanup is
set, we kill the rest of the processes in the process group, and we want
to mark the exit status of those processes as 0. However, I don't think
that is necessary. Having the signal bit-or'ed in the final exit code
does no harm IMO. On the other hand, the extra logic is fragile. For
example, the presetting of the exit code to 1 may mess up due to the order
of socket close event and waitpid event, and result in the temporary
exit code leaked to the final exit code and confuse users.

EDIT: The actual issue is, the previous mechanism of setting `forced_cleanup` flag wasn't clean. It affects the paths where we legitimately sending (e.g. non-kill) signals to processes. Added a second commit to re-implement the intentions of setting exit_status to 0 for purposely killed processes.

ref: https://github.com/pmodels/mpich/pull/5927#issuecomment-1088237906
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
