### PR TITLE
test: fix cuda tests under non-default compiler

### DIFF
--- a/test/mpi/Makefile_cuda.mtest
+++ b/test/mpi/Makefile_cuda.mtest
@@ -29,4 +29,4 @@ LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 
 # How to compile .cu files -- compile with mpicc, but using nvcc
 .cu.o:
-	MPICH_CC=$(NVCC) $(CC) -c -o $@ $<
+	MPICH_CC="$(NVCC)" $(CC) -c -o $@ $<

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -46,6 +46,9 @@ AM_MAINTAINER_MODE([enable])
 # Non-verbose make by default
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+# save CXX before we overwrite it. We need it for NVCC's -ccbin
+save_CXX="$CXX"
+
 if test -z "$mpich_top_srcdir" ; then
     if test -z "$top_srcdir" ; then
        use_top_srcdir=$srcdir
@@ -671,9 +674,17 @@ if test "X${pac_have_cuda}" = "Xyes" ; then
         else
             cuda_LDFLAGS="-L${with_cuda}/lib"
         fi
-        AC_PATH_PROG([NVCC], [nvcc], [nvcc_not_found], [$with_cuda/bin:$PATH])
-    else
-        AC_PATH_PROG([NVCC], [nvcc], [nvcc_not_found])
+    fi
+
+    if test -n "$NVCC" ; then
+        if test -n "${with_cuda}" -a "$with_cuda" != "no" ; then
+            AC_PATH_PROG([NVCC], [nvcc], [nvcc_not_found], [$with_cuda/bin:$PATH])
+        else
+            AC_PATH_PROG([NVCC], [nvcc], [nvcc_not_found])
+        fi
+        if test "$NVCC" != "nvcc_not_found" -a -n "$CXX" ; then
+            NVCC="$NVCC -ccbin $CXX"
+        fi
     fi
     cuda_LIBS="-lcudart"
 


### PR DESCRIPTION

## Pull Request Description
When the chosen compiler is not the default nvcc host compiler, we need
set nvcc's -ccbin option.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
