### PR TITLE
pm/util: restore simple_pmiutil.h

### DIFF
--- a/src/pm/util/Makefile.mk
+++ b/src/pm/util/Makefile.mk
@@ -7,7 +7,6 @@
 # managers that use utility code from this directory
 common_pm_includes = \
     -I${top_builddir}/src/include -I${top_srcdir}/src/include \
-    -I${top_builddir}/src/pmi/simple -I${top_srcdir}/src/pmi/simple \
     -I${top_builddir}/src/pm/util -I${top_srcdir}/src/pm/util
 
 if BUILD_PM_UTIL

--- a/src/pm/util/simple_pmiutil.h
+++ b/src/pm/util/simple_pmiutil.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef SIMPLE_PMIUTIL_H_INCLUDED
+#define SIMPLE_PMIUTIL_H_INCLUDED
+
+/* maximum sizes for arrays */
+#define PMIU_MAXLINE 1024
+#define PMIU_IDSIZE    32
+
+/* we don't have access to MPIR_Assert and friends here in the PMI code */
+#if defined(HAVE_ASSERT_H)
+#include <assert.h>
+#define PMIU_Assert(expr) assert(expr)
+#else
+#define PMIU_Assert(expr)
+#endif
+
+#if defined HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif /* HAVE_ARPA_INET_H */
+
+
+/* prototypes for PMIU routines */
+void PMIU_Set_rank(int PMI_rank);
+void PMIU_SetServer(void);
+void PMIU_printf(int print_flag, const char *fmt, ...);
+int PMIU_readline(int fd, char *buf, int max);
+int PMIU_writeline(int fd, char *buf);
+int PMIU_parse_keyvals(char *st);
+void PMIU_dump_keyvals(void);
+char *PMIU_getval(const char *keystr, char *valstr, int vallen);
+void PMIU_chgval(const char *keystr, char *valstr);
+
+#endif /* SIMPLE_PMIUTIL_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description
The header file simple_pmiutil.h was in src/pmi/simple and it is now
being refactored. It is still needed by gforker and remshell. This
commit restores the file into src/pm/util where it belongs. This fixes
the build for gforker and remshell.

Fixes #5937
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
