### PR TITLE
ch4: remove debug message from posix release_gather code

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
@@ -118,14 +118,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
      * half a datatype in one chunk, but that is fine */
     MPIR_Algo_calculate_pipeline_chunk_info(cellsize, 1, count * type_size, &num_chunks,
                                             &chunk_count_floor, &chunk_count_ceil);
-    /* Print chunking information */
-/* *INDENT-OFF* */
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Bcast shmgr pipeline info: segsize=%d\
-                                             count=" MPI_AINT_FMT_DEC_SPEC " num_chunks=" MPI_AINT_FMT_DEC_SPEC " chunk_count_floor=" MPI_AINT_FMT_DEC_SPEC "\
-                                             chunk_count_ceil=" MPI_AINT_FMT_DEC_SPEC " \n",
-                                             cellsize, count * type_size, num_chunks,
-                                             chunk_count_floor, chunk_count_ceil));
-/* *INDENT-ON* */
 
     /* Do pipelined release-gather */
     for (i = 0; i < num_chunks; i++) {
@@ -240,16 +232,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
                                             MPL_MAX(extent, type_size), count, &num_chunks,
                                             &chunk_size_floor, &chunk_size_ceil);
 
-    /* Print chunking information */
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
-                                             "Reduce shmgr pipeline info: segsize=%d count="
-                                             MPI_AINT_FMT_DEC_SPEC " num_chunks="
-                                             MPI_AINT_FMT_DEC_SPEC " chunk_size_floor="
-                                             MPI_AINT_FMT_DEC_SPEC " chunk_size_ceil="
-                                             MPI_AINT_FMT_DEC_SPEC " \n",
-                                             MPIDI_POSIX_RELEASE_GATHER_REDUCE_CELLSIZE, count,
-                                             num_chunks, chunk_size_floor, chunk_size_ceil));
-
     /* Do pipelined release-gather */
     for (i = 0; i < num_chunks; i++) {
         MPI_Aint chunk_count = (i == 0) ? chunk_size_floor : chunk_size_ceil;
@@ -346,16 +328,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
     MPIR_Algo_calculate_pipeline_chunk_info(MPIDI_POSIX_RELEASE_GATHER_REDUCE_CELLSIZE,
                                             MPL_MAX(extent, type_size), count, &num_chunks,
                                             &chunk_size_floor, &chunk_size_ceil);
-
-    /* Print chunking information */
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
-                                             "Reduce shmgr pipeline info: segsize=%d count="
-                                             MPI_AINT_FMT_DEC_SPEC " num_chunks="
-                                             MPI_AINT_FMT_DEC_SPEC " chunk_size_floor="
-                                             MPI_AINT_FMT_DEC_SPEC " chunk_size_ceil="
-                                             MPI_AINT_FMT_DEC_SPEC " \n",
-                                             MPIDI_POSIX_RELEASE_GATHER_REDUCE_CELLSIZE, count,
-                                             num_chunks, chunk_size_floor, chunk_size_ceil));
 
     /* Do pipelined release-gather */
     for (i = 0; i < num_chunks; i++) {

--- a/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
@@ -404,14 +404,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_nb_release_gather_ireduce_impl(void *se
                                             extent, count, &num_chunks,
                                             &chunk_count_floor, &chunk_count_ceil);
 
-    /* Print chunking information */
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
-                                             "Ireduce shmgr pipeline info: segsize=%d count=%ld "
-                                             "num_chunks=%ld chunk_count_floor=%ld chunk_size_ceil=%ld"
-                                             "\n", MPIDI_POSIX_RELEASE_GATHER_REDUCE_CELLSIZE,
-                                             count, num_chunks, chunk_count_floor,
-                                             chunk_count_ceil));
-
     /* Do pipelined release-gather */
     /* A schedule gets created in the form of a forest, where each tree has 7 vertices (to perform
      * release_gather) and number of trees is same as number of chunks the message is divided


### PR DESCRIPTION

## Pull Request Description
These debug messages currently is causing warnings on the wrong format of
segsize. Rather than fix the format, let's remove them. They are only
needed during debugging when the developer knows what they are looking for,
in which case it is simple enough for the developer to manually add the
debug prints. Keeping them around harms the readability and costs effort
to maintain them.

Partially Fixes #5937
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
