### PR TITLE
hydra: WIP toward reuse proxy for spawning and tree-launch

### DIFF
--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -317,6 +317,8 @@ struct HYD_node {
     int active_processes;
 
     int node_id;
+    int control_fd;
+    int control_fd_refcnt;
 
     /* Username */
     char *user;

--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -565,7 +565,7 @@ void HYDU_sock_finalize(void);
 HYD_status HYDU_sock_get_iface_ip(char *iface, char **ip);
 HYD_status
 HYDU_sock_create_and_listen_portstr(char *iface, char *hostname, char *port_range,
-                                    char **port_str,
+                                    char **port_str, int *listenfd,
                                     HYD_status(*callback) (int fd, HYD_event_t events,
                                                            void *userp), void *userp);
 HYD_status HYDU_sock_cloexec(int fd);

--- a/src/pm/hydra/lib/pmiserv_common.c
+++ b/src/pm/hydra/lib/pmiserv_common.c
@@ -84,30 +84,12 @@ HYD_status HYD_pmcd_pmi_send(int fd, struct PMIU_cmd *pmi, struct HYD_pmcd_hdr *
     goto fn_exit;
 }
 
-HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_pmcd_pmi_kvs **kvs, int pgid)
+HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_pmcd_pmi_kvs **kvs)
 {
     HYD_status status = HYD_SUCCESS;
-    char hostname[MAX_HOSTNAME_LEN - 40];       /* Remove space taken up by the integers and other
-                                                 * characters below. */
-    unsigned int seed;
-    MPL_time_t tv;
-    double secs;
-    int rnd;
-
     HYDU_FUNC_ENTER();
 
-    if (gethostname(hostname, MAX_HOSTNAME_LEN - 40) < 0)
-        HYDU_ERR_SETANDJUMP(status, HYD_SOCK_ERROR, "unable to get local hostname\n");
-
-    MPL_wtime(&tv);
-    MPL_wtime_todouble(&tv, &secs);
-    seed = (unsigned int) (secs * 1e6);
-    srand(seed);
-    rnd = rand();
-
     HYDU_MALLOC_OR_JUMP(*kvs, struct HYD_pmcd_pmi_kvs *, sizeof(struct HYD_pmcd_pmi_kvs), status);
-    MPL_snprintf_nowarn((*kvs)->kvsname, PMI_MAXKVSLEN, "kvs_%d_%d_%d_%s", (int) getpid(), pgid,
-                        rnd, hostname);
     (*kvs)->key_pair = NULL;
     (*kvs)->tail = NULL;
 

--- a/src/pm/hydra/lib/pmiserv_common.h
+++ b/src/pm/hydra/lib/pmiserv_common.h
@@ -30,6 +30,7 @@ struct HYD_pmcd_pmi_kvs {
 /* init header proxy send to server upon connection */
 struct HYD_pmcd_init_hdr {
     char signature[4]; /* HYD\0 */ ;
+    int pgid;
     int proxy_id;
 };
 

--- a/src/pm/hydra/lib/pmiserv_common.h
+++ b/src/pm/hydra/lib/pmiserv_common.h
@@ -23,7 +23,6 @@ struct HYD_pmcd_pmi_kvs_pair {
 };
 
 struct HYD_pmcd_pmi_kvs {
-    char kvsname[PMI_MAXKVSLEN];        /* Name of this kvs */
     struct HYD_pmcd_pmi_kvs_pair *key_pair;
     struct HYD_pmcd_pmi_kvs_pair *tail;
 };
@@ -34,7 +33,7 @@ struct HYD_pmcd_init_hdr {
     int proxy_id;
 };
 
-HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_pmcd_pmi_kvs **kvs, int pgid);
+HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_pmcd_pmi_kvs **kvs);
 void HYD_pmcd_free_pmi_kvs_list(struct HYD_pmcd_pmi_kvs *kvs_list);
 HYD_status HYD_pmcd_pmi_add_kvs(const char *key, const char *val, struct HYD_pmcd_pmi_kvs *kvs,
                                 int *ret);

--- a/src/pm/hydra/lib/pmiserv_common.h
+++ b/src/pm/hydra/lib/pmiserv_common.h
@@ -68,14 +68,14 @@ struct HYD_hdr_pmi {
 
 /* STDOUT/STDERR */
 struct HYD_hdr_io {
-    int pgid;
-    int proxy_id;
     int rank;
 };
 
 struct HYD_pmcd_hdr {
     enum HYD_pmcd_cmd cmd;
     int buflen;
+    int pgid;
+    int proxy_id;
     union {
         int data;               /* for commands with a single integer data */
         struct HYD_hdr_pmi pmi;

--- a/src/pm/hydra/lib/pmiserv_common.h
+++ b/src/pm/hydra/lib/pmiserv_common.h
@@ -62,8 +62,8 @@ enum HYD_pmcd_cmd {
 
 /* PMI_CMD */
 struct HYD_hdr_pmi {
-    int pid;                    /* ID of the requesting process */
     int pmi_version;            /* PMI version */
+    int process_fd;             /* fd of the downstream process at proxy */
 };
 
 /* STDOUT/STDERR */

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -79,6 +79,8 @@ HYD_status HYDU_alloc_node(struct HYD_node **node)
     (*node)->core_count = 0;
     (*node)->active_processes = 0;
     (*node)->node_id = -1;
+    (*node)->control_fd = -1;
+    (*node)->control_fd_refcnt = 0;
     (*node)->user = NULL;
     (*node)->local_binding = NULL;
     (*node)->next = NULL;

--- a/src/pm/hydra/lib/utils/args.c
+++ b/src/pm/hydra/lib/utils/args.c
@@ -213,7 +213,8 @@ HYD_status HYDU_set_int(char *arg, int *var, int val)
 {
     HYD_status status = HYD_SUCCESS;
 
-    HYDU_ERR_CHKANDJUMP(status, *var != -1, HYD_INTERNAL_ERROR, "duplicate setting: %s\n", arg);
+    HYDU_ERR_CHKANDJUMP(status, *var != -1 &&
+                        *var != val, HYD_INTERNAL_ERROR, "duplicate setting: %s\n", arg);
 
     *var = val;
 

--- a/src/pm/hydra/lib/utils/sock.c
+++ b/src/pm/hydra/lib/utils/sock.c
@@ -470,23 +470,23 @@ HYD_status HYDU_sock_get_iface_ip(char *iface, char **ip)
 
 HYD_status
 HYDU_sock_create_and_listen_portstr(char *iface, char *hostname, char *port_range,
-                                    char **port_str,
+                                    char **port_str, int *listenfd,
                                     HYD_status(*callback) (int fd, HYD_event_t events,
                                                            void *userp), void *userp)
 {
-    int listenfd = -1;
     char *sport, *real_port_range, *ip = NULL;
     uint16_t port;
     HYD_status status = HYD_SUCCESS;
 
+    *listenfd = -1;
     /* Listen on a port in the port range */
     port = 0;
     real_port_range = port_range ? MPL_strdup(port_range) : NULL;
-    status = HYDU_sock_listen(&listenfd, real_port_range, &port);
+    status = HYDU_sock_listen(listenfd, real_port_range, &port);
     HYDU_ERR_POP(status, "unable to listen on port\n");
 
     /* Register the listening socket with the demux engine */
-    status = HYDT_dmx_register_fd(1, &listenfd, HYD_POLLIN, userp, callback);
+    status = HYDT_dmx_register_fd(1, listenfd, HYD_POLLIN, userp, callback);
     HYDU_ERR_POP(status, "unable to register fd\n");
 
     /* Create a port string for MPI processes to use to connect to */
@@ -517,8 +517,10 @@ HYDU_sock_create_and_listen_portstr(char *iface, char *hostname, char *port_rang
     return status;
 
   fn_fail:
-    if (-1 != listenfd)
-        close(listenfd);
+    if (-1 != *listenfd) {
+        close(*listenfd);
+        *listenfd = -1;
+    }
     goto fn_exit;
 }
 

--- a/src/pm/hydra/mpiexec/hydra_server.h
+++ b/src/pm/hydra/mpiexec/hydra_server.h
@@ -47,6 +47,9 @@ struct HYD_server_info_s {
     char *nameserver;
     char *localhost;
     time_t time_start;
+    /* for proxies to connect back */
+    char *control_port;
+    int control_listen_fd;
 
     int singleton_port;
     int singleton_pid;

--- a/src/pm/hydra/mpiexec/mpiexec.c
+++ b/src/pm/hydra/mpiexec/mpiexec.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
 {
     struct HYD_exec *exec;
     struct HYD_node *node;
-    int i, user_provided_host_list, global_core_count;
+    int user_provided_host_list;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
@@ -141,6 +141,7 @@ int main(int argc, char **argv)
 
     if (user_provided_host_list) {
         /* Reassign node IDs to each node */
+        int i;
         for (node = HYD_server_info.node_list, i = 0; node; node = node->next, i++)
             node->node_id = i;
 
@@ -167,7 +168,8 @@ int main(int argc, char **argv)
     pg->pg_process_count = 0;
     for (exec = HYD_uii_mpx_exec_list; exec; exec = exec->next) {
         if (exec->proc_count <= 0) {
-            global_core_count = 0;
+            int i;
+            int global_core_count = 0;
             for (node = HYD_server_info.node_list, i = 0; node; node = node->next, i++)
                 global_core_count += node->core_count;
             exec->proc_count = global_core_count;

--- a/src/pm/hydra/mpiexec/pmiserv.h
+++ b/src/pm/hydra/mpiexec/pmiserv.h
@@ -13,5 +13,6 @@ HYD_status HYD_pmcd_pmiserv_control_listen_cb(int fd, HYD_event_t events, void *
 HYD_status HYD_pmcd_pmiserv_cleanup_all_pgs(void);
 HYD_status HYD_pmcd_pmiserv_send_signal(struct HYD_proxy *proxy, int signum);
 HYD_status HYD_control_listen(void);
+HYD_status HYD_send_exec_info(struct HYD_proxy *proxy);
 
 #endif /* PMISERV_H_INCLUDED */

--- a/src/pm/hydra/mpiexec/pmiserv.h
+++ b/src/pm/hydra/mpiexec/pmiserv.h
@@ -12,5 +12,6 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
 HYD_status HYD_pmcd_pmiserv_control_listen_cb(int fd, HYD_event_t events, void *userp);
 HYD_status HYD_pmcd_pmiserv_cleanup_all_pgs(void);
 HYD_status HYD_pmcd_pmiserv_send_signal(struct HYD_proxy *proxy, int signum);
+HYD_status HYD_control_listen(void);
 
 #endif /* PMISERV_H_INCLUDED */

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -557,23 +557,10 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
 
 HYD_status HYD_pmcd_pmiserv_control_listen_cb(int fd, HYD_event_t events, void *userp)
 {
-    int accept_fd = -1, pgid;
-    struct HYD_pg *pg;
-    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
+    int accept_fd = -1;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
-
-    /* Get the PGID of the connection */
-    pgid = ((int) (size_t) userp);
-
-    /* Find the process group */
-    pg = PMISERV_pg_by_id(pgid);
-    if (!pg)
-        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "could not find pg with ID %d\n", pgid);
-
-    pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
-    pg_scratch->control_listen_fd = fd;
 
     /* We got a control socket connection */
     status = HYDU_sock_accept(fd, &accept_fd);

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -504,6 +504,7 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
         close(fd);
         goto fn_exit;
     }
+    HYDU_ASSERT(pgid == init_hdr.pgid, status);
     proxy_id = init_hdr.proxy_id;
 
     /* Find the process group */

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -122,13 +122,17 @@ static HYD_status cleanup_proxy(struct HYD_proxy *proxy)
     HYDU_FUNC_ENTER();
 
     if (proxy->control_fd != HYD_FD_UNSET && proxy->control_fd != HYD_FD_CLOSED) {
-        status = HYDT_dmx_deregister_fd(proxy->control_fd);
-        HYDU_ERR_POP(status, "error deregistering fd\n");
-        close(proxy->control_fd);
-
+        struct HYD_node *node = proxy->node;
         /* Reset the control fd, so when the fd is reused, we don't
          * find the wrong proxy */
         proxy->control_fd = HYD_FD_CLOSED;
+        node->control_fd_refcnt--;
+        HYDU_ASSERT(node->control_fd_refcnt >= 0, status);
+        if (node->control_fd_refcnt == 0) {
+            status = HYDT_dmx_deregister_fd(node->control_fd);
+            HYDU_ERR_POP(status, "error deregistering node->control_fd\n");
+            close(node->control_fd);
+        }
     }
 
     /* If there is an active proxy, don't clean up the PG */
@@ -233,12 +237,12 @@ static HYD_status stdin_cb(int fd, HYD_event_t events, void *userp)
     pg = PMISERV_pg_by_id(pgid);
     proxy = &pg->proxy_list[proxy_id];
 
+    char *buf;
     /* Are we sure HYD_TMPBUF_SIZE (64k) is sufficient? */
     HYDU_MALLOC_OR_JUMP(buf, char *, HYD_TMPBUF_SIZE, status);
     HYDU_ERR_POP(status, "unable to allocate memory\n");
 
     int count, closed;
-    char *buf;
     status = HYDU_sock_read(STDIN_FILENO, buf, HYD_TMPBUF_SIZE, &count, &closed,
                             HYDU_SOCK_COMM_NONE);
     HYDU_ERR_POP(status, "error reading from stdin\n");
@@ -266,33 +270,31 @@ static HYD_status stdin_cb(int fd, HYD_event_t events, void *userp)
 static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
 {
     HYD_status status = HYD_SUCCESS;
-
     HYDU_FUNC_ENTER();
 
-    int count, closed;
     struct HYD_pmcd_hdr hdr;
-    status = HYDU_sock_read(fd, &hdr, sizeof(hdr), &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
-    HYDU_ERR_POP(status, "unable to read command from proxy\n");
-    HYDU_ASSERT(!closed, status);
-
-    int pgid, proxy_id;
-    pgid = hdr.pgid;
-    proxy_id = hdr.proxy_id;
+    {
+        int count, closed;
+        status = HYDU_sock_read(fd, &hdr, sizeof(hdr), &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "unable to read command from proxy\n");
+        HYDU_ASSERT(!closed, status);
+    }
 
     struct HYD_proxy *proxy;
     struct HYD_pg *pg;
-    pg = PMISERV_pg_by_id(pgid);
-    proxy = &pg->proxy_list[proxy_id];
+    pg = PMISERV_pg_by_id(hdr.pgid);
+    proxy = &pg->proxy_list[hdr.proxy_id];
 
     if (hdr.cmd == CMD_PID_LIST) {      /* Got PIDs */
         HYDU_MALLOC_OR_JUMP(proxy->pid, int *, proxy->proxy_process_count * sizeof(int), status);
+        int count, closed;
         status = HYDU_sock_read(fd, (void *) proxy->pid,
                                 proxy->proxy_process_count * sizeof(int),
                                 &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
         HYDU_ERR_POP(status, "unable to read status from proxy\n");
         HYDU_ASSERT(!closed, status);
 
-        if (pgid != 0) {
+        if (hdr.pgid != 0) {
             /* We initialize the debugger code only for non-dynamically
              * spawned processes */
             goto fn_exit;
@@ -311,10 +313,10 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
     } else if (hdr.cmd == CMD_EXIT_STATUS) {
         HYDU_MALLOC_OR_JUMP(proxy->exit_status, int *, proxy->proxy_process_count * sizeof(int),
                             status);
-        status =
-            HYDU_sock_read(fd, (void *) proxy->exit_status,
-                           proxy->proxy_process_count * sizeof(int), &count, &closed,
-                           HYDU_SOCK_COMM_MSGWAIT);
+        int count, closed;
+        status = HYDU_sock_read(fd, (void *) proxy->exit_status,
+                                proxy->proxy_process_count * sizeof(int), &count, &closed,
+                                HYDU_SOCK_COMM_MSGWAIT);
         HYDU_ERR_POP(status, "unable to read status from proxy\n");
         HYDU_ASSERT(!closed, status);
 
@@ -355,13 +357,14 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
         char *buf;
         HYDU_MALLOC_OR_JUMP(buf, char *, hdr.buflen + 1, status);
 
+        int count, closed;
         status = HYDU_sock_read(fd, buf, hdr.buflen, &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
         HYDU_ERR_POP(status, "unable to read PMI command from proxy\n");
         HYDU_ASSERT(!closed, status);
 
         buf[hdr.buflen] = 0;
 
-        status = handle_pmi_cmd(proxy, pgid, hdr.u.pmi.process_fd, buf, hdr.buflen,
+        status = handle_pmi_cmd(proxy, hdr.pgid, hdr.u.pmi.process_fd, buf, hdr.buflen,
                                 hdr.u.pmi.pmi_version);
         HYDU_ERR_POP(status, "unable to process PMI command\n");
 
@@ -370,14 +373,17 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
         char *buf;
         HYDU_MALLOC_OR_JUMP(buf, char *, hdr.buflen, status);
 
+        int count, closed;
         status = HYDU_sock_read(fd, buf, hdr.buflen, &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
         HYDU_ERR_POP(status, "unable to read PMI command from proxy\n");
         HYDU_ASSERT(!closed, status);
 
         if (hdr.cmd == CMD_STDOUT) {
-            status = HYD_server_info.stdout_cb(pgid, proxy_id, hdr.u.io.rank, buf, hdr.buflen);
+            status =
+                HYD_server_info.stdout_cb(hdr.pgid, hdr.proxy_id, hdr.u.io.rank, buf, hdr.buflen);
         } else {
-            status = HYD_server_info.stderr_cb(pgid, proxy_id, hdr.u.io.rank, buf, hdr.buflen);
+            status =
+                HYD_server_info.stderr_cb(hdr.pgid, hdr.proxy_id, hdr.u.io.rank, buf, hdr.buflen);
         }
         HYDU_ERR_POP(status, "error in the UI defined callback\n");
 
@@ -460,12 +466,11 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
   fn_exit:
     HYDU_FUNC_EXIT();
     return status;
-
   fn_fail:
     goto fn_exit;
 }
 
-static HYD_status send_exec_info(struct HYD_proxy *proxy)
+HYD_status HYD_send_exec_info(struct HYD_proxy *proxy)
 {
     struct HYD_pmcd_hdr hdr;
     HYD_status status = HYD_SUCCESS;
@@ -527,10 +532,11 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
     /* This will be the control socket for this proxy */
     // HYDU_ASSERT(proxy->node->control_fd == -1, status);
     proxy->node->control_fd = fd;
+    proxy->node->control_fd_refcnt = 1;
     proxy->control_fd = fd;
 
     /* Send out the executable information */
-    status = send_exec_info(proxy);
+    status = HYD_send_exec_info(proxy);
     HYDU_ERR_POP(status, "unable to send exec info to proxy\n");
 
     status = HYDT_dmx_deregister_fd(fd);

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -13,8 +13,8 @@
 #include "pmiserv_common.h"
 #include "pmiserv_pmi.h"
 
-HYD_status send_hdr_downstream(struct HYD_proxy *proxy, struct HYD_pmcd_hdr *hdr,
-                               void *buf, int buflen)
+static HYD_status send_hdr_downstream(struct HYD_proxy *proxy, struct HYD_pmcd_hdr *hdr,
+                                      void *buf, int buflen)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -212,7 +212,6 @@ HYD_status HYD_pmcd_pmiserv_cleanup_all_pgs(void)
 HYD_status HYD_pmcd_pmiserv_send_signal(struct HYD_proxy *proxy, int signum)
 {
     struct HYD_pmcd_hdr hdr;
-    int sent, closed;
     HYD_status status = HYD_SUCCESS;
 
     HYD_pmcd_init_header(&hdr);
@@ -233,7 +232,6 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
 {
     int count, closed;
     struct HYD_pmcd_hdr hdr;
-    struct HYD_proxy *tproxy;
     struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
     char *buf;
     HYD_status status = HYD_SUCCESS;
@@ -461,7 +459,6 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
 static HYD_status send_exec_info(struct HYD_proxy *proxy)
 {
     struct HYD_pmcd_hdr hdr;
-    int sent, closed;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -508,6 +508,8 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
     proxy = &pg->proxy_list[proxy_id];
 
     /* This will be the control socket for this proxy */
+    // HYDU_ASSERT(proxy->node->control_fd == -1, status);
+    proxy->node->control_fd = fd;
     proxy->control_fd = fd;
 
     /* Send out the executable information */

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -220,37 +220,69 @@ HYD_status HYD_pmcd_pmiserv_send_signal(struct HYD_proxy *proxy, int signum)
     goto fn_exit;
 }
 
+static HYD_status stdin_cb(int fd, HYD_event_t events, void *userp)
+{
+    HYD_status status = HYD_SUCCESS;
+    HYDU_FUNC_ENTER();
+
+    struct HYD_proxy *proxy;
+    struct HYD_pg *pg;
+    /* assume stdin connected to the first pg and first proxy, but
+     * should be configurable */
+    int pgid = 0, proxy_id = 0;
+    pg = PMISERV_pg_by_id(pgid);
+    proxy = &pg->proxy_list[proxy_id];
+
+    /* Are we sure HYD_TMPBUF_SIZE (64k) is sufficient? */
+    HYDU_MALLOC_OR_JUMP(buf, char *, HYD_TMPBUF_SIZE, status);
+    HYDU_ERR_POP(status, "unable to allocate memory\n");
+
+    int count, closed;
+    char *buf;
+    status = HYDU_sock_read(STDIN_FILENO, buf, HYD_TMPBUF_SIZE, &count, &closed,
+                            HYDU_SOCK_COMM_NONE);
+    HYDU_ERR_POP(status, "error reading from stdin\n");
+
+    struct HYD_pmcd_hdr hdr;
+    HYD_pmcd_init_header(&hdr);
+    hdr.cmd = CMD_STDIN;
+    send_hdr_downstream(proxy, &hdr, buf, count);
+    HYDU_ERR_POP(status, "error writing to control socket\n");
+
+    if (!count) {
+        status = HYDT_dmx_deregister_fd(STDIN_FILENO);
+        HYDU_ERR_POP(status, "unable to deregister STDIN\n");
+    }
+
+    MPL_free(buf);
+
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+
 static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
 {
-    int count, closed;
-    struct HYD_pmcd_hdr hdr;
-    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
-    char *buf;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
+    int count, closed;
+    struct HYD_pmcd_hdr hdr;
+    status = HYDU_sock_read(fd, &hdr, sizeof(hdr), &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "unable to read command from proxy\n");
+    HYDU_ASSERT(!closed, status);
+
     int pgid, proxy_id;
-    if (fd == STDIN_FILENO) {
-        HYD_pmcd_init_header(&hdr);
-        hdr.cmd = CMD_STDIN;
-        /* assume stdin connected to the first pg and first proxy, but
-         * should be configurable */
-        pgid = 0;
-        proxy_id = 0;
-    } else {
-        status = HYDU_sock_read(fd, &hdr, sizeof(hdr), &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
-        HYDU_ERR_POP(status, "unable to read command from proxy\n");
-        HYDU_ASSERT(!closed, status);
-        pgid = hdr.pgid;
-        proxy_id = hdr.proxy_id;
-    }
+    pgid = hdr.pgid;
+    proxy_id = hdr.proxy_id;
 
     struct HYD_proxy *proxy;
     struct HYD_pg *pg;
     pg = PMISERV_pg_by_id(pgid);
     proxy = &pg->proxy_list[proxy_id];
-    HYDU_ASSERT(proxy == userp, status);
 
     if (hdr.cmd == CMD_PID_LIST) {      /* Got PIDs */
         HYDU_MALLOC_OR_JUMP(proxy->pid, int *, proxy->proxy_process_count * sizeof(int), status);
@@ -320,6 +352,7 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
             }
         }
     } else if (hdr.cmd == CMD_PMI) {
+        char *buf;
         HYDU_MALLOC_OR_JUMP(buf, char *, hdr.buflen + 1, status);
 
         status = HYDU_sock_read(fd, buf, hdr.buflen, &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
@@ -334,6 +367,7 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
 
         MPL_free(buf);
     } else if (hdr.cmd == CMD_STDOUT || hdr.cmd == CMD_STDERR) {
+        char *buf;
         HYDU_MALLOC_OR_JUMP(buf, char *, hdr.buflen, status);
 
         status = HYDU_sock_read(fd, buf, hdr.buflen, &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
@@ -348,28 +382,11 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
         HYDU_ERR_POP(status, "error in the UI defined callback\n");
 
         MPL_free(buf);
-    } else if (hdr.cmd == CMD_STDIN) {
-        HYDU_MALLOC_OR_JUMP(buf, char *, HYD_TMPBUF_SIZE, status);
-        HYDU_ERR_POP(status, "unable to allocate memory\n");
-
-        status =
-            HYDU_sock_read(STDIN_FILENO, buf, HYD_TMPBUF_SIZE, &count, &closed,
-                           HYDU_SOCK_COMM_NONE);
-        HYDU_ERR_POP(status, "error reading from stdin\n");
-
-        send_hdr_downstream(proxy, &hdr, buf, count);
-        HYDU_ERR_POP(status, "error writing to control socket\n");
-
-        if (!count) {
-            status = HYDT_dmx_deregister_fd(STDIN_FILENO);
-            HYDU_ERR_POP(status, "unable to deregister STDIN\n");
-        }
-
-        MPL_free(buf);
     } else if (hdr.cmd == CMD_PROCESS_TERMINATED) {
         int terminated_rank = hdr.u.data;
         if (HYD_server_info.user_global.auto_cleanup == 0) {
             /* Update the map of the alive processes */
+            struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
             pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
             pg_scratch->dead_process_count++;
 
@@ -531,7 +548,7 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
         HYDU_ERR_POP(status, "unable to check if stdin is valid\n");
 
         if (stdin_valid) {
-            status = HYDT_dmx_register_fd(1, &fd_stdin, HYD_POLLIN, proxy, control_cb);
+            status = HYDT_dmx_register_fd(1, &fd_stdin, HYD_POLLIN, proxy, stdin_cb);
             HYDU_ERR_POP(status, "unable to register fd\n");
         } else {
             hdr.cmd = CMD_STDIN;

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -13,8 +13,8 @@
 #include "pmiserv_common.h"
 #include "pmiserv_pmi.h"
 
-static HYD_status handle_pmi_cmd(struct HYD_proxy *proxy, int pgid, int pid, char *buf, int buflen,
-                                 int pmi_version)
+static HYD_status handle_pmi_cmd(struct HYD_proxy *proxy, int pgid, int process_fd, char *buf,
+                                 int buflen, int pmi_version)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -34,39 +34,39 @@ static HYD_status handle_pmi_cmd(struct HYD_proxy *proxy, int pgid, int pid, cha
 
     switch (pmi.cmd_id) {
         case PMIU_CMD_SPAWN:
-            status = HYD_pmiserv_spawn(proxy, pid, pgid, &pmi);
+            status = HYD_pmiserv_spawn(proxy, process_fd, pgid, &pmi);
             break;
         case PMIU_CMD_PUBLISH:
-            status = HYD_pmiserv_publish(proxy, pid, pgid, &pmi);
+            status = HYD_pmiserv_publish(proxy, process_fd, pgid, &pmi);
             break;
         case PMIU_CMD_UNPUBLISH:
-            status = HYD_pmiserv_unpublish(proxy, pid, pgid, &pmi);
+            status = HYD_pmiserv_unpublish(proxy, process_fd, pgid, &pmi);
             break;
         case PMIU_CMD_LOOKUP:
-            status = HYD_pmiserv_lookup(proxy, pid, pgid, &pmi);
+            status = HYD_pmiserv_lookup(proxy, process_fd, pgid, &pmi);
             break;
         case PMIU_CMD_GET:
-            status = HYD_pmiserv_kvs_get(proxy, pid, pgid, &pmi, false);
+            status = HYD_pmiserv_kvs_get(proxy, process_fd, pgid, &pmi, false);
             break;
         case PMIU_CMD_KVSGET:
-            status = HYD_pmiserv_kvs_get(proxy, pid, pgid, &pmi, true);
+            status = HYD_pmiserv_kvs_get(proxy, process_fd, pgid, &pmi, true);
             break;
         case PMIU_CMD_KVSPUT:
-            status = HYD_pmiserv_kvs_put(proxy, pid, pgid, &pmi);
+            status = HYD_pmiserv_kvs_put(proxy, process_fd, pgid, &pmi);
             break;
         case PMIU_CMD_MPUT:
             /* internal put with multiple key/val pairs */
-            status = HYD_pmiserv_kvs_mput(proxy, pid, pgid, &pmi);
+            status = HYD_pmiserv_kvs_mput(proxy, process_fd, pgid, &pmi);
             break;
         case PMIU_CMD_KVSFENCE:
-            status = HYD_pmiserv_kvs_fence(proxy, pid, pgid, &pmi);
+            status = HYD_pmiserv_kvs_fence(proxy, process_fd, pgid, &pmi);
             break;
         case PMIU_CMD_BARRIER:
             /* barrier_in from proxy */
-            status = HYD_pmiserv_barrier(proxy, pid, pgid, &pmi);
+            status = HYD_pmiserv_barrier(proxy, process_fd, pgid, &pmi);
             break;
         case PMIU_CMD_ABORT:
-            status = HYD_pmiserv_abort(proxy, pid, pgid, &pmi);
+            status = HYD_pmiserv_abort(proxy, process_fd, pgid, &pmi);
             break;
         default:
             /* We don't understand the command */
@@ -303,7 +303,7 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
 
         buf[hdr.buflen] = 0;
 
-        status = handle_pmi_cmd(proxy, proxy->pgid, hdr.u.pmi.pid, buf, hdr.buflen,
+        status = handle_pmi_cmd(proxy, proxy->pgid, hdr.u.pmi.process_fd, buf, hdr.buflen,
                                 hdr.u.pmi.pmi_version);
         HYDU_ERR_POP(status, "unable to process PMI command\n");
 

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -13,6 +13,35 @@
 #include "pmiserv_common.h"
 #include "pmiserv_pmi.h"
 
+HYD_status send_hdr_downstream(struct HYD_proxy *proxy, struct HYD_pmcd_hdr *hdr,
+                               void *buf, int buflen)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    hdr->pgid = proxy->pgid;
+    hdr->proxy_id = proxy->proxy_id;
+    hdr->buflen = buflen;
+
+    int closed, sent;
+    status = HYDU_sock_write(proxy->control_fd, hdr, sizeof(*hdr), &sent,
+                             &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "sock write error\n");
+    HYDU_ASSERT(!closed, status);
+
+    if (buflen > 0) {
+        status = HYDU_sock_write(proxy->control_fd, buf, buflen, &sent,
+                                 &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "sock write error\n");
+        HYDU_ASSERT(!closed, status);
+    }
+
+  fn_exit:
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+
+
 static HYD_status handle_pmi_cmd(struct HYD_proxy *proxy, int pgid, int process_fd, char *buf,
                                  int buflen, int pmi_version)
 {
@@ -190,10 +219,8 @@ HYD_status HYD_pmcd_pmiserv_send_signal(struct HYD_proxy *proxy, int signum)
     hdr.cmd = CMD_SIGNAL;
     hdr.u.data = signum;
 
-    status = HYDU_sock_write(proxy->control_fd, &hdr, sizeof(hdr), &sent, &closed,
-                             HYDU_SOCK_COMM_MSGWAIT);
+    status = send_hdr_downstream(proxy, &hdr, NULL, 0);
     HYDU_ERR_POP(status, "unable to write data to proxy\n");
-    HYDU_ASSERT(!closed, status);
 
   fn_exit:
     return status;
@@ -340,19 +367,10 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
                            HYDU_SOCK_COMM_NONE);
         HYDU_ERR_POP(status, "error reading from stdin\n");
 
-        hdr.buflen = count;
-
-        status = HYDU_sock_write(proxy->control_fd, &hdr, sizeof(hdr), &count, &closed,
-                                 HYDU_SOCK_COMM_MSGWAIT);
+        send_hdr_downstream(proxy, &hdr, buf, count);
         HYDU_ERR_POP(status, "error writing to control socket\n");
-        HYDU_ASSERT(!closed, status);
 
-        if (hdr.buflen) {
-            status = HYDU_sock_write(proxy->control_fd, buf, hdr.buflen, &count, &closed,
-                                     HYDU_SOCK_COMM_MSGWAIT);
-            HYDU_ERR_POP(status, "error writing to control socket\n");
-            HYDU_ASSERT(!closed, status);
-        } else {
+        if (!count) {
             status = HYDT_dmx_deregister_fd(STDIN_FILENO);
             HYDU_ERR_POP(status, "unable to deregister STDIN\n");
         }
@@ -450,10 +468,9 @@ static HYD_status send_exec_info(struct HYD_proxy *proxy)
 
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PROC_INFO;
-    status = HYDU_sock_write(proxy->control_fd, &hdr, sizeof(hdr), &sent, &closed,
-                             HYDU_SOCK_COMM_MSGWAIT);
+
+    status = send_hdr_downstream(proxy, &hdr, NULL, 0);
     HYDU_ERR_POP(status, "unable to write data to proxy\n");
-    HYDU_ASSERT(!closed, status);
 
     status = HYDU_send_strlist(proxy->control_fd, proxy->exec_launch_info);
     HYDU_ERR_POP(status, "error sending exec info\n");
@@ -527,11 +544,8 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
             HYDU_ERR_POP(status, "unable to register fd\n");
         } else {
             hdr.cmd = CMD_STDIN;
-            hdr.buflen = 0;
-            status = HYDU_sock_write(proxy->control_fd, &hdr, sizeof(hdr), &count, &closed,
-                                     HYDU_SOCK_COMM_MSGWAIT);
+            status = send_hdr_downstream(proxy, &hdr, NULL, 0);
             HYDU_ERR_POP(status, "error writing to control socket\n");
-            HYDU_ASSERT(!closed, status);
         }
     }
 

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -206,23 +206,34 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
 {
     int count, closed;
     struct HYD_pmcd_hdr hdr;
-    struct HYD_proxy *proxy, *tproxy;
+    struct HYD_proxy *tproxy;
     struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
     char *buf;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
-    proxy = (struct HYD_proxy *) userp;
-
+    int pgid, proxy_id;
     if (fd == STDIN_FILENO) {
         HYD_pmcd_init_header(&hdr);
         hdr.cmd = CMD_STDIN;
+        /* assume stdin connected to the first pg and first proxy, but
+         * should be configurable */
+        pgid = 0;
+        proxy_id = 0;
     } else {
         status = HYDU_sock_read(fd, &hdr, sizeof(hdr), &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
         HYDU_ERR_POP(status, "unable to read command from proxy\n");
         HYDU_ASSERT(!closed, status);
+        pgid = hdr.pgid;
+        proxy_id = hdr.proxy_id;
     }
+
+    struct HYD_proxy *proxy;
+    struct HYD_pg *pg;
+    pg = PMISERV_pg_by_id(pgid);
+    proxy = &pg->proxy_list[proxy_id];
+    HYDU_ASSERT(proxy == userp, status);
 
     if (hdr.cmd == CMD_PID_LIST) {      /* Got PIDs */
         HYDU_MALLOC_OR_JUMP(proxy->pid, int *, proxy->proxy_process_count * sizeof(int), status);
@@ -232,14 +243,11 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
         HYDU_ERR_POP(status, "unable to read status from proxy\n");
         HYDU_ASSERT(!closed, status);
 
-        if (proxy->pgid != 0) {
+        if (pgid != 0) {
             /* We initialize the debugger code only for non-dynamically
              * spawned processes */
             goto fn_exit;
         }
-
-        struct HYD_pg *pg;
-        pg = PMISERV_pg_by_id(proxy->pgid);
 
         /* Check if all the PIDs have been received */
         for (int i = 0; i < pg->proxy_count; i++) {
@@ -303,7 +311,7 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
 
         buf[hdr.buflen] = 0;
 
-        status = handle_pmi_cmd(proxy, proxy->pgid, hdr.u.pmi.process_fd, buf, hdr.buflen,
+        status = handle_pmi_cmd(proxy, pgid, hdr.u.pmi.process_fd, buf, hdr.buflen,
                                 hdr.u.pmi.pmi_version);
         HYDU_ERR_POP(status, "unable to process PMI command\n");
 
@@ -315,14 +323,11 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
         HYDU_ERR_POP(status, "unable to read PMI command from proxy\n");
         HYDU_ASSERT(!closed, status);
 
-        if (hdr.cmd == CMD_STDOUT)
-            status =
-                HYD_server_info.stdout_cb(hdr.u.io.pgid, hdr.u.io.proxy_id, hdr.u.io.rank, buf,
-                                          hdr.buflen);
-        else
-            status =
-                HYD_server_info.stderr_cb(hdr.u.io.pgid, hdr.u.io.proxy_id, hdr.u.io.rank, buf,
-                                          hdr.buflen);
+        if (hdr.cmd == CMD_STDOUT) {
+            status = HYD_server_info.stdout_cb(pgid, proxy_id, hdr.u.io.rank, buf, hdr.buflen);
+        } else {
+            status = HYD_server_info.stderr_cb(pgid, proxy_id, hdr.u.io.rank, buf, hdr.buflen);
+        }
         HYDU_ERR_POP(status, "error in the UI defined callback\n");
 
         MPL_free(buf);
@@ -357,7 +362,6 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
         int terminated_rank = hdr.u.data;
         if (HYD_server_info.user_global.auto_cleanup == 0) {
             /* Update the map of the alive processes */
-            struct HYD_pg *pg = PMISERV_pg_by_id(proxy->pgid);
             pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
             pg_scratch->dead_process_count++;
 
@@ -408,14 +412,15 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
                 pg_scratch->dead_processes = str;
             }
 
+            /* HZ: do we need broadcast to other pg? */
             for (int i = 0; i < PMISERV_pg_max_id(); i++) {
                 struct HYD_pg *tmp_pg = PMISERV_pg_by_id(i);
                 for (int j = 0; j < tmp_pg->proxy_count; j++) {
-                    tproxy = &tmp_pg->proxy_list[j];
+                    struct HYD_proxy *tproxy = &tmp_pg->proxy_list[j];
                     if (tproxy->control_fd == HYD_FD_UNSET || tproxy->control_fd == HYD_FD_CLOSED)
                         continue;
 
-                    if (tproxy->pgid == proxy->pgid && tproxy->proxy_id == proxy->proxy_id)
+                    if (tproxy == proxy)
                         continue;
 
                     status = HYD_pmcd_pmiserv_send_signal(tproxy, SIGUSR1);

--- a/src/pm/hydra/mpiexec/pmiserv_kvs.c
+++ b/src/pm/hydra/mpiexec/pmiserv_kvs.c
@@ -42,10 +42,10 @@ HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int process_fd, int pgid
     const char *kvsname;
     const char *key;
     pmi_errno = PMIU_msg_get_query_get(pmi, &kvsname, &key);
-    if (kvsname && strcmp(pg_scratch->kvs->kvsname, kvsname) != 0) {
+    if (kvsname && strcmp(pg_scratch->kvsname, kvsname) != 0) {
         HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
                             "kvsname (%s) does not match this group's kvs space (%s)\n",
-                            kvsname, pg_scratch->kvs->kvsname);
+                            kvsname, pg_scratch->kvsname);
     }
 
     int found;

--- a/src/pm/hydra/mpiexec/pmiserv_kvs.c
+++ b/src/pm/hydra/mpiexec/pmiserv_kvs.c
@@ -9,7 +9,7 @@
 
 struct HYD_pmcd_pmi_v2_reqs {
     struct HYD_proxy *proxy;
-    int pid;
+    int process_fd;
     int pgid;
     struct PMIU_cmd *pmi;
     const char *key;
@@ -20,15 +20,15 @@ struct HYD_pmcd_pmi_v2_reqs {
 
 static struct HYD_pmcd_pmi_v2_reqs *pending_reqs = NULL;
 
-static bool check_epoch_reached(struct HYD_pg *pg, int pid);
-static HYD_status HYD_pmcd_pmi_v2_queue_req(struct HYD_proxy *proxy, int pid, int pgid,
+static bool check_epoch_reached(struct HYD_pg *pg, int process_fd);
+static HYD_status HYD_pmcd_pmi_v2_queue_req(struct HYD_proxy *proxy, int process_fd, int pgid,
                                             struct PMIU_cmd *pmi, const char *key);
 static HYD_status check_pending_reqs(const char *key);
 
 static const bool is_static = true;
 
-HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi,
-                               bool sync)
+HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int process_fd, int pgid,
+                               struct PMIU_cmd *pmi, bool sync)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -70,8 +70,8 @@ HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int pid, int pgid, struc
         /* check whether all proxies have arrived at the same epoch or enqueue
          * the "get". A "put" (from another proxy) will poke the progress.
          */
-        if (!check_epoch_reached(pg, pid)) {
-            status = HYD_pmcd_pmi_v2_queue_req(proxy, pid, pgid, pmi, key);
+        if (!check_epoch_reached(pg, process_fd)) {
+            status = HYD_pmcd_pmi_v2_queue_req(proxy, process_fd, pgid, pmi, key);
             HYDU_ERR_POP(status, "unable to queue request\n");
             goto fn_exit;
         }
@@ -89,7 +89,7 @@ HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int pid, int pgid, struc
     }
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = HYD_pmiserv_pmi_reply(proxy, pid, &pmi_response);
+    status = HYD_pmiserv_pmi_reply(proxy, process_fd, &pmi_response);
     HYDU_ERR_POP(status, "error writing PMI line\n");
 
   fn_exit:
@@ -100,7 +100,8 @@ HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int pid, int pgid, struc
     goto fn_exit;
 }
 
-HYD_status HYD_pmiserv_kvs_put(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi)
+HYD_status HYD_pmiserv_kvs_put(struct HYD_proxy *proxy, int process_fd, int pgid,
+                               struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -123,7 +124,7 @@ HYD_status HYD_pmiserv_kvs_put(struct HYD_proxy *proxy, int pid, int pgid, struc
     pmi_errno = PMIU_msg_set_response(pmi, &pmi_response, is_static);
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = HYD_pmiserv_pmi_reply(proxy, pid, &pmi_response);
+    status = HYD_pmiserv_pmi_reply(proxy, process_fd, &pmi_response);
     HYDU_ERR_POP(status, "send command failed\n");
 
     status = check_pending_reqs(key);
@@ -137,7 +138,8 @@ HYD_status HYD_pmiserv_kvs_put(struct HYD_proxy *proxy, int pid, int pgid, struc
 }
 
 /* NOTE: this is an aggregate put from proxy with multiple key=val pairs */
-HYD_status HYD_pmiserv_kvs_mput(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi)
+HYD_status HYD_pmiserv_kvs_mput(struct HYD_proxy *proxy, int process_fd, int pgid,
+                                struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     HYDU_FUNC_ENTER();
@@ -162,7 +164,8 @@ HYD_status HYD_pmiserv_kvs_mput(struct HYD_proxy *proxy, int pid, int pgid, stru
     goto fn_exit;
 }
 
-HYD_status HYD_pmiserv_kvs_fence(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi)
+HYD_status HYD_pmiserv_kvs_fence(struct HYD_proxy *proxy, int process_fd, int pgid,
+                                 struct PMIU_cmd *pmi)
 {
     struct HYD_pg *pg;
     struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
@@ -178,7 +181,7 @@ HYD_status HYD_pmiserv_kvs_fence(struct HYD_proxy *proxy, int pid, int pgid, str
     int cur_epoch = -1;
     /* Try to find the epoch point of this process */
     for (i = 0; i < pg->pg_process_count; i++) {
-        if (pg_scratch->ecount[i].pid == pid) {
+        if (pg_scratch->ecount[i].process_fd == process_fd) {
             pg_scratch->ecount[i].epoch++;
             cur_epoch = pg_scratch->ecount[i].epoch;
             break;
@@ -192,7 +195,7 @@ HYD_status HYD_pmiserv_kvs_fence(struct HYD_proxy *proxy, int pid, int pgid, str
             if (pg_scratch->ecount[i].epoch == -1)
                 break;
 
-        pg_scratch->ecount[i].pid = pid;
+        pg_scratch->ecount[i].process_fd = process_fd;
         pg_scratch->ecount[i].epoch = 0;
         cur_epoch = pg_scratch->ecount[i].epoch;
     }
@@ -201,7 +204,6 @@ HYD_status HYD_pmiserv_kvs_fence(struct HYD_proxy *proxy, int pid, int pgid, str
     pmi_errno = PMIU_msg_set_response(pmi, &pmi_response, is_static);
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = HYD_pmiserv_pmi_reply(proxy, pid, &pmi_response);
     HYDU_ERR_POP(status, "send command failed\n");
 
     if (cur_epoch == pg_scratch->epoch) {
@@ -244,7 +246,7 @@ HYD_status HYD_pmiserv_epoch_init(struct HYD_pg *pg)
     /* initialize as sentinels. The first kvs-fence will fill the entry.
      * Subsequent kvs-fence will increment the epoch. */
     for (int i = 0; i < pg->pg_process_count; i++) {
-        pg_scratch->ecount[i].pid = -1;
+        pg_scratch->ecount[i].process_fd = -1;
         pg_scratch->ecount[i].epoch = -1;
     }
 
@@ -265,14 +267,14 @@ HYD_status HYD_pmiserv_epoch_free(struct HYD_pg *pg)
     return HYD_SUCCESS;
 }
 
-static bool check_epoch_reached(struct HYD_pg *pg, int pid)
+static bool check_epoch_reached(struct HYD_pg *pg, int process_fd)
 {
     struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
     pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
 
     int idx = -1;
     for (int i = 0; i < pg->pg_process_count; i++) {
-        if (pg_scratch->ecount[i].pid == pid) {
+        if (pg_scratch->ecount[i].process_fd == process_fd) {
             idx = i;
             break;
         }
@@ -288,7 +290,7 @@ static bool check_epoch_reached(struct HYD_pg *pg, int pid)
     return true;
 }
 
-static HYD_status HYD_pmcd_pmi_v2_queue_req(struct HYD_proxy *proxy, int pid, int pgid,
+static HYD_status HYD_pmcd_pmi_v2_queue_req(struct HYD_proxy *proxy, int process_fd, int pgid,
                                             struct PMIU_cmd *pmi, const char *key)
 {
     struct HYD_pmcd_pmi_v2_reqs *req, *tmp;
@@ -297,7 +299,7 @@ static HYD_status HYD_pmcd_pmi_v2_queue_req(struct HYD_proxy *proxy, int pid, in
     HYDU_MALLOC_OR_JUMP(req, struct HYD_pmcd_pmi_v2_reqs *, sizeof(struct HYD_pmcd_pmi_v2_reqs),
                         status);
     req->proxy = proxy;
-    req->pid = pid;
+    req->process_fd = process_fd;
     req->pgid = pgid;
     req->prev = NULL;
     req->next = NULL;
@@ -361,7 +363,7 @@ static HYD_status check_pending_reqs(const char *key)
                 list_tail = req;
             }
         } else {
-            status = HYD_pmiserv_kvs_get(req->proxy, req->pid, req->pgid, req->pmi, true);
+            status = HYD_pmiserv_kvs_get(req->proxy, req->process_fd, req->pgid, req->pmi, true);
             HYDU_ERR_POP(status, "kvs_get returned error\n");
 
             /* Free the dequeued request */

--- a/src/pm/hydra/mpiexec/pmiserv_misc.c
+++ b/src/pm/hydra/mpiexec/pmiserv_misc.c
@@ -10,7 +10,8 @@
 #include "pmiserv_utils.h"
 #include "bsci.h"
 
-HYD_status HYD_pmiserv_barrier(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi)
+HYD_status HYD_pmiserv_barrier(struct HYD_proxy *proxy, int process_fd, int pgid,
+                               struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -23,12 +24,12 @@ HYD_status HYD_pmiserv_barrier(struct HYD_proxy *proxy, int pid, int pgid, struc
     if (pg->barrier_count == pg->proxy_count) {
         pg->barrier_count = 0;
 
-        HYD_pmiserv_bcast_keyvals(proxy, pid);
+        HYD_pmiserv_bcast_keyvals(proxy, process_fd);
 
         struct PMIU_cmd pmi_response;
         PMIU_cmd_init_static(&pmi_response, 1, "barrier_out");
         for (int i = 0; i < pg->proxy_count; i++) {
-            status = HYD_pmiserv_pmi_reply(&pg->proxy_list[i], pid, &pmi_response);
+            status = HYD_pmiserv_pmi_reply(&pg->proxy_list[i], process_fd, &pmi_response);
             HYDU_ERR_POP(status, "error writing PMI line\n");
         }
     }
@@ -41,7 +42,8 @@ HYD_status HYD_pmiserv_barrier(struct HYD_proxy *proxy, int pid, int pgid, struc
     goto fn_exit;
 }
 
-HYD_status HYD_pmiserv_abort(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi)
+HYD_status HYD_pmiserv_abort(struct HYD_proxy *proxy, int process_fd, int pgid,
+                             struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;

--- a/src/pm/hydra/mpiexec/pmiserv_pmci.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmci.c
@@ -99,7 +99,7 @@ HYD_status HYD_pmci_launch_procs(void)
                                                  HYD_server_info.localhost,
                                                  HYD_server_info.port_range, &control_port,
                                                  HYD_pmcd_pmiserv_control_listen_cb,
-                                                 (void *) (size_t) 0);
+                                                 (void *) (size_t) pgid);
     HYDU_ERR_POP(status, "unable to create PMI port\n");
     if (HYD_server_info.user_global.debug)
         HYDU_dump(stdout, "Got a control port string of %s\n", control_port);
@@ -124,7 +124,7 @@ HYD_status HYD_pmci_launch_procs(void)
         if (control_fd[i] != HYD_FD_UNSET) {
             pg->proxy_list[i].control_fd = control_fd[i];
 
-            status = HYDT_dmx_register_fd(1, &control_fd[i], HYD_POLLIN, (void *) (size_t) 0,
+            status = HYDT_dmx_register_fd(1, &control_fd[i], HYD_POLLIN, (void *) (size_t) pgid,
                                           HYD_pmcd_pmiserv_proxy_init_cb);
             HYDU_ERR_POP(status, "unable to register fd\n");
         }

--- a/src/pm/hydra/mpiexec/pmiserv_pmci.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmci.c
@@ -75,7 +75,6 @@ static HYD_status ui_cmd_cb(int fd, HYD_event_t events, void *userp)
 HYD_status HYD_pmci_launch_procs(void)
 {
     struct HYD_string_stash proxy_stash;
-    char *control_port = NULL;
     int node_count, i, *control_fd;
     HYD_status status = HYD_SUCCESS;
 
@@ -95,23 +94,10 @@ HYD_status HYD_pmci_launch_procs(void)
     status = HYD_pmiserv_epoch_init(pg);
     HYDU_ERR_POP(status, "unable to init epoch\n");
 
-    int listen_fd;
-    status = HYDU_sock_create_and_listen_portstr(HYD_server_info.user_global.iface,
-                                                 HYD_server_info.localhost,
-                                                 HYD_server_info.port_range, &control_port,
-                                                 &listen_fd,
-                                                 HYD_pmcd_pmiserv_control_listen_cb,
-                                                 (void *) (size_t) pgid);
+    status = HYD_control_listen();
     HYDU_ERR_POP(status, "unable to create PMI port\n");
 
-    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
-    pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) PMISERV_pg_0->pg_scratch;
-    pg_scratch->control_listen_fd = listen_fd;
-
-    if (HYD_server_info.user_global.debug)
-        HYDU_dump(stdout, "Got a control port string of %s\n", control_port);
-
-    status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, control_port, 0);
+    status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, HYD_server_info.control_port, 0);
     HYDU_ERR_POP(status, "unable to fill in proxy arguments\n");
 
     status = HYD_pmcd_pmi_fill_in_exec_launch_info(pg);
@@ -140,7 +126,6 @@ HYD_status HYD_pmci_launch_procs(void)
     MPL_free(control_fd);
 
   fn_exit:
-    MPL_free(control_port);
     HYD_STRING_STASH_FREE(proxy_stash);
     HYDU_FUNC_EXIT();
     return status;

--- a/src/pm/hydra/mpiexec/pmiserv_pmci.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmci.c
@@ -131,7 +131,7 @@ HYD_status HYD_pmci_launch_procs(void)
         if (control_fd[i] != HYD_FD_UNSET) {
             pg->proxy_list[i].control_fd = control_fd[i];
 
-            status = HYDT_dmx_register_fd(1, &control_fd[i], HYD_POLLIN, (void *) (size_t) pgid,
+            status = HYDT_dmx_register_fd(1, &control_fd[i], HYD_POLLIN, NULL,
                                           HYD_pmcd_pmiserv_proxy_init_cb);
             HYDU_ERR_POP(status, "unable to register fd\n");
         }

--- a/src/pm/hydra/mpiexec/pmiserv_pmci.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmci.c
@@ -95,12 +95,19 @@ HYD_status HYD_pmci_launch_procs(void)
     status = HYD_pmiserv_epoch_init(pg);
     HYDU_ERR_POP(status, "unable to init epoch\n");
 
+    int listen_fd;
     status = HYDU_sock_create_and_listen_portstr(HYD_server_info.user_global.iface,
                                                  HYD_server_info.localhost,
                                                  HYD_server_info.port_range, &control_port,
+                                                 &listen_fd,
                                                  HYD_pmcd_pmiserv_control_listen_cb,
                                                  (void *) (size_t) pgid);
     HYDU_ERR_POP(status, "unable to create PMI port\n");
+
+    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
+    pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) PMISERV_pg_0->pg_scratch;
+    pg_scratch->control_listen_fd = listen_fd;
+
     if (HYD_server_info.user_global.debug)
         HYDU_dump(stdout, "Got a control port string of %s\n", control_port);
 

--- a/src/pm/hydra/mpiexec/pmiserv_pmi.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi.c
@@ -17,16 +17,16 @@ HYD_status HYD_pmcd_pmi_finalize(void)
     return status;
 }
 
-HYD_status HYD_pmiserv_pmi_reply(struct HYD_proxy * proxy, int pid, struct PMIU_cmd * pmi)
+HYD_status HYD_pmiserv_pmi_reply(struct HYD_proxy * proxy, int process_fd, struct PMIU_cmd * pmi)
 {
     struct HYD_pmcd_hdr hdr;
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PMI_RESPONSE;
-    hdr.u.pmi.pid = pid;
+    hdr.u.pmi.process_fd = process_fd;
     return HYD_pmcd_pmi_send(proxy->control_fd, pmi, &hdr, HYD_server_info.user_global.debug);
 }
 
-HYD_status HYD_pmiserv_bcast_keyvals(struct HYD_proxy * proxy, int pid)
+HYD_status HYD_pmiserv_bcast_keyvals(struct HYD_proxy * proxy, int process_fd)
 {
     int keyval_count, arg_count, j;
     struct HYD_pmcd_pmi_kvs_pair *run;
@@ -60,7 +60,7 @@ HYD_status HYD_pmiserv_bcast_keyvals(struct HYD_proxy * proxy, int pid)
             if (arg_count >= MAX_PMI_ARGS) {
                 pg_scratch->keyval_dist_count += (arg_count - 1);
                 for (int i = 0; i < pg->proxy_count; i++) {
-                    status = HYD_pmiserv_pmi_reply(&pg->proxy_list[i], pid, &pmi);
+                    status = HYD_pmiserv_pmi_reply(&pg->proxy_list[i], process_fd, &pmi);
                     HYDU_ERR_POP(status, "error writing PMI line\n");
                 }
 
@@ -72,7 +72,7 @@ HYD_status HYD_pmiserv_bcast_keyvals(struct HYD_proxy * proxy, int pid)
         if (arg_count > 1) {
             pg_scratch->keyval_dist_count += (arg_count - 1);
             for (int i = 0; i < pg->proxy_count; i++) {
-                status = HYD_pmiserv_pmi_reply(&pg->proxy_list[i], pid, &pmi);
+                status = HYD_pmiserv_pmi_reply(&pg->proxy_list[i], process_fd, &pmi);
                 HYDU_ERR_POP(status, "error writing PMI line\n");
             }
         }

--- a/src/pm/hydra/mpiexec/pmiserv_pmi.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi.c
@@ -22,6 +22,8 @@ HYD_status HYD_pmiserv_pmi_reply(struct HYD_proxy * proxy, int process_fd, struc
     struct HYD_pmcd_hdr hdr;
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PMI_RESPONSE;
+    hdr.pgid = proxy->pgid;
+    hdr.proxy_id = proxy->proxy_id;
     hdr.u.pmi.process_fd = process_fd;
     return HYD_pmcd_pmi_send(proxy->control_fd, pmi, &hdr, HYD_server_info.user_global.debug);
 }

--- a/src/pm/hydra/mpiexec/pmiserv_pmi.h
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi.h
@@ -21,7 +21,6 @@ struct HYD_pmcd_pmi_pg_scratch {
         int epoch;
     } *ecount;
 
-    int control_listen_fd;
     int pmi_listen_fd;
 
     char *dead_processes;

--- a/src/pm/hydra/mpiexec/pmiserv_pmi.h
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi.h
@@ -27,6 +27,7 @@ struct HYD_pmcd_pmi_pg_scratch {
     char *dead_processes;
     int dead_process_count;
 
+    char kvsname[PMI_MAXKVSLEN];
     struct HYD_pmcd_pmi_kvs *kvs;
     int keyval_dist_count;      /* Number of keyvals distributed */
 };

--- a/src/pm/hydra/mpiexec/pmiserv_pmi.h
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi.h
@@ -17,7 +17,7 @@ struct HYD_pmcd_pmi_pg_scratch {
     int epoch;
     int fence_count;
     struct HYD_pmcd_pmi_ecount {
-        int pid;
+        int process_fd;
         int epoch;
     } *ecount;
 
@@ -33,24 +33,33 @@ struct HYD_pmcd_pmi_pg_scratch {
 
 HYD_status HYD_pmcd_pmi_finalize(void);
 
-HYD_status HYD_pmiserv_pmi_reply(struct HYD_proxy *proxy, int pid, struct PMIU_cmd *pmi);
+HYD_status HYD_pmiserv_pmi_reply(struct HYD_proxy *proxy, int process_fd, struct PMIU_cmd *pmi);
 
-HYD_status HYD_pmiserv_bcast_keyvals(struct HYD_proxy *proxy, int pid);
+HYD_status HYD_pmiserv_bcast_keyvals(struct HYD_proxy *proxy, int process_fd);
 HYD_status HYD_pmiserv_epoch_init(struct HYD_pg *pg);
 HYD_status HYD_pmiserv_epoch_free(struct HYD_pg *pg);
 
-HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi,
-                               bool sync);
-HYD_status HYD_pmiserv_kvs_put(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi);
-HYD_status HYD_pmiserv_kvs_mput(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi);
-HYD_status HYD_pmiserv_kvs_fence(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi);
+HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int process_fd, int pgid,
+                               struct PMIU_cmd *pmi, bool sync);
+HYD_status HYD_pmiserv_kvs_put(struct HYD_proxy *proxy, int process_fd, int pgid,
+                               struct PMIU_cmd *pmi);
+HYD_status HYD_pmiserv_kvs_mput(struct HYD_proxy *proxy, int process_fd, int pgid,
+                                struct PMIU_cmd *pmi);
+HYD_status HYD_pmiserv_kvs_fence(struct HYD_proxy *proxy, int process_fd, int pgid,
+                                 struct PMIU_cmd *pmi);
 
-HYD_status HYD_pmiserv_barrier(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi);
-HYD_status HYD_pmiserv_abort(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi);
+HYD_status HYD_pmiserv_barrier(struct HYD_proxy *proxy, int process_fd, int pgid,
+                               struct PMIU_cmd *pmi);
+HYD_status HYD_pmiserv_abort(struct HYD_proxy *proxy, int process_fd, int pgid,
+                             struct PMIU_cmd *pmi);
 
-HYD_status HYD_pmiserv_spawn(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi);
-HYD_status HYD_pmiserv_publish(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi);
-HYD_status HYD_pmiserv_unpublish(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi);
-HYD_status HYD_pmiserv_lookup(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi);
+HYD_status HYD_pmiserv_spawn(struct HYD_proxy *proxy, int process_fd, int pgid,
+                             struct PMIU_cmd *pmi);
+HYD_status HYD_pmiserv_publish(struct HYD_proxy *proxy, int process_fd, int pgid,
+                               struct PMIU_cmd *pmi);
+HYD_status HYD_pmiserv_unpublish(struct HYD_proxy *proxy, int process_fd, int pgid,
+                                 struct PMIU_cmd *pmi);
+HYD_status HYD_pmiserv_lookup(struct HYD_proxy *proxy, int process_fd, int pgid,
+                              struct PMIU_cmd *pmi);
 
 #endif /* PMISERV_PMI_H_INCLUDED */

--- a/src/pm/hydra/mpiexec/pmiserv_publish.c
+++ b/src/pm/hydra/mpiexec/pmiserv_publish.c
@@ -21,7 +21,8 @@ static HYD_status server_publish(const char *name, const char *port, int *succes
 static HYD_status server_unpublish(const char *name, int *success);
 static HYD_status server_lookup(const char *name, const char **value);
 
-HYD_status HYD_pmiserv_publish(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi)
+HYD_status HYD_pmiserv_publish(struct HYD_proxy *proxy, int process_fd, int pgid,
+                               struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -44,7 +45,7 @@ HYD_status HYD_pmiserv_publish(struct HYD_proxy *proxy, int pid, int pgid, struc
     }
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = HYD_pmiserv_pmi_reply(proxy, pid, &pmi_response);
+    status = HYD_pmiserv_pmi_reply(proxy, process_fd, &pmi_response);
     HYDU_ERR_POP(status, "send command failed\n");
 
   fn_exit:
@@ -55,7 +56,8 @@ HYD_status HYD_pmiserv_publish(struct HYD_proxy *proxy, int pid, int pgid, struc
     goto fn_exit;
 }
 
-HYD_status HYD_pmiserv_unpublish(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi)
+HYD_status HYD_pmiserv_unpublish(struct HYD_proxy *proxy, int process_fd, int pgid,
+                                 struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -78,7 +80,7 @@ HYD_status HYD_pmiserv_unpublish(struct HYD_proxy *proxy, int pid, int pgid, str
     }
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = HYD_pmiserv_pmi_reply(proxy, pid, &pmi_response);
+    status = HYD_pmiserv_pmi_reply(proxy, process_fd, &pmi_response);
     HYDU_ERR_POP(status, "send command failed\n");
 
   fn_exit:
@@ -89,7 +91,8 @@ HYD_status HYD_pmiserv_unpublish(struct HYD_proxy *proxy, int pid, int pgid, str
     goto fn_exit;
 }
 
-HYD_status HYD_pmiserv_lookup(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi)
+HYD_status HYD_pmiserv_lookup(struct HYD_proxy *proxy, int process_fd, int pgid,
+                              struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -113,7 +116,7 @@ HYD_status HYD_pmiserv_lookup(struct HYD_proxy *proxy, int pid, int pgid, struct
     }
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = HYD_pmiserv_pmi_reply(proxy, pid, &pmi_response);
+    status = HYD_pmiserv_pmi_reply(proxy, process_fd, &pmi_response);
     HYDU_ERR_POP(status, "send command failed\n");
 
   fn_exit:

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -254,18 +254,34 @@ static HYD_status do_spawn(void)
     HYDU_ERR_POP(status, "error creating proxy list\n");
     HYDU_free_exec_list(exec_list);
 
-    status = HYD_control_listen();
-    HYDU_ERR_POP(status, "unable to create PMI port\n");
-
-    status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, HYD_server_info.control_port, pg->pgid);
-    HYDU_ERR_POP(status, "unable to fill in proxy arguments\n");
-
     status = HYD_pmcd_pmi_fill_in_exec_launch_info(pg);
     HYDU_ERR_POP(status, "unable to fill in executable arguments\n");
 
-    status = HYDT_bsci_launch_procs(proxy_stash.strlist, pg->proxy_list, pg->proxy_count,
-                                    HYD_FALSE, NULL);
-    HYDU_ERR_POP(status, "launcher cannot launch processes\n");
+    struct HYD_proxy *filtered_proxy_list;
+    filtered_proxy_list = MPL_malloc(pg->proxy_count * sizeof(struct HYD_proxy), MPL_MEM_OTHER);
+    int rem_count = 0;
+    for (int i = 0; i < pg->proxy_count; i++) {
+        if (pg->proxy_list[i].node->control_fd != -1) {
+            pg->proxy_list[i].control_fd = pg->proxy_list[i].node->control_fd;
+            pg->proxy_list[i].node->control_fd_refcnt++;
+            status = HYD_send_exec_info(&pg->proxy_list[i]);
+        } else {
+            filtered_proxy_list[rem_count] = pg->proxy_list[i];
+            rem_count++;
+        }
+    }
+    if (rem_count > 0) {
+        HYDU_ASSERT(HYD_server_info.control_listen_fd >= 0, status);
+
+        status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, HYD_server_info.control_port,
+                                                 pg->pgid);
+        HYDU_ERR_POP(status, "unable to fill in proxy arguments\n");
+
+        status = HYDT_bsci_launch_procs(proxy_stash.strlist, filtered_proxy_list, rem_count,
+                                        HYD_FALSE, NULL);
+        HYDU_ERR_POP(status, "launcher cannot launch processes\n");
+    }
+    MPL_free(filtered_proxy_list);
 
   fn_exit:
     HYD_STRING_STASH_FREE(proxy_stash);

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -254,28 +254,11 @@ static HYD_status do_spawn(void)
     HYDU_ERR_POP(status, "error creating proxy list\n");
     HYDU_free_exec_list(exec_list);
 
-    int pgid = pg->pgid;
-
-    char *control_port;
-    int listen_fd;
-    status = HYDU_sock_create_and_listen_portstr(HYD_server_info.user_global.iface,
-                                                 HYD_server_info.localhost,
-                                                 HYD_server_info.port_range, &control_port,
-                                                 &listen_fd,
-                                                 HYD_pmcd_pmiserv_control_listen_cb,
-                                                 (void *) (size_t) pgid);
+    status = HYD_control_listen();
     HYDU_ERR_POP(status, "unable to create PMI port\n");
 
-    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
-    pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
-    pg_scratch->control_listen_fd = listen_fd;
-
-    if (HYD_server_info.user_global.debug)
-        HYDU_dump(stdout, "Got a control port string of %s\n", control_port);
-
-    status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, control_port, pgid);
+    status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, HYD_server_info.control_port, pg->pgid);
     HYDU_ERR_POP(status, "unable to fill in proxy arguments\n");
-    MPL_free(control_port);
 
     status = HYD_pmcd_pmi_fill_in_exec_launch_info(pg);
     HYDU_ERR_POP(status, "unable to fill in executable arguments\n");

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -26,7 +26,8 @@ static HYD_status parse_info_hosts(const char *host_str, struct HYD_pg *pg);
 
 static const bool is_static = true;
 
-HYD_status HYD_pmiserv_spawn(struct HYD_proxy *proxy, int pid, int pgid, struct PMIU_cmd *pmi)
+HYD_status HYD_pmiserv_spawn(struct HYD_proxy *proxy, int process_fd, int pgid,
+                             struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -99,11 +100,11 @@ HYD_status HYD_pmiserv_spawn(struct HYD_proxy *proxy, int pid, int pgid, struct 
     pmi_errno = PMIU_msg_set_response(pmi, &pmi_response, is_static);
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = HYD_pmiserv_pmi_reply(proxy, pid, &pmi_response);
+    status = HYD_pmiserv_pmi_reply(proxy, process_fd, &pmi_response);
     HYDU_ERR_POP(status, "error writing PMI line\n");
 
     /* Cache the pre-initialized keyvals on the new proxies */
-    HYD_pmiserv_bcast_keyvals(proxy, pid);
+    HYD_pmiserv_bcast_keyvals(proxy, process_fd);
 
   fn_exit:
     if (need_free) {

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -257,12 +257,19 @@ static HYD_status do_spawn(void)
     int pgid = pg->pgid;
 
     char *control_port;
+    int listen_fd;
     status = HYDU_sock_create_and_listen_portstr(HYD_server_info.user_global.iface,
                                                  HYD_server_info.localhost,
                                                  HYD_server_info.port_range, &control_port,
+                                                 &listen_fd,
                                                  HYD_pmcd_pmiserv_control_listen_cb,
                                                  (void *) (size_t) pgid);
     HYDU_ERR_POP(status, "unable to create PMI port\n");
+
+    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
+    pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
+    pg_scratch->control_listen_fd = listen_fd;
+
     if (HYD_server_info.user_global.debug)
         HYDU_dump(stdout, "Got a control port string of %s\n", control_port);
 

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -9,6 +9,8 @@
 #include "pmiserv_pmi.h"
 #include "pmiserv_utils.h"
 
+static HYD_status gen_kvsname(char kvsname[], int pgid);
+
 HYD_status HYD_pmcd_pmi_fill_in_proxy_args(struct HYD_string_stash *proxy_stash,
                                            char *control_port, int pgid)
 {
@@ -387,13 +389,13 @@ HYD_status HYD_pmcd_pmi_fill_in_exec_launch_info(struct HYD_pg *pg)
 
         pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
         HYD_STRING_STASH(exec_stash, MPL_strdup("--pmi-kvsname"), status);
-        HYD_STRING_STASH(exec_stash, MPL_strdup(pg_scratch->kvs->kvsname), status);
+        HYD_STRING_STASH(exec_stash, MPL_strdup(pg_scratch->kvsname), status);
 
         if (pg->spawner_pgid != -1) {
             struct HYD_pg *spawner_pg = PMISERV_pg_by_id(pg->spawner_pgid);
             pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) spawner_pg->pg_scratch;
             HYD_STRING_STASH(exec_stash, MPL_strdup("--pmi-spawner-kvsname"), status);
-            HYD_STRING_STASH(exec_stash, MPL_strdup(pg_scratch->kvs->kvsname), status);
+            HYD_STRING_STASH(exec_stash, MPL_strdup(pg_scratch->kvsname), status);
         }
 
         HYD_STRING_STASH(exec_stash, MPL_strdup("--pmi-process-mapping"), status);
@@ -518,7 +520,10 @@ HYD_status HYD_pmcd_pmi_alloc_pg_scratch(struct HYD_pg *pg)
     pg_scratch->dead_processes = MPL_strdup("");
     pg_scratch->dead_process_count = 0;
 
-    status = HYD_pmcd_pmi_allocate_kvs(&pg_scratch->kvs, pg->pgid);
+    status = gen_kvsname(pg_scratch->kvsname, pg->pgid);
+    HYDU_ERR_POP(status, "error in generating kvsname\n");
+
+    status = HYD_pmcd_pmi_allocate_kvs(&pg_scratch->kvs);
     HYDU_ERR_POP(status, "unable to allocate kvs space\n");
 
     pg_scratch->keyval_dist_count = 0;
@@ -552,4 +557,34 @@ HYD_status HYD_pmcd_pmi_free_pg_scratch(struct HYD_pg *pg)
 
     HYDU_FUNC_EXIT();
     return status;
+}
+
+static HYD_status gen_kvsname(char kvsname[], int pgid)
+{
+    HYD_status status = HYD_SUCCESS;
+    HYDU_FUNC_ENTER();
+
+    char hostname[MAX_HOSTNAME_LEN - 40];       /* Remove space taken up by the integers and other
+                                                 * characters below. */
+    unsigned int seed;
+    MPL_time_t tv;
+    double secs;
+    int rnd;
+
+    if (gethostname(hostname, MAX_HOSTNAME_LEN - 40) < 0)
+        HYDU_ERR_SETANDJUMP(status, HYD_SOCK_ERROR, "unable to get local hostname\n");
+
+    MPL_wtime(&tv);
+    MPL_wtime_todouble(&tv, &secs);
+    seed = (unsigned int) (secs * 1e6);
+    srand(seed);
+    rnd = rand();
+
+    MPL_snprintf_nowarn(kvsname, PMI_MAXKVSLEN, "kvs_%d_%d_%d_%s", (int) getpid(), pgid,
+                        rnd, hostname);
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -514,7 +514,6 @@ HYD_status HYD_pmcd_pmi_alloc_pg_scratch(struct HYD_pg *pg)
     pg_scratch->epoch = 0;
     pg_scratch->fence_count = 0;
 
-    pg_scratch->control_listen_fd = HYD_FD_UNSET;
     pg_scratch->pmi_listen_fd = HYD_FD_UNSET;
 
     pg_scratch->dead_processes = MPL_strdup("");

--- a/src/pm/hydra/mpiexec/uiu.c
+++ b/src/pm/hydra/mpiexec/uiu.c
@@ -35,6 +35,8 @@ void HYD_uiu_init_params(void)
     HYD_server_info.stderr_cb = NULL;
 
     HYD_server_info.node_list = NULL;
+    HYD_server_info.control_port = NULL;
+    HYD_server_info.control_listen_fd = -1;
 
 #if defined ENABLE_PROFILING
     HYD_server_info.enable_profiling = -1;
@@ -59,6 +61,12 @@ void HYD_uiu_free_params(void)
     MPL_free(HYD_ui_mpich_info.prepend_pattern);
     MPL_free(HYD_ui_mpich_info.outfile_pattern);
     MPL_free(HYD_ui_mpich_info.errfile_pattern);
+
+    MPL_free(HYD_server_info.control_port);
+    if (HYD_server_info.control_listen_fd != -1) {
+        close(HYD_server_info.control_listen_fd);
+        HYD_server_info.control_listen_fd = -1;
+    }
 
     for (run = stdoe_fd_list; run;) {
         close(run->fd);

--- a/src/pm/hydra/proxy/Makefile.mk
+++ b/src/pm/hydra/proxy/Makefile.mk
@@ -7,6 +7,7 @@ bin_PROGRAMS += hydra_pmi_proxy
 
 hydra_pmi_proxy_SOURCES = \
     proxy/pmip.c \
+    proxy/pmip_pg.c \
     proxy/pmip_cb.c \
     proxy/pmip_utils.c \
     proxy/pmip_pmi.c

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -17,15 +17,6 @@ static HYD_status init_params(void)
 
     HYDU_init_user_global(&HYD_pmcd_pmip.user_global);
 
-    HYD_pmcd_pmip.system_global.global_core_map.local_filler = -1;
-    HYD_pmcd_pmip.system_global.global_core_map.local_count = -1;
-    HYD_pmcd_pmip.system_global.global_core_map.global_count = -1;
-    HYD_pmcd_pmip.system_global.pmi_id_map.filler_start = -1;
-    HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start = -1;
-
-    HYD_pmcd_pmip.system_global.global_process_count = -1;
-    HYD_pmcd_pmip.system_global.pmi_process_mapping = NULL;
-
     HYD_pmcd_pmip.upstream.server_name = NULL;
     HYD_pmcd_pmip.upstream.server_port = -1;
     HYD_pmcd_pmip.upstream.control = HYD_FD_UNSET;
@@ -34,7 +25,6 @@ static HYD_status init_params(void)
     HYD_pmcd_pmip.local.pgid = -1;
     HYD_pmcd_pmip.local.iface_ip_env_name = NULL;
     HYD_pmcd_pmip.local.hostname = NULL;
-    HYD_pmcd_pmip.local.spawner_kvsname = NULL;
     HYD_pmcd_pmip.local.retries = -1;
 
     HYD_pmcd_pmip.exec_list = NULL;
@@ -50,9 +40,6 @@ static void cleanup_params(void)
 {
     HYDU_finalize_user_global(&HYD_pmcd_pmip.user_global);
 
-    /* System global */
-    MPL_free(HYD_pmcd_pmip.system_global.pmi_process_mapping);
-
 
     /* Upstream */
     MPL_free(HYD_pmcd_pmip.upstream.server_name);
@@ -61,7 +48,6 @@ static void cleanup_params(void)
     /* Local */
     MPL_free(HYD_pmcd_pmip.local.iface_ip_env_name);
     MPL_free(HYD_pmcd_pmip.local.hostname);
-    MPL_free(HYD_pmcd_pmip.local.spawner_kvsname);
 
     HYD_pmcd_free_pmi_kvs_list(HYD_pmcd_pmip.local.kvs);
 

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -24,8 +24,6 @@ static HYD_status init_params(void)
     HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start = -1;
 
     HYD_pmcd_pmip.system_global.global_process_count = -1;
-    HYD_pmcd_pmip.system_global.pmi_fd = NULL;
-    HYD_pmcd_pmip.system_global.pmi_rank = -1;
     HYD_pmcd_pmip.system_global.pmi_process_mapping = NULL;
 
     HYD_pmcd_pmip.upstream.server_name = NULL;
@@ -54,7 +52,6 @@ static void cleanup_params(void)
     HYDU_finalize_user_global(&HYD_pmcd_pmip.user_global);
 
     /* System global */
-    MPL_free(HYD_pmcd_pmip.system_global.pmi_fd);
     MPL_free(HYD_pmcd_pmip.system_global.pmi_process_mapping);
 
 

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -23,8 +23,6 @@ static HYD_status init_params(void)
 
     HYD_pmcd_pmip.local.id = -1;
     HYD_pmcd_pmip.local.pgid = -1;
-    HYD_pmcd_pmip.local.iface_ip_env_name = NULL;
-    HYD_pmcd_pmip.local.hostname = NULL;
     HYD_pmcd_pmip.local.retries = -1;
 
     PMIP_pg_init();
@@ -39,11 +37,6 @@ static void cleanup_params(void)
 
     /* Upstream */
     MPL_free(HYD_pmcd_pmip.upstream.server_name);
-
-
-    /* Local */
-    MPL_free(HYD_pmcd_pmip.local.iface_ip_env_name);
-    MPL_free(HYD_pmcd_pmip.local.hostname);
 
 
     PMIP_pg_finalize();
@@ -66,10 +59,11 @@ static void signal_cb(int sig)
     return;
 }
 
+static HYD_status pg_exit(struct pmip_pg *pg);
+
 int main(int argc, char **argv)
 {
     int pid, ret_status, sent, closed, ret, done;
-    struct HYD_pmcd_hdr hdr;
     HYD_status status = HYD_SUCCESS;
 
     status = HYDU_dbg_init("proxy:unset");
@@ -157,12 +151,12 @@ int main(int argc, char **argv)
         }
     }
 
-    struct pmip_pg *pg_0;
-    pg_0 = PMIP_pg_0();
-    HYDU_ASSERT(pg_0, status);
-
     /* collect exit_status unless it is a singleton */
     if (HYD_pmcd_pmip.user_global.singleton_pid > 0) {
+        struct pmip_pg *pg_0;
+        pg_0 = PMIP_pg_0();
+        HYDU_ASSERT(pg_0, status);
+
         HYDU_ASSERT(pg_0->num_procs == 1, status);
         HYDU_ASSERT(pg_0->downstreams[0].pid == HYD_pmcd_pmip.user_global.singleton_pid, status);
         /* We won't get the singleton's exit status. Assume it's 0. */
@@ -197,15 +191,8 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Send the exit status upstream */
-    HYD_pmcd_init_header(&hdr);
-    hdr.cmd = CMD_EXIT_STATUS;
-
-    int *exit_status_list;
-    exit_status_list = PMIP_pg_get_exit_status_list(pg_0);
-    PMIP_send_hdr_upstream(pg_0, &hdr, exit_status_list, pg_0->num_procs * sizeof(int));
-    HYDU_ERR_POP(status, "unable to send EXIT_STATUS command upstream\n");
-    MPL_free(exit_status_list);
+    status = PMIP_foreach_pg_do(pg_exit);
+    HYDU_ERR_POP(status, "error sending exit statuses for each pg\n");
 
     status = HYDT_dmx_deregister_fd(HYD_pmcd_pmip.upstream.control);
     HYDU_ERR_POP(status, "unable to deregister fd\n");
@@ -227,5 +214,26 @@ int main(int argc, char **argv)
   fn_fail:
     /* kill all processes */
     PMIP_bcast_signal(SIGKILL);
+    goto fn_exit;
+}
+
+static HYD_status pg_exit(struct pmip_pg *pg)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    struct HYD_pmcd_hdr hdr;
+    HYD_pmcd_init_header(&hdr);
+    hdr.cmd = CMD_EXIT_STATUS;
+
+    int *exit_status_list;
+    exit_status_list = PMIP_pg_get_exit_status_list(pg);
+    PMIP_send_hdr_upstream(pg, &hdr, exit_status_list, pg->num_procs * sizeof(int));
+    HYDU_ERR_POP(status, "unable to send EXIT_STATUS command upstream for proxy %d - %d\n",
+                 pg->pgid, pg->proxy_id);
+    MPL_free(exit_status_list);
+
+  fn_exit:
+    return status;
+  fn_fail:
     goto fn_exit;
 }

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -29,8 +29,6 @@ static HYD_status init_params(void)
 
     PMIP_pg_init();
 
-    status = HYD_pmcd_pmi_allocate_kvs(&HYD_pmcd_pmip.local.kvs, -1);
-
     return status;
 }
 
@@ -46,8 +44,6 @@ static void cleanup_params(void)
     /* Local */
     MPL_free(HYD_pmcd_pmip.local.iface_ip_env_name);
     MPL_free(HYD_pmcd_pmip.local.hostname);
-
-    HYD_pmcd_free_pmi_kvs_list(HYD_pmcd_pmip.local.kvs);
 
 
     PMIP_pg_finalize();

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -68,7 +68,7 @@ static void signal_cb(int sig)
 
 int main(int argc, char **argv)
 {
-    int i, count, pid, ret_status, sent, closed, ret, done;
+    int pid, ret_status, sent, closed, ret, done;
     struct HYD_pmcd_hdr hdr;
     HYD_status status = HYD_SUCCESS;
 

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -114,6 +114,7 @@ int main(int argc, char **argv)
 
     struct HYD_pmcd_init_hdr init_hdr;
     strncpy(init_hdr.signature, "HYD", 4);
+    init_hdr.pgid = HYD_pmcd_pmip.local.pgid;
     init_hdr.proxy_id = HYD_pmcd_pmip.local.id;
     status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control,
                              &init_hdr, sizeof(init_hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -35,7 +35,6 @@ static HYD_status init_params(void)
     HYD_pmcd_pmip.local.iface_ip_env_name = NULL;
     HYD_pmcd_pmip.local.hostname = NULL;
     HYD_pmcd_pmip.local.spawner_kvsname = NULL;
-    HYD_pmcd_pmip.local.proxy_core_count = -1;
     HYD_pmcd_pmip.local.retries = -1;
 
     HYD_pmcd_pmip.exec_list = NULL;

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -27,8 +27,6 @@ static HYD_status init_params(void)
     HYD_pmcd_pmip.local.hostname = NULL;
     HYD_pmcd_pmip.local.retries = -1;
 
-    HYD_pmcd_pmip.exec_list = NULL;
-
     PMIP_pg_init();
 
     status = HYD_pmcd_pmi_allocate_kvs(&HYD_pmcd_pmip.local.kvs, -1);
@@ -51,9 +49,6 @@ static void cleanup_params(void)
 
     HYD_pmcd_free_pmi_kvs_list(HYD_pmcd_pmip.local.kvs);
 
-
-    /* Exec list */
-    HYDU_free_exec_list(HYD_pmcd_pmip.exec_list);
 
     PMIP_pg_finalize();
     HYDT_topo_finalize();

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
 
     int *exit_status_list;
     exit_status_list = PMIP_pg_get_exit_status_list(pg_0);
-    PMIP_send_hdr_upstream(&hdr, exit_status_list, pg_0->num_procs * sizeof(int));
+    PMIP_send_hdr_upstream(pg_0, &hdr, exit_status_list, pg_0->num_procs * sizeof(int));
     HYDU_ERR_POP(status, "unable to send EXIT_STATUS command upstream\n");
     MPL_free(exit_status_list);
 

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -245,18 +245,9 @@ int main(int argc, char **argv)
     /* Send the exit status upstream */
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_EXIT_STATUS;
-    status =
-        HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed,
-                        HYDU_SOCK_COMM_MSGWAIT);
+    PMIP_send_hdr_upstream(&hdr, HYD_pmcd_pmip.downstream.exit_status,
+                           HYD_pmcd_pmip.local.proxy_process_count * sizeof(int));
     HYDU_ERR_POP(status, "unable to send EXIT_STATUS command upstream\n");
-    HYDU_ASSERT(!closed, status);
-
-    status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control,
-                             HYD_pmcd_pmip.downstream.exit_status,
-                             HYD_pmcd_pmip.local.proxy_process_count * sizeof(int), &sent,
-                             &closed, HYDU_SOCK_COMM_MSGWAIT);
-    HYDU_ERR_POP(status, "unable to return exit status upstream\n");
-    HYDU_ASSERT(!closed, status);
 
     status = HYDT_dmx_deregister_fd(HYD_pmcd_pmip.upstream.control);
     HYDU_ERR_POP(status, "unable to deregister fd\n");

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -32,24 +32,17 @@ static HYD_status init_params(void)
     HYD_pmcd_pmip.upstream.server_port = -1;
     HYD_pmcd_pmip.upstream.control = HYD_FD_UNSET;
 
-    HYD_pmcd_pmip.downstream.out = NULL;
-    HYD_pmcd_pmip.downstream.err = NULL;
-    HYD_pmcd_pmip.downstream.in = HYD_FD_UNSET;
-    HYD_pmcd_pmip.downstream.pid = NULL;
-    HYD_pmcd_pmip.downstream.exit_status = NULL;
-    HYD_pmcd_pmip.downstream.pmi_rank = NULL;
-    HYD_pmcd_pmip.downstream.pmi_fd = NULL;
-
     HYD_pmcd_pmip.local.id = -1;
     HYD_pmcd_pmip.local.pgid = -1;
     HYD_pmcd_pmip.local.iface_ip_env_name = NULL;
     HYD_pmcd_pmip.local.hostname = NULL;
     HYD_pmcd_pmip.local.spawner_kvsname = NULL;
     HYD_pmcd_pmip.local.proxy_core_count = -1;
-    HYD_pmcd_pmip.local.proxy_process_count = -1;
     HYD_pmcd_pmip.local.retries = -1;
 
     HYD_pmcd_pmip.exec_list = NULL;
+
+    PMIP_pg_init();
 
     status = HYD_pmcd_pmi_allocate_kvs(&HYD_pmcd_pmip.local.kvs, -1);
 
@@ -69,16 +62,6 @@ static void cleanup_params(void)
     MPL_free(HYD_pmcd_pmip.upstream.server_name);
 
 
-    /* Downstream */
-    MPL_free(HYD_pmcd_pmip.downstream.out);
-    MPL_free(HYD_pmcd_pmip.downstream.err);
-    MPL_free(HYD_pmcd_pmip.downstream.pid);
-    MPL_free(HYD_pmcd_pmip.downstream.exit_status);
-    MPL_free(HYD_pmcd_pmip.downstream.pmi_rank);
-    MPL_free(HYD_pmcd_pmip.downstream.pmi_fd);
-    MPL_free(HYD_pmcd_pmip.downstream.pmi_fd_active);
-
-
     /* Local */
     MPL_free(HYD_pmcd_pmip.local.iface_ip_env_name);
     MPL_free(HYD_pmcd_pmip.local.hostname);
@@ -90,6 +73,7 @@ static void cleanup_params(void)
     /* Exec list */
     HYDU_free_exec_list(HYD_pmcd_pmip.exec_list);
 
+    PMIP_pg_finalize();
     HYDT_topo_finalize();
 }
 
@@ -99,9 +83,9 @@ static void signal_cb(int sig)
 
     if (sig == SIGPIPE) {
         /* Upstream socket closed; kill all processes */
-        HYD_pmcd_pmip_send_signal(SIGKILL);
+        PMIP_bcast_signal(SIGKILL);
     } else if (sig == SIGTSTP) {
-        HYD_pmcd_pmip_send_signal(sig);
+        PMIP_bcast_signal(sig);
     }
     /* Ignore other signals for now */
 
@@ -174,65 +158,62 @@ int main(int argc, char **argv)
         status = HYDT_dmx_wait_for_event(-1);
         HYDU_ERR_POP(status, "demux engine error waiting for event\n");
 
-        /* Check to see if there's any open read socket left; if there
-         * are, we will just wait for more events. */
-        count = 0;
-        for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
-            if (HYD_pmcd_pmip.downstream.out[i] != HYD_FD_CLOSED)
-                count++;
-            if (HYD_pmcd_pmip.downstream.err[i] != HYD_FD_CLOSED)
-                count++;
-
-            if (count)
-                break;
+        if (!PMIP_pg_0()) {
+            /* processes haven't been launched yet */
+            continue;
         }
-        if (!count)
+
+        /* Exit the loop if no open read socket left */
+        if (!PMIP_has_open_stdoe()) {
             break;
+        }
 
         pid = waitpid(-1, &ret_status, WNOHANG);
+
         if (pid > 0) {
-            for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
-                if (HYD_pmcd_pmip.downstream.pid[i] == pid) {
-                    HYD_pmcd_pmip.downstream.exit_status[i] = ret_status;
-                    if (WIFSIGNALED(ret_status)) {
-                        /* kill all processes */
-                        HYD_pmcd_pmip_send_signal(SIGKILL);
-                    }
-                    done++;
-                    break;
+            struct pmip_downstream *p = PMIP_find_downstream_by_pid(pid);
+            if (p) {
+                p->exit_status = ret_status;
+                if (WIFSIGNALED(ret_status)) {
+                    /* kill all processes */
+                    PMIP_bcast_signal(SIGKILL);
                 }
+                done++;
             }
         }
     }
 
+    struct pmip_pg *pg_0;
+    pg_0 = PMIP_pg_0();
+    HYDU_ASSERT(pg_0, status);
+
     /* collect exit_status unless it is a singleton */
     if (HYD_pmcd_pmip.user_global.singleton_pid > 0) {
-        HYDU_ASSERT(HYD_pmcd_pmip.local.proxy_process_count == 1, status);
-        HYDU_ASSERT(HYD_pmcd_pmip.downstream.pid[0] == HYD_pmcd_pmip.user_global.singleton_pid,
-                    status);
+        HYDU_ASSERT(pg_0->num_procs == 1, status);
+        HYDU_ASSERT(pg_0->downstreams[0].pid == HYD_pmcd_pmip.user_global.singleton_pid, status);
         /* We won't get the singleton's exit status. Assume it's 0. */
-        if (HYD_pmcd_pmip.downstream.exit_status[0] == PMIP_EXIT_STATUS_UNSET) {
-            HYD_pmcd_pmip.downstream.exit_status[0] = 0;
+        if (pg_0->downstreams[0].exit_status == PMIP_EXIT_STATUS_UNSET) {
+            pg_0->downstreams[0].exit_status = 0;
         }
     } else {
         /* Wait for the processes to finish */
+        int total_count = PMIP_get_total_process_count();
         while (1) {
             pid = waitpid(-1, &ret_status, 0);
 
             /* Find the pid and mark it as complete. */
             if (pid > 0) {
-                for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
-                    if (HYD_pmcd_pmip.downstream.pid[i] == pid) {
-                        if (HYD_pmcd_pmip.downstream.exit_status[i] == PMIP_EXIT_STATUS_UNSET) {
-                            HYD_pmcd_pmip.downstream.exit_status[i] = ret_status;
-                        }
-                        done++;
+                struct pmip_downstream *tmp = PMIP_find_downstream_by_pid(pid);
+                if (tmp) {
+                    if (tmp->exit_status == PMIP_EXIT_STATUS_UNSET) {
+                        tmp->exit_status = ret_status;
                     }
+                    done++;
                 }
             }
 
             /* If no more processes are pending, break out */
-            if (done == HYD_pmcd_pmip.local.proxy_process_count)
+            if (done == total_count)
                 break;
 
             /* Check if there are any messages from the launcher */
@@ -245,9 +226,12 @@ int main(int argc, char **argv)
     /* Send the exit status upstream */
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_EXIT_STATUS;
-    PMIP_send_hdr_upstream(&hdr, HYD_pmcd_pmip.downstream.exit_status,
-                           HYD_pmcd_pmip.local.proxy_process_count * sizeof(int));
+
+    int *exit_status_list;
+    exit_status_list = PMIP_pg_get_exit_status_list(pg_0);
+    PMIP_send_hdr_upstream(&hdr, exit_status_list, pg_0->num_procs * sizeof(int));
     HYDU_ERR_POP(status, "unable to send EXIT_STATUS command upstream\n");
+    MPL_free(exit_status_list);
 
     status = HYDT_dmx_deregister_fd(HYD_pmcd_pmip.upstream.control);
     HYDU_ERR_POP(status, "unable to deregister fd\n");
@@ -268,6 +252,6 @@ int main(int argc, char **argv)
 
   fn_fail:
     /* kill all processes */
-    HYD_pmcd_pmip_send_signal(SIGKILL);
+    PMIP_bcast_signal(SIGKILL);
     goto fn_exit;
 }

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -37,9 +37,6 @@ struct HYD_pmcd_pmip_s {
 
         int retries;
     } local;
-
-    /* Process segmentation information for this proxy */
-    struct HYD_exec *exec_list;
 };
 
 /* downstreams */
@@ -82,10 +79,11 @@ struct pmip_pg {
     } pmi_id_map;
 
     int global_process_count;
-
     char *pmi_process_mapping;
-
     char *spawner_kvsname;
+
+    /* Process segmentation information for this proxy */
+    struct HYD_exec *exec_list;
 };
 
 extern struct HYD_pmcd_pmip_s HYD_pmcd_pmip;

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -58,6 +58,18 @@ struct pmip_downstream {
  * at the server. Each pmip_pg hosts a list of downstream processes.
  */
 
+#define CACHE_PUT_KEYVAL_MAXLEN  (MAX_PMI_ARGS - 1)
+struct cache_put_elem {
+    struct PMIU_token tokens[CACHE_PUT_KEYVAL_MAXLEN + 1];
+    int keyval_len;
+};
+
+struct cache_elem {
+    char *key;
+    char *val;
+    UT_hash_handle hh;
+};
+
 struct pmip_pg {
     int pgid;
     int proxy_id;
@@ -86,6 +98,12 @@ struct pmip_pg {
 
     /* This is for PMI-2 info-putnodeattr. Should it be per-node or per pg? */
     struct HYD_pmcd_pmi_kvs *kvs;
+
+    /* PMI-1 caches server kvs locally */
+    struct cache_put_elem cache_put;
+    struct cache_elem *cache_get;
+    struct cache_elem *hash_get;
+    int num_elems;
 };
 
 extern struct HYD_pmcd_pmip_s HYD_pmcd_pmip;

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -20,24 +20,6 @@ struct HYD_pmcd_pmip_s {
     struct HYD_user_global user_global;
 
     struct {
-        struct {
-            int local_filler;
-            int local_count;
-            int global_count;
-        } global_core_map;
-
-        struct {
-            int filler_start;
-            int non_filler_start;
-        } pmi_id_map;
-
-        int global_process_count;
-
-        /* PMI */
-        char *pmi_process_mapping;
-    } system_global;            /* Global system parameters */
-
-    struct {
         /* Upstream server contact information */
         char *server_name;
         int server_port;
@@ -51,8 +33,7 @@ struct HYD_pmcd_pmip_s {
         char *iface_ip_env_name;
         char *hostname;
 
-        char *spawner_kvsname;
-        struct HYD_pmcd_pmi_kvs *kvs;   /* Node-level KVS space for node attributes */
+        struct HYD_pmcd_pmi_kvs *kvs;
 
         int retries;
     } local;
@@ -88,11 +69,29 @@ struct pmip_pg {
 
     int num_procs;
     struct pmip_downstream *downstreams;
+
+    struct {
+        int local_filler;
+        int local_count;
+        int global_count;
+    } global_core_map;
+
+    struct {
+        int filler_start;
+        int non_filler_start;
+    } pmi_id_map;
+
+    int global_process_count;
+
+    char *pmi_process_mapping;
+
+    char *spawner_kvsname;
 };
 
 extern struct HYD_pmcd_pmip_s HYD_pmcd_pmip;
 extern struct HYD_arg_match_table HYD_pmcd_pmip_match_table[];
 
+void HYD_set_cur_pg(struct pmip_pg *pg);
 HYD_status HYD_pmcd_pmip_get_params(char **t_argv);
 
 #define PMIP_EXIT_STATUS_UNSET -1

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -33,8 +33,6 @@ struct HYD_pmcd_pmip_s {
         char *iface_ip_env_name;
         char *hostname;
 
-        struct HYD_pmcd_pmi_kvs *kvs;
-
         int retries;
     } local;
 };
@@ -81,9 +79,13 @@ struct pmip_pg {
     int global_process_count;
     char *pmi_process_mapping;
     char *spawner_kvsname;
+    char *kvsname;
 
     /* Process segmentation information for this proxy */
     struct HYD_exec *exec_list;
+
+    /* This is for PMI-2 info-putnodeattr. Should it be per-node or per pg? */
+    struct HYD_pmcd_pmi_kvs *kvs;
 };
 
 extern struct HYD_pmcd_pmip_s HYD_pmcd_pmip;

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -28,6 +28,7 @@ struct HYD_pmcd_pmip_s {
 
     /* Proxy details */
     struct {
+        /* (pgid, id) are used for sending back init_hdr to server as initial handshake */
         int id;
         int pgid;
         char *iface_ip_env_name;

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -31,8 +31,6 @@ struct HYD_pmcd_pmip_s {
         /* (pgid, id) are used for sending back init_hdr to server as initial handshake */
         int id;
         int pgid;
-        char *iface_ip_env_name;
-        char *hostname;
 
         int retries;
     } local;
@@ -105,6 +103,10 @@ struct pmip_pg {
     struct cache_elem *cache_get;
     struct cache_elem *hash_get;
     int num_elems;
+
+    /* environment */
+    char *iface_ip_env_name;
+    char *hostname;
 };
 
 extern struct HYD_pmcd_pmip_s HYD_pmcd_pmip;
@@ -125,6 +127,7 @@ void PMIP_pg_init(void);
 void PMIP_pg_finalize(void);
 struct pmip_pg *PMIP_new_pg(int pgid, int proxy_id);
 struct pmip_pg *PMIP_pg_0(void);
+HYD_status PMIP_foreach_pg_do(HYD_status(*callback) (struct pmip_pg * pg));
 HYD_status PMIP_pg_alloc_downstreams(struct pmip_pg *pg, int num_procs);
 struct pmip_pg *PMIP_find_pg(int pgid, int proxy_id);
 void PMIP_free_pg(struct pmip_pg *pg);

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -51,9 +51,6 @@ struct HYD_pmcd_pmip_s {
         char *iface_ip_env_name;
         char *hostname;
 
-        int proxy_core_count;
-        int proxy_process_count;
-
         char *spawner_kvsname;
         struct HYD_pmcd_pmi_kvs *kvs;   /* Node-level KVS space for node attributes */
 

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -88,6 +88,7 @@ HYD_status HYD_pmcd_pmip_get_params(char **t_argv);
 
 #define PMIP_EXIT_STATUS_UNSET -1
 void HYD_pmcd_pmip_send_signal(int sig);
+HYD_status PMIP_send_hdr_upstream(struct HYD_pmcd_hdr *hdr, void *buf, int buflen);
 
 HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp);
 const char *HYD_pmip_get_hwloc_xmlfile(void);

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -66,18 +66,6 @@ struct HYD_pmcd_pmip_s {
     struct HYD_exec *exec_list;
 };
 
-extern struct HYD_pmcd_pmip_s HYD_pmcd_pmip;
-extern struct HYD_arg_match_table HYD_pmcd_pmip_match_table[];
-
-HYD_status HYD_pmcd_pmip_get_params(char **t_argv);
-
-#define PMIP_EXIT_STATUS_UNSET -1
-void HYD_pmcd_pmip_send_signal(int sig);
-HYD_status PMIP_send_hdr_upstream(struct HYD_pmcd_hdr *hdr, void *buf, int buflen);
-
-HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp);
-const char *HYD_pmip_get_hwloc_xmlfile(void);
-
 /* downstreams */
 struct pmip_downstream {
     struct pmip_pg *pg;
@@ -106,6 +94,19 @@ struct pmip_pg {
     int num_procs;
     struct pmip_downstream *downstreams;
 };
+
+extern struct HYD_pmcd_pmip_s HYD_pmcd_pmip;
+extern struct HYD_arg_match_table HYD_pmcd_pmip_match_table[];
+
+HYD_status HYD_pmcd_pmip_get_params(char **t_argv);
+
+#define PMIP_EXIT_STATUS_UNSET -1
+void HYD_pmcd_pmip_send_signal(int sig);
+HYD_status PMIP_send_hdr_upstream(struct pmip_pg *pg, struct HYD_pmcd_hdr *hdr,
+                                  void *buf, int buflen);
+
+HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp);
+const char *HYD_pmip_get_hwloc_xmlfile(void);
 
 void PMIP_pg_init(void);
 void PMIP_pg_finalize(void);

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -93,4 +93,54 @@ HYD_status PMIP_send_hdr_upstream(struct HYD_pmcd_hdr *hdr, void *buf, int bufle
 HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp);
 const char *HYD_pmip_get_hwloc_xmlfile(void);
 
+/* downstreams */
+struct pmip_downstream {
+    struct pmip_pg *pg;
+
+    int out;
+    int err;
+    int in;
+
+    int pid;
+    int exit_status;
+
+    int pmi_appnum;
+    int pmi_rank;
+    int pmi_fd;
+    int pmi_fd_active;
+};
+
+/* Each launch belongs to separate MPI_COMM_WORLD, which is tracked by (pgid, proxy_id)
+ * at the server. Each pmip_pg hosts a list of downstream processes.
+ */
+
+struct pmip_pg {
+    int pgid;
+    int proxy_id;
+
+    int num_procs;
+    struct pmip_downstream *downstreams;
+};
+
+void PMIP_pg_init(void);
+void PMIP_pg_finalize(void);
+struct pmip_pg *PMIP_new_pg(int pgid, int proxy_id);
+struct pmip_pg *PMIP_pg_0(void);
+HYD_status PMIP_pg_alloc_downstreams(struct pmip_pg *pg, int num_procs);
+struct pmip_pg *PMIP_find_pg(int pgid, int proxy_id);
+void PMIP_free_pg(struct pmip_pg *pg);
+
+bool PMIP_pg_has_open_stdoe(struct pmip_pg *pg);
+
+int *PMIP_pg_get_pid_list(struct pmip_pg *pg);
+int *PMIP_pg_get_stdout_list(struct pmip_pg *pg);
+int *PMIP_pg_get_stderr_list(struct pmip_pg *pg);
+int *PMIP_pg_get_exit_status_list(struct pmip_pg *pg);
+
+struct pmip_downstream *PMIP_find_downstream_by_fd(int fd);
+struct pmip_downstream *PMIP_find_downstream_by_pid(int pid);
+int PMIP_get_total_process_count(void);
+bool PMIP_has_open_stdoe(void);
+void PMIP_bcast_signal(int sig);
+
 #endif /* PMIP_H_INCLUDED */

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -46,21 +46,6 @@ struct HYD_pmcd_pmip_s {
         int control;
     } upstream;
 
-    /* Currently our downstream only consists of actual MPI
-     * processes */
-    struct {
-        int *out;
-        int *err;
-        int in;
-
-        int *pid;
-        int *exit_status;
-
-        int *pmi_rank;
-        int *pmi_fd;
-        int *pmi_fd_active;
-    } downstream;
-
     /* Proxy details */
     struct {
         int id;

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -34,8 +34,6 @@ struct HYD_pmcd_pmip_s {
         int global_process_count;
 
         /* PMI */
-        char *pmi_fd;
-        int pmi_rank;           /* If this is -1, we auto-generate it */
         char *pmi_process_mapping;
     } system_global;            /* Global system parameters */
 

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -743,7 +743,7 @@ static HYD_status launch_procs(struct pmip_pg *pg)
     HYDU_FUNC_ENTER();
 
     int num_procs = 0;
-    for (exec = HYD_pmcd_pmip.exec_list; exec; exec = exec->next) {
+    for (exec = pg->exec_list; exec; exec = exec->next) {
         num_procs += exec->proc_count;
     }
 
@@ -778,7 +778,7 @@ static HYD_status launch_procs(struct pmip_pg *pg)
 
     /* Spawn the processes */
     process_id = 0;
-    for (exec = HYD_pmcd_pmip.exec_list; exec; exec = exec->next) {
+    for (exec = pg->exec_list; exec; exec = exec->next) {
 
         /* Increasing priority order: (1) global inherited env; (2)
          * global user env; (3) local user env; (4) system env. We

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -703,8 +703,7 @@ static HYD_status singleton_init(struct pmip_pg *pg, int singleton_pid, int sing
     HYDU_ERR_POP(status, "unable to send msg to singleton process\n");
     status = HYDU_sock_read(fd, msg, 1024, &recvd, &closed, HYDU_SOCK_COMM_NONE);
     HYDU_ERR_POP(status, "unable to read msg from singleton process\n");
-    MPL_snprintf(msg, 1024, "cmd=singinit_info versionok=yes stdio=no kvsname=%s\n",
-                 HYD_pmcd_pmip.local.kvs->kvsname);
+    MPL_snprintf(msg, 1024, "cmd=singinit_info versionok=yes stdio=no kvsname=%s\n", pg->kvsname);
     status = HYDU_sock_write(fd, msg, strlen(msg), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
     HYDU_ERR_POP(status, "unable to send msg to singleton process\n");
 

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -837,7 +837,7 @@ static HYD_status launch_procs(struct pmip_pg *pg)
         }
 
         /* Set the interface hostname based on what the user provided */
-        if (HYD_pmcd_pmip.local.iface_ip_env_name) {
+        if (pg->iface_ip_env_name) {
             if (HYD_pmcd_pmip.user_global.iface) {
                 char *ip;
 
@@ -846,13 +846,11 @@ static HYD_status launch_procs(struct pmip_pg *pg)
                              HYD_pmcd_pmip.user_global.iface);
 
                 /* The user asked us to use a specific interface; let's find it */
-                status = HYDU_append_env_to_list(HYD_pmcd_pmip.local.iface_ip_env_name,
-                                                 ip, &force_env);
+                status = HYDU_append_env_to_list(pg->iface_ip_env_name, ip, &force_env);
                 HYDU_ERR_POP(status, "unable to add env to list\n");
-            } else if (HYD_pmcd_pmip.local.hostname) {
+            } else if (pg->hostname) {
                 /* The second choice is the hostname the user gave */
-                status = HYDU_append_env_to_list(HYD_pmcd_pmip.local.iface_ip_env_name,
-                                                 HYD_pmcd_pmip.local.hostname, &force_env);
+                status = HYDU_append_env_to_list(pg->iface_ip_env_name, pg->hostname, &force_env);
                 HYDU_ERR_POP(status, "unable to add env to list\n");
             }
         }

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -765,9 +765,13 @@ static HYD_status launch_procs(struct pmip_pg *pg)
     }
 
     if (HYD_pmcd_pmip.user_global.pmi_port) {
+        int listen_fd;
         status = HYDU_sock_create_and_listen_portstr(HYD_pmcd_pmip.user_global.iface,
-                                                     NULL, NULL, &pmi_port, pmi_listen_cb, NULL);
+                                                     NULL, NULL, &pmi_port, &listen_fd,
+                                                     pmi_listen_cb, NULL);
         HYDU_ERR_POP(status, "unable to create PMI port\n");
+
+        /* FIXME: should we close(listen_fd) at some point? */
 
         status = HYDU_env_create(&env, "PMI_PORT", pmi_port);
         HYDU_ERR_POP(status, "unable to create env\n");

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -49,7 +49,7 @@ HYD_status PMIP_send_hdr_upstream(struct pmip_pg *pg, struct HYD_pmcd_hdr *hdr,
 
 static HYD_status stdoe_cb(struct pmip_downstream *p, bool is_stdout)
 {
-    int closed, i, recvd;
+    int closed, recvd;
     char buf[HYD_TMPBUF_SIZE];
     struct HYD_pmcd_hdr hdr;
     HYD_status status = HYD_SUCCESS;
@@ -179,8 +179,6 @@ static HYD_status handle_pmi_cmd(struct pmip_downstream *p, char *buf, int bufle
     }
 
     /* We don't understand the command; forward it upstream */
-    int sent, closed;
-
     struct HYD_pmcd_hdr hdr;
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PMI;
@@ -261,8 +259,6 @@ static HYD_status check_pmi_cmd(char **buf, int *buflen_out, int *pmi_version, i
 
 static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
 {
-    char *buf = NULL;
-    int closed, sent, linelen, pid = -1;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
@@ -281,6 +277,7 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
         }
     }
 
+    int closed, linelen;
   read_cmd:
     /* PMI-1 does not tell us how much to read. We read how much ever
      * we can, parse out full PMI commands from it, and process
@@ -349,6 +346,7 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
 
     int repeat;
     do {
+        char *buf = NULL;
         int buflen = 0;
         int pmi_version;
         status = check_pmi_cmd(&buf, &buflen, &pmi_version, &repeat);
@@ -736,7 +734,7 @@ static HYD_status launch_procs(struct pmip_pg *pg)
     struct HYD_env *env, *force_env = NULL;
     struct HYD_exec *exec;
     struct HYD_pmcd_hdr hdr;
-    int sent, closed, pmi_fds[2] = { HYD_FD_UNSET, HYD_FD_UNSET };
+    int pmi_fds[2] = { HYD_FD_UNSET, HYD_FD_UNSET };
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -555,22 +555,20 @@ HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
 
 /* handle_launch_procs - read proc_info and launch procs */
 
-static HYD_status parse_exec_params(char **t_argv);
-static HYD_status procinfo(int fd);
+static HYD_status parse_exec_params(struct pmip_pg *pg, char **t_argv);
+static HYD_status procinfo(struct pmip_pg *pg);
 static HYD_status singleton_init(struct pmip_pg *pg, int singleton_pid, int singleton_port);
 static HYD_status launch_procs(struct pmip_pg *pg);
-static int local_to_global_id(int local_id);
+static void init_pg_params(struct pmip_pg *pg);
+static HYD_status verify_pg_params(struct pmip_pg *pg);
+static int local_to_global_id(struct pmip_pg *pg, int local_id);
 
 static HYD_status handle_launch_procs(struct pmip_pg *pg)
 {
     HYD_status status = HYD_SUCCESS;
     HYDU_FUNC_ENTER();
 
-    int fd = HYD_pmcd_pmip.upstream.control;
-
-    HYD_set_cur_pg(pg);
-
-    status = procinfo(fd);
+    status = procinfo(pg);
     HYDU_ERR_POP(status, "error parsing process info\n");
 
     if (HYD_pmcd_pmip.user_global.singleton_port > 0) {
@@ -589,13 +587,15 @@ static HYD_status handle_launch_procs(struct pmip_pg *pg)
     goto fn_exit;
 }
 
-static HYD_status parse_exec_params(char **t_argv)
+static HYD_status parse_exec_params(struct pmip_pg *pg, char **t_argv)
 {
     char **argv = t_argv;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
+    HYD_set_cur_pg(pg);
+    init_pg_params(pg);
     do {
         /* Get the executable arguments  */
         status = HYDU_parse_array(&argv, HYD_pmcd_pmip_match_table);
@@ -607,21 +607,8 @@ static HYD_status parse_exec_params(char **t_argv)
     } while (1);
 
     /* verify the arguments we got */
-    if (HYD_pmcd_pmip.system_global.global_core_map.local_filler == -1 ||
-        HYD_pmcd_pmip.system_global.global_core_map.local_count == -1 ||
-        HYD_pmcd_pmip.system_global.global_core_map.global_count == -1)
-        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
-                            "cannot find global core map (%d,%d,%d)\n",
-                            HYD_pmcd_pmip.system_global.global_core_map.local_filler,
-                            HYD_pmcd_pmip.system_global.global_core_map.local_count,
-                            HYD_pmcd_pmip.system_global.global_core_map.global_count);
-
-    if (HYD_pmcd_pmip.system_global.pmi_id_map.filler_start == -1 ||
-        HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start == -1)
-        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
-                            "cannot find pmi id map (%d,%d)\n",
-                            HYD_pmcd_pmip.system_global.pmi_id_map.filler_start,
-                            HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start);
+    status = verify_pg_params(pg);
+    HYDU_ERR_POP(status, "missing parameters\n");
 
     /* Set default values */
     if (HYD_pmcd_pmip.user_global.topolib == NULL && HYDRA_DEFAULT_TOPOLIB != NULL) {
@@ -638,13 +625,15 @@ static HYD_status parse_exec_params(char **t_argv)
     goto fn_exit;
 }
 
-static HYD_status procinfo(int fd)
+static HYD_status procinfo(struct pmip_pg *pg)
 {
     char **arglist;
     int num_strings, str_len, recvd, i, closed;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
+
+    int fd = HYD_pmcd_pmip.upstream.control;
 
     /* Read information about the application to launch into a string
      * array and call parse_exec_params() to interpret it and load it into
@@ -669,7 +658,7 @@ static HYD_status procinfo(int fd)
     arglist[num_strings] = NULL;
 
     /* Get the parser to fill in the proxy params structure. */
-    status = parse_exec_params(arglist);
+    status = parse_exec_params(pg, arglist);
     HYDU_ERR_POP(status, "unable to parse argument list\n");
 
     HYDU_free_strlist(arglist);
@@ -775,7 +764,7 @@ static HYD_status launch_procs(struct pmip_pg *pg)
          * PORT. */
         p->pmi_fd = HYD_FD_UNSET;
         p->pmi_fd_active = 0;
-        p->pmi_rank = local_to_global_id(i);
+        p->pmi_rank = local_to_global_id(pg, i);
     }
 
     if (HYD_pmcd_pmip.user_global.pmi_port) {
@@ -976,7 +965,7 @@ static HYD_status launch_procs(struct pmip_pg *pg)
                 MPL_free(str);
 
                 /* PMI_SIZE */
-                str = HYDU_int_to_str(HYD_pmcd_pmip.system_global.global_process_count);
+                str = HYDU_int_to_str(pg->global_process_count);
                 status = HYDU_append_env_to_list("PMI_SIZE", str, &force_env);
                 HYDU_ERR_POP(status, "unable to add env to list\n");
                 MPL_free(str);
@@ -1047,19 +1036,57 @@ static HYD_status launch_procs(struct pmip_pg *pg)
     goto fn_exit;
 }
 
-static int local_to_global_id(int local_id)
+/* global_core_map and pmi_id_map */
+static void init_pg_params(struct pmip_pg *pg)
+{
+    pg->global_core_map.local_filler = -1;
+    pg->global_core_map.local_count = -1;
+    pg->global_core_map.global_count = -1;
+    pg->pmi_id_map.filler_start = -1;
+    pg->pmi_id_map.non_filler_start = -1;
+
+    pg->global_process_count = -1;
+}
+
+static HYD_status verify_pg_params(struct pmip_pg *pg)
+{
+    HYD_status status = HYD_SUCCESS;
+    if (pg->global_core_map.local_filler == -1 ||
+        pg->global_core_map.local_count == -1 || pg->global_core_map.global_count == -1) {
+        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
+                            "cannot find global core map (%d,%d,%d)\n",
+                            pg->global_core_map.local_filler,
+                            pg->global_core_map.local_count, pg->global_core_map.global_count);
+    }
+
+    if (pg->pmi_id_map.filler_start == -1 || pg->pmi_id_map.non_filler_start == -1) {
+        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
+                            "cannot find pmi id map (%d,%d)\n",
+                            pg->pmi_id_map.filler_start, pg->pmi_id_map.non_filler_start);
+    }
+
+    if (pg->global_process_count == -1) {
+        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "cannot find global_process_count\n");
+    }
+
+  fn_exit:
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int local_to_global_id(struct pmip_pg *pg, int local_id)
 {
     int rem1, rem2, layer, ret;
 
-    if (local_id < HYD_pmcd_pmip.system_global.global_core_map.local_filler)
-        ret = HYD_pmcd_pmip.system_global.pmi_id_map.filler_start + local_id;
+    if (local_id < pg->global_core_map.local_filler)
+        ret = pg->pmi_id_map.filler_start + local_id;
     else {
-        rem1 = local_id - HYD_pmcd_pmip.system_global.global_core_map.local_filler;
-        layer = rem1 / HYD_pmcd_pmip.system_global.global_core_map.local_count;
-        rem2 = rem1 - (layer * HYD_pmcd_pmip.system_global.global_core_map.local_count);
+        rem1 = local_id - pg->global_core_map.local_filler;
+        layer = rem1 / pg->global_core_map.local_count;
+        rem2 = rem1 - (layer * pg->global_core_map.local_count);
 
-        ret = HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start +
-            (layer * HYD_pmcd_pmip.system_global.global_core_map.global_count) + rem2;
+        ret = pg->pmi_id_map.non_filler_start + (layer * pg->global_core_map.global_count) + rem2;
     }
 
     return ret;

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -14,13 +14,14 @@
 static int pmi_storage_len = 0;
 static char pmi_storage[HYD_TMPBUF_SIZE], *sptr = pmi_storage;
 
-HYD_status PMIP_send_hdr_upstream(struct HYD_pmcd_hdr *hdr, void *buf, int buflen)
+HYD_status PMIP_send_hdr_upstream(struct pmip_pg *pg, struct HYD_pmcd_hdr *hdr,
+                                  void *buf, int buflen)
 {
     HYD_status status = HYD_SUCCESS;
     int upstream_sock_closed, sent;
 
-    hdr->pgid = HYD_pmcd_pmip.local.pgid;
-    hdr->proxy_id = HYD_pmcd_pmip.local.id;
+    hdr->pgid = pg->pgid;
+    hdr->proxy_id = pg->proxy_id;
     hdr->buflen = buflen;
 
     HYDU_ASSERT(hdr->cmd, status);
@@ -64,7 +65,7 @@ static HYD_status stdoe_cb(struct pmip_downstream *p, bool is_stdout)
         hdr.cmd = is_stdout ? CMD_STDOUT : CMD_STDERR;
         hdr.u.io.rank = p->pmi_rank;
 
-        status = PMIP_send_hdr_upstream(&hdr, buf, recvd);
+        status = PMIP_send_hdr_upstream(p->pg, &hdr, buf, recvd);
         HYDU_ERR_POP(status, "error sending hdr upstream\n");
     }
 
@@ -101,7 +102,7 @@ static HYD_status stderr_cb(int fd, HYD_event_t events, void *userp)
     return stdoe_cb(p, false);
 }
 
-static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, int pmi_version)
+static HYD_status handle_pmi_cmd(struct pmip_downstream *p, char *buf, int buflen, int pmi_version)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -110,7 +111,8 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, int pmi_version)
     char *cmd = PMIU_wire_get_cmd(buf, buflen, pmi_version);
     int cmd_id = PMIU_msg_cmd_to_id(cmd);
 
-    HYD_status(*handler) (int fd, struct PMIU_cmd * pmi) = NULL;
+    HYD_status(*handler) (struct pmip_downstream * p, struct PMIU_cmd * pmi) = NULL;
+    HYD_status(*init_handler) (int fd, struct PMIU_cmd * pmi) = NULL;
     switch (cmd_id) {
         case PMIU_CMD_INIT:
             handler = fn_init;
@@ -119,7 +121,8 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, int pmi_version)
             handler = fn_finalize;
             break;
         case PMIU_CMD_FULLINIT:
-            handler = fn_fullinit;
+            /* no valid downstream yet */
+            init_handler = fn_fullinit;
             break;
         case PMIU_CMD_MAXES:
             handler = fn_get_maxes;
@@ -150,7 +153,7 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, int pmi_version)
             break;
     }
 
-    if (handler) {
+    if (handler || init_handler) {
         struct PMIU_cmd pmi;
         status = PMIU_cmd_parse(buf, buflen, pmi_version, &pmi);
         HYDU_ERR_POP(status, "unable to parse PMI command\n");
@@ -160,7 +163,12 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, int pmi_version)
             HYD_pmcd_pmi_dump(&pmi);
         }
 
-        status = handler(fd, &pmi);
+        if (handler) {
+            HYDU_ASSERT(p->pg, status);
+            status = handler(p, &pmi);
+        } else if (init_handler) {
+            status = init_handler(p->pmi_fd, &pmi);
+        }
         HYDU_ERR_POP(status, "PMI handler returned error\n");
         goto fn_exit;
     }
@@ -177,9 +185,10 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, int pmi_version)
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PMI;
     hdr.u.pmi.pmi_version = pmi_version;
-    hdr.u.pmi.process_fd = fd;
+    hdr.u.pmi.process_fd = p->pmi_fd;
 
-    status = PMIP_send_hdr_upstream(&hdr, buf, buflen);
+    HYDU_ASSERT(p->pg, status);
+    status = PMIP_send_hdr_upstream(p->pg, &hdr, buf, buflen);
     HYDU_ERR_POP(status, "unable to send PMI command upstream\n");
 
   fn_exit:
@@ -258,9 +267,18 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
 
     HYDU_FUNC_ENTER();
 
+    struct pmip_downstream init_p;
     struct pmip_downstream *p = userp;
     if (p == NULL) {
         /* pmi_port path. We need find the downstream */
+        p = PMIP_find_downstream_by_fd(fd);
+        if (!p) {
+            /* when init via pmi_port, we don't have the matching downstream yet,
+             * use init_p. We just need pass on the fd */
+            init_p.pg = NULL;   /* sentinel as not a real downstream */
+            init_p.pmi_fd = fd;
+            p = &init_p;
+        }
     }
 
   read_cmd:
@@ -285,7 +303,7 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
          * We check of we found the PMI FD, and if the FD is "PMI
          * active" (which means that this is an MPI application).
          */
-        if (p && p->pmi_fd_active) {
+        if (p->pg && p->pmi_fd_active) {
             /* Deregister failed socket */
             status = HYDT_dmx_deregister_fd(fd);
             HYDU_ERR_POP(status, "unable to deregister fd\n");
@@ -318,7 +336,8 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
                 /* global rank for the terminated process */
                 hdr.u.data = p->pmi_rank;
 
-                status = PMIP_send_hdr_upstream(&hdr, NULL, 0);
+                HYDU_ASSERT(p, status);
+                status = PMIP_send_hdr_upstream(p->pg, &hdr, NULL, 0);
                 HYDU_ERR_POP(status, "unable to send hdr upstream\n");
             }
         }
@@ -343,11 +362,11 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
          * to identify what PMI FD this is, activate it. If we were not
          * able to identify the PMI FD, we will activate it when we get
          * the PMI initialization command. */
-        if (p && !p->pmi_fd_active) {
+        if (p->pg && !p->pmi_fd_active) {
             p->pmi_fd_active = 1;
         }
 
-        status = handle_pmi_cmd(fd, buf, buflen, pmi_version);
+        status = handle_pmi_cmd(p, buf, buflen, pmi_version);
         HYDU_ERR_POP(status, "unable to handle PMI command\n");
     } while (repeat);
 
@@ -709,7 +728,7 @@ static HYD_status singleton_init(struct pmip_pg *pg, int singleton_pid, int sing
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PID_LIST;
 
-    status = PMIP_send_hdr_upstream(&hdr, &singleton_pid, sizeof(int));
+    status = PMIP_send_hdr_upstream(pg, &hdr, &singleton_pid, sizeof(int));
     HYDU_ERR_POP(status, "unable to send PID_LIST command upstream\n");
 
     /* skip HYDT_dmx_register_fd */
@@ -1006,7 +1025,7 @@ static HYD_status launch_procs(struct pmip_pg *pg)
     hdr.cmd = CMD_PID_LIST;
 
     int *pid_list = PMIP_pg_get_pid_list(pg);
-    status = PMIP_send_hdr_upstream(&hdr, pid_list, num_procs * sizeof(int));
+    status = PMIP_send_hdr_upstream(pg, &hdr, pid_list, num_procs * sizeof(int));
     HYDU_ERR_POP(status, "unable to send PID_LIST command upstream\n");
     MPL_free(pid_list);
 

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -167,7 +167,7 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, int pmi_version)
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PMI;
     hdr.u.pmi.pmi_version = pmi_version;
-    hdr.u.pmi.pid = fd;
+    hdr.u.pmi.process_fd = fd;
     hdr.buflen = buflen;
     status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed,
                              HYDU_SOCK_COMM_MSGWAIT);
@@ -358,7 +358,7 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
     goto fn_exit;
 }
 
-static HYD_status handle_pmi_response(int fd, int buflen, int pmi_version, int pid)
+static HYD_status handle_pmi_response(int fd, int buflen, int pmi_version, int process_fd)
 {
     int count, closed, sent;
     char *buf = NULL;
@@ -401,7 +401,7 @@ static HYD_status handle_pmi_response(int fd, int buflen, int pmi_version, int p
         HYDU_dump(stdout, "we don't understand the response %s; forwarding downstream\n", cmd);
     }
 
-    status = HYDU_sock_write(pid, buf, buflen, &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    status = HYDU_sock_write(process_fd, buf, buflen, &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
     HYDU_ERR_POP(status, "unable to forward PMI response to MPI process\n");
 
     if (HYD_pmcd_pmip.user_global.auto_cleanup) {
@@ -981,7 +981,7 @@ HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
             HYDU_ERR_POP(status, "launch_procs returned error\n");
         }
     } else if (hdr.cmd == CMD_PMI_RESPONSE) {
-        status = handle_pmi_response(fd, hdr.buflen, hdr.u.pmi.pmi_version, hdr.u.pmi.pid);
+        status = handle_pmi_response(fd, hdr.buflen, hdr.u.pmi.pmi_version, hdr.u.pmi.process_fd);
         HYDU_ERR_POP(status, "unable to handle PMI response\n");
     } else if (hdr.cmd == CMD_SIGNAL) {
         int signum = hdr.u.data;

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -45,8 +45,8 @@ static HYD_status stdoe_cb(int fd, HYD_event_t events, void *userp)
 
         HYDU_ASSERT(i < HYD_pmcd_pmip.local.proxy_process_count, status);
 
-        hdr.u.io.pgid = HYD_pmcd_pmip.local.pgid;
-        hdr.u.io.proxy_id = HYD_pmcd_pmip.local.id;
+        hdr.pgid = HYD_pmcd_pmip.local.pgid;
+        hdr.proxy_id = HYD_pmcd_pmip.local.id;
         hdr.u.io.rank = HYD_pmcd_pmip.downstream.pmi_rank[i];
         hdr.buflen = recvd;
 
@@ -166,6 +166,8 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, int pmi_version)
     struct HYD_pmcd_hdr hdr;
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PMI;
+    hdr.pgid = HYD_pmcd_pmip.local.pgid;
+    hdr.proxy_id = HYD_pmcd_pmip.local.id;
     hdr.u.pmi.pmi_version = pmi_version;
     hdr.u.pmi.process_fd = fd;
     hdr.buflen = buflen;
@@ -314,6 +316,8 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
                 HYD_pmcd_init_header(&hdr);
 
                 hdr.cmd = CMD_PROCESS_TERMINATED;
+                hdr.pgid = HYD_pmcd_pmip.local.pgid;
+                hdr.proxy_id = HYD_pmcd_pmip.local.id;
                 /* global rank for the terminated process */
                 hdr.u.data = HYD_pmcd_pmip.downstream.pmi_rank[pid];
                 status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr),
@@ -507,6 +511,8 @@ static HYD_status singleton_init(void)
     struct HYD_pmcd_hdr hdr;
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PID_LIST;
+    hdr.pgid = HYD_pmcd_pmip.local.pgid;
+    hdr.proxy_id = HYD_pmcd_pmip.local.id;
     status =
         HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed,
                         HYDU_SOCK_COMM_MSGWAIT);
@@ -822,6 +828,8 @@ static HYD_status launch_procs(void)
     /* Send the PID list upstream */
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PID_LIST;
+    hdr.pgid = HYD_pmcd_pmip.local.pgid;
+    hdr.proxy_id = HYD_pmcd_pmip.local.id;
     status =
         HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed,
                         HYDU_SOCK_COMM_MSGWAIT);

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -23,6 +23,11 @@ HYD_status PMIP_send_hdr_upstream(struct HYD_pmcd_hdr *hdr, void *buf, int bufle
     hdr->proxy_id = HYD_pmcd_pmip.local.id;
     hdr->buflen = buflen;
 
+    HYDU_ASSERT(hdr->cmd, status);
+    if (HYD_pmcd_pmip.user_global.debug) {
+        HYDU_dump(stdout, "Sending upstream hdr.cmd = %d\n", hdr->cmd);
+    }
+
     status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, hdr, sizeof(*hdr), &sent,
                              &upstream_sock_closed, HYDU_SOCK_COMM_MSGWAIT);
     HYDU_ERR_POP(status, "sock write error\n");
@@ -41,7 +46,7 @@ HYD_status PMIP_send_hdr_upstream(struct HYD_pmcd_hdr *hdr, void *buf, int bufle
     goto fn_exit;
 }
 
-static HYD_status stdoe_cb(int fd, bool is_stdout)
+static HYD_status stdoe_cb(struct pmip_downstream *p, bool is_stdout)
 {
     int closed, i, recvd;
     char buf[HYD_TMPBUF_SIZE];
@@ -50,27 +55,14 @@ static HYD_status stdoe_cb(int fd, bool is_stdout)
 
     HYDU_FUNC_ENTER();
 
+    int fd = is_stdout ? p->out : p->err;
+
     status = HYDU_sock_read(fd, buf, HYD_TMPBUF_SIZE, &recvd, &closed, HYDU_SOCK_COMM_NONE);
     HYDU_ERR_POP(status, "sock read error\n");
 
     if (recvd) {
-        if (is_stdout) {
-            HYD_pmcd_init_header(&hdr);
-            hdr.cmd = CMD_STDOUT;
-            for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++)
-                if (HYD_pmcd_pmip.downstream.out[i] == fd)
-                    break;
-        } else {
-            HYD_pmcd_init_header(&hdr);
-            hdr.cmd = CMD_STDERR;
-            for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++)
-                if (HYD_pmcd_pmip.downstream.err[i] == fd)
-                    break;
-        }
-
-        HYDU_ASSERT(i < HYD_pmcd_pmip.local.proxy_process_count, status);
-
-        hdr.u.io.rank = HYD_pmcd_pmip.downstream.pmi_rank[i];
+        hdr.cmd = is_stdout ? CMD_STDOUT : CMD_STDERR;
+        hdr.u.io.rank = p->pmi_rank;
 
         status = PMIP_send_hdr_upstream(&hdr, buf, recvd);
         HYDU_ERR_POP(status, "error sending hdr upstream\n");
@@ -82,15 +74,10 @@ static HYD_status stdoe_cb(int fd, bool is_stdout)
         HYDU_ERR_POP(status, "unable to deregister fd\n");
 
         if (is_stdout) {
-            for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++)
-                if (HYD_pmcd_pmip.downstream.out[i] == fd)
-                    HYD_pmcd_pmip.downstream.out[i] = HYD_FD_CLOSED;
+            p->out = HYD_FD_CLOSED;
         } else {
-            for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++)
-                if (HYD_pmcd_pmip.downstream.err[i] == fd)
-                    HYD_pmcd_pmip.downstream.err[i] = HYD_FD_CLOSED;
+            p->err = HYD_FD_CLOSED;
         }
-
         close(fd);
     }
 
@@ -104,12 +91,14 @@ static HYD_status stdoe_cb(int fd, bool is_stdout)
 
 static HYD_status stdout_cb(int fd, HYD_event_t events, void *userp)
 {
-    return stdoe_cb(fd, true);
+    struct pmip_downstream *p = userp;
+    return stdoe_cb(p, true);
 }
 
 static HYD_status stderr_cb(int fd, HYD_event_t events, void *userp)
 {
-    return stdoe_cb(fd, false);
+    struct pmip_downstream *p = userp;
+    return stdoe_cb(p, false);
 }
 
 static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, int pmi_version)
@@ -269,12 +258,9 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
 
     HYDU_FUNC_ENTER();
 
-    /* Try to find the PMI FD */
-    for (int i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
-        if (HYD_pmcd_pmip.downstream.pmi_fd[i] == fd) {
-            pid = i;
-            break;
-        }
+    struct pmip_downstream *p = userp;
+    if (p == NULL) {
+        /* pmi_port path. We need find the downstream */
     }
 
   read_cmd:
@@ -299,7 +285,7 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
          * We check of we found the PMI FD, and if the FD is "PMI
          * active" (which means that this is an MPI application).
          */
-        if (pid != -1 && HYD_pmcd_pmip.downstream.pmi_fd_active[pid]) {
+        if (p && p->pmi_fd_active) {
             /* Deregister failed socket */
             status = HYDT_dmx_deregister_fd(fd);
             HYDU_ERR_POP(status, "unable to deregister fd\n");
@@ -308,13 +294,14 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
             if (HYD_pmcd_pmip.user_global.auto_cleanup) {
                 /* kill all processes */
                 /* preset all exit_status except for the closed pid */
-                for (int i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
-                    if (i != pid &&
-                        HYD_pmcd_pmip.downstream.exit_status[i] == PMIP_EXIT_STATUS_UNSET) {
-                        HYD_pmcd_pmip.downstream.exit_status[i] = 0;
+                struct pmip_pg *pg = p->pg;
+                for (int i = 0; i < pg->num_procs; i++) {
+                    if (p != &pg->downstreams[i] &&
+                        pg->downstreams[i].exit_status == PMIP_EXIT_STATUS_UNSET) {
+                        pg->downstreams[i].exit_status = 0;
                     }
                 }
-                HYD_pmcd_pmip_send_signal(SIGKILL);
+                PMIP_bcast_signal(SIGKILL);
             } else {
                 /* If the user doesn't want to automatically cleanup,
                  * signal the remaining processes, and send this
@@ -322,14 +309,14 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
 
                 /* FIXME: This code needs to change from sending the
                  * SIGUSR1 signal to a PMI-2 notification message. */
-                HYD_pmcd_pmip_send_signal(SIGUSR1);
+                PMIP_bcast_signal(SIGUSR1);
 
                 struct HYD_pmcd_hdr hdr;
                 HYD_pmcd_init_header(&hdr);
 
                 hdr.cmd = CMD_PROCESS_TERMINATED;
                 /* global rank for the terminated process */
-                hdr.u.data = HYD_pmcd_pmip.downstream.pmi_rank[pid];
+                hdr.u.data = p->pmi_rank;
 
                 status = PMIP_send_hdr_upstream(&hdr, NULL, 0);
                 HYDU_ERR_POP(status, "unable to send hdr upstream\n");
@@ -356,8 +343,9 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
          * to identify what PMI FD this is, activate it. If we were not
          * able to identify the PMI FD, we will activate it when we get
          * the PMI initialization command. */
-        if (pid != -1 && !HYD_pmcd_pmip.downstream.pmi_fd_active[pid])
-            HYD_pmcd_pmip.downstream.pmi_fd_active[pid] = 1;
+        if (p && !p->pmi_fd_active) {
+            p->pmi_fd_active = 1;
+        }
 
         status = handle_pmi_cmd(fd, buf, buflen, pmi_version);
         HYDU_ERR_POP(status, "unable to handle PMI command\n");
@@ -371,7 +359,8 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
     goto fn_exit;
 }
 
-static HYD_status handle_pmi_response(int fd, int buflen, int pmi_version, int process_fd)
+static HYD_status handle_pmi_response(struct pmip_pg *pg, int buflen, int pmi_version,
+                                      int process_fd)
 {
     int count, closed, sent;
     char *buf = NULL;
@@ -381,7 +370,8 @@ static HYD_status handle_pmi_response(int fd, int buflen, int pmi_version, int p
 
     HYDU_MALLOC_OR_JUMP(buf, char *, buflen + 1, status);
 
-    status = HYDU_sock_read(fd, buf, buflen, &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    status = HYDU_sock_read(HYD_pmcd_pmip.upstream.control, buf, buflen,
+                            &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
     HYDU_ERR_POP(status, "unable to read PMI response from proxy\n");
     HYDU_ASSERT(!closed, status);
 
@@ -390,7 +380,7 @@ static HYD_status handle_pmi_response(int fd, int buflen, int pmi_version, int p
     char *cmd = PMIU_wire_get_cmd(buf, buflen, pmi_version);
     int cmd_id = PMIU_msg_cmd_to_id(cmd);
 
-    HYD_status(*handler) (int fd, struct PMIU_cmd * pmi) = NULL;
+    HYD_status(*handler) (struct pmip_pg * pg, struct PMIU_cmd * pmi) = NULL;
     if (cmd_id == PMIU_CMD_KVSCACHE) {
         handler = fn_keyval_cache;
     } else if (cmd_id == PMIU_CMD_BARRIEROUT) {
@@ -403,7 +393,7 @@ static HYD_status handle_pmi_response(int fd, int buflen, int pmi_version, int p
         status = PMIU_cmd_parse(buf, buflen, pmi_version, &pmi);
         HYDU_ERR_POP(status, "unable to parse PMI command\n");
 
-        status = handler(fd, &pmi);
+        status = handler(pg, &pmi);
         HYDU_ERR_POP(status, "PMI handler returned error\n");
 
         PMIU_cmd_free_buf(&pmi);
@@ -455,7 +445,7 @@ static HYD_status pmi_listen_cb(int fd, HYD_event_t events, void *userp)
     goto fn_exit;
 }
 
-static HYD_status handle_launch_procs(int fd);
+static HYD_status handle_launch_procs(struct pmip_pg *pg);
 
 HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
 {
@@ -465,41 +455,52 @@ HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
+    HYDU_ASSERT(fd == HYD_pmcd_pmip.upstream.control, status);
 
     /* We got a command from upstream */
     status = HYDU_sock_read(fd, &hdr, sizeof(hdr), &cmd_len, &closed, HYDU_SOCK_COMM_MSGWAIT);
     HYDU_ERR_POP(status, "error reading command from launcher\n");
     HYDU_ASSERT(!closed, status);
 
+    struct pmip_pg *pg;
+    pg = PMIP_find_pg(hdr.pgid, hdr.proxy_id);
+
     if (hdr.cmd == CMD_PROC_INFO) {
-        status = handle_launch_procs(fd);
+        HYDU_ASSERT(pg == NULL, status);
+        pg = PMIP_new_pg(hdr.pgid, hdr.proxy_id);
+        HYDU_ASSERT(pg, status);
+
+        status = handle_launch_procs(pg);
         HYDU_ERR_POP(status, "launch_procs returned error\n");
     } else if (hdr.cmd == CMD_PMI_RESPONSE) {
-        status = handle_pmi_response(fd, hdr.buflen, hdr.u.pmi.pmi_version, hdr.u.pmi.process_fd);
+        status = handle_pmi_response(pg, hdr.buflen, hdr.u.pmi.pmi_version, hdr.u.pmi.process_fd);
         HYDU_ERR_POP(status, "unable to handle PMI response\n");
     } else if (hdr.cmd == CMD_SIGNAL) {
         int signum = hdr.u.data;
         /* FIXME: This code needs to change from sending the signal to
          * a PMI-2 notification message. */
-        HYD_pmcd_pmip_send_signal(signum);
+        PMIP_bcast_signal(signum);
     } else if (hdr.cmd == CMD_STDIN) {
-        int count;
+        HYDU_ASSERT(pg, status);
+        /* stdin is connected to the first local process */
+        struct pmip_downstream *p = &pg->downstreams[0];
+        HYDU_ASSERT(p, status);
 
         if (hdr.buflen) {
             HYDU_MALLOC_OR_JUMP(buf, char *, hdr.buflen, status);
             HYDU_ERR_POP(status, "unable to allocate memory\n");
 
+            int count;
             status = HYDU_sock_read(fd, buf, hdr.buflen, &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
             HYDU_ERR_POP(status, "unable to read from control socket\n");
             HYDU_ASSERT(!closed, status);
 
-            if (HYD_pmcd_pmip.downstream.in == HYD_FD_CLOSED) {
+            if (p->in == HYD_FD_CLOSED) {
                 MPL_free(buf);
                 goto fn_exit;
             }
 
-            status = HYDU_sock_write(HYD_pmcd_pmip.downstream.in, buf, hdr.buflen, &count,
-                                     &closed, HYDU_SOCK_COMM_NONE);
+            status = HYDU_sock_write(p->in, buf, hdr.buflen, &count, &closed, HYDU_SOCK_COMM_NONE);
             HYDU_ERR_POP(status, "unable to write to downstream stdin\n");
 
             HYDU_ERR_CHKANDJUMP(status, count != hdr.buflen, HYD_INTERNAL_ERROR,
@@ -510,14 +511,14 @@ HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
             if (HYD_pmcd_pmip.user_global.auto_cleanup) {
                 HYDU_ASSERT(!closed, status);
             } else if (closed) {
-                close(HYD_pmcd_pmip.downstream.in);
-                HYD_pmcd_pmip.downstream.in = HYD_FD_CLOSED;
+                close(p->in);
+                p->in = HYD_FD_CLOSED;
             }
 
             MPL_free(buf);
         } else {
-            close(HYD_pmcd_pmip.downstream.in);
-            HYD_pmcd_pmip.downstream.in = HYD_FD_CLOSED;
+            close(p->in);
+            p->in = HYD_FD_CLOSED;
         }
     } else {
         status = HYD_INTERNAL_ERROR;
@@ -537,23 +538,26 @@ HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
 
 static HYD_status parse_exec_params(char **t_argv);
 static HYD_status procinfo(int fd);
-static HYD_status singleton_init(void);
-static HYD_status launch_procs(void);
+static HYD_status singleton_init(struct pmip_pg *pg, int singleton_pid, int singleton_port);
+static HYD_status launch_procs(struct pmip_pg *pg);
 static int local_to_global_id(int local_id);
 
-static HYD_status handle_launch_procs(int fd)
+static HYD_status handle_launch_procs(struct pmip_pg *pg)
 {
     HYD_status status = HYD_SUCCESS;
     HYDU_FUNC_ENTER();
+
+    int fd = HYD_pmcd_pmip.upstream.control;
 
     status = procinfo(fd);
     HYDU_ERR_POP(status, "error parsing process info\n");
 
     if (HYD_pmcd_pmip.user_global.singleton_port > 0) {
-        status = singleton_init();
+        status = singleton_init(pg, HYD_pmcd_pmip.user_global.singleton_pid,
+                                HYD_pmcd_pmip.user_global.singleton_port);
         HYDU_ERR_POP(status, "singleton_init returned error\n");
     } else {
-        status = launch_procs();
+        status = launch_procs(pg);
         HYDU_ERR_POP(status, "launch_procs returned error\n");
     }
 
@@ -665,34 +669,26 @@ static HYD_status procinfo(int fd)
     goto fn_exit;
 }
 
-static HYD_status singleton_init(void)
+static HYD_status singleton_init(struct pmip_pg *pg, int singleton_pid, int singleton_port)
 {
     HYD_status status = HYD_SUCCESS;
     int sent, recvd, closed;
 
-    HYD_pmcd_pmip.local.proxy_process_count = 1;
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.out, int *, sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.err, int *, sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.pid, int *, sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.exit_status, int *, sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.pmi_rank, int *, sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.pmi_fd, int *, sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.pmi_fd_active, int *, sizeof(int), status);
+    status = PMIP_pg_alloc_downstreams(pg, 1);
+    HYDU_ERR_POP(status, "unable to allocate singleton downstreams\n");
 
-    HYD_pmcd_pmip.downstream.out[0] = 0;
-    HYD_pmcd_pmip.downstream.err[0] = 0;
-    HYD_pmcd_pmip.downstream.pid[0] = HYD_pmcd_pmip.user_global.singleton_pid;
-    HYD_pmcd_pmip.downstream.exit_status[0] = PMIP_EXIT_STATUS_UNSET;
-    HYD_pmcd_pmip.downstream.pmi_rank[0] = 0;
-    HYD_pmcd_pmip.downstream.pmi_fd[0] = HYD_FD_UNSET;
-    HYD_pmcd_pmip.downstream.pmi_fd_active[0] = 1;
+    struct pmip_downstream *p;
+    p = &pg->downstreams[0];
 
     int fd;
-    status =
-        HYDU_sock_connect("localhost", HYD_pmcd_pmip.user_global.singleton_port, &fd, 0,
-                          HYD_CONNECT_DELAY);
+    status = HYDU_sock_connect("localhost", singleton_port, &fd, 0, HYD_CONNECT_DELAY);
     HYDU_ERR_POP(status, "unable to connect to singleton process\n");
-    HYD_pmcd_pmip.downstream.pmi_fd[0] = fd;
+
+    p->pid = singleton_pid;
+    p->exit_status = PMIP_EXIT_STATUS_UNSET;
+    p->pmi_rank = 0;
+    p->pmi_fd = fd;
+    p->pmi_fd_active = 1;
 
     char msg[1024];
     strcpy(msg, "cmd=singinit authtype=none\n");
@@ -713,8 +709,7 @@ static HYD_status singleton_init(void)
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PID_LIST;
 
-    status = PMIP_send_hdr_upstream(&hdr, HYD_pmcd_pmip.downstream.pid,
-                                    HYD_pmcd_pmip.local.proxy_process_count * sizeof(int));
+    status = PMIP_send_hdr_upstream(&hdr, &singleton_pid, sizeof(int));
     HYDU_ERR_POP(status, "unable to send PID_LIST command upstream\n");
 
     /* skip HYDT_dmx_register_fd */
@@ -727,9 +722,9 @@ static HYD_status singleton_init(void)
     goto fn_exit;
 }
 
-static HYD_status launch_procs(void)
+static HYD_status launch_procs(struct pmip_pg *pg)
 {
-    int i, j, process_id, dummy;
+    int j, process_id, dummy;
     char *str, *envstr, *list, *pmi_port = NULL;
     struct HYD_string_stash stash;
     struct HYD_env *env, *force_env = NULL;
@@ -740,39 +735,29 @@ static HYD_status launch_procs(void)
 
     HYDU_FUNC_ENTER();
 
-    HYD_pmcd_pmip.local.proxy_process_count = 0;
-    for (exec = HYD_pmcd_pmip.exec_list; exec; exec = exec->next)
-        HYD_pmcd_pmip.local.proxy_process_count += exec->proc_count;
+    int num_procs = 0;
+    for (exec = HYD_pmcd_pmip.exec_list; exec; exec = exec->next) {
+        num_procs += exec->proc_count;
+    }
 
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.out, int *,
-                        HYD_pmcd_pmip.local.proxy_process_count * sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.err, int *,
-                        HYD_pmcd_pmip.local.proxy_process_count * sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.pid, int *,
-                        HYD_pmcd_pmip.local.proxy_process_count * sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.exit_status, int *,
-                        HYD_pmcd_pmip.local.proxy_process_count * sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.pmi_rank, int *,
-                        HYD_pmcd_pmip.local.proxy_process_count * sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.pmi_fd, int *,
-                        HYD_pmcd_pmip.local.proxy_process_count * sizeof(int), status);
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.downstream.pmi_fd_active, int *,
-                        HYD_pmcd_pmip.local.proxy_process_count * sizeof(int), status);
+    status = PMIP_pg_alloc_downstreams(pg, num_procs);
+    HYDU_ERR_POP(status, "unable to allocate singleton downstreams\n");
 
     /* Initialize the PMI_FD and PMI FD active state, and exit status */
-    for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
+    for (int i = 0; i < num_procs; i++) {
+        struct pmip_downstream *p = &pg->downstreams[i];
         /* The exit status is populated when the processes terminate */
-        HYD_pmcd_pmip.downstream.exit_status[i] = PMIP_EXIT_STATUS_UNSET;
+        p->exit_status = PMIP_EXIT_STATUS_UNSET;
 
-        /* If we use PMI_FD, the pmi_fd and pmi_fd_active arrays will
+        /* If we use PMI_FD, the pmi_fd and pmi_fd_active will
          * be filled out in this function. But if we are using
          * PMI_PORT, we will fill them out later when the processes
          * send the PMI initialization message. Note that non-MPI
          * processes are never "PMI active" when we use the PMI
          * PORT. */
-        HYD_pmcd_pmip.downstream.pmi_fd[i] = HYD_FD_UNSET;
-        HYD_pmcd_pmip.downstream.pmi_fd_active[i] = 0;
-        HYD_pmcd_pmip.downstream.pmi_rank[i] = local_to_global_id(i);
+        p->pmi_fd = HYD_FD_UNSET;
+        p->pmi_fd_active = 0;
+        p->pmi_rank = local_to_global_id(i);
     }
 
     if (HYD_pmcd_pmip.user_global.pmi_port) {
@@ -878,9 +863,12 @@ static HYD_status launch_procs(void)
             allocate_subdev = false;
             n_local_gpus = HYD_pmcd_pmip.user_global.gpus_per_proc;
         }
-        for (i = 0; i < exec->proc_count; i++) {
+        for (int i = 0; i < exec->proc_count; i++) {
+            struct pmip_downstream *p = &pg->downstreams[process_id];
+            p->pmi_appnum = exec->appnum;
+
             /* FIXME: these envvars should be set by MPICH instead. See #2360 */
-            str = HYDU_int_to_str(HYD_pmcd_pmip.local.proxy_process_count);
+            str = HYDU_int_to_str(pg->num_procs);
             status = HYDU_append_env_to_list("MPI_LOCALNRANKS", str, &force_env);
             HYDU_ERR_POP(status, "unable to add env to list\n");
             MPL_free(str);
@@ -942,13 +930,13 @@ static HYD_status launch_procs(void)
                 HYDU_ERR_POP(status, "unable to add env to list\n");
 
                 /* PMI_ID */
-                str = HYDU_int_to_str(HYD_pmcd_pmip.downstream.pmi_rank[process_id]);
+                str = HYDU_int_to_str(p->pmi_rank);
                 status = HYDU_append_env_to_list("PMI_ID", str, &force_env);
                 HYDU_ERR_POP(status, "unable to add env to list\n");
                 MPL_free(str);
             } else {
                 /* PMI_RANK */
-                str = HYDU_int_to_str(HYD_pmcd_pmip.downstream.pmi_rank[process_id]);
+                str = HYDU_int_to_str(p->pmi_rank);
                 status = HYDU_append_env_to_list("PMI_RANK", str, &force_env);
                 HYDU_ERR_POP(status, "unable to add env to list\n");
                 MPL_free(str);
@@ -956,13 +944,13 @@ static HYD_status launch_procs(void)
                 if (socketpair(AF_UNIX, SOCK_STREAM, 0, pmi_fds) < 0)
                     HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "pipe error\n");
 
-                status = HYDT_dmx_register_fd(1, &pmi_fds[0], HYD_POLLIN, NULL, pmi_cb);
+                status = HYDT_dmx_register_fd(1, &pmi_fds[0], HYD_POLLIN, p, pmi_cb);
                 HYDU_ERR_POP(status, "unable to register fd\n");
 
                 status = HYDU_sock_cloexec(pmi_fds[0]);
                 HYDU_ERR_POP(status, "unable to set socket to close on exec\n");
 
-                HYD_pmcd_pmip.downstream.pmi_fd[process_id] = pmi_fds[0];
+                p->pmi_fd = pmi_fds[0];
                 str = HYDU_int_to_str(pmi_fds[1]);
 
                 status = HYDU_append_env_to_list("PMI_FD", str, &force_env);
@@ -990,15 +978,12 @@ static HYD_status launch_procs(void)
              * but this is a safe-guard to workaround that.  See
              * ticket #1622 for more details. */
             status = HYDU_create_process(stash.strlist, force_env,
-                                         HYD_pmcd_pmip.downstream.pmi_rank[process_id] ? &dummy :
-                                         &HYD_pmcd_pmip.downstream.in,
-                                         &HYD_pmcd_pmip.downstream.out[process_id],
-                                         &HYD_pmcd_pmip.downstream.err[process_id],
-                                         &HYD_pmcd_pmip.downstream.pid[process_id], process_id);
+                                         p->pmi_rank ? &dummy : &p->in,
+                                         &p->out, &p->err, &p->pid, process_id);
             HYDU_ERR_POP(status, "create process returned error\n");
 
-            if (HYD_pmcd_pmip.downstream.in != HYD_FD_UNSET) {
-                status = HYDU_sock_set_nonblock(HYD_pmcd_pmip.downstream.in);
+            if (p->in != HYD_FD_UNSET) {
+                status = HYDU_sock_set_nonblock(p->in);
                 HYDU_ERR_POP(status, "unable to set stdin socket to non-blocking\n");
             }
 
@@ -1020,18 +1005,21 @@ static HYD_status launch_procs(void)
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PID_LIST;
 
-    status = PMIP_send_hdr_upstream(&hdr, HYD_pmcd_pmip.downstream.pid,
-                                    HYD_pmcd_pmip.local.proxy_process_count * sizeof(int));
+    int *pid_list = PMIP_pg_get_pid_list(pg);
+    status = PMIP_send_hdr_upstream(&hdr, pid_list, num_procs * sizeof(int));
     HYDU_ERR_POP(status, "unable to send PID_LIST command upstream\n");
+    MPL_free(pid_list);
 
     /* Everything is spawned, register the required FDs  */
-    status = HYDT_dmx_register_fd(HYD_pmcd_pmip.local.proxy_process_count,
-                                  HYD_pmcd_pmip.downstream.out, HYD_POLLIN, NULL, stdout_cb);
-    HYDU_ERR_POP(status, "unable to register fd\n");
+    for (int i = 0; i < num_procs; i++) {
+        struct pmip_downstream *p = &pg->downstreams[i];
 
-    status = HYDT_dmx_register_fd(HYD_pmcd_pmip.local.proxy_process_count,
-                                  HYD_pmcd_pmip.downstream.err, HYD_POLLIN, NULL, stderr_cb);
-    HYDU_ERR_POP(status, "unable to register fd\n");
+        status = HYDT_dmx_register_fd(1, &p->out, HYD_POLLIN, p, stdout_cb);
+        HYDU_ERR_POP(status, "unable to register fd\n");
+
+        status = HYDT_dmx_register_fd(1, &p->err, HYD_POLLIN, p, stderr_cb);
+        HYDU_ERR_POP(status, "unable to register fd\n");
+    }
 
   fn_exit:
     HYDU_FUNC_EXIT();

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -14,9 +14,36 @@
 static int pmi_storage_len = 0;
 static char pmi_storage[HYD_TMPBUF_SIZE], *sptr = pmi_storage;
 
+HYD_status PMIP_send_hdr_upstream(struct HYD_pmcd_hdr *hdr, void *buf, int buflen)
+{
+    HYD_status status = HYD_SUCCESS;
+    int upstream_sock_closed, sent;
+
+    hdr->pgid = HYD_pmcd_pmip.local.pgid;
+    hdr->proxy_id = HYD_pmcd_pmip.local.id;
+    hdr->buflen = buflen;
+
+    status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, hdr, sizeof(*hdr), &sent,
+                             &upstream_sock_closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "sock write error\n");
+    HYDU_ASSERT(!upstream_sock_closed, status);
+
+    if (buflen > 0) {
+        status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, buf, buflen, &sent,
+                                 &upstream_sock_closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "sock write error\n");
+        HYDU_ASSERT(!upstream_sock_closed, status);
+    }
+
+  fn_exit:
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+
 static HYD_status stdoe_cb(int fd, HYD_event_t events, void *userp)
 {
-    int closed, i, sent, recvd, stdfd;
+    int closed, i, recvd, stdfd;
     char buf[HYD_TMPBUF_SIZE];
     struct HYD_pmcd_hdr hdr;
     HYD_status status = HYD_SUCCESS;
@@ -45,24 +72,10 @@ static HYD_status stdoe_cb(int fd, HYD_event_t events, void *userp)
 
         HYDU_ASSERT(i < HYD_pmcd_pmip.local.proxy_process_count, status);
 
-        hdr.pgid = HYD_pmcd_pmip.local.pgid;
-        hdr.proxy_id = HYD_pmcd_pmip.local.id;
         hdr.u.io.rank = HYD_pmcd_pmip.downstream.pmi_rank[i];
-        hdr.buflen = recvd;
 
-        {
-            int upstream_sock_closed;
-
-            status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent,
-                                     &upstream_sock_closed, HYDU_SOCK_COMM_MSGWAIT);
-            HYDU_ERR_POP(status, "sock write error\n");
-            HYDU_ASSERT(!upstream_sock_closed, status);
-
-            status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, buf, recvd, &sent,
-                                     &upstream_sock_closed, HYDU_SOCK_COMM_MSGWAIT);
-            HYDU_ERR_POP(status, "sock write error\n");
-            HYDU_ASSERT(!upstream_sock_closed, status);
-        }
+        status = PMIP_send_hdr_upstream(&hdr, buf, recvd);
+        HYDU_ERR_POP(status, "error sending hdr upstream\n");
     }
 
     if (closed) {
@@ -166,20 +179,11 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, int pmi_version)
     struct HYD_pmcd_hdr hdr;
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PMI;
-    hdr.pgid = HYD_pmcd_pmip.local.pgid;
-    hdr.proxy_id = HYD_pmcd_pmip.local.id;
     hdr.u.pmi.pmi_version = pmi_version;
     hdr.u.pmi.process_fd = fd;
-    hdr.buflen = buflen;
-    status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed,
-                             HYDU_SOCK_COMM_MSGWAIT);
-    HYDU_ERR_POP(status, "unable to send PMI header upstream\n");
-    HYDU_ASSERT(!closed, status);
 
-    status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, buf, buflen, &sent, &closed,
-                             HYDU_SOCK_COMM_MSGWAIT);
+    status = PMIP_send_hdr_upstream(&hdr, buf, buflen);
     HYDU_ERR_POP(status, "unable to send PMI command upstream\n");
-    HYDU_ASSERT(!closed, status);
 
   fn_exit:
     HYDU_FUNC_EXIT();
@@ -316,14 +320,11 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
                 HYD_pmcd_init_header(&hdr);
 
                 hdr.cmd = CMD_PROCESS_TERMINATED;
-                hdr.pgid = HYD_pmcd_pmip.local.pgid;
-                hdr.proxy_id = HYD_pmcd_pmip.local.id;
                 /* global rank for the terminated process */
                 hdr.u.data = HYD_pmcd_pmip.downstream.pmi_rank[pid];
-                status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr),
-                                         &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
-                HYDU_ERR_POP(status, "unable to send PMI header upstream\n");
-                HYDU_ASSERT(!closed, status);
+
+                status = PMIP_send_hdr_upstream(&hdr, NULL, 0);
+                HYDU_ERR_POP(status, "unable to send hdr upstream\n");
             }
         }
         goto fn_exit;
@@ -511,20 +512,10 @@ static HYD_status singleton_init(void)
     struct HYD_pmcd_hdr hdr;
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PID_LIST;
-    hdr.pgid = HYD_pmcd_pmip.local.pgid;
-    hdr.proxy_id = HYD_pmcd_pmip.local.id;
-    status =
-        HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed,
-                        HYDU_SOCK_COMM_MSGWAIT);
-    HYDU_ERR_POP(status, "unable to send PID_LIST command upstream\n");
-    HYDU_ASSERT(!closed, status);
 
-    status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control,
-                             HYD_pmcd_pmip.downstream.pid,
-                             HYD_pmcd_pmip.local.proxy_process_count * sizeof(int), &sent,
-                             &closed, HYDU_SOCK_COMM_MSGWAIT);
-    HYDU_ERR_POP(status, "unable to send PID list upstream\n");
-    HYDU_ASSERT(!closed, status);
+    status = PMIP_send_hdr_upstream(&hdr, HYD_pmcd_pmip.downstream.pid,
+                                    HYD_pmcd_pmip.local.proxy_process_count * sizeof(int));
+    HYDU_ERR_POP(status, "unable to send PID_LIST command upstream\n");
 
     /* skip HYDT_dmx_register_fd */
 
@@ -828,20 +819,10 @@ static HYD_status launch_procs(void)
     /* Send the PID list upstream */
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PID_LIST;
-    hdr.pgid = HYD_pmcd_pmip.local.pgid;
-    hdr.proxy_id = HYD_pmcd_pmip.local.id;
-    status =
-        HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed,
-                        HYDU_SOCK_COMM_MSGWAIT);
-    HYDU_ERR_POP(status, "unable to send PID_LIST command upstream\n");
-    HYDU_ASSERT(!closed, status);
 
-    status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control,
-                             HYD_pmcd_pmip.downstream.pid,
-                             HYD_pmcd_pmip.local.proxy_process_count * sizeof(int), &sent,
-                             &closed, HYDU_SOCK_COMM_MSGWAIT);
-    HYDU_ERR_POP(status, "unable to send PID list upstream\n");
-    HYDU_ASSERT(!closed, status);
+    status = PMIP_send_hdr_upstream(&hdr, HYD_pmcd_pmip.downstream.pid,
+                                    HYD_pmcd_pmip.local.proxy_process_count * sizeof(int));
+    HYDU_ERR_POP(status, "unable to send PID_LIST command upstream\n");
 
     /* Everything is spawned, register the required FDs  */
     status = HYDT_dmx_register_fd(HYD_pmcd_pmip.local.proxy_process_count,

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -568,6 +568,8 @@ static HYD_status handle_launch_procs(struct pmip_pg *pg)
 
     int fd = HYD_pmcd_pmip.upstream.control;
 
+    HYD_set_cur_pg(pg);
+
     status = procinfo(fd);
     HYDU_ERR_POP(status, "error parsing process info\n");
 

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -621,9 +621,6 @@ static HYD_status parse_exec_params(char **t_argv)
                             HYD_pmcd_pmip.system_global.pmi_id_map.filler_start,
                             HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start);
 
-    if (HYD_pmcd_pmip.local.proxy_core_count == -1)
-        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "proxy core count not available\n");
-
     /* Set default values */
     if (HYD_pmcd_pmip.user_global.topolib == NULL && HYDRA_DEFAULT_TOPOLIB != NULL) {
         /* need to prevent compiler seeing MPL_strdup(NULL) or it will warn */

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -455,22 +455,214 @@ static HYD_status pmi_listen_cb(int fd, HYD_event_t events, void *userp)
     goto fn_exit;
 }
 
-static int local_to_global_id(int local_id)
+static HYD_status handle_launch_procs(int fd);
+
+HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
 {
-    int rem1, rem2, layer, ret;
+    int cmd_len, closed;
+    struct HYD_pmcd_hdr hdr;
+    char *buf;
+    HYD_status status = HYD_SUCCESS;
 
-    if (local_id < HYD_pmcd_pmip.system_global.global_core_map.local_filler)
-        ret = HYD_pmcd_pmip.system_global.pmi_id_map.filler_start + local_id;
-    else {
-        rem1 = local_id - HYD_pmcd_pmip.system_global.global_core_map.local_filler;
-        layer = rem1 / HYD_pmcd_pmip.system_global.global_core_map.local_count;
-        rem2 = rem1 - (layer * HYD_pmcd_pmip.system_global.global_core_map.local_count);
+    HYDU_FUNC_ENTER();
 
-        ret = HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start +
-            (layer * HYD_pmcd_pmip.system_global.global_core_map.global_count) + rem2;
+    /* We got a command from upstream */
+    status = HYDU_sock_read(fd, &hdr, sizeof(hdr), &cmd_len, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "error reading command from launcher\n");
+    HYDU_ASSERT(!closed, status);
+
+    if (hdr.cmd == CMD_PROC_INFO) {
+        status = handle_launch_procs(fd);
+        HYDU_ERR_POP(status, "launch_procs returned error\n");
+    } else if (hdr.cmd == CMD_PMI_RESPONSE) {
+        status = handle_pmi_response(fd, hdr.buflen, hdr.u.pmi.pmi_version, hdr.u.pmi.process_fd);
+        HYDU_ERR_POP(status, "unable to handle PMI response\n");
+    } else if (hdr.cmd == CMD_SIGNAL) {
+        int signum = hdr.u.data;
+        /* FIXME: This code needs to change from sending the signal to
+         * a PMI-2 notification message. */
+        HYD_pmcd_pmip_send_signal(signum);
+    } else if (hdr.cmd == CMD_STDIN) {
+        int count;
+
+        if (hdr.buflen) {
+            HYDU_MALLOC_OR_JUMP(buf, char *, hdr.buflen, status);
+            HYDU_ERR_POP(status, "unable to allocate memory\n");
+
+            status = HYDU_sock_read(fd, buf, hdr.buflen, &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
+            HYDU_ERR_POP(status, "unable to read from control socket\n");
+            HYDU_ASSERT(!closed, status);
+
+            if (HYD_pmcd_pmip.downstream.in == HYD_FD_CLOSED) {
+                MPL_free(buf);
+                goto fn_exit;
+            }
+
+            status = HYDU_sock_write(HYD_pmcd_pmip.downstream.in, buf, hdr.buflen, &count,
+                                     &closed, HYDU_SOCK_COMM_NONE);
+            HYDU_ERR_POP(status, "unable to write to downstream stdin\n");
+
+            HYDU_ERR_CHKANDJUMP(status, count != hdr.buflen, HYD_INTERNAL_ERROR,
+                                "process reading stdin too slowly; can't keep up\n");
+
+            HYDU_ASSERT(count == hdr.buflen, status);
+
+            if (HYD_pmcd_pmip.user_global.auto_cleanup) {
+                HYDU_ASSERT(!closed, status);
+            } else if (closed) {
+                close(HYD_pmcd_pmip.downstream.in);
+                HYD_pmcd_pmip.downstream.in = HYD_FD_CLOSED;
+            }
+
+            MPL_free(buf);
+        } else {
+            close(HYD_pmcd_pmip.downstream.in);
+            HYD_pmcd_pmip.downstream.in = HYD_FD_CLOSED;
+        }
+    } else {
+        status = HYD_INTERNAL_ERROR;
     }
 
-    return ret;
+    HYDU_ERR_POP(status, "error handling proxy command\n");
+
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+/* handle_launch_procs - read proc_info and launch procs */
+
+static HYD_status parse_exec_params(char **t_argv);
+static HYD_status procinfo(int fd);
+static HYD_status singleton_init(void);
+static HYD_status launch_procs(void);
+static int local_to_global_id(int local_id);
+
+static HYD_status handle_launch_procs(int fd)
+{
+    HYD_status status = HYD_SUCCESS;
+    HYDU_FUNC_ENTER();
+
+    status = procinfo(fd);
+    HYDU_ERR_POP(status, "error parsing process info\n");
+
+    if (HYD_pmcd_pmip.user_global.singleton_port > 0) {
+        status = singleton_init();
+        HYDU_ERR_POP(status, "singleton_init returned error\n");
+    } else {
+        status = launch_procs();
+        HYDU_ERR_POP(status, "launch_procs returned error\n");
+    }
+
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+
+static HYD_status parse_exec_params(char **t_argv)
+{
+    char **argv = t_argv;
+    HYD_status status = HYD_SUCCESS;
+
+    HYDU_FUNC_ENTER();
+
+    do {
+        /* Get the executable arguments  */
+        status = HYDU_parse_array(&argv, HYD_pmcd_pmip_match_table);
+        HYDU_ERR_POP(status, "error parsing input array\n");
+
+        /* No more arguments left */
+        if (!(*argv))
+            break;
+    } while (1);
+
+    /* verify the arguments we got */
+    if (HYD_pmcd_pmip.system_global.global_core_map.local_filler == -1 ||
+        HYD_pmcd_pmip.system_global.global_core_map.local_count == -1 ||
+        HYD_pmcd_pmip.system_global.global_core_map.global_count == -1)
+        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
+                            "cannot find global core map (%d,%d,%d)\n",
+                            HYD_pmcd_pmip.system_global.global_core_map.local_filler,
+                            HYD_pmcd_pmip.system_global.global_core_map.local_count,
+                            HYD_pmcd_pmip.system_global.global_core_map.global_count);
+
+    if (HYD_pmcd_pmip.system_global.pmi_id_map.filler_start == -1 ||
+        HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start == -1)
+        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
+                            "cannot find pmi id map (%d,%d)\n",
+                            HYD_pmcd_pmip.system_global.pmi_id_map.filler_start,
+                            HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start);
+
+    if (HYD_pmcd_pmip.local.proxy_core_count == -1)
+        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "proxy core count not available\n");
+
+    /* Set default values */
+    if (HYD_pmcd_pmip.user_global.topolib == NULL && HYDRA_DEFAULT_TOPOLIB != NULL) {
+        /* need to prevent compiler seeing MPL_strdup(NULL) or it will warn */
+        const char *topolib = HYDRA_DEFAULT_TOPOLIB;
+        HYD_pmcd_pmip.user_global.topolib = MPL_strdup(topolib);
+    }
+
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static HYD_status procinfo(int fd)
+{
+    char **arglist;
+    int num_strings, str_len, recvd, i, closed;
+    HYD_status status = HYD_SUCCESS;
+
+    HYDU_FUNC_ENTER();
+
+    /* Read information about the application to launch into a string
+     * array and call parse_exec_params() to interpret it and load it into
+     * the proxy handle. */
+    status = HYDU_sock_read(fd, &num_strings, sizeof(int), &recvd, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "error reading data from upstream\n");
+    HYDU_ASSERT(!closed, status);
+
+    HYDU_MALLOC_OR_JUMP(arglist, char **, (num_strings + 1) * sizeof(char *), status);
+
+    for (i = 0; i < num_strings; i++) {
+        status = HYDU_sock_read(fd, &str_len, sizeof(int), &recvd, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "error reading data from upstream\n");
+        HYDU_ASSERT(!closed, status);
+
+        HYDU_MALLOC_OR_JUMP(arglist[i], char *, str_len, status);
+
+        status = HYDU_sock_read(fd, arglist[i], str_len, &recvd, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "error reading data from upstream\n");
+        HYDU_ASSERT(!closed, status);
+    }
+    arglist[num_strings] = NULL;
+
+    /* Get the parser to fill in the proxy params structure. */
+    status = parse_exec_params(arglist);
+    HYDU_ERR_POP(status, "unable to parse argument list\n");
+
+    HYDU_free_strlist(arglist);
+    MPL_free(arglist);
+
+    /* Save this fd as we need to send back the exit status on
+     * this. */
+    HYD_pmcd_pmip.upstream.control = fd;
+
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    goto fn_exit;
 }
 
 static HYD_status singleton_init(void)
@@ -849,187 +1041,20 @@ static HYD_status launch_procs(void)
     goto fn_exit;
 }
 
-static HYD_status parse_exec_params(char **t_argv)
+static int local_to_global_id(int local_id)
 {
-    char **argv = t_argv;
-    HYD_status status = HYD_SUCCESS;
+    int rem1, rem2, layer, ret;
 
-    HYDU_FUNC_ENTER();
+    if (local_id < HYD_pmcd_pmip.system_global.global_core_map.local_filler)
+        ret = HYD_pmcd_pmip.system_global.pmi_id_map.filler_start + local_id;
+    else {
+        rem1 = local_id - HYD_pmcd_pmip.system_global.global_core_map.local_filler;
+        layer = rem1 / HYD_pmcd_pmip.system_global.global_core_map.local_count;
+        rem2 = rem1 - (layer * HYD_pmcd_pmip.system_global.global_core_map.local_count);
 
-    do {
-        /* Get the executable arguments  */
-        status = HYDU_parse_array(&argv, HYD_pmcd_pmip_match_table);
-        HYDU_ERR_POP(status, "error parsing input array\n");
-
-        /* No more arguments left */
-        if (!(*argv))
-            break;
-    } while (1);
-
-    /* verify the arguments we got */
-    if (HYD_pmcd_pmip.system_global.global_core_map.local_filler == -1 ||
-        HYD_pmcd_pmip.system_global.global_core_map.local_count == -1 ||
-        HYD_pmcd_pmip.system_global.global_core_map.global_count == -1)
-        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
-                            "cannot find global core map (%d,%d,%d)\n",
-                            HYD_pmcd_pmip.system_global.global_core_map.local_filler,
-                            HYD_pmcd_pmip.system_global.global_core_map.local_count,
-                            HYD_pmcd_pmip.system_global.global_core_map.global_count);
-
-    if (HYD_pmcd_pmip.system_global.pmi_id_map.filler_start == -1 ||
-        HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start == -1)
-        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
-                            "cannot find pmi id map (%d,%d)\n",
-                            HYD_pmcd_pmip.system_global.pmi_id_map.filler_start,
-                            HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start);
-
-    if (HYD_pmcd_pmip.local.proxy_core_count == -1)
-        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "proxy core count not available\n");
-
-    /* Set default values */
-    if (HYD_pmcd_pmip.user_global.topolib == NULL && HYDRA_DEFAULT_TOPOLIB != NULL) {
-        /* need to prevent compiler seeing MPL_strdup(NULL) or it will warn */
-        const char *topolib = HYDRA_DEFAULT_TOPOLIB;
-        HYD_pmcd_pmip.user_global.topolib = MPL_strdup(topolib);
+        ret = HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start +
+            (layer * HYD_pmcd_pmip.system_global.global_core_map.global_count) + rem2;
     }
 
-  fn_exit:
-    HYDU_FUNC_EXIT();
-    return status;
-
-  fn_fail:
-    goto fn_exit;
-}
-
-static HYD_status procinfo(int fd)
-{
-    char **arglist;
-    int num_strings, str_len, recvd, i, closed;
-    HYD_status status = HYD_SUCCESS;
-
-    HYDU_FUNC_ENTER();
-
-    /* Read information about the application to launch into a string
-     * array and call parse_exec_params() to interpret it and load it into
-     * the proxy handle. */
-    status = HYDU_sock_read(fd, &num_strings, sizeof(int), &recvd, &closed, HYDU_SOCK_COMM_MSGWAIT);
-    HYDU_ERR_POP(status, "error reading data from upstream\n");
-    HYDU_ASSERT(!closed, status);
-
-    HYDU_MALLOC_OR_JUMP(arglist, char **, (num_strings + 1) * sizeof(char *), status);
-
-    for (i = 0; i < num_strings; i++) {
-        status = HYDU_sock_read(fd, &str_len, sizeof(int), &recvd, &closed, HYDU_SOCK_COMM_MSGWAIT);
-        HYDU_ERR_POP(status, "error reading data from upstream\n");
-        HYDU_ASSERT(!closed, status);
-
-        HYDU_MALLOC_OR_JUMP(arglist[i], char *, str_len, status);
-
-        status = HYDU_sock_read(fd, arglist[i], str_len, &recvd, &closed, HYDU_SOCK_COMM_MSGWAIT);
-        HYDU_ERR_POP(status, "error reading data from upstream\n");
-        HYDU_ASSERT(!closed, status);
-    }
-    arglist[num_strings] = NULL;
-
-    /* Get the parser to fill in the proxy params structure. */
-    status = parse_exec_params(arglist);
-    HYDU_ERR_POP(status, "unable to parse argument list\n");
-
-    HYDU_free_strlist(arglist);
-    MPL_free(arglist);
-
-    /* Save this fd as we need to send back the exit status on
-     * this. */
-    HYD_pmcd_pmip.upstream.control = fd;
-
-  fn_exit:
-    HYDU_FUNC_EXIT();
-    return status;
-
-  fn_fail:
-    goto fn_exit;
-}
-
-HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
-{
-    int cmd_len, closed;
-    struct HYD_pmcd_hdr hdr;
-    char *buf;
-    HYD_status status = HYD_SUCCESS;
-
-    HYDU_FUNC_ENTER();
-
-    /* We got a command from upstream */
-    status = HYDU_sock_read(fd, &hdr, sizeof(hdr), &cmd_len, &closed, HYDU_SOCK_COMM_MSGWAIT);
-    HYDU_ERR_POP(status, "error reading command from launcher\n");
-    HYDU_ASSERT(!closed, status);
-
-    if (hdr.cmd == CMD_PROC_INFO) {
-        status = procinfo(fd);
-        HYDU_ERR_POP(status, "error parsing process info\n");
-
-        if (HYD_pmcd_pmip.user_global.singleton_port > 0) {
-            status = singleton_init();
-            HYDU_ERR_POP(status, "singleton_init returned error\n");
-        } else {
-            status = launch_procs();
-            HYDU_ERR_POP(status, "launch_procs returned error\n");
-        }
-    } else if (hdr.cmd == CMD_PMI_RESPONSE) {
-        status = handle_pmi_response(fd, hdr.buflen, hdr.u.pmi.pmi_version, hdr.u.pmi.process_fd);
-        HYDU_ERR_POP(status, "unable to handle PMI response\n");
-    } else if (hdr.cmd == CMD_SIGNAL) {
-        int signum = hdr.u.data;
-        /* FIXME: This code needs to change from sending the signal to
-         * a PMI-2 notification message. */
-        HYD_pmcd_pmip_send_signal(signum);
-    } else if (hdr.cmd == CMD_STDIN) {
-        int count;
-
-        if (hdr.buflen) {
-            HYDU_MALLOC_OR_JUMP(buf, char *, hdr.buflen, status);
-            HYDU_ERR_POP(status, "unable to allocate memory\n");
-
-            status = HYDU_sock_read(fd, buf, hdr.buflen, &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
-            HYDU_ERR_POP(status, "unable to read from control socket\n");
-            HYDU_ASSERT(!closed, status);
-
-            if (HYD_pmcd_pmip.downstream.in == HYD_FD_CLOSED) {
-                MPL_free(buf);
-                goto fn_exit;
-            }
-
-            status = HYDU_sock_write(HYD_pmcd_pmip.downstream.in, buf, hdr.buflen, &count,
-                                     &closed, HYDU_SOCK_COMM_NONE);
-            HYDU_ERR_POP(status, "unable to write to downstream stdin\n");
-
-            HYDU_ERR_CHKANDJUMP(status, count != hdr.buflen, HYD_INTERNAL_ERROR,
-                                "process reading stdin too slowly; can't keep up\n");
-
-            HYDU_ASSERT(count == hdr.buflen, status);
-
-            if (HYD_pmcd_pmip.user_global.auto_cleanup) {
-                HYDU_ASSERT(!closed, status);
-            } else if (closed) {
-                close(HYD_pmcd_pmip.downstream.in);
-                HYD_pmcd_pmip.downstream.in = HYD_FD_CLOSED;
-            }
-
-            MPL_free(buf);
-        } else {
-            close(HYD_pmcd_pmip.downstream.in);
-            HYD_pmcd_pmip.downstream.in = HYD_FD_CLOSED;
-        }
-    } else {
-        status = HYD_INTERNAL_ERROR;
-    }
-
-    HYDU_ERR_POP(status, "error handling proxy command\n");
-
-  fn_exit:
-    HYDU_FUNC_EXIT();
-    return status;
-
-  fn_fail:
-    goto fn_exit;
+    return ret;
 }

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -41,22 +41,20 @@ HYD_status PMIP_send_hdr_upstream(struct HYD_pmcd_hdr *hdr, void *buf, int bufle
     goto fn_exit;
 }
 
-static HYD_status stdoe_cb(int fd, HYD_event_t events, void *userp)
+static HYD_status stdoe_cb(int fd, bool is_stdout)
 {
-    int closed, i, recvd, stdfd;
+    int closed, i, recvd;
     char buf[HYD_TMPBUF_SIZE];
     struct HYD_pmcd_hdr hdr;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
-    stdfd = (int) (size_t) userp;
-
     status = HYDU_sock_read(fd, buf, HYD_TMPBUF_SIZE, &recvd, &closed, HYDU_SOCK_COMM_NONE);
     HYDU_ERR_POP(status, "sock read error\n");
 
     if (recvd) {
-        if (stdfd == STDOUT_FILENO) {
+        if (is_stdout) {
             HYD_pmcd_init_header(&hdr);
             hdr.cmd = CMD_STDOUT;
             for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++)
@@ -83,7 +81,7 @@ static HYD_status stdoe_cb(int fd, HYD_event_t events, void *userp)
         status = HYDT_dmx_deregister_fd(fd);
         HYDU_ERR_POP(status, "unable to deregister fd\n");
 
-        if (stdfd == STDOUT_FILENO) {
+        if (is_stdout) {
             for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++)
                 if (HYD_pmcd_pmip.downstream.out[i] == fd)
                     HYD_pmcd_pmip.downstream.out[i] = HYD_FD_CLOSED;
@@ -102,6 +100,16 @@ static HYD_status stdoe_cb(int fd, HYD_event_t events, void *userp)
 
   fn_fail:
     goto fn_exit;
+}
+
+static HYD_status stdout_cb(int fd, HYD_event_t events, void *userp)
+{
+    return stdoe_cb(fd, true);
+}
+
+static HYD_status stderr_cb(int fd, HYD_event_t events, void *userp)
+{
+    return stdoe_cb(fd, false);
 }
 
 static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, int pmi_version)
@@ -826,13 +834,11 @@ static HYD_status launch_procs(void)
 
     /* Everything is spawned, register the required FDs  */
     status = HYDT_dmx_register_fd(HYD_pmcd_pmip.local.proxy_process_count,
-                                  HYD_pmcd_pmip.downstream.out, HYD_POLLIN,
-                                  (void *) (size_t) STDOUT_FILENO, stdoe_cb);
+                                  HYD_pmcd_pmip.downstream.out, HYD_POLLIN, NULL, stdout_cb);
     HYDU_ERR_POP(status, "unable to register fd\n");
 
     status = HYDT_dmx_register_fd(HYD_pmcd_pmip.local.proxy_process_count,
-                                  HYD_pmcd_pmip.downstream.err, HYD_POLLIN,
-                                  (void *) (size_t) STDERR_FILENO, stdoe_cb);
+                                  HYD_pmcd_pmip.downstream.err, HYD_POLLIN, NULL, stderr_cb);
     HYDU_ERR_POP(status, "unable to register fd\n");
 
   fn_exit:

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -36,6 +36,8 @@ struct pmip_pg *PMIP_new_pg(int pgid, int proxy_id)
 
     pg->pgid = pgid;
     pg->proxy_id = proxy_id;
+
+    HYD_pmcd_pmi_allocate_kvs(&pg->kvs, -1);
     /* the rest of the fields have been zero-filled */
 
     return pg;
@@ -93,9 +95,11 @@ void PMIP_free_pg(struct pmip_pg *pg)
     struct pmip_pg *arr = ut_type_array(PMIP_pgs, struct pmip_pg *);
 
     MPL_free(pg->spawner_kvsname);
+    MPL_free(pg->kvsname);
     MPL_free(pg->pmi_process_mapping);
     MPL_free(pg->downstreams);
     HYDU_free_exec_list(pg->exec_list);
+    HYD_pmcd_free_pmi_kvs_list(pg->kvs);
 
     int idx = pg - arr;
     if (idx < 0 || idx >= n) {

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -52,6 +52,24 @@ struct pmip_pg *PMIP_pg_0(void)
     }
 }
 
+/* iterate each pg */
+HYD_status PMIP_foreach_pg_do(HYD_status(*callback) (struct pmip_pg * pg))
+{
+    HYD_status status = HYD_SUCCESS;
+
+    int n = utarray_len(PMIP_pgs);
+    struct pmip_pg *arr = ut_type_array(PMIP_pgs, struct pmip_pg *);
+    for (int i = 0; i < n; i++) {
+        status = callback(&arr[i]);
+        HYDU_ERR_POP(status, "foreach_pg_do failed at i = %d / %d", i, n);
+    }
+
+  fn_exit:
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+
 /* linear search.
  * Typical case is the first pg when spawn is not used. When spawn is used, we don't
  * expect a single proxy to host too many active spawns
@@ -98,6 +116,8 @@ void PMIP_free_pg(struct pmip_pg *pg)
     MPL_free(pg->kvsname);
     MPL_free(pg->pmi_process_mapping);
     MPL_free(pg->downstreams);
+    MPL_free(pg->iface_ip_env_name);
+    MPL_free(pg->hostname);
     HYDU_free_exec_list(pg->exec_list);
     HYD_pmcd_free_pmi_kvs_list(pg->kvs);
 

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -95,6 +95,7 @@ void PMIP_free_pg(struct pmip_pg *pg)
     MPL_free(pg->spawner_kvsname);
     MPL_free(pg->pmi_process_mapping);
     MPL_free(pg->downstreams);
+    HYDU_free_exec_list(pg->exec_list);
 
     int idx = pg - arr;
     if (idx < 0 || idx >= n) {

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -101,6 +101,13 @@ void PMIP_free_pg(struct pmip_pg *pg)
     HYDU_free_exec_list(pg->exec_list);
     HYD_pmcd_free_pmi_kvs_list(pg->kvs);
 
+    HASH_CLEAR(hh, pg->hash_get);
+    for (int i = 0; i < pg->num_elems; i++) {
+        MPL_free((pg->cache_get + i)->key);
+        MPL_free((pg->cache_get + i)->val);
+    }
+    MPL_free(pg->cache_get);
+
     int idx = pg - arr;
     if (idx < 0 || idx >= n) {
         /* ERROR */

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -92,6 +92,8 @@ void PMIP_free_pg(struct pmip_pg *pg)
     int n = utarray_len(PMIP_pgs);
     struct pmip_pg *arr = ut_type_array(PMIP_pgs, struct pmip_pg *);
 
+    MPL_free(pg->spawner_kvsname);
+    MPL_free(pg->pmi_process_mapping);
     MPL_free(pg->downstreams);
 
     int idx = pg - arr;

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -37,7 +37,7 @@ struct pmip_pg *PMIP_new_pg(int pgid, int proxy_id)
     pg->pgid = pgid;
     pg->proxy_id = proxy_id;
 
-    HYD_pmcd_pmi_allocate_kvs(&pg->kvs, -1);
+    HYD_pmcd_pmi_allocate_kvs(&pg->kvs);
     /* the rest of the fields have been zero-filled */
 
     return pg;

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "pmip.h"
+#include "utarray.h"
+
+static UT_array *PMIP_pgs;
+static UT_icd pg_icd = { sizeof(struct pmip_pg), NULL, NULL, NULL };
+
+#define FIND_DOWNSTREAM(fd, field) do { \
+    struct pmip_downstream *arr = ut_type_array(PMIP_downstreams, struct pmip_downstream *); \
+    for (int i = 0; i < utarray_len(PMIP_downstreams); i++) { \
+        if (arr[i].field == fd) { \
+            return &arr[i]; \
+        } \
+    } \
+    return NULL; \
+} while (0)
+
+void PMIP_pg_init(void)
+{
+    utarray_new(PMIP_pgs, &pg_icd, MPL_MEM_OTHER);
+}
+
+void PMIP_pg_finalize(void)
+{
+    utarray_free(PMIP_pgs);
+}
+
+struct pmip_pg *PMIP_new_pg(int pgid, int proxy_id)
+{
+    utarray_extend_back(PMIP_pgs, MPL_MEM_OTHER);
+    struct pmip_pg *pg = (void *) utarray_back(PMIP_pgs);
+
+    pg->pgid = pgid;
+    pg->proxy_id = proxy_id;
+    /* the rest of the fields have been zero-filled */
+
+    return pg;
+}
+
+struct pmip_pg *PMIP_pg_0(void)
+{
+    if (utarray_len(PMIP_pgs) > 0) {
+        return (void *) utarray_front(PMIP_pgs);
+    } else {
+        return NULL;
+    }
+}
+
+/* linear search.
+ * Typical case is the first pg when spawn is not used. When spawn is used, we don't
+ * expect a single proxy to host too many active spawns
+ */
+struct pmip_pg *PMIP_find_pg(int pgid, int proxy_id)
+{
+    int n = utarray_len(PMIP_pgs);
+    struct pmip_pg *arr = ut_type_array(PMIP_pgs, struct pmip_pg *);
+    for (int i = 0; i < n; i++) {
+        if (arr[i].pgid == pgid && arr[i].proxy_id == proxy_id) {
+            return &arr[i];
+        }
+    }
+    return NULL;
+}
+
+HYD_status PMIP_pg_alloc_downstreams(struct pmip_pg * pg, int num_procs)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    pg->num_procs = num_procs;
+    pg->downstreams = MPL_calloc(num_procs, sizeof(struct pmip_downstream), MPL_MEM_OTHER);
+    HYDU_ASSERT(pg->downstreams, status);
+
+    for (int i = 0; i < num_procs; i++) {
+        pg->downstreams[i].pg = pg;
+        pg->downstreams[i].pid = -1;
+        pg->downstreams[i].exit_status = PMIP_EXIT_STATUS_UNSET;
+        pg->downstreams[i].pmi_fd = HYD_FD_UNSET;
+    }
+
+  fn_exit:
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+
+void PMIP_free_pg(struct pmip_pg *pg)
+{
+    int n = utarray_len(PMIP_pgs);
+    struct pmip_pg *arr = ut_type_array(PMIP_pgs, struct pmip_pg *);
+
+    MPL_free(pg->downstreams);
+
+    int idx = pg - arr;
+    if (idx < 0 || idx >= n) {
+        /* ERROR */
+        return;
+    } else if (idx < n - 1) {
+        /* move the last element to replace the hole */
+        memcpy(pg, arr + n - 1, sizeof(struct pmip_pg));
+    }
+
+    utarray_pop_back(PMIP_pgs);
+}
+
+/* whole-pg downstreams query utilities */
+
+#define GET_DOWNSTREAM_INTARR(pg, field) do { \
+    int *p = MPL_malloc(pg->num_procs * sizeof(int), MPL_MEM_OTHER); \
+    if (p) { \
+        for (int i = 0; i < pg->num_procs; i++) { \
+            p[i] = pg->downstreams[i].field; \
+        } \
+    } \
+    return p; \
+} while (0)
+
+bool PMIP_pg_has_open_stdoe(struct pmip_pg *pg)
+{
+    for (int i = 0; i < pg->num_procs; i++) {
+        if (pg->downstreams[i].out != HYD_FD_CLOSED || pg->downstreams[i].err != HYD_FD_CLOSED) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int *PMIP_pg_get_pid_list(struct pmip_pg *pg)
+{
+    GET_DOWNSTREAM_INTARR(pg, pid);
+}
+
+int *PMIP_pg_get_stdout_list(struct pmip_pg *pg)
+{
+    GET_DOWNSTREAM_INTARR(pg, out);
+}
+
+int *PMIP_pg_get_stderr_list(struct pmip_pg *pg)
+{
+    GET_DOWNSTREAM_INTARR(pg, err);
+}
+
+int *PMIP_pg_get_exit_status_list(struct pmip_pg *pg)
+{
+    GET_DOWNSTREAM_INTARR(pg, exit_status);
+}
+
+#define FIND_DOWNSTREAM_BY(field) do { \
+    int n = utarray_len(PMIP_pgs); \
+    struct pmip_pg *arr = ut_type_array(PMIP_pgs, struct pmip_pg *); \
+    for (int i = 0; i < n; i++) { \
+        for (int j = 0; j < arr[i].num_procs; j++) { \
+            if (arr[i].downstreams[j].field == field) { \
+                return &arr[i].downstreams[j]; \
+            } \
+        } \
+    } \
+} while (0)
+
+
+struct pmip_downstream *PMIP_find_downstream_by_fd(int pmi_fd)
+{
+    FIND_DOWNSTREAM_BY(pmi_fd);
+    return NULL;
+}
+
+struct pmip_downstream *PMIP_find_downstream_by_pid(int pid)
+{
+    FIND_DOWNSTREAM_BY(pid);
+    return NULL;
+}
+
+int PMIP_get_total_process_count(void)
+{
+    int count = 0;
+
+    int n = utarray_len(PMIP_pgs);
+    struct pmip_pg *arr = ut_type_array(PMIP_pgs, struct pmip_pg *);
+    for (int i = 0; i < n; i++) {
+        count += arr[i].num_procs;
+    }
+
+    return count;
+}
+
+bool PMIP_has_open_stdoe(void)
+{
+    int n = utarray_len(PMIP_pgs);
+    struct pmip_pg *arr = ut_type_array(PMIP_pgs, struct pmip_pg *);
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < arr[i].num_procs; j++) {
+            if (arr[i].downstreams[j].out != HYD_FD_CLOSED ||
+                arr[i].downstreams[j].err != HYD_FD_CLOSED) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void PMIP_bcast_signal(int sig)
+{
+    int n = utarray_len(PMIP_pgs);
+    struct pmip_pg *arr = ut_type_array(PMIP_pgs, struct pmip_pg *);
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < arr[i].num_procs; j++) {
+            int pid = arr[i].downstreams[j].pid;
+            if (pid != -1) {
+#if defined(HAVE_GETPGID) && defined(HAVE_SETSID)
+                /* If we are able to get the process group ID, and the
+                 * child process has its own process group ID, send a
+                 * signal to the entire process group */
+                int pgid = getpgid(pid);
+                killpg(pgid, sig);
+#else
+                kill(pid, sig);
+#endif
+            }
+        }
+    }
+}

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -378,8 +378,7 @@ HYD_status fn_get_my_kvsname(struct pmip_downstream *p, struct PMIU_cmd *pmi)
     HYDU_FUNC_ENTER();
 
     struct PMIU_cmd pmi_response;
-    pmi_errno = PMIU_msg_set_response_kvsname(pmi, &pmi_response, is_static,
-                                              HYD_pmcd_pmip.local.kvs->kvsname);
+    pmi_errno = PMIU_msg_set_response_kvsname(pmi, &pmi_response, is_static, p->pg->kvsname);
     HYDU_ASSERT(!pmi_errno, status);
 
     status = send_cmd_downstream(p->pmi_fd, &pmi_response);
@@ -681,7 +680,7 @@ HYD_status fn_info_putnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
         goto fn_exit;
     }
 
-    status = HYD_pmcd_pmi_add_kvs(key, val, HYD_pmcd_pmip.local.kvs, &ret);
+    status = HYD_pmcd_pmi_add_kvs(key, val, p->pg->kvs, &ret);
     HYDU_ERR_POP(status, "unable to put data into kvs\n");
 
     pmi_errno = PMIU_msg_set_response(pmi, &pmi_response, is_static);
@@ -718,8 +717,9 @@ HYD_status fn_info_getnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
     int found;
     found = 0;
 
+    /* FIXME: wrap it in e.g. HYD_pmcd_pmi_find_kvs */
     struct HYD_pmcd_pmi_kvs_pair *run;
-    for (run = HYD_pmcd_pmip.local.kvs->key_pair; run; run = run->next) {
+    for (run = p->pg->kvs->key_pair; run; run = run->next) {
         if (!strcmp(run->key, key)) {
             found = 1;
             break;

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -304,14 +304,14 @@ HYD_status fn_fullinit(int fd, struct PMIU_cmd *pmi)
     }
     HYDU_ASSERT(p, status);
 
-    int size = HYD_pmcd_pmip.system_global.global_process_count;
+    int size = pg->global_process_count;
     int rank = id;
     int debug = HYD_pmcd_pmip.user_global.debug;
     int appnum = p->pmi_appnum;
 
     struct PMIU_cmd pmi_response;
     pmi_errno = PMIU_msg_set_response_fullinit(pmi, &pmi_response, is_static, rank, size, appnum,
-                                               HYD_pmcd_pmip.local.spawner_kvsname, debug);
+                                               pg->spawner_kvsname, debug);
     HYDU_ASSERT(!pmi_errno, status);
 
     status = send_cmd_downstream(fd, &pmi_response);
@@ -401,7 +401,7 @@ HYD_status fn_get_usize(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 
     int universe_size;
     if (HYD_pmcd_pmip.user_global.usize == HYD_USIZE_SYSTEM) {
-        universe_size = HYD_pmcd_pmip.system_global.global_core_map.global_count;
+        universe_size = p->pg->global_core_map.global_count;
     } else if (HYD_pmcd_pmip.user_global.usize == HYD_USIZE_INFINITE) {
         universe_size = -1;
     } else {

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -173,7 +173,7 @@ static HYD_status send_cmd_upstream(struct PMIU_cmd *pmi, int fd)
 {
     struct HYD_pmcd_hdr hdr;
     hdr.cmd = CMD_PMI;
-    hdr.u.pmi.pid = fd;
+    hdr.u.pmi.process_fd = fd;
     return HYD_pmcd_pmi_send(HYD_pmcd_pmip.upstream.control, pmi, &hdr,
                              HYD_pmcd_pmip.user_global.debug);
 }

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -250,6 +250,7 @@ HYD_status fn_fullinit(int fd, struct PMIU_cmd *pmi)
 
     /* locate and initialize the downstream */
     struct pmip_downstream *p;
+    p = NULL;
     for (int i = 0; i < pg->num_procs; i++) {
         p = &pg->downstreams[i];
         if (p->pmi_rank == id) {

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -171,11 +171,35 @@ static int get_appnum(int local_rank)
 
 static HYD_status send_cmd_upstream(struct PMIU_cmd *pmi, int fd)
 {
+    HYD_status status = HYD_SUCCESS;
+    HYDU_FUNC_ENTER();
+
+    char *buf = NULL;
+    int buflen = 0;
+
+    int pmi_errno = PMIU_cmd_output(pmi, &buf, &buflen);
+    HYDU_ASSERT(!pmi_errno, status);
+
+    if (HYD_pmcd_pmip.user_global.debug) {
+        HYDU_dump(stdout, "Sending upstream internal PMI command:\n");
+        if (buf[buflen - 1] == '\n') {
+            HYDU_dump_noprefix(stdout, "    %s", buf);
+        } else {
+            HYDU_dump_noprefix(stdout, "%s\n", buf);
+        }
+    }
+
     struct HYD_pmcd_hdr hdr;
     hdr.cmd = CMD_PMI;
     hdr.u.pmi.process_fd = fd;
-    return HYD_pmcd_pmi_send(HYD_pmcd_pmip.upstream.control, pmi, &hdr,
-                             HYD_pmcd_pmip.user_global.debug);
+    status = PMIP_send_hdr_upstream(&hdr, buf, buflen);
+    HYDU_ERR_POP(status, "unable to send hdr\n");
+
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+  fn_fail:
+    goto fn_exit;
 }
 
 static HYD_status send_cmd_downstream(int fd, struct PMIU_cmd *pmi)

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -37,6 +37,7 @@ struct cache_elem {
     UT_hash_handle hh;
 };
 
+/* TODO: move static variables inside pmip_pg */
 static struct cache_put_elem cache_put;
 static struct cache_elem *cache_get = NULL, *hash_get = NULL;
 static int num_elems = 0;
@@ -156,19 +157,6 @@ static HYD_status poke_progress(const char *key)
     goto fn_exit;
 }
 
-static int get_appnum(int local_rank)
-{
-    int ranks = 0;
-    struct HYD_exec *exec;
-    for (exec = HYD_pmcd_pmip.exec_list; exec; exec = exec->next) {
-        ranks += exec->proc_count;
-        if (local_rank < ranks) {
-            return exec->appnum;
-        }
-    }
-    return -1;
-}
-
 static HYD_status send_cmd_upstream(struct PMIU_cmd *pmi, int fd)
 {
     HYD_status status = HYD_SUCCESS;
@@ -191,6 +179,7 @@ static HYD_status send_cmd_upstream(struct PMIU_cmd *pmi, int fd)
 
     struct HYD_pmcd_hdr hdr;
     hdr.cmd = CMD_PMI;
+    hdr.u.pmi.pmi_version = pmi->version;
     hdr.u.pmi.process_fd = fd;
     status = PMIP_send_hdr_upstream(&hdr, buf, buflen);
     HYDU_ERR_POP(status, "unable to send hdr\n");
@@ -298,22 +287,26 @@ HYD_status fn_fullinit(int fd, struct PMIU_cmd *pmi)
     pmi_errno = PMIU_msg_get_query_fullinit(pmi, &id);
     HYDU_ASSERT(!pmi_errno, status);
 
+    struct pmip_pg *pg;
+    pg = PMIP_pg_0();
+    HYDU_ASSERT(pg, status);
+
     /* Store the PMI_ID to fd mapping */
-    int local_rank = -1;
-    for (int i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
-        if (HYD_pmcd_pmip.downstream.pmi_rank[i] == id) {
-            HYD_pmcd_pmip.downstream.pmi_fd[i] = fd;
-            HYD_pmcd_pmip.downstream.pmi_fd_active[i] = 1;
-            local_rank = i;
+    struct pmip_downstream *p;
+    for (int i = 0; i < pg->num_procs; i++) {
+        p = &pg->downstreams[i];
+        if (p->pmi_rank == id) {
+            p->pmi_fd = fd;
+            p->pmi_fd_active = 1;
             break;
         }
     }
-    HYDU_ASSERT(local_rank != -1, status);
+    HYDU_ASSERT(p, status);
 
     int size = HYD_pmcd_pmip.system_global.global_process_count;
     int rank = id;
     int debug = HYD_pmcd_pmip.user_global.debug;
-    int appnum = get_appnum(local_rank);
+    int appnum = p->pmi_appnum;
 
     struct PMIU_cmd pmi_response;
     pmi_errno = PMIU_msg_set_response_fullinit(pmi, &pmi_response, is_static, rank, size, appnum,
@@ -360,17 +353,11 @@ HYD_status fn_get_appnum(int fd, struct PMIU_cmd *pmi)
     HYDU_FUNC_ENTER();
 
     /* Get the process index */
-    int idx = -1;
-    for (int i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
-        if (HYD_pmcd_pmip.downstream.pmi_fd[i] == fd) {
-            idx = i;
-            break;
-        }
-    }
-    HYDU_ASSERT(idx != -1, status);
+    struct pmip_downstream *p = PMIP_find_downstream_by_fd(fd);
+    HYDU_ASSERT(p, status);
 
     int appnum;
-    appnum = get_appnum(idx);
+    appnum = p->pmi_appnum;
 
     struct PMIU_cmd pmi_response;
     pmi_errno = PMIU_msg_set_response_appnum(pmi, &pmi_response, is_static, appnum);
@@ -548,7 +535,7 @@ HYD_status fn_put(int fd, struct PMIU_cmd *pmi)
     goto fn_exit;
 }
 
-HYD_status fn_keyval_cache(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_keyval_cache(struct pmip_pg *pg, struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -594,8 +581,10 @@ HYD_status fn_barrier_in(int fd, struct PMIU_cmd *pmi)
 
     HYDU_FUNC_ENTER();
 
+    struct pmip_downstream *p = PMIP_find_downstream_by_fd(fd);
+
     barrier_count++;
-    if (barrier_count == HYD_pmcd_pmip.local.proxy_process_count) {
+    if (barrier_count == p->pg->num_procs) {
         barrier_count = 0;
 
         cache_put_flush(fd);
@@ -612,7 +601,7 @@ HYD_status fn_barrier_in(int fd, struct PMIU_cmd *pmi)
     goto fn_exit;
 }
 
-HYD_status fn_barrier_out(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_barrier_out(struct pmip_pg *pg, struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     HYDU_FUNC_ENTER();
@@ -620,8 +609,8 @@ HYD_status fn_barrier_out(int fd, struct PMIU_cmd *pmi)
     struct PMIU_cmd pmi_response;
     PMIU_cmd_init_static(&pmi_response, pmi->version, "barrier_out");
 
-    for (int i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
-        status = send_cmd_downstream(HYD_pmcd_pmip.downstream.pmi_fd[i], &pmi_response);
+    for (int i = 0; i < pg->num_procs; i++) {
+        status = send_cmd_downstream(pg->downstreams[i].pmi_fd, &pmi_response);
         HYDU_ERR_POP(status, "error sending PMI response\n");
     }
 
@@ -640,6 +629,9 @@ HYD_status fn_finalize(int fd, struct PMIU_cmd *pmi)
     int pmi_errno;
     HYDU_FUNC_ENTER();
 
+    struct pmip_downstream *p = PMIP_find_downstream_by_fd(fd);
+    struct pmip_pg *pg = p->pg;
+
     struct PMIU_cmd pmi_response;
     pmi_errno = PMIU_msg_set_response(pmi, &pmi_response, is_static);
     HYDU_ASSERT(!pmi_errno, status);
@@ -655,12 +647,12 @@ HYD_status fn_finalize(int fd, struct PMIU_cmd *pmi)
 
     /* mark singleton's stdio sockets as closed */
     if (HYD_pmcd_pmip.user_global.singleton_pid > 0) {
-        HYDU_ASSERT(HYD_pmcd_pmip.local.proxy_process_count == 1, status);
-        HYD_pmcd_pmip.downstream.out[0] = HYD_FD_CLOSED;
-        HYD_pmcd_pmip.downstream.err[0] = HYD_FD_CLOSED;
+        HYDU_ASSERT(pg->num_procs == 1, status);
+        p->out = HYD_FD_CLOSED;
+        p->err = HYD_FD_CLOSED;
     }
 
-    if (finalize_count == HYD_pmcd_pmip.local.proxy_process_count) {
+    if (finalize_count == pg->num_procs) {
         /* All processes have finalized */
         internal_finalize();
     }

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -59,7 +59,7 @@ static void internal_finalize(void)
 
 /* info_getnodeattr will wait for info_putnodeattr */
 struct HYD_pmcd_pmi_v2_reqs {
-    int fd;
+    struct pmip_downstream *downstream_ptr;
     struct PMIU_cmd *pmi;
     const char *key;
 
@@ -69,14 +69,15 @@ struct HYD_pmcd_pmi_v2_reqs {
 
 static struct HYD_pmcd_pmi_v2_reqs *pending_reqs = NULL;
 
-static HYD_status HYD_pmcd_pmi_v2_queue_req(int fd, struct PMIU_cmd *pmi, const char *key)
+static HYD_status HYD_pmcd_pmi_v2_queue_req(struct pmip_downstream *p, struct PMIU_cmd *pmi,
+                                            const char *key)
 {
     struct HYD_pmcd_pmi_v2_reqs *req, *tmp;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_MALLOC_OR_JUMP(req, struct HYD_pmcd_pmi_v2_reqs *, sizeof(struct HYD_pmcd_pmi_v2_reqs),
                         status);
-    req->fd = fd;
+    req->downstream_ptr = p;
     req->prev = NULL;
     req->next = NULL;
 
@@ -136,7 +137,7 @@ static HYD_status poke_progress(const char *key)
                 list_tail = req;
             }
         } else {
-            status = fn_info_getnodeattr(req->fd, req->pmi);
+            status = fn_info_getnodeattr(req->downstream_ptr, req->pmi);
             HYDU_ERR_POP(status, "getnodeattr returned error\n");
 
             /* Free the dequeued request */
@@ -157,7 +158,7 @@ static HYD_status poke_progress(const char *key)
     goto fn_exit;
 }
 
-static HYD_status send_cmd_upstream(struct PMIU_cmd *pmi, int fd)
+static HYD_status send_cmd_upstream(struct pmip_pg *pg, struct PMIU_cmd *pmi, int process_fd)
 {
     HYD_status status = HYD_SUCCESS;
     HYDU_FUNC_ENTER();
@@ -180,8 +181,8 @@ static HYD_status send_cmd_upstream(struct PMIU_cmd *pmi, int fd)
     struct HYD_pmcd_hdr hdr;
     hdr.cmd = CMD_PMI;
     hdr.u.pmi.pmi_version = pmi->version;
-    hdr.u.pmi.process_fd = fd;
-    status = PMIP_send_hdr_upstream(&hdr, buf, buflen);
+    hdr.u.pmi.process_fd = process_fd;
+    status = PMIP_send_hdr_upstream(pg, &hdr, buf, buflen);
     HYDU_ERR_POP(status, "unable to send hdr\n");
 
   fn_exit:
@@ -199,7 +200,7 @@ static HYD_status send_cmd_downstream(int fd, struct PMIU_cmd *pmi)
 /* "put" adds to cache_put locally. It gets flushed when there are more than
  * CACHE_PUT_KEYVAL_MAXLEN keyvals or when a barrier is received.
  */
-static HYD_status cache_put_flush(int fd)
+static HYD_status cache_put_flush(struct pmip_pg *pg)
 {
     HYD_status status = HYD_SUCCESS;
     HYDU_FUNC_ENTER();
@@ -220,7 +221,7 @@ static HYD_status cache_put_flush(int fd)
         HYDU_dump(stdout, "forwarding command upstream:\n");
         HYD_pmcd_pmi_dump(&pmi);
     }
-    status = send_cmd_upstream(&pmi, fd);
+    status = send_cmd_upstream(pg, &pmi, 0 /* dummy fd */);
     HYDU_ERR_POP(status, "error sending command upstream\n");
 
     for (int i = 0; i < cache_put.keyval_len; i++) {
@@ -238,7 +239,7 @@ static HYD_status cache_put_flush(int fd)
     goto fn_exit;
 }
 
-HYD_status fn_init(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_init(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -260,7 +261,7 @@ HYD_status fn_init(int fd, struct PMIU_cmd *pmi)
                             "PMI version mismatch; %d.%d\n", pmi_version, pmi_subversion);
     }
 
-    status = send_cmd_downstream(fd, &pmi_response);
+    status = send_cmd_downstream(p->pmi_fd, &pmi_response);
     HYDU_ERR_POP(status, "error sending PMI response\n");
 
     static int global_init = 1;
@@ -291,7 +292,7 @@ HYD_status fn_fullinit(int fd, struct PMIU_cmd *pmi)
     pg = PMIP_pg_0();
     HYDU_ASSERT(pg, status);
 
-    /* Store the PMI_ID to fd mapping */
+    /* locate and initialize the downstream */
     struct pmip_downstream *p;
     for (int i = 0; i < pg->num_procs; i++) {
         p = &pg->downstreams[i];
@@ -324,7 +325,7 @@ HYD_status fn_fullinit(int fd, struct PMIU_cmd *pmi)
     goto fn_exit;
 }
 
-HYD_status fn_get_maxes(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_get_maxes(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -335,7 +336,7 @@ HYD_status fn_get_maxes(int fd, struct PMIU_cmd *pmi)
                                             PMI_MAXKVSLEN, PMI_MAXKEYLEN, PMI_MAXVALLEN);
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = send_cmd_downstream(fd, &pmi_response);
+    status = send_cmd_downstream(p->pmi_fd, &pmi_response);
     HYDU_ERR_POP(status, "error sending PMI response\n");
 
   fn_exit:
@@ -346,15 +347,11 @@ HYD_status fn_get_maxes(int fd, struct PMIU_cmd *pmi)
     goto fn_exit;
 }
 
-HYD_status fn_get_appnum(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_get_appnum(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
     HYDU_FUNC_ENTER();
-
-    /* Get the process index */
-    struct pmip_downstream *p = PMIP_find_downstream_by_fd(fd);
-    HYDU_ASSERT(p, status);
 
     int appnum;
     appnum = p->pmi_appnum;
@@ -363,7 +360,7 @@ HYD_status fn_get_appnum(int fd, struct PMIU_cmd *pmi)
     pmi_errno = PMIU_msg_set_response_appnum(pmi, &pmi_response, is_static, appnum);
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = send_cmd_downstream(fd, &pmi_response);
+    status = send_cmd_downstream(p->pmi_fd, &pmi_response);
     HYDU_ERR_POP(status, "error sending PMI response\n");
 
   fn_exit:
@@ -374,7 +371,7 @@ HYD_status fn_get_appnum(int fd, struct PMIU_cmd *pmi)
     goto fn_exit;
 }
 
-HYD_status fn_get_my_kvsname(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_get_my_kvsname(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -385,7 +382,7 @@ HYD_status fn_get_my_kvsname(int fd, struct PMIU_cmd *pmi)
                                               HYD_pmcd_pmip.local.kvs->kvsname);
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = send_cmd_downstream(fd, &pmi_response);
+    status = send_cmd_downstream(p->pmi_fd, &pmi_response);
     HYDU_ERR_POP(status, "error sending PMI response\n");
 
   fn_exit:
@@ -396,7 +393,7 @@ HYD_status fn_get_my_kvsname(int fd, struct PMIU_cmd *pmi)
     goto fn_exit;
 }
 
-HYD_status fn_get_usize(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_get_usize(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -415,7 +412,7 @@ HYD_status fn_get_usize(int fd, struct PMIU_cmd *pmi)
     pmi_errno = PMIU_msg_set_response_universe(pmi, &pmi_response, is_static, universe_size);
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = send_cmd_downstream(fd, &pmi_response);
+    status = send_cmd_downstream(p->pmi_fd, &pmi_response);
     HYDU_ERR_POP(status, "error sending PMI response\n");
 
   fn_exit:
@@ -426,17 +423,17 @@ HYD_status fn_get_usize(int fd, struct PMIU_cmd *pmi)
     goto fn_exit;
 }
 
-static const char *get_jobattr(const char *key)
+static const char *get_jobattr(struct pmip_downstream *p, const char *key)
 {
     if (strcmp(key, "PMI_process_mapping") == 0) {
-        return HYD_pmcd_pmip.system_global.pmi_process_mapping;
+        return p->pg->pmi_process_mapping;
     } else if (!strcmp(key, "PMI_hwloc_xmlfile")) {
         return HYD_pmip_get_hwloc_xmlfile();
     }
     return NULL;
 }
 
-HYD_status fn_get(int fd, struct PMIU_cmd * pmi)
+HYD_status fn_get(struct pmip_downstream * p, struct PMIU_cmd * pmi)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -449,7 +446,7 @@ HYD_status fn_get(int fd, struct PMIU_cmd * pmi)
     bool found = false;
     const char *val;
     if (strncmp(key, "PMI_", 4) == 0) {
-        val = get_jobattr(key);
+        val = get_jobattr(p, key);
         if (val) {
             found = true;
         }
@@ -466,11 +463,11 @@ HYD_status fn_get(int fd, struct PMIU_cmd * pmi)
         struct PMIU_cmd pmi_response;
         PMIU_msg_set_response_get(pmi, &pmi_response, is_static, val, found);
 
-        status = send_cmd_downstream(fd, &pmi_response);
+        status = send_cmd_downstream(p->pmi_fd, &pmi_response);
         HYDU_ERR_POP(status, "error sending PMI response\n");
     } else {
         /* if we can't find the key locally, ask upstream */
-        status = send_cmd_upstream(pmi, fd);
+        status = send_cmd_upstream(p->pg, pmi, p->pmi_fd);
     }
 
   fn_exit:
@@ -481,7 +478,7 @@ HYD_status fn_get(int fd, struct PMIU_cmd * pmi)
     goto fn_exit;
 }
 
-HYD_status fn_put(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_put(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -501,7 +498,7 @@ HYD_status fn_put(int fd, struct PMIU_cmd *pmi)
                                             1, "Keys with PMI_ prefix are reserved");
         HYDU_ASSERT(!pmi_errno, status);
 
-        status = send_cmd_downstream(fd, &pmi_response);
+        status = send_cmd_downstream(p->pmi_fd, &pmi_response);
         HYDU_ERR_POP(status, "error sending command downstream\n");
 
         goto fn_exit;
@@ -518,13 +515,13 @@ HYD_status fn_put(int fd, struct PMIU_cmd *pmi)
     debug("cached command: %s=%s\n", key, val);
 
     if (cache_put.keyval_len >= CACHE_PUT_KEYVAL_MAXLEN) {
-        cache_put_flush(fd);
+        cache_put_flush(p->pg);
     }
 
     pmi_errno = PMIU_msg_set_response(pmi, &pmi_response, is_static);
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = send_cmd_downstream(fd, &pmi_response);
+    status = send_cmd_downstream(p->pmi_fd, &pmi_response);
     HYDU_ERR_POP(status, "error sending PMI response\n");
 
   fn_exit:
@@ -574,22 +571,20 @@ HYD_status fn_keyval_cache(struct pmip_pg *pg, struct PMIU_cmd *pmi)
     goto fn_exit;
 }
 
-HYD_status fn_barrier_in(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_barrier_in(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
     static int barrier_count = 0;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
-    struct pmip_downstream *p = PMIP_find_downstream_by_fd(fd);
-
     barrier_count++;
     if (barrier_count == p->pg->num_procs) {
         barrier_count = 0;
 
-        cache_put_flush(fd);
+        cache_put_flush(p->pg);
 
-        status = send_cmd_upstream(pmi, fd);
+        status = send_cmd_upstream(p->pg, pmi, p->pmi_fd);
         HYDU_ERR_POP(status, "error sending command upstream\n");
     }
 
@@ -622,26 +617,25 @@ HYD_status fn_barrier_out(struct pmip_pg *pg, struct PMIU_cmd *pmi)
     goto fn_exit;
 }
 
-HYD_status fn_finalize(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_finalize(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
     static int finalize_count = 0;
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
     HYDU_FUNC_ENTER();
 
-    struct pmip_downstream *p = PMIP_find_downstream_by_fd(fd);
     struct pmip_pg *pg = p->pg;
 
     struct PMIU_cmd pmi_response;
     pmi_errno = PMIU_msg_set_response(pmi, &pmi_response, is_static);
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = send_cmd_downstream(fd, &pmi_response);
+    status = send_cmd_downstream(p->pmi_fd, &pmi_response);
     HYDU_ERR_POP(status, "error sending PMI response\n");
 
-    status = HYDT_dmx_deregister_fd(fd);
+    status = HYDT_dmx_deregister_fd(p->pmi_fd);
     HYDU_ERR_POP(status, "unable to deregister fd\n");
-    close(fd);
+    close(p->pmi_fd);
 
     finalize_count++;
 
@@ -665,7 +659,7 @@ HYD_status fn_finalize(int fd, struct PMIU_cmd *pmi)
     goto fn_exit;
 }
 
-HYD_status fn_info_putnodeattr(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_info_putnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int ret, pmi_errno;
@@ -681,7 +675,7 @@ HYD_status fn_info_putnodeattr(int fd, struct PMIU_cmd *pmi)
                                             1, "Keys with PMI_ prefix are reserved");
         HYDU_ASSERT(!pmi_errno, status);
 
-        status = send_cmd_downstream(fd, &pmi_response);
+        status = send_cmd_downstream(p->pmi_fd, &pmi_response);
         HYDU_ERR_POP(status, "error sending command downstream\n");
 
         goto fn_exit;
@@ -693,7 +687,7 @@ HYD_status fn_info_putnodeattr(int fd, struct PMIU_cmd *pmi)
     pmi_errno = PMIU_msg_set_response(pmi, &pmi_response, is_static);
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = send_cmd_downstream(fd, &pmi_response);
+    status = send_cmd_downstream(p->pmi_fd, &pmi_response);
     HYDU_ERR_POP(status, "error sending command downstream\n");
 
     status = poke_progress(key);
@@ -707,7 +701,7 @@ HYD_status fn_info_putnodeattr(int fd, struct PMIU_cmd *pmi)
     goto fn_exit;
 }
 
-HYD_status fn_info_getnodeattr(int fd, struct PMIU_cmd *pmi)
+HYD_status fn_info_getnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
     int pmi_errno;
@@ -733,7 +727,7 @@ HYD_status fn_info_getnodeattr(int fd, struct PMIU_cmd *pmi)
     }
 
     if (!found && wait) {
-        status = HYD_pmcd_pmi_v2_queue_req(fd, pmi, key);
+        status = HYD_pmcd_pmi_v2_queue_req(p, pmi, key);
         HYDU_ERR_POP(status, "unable to queue request\n");
         goto fn_exit;
     }
@@ -747,7 +741,7 @@ HYD_status fn_info_getnodeattr(int fd, struct PMIU_cmd *pmi)
     }
     HYDU_ASSERT(!pmi_errno, status);
 
-    status = send_cmd_downstream(fd, &pmi_response);
+    status = send_cmd_downstream(p->pmi_fd, &pmi_response);
     HYDU_ERR_POP(status, "error sending command downstream\n");
 
   fn_exit:

--- a/src/pm/hydra/proxy/pmip_pmi.h
+++ b/src/pm/hydra/proxy/pmip_pmi.h
@@ -15,19 +15,21 @@ struct HYD_pmcd_pmip_pmi_handle {
      HYD_status(*handler) (int fd, struct PMIU_cmd * pmi);
 };
 
-HYD_status fn_init(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_initack(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_get_maxes(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_get_appnum(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_get_my_kvsname(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_get_usize(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_get(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_put(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_barrier_in(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_finalize(int fd, struct PMIU_cmd *pmi);
+/* handlers for initialization via pmi port */
 HYD_status fn_fullinit(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_info_putnodeattr(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_info_getnodeattr(int fd, struct PMIU_cmd *pmi);
+
+/* handlers for client pmi commands */
+HYD_status fn_init(struct pmip_downstream *p, struct PMIU_cmd *pmi);
+HYD_status fn_get_maxes(struct pmip_downstream *p, struct PMIU_cmd *pmi);
+HYD_status fn_get_appnum(struct pmip_downstream *p, struct PMIU_cmd *pmi);
+HYD_status fn_get_my_kvsname(struct pmip_downstream *p, struct PMIU_cmd *pmi);
+HYD_status fn_get_usize(struct pmip_downstream *p, struct PMIU_cmd *pmi);
+HYD_status fn_get(struct pmip_downstream *p, struct PMIU_cmd *pmi);
+HYD_status fn_put(struct pmip_downstream *p, struct PMIU_cmd *pmi);
+HYD_status fn_barrier_in(struct pmip_downstream *p, struct PMIU_cmd *pmi);
+HYD_status fn_finalize(struct pmip_downstream *p, struct PMIU_cmd *pmi);
+HYD_status fn_info_putnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi);
+HYD_status fn_info_getnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi);
 
 /* handlers for server pmi commands */
 HYD_status fn_keyval_cache(struct pmip_pg *pg, struct PMIU_cmd *pmi);

--- a/src/pm/hydra/proxy/pmip_pmi.h
+++ b/src/pm/hydra/proxy/pmip_pmi.h
@@ -8,6 +8,7 @@
 
 #include "hydra.h"
 #include "pmiserv_common.h"
+#include "pmip.h"
 
 struct HYD_pmcd_pmip_pmi_handle {
     const char *cmd;
@@ -22,12 +23,14 @@ HYD_status fn_get_my_kvsname(int fd, struct PMIU_cmd *pmi);
 HYD_status fn_get_usize(int fd, struct PMIU_cmd *pmi);
 HYD_status fn_get(int fd, struct PMIU_cmd *pmi);
 HYD_status fn_put(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_keyval_cache(int fd, struct PMIU_cmd *pmi);
 HYD_status fn_barrier_in(int fd, struct PMIU_cmd *pmi);
-HYD_status fn_barrier_out(int fd, struct PMIU_cmd *pmi);
 HYD_status fn_finalize(int fd, struct PMIU_cmd *pmi);
 HYD_status fn_fullinit(int fd, struct PMIU_cmd *pmi);
 HYD_status fn_info_putnodeattr(int fd, struct PMIU_cmd *pmi);
 HYD_status fn_info_getnodeattr(int fd, struct PMIU_cmd *pmi);
+
+/* handlers for server pmi commands */
+HYD_status fn_keyval_cache(struct pmip_pg *pg, struct PMIU_cmd *pmi);
+HYD_status fn_barrier_out(struct pmip_pg *pg, struct PMIU_cmd *pmi);
 
 #endif /* PMIP_PMI_H_INCLUDED */

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -468,11 +468,11 @@ static HYD_status exec_fn(char *arg, char ***argv)
     struct HYD_exec *exec = NULL;
     HYD_status status = HYD_SUCCESS;
 
-    if (HYD_pmcd_pmip.exec_list == NULL) {
-        status = HYDU_alloc_exec(&HYD_pmcd_pmip.exec_list);
+    if (cur_pg->exec_list == NULL) {
+        status = HYDU_alloc_exec(&cur_pg->exec_list);
         HYDU_ERR_POP(status, "unable to allocate proxy exec\n");
     } else {
-        for (exec = HYD_pmcd_pmip.exec_list; exec->next; exec = exec->next);
+        for (exec = cur_pg->exec_list; exec->next; exec = exec->next);
         status = HYDU_alloc_exec(&exec->next);
         HYDU_ERR_POP(status, "unable to allocate proxy exec\n");
     }
@@ -490,7 +490,7 @@ static HYD_status exec_appnum_fn(char *arg, char ***argv)
     struct HYD_exec *exec = NULL;
     HYD_status status = HYD_SUCCESS;
 
-    for (exec = HYD_pmcd_pmip.exec_list; exec->next; exec = exec->next);
+    for (exec = cur_pg->exec_list; exec->next; exec = exec->next);
     status = HYDU_set_int(arg, &exec->appnum, atoi(**argv));
 
     (*argv)++;
@@ -503,7 +503,7 @@ static HYD_status exec_proc_count_fn(char *arg, char ***argv)
     struct HYD_exec *exec = NULL;
     HYD_status status = HYD_SUCCESS;
 
-    for (exec = HYD_pmcd_pmip.exec_list; exec->next; exec = exec->next);
+    for (exec = cur_pg->exec_list; exec->next; exec = exec->next);
     status = HYDU_set_int(arg, &exec->proc_count, atoi(**argv));
 
     (*argv)++;
@@ -521,7 +521,7 @@ static HYD_status exec_local_env_fn(char *arg, char ***argv)
     if (**argv == NULL)
         HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "NULL argument to exec local env\n");
 
-    for (exec = HYD_pmcd_pmip.exec_list; exec->next; exec = exec->next);
+    for (exec = cur_pg->exec_list; exec->next; exec = exec->next);
 
     count = atoi(**argv);
     for (i = 0; i < count; i++) {
@@ -550,7 +550,7 @@ static HYD_status exec_env_prop_fn(char *arg, char ***argv)
     struct HYD_exec *exec = NULL;
     HYD_status status = HYD_SUCCESS;
 
-    for (exec = HYD_pmcd_pmip.exec_list; exec->next; exec = exec->next);
+    for (exec = cur_pg->exec_list; exec->next; exec = exec->next);
 
     status = HYDU_set_str(arg, &exec->env_prop, **argv);
 
@@ -564,7 +564,7 @@ static HYD_status exec_wdir_fn(char *arg, char ***argv)
     struct HYD_exec *exec = NULL;
     HYD_status status = HYD_SUCCESS;
 
-    for (exec = HYD_pmcd_pmip.exec_list; exec->next; exec = exec->next);
+    for (exec = cur_pg->exec_list; exec->next; exec = exec->next);
 
     status = HYDU_set_str(arg, &exec->wdir, **argv);
 
@@ -582,7 +582,7 @@ static HYD_status exec_args_fn(char *arg, char ***argv)
     if (**argv == NULL)
         HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "NULL argument to exec args\n");
 
-    for (exec = HYD_pmcd_pmip.exec_list; exec->next; exec = exec->next);
+    for (exec = cur_pg->exec_list; exec->next; exec = exec->next);
 
     errno = 0;
     count = strtol(**argv, NULL, 10);

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -223,7 +223,9 @@ static HYD_status retries_fn(char *arg, char ***argv)
 
 static HYD_status pmi_kvsname_fn(char *arg, char ***argv)
 {
-    MPL_snprintf(HYD_pmcd_pmip.local.kvs->kvsname, PMI_MAXKVSLEN, "%s", **argv);
+    HYD_status status = HYD_SUCCESS;
+
+    status = HYDU_set_str(arg, &cur_pg->kvsname, **argv);
     (*argv)++;
 
     return HYD_SUCCESS;

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -11,6 +11,13 @@
 
 #include "pmi_util.h"   /* from libpmi, for PMIU_verbose */
 
+static pmip_pg *cur_pg = NULL;
+
+void HYD_set_cur_pg(static pmip_pg * pg)
+{
+    cur_pg = pg;
+}
+
 /* For unused options, use dummy handler to prevent parsing errors */
 static HYD_status dummy1_fn(char *arg, char ***argv)
 {

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -443,7 +443,7 @@ static HYD_status iface_ip_env_name_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
 
-    status = HYDU_set_str(arg, &HYD_pmcd_pmip.local.iface_ip_env_name, **argv);
+    status = HYDU_set_str(arg, &cur_pg->iface_ip_env_name, **argv);
 
     (*argv)++;
 
@@ -454,7 +454,7 @@ static HYD_status hostname_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
 
-    status = HYDU_set_str(arg, &HYD_pmcd_pmip.local.hostname, **argv);
+    status = HYDU_set_str(arg, &cur_pg->hostname, **argv);
 
     (*argv)++;
 

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -228,7 +228,7 @@ static HYD_status pmi_kvsname_fn(char *arg, char ***argv)
     status = HYDU_set_str(arg, &cur_pg->kvsname, **argv);
     (*argv)++;
 
-    return HYD_SUCCESS;
+    return status;
 }
 
 static HYD_status pmi_spawner_kvsname_fn(char *arg, char ***argv)
@@ -238,11 +238,7 @@ static HYD_status pmi_spawner_kvsname_fn(char *arg, char ***argv)
     status = HYDU_set_str(arg, &cur_pg->spawner_kvsname, **argv);
     (*argv)++;
 
-  fn_exit:
     return status;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 static HYD_status pmi_process_mapping_fn(char *arg, char ***argv)

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -11,25 +11,6 @@
 
 #include "pmi_util.h"   /* from libpmi, for PMIU_verbose */
 
-void HYD_pmcd_pmip_send_signal(int sig)
-{
-    int i, pgid;
-
-    /* Send the kill signal to all processes */
-    for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++)
-        if (HYD_pmcd_pmip.downstream.pid[i] != -1) {
-#if defined(HAVE_GETPGID) && defined(HAVE_SETSID)
-            /* If we are able to get the process group ID, and the
-             * child process has its own process group ID, send a
-             * signal to the entire process group */
-            pgid = getpgid(HYD_pmcd_pmip.downstream.pid[i]);
-            killpg(pgid, sig);
-#else
-            kill(HYD_pmcd_pmip.downstream.pid[i], sig);
-#endif
-        }
-}
-
 static HYD_status control_port_fn(char *arg, char ***argv)
 {
     char *port = NULL, *name;

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -11,9 +11,9 @@
 
 #include "pmi_util.h"   /* from libpmi, for PMIU_verbose */
 
-static pmip_pg *cur_pg = NULL;
+static struct pmip_pg *cur_pg = NULL;
 
-void HYD_set_cur_pg(static pmip_pg * pg)
+void HYD_set_cur_pg(struct pmip_pg *pg)
 {
     cur_pg = pg;
 }
@@ -233,9 +233,7 @@ static HYD_status pmi_spawner_kvsname_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
 
-    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.local.spawner_kvsname, char *, PMI_MAXKVSLEN, status);
-
-    MPL_snprintf(HYD_pmcd_pmip.local.spawner_kvsname, PMI_MAXKVSLEN, "%s", **argv);
+    status = HYDU_set_str(arg, &cur_pg->spawner_kvsname, **argv);
     (*argv)++;
 
   fn_exit:
@@ -249,11 +247,15 @@ static HYD_status pmi_process_mapping_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
 
-    status = HYDU_set_str(arg, &HYD_pmcd_pmip.system_global.pmi_process_mapping, **argv);
+    HYDU_ASSERT(cur_pg, status);
+    status = HYDU_set_str(arg, &cur_pg->pmi_process_mapping, **argv);
 
     (*argv)++;
 
+  fn_exit:
     return status;
+  fn_fail:
+    goto fn_exit;
 }
 
 static HYD_status binding_fn(char *arg, char ***argv)
@@ -357,15 +359,15 @@ static HYD_status global_core_map_fn(char *arg, char ***argv)
 
     tmp = strtok(map, ",");
     HYDU_ASSERT(tmp, status);
-    HYD_pmcd_pmip.system_global.global_core_map.local_filler = atoi(tmp);
+    cur_pg->global_core_map.local_filler = atoi(tmp);
 
     tmp = strtok(NULL, ",");
     HYDU_ASSERT(tmp, status);
-    HYD_pmcd_pmip.system_global.global_core_map.local_count = atoi(tmp);
+    cur_pg->global_core_map.local_count = atoi(tmp);
 
     tmp = strtok(NULL, ",");
     HYDU_ASSERT(tmp, status);
-    HYD_pmcd_pmip.system_global.global_core_map.global_count = atoi(tmp);
+    cur_pg->global_core_map.global_count = atoi(tmp);
 
     MPL_free(map);
 
@@ -384,17 +386,19 @@ static HYD_status pmi_id_map_fn(char *arg, char ***argv)
     char *map, *tmp;
     HYD_status status = HYD_SUCCESS;
 
+    HYDU_ASSERT(cur_pg, status);
+
     /* Split the core map into three different segments */
     map = MPL_strdup(**argv);
     HYDU_ASSERT(map, status);
 
     tmp = strtok(map, ",");
     HYDU_ASSERT(tmp, status);
-    HYD_pmcd_pmip.system_global.pmi_id_map.filler_start = atoi(tmp);
+    cur_pg->pmi_id_map.filler_start = atoi(tmp);
 
     tmp = strtok(NULL, ",");
     HYDU_ASSERT(tmp, status);
-    HYD_pmcd_pmip.system_global.pmi_id_map.non_filler_start = atoi(tmp);
+    cur_pg->pmi_id_map.non_filler_start = atoi(tmp);
 
     MPL_free(map);
 
@@ -412,7 +416,7 @@ static HYD_status global_process_count_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
 
-    status = HYDU_set_int(arg, &HYD_pmcd_pmip.system_global.global_process_count, atoi(**argv));
+    status = HYDU_set_int(arg, &cur_pg->global_process_count, atoi(**argv));
 
     (*argv)++;
 

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -11,6 +11,13 @@
 
 #include "pmi_util.h"   /* from libpmi, for PMIU_verbose */
 
+/* For unused options, use dummy handler to prevent parsing errors */
+static HYD_status dummy1_fn(char *arg, char ***argv)
+{
+    (*argv)++;
+    return HYD_SUCCESS;
+}
+
 static HYD_status control_port_fn(char *arg, char ***argv)
 {
     char *port = NULL, *name;
@@ -445,17 +452,6 @@ static HYD_status hostname_fn(char *arg, char ***argv)
     return status;
 }
 
-static HYD_status proxy_core_count_fn(char *arg, char ***argv)
-{
-    HYD_status status = HYD_SUCCESS;
-
-    status = HYDU_set_int(arg, &HYD_pmcd_pmip.local.proxy_core_count, atoi(**argv));
-
-    (*argv)++;
-
-    return status;
-}
-
 static HYD_status exec_fn(char *arg, char ***argv)
 {
     struct HYD_exec *exec = NULL;
@@ -635,7 +631,7 @@ struct HYD_arg_match_table HYD_pmcd_pmip_match_table[] = {
     {"version", version_fn, NULL},
     {"iface-ip-env-name", iface_ip_env_name_fn, NULL},
     {"hostname", hostname_fn, NULL},
-    {"proxy-core-count", proxy_core_count_fn, NULL},
+    {"proxy-core-count", dummy1_fn, NULL},
     {"exec", exec_fn, NULL},
     {"exec-appnum", exec_appnum_fn, NULL},
     {"exec-proc-count", exec_proc_count_fn, NULL},


### PR DESCRIPTION
## Pull Request Description
The is a WIP PR working toward 
* Reuse the proxy to launch processes from spawn, rather than launch separate proxies each time
* Support proxy tree-launch

So far, it is accumulating refactoring commits. Some of these probably will be split into separate preparation PRs.

[skip warnings]

Related issues: 
* https://github.com/pmodels/mpich/issues/2277
* https://github.com/pmodels/mpich/issues/2913
* https://github.com/pmodels/mpich/issues/5903
## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
