### PR TITLE
info: add MPIX_Info_set_hex

### DIFF
--- a/src/binding/c/info_api.txt
+++ b/src/binding/c/info_api.txt
@@ -79,3 +79,9 @@ MPI_Info_create_env:
             integer info, ierr
         .ve
 */
+
+MPIX_Info_set_hex:
+    info: INFO, direction=in, [info object]
+    key: STRING, constant=True, [key]
+    value: BUFFER, constant=True, [value]
+    value_size: INFO_VALUE_LENGTH, [size of value]

--- a/src/include/mpir_info.h
+++ b/src/include/mpir_info.h
@@ -104,4 +104,7 @@ void MPIR_Info_setup_env(MPIR_Info * info_ptr);
 int MPIR_Info_push(MPIR_Info * info_ptr, const char *key, const char *val);
 const char *MPIR_Info_lookup(MPIR_Info * info_ptr, const char *key);
 
+/* utility to decode hex info value */
+int MPIR_Info_decode_hex(const char *str, void *buf, int len);
+
 #endif /* MPIR_INFO_H_INCLUDED */

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -380,6 +380,7 @@ be in the range 0 to %d
 **infonkey %d %d:Requested key %d but this MPI_Info only has %d keys
 **infonoteq:MPI_Info key value are not consistent for all processes
 **infonoteq %s:MPI_Info value with key %s is not consistent for all processes
+**infohexinvalid:MPI_Info key value is invalid
 **io:Other I/O error 
 **io %s:Other I/O error %s
 **iobadoverlap: write voilates monotonically non-decreasing

--- a/src/mpi/info/info_impl.c
+++ b/src/mpi/info/info_impl.c
@@ -209,3 +209,88 @@ int MPIR_Info_create_env_impl(int argc, char **argv, MPIR_Info ** new_info_ptr)
   fn_fail:
     goto fn_exit;
 }
+
+static int hex_encode(char *str, const void *value, int len);
+static int hex_decode(const char *str, void *buf, int len);
+
+int MPIR_Info_set_hex_impl(MPIR_Info * info_ptr, const char *key, const void *value, int value_size)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    char value_buf[1024];
+    MPIR_Assertp(value_size * 2 + 1 < 1024);
+
+    hex_encode(value_buf, value, value_size);
+
+    mpi_errno = MPIR_Info_set_impl(info_ptr, key, value_buf);
+
+    return mpi_errno;
+}
+
+int MPIR_Info_decode_hex(const char *str, void *buf, int len)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    int rc = hex_decode(str, buf, len);
+    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**infohexinvalid");
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* ---- internal utility ---- */
+
+/* Simple hex encoding binary as hexadecimal string. For example,
+ * a binary with 4 bytes, 0x12, 0x34, 0x56, 0x78, will be encoded
+ * as ascii string "12345678". The encoded string will have string
+ * length of exactly double the binary size plus a terminating "NUL".
+ */
+
+static int hex_val(char c)
+{
+    /* translate a hex char [0-9a-fA-F] to its value (0-15) */
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    } else if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 10;
+    } else if (c >= 'A' && c <= 'F') {
+        return c - 'A' + 10;
+    } else {
+        return -1;
+    }
+}
+
+static int hex_encode(char *str, const void *value, int len)
+{
+    /* assume the size of str is already validated */
+
+    const unsigned char *s = value;
+
+    for (int i = 0; i < len; i++) {
+        sprintf(str + i * 2, "%02x", s[i]);
+    }
+
+    return 0;
+}
+
+static int hex_decode(const char *str, void *buf, int len)
+{
+    int n = strlen(str);
+    if (n != len * 2) {
+        return 1;
+    }
+
+    unsigned char *s = buf;
+    for (int i = 0; i < len; i++) {
+        int a = hex_val(str[i * 2]);
+        int b = hex_val(str[i * 2 + 1]);
+        if (a < 0 || b < 0) {
+            return 1;
+        }
+        s[i] = (unsigned char) ((a << 4) + b);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Pull Request Description

Add MPIX_Info_set_hex to allow the user to provide info hints with binary
values. This routine provides a consistent way of encoding binary values
into strings that implementation can decode.

Also, add MPIR_Info_decode_hex for internally retrieving the binary data.
We will only try to decode a hex value when we know what binary type we are
getting.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
