### PR TITLE
ch4: code simplification assuming consistent vci/vni

### DIFF
--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_probe.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_probe.h
@@ -13,7 +13,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
                                                   int *flag, MPIR_Request ** message,
                                                   MPI_Status * status)
 {
-    return MPIDIG_mpi_improbe(source, tag, comm, context_offset, 0, flag, message, status);
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, 0, flag, message, status);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
@@ -22,7 +28,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
                                                  int context_offset, MPIDI_av_entry_t * addr,
                                                  int *flag, MPI_Status * status)
 {
-    return MPIDIG_mpi_iprobe(source, tag, comm, context_offset, 0, flag, status);
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, 0, flag, status);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 #endif /* NETMOD_AM_FALLBACK_PROBE_H_INCLUDED */

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
@@ -10,7 +10,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
                                                  MPI_Aint count, MPI_Datatype datatype,
                                                  MPIR_Request * message)
 {
-    return MPIDIG_mpi_imrecv(buf, count, datatype, message);
+    int mpi_errno = MPI_SUCCESS;
+
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
+    int vci = MPIDI_Request_get_vci(message);
+#endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    mpi_errno = MPIDIG_mpi_imrecv(buf, count, datatype, message);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
@@ -22,8 +31,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request,
                                                 MPIR_Request * partner)
 {
-    return MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, 0, request, 0,
-                            partner);
+    int mpi_errno = MPI_SUCCESS;
+
+    /* For anysource recv, we may be called while holding the vci lock of shm request (to
+     * prevent shm progress). Therefore, recursive locking is allowed here */
+    MPID_THREAD_CS_ENTER_REC_VCI(MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, 0,
+                                 request, 0, partner);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
@@ -14,8 +14,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
                                                 MPIR_Comm * comm, int context_offset,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                            request);
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
+                                 request);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf,
@@ -26,8 +32,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf,
                                                  MPIR_Comm * comm, int context_offset,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                             request);
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
+                                  request);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,
@@ -36,8 +48,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request,
                                                  MPIR_Errflag_t * errflag)
 {
-    return MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                             0, 0, request, errflag);
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                  0, 0, request, errflag);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq)

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -118,8 +118,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vni, struct fi_cq_tagged_e
         MPIR_Comm *c = rreq->comm;
         int r = rreq->status.MPI_SOURCE;
         /* NOTE: use target rank, reply to src */
-        int vni_src = MPIDI_OFI_get_vni(SRC_VCI_FROM_RECVER, c, r, c->rank, rreq->status.MPI_TAG);
-        int vni_dst = MPIDI_OFI_get_vni(DST_VCI_FROM_RECVER, c, r, c->rank, rreq->status.MPI_TAG);
+        int vni_src = MPIDI_get_vci(SRC_VCI_FROM_RECVER, c, r, c->rank, rreq->status.MPI_TAG);
+        int vni_dst = MPIDI_get_vci(DST_VCI_FROM_RECVER, c, r, c->rank, rreq->status.MPI_TAG);
         int vni_local = vni_dst;
         int vni_remote = vni_src;
         MPIR_Assert(vni_local == vni);

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -41,29 +41,6 @@ ATTRIBUTE((unused));
 int MPIDI_OFI_progress_uninlined(int vni);
 int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret);
 
-/* vni mapping */
-/* NOTE: concerned by the modulo? If we restrict num_vnis to power of 2,
- * we may get away with bit mask */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_vni(int flag, MPIR_Comm * comm_ptr,
-                                               int src_rank, int dst_rank, int tag)
-{
-#if MPIDI_CH4_MAX_VCIS == 1
-    return 0;
-#else
-    int vni = MPIDI_get_vci(flag, comm_ptr, src_rank, dst_rank, tag);
-    MPIR_Assert(vni < MPIDI_OFI_global.num_vnis);
-    return vni;
-#endif
-}
-
-/* for RMA, vni need be persistent with window */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_win_vni(MPIR_Win * win)
-{
-    int win_idx = 0;
-    return MPIDI_get_vci(SRC_VCI_FROM_SENDER, win->comm_ptr, 0, 0, win_idx) %
-        MPIDI_OFI_global.num_vnis;
-}
-
 /*
  * Helper routines and macros for request completion
  */

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -118,8 +118,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
 #define MPIDI_OFI_PROBE_VNIS(vni_src_, vni_dst_) \
     do { \
         /* NOTE: hashing is based on target rank */ \
-        vni_src_ = MPIDI_OFI_get_vni(SRC_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
-        vni_dst_ = MPIDI_OFI_get_vni(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
+        vni_src_ = MPIDI_get_vci(SRC_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
+        vni_dst_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
     } while (0)
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -136,22 +136,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
     int vni_src, vni_dst;
     MPIDI_OFI_PROBE_VNIS(vni_src, vni_dst);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno =
-            MPIDIG_mpi_improbe(source, tag, comm, context_offset, vni_dst, flag, message, status);
-        goto fn_exit;
-    }
-
     MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_dst);
-    /* Set flags for mprobe peek, when ready */
-    mpi_errno = MPIDI_OFI_do_iprobe(source, tag, comm, context_offset, addr, vni_src, vni_dst,
-                                    flag, status, message);
+    if (!MPIDI_OFI_ENABLE_TAGGED) {
+        mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, vni_dst, flag, message,
+                                       status);
+    } else {
+        /* Set flags for mprobe peek, when ready */
+        mpi_errno = MPIDI_OFI_do_iprobe(source, tag, comm, context_offset, addr, vni_src, vni_dst,
+                                        flag, status, message);
+    }
     MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_dst);
 
-    if (mpi_errno != MPI_SUCCESS)
-        goto fn_exit;
-
-  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }
@@ -168,14 +163,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
     int vni_src, vni_dst;
     MPIDI_OFI_PROBE_VNIS(vni_src, vni_dst);
 
+    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_dst);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, vni_dst, flag, status);
     } else {
-        MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_dst);
         mpi_errno = MPIDI_OFI_do_iprobe(source, tag, comm, context_offset, addr,
                                         vni_src, vni_dst, flag, status, NULL);
-        MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_dst);
     }
+    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_dst);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -299,19 +299,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
     MPIDI_av_entry_t *av;
     MPIR_FUNC_ENTER;
 
+    int vci = MPIDI_Request_get_vci(message);
+    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vci);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_imrecv(buf, count, datatype, message);
     } else {
         rreq = message;
-        int vci = MPIDI_Request_get_vci(rreq);
-        MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vci);
         av = MPIDIU_comm_rank_to_av(rreq->comm, message->status.MPI_SOURCE);
         /* FIXME: need get vni_src in the request */
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, message->status.MPI_SOURCE,
                                        message->status.MPI_TAG, rreq->comm, 0, av, 0, vci,
                                        &rreq, MPIDI_OFI_USE_EXISTING, FI_CLAIM | FI_COMPLETION);
-        MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vci);
     }
+    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vci);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -333,17 +333,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
     MPIDI_OFI_RECV_VNIS(vni_src, vni_dst);
     /* For anysource recv, we may be called while holding the vci lock of shm request (to
      * prevent shm progress). Therefore, recursive locking is allowed here */
+    MPIDI_OFI_THREAD_CS_ENTER_REC_VCI_OPTIONAL(vni_dst);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
                                      vni_dst, request, 0, partner);
     } else {
-        MPIDI_OFI_THREAD_CS_ENTER_REC_VCI_OPTIONAL(vni_dst);
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, rank, tag, comm,
                                        context_offset, addr, vni_src, vni_dst, request,
                                        MPIDI_OFI_ON_HEAP, 0ULL);
         MPIDI_REQUEST_SET_LOCAL(*request, 0, partner);
-        MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_dst);
     }
+    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_dst);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -284,8 +284,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
             vni_dst_ = 0; \
         } else { \
             /* NOTE: hashing is based on target rank */ \
-            vni_src_ = MPIDI_OFI_get_vni(SRC_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
-            vni_dst_ = MPIDI_OFI_get_vni(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
+            vni_src_ = MPIDI_get_vci(SRC_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
+            vni_dst_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
         } \
     } while (0)
 

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -465,16 +465,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
 
     int vni_src, vni_dst;
     MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
+    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                      vni_src, vni_dst, request);
     } else {
-        MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, vni_src, vni_dst,
                                    request, 0, 0ULL, MPIR_ERR_NONE);
-        MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_src);
     }
+    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_src);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -506,16 +506,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
 
     int vni_src, vni_dst;
     MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
+    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                       vni_src, vni_dst, request, errflag);
     } else {
-        MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, vni_src, vni_dst, request, 0, 0ULL,
                                    *errflag);
-        MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_src);
     }
+    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_src);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -531,16 +531,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count
 
     int vni_src, vni_dst;
     MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
+    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                       vni_src, vni_dst, request);
     } else {
-        MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, vni_src, vni_dst, request, 0,
                                    MPIDI_OFI_SYNC_SEND, MPIR_ERR_NONE);
-        MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_src);
     }
+    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_src);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -450,8 +450,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
             vni_src_ = 0; \
             vni_dst_ = 0; \
         } else { \
-            vni_src_ = MPIDI_OFI_get_vni(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
-            vni_dst_ = MPIDI_OFI_get_vni(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+            vni_src_ = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+            vni_dst_ = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
         } \
     } while (0)
 

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -17,6 +17,11 @@ static int win_init_global(MPIR_Win * win);
 static int win_init(MPIR_Win * win);
 static void win_init_am(MPIR_Win * win);
 
+#define MPIDI_OFI_WIN_VNI(win, vni_) \
+    do { \
+        vni_ = MPIDI_get_vci(SRC_VCI_FROM_SENDER, (win)->comm_ptr, 0, 0, 0); \
+    } while (0)
+
 static void load_acc_hint(MPIR_Win * win)
 {
     int op_index = 0, i;
@@ -160,7 +165,7 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
     }
 
     /* we need register mr on the correct domain for the vni */
-    int vni = MPIDI_OFI_get_win_vni(win);
+    int vni = MPIDI_OFI_WIN(win).vni;
     int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
     /* Register the allocated win buffer or MPI_BOTTOM (NULL) for dynamic win.
@@ -616,7 +621,7 @@ static int win_init(MPIR_Win * win)
      * NOTE: we could assign vni per epoch, then we need run `win_init_{sep,stx,global}`
      * at start of every epoch.
      */
-    MPIDI_OFI_WIN(win).vni = MPIDI_OFI_get_win_vni(win);
+    MPIDI_OFI_WIN_VNI(win, MPIDI_OFI_WIN(win).vni);
 
     /* First, try to enable scalable EP. */
     if (MPIR_CVAR_CH4_OFI_ENABLE_SCALABLE_ENDPOINTS && MPIR_CVAR_CH4_OFI_MAX_RMA_SEP_CTX > 0) {

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -114,27 +114,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_vci_to_vni(int vci)
     return vci < MPIDI_UCX_global.num_vnis ? vci : -1;
 }
 
-/* vni mapping */
-/* NOTE: concerned by the modulo? If we restrict num_vnis to power of 2,
- * we may get away with bit mask */
-MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_get_vni(int flag, MPIR_Comm * comm_ptr,
-                                               int src_rank, int dst_rank, int tag)
-{
-    int vni;
-    return MPIDI_get_vci(flag, comm_ptr, src_rank, dst_rank, tag);
-    MPIR_Assert(vni < MPIDI_UCX_global.num_vnis);
-    return vni;
-}
-
-/* for rma, we need ensure rkey is consistent with the per-vni ep,
- * which essentially means we only need consistent vni per-window */
-MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_get_win_vni(MPIR_Win * win)
-{
-    int win_idx = 0;
-    return MPIDI_get_vci(SRC_VCI_FROM_SENDER, win->comm_ptr, 0, 0, win_idx) %
-        MPIDI_UCX_global.num_vnis;
-}
-
 /* Need both local and remote vni to be the same, or the synchronization call
  * may blocked at flushing the remote ep (due to missing remote progress) */
 #define MPIDI_UCX_WIN_TO_EP(win,rank,vni) \

--- a/src/mpid/ch4/netmod/ucx/ucx_pre.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_pre.h
@@ -64,6 +64,7 @@ typedef struct {
     ucp_mem_h mem_h;
     bool mem_mapped;            /* Indicate whether mem_h has been mapped (e.g., supported mem type).
                                  * Set at win init and checked at win free for mem_unmap */
+    int vni;
 
     MPIDI_UCX_win_target_sync_t *target_sync;
 } MPIDI_UCX_win_t;

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -23,7 +23,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
     ucp_tag_message_h message_h;
     MPIR_Request *req = NULL;
 
-    int vni_dst = MPIDI_UCX_get_vni(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
+    int vni_dst = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_dst).lock);
 
     tag_mask = MPIDI_UCX_tag_mask(tag, source);
@@ -69,7 +69,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
     ucp_tag_recv_info_t info;
     ucp_tag_message_h message_h;
 
-    int vni_dst = MPIDI_UCX_get_vni(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
+    int vni_dst = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_dst).lock);
 
     tag_mask = MPIDI_UCX_tag_mask(tag, source);

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -198,7 +198,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
 {
     int mpi_errno;
 
-    int vni_dst = MPIDI_UCX_get_vni(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag);
+    int vni_dst = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag);
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -218,14 +218,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_put(const void *origin_addr,
     }
 
     if (origin_contig && target_contig) {
-        int vni = MPIDI_UCX_get_win_vni(win);
+        int vni = MPIDI_UCX_WIN(win).vni;
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         mpi_errno =
             MPIDI_UCX_contig_put(MPIR_get_contig_ptr(origin_addr, origin_true_lb), origin_bytes,
                                  target_rank, target_disp, target_true_lb, win, addr, reqptr, vni);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
     } else if (target_contig) {
-        int vni = MPIDI_UCX_get_win_vni(win);
+        int vni = MPIDI_UCX_WIN(win).vni;
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         mpi_errno = MPIDI_UCX_noncontig_put(origin_addr, origin_count, origin_datatype, target_rank,
                                             target_bytes, target_disp, target_true_lb, win, addr,
@@ -279,7 +279,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_get(void *origin_addr,
     }
 
     if (origin_contig && target_contig) {
-        int vni = MPIDI_UCX_get_win_vni(win);
+        int vni = MPIDI_UCX_WIN(win).vni;
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         mpi_errno =
             MPIDI_UCX_contig_get(MPIR_get_contig_ptr(origin_addr, origin_true_lb), origin_bytes,

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -113,8 +113,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
-    int vni_src = MPIDI_UCX_get_vni(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
-    int vni_dst = MPIDI_UCX_get_vni(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
+    int vni_src = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
+    int vni_dst = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
 
     switch (*errflag) {
@@ -145,8 +145,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
-    int vni_src = MPIDI_UCX_get_vni(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
-    int vni_dst = MPIDI_UCX_get_vni(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
+    int vni_src = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
+    int vni_dst = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
 
     MPIR_FUNC_ENTER;
 
@@ -168,8 +168,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
-    int vni_src = MPIDI_UCX_get_vni(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
-    int vni_dst = MPIDI_UCX_get_vni(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
+    int vni_src = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
+    int vni_dst = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -14,6 +14,11 @@ struct ucx_share {
 static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void **base_ptr);
 static int win_init(MPIR_Win * win);
 
+#define MPIDI_UCX_WIN_VNI(win, vni_) \
+    do { \
+        vni_ = MPIDI_get_vci(SRC_VCI_FROM_SENDER, (win)->comm_ptr, 0, 0, 0); \
+    } while (0)
+
 static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void **base_ptr)
 {
 
@@ -105,7 +110,7 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
      * and remote windows (at least now). If win_create is used, the key cannot be unpackt -
      * then we need our fallback-solution */
 
-    int vni = MPIDI_UCX_get_win_vni(win);
+    int vni = MPIDI_UCX_WIN(win).vni;
     bool all_reachable = true, none_reachable = true;
     for (i = 0; i < comm_ptr->local_size; i++) {
         /* Skip unmapped remote region. */
@@ -179,6 +184,7 @@ static int win_init(MPIR_Win * win)
     MPIR_Assert(MPIDI_WIN(win, am_vci) < MPIDI_UCX_global.num_vnis);
 
     memset(&MPIDI_UCX_WIN(win), 0, sizeof(MPIDI_UCX_win_t));
+    MPIDI_UCX_WIN_VNI(win, MPIDI_UCX_WIN(win).vni);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -155,7 +155,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
 
     if (MPIDI_UCX_WIN(win).info_table && MPIDI_UCX_win_need_flush(win)) {
         ucs_status_t ucp_status;
-        int vni = MPIDI_UCX_get_win_vni(win);
+        int vni = MPIDI_UCX_WIN(win).vni;
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         ucp_status = MPIDI_UCX_flush(vni);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
@@ -180,7 +180,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
 
         /* currently, UCP does not support local flush, so we have to call
          * a global flush. This is not good for performance - but OK for now */
-        int vni = MPIDI_UCX_get_win_vni(win);
+        int vni = MPIDI_UCX_WIN(win).vni;
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         ucp_status = MPIDI_UCX_flush(vni);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
@@ -207,7 +207,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank, MPIR_Win * 
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync >= MPIDI_UCX_WIN_SYNC_FLUSH_LOCAL) {
 
         ucs_status_t ucp_status;
-        int vni = MPIDI_UCX_get_win_vni(win);
+        int vni = MPIDI_UCX_WIN(win).vni;
         ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni);
         /* only flush the endpoint */
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
@@ -233,7 +233,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync == MPIDI_UCX_WIN_SYNC_FLUSH_LOCAL) {
         ucs_status_t ucp_status;
 
-        int vni = MPIDI_UCX_get_win_vni(win);
+        int vni = MPIDI_UCX_WIN(win).vni;
         ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni);
         /* currently, UCP does not support local flush, so we have to call
          * a global flush. This is not good for performance - but OK for now */

--- a/src/mpid/ch4/shm/posix/posix_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_impl.h
@@ -16,10 +16,4 @@
 
 void MPIDI_POSIX_delay_shm_mutex_destroy(int rank, MPL_proc_mutex_t * shm_mutex_ptr);
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_get_vsi(int flag, MPIR_Comm * comm_ptr,
-                                                 int src_rank, int dst_rank, int tag)
-{
-    return MPIDI_get_vci(flag, comm_ptr, src_rank, dst_rank, tag) % MPIDI_POSIX_global.num_vsis;
-}
-
 #endif /* POSIX_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/posix_probe.h
+++ b/src/mpid/ch4/shm/posix/posix_probe.h
@@ -18,7 +18,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_improbe(int source,
                                                      MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
-    int vsi = MPIDI_POSIX_get_vsi(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
+    int vsi = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
     mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, vsi, flag, message, status);
@@ -34,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iprobe(int source,
                                                     MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
-    int vsi = MPIDI_POSIX_get_vsi(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
+    int vsi = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
     mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, vsi, flag, status);

--- a/src/mpid/ch4/shm/posix/posix_probe.h
+++ b/src/mpid/ch4/shm/posix/posix_probe.h
@@ -17,8 +17,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_improbe(int source,
                                                      int *flag, MPIR_Request ** message,
                                                      MPI_Status * status)
 {
+    int mpi_errno = MPI_SUCCESS;
     int vsi = MPIDI_POSIX_get_vsi(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
-    return MPIDIG_mpi_improbe(source, tag, comm, context_offset, vsi, flag, message, status);
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
+    mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, vsi, flag, message, status);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iprobe(int source,
@@ -27,8 +33,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iprobe(int source,
                                                     int context_offset, int *flag,
                                                     MPI_Status * status)
 {
+    int mpi_errno = MPI_SUCCESS;
     int vsi = MPIDI_POSIX_get_vsi(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
-    return MPIDIG_mpi_iprobe(source, tag, comm, context_offset, vsi, flag, status);
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
+    mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, vsi, flag, status);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
+
+    return mpi_errno;
 }
 
 #endif /* POSIX_PROBE_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/posix_recv.h
+++ b/src/mpid/ch4/shm/posix/posix_recv.h
@@ -14,7 +14,7 @@
 #define MPIDI_OFI_RECV_VSI(vsi_) \
     do { \
         /* NOTE: hashing is based on target rank */ \
-        vsi_ = MPIDI_POSIX_get_vsi(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
+        vsi_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
     } while (0)
 
 /* Hook triggered after posting a SHM receive request.
@@ -52,7 +52,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_irecv(void *buf,
                                                    MPIR_Comm * comm, int context_offset,
                                                    MPIR_Request ** request)
 {
-    int vsi = MPIDI_POSIX_get_vsi(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag);
+    int vsi = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag);
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
     int mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
                                      vsi, request, 1, NULL);

--- a/src/mpid/ch4/shm/posix/posix_recv.h
+++ b/src/mpid/ch4/shm/posix/posix_recv.h
@@ -32,7 +32,16 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_recv_posted_hook(MPIR_Request * reques
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_imrecv(void *buf, MPI_Aint count,
                                                     MPI_Datatype datatype, MPIR_Request * message)
 {
-    return MPIDIG_mpi_imrecv(buf, count, datatype, message);
+    int mpi_errno = MPI_SUCCESS;
+
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
+    int vci = MPIDI_Request_get_vci(message);
+#endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    mpi_errno = MPIDIG_mpi_imrecv(buf, count, datatype, message);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_irecv(void *buf,
@@ -44,8 +53,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_irecv(void *buf,
                                                    MPIR_Request ** request)
 {
     int vsi = MPIDI_POSIX_get_vsi(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
     int mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
                                      vsi, request, 1, NULL);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi).lock);
     MPIDI_POSIX_recv_posted_hook(*request, rank, comm);
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -27,11 +27,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint cou
                                                    MPIR_Comm * comm, int context_offset,
                                                    MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
+    int mpi_errno = MPI_SUCCESS;
+
     int vsi_src, vsi_dst;
     MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
 
-    return MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                            vsi_src, vsi_dst, request);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi_src).lock);
+    mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                 vsi_src, vsi_dst, request);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi_src).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_isend_coll(const void *buf, MPI_Aint count,
@@ -41,11 +47,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_isend_coll(const void *buf, MPI_Aint co
                                                     MPIR_Request ** request,
                                                     MPIR_Errflag_t * errflag)
 {
+    int mpi_errno = MPI_SUCCESS;
+
     int vsi_src, vsi_dst;
     MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
 
-    return MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                             vsi_src, vsi_dst, request, errflag);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi_src).lock);
+    mpi_errno = MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                  vsi_src, vsi_dst, request, errflag);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi_src).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_issend(const void *buf, MPI_Aint count,
@@ -54,11 +66,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_issend(const void *buf, MPI_Aint co
                                                     MPIDI_av_entry_t * addr,
                                                     MPIR_Request ** request)
 {
+    int mpi_errno = MPI_SUCCESS;
+
     int vsi_src, vsi_dst;
     MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
 
-    return MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                             vsi_src, vsi_dst, request);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi_src).lock);
+    mpi_errno = MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                  vsi_src, vsi_dst, request);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi_src).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_cancel_send(MPIR_Request * sreq)

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -18,8 +18,8 @@
 
 #define MPIDI_POSIX_SEND_VSIS(vsi_src_, vsi_dst_) \
     do { \
-        vsi_src_ = MPIDI_POSIX_get_vsi(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
-        vsi_dst_ = MPIDI_POSIX_get_vsi(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+        vsi_src_ = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+        vsi_dst_ = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
     } while (0)
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint count,

--- a/src/mpid/ch4/shm/src/shm_am_fallback_probe.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_probe.h
@@ -13,7 +13,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_improbe(int source,
                                                    int *flag, MPIR_Request ** message,
                                                    MPI_Status * status)
 {
-    return MPIDIG_mpi_improbe(source, tag, comm, context_offset, 0, flag, message, status);
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, 0, flag, message, status);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iprobe(int source,
@@ -22,7 +28,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iprobe(int source,
                                                   int context_offset,
                                                   int *flag, MPI_Status * status)
 {
-    return MPIDIG_mpi_iprobe(source, tag, comm, context_offset, 0, flag, status);
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, 0, flag, status);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 #endif /* SHM_AM_FALLBACK_PROBE_H_INCLUDED */

--- a/src/mpid/ch4/shm/src/shm_am_fallback_recv.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_recv.h
@@ -10,7 +10,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf,
                                                   MPI_Aint count, MPI_Datatype datatype,
                                                   MPIR_Request * message)
 {
-    return MPIDIG_mpi_imrecv(buf, count, datatype, message);
+    int mpi_errno = MPI_SUCCESS;
+
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
+    int vci = MPIDI_Request_get_vci(message);
+#endif
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    mpi_errno = MPIDIG_mpi_imrecv(buf, count, datatype, message);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf,
@@ -21,8 +30,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf,
                                                  MPIR_Comm * comm, int context_offset,
                                                  MPIR_Request ** request)
 {
-    return MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, 0, request, 1,
-                            NULL);
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
+                                 0, request, 1, NULL);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq)

--- a/src/mpid/ch4/shm/src/shm_am_fallback_send.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_send.h
@@ -14,8 +14,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf,
                                                  MPIR_Comm * comm, int context_offset,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                            request);
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
+                                 request);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf,
@@ -26,8 +32,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf,
                                                   MPIR_Comm * comm, int context_offset,
                                                   MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                             request);
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
+                                  request);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_isend_coll(const void *buf, MPI_Aint count,
@@ -36,8 +48,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_isend_coll(const void *buf, MPI_Aint coun
                                                   MPIDI_av_entry_t * addr, MPIR_Request ** request,
                                                   MPIR_Errflag_t * errflag)
 {
-    return MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                             0, 0, request, errflag);
+    int mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    mpi_errno = MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                  0, 0, request, errflag);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_send(MPIR_Request * sreq)

--- a/src/mpid/ch4/src/mpidig_probe.h
+++ b/src/mpid/ch4/src/mpidig_probe.h
@@ -15,7 +15,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *unexp_req;
     MPIR_FUNC_ENTER;
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
 
     MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
 
@@ -35,7 +34,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
         *flag = 0;
     }
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }
@@ -48,7 +46,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
     MPIR_Request *unexp_req;
 
     MPIR_FUNC_ENTER;
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
 
     MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
 
@@ -76,7 +73,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
         *flag = 0;
     }
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }

--- a/src/mpid/ch4/src/mpidig_send.h
+++ b/src/mpid/ch4/src/mpidig_send.h
@@ -121,13 +121,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(src_vci).lock);
 
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                   MPIDIG_AM_SEND_FLAGS_NONE, src_vci, dst_vci,
                                   request, MPIR_ERR_NONE);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(src_vci).lock);
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }
@@ -141,12 +139,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_coll(const void *buf, MPI_Aint count,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(src_vci).lock);
 
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                   MPIDIG_AM_SEND_FLAGS_NONE, src_vci, dst_vci, request, *errflag);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(src_vci).lock);
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }
@@ -162,13 +158,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_issend(const void *buf,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(src_vci).lock);
 
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                   MPIDIG_AM_SEND_FLAGS_SYNC, src_vci, dst_vci,
                                   request, MPIR_ERR_NONE);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(src_vci).lock);
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }


### PR DESCRIPTION
## Pull Request Description
Now that we support multiple vci for both netmod/shm/am path, we can simply assume a direct mapping of vci/vni/vsi, and move critical sections outside `mpidig` functions. This consolidates the critical section decisions. We also remove the separate hashing inside netmod and posix to avoid extra code indirection and potential extra modulo.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
