### PR TITLE
adi: replace context_offset with attr in pt2pt functions

### DIFF
--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -6,6 +6,23 @@
 #ifndef MPIR_PT2PT_H_INCLUDED
 #define MPIR_PT2PT_H_INCLUDED
 
+/* NOTE: All explicit vci (allocated) must be greater than 0 */
+
+#define MPIR_PT2PT_ATTR_SRC_VCI_SHIFT 8
+#define MPIR_PT2PT_ATTR_DST_VCI_SHIFT 16
+
+#define MPIR_PT2PT_ATTR_HAS_VCI(attr) ((attr) & 0xffff00)
+#define MPIR_PT2PT_ATTR_SRC_VCI(attr) (((attr) >> MPIR_PT2PT_ATTR_SRC_VCI_SHIFT) & 0xff)
+#define MPIR_PT2PT_ATTR_DST_VCI(attr) (((attr) >> MPIR_PT2PT_ATTR_DST_VCI_SHIFT) & 0xff)
+#define MPIR_PT2PT_ATTR_SET_VCIS(attr, src_vci, dst_vci) \
+    do { \
+        (attr) |= ((src_vci) << MPIR_PT2PT_ATTR_SRC_VCI_SHIFT) | ((dst_vci) << MPIR_PT2PT_ATTR_DST_VCI_SHIFT); \
+    } while (0)
+
+/* bit 0: context_offset */
+#define MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr) ((attr) & 0x01)
+#define MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, context_offset) (attr) |= (context_offset)
+
 int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
                      MPIR_Comm * comm_ptr, MPI_Request * request);
 

--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -23,6 +23,26 @@
 #define MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr) ((attr) & 0x01)
 #define MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, context_offset) (attr) |= (context_offset)
 
+/* bit 1-2: errflag */
+#define MPIR_PT2PT_ATTR_GET_ERRFLAG(attr) \
+    ((!((attr) & 0x6)) ? MPIR_ERR_NONE : \
+        (((attr) & 0x2) ? MPIX_ERR_PROC_FAILED : MPI_ERR_OTHER))
+
+#define MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag) \
+    do { \
+        if (errflag) { \
+            if (errflag == MPIR_ERR_PROC_FAILED) { \
+                (attr) |= 0x2; \
+            } else { \
+                (attr) |= 0x4; \
+            } \
+        } \
+    } while (0)
+
+/* bit 3: syncflag */
+#define MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr)  (((attr) & 0x8) ? 1 : 0)
+#define MPIR_PT2PT_ATTR_SET_SYNCFLAG(attr)  (attr) |= 0x8
+
 int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
                      MPIR_Comm * comm_ptr, MPI_Request * request);
 

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -560,60 +560,60 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
 int MPID_Comm_revoke(MPIR_Comm *comm, int is_remote);
 
 int MPID_Send( const void *buf, MPI_Aint count, MPI_Datatype datatype,
-	       int dest, int tag, MPIR_Comm *comm, int context_offset,
+	       int dest, int tag, MPIR_Comm *comm, int attr,
 	       MPIR_Request **request );
 
 int MPID_Send_coll( const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                    int dest, int tag, MPIR_Comm *comm, int context_offset,
+                    int dest, int tag, MPIR_Comm *comm, int attr,
                     MPIR_Request **request, MPIR_Errflag_t * errflag );
 
 int MPID_Rsend( const void *buf, int count, MPI_Datatype datatype,
-		int dest, int tag, MPIR_Comm *comm, int context_offset,
+		int dest, int tag, MPIR_Comm *comm, int attr,
 		MPIR_Request **request );
 
 int MPID_Ssend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
-		int dest, int tag, MPIR_Comm *comm, int context_offset,
+		int dest, int tag, MPIR_Comm *comm, int attr,
 		MPIR_Request **request );
 
 int MPID_Isend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
-		int dest, int tag, MPIR_Comm *comm, int context_offset,
+		int dest, int tag, MPIR_Comm *comm, int attr,
 		MPIR_Request **request );
 
 int MPID_Isend_coll( const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                     int dest, int tag, MPIR_Comm *comm, int context_offset,
+                     int dest, int tag, MPIR_Comm *comm, int attr,
                      MPIR_Request **request, MPIR_Errflag_t * errflag );
 
 int MPID_Irsend( const void *buf, int count, MPI_Datatype datatype,
-		 int dest, int tag, MPIR_Comm *comm, int context_offset,
+		 int dest, int tag, MPIR_Comm *comm, int attr,
 		 MPIR_Request **request );
 
 int MPID_Issend( const void *buf, int count, MPI_Datatype datatype,
-		 int dest, int tag, MPIR_Comm *comm, int context_offset,
+		 int dest, int tag, MPIR_Comm *comm, int attr,
 		 MPIR_Request **request );
 
 int MPID_Recv( void *buf, MPI_Aint count, MPI_Datatype datatype,
-	       int source, int tag, MPIR_Comm *comm, int context_offset,
+	       int source, int tag, MPIR_Comm *comm, int attr,
 	       MPI_Status *status, MPIR_Request **request );
 
 int MPID_Irecv( void *buf, MPI_Aint count, MPI_Datatype datatype,
-		int source, int tag, MPIR_Comm *comm, int context_offset,
+		int source, int tag, MPIR_Comm *comm, int attr,
 		MPIR_Request **request );
 
 int MPID_Send_init( const void *buf, int count, MPI_Datatype datatype,
-		    int dest, int tag, MPIR_Comm *comm, int context_offset,
+		    int dest, int tag, MPIR_Comm *comm, int attr,
 		    MPIR_Request **request );
 
 int MPID_Bsend_init(const void *, int, MPI_Datatype, int, int, MPIR_Comm *,
 		   int, MPIR_Request **);
 int MPID_Rsend_init( const void *buf, int count, MPI_Datatype datatype,
-		     int dest, int tag, MPIR_Comm *comm, int context_offset,
+		     int dest, int tag, MPIR_Comm *comm, int attr,
 		     MPIR_Request **request );
 int MPID_Ssend_init( const void *buf, int count, MPI_Datatype datatype,
-		     int dest, int tag, MPIR_Comm *comm, int context_offset,
+		     int dest, int tag, MPIR_Comm *comm, int attr,
 		     MPIR_Request **request );
 
 int MPID_Recv_init( void *buf, int count, MPI_Datatype datatype,
-		    int source, int tag, MPIR_Comm *comm, int context_offset,
+		    int source, int tag, MPIR_Comm *comm, int attr,
 		    MPIR_Request **request );
 
 int MPID_Startall(int count, MPIR_Request *requests[]);
@@ -711,13 +711,13 @@ int MPID_Neighbor_alltoallw_init(const void *sendbuf, const MPI_Aint sendcounts[
                                  const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
                                  MPIR_Comm * comm, MPIR_Info * info, MPIR_Request ** request);
 
-int MPID_Probe(int, int, MPIR_Comm *, int, MPI_Status *);
-int MPID_Iprobe(int, int, MPIR_Comm *, int, int *, MPI_Status *);
+int MPID_Probe(int source, int tag, MPIR_Comm *comm, int attr, MPI_Status * status);
+int MPID_Iprobe(int source, int tag, MPIR_Comm *comm, int attr, int *flag, MPI_Status *status);
 
-int MPID_Mprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
+int MPID_Mprobe(int source, int tag, MPIR_Comm *comm, int attr,
                 MPIR_Request **message, MPI_Status *status);
 
-int MPID_Improbe(int source, int tag, MPIR_Comm *comm, int context_offset,
+int MPID_Improbe(int source, int tag, MPIR_Comm *comm, int attr,
                  int *flag, MPIR_Request **message, MPI_Status *status);
 
 int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,

--- a/src/mpid/ch3/src/mpid_improbe.c
+++ b/src/mpid/ch3/src/mpid_improbe.c
@@ -9,10 +9,11 @@ int (*MPIDI_Anysource_improbe_fn)(int tag, MPIR_Comm * comm, int context_offset,
                                   int *flag, MPIR_Request **message,
                                   MPI_Status * status) = NULL;
 
-int MPID_Improbe(int source, int tag, MPIR_Comm *comm, int context_offset,
+int MPID_Improbe(int source, int tag, MPIR_Comm *comm, int attr,
                  int *flag, MPIR_Request **message, MPI_Status *status)
 {
     int mpi_errno = MPI_SUCCESS;
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int context_id = comm->recvcontext_id + context_offset;
 
     *message = NULL;

--- a/src/mpid/ch3/src/mpid_iprobe.c
+++ b/src/mpid/ch3/src/mpid_iprobe.c
@@ -8,9 +8,10 @@
 int (*MPIDI_Anysource_iprobe_fn)(int tag, MPIR_Comm * comm, int context_offset, int *flag,
                                  MPI_Status * status) = NULL;
 
-int MPID_Iprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
+int MPID_Iprobe(int source, int tag, MPIR_Comm *comm, int attr,
 		int *flag, MPI_Status *status)
 {
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     const int context = comm->recvcontext_id + context_offset;
     int found = 0;
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch3/src/mpid_irecv.c
+++ b/src/mpid/ch3/src/mpid_irecv.c
@@ -6,7 +6,7 @@
 #include "mpidimpl.h"
 
 int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-	       MPIR_Comm * comm, int context_offset,
+	       MPIR_Comm * comm, int attr,
                MPIR_Request ** request)
 {
     MPIR_Request * rreq = NULL;
@@ -15,6 +15,7 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
 			"rank=%d, tag=%d, context=%d", 
 			rank, tag, comm->recvcontext_id + context_offset));

--- a/src/mpid/ch3/src/mpid_irsend.c
+++ b/src/mpid/ch3/src/mpid_irsend.c
@@ -8,7 +8,7 @@
 /*
  * MPID_Irsend()
  */
-int MPID_Irsend(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int context_offset,
+int MPID_Irsend(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		MPIR_Request ** request)
 {
     MPIDI_CH3_Pkt_t upkt;
@@ -26,6 +26,7 @@ int MPID_Irsend(const void * buf, int count, MPI_Datatype datatype, int rank, in
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                 "rank=%d, tag=%d, context=%d", 
                 rank, tag, comm->context_id + context_offset));

--- a/src/mpid/ch3/src/mpid_isend.c
+++ b/src/mpid/ch3/src/mpid_isend.c
@@ -21,7 +21,7 @@
  * MPID_Isend()
  */
 int MPID_Isend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank,
-	       int tag, MPIR_Comm * comm, int context_offset,
+	       int tag, MPIR_Comm * comm, int attr,
                MPIR_Request ** request)
 {
     intptr_t data_sz;
@@ -38,6 +38,7 @@ int MPID_Isend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                   "rank=%d, tag=%d, context=%d", 
                   rank, tag, comm->context_id + context_offset));
@@ -176,7 +177,7 @@ int MPID_Isend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
 }
 
 int MPID_Isend_coll(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-                    MPIR_Comm * comm, int context_offset, MPIR_Request ** request,
+                    MPIR_Comm * comm, int attr, MPIR_Request ** request,
                     MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -193,7 +194,7 @@ int MPID_Isend_coll(const void * buf, MPI_Aint count, MPI_Datatype datatype, int
         MPIR_TAG_SET_ERROR_BIT(tag);
     }
 
-    mpi_errno = MPID_Isend(buf, count, datatype, rank, tag, comm, context_offset, request);
+    mpi_errno = MPID_Isend(buf, count, datatype, rank, tag, comm, attr, request);
 
     MPIR_FUNC_EXIT;
 

--- a/src/mpid/ch3/src/mpid_issend.c
+++ b/src/mpid/ch3/src/mpid_issend.c
@@ -8,7 +8,7 @@
 /*
  * MPID_Issend()
  */
-int MPID_Issend(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int context_offset,
+int MPID_Issend(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		MPIR_Request ** request)
 {
     intptr_t data_sz;
@@ -25,6 +25,7 @@ int MPID_Issend(const void * buf, int count, MPI_Datatype datatype, int rank, in
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                  "rank=%d, tag=%d, context=%d", 
                  rank, tag, comm->context_id + context_offset));

--- a/src/mpid/ch3/src/mpid_mprobe.c
+++ b/src/mpid/ch3/src/mpid_mprobe.c
@@ -5,12 +5,13 @@
 
 #include "mpidimpl.h"
 
-int MPID_Mprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
+int MPID_Mprobe(int source, int tag, MPIR_Comm *comm, int attr,
                 MPIR_Request **message, MPI_Status *status)
 {
     int mpi_errno = MPI_SUCCESS;
     MPID_Progress_state progress_state;
     int found = FALSE;
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int context_id = comm->recvcontext_id + context_offset;
 
     *message = NULL;

--- a/src/mpid/ch3/src/mpid_probe.c
+++ b/src/mpid/ch3/src/mpid_probe.c
@@ -5,10 +5,11 @@
 
 #include "mpidimpl.h"
 
-int MPID_Probe(int source, int tag, MPIR_Comm * comm, int context_offset,
+int MPID_Probe(int source, int tag, MPIR_Comm * comm, int attr,
 	       MPI_Status * status)
 {
     MPID_Progress_state progress_state;
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     const int context = comm->recvcontext_id + context_offset;
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch3/src/mpid_recv.c
+++ b/src/mpid/ch3/src/mpid_recv.c
@@ -6,7 +6,7 @@
 #include "mpidimpl.h"
 
 int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-	      MPIR_Comm * comm, int context_offset,
+	      MPIR_Comm * comm, int attr,
 	      MPI_Status * status, MPIR_Request ** request)
 {
     /* FIXME: in the common case, we want to simply complete the message
@@ -22,6 +22,7 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                       "rank=%d, tag=%d, context=%d", rank, tag,
 		      comm->recvcontext_id + context_offset));

--- a/src/mpid/ch3/src/mpid_rsend.c
+++ b/src/mpid/ch3/src/mpid_rsend.c
@@ -12,7 +12,7 @@
 /*
  * MPID_Rsend()
  */
-int MPID_Rsend(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int context_offset,
+int MPID_Rsend(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 	       MPIR_Request ** request)
 {
     intptr_t data_sz;
@@ -28,6 +28,7 @@ int MPID_Rsend(const void * buf, int count, MPI_Datatype datatype, int rank, int
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
 					"rank=%d, tag=%d, context=%d", 
                               rank, tag, comm->context_id + context_offset));

--- a/src/mpid/ch3/src/mpid_send.c
+++ b/src/mpid/ch3/src/mpid_send.c
@@ -9,7 +9,7 @@
  * MPID_Send()
  */
 int MPID_Send(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank,
-	      int tag, MPIR_Comm * comm, int context_offset,
+	      int tag, MPIR_Comm * comm, int attr,
 	      MPIR_Request ** request)
 {
     intptr_t data_sz;
@@ -26,6 +26,7 @@ int MPID_Send(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank,
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                 "rank=%d, tag=%d, context=%d", 
 		rank, tag, comm->context_id + context_offset));
@@ -182,7 +183,7 @@ int MPID_Send(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank,
 }
 
 int MPID_Send_coll(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-                   MPIR_Comm * comm, int context_offset, MPIR_Request ** request,
+                   MPIR_Comm * comm, int attr, MPIR_Request ** request,
                    MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -199,7 +200,7 @@ int MPID_Send_coll(const void *buf, MPI_Aint count, MPI_Datatype datatype, int r
         MPIR_TAG_SET_ERROR_BIT(tag);
     }
 
-    mpi_errno = MPID_Send(buf, count, datatype, rank, tag, comm, context_offset, request);
+    mpi_errno = MPID_Send(buf, count, datatype, rank, tag, comm, attr, request);
 
     MPIR_FUNC_EXIT;
 

--- a/src/mpid/ch3/src/mpid_ssend.c
+++ b/src/mpid/ch3/src/mpid_ssend.c
@@ -8,7 +8,7 @@
 /*
  * MPID_Ssend()
  */
-int MPID_Ssend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int context_offset,
+int MPID_Ssend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 	       MPIR_Request ** request)
 {
     intptr_t data_sz;
@@ -25,6 +25,7 @@ int MPID_Ssend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
               "rank=%d, tag=%d, context=%d", 
               rank, tag, comm->context_id + context_offset));

--- a/src/mpid/ch3/src/mpid_startall.c
+++ b/src/mpid/ch3/src/mpid_startall.c
@@ -161,7 +161,7 @@ int MPID_Startall(int count, MPIR_Request * requests[])
 /*
  * MPID_Send_init()
  */
-int MPID_Send_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int context_offset,
+int MPID_Send_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		   MPIR_Request ** request)
 {
     MPIR_Request * sreq;
@@ -169,6 +169,7 @@ int MPID_Send_init(const void * buf, int count, MPI_Datatype datatype, int rank,
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPIDI_Request_create_psreq(sreq, mpi_errno, goto fn_exit);
     MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_SEND);
     if (!HANDLE_IS_BUILTIN(datatype))
@@ -186,7 +187,7 @@ int MPID_Send_init(const void * buf, int count, MPI_Datatype datatype, int rank,
 /*
  * MPID_Ssend_init()
  */
-int MPID_Ssend_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int context_offset,
+int MPID_Ssend_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		    MPIR_Request ** request)
 {
     MPIR_Request * sreq;
@@ -194,6 +195,7 @@ int MPID_Ssend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPIDI_Request_create_psreq(sreq, mpi_errno, goto fn_exit);
     MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_SSEND);
     if (!HANDLE_IS_BUILTIN(datatype))
@@ -211,7 +213,7 @@ int MPID_Ssend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 /*
  * MPID_Rsend_init()
  */
-int MPID_Rsend_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int context_offset,
+int MPID_Rsend_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		    MPIR_Request ** request)
 {
     MPIR_Request * sreq;
@@ -219,6 +221,7 @@ int MPID_Rsend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPIDI_Request_create_psreq(sreq, mpi_errno, goto fn_exit);
     MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_RSEND);
     if (!HANDLE_IS_BUILTIN(datatype))
@@ -236,7 +239,7 @@ int MPID_Rsend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 /*
  * MPID_Bsend_init()
  */
-int MPID_Bsend_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int context_offset,
+int MPID_Bsend_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		    MPIR_Request ** request)
 {
     MPIR_Request * sreq;
@@ -244,6 +247,7 @@ int MPID_Bsend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPIDI_Request_create_psreq(sreq, mpi_errno, goto fn_exit);
     MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_BSEND);
     if (!HANDLE_IS_BUILTIN(datatype))

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -104,21 +104,20 @@ Non Native API:
 
 Native API:
   mpi_isend : int
-      NM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
-     SHM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
+      NM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
+     SHM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
   isend_coll : int
-      NM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
-     SHM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p, errflag
+      NM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p, errflag
+     SHM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p, errflag
   mpi_issend : int
-      NM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
-     SHM*: buf, count, datatype, rank, tag, comm, context_offset, addr, req_p
+      NM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
+     SHM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
   mpi_cancel_send : int
       NM*: sreq
      SHM*: sreq
   mpi_irecv : int
-      NM*: buf-2, count, datatype, rank, tag, comm, context_offset, addr, req_p, partner
-     SHM*: buf-2, count, datatype, rank, tag, comm, context_offset, req_p
-     MPIDIG: buf-2, count, datatype, rank, tag, comm, context_offset, vci, req_p
+      NM*: buf-2, count, datatype, rank, tag, comm, attr-2, addr, req_p, partner
+     SHM*: buf-2, count, datatype, rank, tag, comm, attr-2, req_p
   mpi_imrecv : int
       NM*: buf-2, count, datatype, message
      SHM*: buf-2, count, datatype, message
@@ -150,11 +149,11 @@ Native API:
       NM : ptr
      SHM : ptr
   mpi_improbe : int
-      NM*: source, tag, comm, context_offset, addr, flag, message_p, status
-     SHM*: source, tag, comm, context_offset, flag, message_p, status
+      NM*: source, tag, comm, attr-2, addr, flag, message_p, status
+     SHM*: source, tag, comm, attr-2, flag, message_p, status
   mpi_iprobe : int
-      NM*: source, tag, comm, context_offset, addr, flag, status
-     SHM*: source, tag, comm, context_offset, flag, status
+      NM*: source, tag, comm, attr-2, addr, flag, status
+     SHM*: source, tag, comm, attr-2, flag, status
   mpi_win_set_info : int
       NM : win, info
      SHM : win, info
@@ -403,6 +402,7 @@ PARAM:
     appnum: int
     assert: int
     attr: uint32_t
+    attr-2: int
     av: MPIDI_av_entry_t *
     base: void *
     base-2: const void *
@@ -416,7 +416,6 @@ PARAM:
     comm_ptr: MPIR_Comm *
     compare_addr: const void *
     context_id: MPIR_Context_id_t
-    context_offset: int
     count: MPI_Aint
     data: const void *
     data_sz: MPI_Aint

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -106,12 +106,6 @@ Native API:
   mpi_isend : int
       NM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
      SHM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
-  isend_coll : int
-      NM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p, errflag
-     SHM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p, errflag
-  mpi_issend : int
-      NM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
-     SHM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
   mpi_cancel_send : int
       NM*: sreq
      SHM*: sreq

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_probe.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_probe.h
@@ -9,11 +9,12 @@
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
                                                   int tag,
                                                   MPIR_Comm * comm,
-                                                  int context_offset, MPIDI_av_entry_t * addr,
+                                                  int attr, MPIDI_av_entry_t * addr,
                                                   int *flag, MPIR_Request ** message,
                                                   MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, 0, flag, message, status);
@@ -25,10 +26,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
                                                  int tag,
                                                  MPIR_Comm * comm,
-                                                 int context_offset, MPIDI_av_entry_t * addr,
+                                                 int attr, MPIDI_av_entry_t * addr,
                                                  int *flag, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, 0, flag, status);

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
@@ -27,11 +27,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 MPI_Datatype datatype,
                                                 int rank,
                                                 int tag,
-                                                MPIR_Comm * comm, int context_offset,
+                                                MPIR_Comm * comm, int attr,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request,
                                                 MPIR_Request * partner)
 {
     int mpi_errno = MPI_SUCCESS;
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
     /* For anysource recv, we may be called while holding the vci lock of shm request (to
      * prevent shm progress). Therefore, recursive locking is allowed here */

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
@@ -11,10 +11,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
                                                 MPI_Datatype datatype,
                                                 int rank,
                                                 int tag,
-                                                MPIR_Comm * comm, int context_offset,
+                                                MPIR_Comm * comm, int attr,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
@@ -29,10 +30,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf,
                                                  MPI_Datatype datatype,
                                                  int rank,
                                                  int tag,
-                                                 MPIR_Comm * comm, int context_offset,
+                                                 MPIR_Comm * comm, int attr,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
@@ -44,11 +46,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
+                                                 MPIR_Comm * comm, int attr,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request,
                                                  MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     mpi_errno = MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
@@ -15,48 +15,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
+
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
+    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                                 request);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    int vni_src, vni_dst;
+    vni_src = 0;
+    vni_dst = 0;
 
-    return mpi_errno;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf,
-                                                 MPI_Aint count,
-                                                 MPI_Datatype datatype,
-                                                 int rank,
-                                                 int tag,
-                                                 MPIR_Comm * comm, int attr,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    mpi_errno = MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                                  request);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
-    return mpi_errno;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int attr,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                 MPIR_Errflag_t * errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    mpi_errno = MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                  0, 0, request, errflag);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
+    mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                 vni_src, vni_dst, request, syncflag, errflag);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -125,7 +125,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
                                                   int tag,
                                                   MPIR_Comm * comm,
-                                                  int context_offset, MPIDI_av_entry_t * addr,
+                                                  int attr, MPIDI_av_entry_t * addr,
                                                   int *flag, MPIR_Request ** message,
                                                   MPI_Status * status)
 {
@@ -133,6 +133,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vni_src, vni_dst;
     MPIDI_OFI_PROBE_VNIS(vni_src, vni_dst);
 
@@ -154,12 +155,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
                                                  int tag,
                                                  MPIR_Comm * comm,
-                                                 int context_offset, MPIDI_av_entry_t * addr,
+                                                 int attr, MPIDI_av_entry_t * addr,
                                                  int *flag, MPI_Status * status)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vni_src, vni_dst;
     MPIDI_OFI_PROBE_VNIS(vni_src, vni_dst);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -322,15 +322,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 MPI_Datatype datatype,
                                                 int rank,
                                                 int tag,
-                                                MPIR_Comm * comm, int context_offset,
+                                                MPIR_Comm * comm, int attr,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request,
                                                 MPIR_Request * partner)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vni_src, vni_dst;
     MPIDI_OFI_RECV_VNIS(vni_src, vni_dst);
+
     /* For anysource recv, we may be called while holding the vci lock of shm request (to
      * prevent shm progress). Therefore, recursive locking is allowed here */
     MPIDI_OFI_THREAD_CS_ENTER_REC_VCI_OPTIONAL(vni_dst);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -457,14 +457,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
+                                                MPIR_Comm * comm, int attr,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vni_src, vni_dst;
     MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
+
     MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
@@ -497,15 +499,17 @@ Input Parameters:
 @*/
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
+                                                 MPIR_Comm * comm, int attr,
                                                  MPIDI_av_entry_t * addr,
                                                  MPIR_Request ** request, MPIR_Errflag_t * errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vni_src, vni_dst;
     MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
+
     MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
@@ -523,14 +527,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
+                                                 MPIR_Comm * comm, int attr,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vni_src, vni_dst;
     MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
+
     MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr,

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -464,87 +464,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
     MPIR_FUNC_ENTER;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
+    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+
     int vni_src, vni_dst;
     MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
 
     MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
+        bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr) ? MPIDIG_AM_SEND_FLAGS_SYNC : 0;
         mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                     vni_src, vni_dst, request);
+                                     vni_src, vni_dst, request, syncflag, errflag);
     } else {
+        uint64_t syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr) ? MPIDI_OFI_SYNC_SEND : 0;
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
                                    context_offset, addr, vni_src, vni_dst,
-                                   request, 0, 0ULL, MPIR_ERR_NONE);
-    }
-    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_src);
-
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-}
-
-/*@
-    MPIDI_NM_isend_coll - NM_mpi_isend function for collectives which takes an additional error
-    flag argument.
-Input Parameters:
-    buf - starting address of buffer to send
-    count - number of elements to send
-    datatype - data type of each send buffer element
-    dst_rank - rank of destination rank
-    tag - message tag
-    comm - handle to communicator
-    context_offset - offset into context object
-    addr - address vector entry for destination
-    request - handle to request pointer
-    errflag - the error flag to be passed along with the message
-@*/
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int attr,
-                                                 MPIDI_av_entry_t * addr,
-                                                 MPIR_Request ** request, MPIR_Errflag_t * errflag)
-{
-    int mpi_errno;
-    MPIR_FUNC_ENTER;
-
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    int vni_src, vni_dst;
-    MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
-
-    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno = MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                      vni_src, vni_dst, request, errflag);
-    } else {
-        mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, vni_src, vni_dst, request, 0, 0ULL,
-                                   *errflag);
-    }
-    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_src);
-
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int attr,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    int mpi_errno;
-    MPIR_FUNC_ENTER;
-
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    int vni_src, vni_dst;
-    MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
-
-    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno = MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                      vni_src, vni_dst, request);
-    } else {
-        mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, vni_src, vni_dst, request, 0,
-                                   MPIDI_OFI_SYNC_SEND, MPIR_ERR_NONE);
+                                   request, 0, syncflag, errflag);
     }
     MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_src);
 

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -11,7 +11,7 @@
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
                                                   int tag,
                                                   MPIR_Comm * comm,
-                                                  int context_offset,
+                                                  int attr,
                                                   MPIDI_av_entry_t * addr,
                                                   int *flag, MPIR_Request ** message,
                                                   MPI_Status * status)
@@ -23,7 +23,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
     ucp_tag_message_h message_h;
     MPIR_Request *req = NULL;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vni_dst = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
+
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_dst).lock);
 
     tag_mask = MPIDI_UCX_tag_mask(tag, source);
@@ -59,7 +61,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
                                                  int tag,
                                                  MPIR_Comm * comm,
-                                                 int context_offset,
+                                                 int attr,
                                                  MPIDI_av_entry_t * addr, int *flag,
                                                  MPI_Status * status)
 {
@@ -69,7 +71,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
     ucp_tag_recv_info_t info;
     ucp_tag_message_h message_h;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vni_dst = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
+
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_dst).lock);
 
     tag_mask = MPIDI_UCX_tag_mask(tag, source);

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -192,12 +192,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 MPI_Datatype datatype,
                                                 int rank,
                                                 int tag,
-                                                MPIR_Comm * comm, int context_offset,
+                                                MPIR_Comm * comm, int attr,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request,
                                                 MPIR_Request * partner)
 {
     int mpi_errno;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vni_dst = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag);
 
     MPIR_FUNC_ENTER;

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -106,15 +106,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
+                                                 MPIR_Comm * comm, int attr,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request,
                                                  MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
+
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vni_src = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
     int vni_dst = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
+
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
 
     switch (*errflag) {
@@ -141,14 +144,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
                                                 MPI_Datatype datatype,
                                                 int rank,
                                                 int tag,
-                                                MPIR_Comm * comm, int context_offset,
+                                                MPIR_Comm * comm, int attr,
                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
+    MPIR_FUNC_ENTER;
+
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vni_src = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
     int vni_dst = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
-
-    MPIR_FUNC_ENTER;
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
     mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
@@ -164,14 +168,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf,
                                                  MPI_Datatype datatype,
                                                  int rank,
                                                  int tag,
-                                                 MPIR_Comm * comm, int context_offset,
+                                                 MPIR_Comm * comm, int attr,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
-    int vni_src = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
-    int vni_dst = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
 
     MPIR_FUNC_ENTER;
+
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
+    int vni_src = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
+    int vni_dst = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
     mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -15,15 +15,16 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint count,
                                                       MPI_Datatype datatype, int rank, int tag,
-                                                      MPIR_Comm * comm, int context_offset,
+                                                      MPIR_Comm * comm, int attr,
                                                       MPIDI_av_entry_t * addr,
                                                       MPIR_Request ** request, bool * done)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    /* note: MPIDI_POSIX_SEND_VSIS defined in posix_send.h */
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vsi_src, vsi_dst;
+    /* note: MPIDI_POSIX_SEND_VSIS defined in posix_send.h */
     MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi_src).lock);

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -123,11 +123,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_isend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
+                                                 MPIR_Comm * comm, int attr,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
+
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
     bool done = false;
     mpi_errno = MPIDI_IPCI_try_lmt_isend(buf, count, datatype, rank, tag, comm,
@@ -136,7 +138,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_isend(const void *buf, MPI_Aint count
 
     if (!done) {
         mpi_errno = MPIDI_POSIX_mpi_isend(buf, count, datatype, rank, tag, comm,
-                                          context_offset, addr, request);
+                                          attr, addr, request);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/shm/posix/posix_probe.h
+++ b/src/mpid/ch4/shm/posix/posix_probe.h
@@ -13,11 +13,13 @@
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_improbe(int source,
                                                      int tag,
                                                      MPIR_Comm * comm,
-                                                     int context_offset,
+                                                     int attr,
                                                      int *flag, MPIR_Request ** message,
                                                      MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vsi = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
@@ -30,10 +32,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_improbe(int source,
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iprobe(int source,
                                                     int tag,
                                                     MPIR_Comm * comm,
-                                                    int context_offset, int *flag,
-                                                    MPI_Status * status)
+                                                    int attr, int *flag, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vsi = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);

--- a/src/mpid/ch4/shm/posix/posix_recv.h
+++ b/src/mpid/ch4/shm/posix/posix_recv.h
@@ -49,14 +49,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_irecv(void *buf,
                                                    MPI_Datatype datatype,
                                                    int rank,
                                                    int tag,
-                                                   MPIR_Comm * comm, int context_offset,
+                                                   MPIR_Comm * comm, int attr,
                                                    MPIR_Request ** request)
 {
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vsi = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag);
+
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
     int mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
                                      vsi, request, 1, NULL);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi).lock);
+
     MPIDI_POSIX_recv_posted_hook(*request, rank, comm);
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -24,11 +24,12 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint count,
                                                    MPI_Datatype datatype, int rank, int tag,
-                                                   MPIR_Comm * comm, int context_offset,
+                                                   MPIR_Comm * comm, int attr,
                                                    MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vsi_src, vsi_dst;
     MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
 
@@ -42,13 +43,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint cou
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_isend_coll(const void *buf, MPI_Aint count,
                                                     MPI_Datatype datatype, int rank, int tag,
-                                                    MPIR_Comm * comm, int context_offset,
+                                                    MPIR_Comm * comm, int attr,
                                                     MPIDI_av_entry_t * addr,
                                                     MPIR_Request ** request,
                                                     MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vsi_src, vsi_dst;
     MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
 
@@ -62,12 +64,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_isend_coll(const void *buf, MPI_Aint co
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_issend(const void *buf, MPI_Aint count,
                                                     MPI_Datatype datatype, int rank, int tag,
-                                                    MPIR_Comm * comm, int context_offset,
+                                                    MPIR_Comm * comm, int attr,
                                                     MPIDI_av_entry_t * addr,
                                                     MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vsi_src, vsi_dst;
     MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
 

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -30,53 +30,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint cou
     int mpi_errno = MPI_SUCCESS;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
+    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
+
     int vsi_src, vsi_dst;
     MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi_src).lock);
     mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                 vsi_src, vsi_dst, request);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi_src).lock);
-
-    return mpi_errno;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_isend_coll(const void *buf, MPI_Aint count,
-                                                    MPI_Datatype datatype, int rank, int tag,
-                                                    MPIR_Comm * comm, int attr,
-                                                    MPIDI_av_entry_t * addr,
-                                                    MPIR_Request ** request,
-                                                    MPIR_Errflag_t * errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    int vsi_src, vsi_dst;
-    MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
-
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi_src).lock);
-    mpi_errno = MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                  vsi_src, vsi_dst, request, errflag);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi_src).lock);
-
-    return mpi_errno;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_issend(const void *buf, MPI_Aint count,
-                                                    MPI_Datatype datatype, int rank, int tag,
-                                                    MPIR_Comm * comm, int attr,
-                                                    MPIDI_av_entry_t * addr,
-                                                    MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    int vsi_src, vsi_dst;
-    MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
-
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi_src).lock);
-    mpi_errno = MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                  vsi_src, vsi_dst, request);
+                                 vsi_src, vsi_dst, request, syncflag, errflag);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi_src).lock);
 
     return mpi_errno;

--- a/src/mpid/ch4/shm/src/shm_am_fallback_send.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_send.h
@@ -11,49 +11,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf,
                                                  MPI_Datatype datatype,
                                                  int rank,
                                                  int tag,
-                                                 MPIR_Comm * comm, int context_offset,
+                                                 MPIR_Comm * comm, int attr,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                                 request);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
+    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
 
-    return mpi_errno;
-}
+    int vni_src, vni_dst;
+    vni_src = 0;
+    vni_dst = 0;
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf,
-                                                  MPI_Aint count,
-                                                  MPI_Datatype datatype,
-                                                  int rank,
-                                                  int tag,
-                                                  MPIR_Comm * comm, int context_offset,
-                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    mpi_errno = MPIDIG_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr, 0, 0,
-                                  request);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
-
-    return mpi_errno;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_isend_coll(const void *buf, MPI_Aint count,
-                                                  MPI_Datatype datatype, int rank, int tag,
-                                                  MPIR_Comm * comm, int context_offset,
-                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                  MPIR_Errflag_t * errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    mpi_errno = MPIDIG_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                  0, 0, request, errflag);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
+    mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                 vni_src, vni_dst, request, syncflag, errflag);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -12,15 +12,20 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
+                                                 MPIR_Comm * comm, int attr,
                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIDI_IPC_mpi_isend(buf, count, datatype, rank, tag, comm,
-                                    context_offset, addr, request);
+    if (!attr) {
+        /* not collective, not ssend. We are assuming pt2pt context_offset is 0. */
+        mpi_errno = MPIDI_IPC_mpi_isend(buf, count, datatype, rank, tag, comm, attr, addr, request);
+    } else {
+        mpi_errno = MPIDI_POSIX_mpi_isend(buf, count, datatype, rank, tag, comm,
+                                          attr, addr, request);
+    }
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -28,41 +33,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count
     return mpi_errno;
   fn_fail:
     goto fn_exit;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_isend_coll(const void *buf, MPI_Aint count,
-                                                  MPI_Datatype datatype, int rank, int tag,
-                                                  MPIR_Comm * comm, int context_offset,
-                                                  MPIDI_av_entry_t * addr,
-                                                  MPIR_Request ** request, MPIR_Errflag_t * errflag)
-{
-    int ret;
-
-    MPIR_FUNC_ENTER;
-
-    ret =
-        MPIDI_POSIX_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                               request, errflag);
-
-    MPIR_FUNC_EXIT;
-    return ret;
-}
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf, MPI_Aint count,
-                                                  MPI_Datatype datatype, int rank, int tag,
-                                                  MPIR_Comm * comm, int context_offset,
-                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
-{
-    int ret;
-
-    MPIR_FUNC_ENTER;
-
-    ret =
-        MPIDI_POSIX_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                               request);
-
-    MPIR_FUNC_EXIT;
-    return ret;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_send(MPIR_Request * sreq)

--- a/src/mpid/ch4/src/ch4_probe.h
+++ b/src/mpid/ch4/src/ch4_probe.h
@@ -16,7 +16,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe(int source,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     MPIDI_workq_vci_progress_unsafe();
@@ -24,17 +23,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe(int source,
 #endif
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_iprobe(source, tag, comm, context_offset, av, flag, status);
+    mpi_errno = MPIDI_NM_mpi_iprobe(source, tag, comm, attr, av, flag, status);
 #else
     if (unlikely(source == MPI_ANY_SOURCE)) {
-        mpi_errno = MPIDI_SHM_mpi_iprobe(source, tag, comm, context_offset, flag, status);
+        mpi_errno = MPIDI_SHM_mpi_iprobe(source, tag, comm, attr, flag, status);
         MPIR_ERR_CHECK(mpi_errno);
         if (!*flag)
-            mpi_errno = MPIDI_NM_mpi_iprobe(source, tag, comm, context_offset, av, flag, status);
+            mpi_errno = MPIDI_NM_mpi_iprobe(source, tag, comm, attr, av, flag, status);
     } else if (MPIDI_rank_is_local(source, comm)) {
-        mpi_errno = MPIDI_SHM_mpi_iprobe(source, tag, comm, context_offset, flag, status);
+        mpi_errno = MPIDI_SHM_mpi_iprobe(source, tag, comm, attr, flag, status);
     } else {
-        mpi_errno = MPIDI_NM_mpi_iprobe(source, tag, comm, context_offset, av, flag, status);
+        mpi_errno = MPIDI_NM_mpi_iprobe(source, tag, comm, attr, av, flag, status);
     }
 #endif
     MPIR_ERR_CHECK(mpi_errno);
@@ -56,7 +55,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_improbe(int source,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     MPIDI_workq_vci_progress_unsafe();
@@ -64,30 +62,28 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_improbe(int source,
 #endif
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_improbe(source, tag, comm, context_offset, av, flag, message, status);
+    mpi_errno = MPIDI_NM_mpi_improbe(source, tag, comm, attr, av, flag, message, status);
     MPIR_ERR_CHECK(mpi_errno);
 #else
     if (unlikely(source == MPI_ANY_SOURCE)) {
-        mpi_errno = MPIDI_SHM_mpi_improbe(source, tag, comm, context_offset, flag, message, status);
+        mpi_errno = MPIDI_SHM_mpi_improbe(source, tag, comm, attr, flag, message, status);
         MPIR_ERR_CHECK(mpi_errno);
         if (*flag) {
             MPIDI_REQUEST(*message, is_local) = 1;
         } else {
-            mpi_errno =
-                MPIDI_NM_mpi_improbe(source, tag, comm, context_offset, av, flag, message, status);
+            mpi_errno = MPIDI_NM_mpi_improbe(source, tag, comm, attr, av, flag, message, status);
             MPIR_ERR_CHECK(mpi_errno);
             if (*flag) {
                 MPIDI_REQUEST(*message, is_local) = 0;
             }
         }
     } else if (MPIDI_av_is_local(av)) {
-        mpi_errno = MPIDI_SHM_mpi_improbe(source, tag, comm, context_offset, flag, message, status);
+        mpi_errno = MPIDI_SHM_mpi_improbe(source, tag, comm, attr, flag, message, status);
         MPIR_ERR_CHECK(mpi_errno);
         if (*flag)
             MPIDI_REQUEST(*message, is_local) = 1;
     } else {
-        mpi_errno =
-            MPIDI_NM_mpi_improbe(source, tag, comm, context_offset, av, flag, message, status);
+        mpi_errno = MPIDI_NM_mpi_improbe(source, tag, comm, attr, av, flag, message, status);
         MPIR_ERR_CHECK(mpi_errno);
         if (*flag)
             MPIDI_REQUEST(*message, is_local) = 0;

--- a/src/mpid/ch4/src/ch4_self.c
+++ b/src/mpid/ch4/src/ch4_self.c
@@ -117,7 +117,7 @@ int MPIDI_Self_finalize(void)
     } while (0)
 
 int MPIDI_Self_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
+                     MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
     MPIR_Request *sreq = NULL;
     MPIR_Request *rreq = NULL;
@@ -148,7 +148,7 @@ int MPIDI_Self_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int
 }
 
 int MPIDI_Self_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
+                     MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
     MPIR_Request *sreq = NULL;
     MPIR_Request *rreq = NULL;
@@ -181,8 +181,7 @@ int MPIDI_Self_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
     return MPI_SUCCESS;
 }
 
-int MPIDI_Self_iprobe(int rank, int tag, MPIR_Comm * comm, int context_offset,
-                      int *flag, MPI_Status * status)
+int MPIDI_Self_iprobe(int rank, int tag, MPIR_Comm * comm, int attr, int *flag, MPI_Status * status)
 {
     MPIR_Request *sreq = NULL;
     MPIR_FUNC_ENTER;
@@ -208,7 +207,7 @@ int MPIDI_Self_iprobe(int rank, int tag, MPIR_Comm * comm, int context_offset,
     return MPI_SUCCESS;
 }
 
-int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int context_offset,
+int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int attr,
                        int *flag, MPIR_Request ** message, MPI_Status * status)
 {
     MPIR_Request *sreq = NULL;

--- a/src/mpid/ch4/src/ch4_self.h
+++ b/src/mpid/ch4/src/ch4_self.h
@@ -12,12 +12,12 @@
 int MPIDI_Self_init(void);
 int MPIDI_Self_finalize(void);
 int MPIDI_Self_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request);
+                     MPIR_Comm * comm, int attr, MPIR_Request ** request);
 int MPIDI_Self_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request);
-int MPIDI_Self_iprobe(int rank, int tag, MPIR_Comm * comm, int context_offset,
+                     MPIR_Comm * comm, int attr, MPIR_Request ** request);
+int MPIDI_Self_iprobe(int rank, int tag, MPIR_Comm * comm, int attr,
                       int *flag, MPI_Status * status);
-int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int context_offset,
+int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int attr,
                        int *flag, MPIR_Request ** message, MPI_Status * status);
 int MPIDI_Self_imrecv(char *buf, MPI_Aint count, MPI_Datatype datatype,
                       MPIR_Request * message, MPIR_Request ** request);

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -20,7 +20,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0, 1);
@@ -28,21 +27,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend(const void *buf,
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(ISEND, buf, NULL /*recv_buf */ , count, datatype,
-                              rank, tag, comm, context_offset, av,
-                              NULL /*status */ , *req, NULL /*flag */ ,
+                              rank, tag, comm, attr, av, NULL /*status */ , *req, NULL /*flag */ ,
                               NULL /*message */ , NULL /*processed */);
 #else
     *(req) = NULL;
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, av, req);
+    mpi_errno = MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, attr, av, req);
 #else
     int r;
     if ((r = MPIDI_av_is_local(av)))
-        mpi_errno =
-            MPIDI_SHM_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, av, req);
+        mpi_errno = MPIDI_SHM_mpi_isend(buf, count, datatype, rank, tag, comm, attr, av, req);
     else
-        mpi_errno =
-            MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, av, req);
+        mpi_errno = MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, attr, av, req);
     if (mpi_errno == MPI_SUCCESS)
         MPIDI_REQUEST(*req, is_local) = r;
 #endif
@@ -70,7 +66,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll(const void *buf,
 
     MPIR_FUNC_ENTER;
 
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0, 1);
@@ -78,23 +73,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll(const void *buf,
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_csend_enqueue(ICSEND, buf, count, datatype, rank, tag, comm,
-                              context_offset, av, *req, errflag);
+                              attr, av, *req, errflag);
 #else
     *(req) = NULL;
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno =
-        MPIDI_NM_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, av, req,
-                            errflag);
+    mpi_errno = MPIDI_NM_isend_coll(buf, count, datatype, rank, tag, comm, attr, av, req, errflag);
 #else
     int r;
     if ((r = MPIDI_av_is_local(av)))
         mpi_errno =
-            MPIDI_SHM_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, av,
-                                 req, errflag);
+            MPIDI_SHM_isend_coll(buf, count, datatype, rank, tag, comm, attr, av, req, errflag);
     else
         mpi_errno =
-            MPIDI_NM_isend_coll(buf, count, datatype, rank, tag, comm, context_offset, av,
-                                req, errflag);
+            MPIDI_NM_isend_coll(buf, count, datatype, rank, tag, comm, attr, av, req, errflag);
     if (mpi_errno == MPI_SUCCESS)
         MPIDI_REQUEST(*req, is_local) = r;
 #endif
@@ -120,7 +111,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0, 1);
@@ -128,21 +118,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend(const void *buf,
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
-                              rank, tag, comm, context_offset, av,
-                              NULL /*status */ , *req, NULL /*flag */ ,
+                              rank, tag, comm, attr, av, NULL /*status */ , *req, NULL /*flag */ ,
                               NULL /*message */ , NULL /*processed */);
 #else
     *(req) = NULL;
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, av, req);
+    mpi_errno = MPIDI_NM_mpi_issend(buf, count, datatype, rank, tag, comm, attr, av, req);
 #else
     int r;
     if ((r = MPIDI_av_is_local(av)))
-        mpi_errno =
-            MPIDI_SHM_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, av, req);
+        mpi_errno = MPIDI_SHM_mpi_issend(buf, count, datatype, rank, tag, comm, attr, av, req);
     else
-        mpi_errno =
-            MPIDI_NM_mpi_issend(buf, count, datatype, rank, tag, comm, context_offset, av, req);
+        mpi_errno = MPIDI_NM_mpi_issend(buf, count, datatype, rank, tag, comm, attr, av, req);
 
     if (mpi_errno == MPI_SUCCESS)
         MPIDI_REQUEST(*req, is_local) = r;
@@ -169,13 +156,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_ENTER;
 
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     if (MPIDI_is_self_comm(comm)) {
-        mpi_errno =
-            MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, context_offset, request);
+        mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, attr, request);
     } else {
         av = MPIDIU_comm_rank_to_av(comm, rank);
-        mpi_errno = MPIDI_isend(buf, count, datatype, rank, tag, comm, context_offset, av, request);
+        mpi_errno = MPIDI_isend(buf, count, datatype, rank, tag, comm, attr, av, request);
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -198,14 +183,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend_coll(const void *buf,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_ENTER;
 
-    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     if (MPIDI_is_self_comm(comm)) {
         /* FIXME: do we need do anything about errflag? */
-        mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, context_offset,
-                                     request);
+        mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, attr, request);
     } else {
         av = MPIDIU_comm_rank_to_av(comm, rank);
-        mpi_errno = MPIDI_isend_coll(buf, count, datatype, rank, tag, comm, context_offset,
+        mpi_errno = MPIDI_isend_coll(buf, count, datatype, rank, tag, comm, attr,
                                      av, request, errflag);
     }
 

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -14,12 +14,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend(const void *buf,
                                          MPI_Datatype datatype,
                                          int rank,
                                          int tag,
-                                         MPIR_Comm * comm, int context_offset,
+                                         MPIR_Comm * comm, int attr,
                                          MPIDI_av_entry_t * av, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0, 1);
@@ -61,7 +62,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll(const void *buf,
                                               MPI_Datatype datatype,
                                               int rank,
                                               int tag,
-                                              MPIR_Comm * comm, int context_offset,
+                                              MPIR_Comm * comm, int attr,
                                               MPIDI_av_entry_t * av, MPIR_Request ** req,
                                               MPIR_Errflag_t * errflag)
 {
@@ -69,6 +70,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll(const void *buf,
 
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0, 1);
@@ -112,12 +114,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend(const void *buf,
                                           MPI_Datatype datatype,
                                           int rank,
                                           int tag,
-                                          MPIR_Comm * comm, int context_offset,
+                                          MPIR_Comm * comm, int attr,
                                           MPIDI_av_entry_t * av, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0, 1);
@@ -160,13 +163,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
                                         MPI_Datatype datatype,
                                         int rank,
                                         int tag,
-                                        MPIR_Comm * comm, int context_offset,
-                                        MPIR_Request ** request)
+                                        MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     if (MPIDI_is_self_comm(comm)) {
         mpi_errno =
             MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, context_offset, request);
@@ -188,13 +191,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend_coll(const void *buf,
                                              MPI_Datatype datatype,
                                              int rank,
                                              int tag,
-                                             MPIR_Comm * comm, int context_offset,
+                                             MPIR_Comm * comm, int attr,
                                              MPIR_Request ** request, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_ENTER;
 
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     if (MPIDI_is_self_comm(comm)) {
         /* FIXME: do we need do anything about errflag? */
         mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, context_offset,
@@ -217,11 +221,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,
                                        MPI_Aint count,
                                        MPI_Datatype datatype,
                                        int rank,
-                                       int tag,
-                                       MPIR_Comm * comm, int context_offset,
-                                       MPIR_Request ** request)
+                                       int tag, MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
-    return MPID_Isend(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPID_Isend(buf, count, datatype, rank, tag, comm, attr, request);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Send_coll(const void *buf,
@@ -229,10 +231,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send_coll(const void *buf,
                                             MPI_Datatype datatype,
                                             int rank,
                                             int tag,
-                                            MPIR_Comm * comm, int context_offset,
+                                            MPIR_Comm * comm, int attr,
                                             MPIR_Request ** request, MPIR_Errflag_t * errflag)
 {
-    return MPID_Isend_coll(buf, count, datatype, rank, tag, comm, context_offset, request, errflag);
+    return MPID_Isend_coll(buf, count, datatype, rank, tag, comm, attr, request, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *buf,
@@ -240,10 +242,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *buf,
                                         MPI_Datatype datatype,
                                         int rank,
                                         int tag,
-                                        MPIR_Comm * comm, int context_offset,
-                                        MPIR_Request ** request)
+                                        MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
-    return MPID_Irsend(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPID_Irsend(buf, count, datatype, rank, tag, comm, attr, request);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
@@ -251,8 +252,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
                                          MPI_Datatype datatype,
                                          int rank,
                                          int tag,
-                                         MPIR_Comm * comm, int context_offset,
-                                         MPIR_Request ** request)
+                                         MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
     /*
      * FIXME: this implementation of MPID_Irsend is identical to that of MPID_Isend.
@@ -265,11 +265,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
     MPIR_FUNC_ENTER;
 
     if (MPIDI_is_self_comm(comm)) {
-        mpi_errno =
-            MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, context_offset, request);
+        mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, attr, request);
     } else {
         av = MPIDIU_comm_rank_to_av(comm, rank);
-        mpi_errno = MPIDI_isend(buf, count, datatype, rank, tag, comm, context_offset, av, request);
+        mpi_errno = MPIDI_isend(buf, count, datatype, rank, tag, comm, attr, av, request);
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -285,10 +284,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ssend(const void *buf,
                                         MPI_Datatype datatype,
                                         int rank,
                                         int tag,
-                                        MPIR_Comm * comm, int context_offset,
-                                        MPIR_Request ** request)
+                                        MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
-    return MPID_Issend(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPID_Issend(buf, count, datatype, rank, tag, comm, attr, request);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Issend(const void *buf,
@@ -296,20 +294,17 @@ MPL_STATIC_INLINE_PREFIX int MPID_Issend(const void *buf,
                                          MPI_Datatype datatype,
                                          int rank,
                                          int tag,
-                                         MPIR_Comm * comm, int context_offset,
-                                         MPIR_Request ** request)
+                                         MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_ENTER;
 
     if (MPIDI_is_self_comm(comm)) {
-        mpi_errno =
-            MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, context_offset, request);
+        mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, attr, request);
     } else {
         av = MPIDIU_comm_rank_to_av(comm, rank);
-        mpi_errno =
-            MPIDI_issend(buf, count, datatype, rank, tag, comm, context_offset, av, request);
+        mpi_errno = MPIDI_issend(buf, count, datatype, rank, tag, comm, attr, av, request);
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -327,13 +322,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_psend_init(MPIDI_ptype ptype,
                                               MPI_Datatype datatype,
                                               int rank,
                                               int tag,
-                                              MPIR_Comm * comm, int context_offset,
-                                              MPIR_Request ** request)
+                                              MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;
 
     MPIR_FUNC_ENTER;
+
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     MPIDI_CH4_REQUEST_CREATE(sreq, MPIR_REQUEST_KIND__PREQUEST_SEND, 0, 1);
@@ -368,15 +364,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send_init(const void *buf,
                                             MPI_Datatype datatype,
                                             int rank,
                                             int tag,
-                                            MPIR_Comm * comm, int context_offset,
-                                            MPIR_Request ** request)
+                                            MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIDI_psend_init(MPIDI_PTYPE_SEND,
-                                 buf, count, datatype, rank, tag, comm, context_offset, request);
+                                 buf, count, datatype, rank, tag, comm, attr, request);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -391,14 +386,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ssend_init(const void *buf,
                                              MPI_Datatype datatype,
                                              int rank,
                                              int tag,
-                                             MPIR_Comm * comm, int context_offset,
-                                             MPIR_Request ** request)
+                                             MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIDI_psend_init(MPIDI_PTYPE_SSEND,
-                                 buf, count, datatype, rank, tag, comm, context_offset, request);
+                                 buf, count, datatype, rank, tag, comm, attr, request);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -413,14 +407,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Bsend_init(const void *buf,
                                              MPI_Datatype datatype,
                                              int rank,
                                              int tag,
-                                             MPIR_Comm * comm, int context_offset,
-                                             MPIR_Request ** request)
+                                             MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIDI_psend_init(MPIDI_PTYPE_BSEND,
-                                 buf, count, datatype, rank, tag, comm, context_offset, request);
+                                 buf, count, datatype, rank, tag, comm, attr, request);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -435,8 +428,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend_init(const void *buf,
                                              MPI_Datatype datatype,
                                              int rank,
                                              int tag,
-                                             MPIR_Comm * comm, int context_offset,
-                                             MPIR_Request ** request)
+                                             MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -444,7 +436,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend_init(const void *buf,
 
     /* TODO: Currently we don't distinguish SEND and RSEND */
     mpi_errno = MPIDI_psend_init(MPIDI_PTYPE_SEND,
-                                 buf, count, datatype, rank, tag, comm, context_offset, request);
+                                 buf, count, datatype, rank, tag, comm, attr, request);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -50,7 +50,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_pt2pt_enqueue(MPIDI_workq_op_t op,
                                                         int rank,
                                                         int tag,
                                                         MPIR_Comm * comm_ptr,
-                                                        int context_offset,
+                                                        int attr,
                                                         MPIDI_av_entry_t * addr,
                                                         MPI_Status * status,
                                                         MPIR_Request * request,
@@ -59,6 +59,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_pt2pt_enqueue(MPIDI_workq_op_t op,
                                                         MPL_atomic_int_t * processed)
 {
     MPIDI_workq_elemt_t *pt2pt_elemt;
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
     MPIR_Assert(request != NULL);
 
@@ -170,13 +171,14 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_csend_enqueue(MPIDI_workq_op_t op,
                                                         int rank,
                                                         int tag,
                                                         MPIR_Comm * comm_ptr,
-                                                        int context_offset,
+                                                        int attr,
                                                         MPIDI_av_entry_t * addr,
                                                         MPIR_Request * request,
                                                         MPIR_Errflag_t * errflag)
 {
     MPIDI_workq_elemt_t *pt2pt_elemt;
     struct MPIDI_workq_csend *wd;
+    int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
     MPIR_Assert(request != NULL);
     MPIR_Assert(op == CSEND || op == ICSEND);

--- a/src/mpid/ch4/src/mpidig_send.h
+++ b/src/mpid/ch4/src/mpidig_send.h
@@ -117,51 +117,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
                                               int rank,
                                               int tag, MPIR_Comm * comm, int context_offset,
                                               MPIDI_av_entry_t * addr, int src_vci, int dst_vci,
-                                              MPIR_Request ** request)
+                                              MPIR_Request ** request,
+                                              bool syncflag, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
+    uint8_t flags = syncflag ? MPIDIG_AM_SEND_FLAGS_SYNC : MPIDIG_AM_SEND_FLAGS_NONE;
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                  MPIDIG_AM_SEND_FLAGS_NONE, src_vci, dst_vci,
-                                  request, MPIR_ERR_NONE);
-
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-}
-
-
-MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_coll(const void *buf, MPI_Aint count,
-                                               MPI_Datatype datatype, int rank,
-                                               int tag, MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, int src_vci, int dst_vci,
-                                               MPIR_Request ** request, MPIR_Errflag_t * errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_ENTER;
-
-    mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                  MPIDIG_AM_SEND_FLAGS_NONE, src_vci, dst_vci, request, *errflag);
-
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-}
-
-
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_issend(const void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag, MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr,
-                                               int src_vci, int dst_vci, MPIR_Request ** request)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_ENTER;
-
-    mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                  MPIDIG_AM_SEND_FLAGS_SYNC, src_vci, dst_vci,
-                                  request, MPIR_ERR_NONE);
+                                  flags, src_vci, dst_vci, request, errflag);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;


### PR DESCRIPTION
## Pull Request Description

Replacing `context_offset` with `int attr` allows us to pass additional information from MPIR-layer down to the device layer. For example, with multiplex explicit streams, the user can directly specify the desired vci for the individual pt2pt operation.

This is needed to implement the proposal [multiplex stream communicator](https://github.com/pmodels/mpich/discussions/5908)

Depend on a commit in PR #5949
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
