### PR TITLE
pmi: remove const from PMI_keyval_t

### DIFF
--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -1357,7 +1357,7 @@ static void free_pmi_keyvals(INFO_TYPE ** kv, int size, int *counts)
 
     for (int i = 0; i < size; i++) {
         for (int j = 0; j < counts[i]; j++) {
-            MPL_free(INFO_TYPE_KEY(kv[i][j]));
+            MPL_free((char *) INFO_TYPE_KEY(kv[i][j]));
             MPL_free(INFO_TYPE_VAL(kv[i][j]));
         }
         MPL_free(kv[i]);


### PR DESCRIPTION
## Pull Request Description
We are using const char * for an allocated string, and it need cast the
const away for the free function.

The warning --
```
In directory: /tmp/jenkins.tmp.6MyIsudS
  CC       src/mpid/ch4/shm/src/lib_libmpi_la-shm_init.lo
In file included from /tmp/jenkins.tmp.6MyIsudS/src/mpl/include/mpl.h:17,
                 from ./src/include/mpiimpl.h:119,
                 from src/util/mpir_pmi.c:7:
src/util/mpir_pmi.c: In function 'free_pmi_keyvals':
src/util/mpir_pmi.c:82:31: warning: passing argument 1 of 'MPL_trfree' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   82 | #define INFO_TYPE_KEY(kv) (kv).key
      |                           ~~~~^~~~
/tmp/jenkins.tmp.6MyIsudS/src/mpl/include/mpl_trmem.h:347:37: note: in definition of macro 'MPL_free'
  347 | #define MPL_free(a)      MPL_trfree(a,__LINE__,__FILE__)
      |                                     ^
src/util/mpir_pmi.c:1360:22: note: in expansion of macro 'INFO_TYPE_KEY'
 1360 |             MPL_free(INFO_TYPE_KEY(kv[i][j]));
      |                      ^~~~~~~~~~~~~
/tmp/jenkins.tmp.6MyIsudS/src/mpl/include/mpl_trmem.h:503:17: note: expected 'void *' but argument is of type 'const char *'
  503 | void MPL_trfree(void *, int, const char[]);
      |                 ^~~~~~
```
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
