### PR TITLE
romio: use MPL_initlock for romio_mutex

### DIFF
--- a/src/glue/romio/glue_romio.c
+++ b/src/glue/romio/glue_romio.c
@@ -18,34 +18,14 @@ int MPIR_Ext_dbg_romio_terse_enabled = 0;
 int MPIR_Ext_dbg_romio_typical_enabled = 0;
 int MPIR_Ext_dbg_romio_verbose_enabled = 0;
 
-/* NOTE: we'll lazily initialize this mutex */
-static MPL_thread_mutex_t romio_mutex;
-static MPL_atomic_int_t romio_mutex_initialized = MPL_ATOMIC_INT_T_INITIALIZER(0);
+static MPL_initlock_t romio_mutex = MPL_INITLOCK_INITIALIZER;
 
 void MPIR_Ext_mutex_init(void)
 {
-#if defined(MPICH_IS_THREADED)
-    if (!MPL_atomic_load_int(&romio_mutex_initialized)) {
-        int err;
-        MPL_thread_mutex_create(&romio_mutex, &err);
-        MPIR_Assert(err == 0);
-
-        MPL_atomic_store_int(&romio_mutex_initialized, 1);
-    }
-#endif
 }
 
 void MPIR_Ext_mutex_finalize(void)
 {
-#if defined(MPICH_IS_THREADED)
-    if (MPL_atomic_load_int(&romio_mutex_initialized)) {
-        int err;
-        MPL_thread_mutex_destroy(&romio_mutex, &err);
-        MPIR_Assert(err == 0);
-
-        MPL_atomic_store_int(&romio_mutex_initialized, 0);
-    }
-#endif
 }
 
 /* to be called early by ROMIO's initialization process in order to setup init-time
@@ -84,12 +64,7 @@ void MPIR_Ext_cs_enter(void)
 {
 #if defined(MPICH_IS_THREADED)
     if (MPIR_ThreadInfo.isThreaded) {
-        /* lazily initialize the mutex */
-        MPIR_Ext_mutex_init();
-
-        int err;
-        MPL_thread_mutex_lock(&romio_mutex, &err, MPL_THREAD_PRIO_HIGH);
-        MPIR_Assert(err == 0);
+        MPL_initlock_lock(&romio_mutex);
     }
 #endif
 }
@@ -98,9 +73,7 @@ void MPIR_Ext_cs_exit(void)
 {
 #if defined(MPICH_IS_THREADED)
     if (MPIR_ThreadInfo.isThreaded) {
-        int err;
-        MPL_thread_mutex_unlock(&romio_mutex, &err);
-        MPIR_Assert(err == 0);
+        MPL_initlock_unlock(&romio_mutex);
     }
 #endif
 }


### PR DESCRIPTION
## Pull Request Description
There is no good place to initialize mutex in ROMIO, thus it needs to
use a mutex that can be statically initialized. MPL_initlock fits the
bill.

Reference discussion https://github.com/pmodels/mpich/pull/4215#issuecomment-1102150092



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
