### PR TITLE
ch3/ofi: replace direct PMI calls with MPIR_pmi utilities

### DIFF
--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
@@ -32,7 +32,7 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     info_t *hints, *prov_tagged, *prov_use;
     cq_attr_t cq_attr;
     av_attr_t av_attr;
-    char kvsname[MPIDI_OFI_KVSAPPSTRLEN], key[MPIDI_OFI_KVSAPPSTRLEN], bc[MPIDI_OFI_KVSAPPSTRLEN];
+    char key[MPIDI_OFI_KVSAPPSTRLEN], bc[MPIDI_OFI_KVSAPPSTRLEN];
     char *my_bc, *addrs, *null_addr;
     fi_addr_t *fi_addrs = NULL;
     MPIDI_VC_t *vc;
@@ -206,11 +206,10 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     /* Publish the business card        */
     /* to the KVS                       */
     /* -------------------------------- */
-    PMI_RC(PMI_KVS_Get_my_name(kvsname, MPIDI_OFI_KVSAPPSTRLEN), pmi);
     MPL_snprintf(key, sizeof(key), "OFI-%d", pg_rank);
 
-    PMI_RC(PMI_KVS_Put(kvsname, key, my_bc), pmi);
-    PMI_RC(PMI_KVS_Commit(kvsname), pmi);
+    mpi_errno = MPIR_pmi_kvs_put(key, my_bc);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* -------------------------------- */
     /* Set the number of tag bits       */
@@ -222,7 +221,9 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     /* their business card               */
     /* --------------------------------- */
     gl_data.rts_cts_in_flight = 0;
-    PMI_Barrier();
+
+    mpi_errno = MPIR_pmi_barrier();
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* --------------------------------- */
     /* Retrieve every rank's address     */
@@ -235,7 +236,9 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     for (i = 0; i < pg_p->size; ++i) {
         MPL_snprintf(key, sizeof(key), "OFI-%d", i);
 
-        PMI_RC(PMI_KVS_Get(kvsname, key, bc, MPIDI_OFI_KVSAPPSTRLEN), pmi);
+        mpi_errno = MPIR_pmi_kvs_get(-1, key, bc, MPIDI_OFI_KVSAPPSTRLEN);
+        MPIR_ERR_CHECK(mpi_errno);
+
         ret = MPL_str_get_binary_arg(bc, "OFI",
                                      (char *) &addrs[i * gl_data.bound_addrlen],
                                      gl_data.bound_addrlen, &len);


### PR DESCRIPTION

## Pull Request Description
Last commit (c2c96bc) missed the PMI usages in ch3/ofi. It is currently
broken because we removed the PMI_RC macro. This commit finishes
replacing direct PMI calls.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
