### PR TITLE
ch4: default MPIDI_CH4_MAX_VCIS to 64

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -152,7 +152,7 @@ int MPIDI_POSIX_init_local(int *tag_bits /* unused */)
 
     MPIDI_POSIX_global.num_vsis = MPIDI_global.n_total_vcis;
     /* This is used to track messages that the eager submodule was not ready to send. */
-    for (int vsi = 0; vsi < MPIDI_CH4_MAX_VCIS; vsi++) {
+    for (int vsi = 0; vsi < MPIDI_global.n_total_vcis; vsi++) {
         mpi_errno = MPIDU_genq_private_pool_create_unsafe(MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE,
                                                           MPIDI_POSIX_AM_HDR_POOL_NUM_CELLS_PER_CHUNK,
                                                           0 /* unlimited */ ,
@@ -251,7 +251,7 @@ int MPIDI_POSIX_mpi_finalize_hook(void)
         utarray_free(shm_mutex_free_list);
     }
 
-    for (int vsi = 0; vsi < MPIDI_CH4_MAX_VCIS; vsi++) {
+    for (int vsi = 0; vsi < MPIDI_global.n_total_vcis; vsi++) {
         MPIDU_genq_private_pool_destroy_unsafe(MPIDI_POSIX_global.per_vsi[vsi].am_hdr_buf_pool);
         MPL_free(MPIDI_POSIX_global.per_vsi[vsi].active_rreq);
     }

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -310,19 +310,7 @@ dnl request handle to encode pool index
 AC_ARG_WITH(ch4-max-vcis,
     [--with-ch4-max-vcis=<N>
        Select max number of VCIs to configure (default is 1; minimum is 1; maximum is 64)],
-    [], [with_ch4_max_vcis=default])
-
-if test "$with_ch4_max_vcis" = "default" ; then
-    if test $thread_granularity = MPICH_THREAD_GRANULARITY__VCI ; then
-        with_ch4_max_vcis=64
-    else
-        with_ch4_max_vcis=1
-    fi
-else
-    if test $thread_granularity != MPICH_THREAD_GRANULARITY__VCI ; then
-        AC_MSG_ERROR(Option --with-ch4-max-vcis requires --enable-thread-cs=per-vci)
-    fi
-fi
+    [], [with_ch4_max_vcis=64])
 
 if test $with_ch4_max_vcis -lt 1 -o $with_ch4_max_vcis -gt 64; then
    AC_MSG_ERROR(Number of VCIs must be between 1 and 64)


### PR DESCRIPTION
## Pull Request Description
VCI is useful to isolate communications beyond multi-threading usages.
For example, we may want to use different networ resource for dynamic
processes; or we may need separate GPU communications from CPU
communications. Configure with default MPIDI_CH4_MAX_VCIS makes vci
usage, in particular, single threaded cases. After all,
--enable-thread-cs=per-vci and --with-ch4-max-vcis are orthogonal
options.

The impact of MPIDI_CH4_MAX_VCIS are static memory usages, which I
believe is negligible. Runtime resources are still controlled by CVARs.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
