### PR TITLE
Revert "ch4/ofi: suppress warning of discarding volatile qualifier"

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_huge.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_huge.c
@@ -384,8 +384,7 @@ int MPIDI_OFI_huge_chunk_done_event(int vni, struct fi_cq_tagged_entry *wc, void
     MPIR_cc_decr(chunk_req->chunks_outstanding, &c);
 
     if (c == 0) {
-        /* cast to suppress warning -- discard volatile qualifier */
-        MPL_free((void *) chunk_req->chunks_outstanding);
+        MPL_free(chunk_req->chunks_outstanding);
         mpi_errno = get_huge_complete(chunk_req->localreq);
         MPIR_ERR_CHECK(mpi_errno);
     }


### PR DESCRIPTION
## Pull Request Description

This reverts commit 188865158d3fa808bf92d15a6953b442cf41573e. It is no
longer needed after the merge of pmodels/mpich#5642.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
