### PR TITLE
ch4: enable vci table for window from a stream comm

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -508,6 +508,7 @@ typedef struct {
     MPIDIG_win_t am;
     int am_vci;                 /* both netmod and shm have to use the same vci for am operations or
                                  * we won't be able to effectively progress at synchronization */
+    int *vci_table;
     union {
     MPIDI_NM_WIN_DECL} netmod;
 #ifndef MPIDI_CH4_DIRECT_NETMOD

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -250,7 +250,6 @@ typedef struct {
     struct fid_ep *ep;          /* EP with counter & completion */
     int sep_tx_idx;             /* transmit context index for scalable EP,
                                  * -1 means using non scalable EP. */
-    int vni;
 #if defined(MPIDI_CH4_USE_MT_RUNTIME) || defined(MPIDI_CH4_USE_MT_LOCKLESS)
     MPL_atomic_uint64_t *issued_cntr;   /* atomic counter in support of lockless and runtime mt models */
 #else

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -72,7 +72,7 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    req->vni = MPIDI_OFI_WIN(win).vni;
+    req->vni = MPIDI_WIN(win, am_vci);
     req->next = MPIDI_OFI_WIN(win).syncQ;
     MPIDI_OFI_WIN(win).syncQ = req;
     req->sigreq = sigreq;
@@ -131,7 +131,7 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
 
         msg_len = MPL_MIN(origin_iov[origin_cur].iov_len, target_iov[target_cur].iov_len);
 
-        int vni = MPIDI_OFI_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         int nic = 0;
         msg.desc = NULL;
         msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni);
@@ -377,7 +377,7 @@ int MPIDI_OFI_pack_put(const void *origin_addr, int origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    req->vni = MPIDI_OFI_WIN(win).vni;
+    req->vni = MPIDI_WIN(win, am_vci);
     req->sigreq = sigreq;
 
     /* allocate target iovecs */
@@ -438,7 +438,7 @@ int MPIDI_OFI_pack_get(void *origin_addr, int origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    req->vni = MPIDI_OFI_WIN(win).vni;
+    req->vni = MPIDI_WIN(win, am_vci);
     req->sigreq = sigreq;
 
     /* allocate target iovecs */

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -197,7 +197,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
     MPIDI_Datatype_check_contig_size_extent_lb(target_datatype, target_count, target_contig,
                                                target_bytes, target_extent, target_true_lb);
 
-    int vni = MPIDI_OFI_WIN(win).vni;
+    int vni = MPIDI_WIN(win, am_vci);
 
     /* zero-byte messages */
     if (unlikely(origin_bytes == 0))
@@ -387,7 +387,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
     MPIDI_Datatype_check_contig_size_extent_lb(target_datatype, target_count, target_contig,
                                                target_bytes, target_extent, target_true_lb);
 
-    int vni = MPIDI_OFI_WIN(win).vni;
+    int vni = MPIDI_WIN(win, am_vci);
 
     /* zero-byte messages */
     if (unlikely(target_bytes == 0))
@@ -588,7 +588,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     struct fi_msg_atomic msg;
     int nic = 0;
 
-    int vni = MPIDI_OFI_WIN(win).vni;
+    int vni = MPIDI_WIN(win, am_vci);
 
     if (
 #ifndef MPIDI_CH4_DIRECT_NETMOD
@@ -714,7 +714,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
     if (origin_bytes == 0)
         goto null_op_exit;
 
-    int vni = MPIDI_OFI_WIN(win).vni;
+    int vni = MPIDI_WIN(win, am_vci);
 
     /* prepare remote addr and mr key.
      * Continue native path only when all segments are in the same registered memory region */
@@ -858,7 +858,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
     if (target_bytes == 0)
         goto null_op_exit;
 
-    int vni = MPIDI_OFI_WIN(win).vni;
+    int vni = MPIDI_WIN(win, am_vci);
 
     /* contiguous messages */
     if (origin_contig && target_contig && result_contig) {
@@ -1093,7 +1093,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     struct fi_msg_atomic msg;
     MPIR_FUNC_ENTER;
 
-    int vni = MPIDI_OFI_WIN(win).vni;
+    int vni = MPIDI_WIN(win, am_vci);
     int nic = 0;
 
     if (

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -198,6 +198,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
                                                target_bytes, target_extent, target_true_lb);
 
     int vni = MPIDI_WIN(win, am_vci);
+    int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
 
     /* zero-byte messages */
     if (unlikely(origin_bytes == 0))
@@ -234,7 +235,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         MPIDI_OFI_CALL_RETRY(fi_inject_write(MPIDI_OFI_WIN(win).ep,
                                              MPIR_get_contig_ptr(origin_addr, origin_true_lb),
                                              target_bytes,
-                                             MPIDI_OFI_av_to_phys(addr, nic, vni, vni),
+                                             MPIDI_OFI_av_to_phys(addr, nic, vni, vni_target),
                                              target_mr.addr + target_true_lb,
                                              target_mr.mr_key), vni, rdma_inject_write, FALSE);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
@@ -258,7 +259,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
             flags = FI_DELIVERY_COMPLETE;
         }
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni_target);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -388,6 +389,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
                                                target_bytes, target_extent, target_true_lb);
 
     int vni = MPIDI_WIN(win, am_vci);
+    int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
 
     /* zero-byte messages */
     if (unlikely(target_bytes == 0))
@@ -435,7 +437,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         msg.desc = NULL;
         msg.msg_iov = &iov;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni_target);
         msg.rma_iov = &riov;
         msg.rma_iov_count = 1;
         msg.context = NULL;
@@ -589,6 +591,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     int nic = 0;
 
     int vni = MPIDI_WIN(win, am_vci);
+    int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
 
     if (
 #ifndef MPIDI_CH4_DIRECT_NETMOD
@@ -656,7 +659,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vni, vni);
+    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vni, vni_target);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;
@@ -715,6 +718,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         goto null_op_exit;
 
     int vni = MPIDI_WIN(win, am_vci);
+    int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
 
     /* prepare remote addr and mr key.
      * Continue native path only when all segments are in the same registered memory region */
@@ -784,7 +788,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         msg.msg_iov = &originv;
         msg.desc = NULL;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni_target);
         msg.rma_iov = &targetv;
         msg.rma_iov_count = 1;
         msg.datatype = fi_dt;
@@ -859,6 +863,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         goto null_op_exit;
 
     int vni = MPIDI_WIN(win, am_vci);
+    int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
 
     /* contiguous messages */
     if (origin_contig && target_contig && result_contig) {
@@ -930,7 +935,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         msg.msg_iov = &originv;
         msg.desc = NULL;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vni, vni_target);
         msg.rma_iov = &targetv;
         msg.rma_iov_count = 1;
         msg.datatype = fi_dt;
@@ -1094,6 +1099,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     MPIR_FUNC_ENTER;
 
     int vni = MPIDI_WIN(win, am_vci);
+    int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
     int nic = 0;
 
     if (
@@ -1157,7 +1163,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vni, vni);
+    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vni, vni_target);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -17,11 +17,6 @@ static int win_init_global(MPIR_Win * win);
 static int win_init(MPIR_Win * win);
 static void win_init_am(MPIR_Win * win);
 
-#define MPIDI_OFI_WIN_VNI(win, vni_) \
-    do { \
-        vni_ = MPIDI_get_vci(SRC_VCI_FROM_SENDER, (win)->comm_ptr, 0, 0, 0); \
-    } while (0)
-
 static void load_acc_hint(MPIR_Win * win)
 {
     int op_index = 0, i;
@@ -165,7 +160,7 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
     }
 
     /* we need register mr on the correct domain for the vni */
-    int vni = MPIDI_OFI_WIN(win).vni;
+    int vni = MPIDI_WIN(win, am_vci);
     int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
     /* Register the allocated win buffer or MPI_BOTTOM (NULL) for dynamic win.
@@ -275,7 +270,8 @@ static int win_set_per_win_sync(MPIR_Win * win)
 {
     int ret, mpi_errno = MPI_SUCCESS;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, MPIDI_OFI_WIN(win).vni, nic);
+    int vni = MPIDI_WIN(win, am_vci);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
     MPIR_FUNC_ENTER;
 
@@ -332,7 +328,7 @@ static int win_init_sep(MPIR_Win * win)
     int i, ret, mpi_errno = MPI_SUCCESS;
     struct fi_info *finfo;
     int nic = 0;
-    int vni = MPIDI_OFI_WIN(win).vni;
+    int vni = MPIDI_WIN(win, am_vci);
     int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
     MPIR_FUNC_ENTER;
@@ -460,7 +456,7 @@ static int win_init_stx(MPIR_Win * win)
     struct fi_info *finfo;
     bool have_per_win_cntr = false;
     int nic = 0;
-    int vni = MPIDI_OFI_WIN(win).vni;
+    int vni = MPIDI_WIN(win, am_vci);
     int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
     MPIR_FUNC_ENTER;
@@ -574,7 +570,7 @@ static int win_init_global(MPIR_Win * win)
 {
     MPIR_FUNC_ENTER;
 
-    int vni = MPIDI_OFI_WIN(win).vni;
+    int vni = MPIDI_WIN(win, am_vci);
     int nic = 0;
     int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
@@ -619,12 +615,6 @@ static int win_init(MPIR_Win * win)
 
     MPIDI_OFI_WIN(win).sep_tx_idx = -1; /* By default, -1 means not using scalable EP. */
     MPIDI_OFI_WIN(win).progress_counter = 1;
-
-    /* Assign vni to window.
-     * NOTE: we could assign vni per epoch, then we need run `win_init_{sep,stx,global}`
-     * at start of every epoch.
-     */
-    MPIDI_OFI_WIN_VNI(win, MPIDI_OFI_WIN(win).vni);
 
     /* First, try to enable scalable EP. */
     if (MPIR_CVAR_CH4_OFI_ENABLE_SCALABLE_ENDPOINTS && MPIR_CVAR_CH4_OFI_MAX_RMA_SEP_CTX > 0) {
@@ -928,7 +918,8 @@ int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
     dwin_target_mr_t *target_mrs;
     int mpl_err = MPL_SUCCESS, i;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, MPIDI_OFI_WIN(win).vni, nic);
+    int vni = MPIDI_WIN(win, am_vci);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
 
     MPIR_FUNC_ENTER;
 
@@ -1075,7 +1066,7 @@ int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win)
     MPIR_FUNC_ENTER;
 
     if (MPIDI_OFI_ENABLE_RMA) {
-        int vni = MPIDI_OFI_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
         MPIDI_OFI_mr_key_free(MPIDI_OFI_COLL_MR_KEY, MPIDI_OFI_WIN(win).win_id);
         MPIDIU_map_erase(MPIDI_OFI_global.win_map, MPIDI_OFI_WIN(win).win_id);

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -310,7 +310,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_ENTER;
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        int vni = MPIDI_OFI_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
@@ -330,7 +330,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_ENTER;
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        int vni = MPIDI_OFI_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
@@ -351,7 +351,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank ATTRIBUTE((u
     MPIR_FUNC_ENTER;
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        int vni = MPIDI_OFI_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
@@ -372,7 +372,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank ATTRIB
     MPIR_FUNC_ENTER;
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        int vni = MPIDI_OFI_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -130,10 +130,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_vci_to_vni(int vci)
 
 /* Need both local and remote vni to be the same, or the synchronization call
  * may blocked at flushing the remote ep (due to missing remote progress) */
-#define MPIDI_UCX_WIN_TO_EP(win,rank,vni) \
-    MPIDI_UCX_AV(MPIDIU_comm_rank_to_av(win->comm_ptr, rank)).dest[vni][vni]
+#define MPIDI_UCX_WIN_TO_EP(win,rank,vni,vni_target) \
+    MPIDI_UCX_AV(MPIDIU_comm_rank_to_av(win->comm_ptr, rank)).dest[vni][vni_target]
 
-#define MPIDI_UCX_WIN_AV_TO_EP(av, vni) MPIDI_UCX_AV((av)).dest[vni][vni]
+#define MPIDI_UCX_WIN_AV_TO_EP(av, vni, vni_target) MPIDI_UCX_AV((av)).dest[vni][vni_target]
 
 ucs_status_t MPIDI_UCX_am_handler(void *arg, void *data, size_t length, ucp_ep_h reply_ep,
                                   unsigned flags);

--- a/src/mpid/ch4/netmod/ucx/ucx_pre.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_pre.h
@@ -64,7 +64,6 @@ typedef struct {
     ucp_mem_h mem_h;
     bool mem_mapped;            /* Indicate whether mem_h has been mapped (e.g., supported mem type).
                                  * Set at win init and checked at win free for mem_unmap */
-    int vni;
 
     MPIDI_UCX_win_target_sync_t *target_sync;
 } MPIDI_UCX_win_t;

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -218,14 +218,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_put(const void *origin_addr,
     }
 
     if (origin_contig && target_contig) {
-        int vni = MPIDI_UCX_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
         mpi_errno =
             MPIDI_UCX_contig_put(MPIR_get_contig_ptr(origin_addr, origin_true_lb), origin_bytes,
                                  target_rank, target_disp, target_true_lb, win, addr, reqptr, vni);
         MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
     } else if (target_contig) {
-        int vni = MPIDI_UCX_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
         mpi_errno = MPIDI_UCX_noncontig_put(origin_addr, origin_count, origin_datatype, target_rank,
                                             target_bytes, target_disp, target_true_lb, win, addr,
@@ -279,7 +279,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_get(void *origin_addr,
     }
 
     if (origin_contig && target_contig) {
-        int vni = MPIDI_UCX_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
         mpi_errno =
             MPIDI_UCX_contig_get(MPIR_get_contig_ptr(origin_addr, origin_true_lb), origin_bytes,

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -29,7 +29,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
                                                   int target_rank,
                                                   MPI_Aint target_disp, MPI_Aint true_lb,
                                                   MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                  MPIR_Request ** reqptr, int vni)
+                                                  MPIR_Request ** reqptr, int vni, int vni_target)
 {
 
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
     uint64_t base;
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request ATTRIBUTE((unused)) = NULL;
-    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vni);
+    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vni, vni_target);
 
     base = win_info->addr;
     offset = target_disp * win_info->disp + true_lb;
@@ -91,14 +91,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_noncontig_put(const void *origin_addr,
                                                      MPI_Aint target_disp, MPI_Aint true_lb,
                                                      MPIR_Win * win, MPIDI_av_entry_t * addr,
                                                      MPIR_Request ** reqptr ATTRIBUTE((unused)),
-                                                     int vni)
+                                                     int vni, int vni_target)
 {
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
     size_t base, offset;
     int mpi_errno = MPI_SUCCESS;
     ucs_status_t status;
     char *buffer = NULL;
-    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vni);
+    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vni, vni_target);
 
     buffer = MPL_malloc(size, MPL_MEM_BUFFER);
     MPIR_Assert(buffer);
@@ -131,14 +131,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
                                                   int target_rank,
                                                   MPI_Aint target_disp, MPI_Aint true_lb,
                                                   MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                  MPIR_Request ** reqptr, int vni)
+                                                  MPIR_Request ** reqptr, int vni, int vni_target)
 {
 
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
     size_t base, offset;
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request ATTRIBUTE((unused)) = NULL;
-    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vni);
+    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vni, vni_target);
 
     base = win_info->addr;
     offset = target_disp * win_info->disp + true_lb;
@@ -219,17 +219,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_put(const void *origin_addr,
 
     if (origin_contig && target_contig) {
         int vni = MPIDI_WIN(win, am_vci);
+        int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
         MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
         mpi_errno =
             MPIDI_UCX_contig_put(MPIR_get_contig_ptr(origin_addr, origin_true_lb), origin_bytes,
-                                 target_rank, target_disp, target_true_lb, win, addr, reqptr, vni);
+                                 target_rank, target_disp, target_true_lb, win, addr,
+                                 reqptr, vni, vni_target);
         MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
     } else if (target_contig) {
         int vni = MPIDI_WIN(win, am_vci);
+        int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
         MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
         mpi_errno = MPIDI_UCX_noncontig_put(origin_addr, origin_count, origin_datatype, target_rank,
                                             target_bytes, target_disp, target_true_lb, win, addr,
-                                            reqptr, vni);
+                                            reqptr, vni, vni_target);
         MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
     } else {
         mpi_errno = MPIDIG_mpi_put(origin_addr, origin_count, origin_datatype, target_rank,
@@ -280,10 +283,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_get(void *origin_addr,
 
     if (origin_contig && target_contig) {
         int vni = MPIDI_WIN(win, am_vci);
+        int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
         MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
         mpi_errno =
             MPIDI_UCX_contig_get(MPIR_get_contig_ptr(origin_addr, origin_true_lb), origin_bytes,
-                                 target_rank, target_disp, target_true_lb, win, addr, reqptr, vni);
+                                 target_rank, target_disp, target_true_lb, win, addr, reqptr, vni,
+                                 vni_target);
         MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
     } else {
         mpi_errno = MPIDIG_mpi_get(origin_addr, origin_count, origin_datatype, target_rank,

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -14,11 +14,6 @@ struct ucx_share {
 static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void **base_ptr);
 static int win_init(MPIR_Win * win);
 
-#define MPIDI_UCX_WIN_VNI(win, vni_) \
-    do { \
-        vni_ = MPIDI_get_vci(SRC_VCI_FROM_SENDER, (win)->comm_ptr, 0, 0, 0); \
-    } while (0)
-
 static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void **base_ptr)
 {
 
@@ -110,7 +105,7 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
      * and remote windows (at least now). If win_create is used, the key cannot be unpackt -
      * then we need our fallback-solution */
 
-    int vni = MPIDI_UCX_WIN(win).vni;
+    int vni = MPIDI_WIN(win, am_vci);
     bool all_reachable = true, none_reachable = true;
     for (i = 0; i < comm_ptr->local_size; i++) {
         /* Skip unmapped remote region. */
@@ -184,7 +179,6 @@ static int win_init(MPIR_Win * win)
     MPIR_Assert(MPIDI_WIN(win, am_vci) < MPIDI_UCX_global.num_vnis);
 
     memset(&MPIDI_UCX_WIN(win), 0, sizeof(MPIDI_UCX_win_t));
-    MPIDI_UCX_WIN_VNI(win, MPIDI_UCX_WIN(win).vni);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -115,7 +115,8 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
             continue;
         }
 
-        status = ucp_ep_rkey_unpack(MPIDI_UCX_WIN_TO_EP(win, i, vni),
+        int vni_target = MPIDI_WIN_TARGET_VCI(win, i);
+        status = ucp_ep_rkey_unpack(MPIDI_UCX_WIN_TO_EP(win, i, vni, vni_target),
                                     &rkey_recv_buff[recv_disps[i]],
                                     &(MPIDI_UCX_WIN_INFO(win, i).rkey));
         if (status == UCS_ERR_UNREACHABLE) {

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -155,7 +155,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
 
     if (MPIDI_UCX_WIN(win).info_table && MPIDI_UCX_win_need_flush(win)) {
         ucs_status_t ucp_status;
-        int vni = MPIDI_UCX_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
         ucp_status = MPIDI_UCX_flush(vni);
         MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
@@ -180,7 +180,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
 
         /* currently, UCP does not support local flush, so we have to call
          * a global flush. This is not good for performance - but OK for now */
-        int vni = MPIDI_UCX_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
         ucp_status = MPIDI_UCX_flush(vni);
         MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
@@ -207,7 +207,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank, MPIR_Win * 
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync >= MPIDI_UCX_WIN_SYNC_FLUSH_LOCAL) {
 
         ucs_status_t ucp_status;
-        int vni = MPIDI_UCX_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni);
         /* only flush the endpoint */
         MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
@@ -233,7 +233,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync == MPIDI_UCX_WIN_SYNC_FLUSH_LOCAL) {
         ucs_status_t ucp_status;
 
-        int vni = MPIDI_UCX_WIN(win).vni;
+        int vni = MPIDI_WIN(win, am_vci);
         ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni);
         /* currently, UCP does not support local flush, so we have to call
          * a global flush. This is not good for performance - but OK for now */

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -208,7 +208,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank, MPIR_Win * 
 
         ucs_status_t ucp_status;
         int vni = MPIDI_WIN(win, am_vci);
-        ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni);
+        int vni_target = MPIDI_WIN_TARGET_VCI(win, rank);
+        ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni, vni_target);
         /* only flush the endpoint */
         MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
         ucp_status = ucp_ep_flush(ep);
@@ -234,7 +235,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
         ucs_status_t ucp_status;
 
         int vni = MPIDI_WIN(win, am_vci);
-        ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni);
+        int vni_target = MPIDI_WIN_TARGET_VCI(win, rank);
+        ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni, vni_target);
         /* currently, UCP does not support local flush, so we have to call
          * a global flush. This is not good for performance - but OK for now */
         MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);

--- a/src/mpid/ch4/shm/posix/posix_win.c
+++ b/src/mpid/ch4/shm/posix/posix_win.c
@@ -129,7 +129,7 @@ int MPIDI_POSIX_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_
 
 static void posix_win_init_common(MPIR_Win * win)
 {
-    MPIDI_WIN(win, am_vci) %= MPIDI_POSIX_global.num_vsis;
+    MPIR_Assert(MPIDI_WIN(win, am_vci) < MPIDI_POSIX_global.num_vsis);
 
     MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;
     posix_win->shm_mutex_ptr = NULL;

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -620,6 +620,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_progress_test_vci(int vci);
 #define MPIDIG_EPOCH_FENCE_EVENT(win, massert) do {} while (0)
 #endif /* HAVE_ERROR_CHECKING */
 
+#define MPIDI_WIN_TARGET_VCI(win, rank) \
+    (MPIDI_WIN(win, vci_table) ? MPIDI_WIN(win, vci_table)[rank] : MPIDI_WIN(win, am_vci))
+
 /*
   Calculate base address of the target window at the origin side
   Return zero to let the target side calculate the actual address

--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -340,6 +340,7 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
     /* we need consistent vci to run am operations.
      * Note: netmod and shm may further hash it down */
     MPIDI_WIN(win, am_vci) = MPIDI_get_vci(SRC_VCI_FROM_SENDER, win->comm_ptr, 0, 0, 0);
+    MPIDI_WIN(win, vci_table) = NULL;
 
     /* set winattr for performance optimization at fast path:
      * - check if comm is COMM_WORLD or dup of COMM_WORLD

--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -337,10 +337,27 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
     MPIDIG_WIN(win, win_id) = MPIDIG_generate_win_id(comm_ptr);
     MPIDIU_map_set(MPIDI_global.win_map, MPIDIG_WIN(win, win_id), win, MPL_MEM_RMA);
 
-    /* we need consistent vci to run am operations.
-     * Note: netmod and shm may further hash it down */
-    MPIDI_WIN(win, am_vci) = MPIDI_get_vci(SRC_VCI_FROM_SENDER, win->comm_ptr, 0, 0, 0);
-    MPIDI_WIN(win, vci_table) = NULL;
+    if (comm_ptr->stream_comm_type == MPIR_STREAM_COMM_NONE) {
+        MPIDI_WIN(win, am_vci) = MPIDI_get_vci(SRC_VCI_FROM_SENDER, win->comm_ptr, 0, 0, 0);
+        MPIDI_WIN(win, vci_table) = NULL;
+    } else if (comm_ptr->stream_comm_type == MPIR_STREAM_COMM_SINGLE) {
+        int *vci_table = MPL_malloc(comm_ptr->local_size * sizeof(int), MPL_MEM_OTHER);
+        for (int i = 0; i < comm_ptr->local_size; i++) {
+            vci_table[i] = comm_ptr->stream_comm.single.vci_table[i];
+        }
+        MPIDI_WIN(win, am_vci) = vci_table[comm_ptr->rank];
+        MPIDI_WIN(win, vci_table) = vci_table;
+    } else if (comm_ptr->stream_comm_type == MPIR_STREAM_COMM_MULTIPLEX) {
+        int *vci_table = MPL_malloc(comm_ptr->local_size * sizeof(int), MPL_MEM_OTHER);
+        for (int i = 0; i < comm_ptr->local_size; i++) {
+            int displ = comm_ptr->stream_comm.multiplex.vci_displs[i];
+            vci_table[i] = comm_ptr->stream_comm.multiplex.vci_table[displ];
+        }
+        MPIDI_WIN(win, am_vci) = vci_table[comm_ptr->rank];
+        MPIDI_WIN(win, vci_table) = vci_table;
+    } else {
+        MPIR_Assert(0);
+    }
 
     /* set winattr for performance optimization at fast path:
      * - check if comm is COMM_WORLD or dup of COMM_WORLD
@@ -407,6 +424,8 @@ static int win_finalize(MPIR_Win ** win_ptr)
             (MPIR_cc_get(MPIDIG_WIN(win, remote_acc_cmpl_cnts)) == 0) &&
             all_local_completed && all_remote_completed;
     } while (all_completed != 1);
+
+    MPL_free(MPIDI_WIN(win, vci_table));
 
     mpi_errno = MPIDI_NM_mpi_win_free_hook(win);
     MPIR_ERR_CHECK(mpi_errno);


### PR DESCRIPTION
## Pull Request Description
When we create a window from a stream communicator, inherit the vci table from the communicator and use specific origin vci and target vci. This is particularly useful for passive synchronization where a passive target can simply have a progress thread progress the corresponding vci.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
