### PR TITLE
test: fix configure NVCC

### DIFF
--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -676,14 +676,14 @@ if test "X${pac_have_cuda}" = "Xyes" ; then
         fi
     fi
 
-    if test -n "$NVCC" ; then
+    if test -z "$NVCC" ; then
         if test -n "${with_cuda}" -a "$with_cuda" != "no" ; then
             AC_PATH_PROG([NVCC], [nvcc], [nvcc_not_found], [$with_cuda/bin:$PATH])
         else
             AC_PATH_PROG([NVCC], [nvcc], [nvcc_not_found])
         fi
-        if test "$NVCC" != "nvcc_not_found" -a -n "$CXX" ; then
-            NVCC="$NVCC -ccbin $CXX"
+        if test "$NVCC" != "nvcc_not_found" -a -n "$save_CXX" ; then
+            NVCC="$NVCC -ccbin $save_CXX"
         fi
     fi
     cuda_LIBS="-lcudart"


### PR DESCRIPTION
## Pull Request Description
We accidentally used `-n` when we meant `-z`.

We also accidentally used `$NVCC -ccbin $CXX` when we should be using
`$NVCC -ccbin $save_CXX`.

The mistake was made in #5933
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
