### PR TITLE
ch4/posix: fix typos in posix vci usage

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_probe.h
+++ b/src/mpid/ch4/shm/posix/posix_probe.h
@@ -22,7 +22,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_improbe(int source,
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
     mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, vsi, flag, message, status);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi).lock);
 
     return mpi_errno;
 }
@@ -38,7 +38,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iprobe(int source,
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
     mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, vsi, flag, status);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi).lock);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/posix/posix_recv.h
+++ b/src/mpid/ch4/shm/posix/posix_recv.h
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_imrecv(void *buf, MPI_Aint count,
 #endif
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
     mpi_errno = MPIDIG_mpi_imrecv(buf, count, datatype, message);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
 
     return mpi_errno;
 }


### PR DESCRIPTION

## Pull Request Description
Typos slipped through from https://github.com/pmodels/mpich/pull/5949
[skip warnings]
## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
