### PR TITLE
ch4/self: Add references to enqueued requests

### DIFF
--- a/src/mpid/ch4/src/ch4_self.c
+++ b/src/mpid/ch4/src/ch4_self.c
@@ -25,6 +25,7 @@ static MPIR_Request *self_recv_queue;
 
 #define ENQUEUE_SELF(req_, buf_, count_, datatype_, tag_, context_id_, queue) \
     do { \
+        MPIR_Request_add_ref(req_); \
         req_->dev.ch4.self.buf = (char *) buf_; \
         req_->dev.ch4.self.count = count_; \
         req_->dev.ch4.self.datatype = datatype_; \
@@ -128,9 +129,9 @@ int MPIDI_Self_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int
     if (rreq) {
         SELF_COPY(buf, count, datatype, rreq->dev.ch4.self.buf,
                   rreq->dev.ch4.self.count, rreq->dev.ch4.self.datatype, rreq->status, tag);
-        MPIR_cc_set(&rreq->cc, 0);
         /* comm will be released by MPIR_Request_free(rreq) */
         MPIR_Datatype_release_if_not_builtin(rreq->dev.ch4.self.datatype);
+        MPIR_Request_complete(rreq);
         sreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
     } else {
         sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
@@ -163,9 +164,9 @@ int MPIDI_Self_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
                   sreq->dev.ch4.self.count,
                   sreq->dev.ch4.self.datatype,
                   buf, count, datatype, rreq->status, sreq->dev.ch4.self.tag);
-        MPIR_cc_set(&sreq->cc, 0);
         /* comm will be released by MPIR_Request_free(sreq) */
         MPIR_Datatype_release_if_not_builtin(sreq->dev.ch4.self.datatype);
+        MPIR_Request_complete(sreq);
         MPIR_cc_set(&rreq->cc, 0);
         MPII_UNEXPQ_FORGET(sreq);
     } else {
@@ -254,9 +255,9 @@ int MPIDI_Self_imrecv(char *buf, MPI_Aint count, MPI_Datatype datatype,
               sreq->dev.ch4.self.count,
               sreq->dev.ch4.self.datatype,
               buf, count, datatype, rreq->status, sreq->dev.ch4.self.tag);
-    MPIR_cc_set(&sreq->cc, 0);
     /* comm will be released by MPIR_Request_free(sreq) */
     MPIR_Datatype_release_if_not_builtin(sreq->dev.ch4.self.datatype);
+    MPIR_Request_complete(sreq);
     MPIR_cc_set(&rreq->cc, 0);
 
     *request = rreq;
@@ -297,7 +298,7 @@ int MPIDI_Self_cancel(MPIR_Request * request)
         }
         MPIR_STATUS_SET_CANCEL_BIT(request->status, TRUE);
         MPIR_STATUS_SET_COUNT(request->status, 0);
-        MPIR_cc_set(&request->cc, 0);
+        MPIR_Request_complete(request);
     }
 
   fn_exit:

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1291,6 +1291,7 @@
 /pt2pt/many_isend
 /pt2pt/manylmt
 /pt2pt/mprobe
+/pt2pt/mprobe_self_free
 /pt2pt/multi_psend_derived
 /pt2pt/pingping
 /pt2pt/pingping_barrier

--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -69,7 +69,8 @@ noinst_PROGRAMS =  \
     sendself \
     pt2pt_large \
     precv_anysrc \
-    precv_anysrc_exp
+    precv_anysrc_exp \
+    mprobe_self_free
 
 irecv_any_CPPFLAGS = -DTEST_NB $(AM_CPPFLAGS)
 irecv_any_SOURCES  = recv_any.c

--- a/test/mpi/pt2pt/mprobe_self_free.c
+++ b/test/mpi/pt2pt/mprobe_self_free.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <mpitest.h>
+#include <mpi.h>
+
+/*
+static char MTEST_Descrip[] = "Isend to self with MPI_Request_free + Mprobe/Mrecv";
+*/
+
+int main(void)
+{
+    int errs = 0;
+    MTest_Init(NULL, NULL);
+
+    const int dummy_data = 42;
+
+    MPI_Request req;
+    MPI_Isend(&dummy_data, 1, MPI_INT, 0, 0, MPI_COMM_SELF, &req);
+
+    MPI_Request_free(&req);
+
+    MPI_Message mpi_msg;
+    MPI_Mprobe(0, 0, MPI_COMM_SELF, &mpi_msg, MPI_STATUS_IGNORE);
+
+    int recvd_data = 0;
+    MPI_Mrecv(&recvd_data, 1, MPI_INT, &mpi_msg, MPI_STATUS_IGNORE);
+
+    if (recvd_data != dummy_data) {
+        errs++;
+    }
+
+    MTest_Finalize(errs);
+
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -72,3 +72,4 @@ precv_anysrc 2 timeLimit=60
 precv_anysrc 2 timeLimit=60 env=MPIR_CVAR_CH4_OFI_AM_LONG_FORCE_PIPELINE=true
 precv_anysrc_exp 2 timeLimit=60
 pt2pt_large 2
+mprobe_self_free 1


### PR DESCRIPTION
## Pull Request Description

We need to add a reference to any request that will be used in future
operations. Otherwise, it may be prematurely freed if the user calls
MPI_REQUEST_FREE, leading to a segfault. Fixes pmodels/mpich#5977.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
