### PR TITLE
stream: fix nonblocking enqueue APIs and expand test

### DIFF
--- a/src/mpi/stream/stream_impl.c
+++ b/src/mpi/stream/stream_impl.c
@@ -620,6 +620,9 @@ int MPIR_Irecv_enqueue_impl(void *buf, MPI_Aint count, MPI_Datatype datatype,
     p->tag = tag;
     p->comm_ptr = comm_ptr;
     p->status = MPI_STATUS_IGNORE;
+    p->buf = buf;
+    p->count = count;
+    p->datatype = datatype;
 
     if (MPIR_GPU_query_pointer_is_dev(buf)) {
         MPI_Aint dt_size;
@@ -628,18 +631,9 @@ int MPIR_Irecv_enqueue_impl(void *buf, MPI_Aint count, MPI_Datatype datatype,
 
         MPIR_gpu_malloc_host(&p->host_buf, p->data_sz);
 
-        MPL_gpu_launch_hostfn(gpu_stream, recv_enqueue_cb, p);
-
-        mpi_errno = MPIR_Typerep_unpack_stream(p->host_buf, p->data_sz, buf, count, datatype, 0,
-                                               &p->actual_unpack_bytes, &gpu_stream);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        MPL_gpu_launch_hostfn(gpu_stream, recv_stream_cleanup_cb, p);
+        MPL_gpu_launch_hostfn(gpu_stream, irecv_enqueue_cb, p);
     } else {
         p->host_buf = NULL;
-        p->buf = buf;
-        p->count = count;
-        p->datatype = datatype;
 
         MPL_gpu_launch_hostfn(gpu_stream, irecv_enqueue_cb, p);
     }
@@ -656,6 +650,7 @@ static void wait_enqueue_cb(void *data)
     int mpi_errno;
     MPIR_Request *enqueue_req = data;
     MPIR_Request *real_req = enqueue_req->u.enqueue.real_request;
+    MPIR_Assert(real_req);
 
     if (enqueue_req->u.enqueue.is_send) {
         struct send_data *p = enqueue_req->u.enqueue.data;
@@ -698,7 +693,22 @@ int MPIR_Wait_enqueue_impl(MPIR_Request * req_ptr, MPI_Status * status)
 
     MPL_gpu_launch_hostfn(gpu_stream, wait_enqueue_cb, req_ptr);
 
+    if (!req_ptr->u.enqueue.is_send) {
+        struct recv_data *p = req_ptr->u.enqueue.data;
+        if (p->host_buf) {
+            mpi_errno = MPIR_Typerep_unpack_stream(p->host_buf, p->data_sz,
+                                                   p->buf, p->count, p->datatype, 0,
+                                                   &p->actual_unpack_bytes, &gpu_stream);
+            MPIR_ERR_CHECK(mpi_errno);
+
+            MPL_gpu_launch_hostfn(gpu_stream, recv_stream_cleanup_cb, p);
+        }
+    }
+
+  fn_exit:
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 /* ---- waitall enqueue ---- */
@@ -772,6 +782,24 @@ int MPIR_Waitall_enqueue_impl(int count, MPI_Request * array_of_requests,
     p->array_of_statuses = array_of_statuses;
 
     MPL_gpu_launch_hostfn(gpu_stream, waitall_enqueue_cb, p);
+
+    for (int i = 0; i < count; i++) {
+        MPIR_Request *enqueue_req;
+        MPIR_Request_get_ptr(array_of_requests[i], enqueue_req);
+        if (!enqueue_req->u.enqueue.is_send) {
+            struct recv_data *p2 = enqueue_req->u.enqueue.data;
+            if (p2->host_buf) {
+                mpi_errno = MPIR_Typerep_unpack_stream(p2->host_buf, p2->data_sz,
+                                                       p2->buf, p2->count, p2->datatype, 0,
+                                                       &p2->actual_unpack_bytes, &gpu_stream);
+                MPIR_ERR_CHECK(mpi_errno);
+
+                MPL_gpu_launch_hostfn(gpu_stream, recv_stream_cleanup_cb, p2);
+            }
+
+        }
+
+    }
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/stream/stream_impl.c
+++ b/src/mpi/stream/stream_impl.c
@@ -343,7 +343,7 @@ static void send_enqueue_cb(void *data)
 
     struct send_data *p = data;
     if (p->host_buf) {
-        assert(p->actual_pack_bytes == p->data_sz);
+        MPIR_Assertp(p->actual_pack_bytes == p->data_sz);
 
         mpi_errno = MPID_Send(p->host_buf, p->data_sz, MPI_BYTE, p->dest, p->tag, p->comm_ptr,
                               MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
@@ -351,11 +351,11 @@ static void send_enqueue_cb(void *data)
         mpi_errno = MPID_Send(p->buf, p->count, p->datatype, p->dest, p->tag, p->comm_ptr,
                               MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     }
-    assert(mpi_errno == MPI_SUCCESS);
-    assert(request_ptr != NULL);
+    MPIR_Assertp(mpi_errno == MPI_SUCCESS);
+    MPIR_Assertp(request_ptr != NULL);
 
     mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
-    assert(mpi_errno == MPI_SUCCESS);
+    MPIR_Assertp(mpi_errno == MPI_SUCCESS);
 
     MPIR_Request_free(request_ptr);
 
@@ -436,11 +436,11 @@ static void recv_enqueue_cb(void *data)
         mpi_errno = MPID_Recv(p->buf, p->count, p->datatype, p->source, p->tag, p->comm_ptr,
                               MPIR_CONTEXT_INTRA_PT2PT, p->status, &request_ptr);
     }
-    assert(mpi_errno == MPI_SUCCESS);
-    assert(request_ptr != NULL);
+    MPIR_Assertp(mpi_errno == MPI_SUCCESS);
+    MPIR_Assertp(request_ptr != NULL);
 
     mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
-    assert(mpi_errno == MPI_SUCCESS);
+    MPIR_Assertp(mpi_errno == MPI_SUCCESS);
 
     MPIR_Request_extract_status(request_ptr, p->status);
     MPIR_Request_free(request_ptr);
@@ -454,7 +454,7 @@ static void recv_enqueue_cb(void *data)
 static void recv_stream_cleanup_cb(void *data)
 {
     struct recv_data *p = data;
-    assert(p->actual_unpack_bytes == p->data_sz);
+    MPIR_Assertp(p->actual_unpack_bytes == p->data_sz);
 
     MPIR_gpu_free_host(p->host_buf);
     MPL_free(data);
@@ -515,7 +515,7 @@ static void isend_enqueue_cb(void *data)
 
     struct send_data *p = data;
     if (p->host_buf) {
-        assert(p->actual_pack_bytes == p->data_sz);
+        MPIR_Assertp(p->actual_pack_bytes == p->data_sz);
 
         mpi_errno = MPID_Send(p->host_buf, p->data_sz, MPI_BYTE, p->dest, p->tag, p->comm_ptr,
                               MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
@@ -523,8 +523,8 @@ static void isend_enqueue_cb(void *data)
         mpi_errno = MPID_Send(p->buf, p->count, p->datatype, p->dest, p->tag, p->comm_ptr,
                               MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     }
-    assert(mpi_errno == MPI_SUCCESS);
-    assert(request_ptr != NULL);
+    MPIR_Assertp(mpi_errno == MPI_SUCCESS);
+    MPIR_Assertp(request_ptr != NULL);
 
     p->req->u.enqueue.real_request = request_ptr;
 }
@@ -591,8 +591,8 @@ static void irecv_enqueue_cb(void *data)
         mpi_errno = MPID_Recv(p->buf, p->count, p->datatype, p->source, p->tag, p->comm_ptr,
                               MPIR_CONTEXT_INTRA_PT2PT, p->status, &request_ptr);
     }
-    assert(mpi_errno == MPI_SUCCESS);
-    assert(request_ptr != NULL);
+    MPIR_Assertp(mpi_errno == MPI_SUCCESS);
+    MPIR_Assertp(request_ptr != NULL);
 
     p->req->u.enqueue.real_request = request_ptr;
 }
@@ -656,7 +656,7 @@ static void wait_enqueue_cb(void *data)
         struct send_data *p = enqueue_req->u.enqueue.data;
 
         mpi_errno = MPID_Wait(real_req, MPI_STATUS_IGNORE);
-        assert(mpi_errno == MPI_SUCCESS);
+        MPIR_Assertp(mpi_errno == MPI_SUCCESS);
 
         MPIR_Request_free(real_req);
 
@@ -668,7 +668,7 @@ static void wait_enqueue_cb(void *data)
         struct recv_data *p = enqueue_req->u.enqueue.data;
 
         mpi_errno = MPID_Wait(real_req, MPI_STATUS_IGNORE);
-        assert(mpi_errno == MPI_SUCCESS);
+        MPIR_Assertp(mpi_errno == MPI_SUCCESS);
 
         MPIR_Request_extract_status(real_req, p->status);
         MPIR_Request_free(real_req);

--- a/test/mpi/impls/mpich/cuda/stream.cu
+++ b/test/mpi/impls/mpich/cuda/stream.cu
@@ -102,6 +102,44 @@ int main(void)
         errs += check_result(y);
     }
 
+    /* Test again with MPIX_Isend_enqueue and MPIX_Wait_enqueue */
+    if (rank == 0) {
+        for (int i = 0; i < N; i++) {
+            x[i] = x_val;
+        }
+        /* we are directly sending from x in this test */
+        MPI_Request req;
+        mpi_errno = MPIX_Isend_enqueue(x, N, MPI_FLOAT, 1, 0, stream_comm, &req);
+        assert(mpi_errno == MPI_SUCCESS);
+        /* req won't reset to MPI_REQUEST_NULL, but user shouldn't use it afterward */
+        mpi_errno = MPIX_Wait_enqueue(&req, MPI_STATUS_IGNORE);
+        assert(mpi_errno == MPI_SUCCESS);
+
+        cudaStreamSynchronize(stream);
+    } else if (rank == 1) {
+        /* reset d_x, d_y */
+        for (int i = 0; i < N; i++) {
+            x[i] = 0.0;
+            y[i] = y_val;
+        }
+        cudaMemcpyAsync(d_x, x, N*sizeof(float), cudaMemcpyHostToDevice, stream);
+        cudaMemcpyAsync(d_y, y, N*sizeof(float), cudaMemcpyHostToDevice, stream);
+
+        MPI_Request req;
+        mpi_errno = MPIX_Irecv_enqueue(d_x, N, MPI_FLOAT, 0, 0, stream_comm, &req);
+        assert(mpi_errno == MPI_SUCCESS);
+        mpi_errno = MPIX_Waitall_enqueue(1, &req, MPI_STATUSES_IGNORE);
+        assert(mpi_errno == MPI_SUCCESS);
+
+        saxpy<<<(N+255)/256, 256, 0, stream>>>(N, a, d_x, d_y);
+
+        cudaMemcpyAsync(y, d_y, N*sizeof(float), cudaMemcpyDeviceToHost, stream);
+
+        cudaStreamSynchronize(stream);
+        errs += check_result(y);
+    }
+
+
     MPI_Comm_free(&stream_comm);
     MPIX_Stream_free(&mpi_stream);
 


### PR DESCRIPTION
## Pull Request Description
Fix wait enqueue functions to use MPIX prefix.

Enhance `impls/mpich/cuda/stream.cu` to cover testing of nonblocking enqueue functions.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
