### PR TITLE
ch4: Fix comm references for mprobe/mrecv

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -48,6 +48,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
         *flag = 1;
         req = (MPIR_Request *) MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__MPROBE, vni_dst, 2);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+        req->comm = comm;
+        MPIR_Comm_add_ref(comm);
         MPIDI_UCX_REQ(req).message_handler = message_h;
 
         if (status != MPI_STATUS_IGNORE) {

--- a/src/mpid/ch4/src/ch4_self.c
+++ b/src/mpid/ch4/src/ch4_self.c
@@ -231,6 +231,7 @@ int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int attr,
         *message = MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE);
         (*message)->dev.ch4.self.match_req = sreq;
         (*message)->comm = sreq->comm;  /* set so we can check it in MPI_{M,Im}recv */
+        MPIR_Comm_add_ref((*message)->comm);
         MPII_UNEXPQ_FORGET(sreq);
     } else {
         *flag = FALSE;
@@ -245,8 +246,6 @@ int MPIDI_Self_imrecv(char *buf, MPI_Aint count, MPI_Datatype datatype,
 {
     MPIR_FUNC_ENTER;
     MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SELF_MUTEX);
-
-    message->comm = NULL;       /* was set in MPIDI_Self_improbe */
 
     MPIR_Request *sreq = message->dev.ch4.self.match_req;
     MPIR_Request *rreq = message;


### PR DESCRIPTION
## Pull Request Description

Reference the communicator associated with an MPI_Message handle. This
was the subsequent mrecv call can identify it as a self message, and
fixes support for exposing the message via the message queue dumping
interface.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
