### PR TITLE
configure: set pac_cv_f77_sizeof_logical=0

### DIFF
--- a/confdb/aclocal_datatype.m4
+++ b/confdb/aclocal_datatype.m4
@@ -5,7 +5,9 @@ AC_DEFUN([PAC_DATATYPE_UTILS], [
 # Take decimal and turn it into two hex digits
 to_hex() {
     len=$[]1
-    if test $len -le 9 ; then
+    if test -z $len ; then
+        pac_retval="00"
+    elif test $len -le 9 ; then
         dnl avoid subshell for speed
         pac_retval="0${len}"
     elif test $len -eq 16 ; then
@@ -89,7 +91,7 @@ dnl Multiplier can be used to define double types
 dnl     e.g. PAC_SET_MPI_TYPE(48, MPI_COMPLEX, $pac_cv_f77_sizeof_real, 2)
 dnl
 AC_DEFUN([PAC_SET_MPI_TYPE], [
-    if test $3 = 0 ; then
+    if test -z "$3" -o $3 = 0 ; then
         $2=MPI_DATATYPE_NULL
         F77_$2=MPI_DATATYPE_NULL
         F08_$2=MPI_DATATYPE_NULL%MPI_VAL

--- a/configure.ac
+++ b/configure.ac
@@ -3286,6 +3286,7 @@ else
     pac_cv_f77_sizeof_integer=0
     pac_cv_f77_sizeof_real=0
     pac_cv_f77_sizeof_double_precision=0
+    pac_cv_f77_sizeof_logical=0
     pac_cv_f77_sizeof_integer1=0
     pac_cv_f77_sizeof_integer2=0
     pac_cv_f77_sizeof_integer4=0


### PR DESCRIPTION
## Pull Request Description
set pac_cv_f77_sizeof_logical=0 when Fortran is disabled. The previous
commit configures MPI_LOGICAL separately but neglected to initialize
pac_cv_f77_sizeof_logical when Fortran is disabled.

Fixes #5995 


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
