### PR TITLE
datatype: return MPII_Type_zerolen when oldtype is 0-sized

### DIFF
--- a/src/mpi/datatype/type_create.c
+++ b/src/mpi/datatype/type_create.c
@@ -37,12 +37,19 @@
         new_dtp->typerep.handle = MPIR_TYPEREP_HANDLE_NULL; \
     } while (0)
 
+static bool type_size_is_zero(MPI_Datatype dt)
+{
+    MPI_Aint dt_size;
+    MPIR_Datatype_get_size_macro(dt, dt_size);
+    return dt_size == 0;
+}
+
 int MPIR_Type_contiguous(MPI_Aint count, MPI_Datatype oldtype, MPI_Datatype * newtype)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype *new_dtp;
 
-    if (count == 0)
+    if (type_size_is_zero(oldtype) || count == 0)
         return MPII_Type_zerolen(newtype);
 
     CREATE_NEW_DTP(new_dtp);
@@ -67,7 +74,7 @@ int MPIR_Type_vector(MPI_Aint count, MPI_Aint blocklength, MPI_Aint stride,
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype *new_dtp;
 
-    if (count == 0)
+    if (type_size_is_zero(oldtype) || count == 0)
         return MPII_Type_zerolen(newtype);
 
     CREATE_NEW_DTP(new_dtp);
@@ -99,7 +106,7 @@ int MPIR_Type_blockindexed(MPI_Aint count, MPI_Aint blocklength,
 
     MPIR_Datatype *new_dtp;
 
-    if (count == 0)
+    if (type_size_is_zero(oldtype) || count == 0)
         return MPII_Type_zerolen(newtype);
 
     CREATE_NEW_DTP(new_dtp);
@@ -131,7 +138,7 @@ int MPIR_Type_indexed(MPI_Aint count, const MPI_Aint * blocklength_array,
     MPIR_Datatype *new_dtp;
     MPI_Aint i;
 
-    if (count == 0)
+    if (type_size_is_zero(oldtype) || count == 0)
         return MPII_Type_zerolen(newtype);
 
     /* sanity check that blocklens are all non-negative */

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -76,6 +76,10 @@
 # timeout due to lack of passive progress
 * * vci ch4:ofi *       /^rma_contig.*iter=10000/        xfail=issue5565        rma/testlist
 
+# multiple vci + too many process may run out of endpoints or descriptors
+* * vci ch4:ofi *       /^darray_pack 72/                xfail=pr5998           datatype/testlist
+* * vci ch4:ofi *       /^spawn_rootargs 10/             xfail=pr5998           spawn/testlist
+
 # Sunf90 forbid passing cray pointer as integer
 * solstudio * * *       /^allocmemf90/          xfail=ticket0      f90/ext/testlist
 

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -34,10 +34,6 @@
 ################################################################################
 # misc special build
 * * nofast * *          /^large_acc_flush_local/ xfail=issue4663 rma/testlist
-#ch3:ofi
-* * * ch3:ofi *         /^manyget/               xfail=ticket0   rma/testlist
-* * * ch3:ofi *         /^manyrma2/              xfail=ticket0   rma/testlist
-* * * ch3:ofi *         /^manyrma2_shm/          xfail=ticket0   rma/testlist
 ################################################################################
 * * * * osx             /^throwtest/            xfail=ticket0   errors/cxx/errhan/testlist
 * * * * osx             /^commerrx/             xfail=ticket0   errors/cxx/errhan/testlist
@@ -58,9 +54,6 @@
 * * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   rma/testlist.dtp
 # Bug - Github Issue https://github.com/pmodels/mpich/issues/3618
 * * * ch4:ucx *         /^darray_pack/   xfail=ticket0   datatype/testlist
-# some of the bcastlength test that is still failing
-* * * ch3:ofi *         /^ibcastlength/         xfail=issue3775         errors/coll/testlist
-* * * ch3:ofi *         /^bcastlength/          xfail=issue4373         errors/coll/testlist
 # hwloc is unable to detect topology info on FreeBSD in strict mode with GCC
 * gnu strict * freebsd64        /^cmsplit_type/         xfail=ticket3972        comm/testlist
 * gnu strict * freebsd32        /^cmsplit_type/         xfail=ticket3972        comm/testlist


### PR DESCRIPTION
## Pull Request Description
Especially for creating indexed datatype, this avoids assertion errors
in dataloop or yaksa code due to old datatype being size 0.

Partially fixes #5995.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
