### PR TITLE
comm: avoid calling MPID_Allreduce directly

### DIFF
--- a/src/mpi/comm/comm_split_type_nbhd.c
+++ b/src/mpi/comm/comm_split_type_nbhd.c
@@ -271,7 +271,7 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
         MPIR_Assert(num_processes_at_node != NULL);
         /* Send the count to processes */
         mpi_errno =
-            MPID_Allreduce(MPI_IN_PLACE, num_processes_at_node, num_nodes, MPI_INT,
+            MPIR_Allreduce(MPI_IN_PLACE, num_processes_at_node, num_nodes, MPI_INT,
                            MPI_SUM, comm_ptr, &errflag);
 
         if (topo_type == MPIR_NETTOPO_TYPE__FAT_TREE ||
@@ -371,7 +371,7 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
             tree_depth = MPIR_hwtopo_get_depth(obj_containing_cpuset);
 
             /* get min tree depth to all processes */
-            MPID_Allreduce(&tree_depth, &min_tree_depth, 1, MPI_INT, MPI_MIN, node_comm, &errflag);
+            MPIR_Allreduce(&tree_depth, &min_tree_depth, 1, MPI_INT, MPI_MIN, node_comm, &errflag);
 
             if (min_tree_depth) {
                 int num_hwloc_objs_at_depth;
@@ -384,7 +384,7 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
                 parent_idx[subcomm_rank] = obj_containing_cpuset;
 
                 /* get parent_idx to all processes */
-                MPID_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, parent_idx, 1, MPI_INT,
+                MPIR_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, parent_idx, 1, MPI_INT,
                                node_comm, &errflag);
 
                 /* reorder parent indices */

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -1158,13 +1158,13 @@ int MPII_compare_info_hint(const char *hint_str, MPIR_Comm * comm_ptr, int *info
      * its hint_str size to the global max, and makes sure that this
      * comparison is successful on all processes. */
     mpi_errno =
-        MPID_Allreduce(&hint_str_size, &hint_str_size_max, 1, MPI_INT, MPI_MAX, comm_ptr, &errflag);
+        MPIR_Allreduce(&hint_str_size, &hint_str_size_max, 1, MPI_INT, MPI_MAX, comm_ptr, &errflag);
     MPIR_ERR_CHECK(mpi_errno);
 
     hint_str_equal = (hint_str_size == hint_str_size_max);
 
     mpi_errno =
-        MPID_Allreduce(&hint_str_equal, &hint_str_equal_global, 1, MPI_INT, MPI_LAND,
+        MPIR_Allreduce(&hint_str_equal, &hint_str_equal_global, 1, MPI_INT, MPI_LAND,
                        comm_ptr, &errflag);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -1177,14 +1177,14 @@ int MPII_compare_info_hint(const char *hint_str, MPIR_Comm * comm_ptr, int *info
     hint_str_global = (char *) MPL_malloc(strlen(hint_str), MPL_MEM_OTHER);
 
     mpi_errno =
-        MPID_Allreduce(hint_str, hint_str_global, strlen(hint_str), MPI_CHAR,
+        MPIR_Allreduce(hint_str, hint_str_global, strlen(hint_str), MPI_CHAR,
                        MPI_MAX, comm_ptr, &errflag);
     MPIR_ERR_CHECK(mpi_errno);
 
     hint_str_equal = !memcmp(hint_str, hint_str_global, strlen(hint_str));
 
     mpi_errno =
-        MPID_Allreduce(&hint_str_equal, &hint_str_equal_global, 1, MPI_INT, MPI_LAND,
+        MPIR_Allreduce(&hint_str_equal, &hint_str_equal_global, 1, MPI_INT, MPI_LAND,
                        comm_ptr, &errflag);
     MPIR_ERR_CHECK(mpi_errno);
 


### PR DESCRIPTION
## Pull Request Description

The inlining of `MPID_Allreduce` is too deep, resulting in compiler crashes when `--enable-fast=all` is turned on. 

Unless there is specific reason, do not call MPID collectives.
Call MPIR_Allreduce or a particular MPIR collective algorithm
instead.

This makes both `commutil.c` and `comm_split_type_nbhd` compiles instantly. `commutil.c` is the one causing compiler crash due to its use of 3 `MPID_Allreduce` in `MPII_compare_info_hint`.

`src/mpi/coll/mpir_coll.c` compiles slowly but seems compiler is still able to handle it.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
