### PR TITLE
request: call PMPI routines instead of MPI routines

### DIFF
--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -1317,7 +1317,7 @@ int MPIR_Waitany(int count, MPI_Request array_of_requests[], MPIR_Request * requ
     if (*indx == MPI_UNDEFINED) {
         if (unlikely(last_disabled_anysource != -1)) {
             int flag;
-            mpi_errno = MPI_Testany(count, array_of_requests, indx, &flag, status);
+            mpi_errno = PMPI_Testany(count, array_of_requests, indx, &flag, status);
             goto fn_exit;
         }
 
@@ -1452,8 +1452,8 @@ int MPIR_Waitsome(int incount, MPI_Request array_of_requests[], MPIR_Request * r
     }
 
     if (unlikely(disabled_anysource)) {
-        mpi_errno =
-            MPI_Testsome(incount, array_of_requests, outcount, array_of_indices, array_of_statuses);
+        mpi_errno = PMPI_Testsome(incount, array_of_requests, outcount, array_of_indices,
+                                  array_of_statuses);
         goto fn_exit;
     }
 


### PR DESCRIPTION
## Pull Request Description
Calling MPI_Testany and MPI_Testsome creats a back reference from
libpmpi.so to libmpi.so, which creates issues when weak symbols are
disabled.

This is discovered when trying to build on Cygwin.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
