### PR TITLE
testsuite: cannot case-switch on MPI handles

### DIFF
--- a/test/mpi/datatype/pack_external.c
+++ b/test/mpi/datatype/pack_external.c
@@ -122,57 +122,57 @@ static bool mpi_type_is_bool(MPI_Datatype mpi_type)
 
 static const void *get_in_buffer(struct dt dt)
 {
-    switch (dt.mpi_type) {
-        case MPI_INT:
-            return int_data;
-        case MPI_LONG:
-            return long_data;
-        case MPI_LONG_LONG_INT:
-            return long_long_data;
-        case MPI_FLOAT:
-            return float_data;
+    if (dt.mpi_type == MPI_INT) {
+        return int_data;
+    } else if (dt.mpi_type == MPI_LONG) {
+        return long_data;
+    } else if (dt.mpi_type == MPI_LONG_LONG_INT) {
+        return long_long_data;
+    } else if (dt.mpi_type == MPI_FLOAT) {
+        return float_data;
+    }
 #ifdef TEST_LONG_DOUBLE
-        case MPI_LONG_DOUBLE:
-            return long_double_data;
+    else if (dt.mpi_type == MPI_LONG_DOUBLE) {
+        return long_double_data;
+    }
 #endif
 #ifdef TEST_COMPLEX
-        case MPI_C_COMPLEX:
-            return complex_data;
-#endif
-        case MPI_C_BOOL:
-            return bool_data;
-        default:
-            /* TODO: add more datatypes */
-            return NULL;
+    else if (dt.mpi_type == MPI_C_COMPLEX) {
+        return complex_data;
     }
+#endif
+    else if (dt.mpi_type == MPI_C_BOOL) {
+        return bool_data;
+    }
+    /* TODO: add more datatypes */
     return NULL;
 }
 
 static const void *get_pack_buffer(struct dt dt)
 {
-    switch (dt.mpi_type) {
-        case MPI_INT:
-            return int_pack;
-        case MPI_LONG:
-            return long_pack;;
-        case MPI_LONG_LONG_INT:
-            return long_long_pack;
-        case MPI_FLOAT:
-            return float_pack;
+    if (dt.mpi_type == MPI_INT) {
+        return int_pack;
+    } else if (dt.mpi_type == MPI_LONG) {
+        return long_pack;
+    } else if (dt.mpi_type == MPI_LONG_LONG_INT) {
+        return long_long_pack;
+    } else if (dt.mpi_type == MPI_FLOAT) {
+        return float_pack;
+    }
 #ifdef TEST_LONG_DOUBLE
-        case MPI_LONG_DOUBLE:
-            return long_double_pack;
+    else if (dt.mpi_type == MPI_LONG_DOUBLE) {
+        return long_double_pack;
+    }
 #endif
 #ifdef TEST_COMPLEX
-        case MPI_C_COMPLEX:
-            return complex_pack;
-#endif
-        case MPI_C_BOOL:
-            return bool_pack;
-        default:
-            /* TODO: add more datatypes */
-            return NULL;
+    else if (dt.mpi_type == MPI_C_COMPLEX) {
+        return complex_pack;
     }
+#endif
+    else if (dt.mpi_type == MPI_C_BOOL) {
+        return bool_pack;
+    }
+    /* TODO: add more packtypes */
     return NULL;
 }
 

--- a/test/mpi/rma/rma_contig.c
+++ b/test/mpi/rma/rma_contig.c
@@ -33,20 +33,17 @@ static void run_test(int lock_mode, int lock_assert)
 
         printf("Synchronization mode: ");
 
-        switch (lock_mode) {
-            case MPI_LOCK_EXCLUSIVE:
-                printf("Exclusive lock");
-                break;
-            case MPI_LOCK_SHARED:
-                printf("Shared lock");
-                break;
-            default:
-                printf("Unknown lock");
-                break;
+        if (lock_mode == MPI_LOCK_EXCLUSIVE) {
+            printf("Exclusive lock");
+        } else if (lock_mode == MPI_LOCK_SHARED) {
+            printf("Shared lock");
+        } else {
+            printf("Unknown lock");
         }
 
-        if (lock_assert & MPI_MODE_NOCHECK)
+        if (lock_assert & MPI_MODE_NOCHECK) {
             printf(", MPI_MODE_NOCHECK");
+        }
 
         printf("\n");
     }

--- a/test/mpi/topo/dgraph_unwgt.c
+++ b/test/mpi/topo/dgraph_unwgt.c
@@ -24,12 +24,8 @@ static int validate_dgraph(MPI_Comm dgraph_comm)
 
     comm_topo = MPI_UNDEFINED;
     MPI_Topo_test(dgraph_comm, &comm_topo);
-    switch (comm_topo) {
-        case MPI_DIST_GRAPH:
-            break;
-        default:
-            fprintf(stderr, "dgraph_comm is NOT of type MPI_DIST_GRAPH\n");
-            return 0;
+    if (comm_topo != MPI_DIST_GRAPH) {
+        fprintf(stderr, "dgraph_comm is NOT of type MPI_DIST_GRAPH\n");
     }
 
     ierr = MPI_Dist_graph_neighbors_count(dgraph_comm, &src_sz, &dest_sz, &wgt_flag);


### PR DESCRIPTION
## Pull Request Description


## Author Checklist
* [x] **Provide Description** 

It is a violation of the MPI standard to use switch-case on MPI handles, except for the ones that are explicitly stated to be compile-time constants.  See MPI-4 2.5.4 for details.

* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**

I will wait for CI.

* [?] **Contribution Agreement**

I assume I'm covered by the one Mellanox uses.