### PR TITLE
misc: workaround for static linking romio without weak symbols

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -203,6 +203,11 @@ test-clean:
 ## better approach might be to have each Makefile.mk append to a
 ## common set of rules.
 install-exec-hook:
+	if test -e lib/lib@PMPILIBNAME@.la ; then \
+	    . lib/lib@PMPILIBNAME@.la ; \
+	elif test -e lib/lib@MPILIBNAME@.la ; then \
+	    . lib/lib@MPILIBNAME@.la ; \
+	fi ; \
 	for e in ${DESTDIR}${bindir}/@MPICC_NAME@ ${DESTDIR}${bindir}/@MPICXX_NAME@ \
 		${DESTDIR}${bindir}/@MPIF77_NAME@ ${DESTDIR}${bindir}/@MPIFORT_NAME@ ; do \
 		if test -e $${e} ; then \
@@ -210,7 +215,8 @@ install-exec-hook:
 				-e 's|__EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__|${exec_prefix}|g' \
 				-e 's|__SYSCONFDIR_TO_BE_FILLED_AT_INSTALL_TIME__|${sysconfdir}|g' \
 				-e 's|__INCLUDEDIR_TO_BE_FILLED_AT_INSTALL_TIME__|${includedir}|g' \
-				-e 's|__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__|${libdir}|g' $${e} > $${e}.tmp ; \
+				-e 's|__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__|${libdir}|g' \
+				-e "s|__LIBS_TO_BE_FILLED_AT_INSTALL_TIME__|$$dependency_libs|g" $${e} > $${e}.tmp ; \
 			$(INSTALL_SCRIPT) $${e}.tmp $${e} ; \
 			rm -f $${e}.tmp ; \
 		fi ; \

--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -95,14 +95,6 @@ AC_DEFUN([PAC_CONFIG_HWLOC],[
             fi
             PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/hwloc/include],[CPPFLAGS])
             PAC_APPEND_FLAG([-I${main_top_builddir}/modules/hwloc/include],[CPPFLAGS])
-
-            # capture the line -- S["HWLOC_EMBEDDED_LIBS"]="-lm "
-            hwloc_embedded_libs=$(awk -F'"' '/^S."HWLOC_EMBEDDED_LIBS"/ {print $[]4}' modules/hwloc/config.status)
-            echo "hwloc_embedded_libs = $hwloc_embedded_libs"
-            if test -n "$hwloc_embedded_libs" ; then
-                dnl TODO: split and add individual lib
-                PAC_LIBS_ADD([$hwloc_embedded_libs])
-            fi
         ], [
             dnl ---- sub-configure (hydra) ----
             if test "$FROM_MPICH" = "yes"; then

--- a/src/env/mpicc.bash.in
+++ b/src/env/mpicc.bash.in
@@ -253,7 +253,7 @@ final_ldflags="@MPICH_MPICC_LDFLAGS@ @WRAPPER_LDFLAGS@"
 final_libs="@MPICH_MPICC_LIBS@"
 if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
     final_ldflags="${final_ldflags} @LDFLAGS@"
-    final_libs="${final_libs} @LIBS@ @WRAPPER_LIBS@"
+    final_libs="${final_libs} __LIBS_TO_BE_FILLED_AT_INSTALL_TIME__"
 fi
 
 # -----------------------------------------------------------------------

--- a/src/env/mpicc.sh.in
+++ b/src/env/mpicc.sh.in
@@ -259,7 +259,7 @@ final_ldflags="@MPICH_MPICC_LDFLAGS@ @WRAPPER_LDFLAGS@"
 final_libs="@MPICH_MPICC_LIBS@"
 if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
     final_ldflags="${final_ldflags} @LDFLAGS@"
-    final_libs="${final_libs} @LIBS@ @WRAPPER_LIBS@"
+    final_libs="${final_libs} __LIBS_TO_BE_FILLED_AT_INSTALL_TIME__"
 fi
 
 # -----------------------------------------------------------------------

--- a/src/env/mpicxx.bash.in
+++ b/src/env/mpicxx.bash.in
@@ -259,7 +259,7 @@ final_ldflags="@MPICH_MPICXX_LDFLAGS@ @WRAPPER_LDFLAGS@"
 final_libs="@MPICH_MPICXX_LIBS@"
 if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
     final_ldflags="${final_ldflags} @LDFLAGS@"
-    final_libs="${final_libs} @LIBS@ @WRAPPER_LIBS@"
+    final_libs="${final_libs} __LIBS_TO_BE_FILLED_AT_INSTALL_TIME__"
 fi
 
 # A temporary statement to invoke the compiler

--- a/src/env/mpicxx.sh.in
+++ b/src/env/mpicxx.sh.in
@@ -265,7 +265,7 @@ final_ldflags="@MPICH_MPICXX_LDFLAGS@ @WRAPPER_LDFLAGS@"
 final_libs="@MPICH_MPICXX_LIBS@"
 if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
     final_ldflags="${final_ldflags} @LDFLAGS@"
-    final_libs="${final_libs} @LIBS@ @WRAPPER_LIBS@"
+    final_libs="${final_libs} __LIBS_TO_BE_FILLED_AT_INSTALL_TIME__"
 fi
 
 # A temporary statement to invoke the compiler

--- a/src/env/mpifort.bash.in
+++ b/src/env/mpifort.bash.in
@@ -340,7 +340,7 @@ final_ldflags="@MPICH_MPIFORT_LDFLAGS@ @WRAPPER_LDFLAGS@"
 final_libs="@MPICH_MPIFORT_LIBS@"
 if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
     final_ldflags="${final_ldflags} @LDFLAGS@"
-    final_libs="${final_libs} @LIBS@ @WRAPPER_LIBS@"
+    final_libs="${final_libs} __LIBS_TO_BE_FILLED_AT_INSTALL_TIME__"
 fi
 
 extra_f77_flags="@WRAPPER_EXTRA_F77_FLAGS@"

--- a/src/env/mpifort.sh.in
+++ b/src/env/mpifort.sh.in
@@ -357,7 +357,7 @@ final_ldflags="@MPICH_MPIFORT_LDFLAGS@ @WRAPPER_LDFLAGS@"
 final_libs="@MPICH_MPIFORT_LIBS@"
 if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
     final_ldflags="${final_ldflags} @LDFLAGS@"
-    final_libs="${final_libs} @LIBS@ @WRAPPER_LIBS@"
+    final_libs="${final_libs} __LIBS_TO_BE_FILLED_AT_INSTALL_TIME__"
 fi
 
 extra_f77_flags="@WRAPPER_EXTRA_F77_FLAGS@"

--- a/src/mpi/errhan/Makefile.mk
+++ b/src/mpi/errhan/Makefile.mk
@@ -5,6 +5,7 @@
 
 mpi_core_sources +=             \
     src/mpi/errhan/errhan_impl.c \
+    src/mpi/errhan/errhan_file.c \
     src/mpi/errhan/errutil.c    \
     src/mpi/errhan/dynerrutil.c
 

--- a/src/mpi/errhan/errhan_file.c
+++ b/src/mpi/errhan/errhan_file.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+#include "mpir_ext.h"
+
+int MPIR_File_create_errhandler_impl(MPI_File_errhandler_function * file_errhandler_fn,
+                                     MPIR_Errhandler ** errhandler_ptr)
+{
+#ifdef MPI_MODE_RDONLY
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Errhandler *errhan_ptr;
+
+    errhan_ptr = (MPIR_Errhandler *) MPIR_Handle_obj_alloc(&MPIR_Errhandler_mem);
+    MPIR_ERR_CHKANDJUMP(!errhan_ptr, mpi_errno, MPI_ERR_OTHER, "**nomem");
+    errhan_ptr->language = MPIR_LANG__C;
+    errhan_ptr->kind = MPIR_FILE;
+    MPIR_Object_set_ref(errhan_ptr, 1);
+    errhan_ptr->errfn.C_File_Handler_function = file_errhandler_fn;
+
+    *errhandler_ptr = errhan_ptr;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+#else
+    return MPI_ERR_INTERN;
+#endif
+}
+
+/* File is handled differently from Comm/Win due to ROMIO abstraction */
+int MPIR_File_get_errhandler_impl(MPI_File file, MPI_Errhandler * errhandler)
+{
+#ifdef MPI_MODE_RDONLY
+    MPI_Errhandler eh;
+    MPIR_Errhandler *e;
+
+    MPIR_ROMIO_Get_file_errhand(file, &eh);
+    if (!eh) {
+        MPIR_Errhandler_get_ptr(MPI_ERRORS_RETURN, e);
+    } else {
+        MPIR_Errhandler_get_ptr(eh, e);
+    }
+
+    MPIR_Errhandler_add_ref(e);
+    *errhandler = e->handle;
+
+    return MPI_SUCCESS;
+#else
+    return MPI_ERR_INTERN;
+#endif
+}
+
+int MPIR_File_set_errhandler_impl(MPI_File file, MPIR_Errhandler * errhan_ptr)
+{
+#ifdef MPI_MODE_RDONLY
+    MPIR_Errhandler *old_errhandler_ptr;
+    MPI_Errhandler old_errhandler;
+
+    MPIR_ROMIO_Get_file_errhand(file, &old_errhandler);
+    if (!old_errhandler) {
+        /* MPI_File objects default to the errhandler set on MPI_FILE_NULL
+         * at file open time, or MPI_ERRORS_RETURN if no errhandler is set
+         * on MPI_FILE_NULL. (MPI-2.2, sec 13.7) */
+        MPIR_Errhandler_get_ptr(MPI_ERRORS_RETURN, old_errhandler_ptr);
+    } else {
+        MPIR_Errhandler_get_ptr(old_errhandler, old_errhandler_ptr);
+    }
+
+    if (old_errhandler_ptr) {
+        MPIR_Errhandler_free_impl(old_errhandler_ptr);
+    }
+
+    MPIR_Errhandler_add_ref(errhan_ptr);
+    MPIR_ROMIO_Set_file_errhand(file, errhan_ptr->handle);
+    return MPI_SUCCESS;
+#else
+    return MPI_ERR_INTERN;
+#endif
+}
+
+int MPIR_File_call_errhandler_impl(MPI_File fh, int errorcode)
+{
+#ifdef MPI_MODE_RDONLY
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Errhandler *e;
+    MPI_Errhandler eh;
+
+    MPIR_ROMIO_Get_file_errhand(fh, &eh);
+    /* Check for the special case of errors-throw-exception.  In this case
+     * return the error code; the C++ wrapper will cause an exception to
+     * be thrown.
+     */
+#ifdef HAVE_CXX_BINDING
+    if (eh == MPIR_ERRORS_THROW_EXCEPTIONS) {
+        mpi_errno = errorcode;
+        goto fn_exit;
+    }
+#endif
+    if (!eh) {
+        MPIR_Errhandler_get_ptr(MPI_ERRORS_RETURN, e);
+    } else {
+        MPIR_Errhandler_get_ptr(eh, e);
+    }
+
+    /* Note that, unlike the rest of MPICH, MPI_File objects are pointers,
+     * not integers.  */
+
+    if (e->handle == MPI_ERRORS_RETURN) {
+        goto fn_exit;
+    }
+
+    if (e->handle == MPI_ERRORS_ARE_FATAL || e->handle == MPI_ERRORS_ABORT) {
+        MPIR_Handle_fatal_error(NULL, "MPI_File_call_errhandler", errorcode);
+    }
+
+    switch (e->language) {
+        case MPIR_LANG__C:
+            (*e->errfn.C_File_Handler_function) (&fh, &errorcode);
+            break;
+#ifdef HAVE_CXX_BINDING
+        case MPIR_LANG__CXX:
+            /* See HAVE_LANGUAGE_FORTRAN below for an explanation */
+            {
+                void *fh1 = (void *) &fh;
+                (*MPIR_Process.cxx_call_errfn) (1, fh1, &errorcode,
+                                                (void (*)(void)) *e->errfn.C_File_Handler_function);
+            }
+            break;
+#endif
+#ifdef HAVE_FORTRAN_BINDING
+        case MPIR_LANG__FORTRAN90:
+        case MPIR_LANG__FORTRAN:
+            /* The assignemt to a local variable prevents the compiler
+             * from generating a warning about a type-punned pointer.  Since
+             * the value is really const (but MPI didn't define error handlers
+             * with const), this preserves the intent */
+            {
+                void *fh1 = (void *) &fh;
+                MPI_Fint ferr = errorcode;      /* Needed if MPI_Fint and int aren't
+                                                 * the same size */
+                (*e->errfn.F77_Handler_function) (fh1, &ferr);
+            }
+            break;
+#endif
+    }
+
+  fn_exit:
+    return mpi_errno;
+#else /* MPI_MODE_RDONLY */
+    /* Dummy in case ROMIO is not defined */
+    return MPI_ERR_INTERN;
+#endif /* MPI_MODE_RDONLY */
+}
+
+/* Export this routine only once (if we need to compile this file twice
+   to get the PMPI and MPI versions without weak symbols */
+void MPIR_Get_file_error_routine(MPI_Errhandler e, void (**c) (MPI_File *, int *, ...), int *kind)
+{
+    MPIR_Errhandler *e_ptr = 0;
+    int mpi_errno = MPI_SUCCESS;
+
+    /* Convert the MPI_Errhandler into an MPIR_Errhandler */
+
+    if (!e) {
+        *c = 0;
+        *kind = 1;      /* Use errors return as the default */
+    } else {
+        MPIR_ERRTEST_ERRHANDLER(e, mpi_errno);
+        MPIR_Errhandler_get_ptr(e, e_ptr);
+        if (!e_ptr) {
+            /* FIXME: We need an error return */
+            *c = 0;
+            *kind = 1;
+            return;
+        }
+        if (e_ptr->handle == MPI_ERRORS_RETURN) {
+            *c = 0;
+            *kind = 1;
+        } else if (e_ptr->handle == MPI_ERRORS_ARE_FATAL || e_ptr->handle == MPI_ERRORS_ABORT) {
+            *c = 0;
+            *kind = 0;
+        } else {
+            *c = e_ptr->errfn.C_File_Handler_function;
+            *kind = 2;
+            /* If the language is C++, we need to use a special call
+             * interface.  This is MPIR_File_call_cxx_errhandler.
+             * See file_call_errhandler.c */
+#ifdef HAVE_CXX_BINDING
+            if (e_ptr->language == MPIR_LANG__CXX)
+                *kind = 3;
+#endif
+        }
+    }
+  fn_fail:
+    return;
+}
+
+/* This is a glue routine that can be used by ROMIO
+   (see mpi-io/glue/mpich/mpio_err.c) to properly invoke the C++
+   error handler */
+int MPIR_File_call_cxx_errhandler(MPI_File * fh, int *errorcode,
+                                  void (*c_errhandler) (MPI_File *, int *, ...))
+{
+    /* ROMIO will contain a reference to this routine, so if there is
+     * no C++ support, it will never be called but it must be available. */
+#ifdef HAVE_CXX_BINDING
+    void *fh1 = (void *) fh;
+    (*MPIR_Process.cxx_call_errfn) (1, fh1, errorcode, (void (*)(void)) c_errhandler);
+    /* The C++ code throws an exception if the error handler
+     * returns something other than MPI_SUCCESS. There is no "return"
+     * of an error code. This code mirrors that in errutil.c */
+    *errorcode = MPI_SUCCESS;
+#endif
+    return *errorcode;
+}

--- a/src/mpi/errhan/errhan_impl.c
+++ b/src/mpi/errhan/errhan_impl.c
@@ -4,7 +4,6 @@
  */
 
 #include "mpiimpl.h"
-#include "mpir_ext.h"
 
 int MPIR_Comm_create_errhandler_impl(MPI_Comm_errhandler_function * comm_errhandler_fn,
                                      MPIR_Errhandler ** errhandler_ptr)
@@ -70,31 +69,6 @@ int MPIR_Session_create_errhandler_impl(MPI_Session_errhandler_function * sessio
     goto fn_exit;
 }
 
-int MPIR_File_create_errhandler_impl(MPI_File_errhandler_function * file_errhandler_fn,
-                                     MPIR_Errhandler ** errhandler_ptr)
-{
-#ifdef MPI_MODE_RDONLY
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_Errhandler *errhan_ptr;
-
-    errhan_ptr = (MPIR_Errhandler *) MPIR_Handle_obj_alloc(&MPIR_Errhandler_mem);
-    MPIR_ERR_CHKANDJUMP(!errhan_ptr, mpi_errno, MPI_ERR_OTHER, "**nomem");
-    errhan_ptr->language = MPIR_LANG__C;
-    errhan_ptr->kind = MPIR_FILE;
-    MPIR_Object_set_ref(errhan_ptr, 1);
-    errhan_ptr->errfn.C_File_Handler_function = file_errhandler_fn;
-
-    *errhandler_ptr = errhan_ptr;
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-#else
-    return MPI_ERR_INTERN;
-#endif
-}
-
 /* MPIR_Comm_get_errhandler_impl
    returning NULL for errhandler_ptr means the default handler, MPI_ERRORS_ARE_FATAL is used */
 int MPIR_Comm_get_errhandler_impl(MPIR_Comm * comm_ptr, MPI_Errhandler * errhandler)
@@ -143,29 +117,6 @@ int MPIR_Session_get_errhandler_impl(MPIR_Session * session_ptr, MPI_Errhandler 
     }
 
     return MPI_SUCCESS;
-}
-
-/* File is handled differently from Comm/Win due to ROMIO abstraction */
-int MPIR_File_get_errhandler_impl(MPI_File file, MPI_Errhandler * errhandler)
-{
-#ifdef MPI_MODE_RDONLY
-    MPI_Errhandler eh;
-    MPIR_Errhandler *e;
-
-    MPIR_ROMIO_Get_file_errhand(file, &eh);
-    if (!eh) {
-        MPIR_Errhandler_get_ptr(MPI_ERRORS_RETURN, e);
-    } else {
-        MPIR_Errhandler_get_ptr(eh, e);
-    }
-
-    MPIR_Errhandler_add_ref(e);
-    *errhandler = e->handle;
-
-    return MPI_SUCCESS;
-#else
-    return MPI_ERR_INTERN;
-#endif
 }
 
 int MPIR_Comm_set_errhandler_impl(MPIR_Comm * comm_ptr, MPIR_Errhandler * errhandler_ptr)
@@ -221,34 +172,6 @@ int MPIR_Session_set_errhandler_impl(MPIR_Session * session_ptr, MPIR_Errhandler
     session_ptr->errhandler = errhandler_ptr;
 
     return MPI_SUCCESS;
-}
-
-int MPIR_File_set_errhandler_impl(MPI_File file, MPIR_Errhandler * errhan_ptr)
-{
-#ifdef MPI_MODE_RDONLY
-    MPIR_Errhandler *old_errhandler_ptr;
-    MPI_Errhandler old_errhandler;
-
-    MPIR_ROMIO_Get_file_errhand(file, &old_errhandler);
-    if (!old_errhandler) {
-        /* MPI_File objects default to the errhandler set on MPI_FILE_NULL
-         * at file open time, or MPI_ERRORS_RETURN if no errhandler is set
-         * on MPI_FILE_NULL. (MPI-2.2, sec 13.7) */
-        MPIR_Errhandler_get_ptr(MPI_ERRORS_RETURN, old_errhandler_ptr);
-    } else {
-        MPIR_Errhandler_get_ptr(old_errhandler, old_errhandler_ptr);
-    }
-
-    if (old_errhandler_ptr) {
-        MPIR_Errhandler_free_impl(old_errhandler_ptr);
-    }
-
-    MPIR_Errhandler_add_ref(errhan_ptr);
-    MPIR_ROMIO_Set_file_errhand(file, errhan_ptr->handle);
-    return MPI_SUCCESS;
-#else
-    return MPI_ERR_INTERN;
-#endif
 }
 
 static int call_errhandler(MPIR_Errhandler * errhandler, int errorcode, int handle)
@@ -363,142 +286,6 @@ int MPIR_Session_call_errhandler_impl(MPIR_Session * session_ptr, int errorcode)
     mpi_errno = call_errhandler(session_ptr->errhandler, errorcode, session_ptr->handle);
 
     return mpi_errno;
-}
-
-int MPIR_File_call_errhandler_impl(MPI_File fh, int errorcode)
-{
-#ifdef MPI_MODE_RDONLY
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_Errhandler *e;
-    MPI_Errhandler eh;
-
-    MPIR_ROMIO_Get_file_errhand(fh, &eh);
-    /* Check for the special case of errors-throw-exception.  In this case
-     * return the error code; the C++ wrapper will cause an exception to
-     * be thrown.
-     */
-#ifdef HAVE_CXX_BINDING
-    if (eh == MPIR_ERRORS_THROW_EXCEPTIONS) {
-        mpi_errno = errorcode;
-        goto fn_exit;
-    }
-#endif
-    if (!eh) {
-        MPIR_Errhandler_get_ptr(MPI_ERRORS_RETURN, e);
-    } else {
-        MPIR_Errhandler_get_ptr(eh, e);
-    }
-
-    /* Note that, unlike the rest of MPICH, MPI_File objects are pointers,
-     * not integers.  */
-
-    if (e->handle == MPI_ERRORS_RETURN) {
-        goto fn_exit;
-    }
-
-    if (e->handle == MPI_ERRORS_ARE_FATAL || e->handle == MPI_ERRORS_ABORT) {
-        MPIR_Handle_fatal_error(NULL, "MPI_File_call_errhandler", errorcode);
-    }
-
-    switch (e->language) {
-        case MPIR_LANG__C:
-            (*e->errfn.C_File_Handler_function) (&fh, &errorcode);
-            break;
-#ifdef HAVE_CXX_BINDING
-        case MPIR_LANG__CXX:
-            /* See HAVE_LANGUAGE_FORTRAN below for an explanation */
-            {
-                void *fh1 = (void *) &fh;
-                (*MPIR_Process.cxx_call_errfn) (1, fh1, &errorcode,
-                                                (void (*)(void)) *e->errfn.C_File_Handler_function);
-            }
-            break;
-#endif
-#ifdef HAVE_FORTRAN_BINDING
-        case MPIR_LANG__FORTRAN90:
-        case MPIR_LANG__FORTRAN:
-            /* The assignemt to a local variable prevents the compiler
-             * from generating a warning about a type-punned pointer.  Since
-             * the value is really const (but MPI didn't define error handlers
-             * with const), this preserves the intent */
-            {
-                void *fh1 = (void *) &fh;
-                MPI_Fint ferr = errorcode;      /* Needed if MPI_Fint and int aren't
-                                                 * the same size */
-                (*e->errfn.F77_Handler_function) (fh1, &ferr);
-            }
-            break;
-#endif
-    }
-
-  fn_exit:
-    return mpi_errno;
-#else /* MPI_MODE_RDONLY */
-    /* Dummy in case ROMIO is not defined */
-    return MPI_ERR_INTERN;
-#endif /* MPI_MODE_RDONLY */
-}
-
-/* Export this routine only once (if we need to compile this file twice
-   to get the PMPI and MPI versions without weak symbols */
-void MPIR_Get_file_error_routine(MPI_Errhandler e, void (**c) (MPI_File *, int *, ...), int *kind)
-{
-    MPIR_Errhandler *e_ptr = 0;
-    int mpi_errno = MPI_SUCCESS;
-
-    /* Convert the MPI_Errhandler into an MPIR_Errhandler */
-
-    if (!e) {
-        *c = 0;
-        *kind = 1;      /* Use errors return as the default */
-    } else {
-        MPIR_ERRTEST_ERRHANDLER(e, mpi_errno);
-        MPIR_Errhandler_get_ptr(e, e_ptr);
-        if (!e_ptr) {
-            /* FIXME: We need an error return */
-            *c = 0;
-            *kind = 1;
-            return;
-        }
-        if (e_ptr->handle == MPI_ERRORS_RETURN) {
-            *c = 0;
-            *kind = 1;
-        } else if (e_ptr->handle == MPI_ERRORS_ARE_FATAL || e_ptr->handle == MPI_ERRORS_ABORT) {
-            *c = 0;
-            *kind = 0;
-        } else {
-            *c = e_ptr->errfn.C_File_Handler_function;
-            *kind = 2;
-            /* If the language is C++, we need to use a special call
-             * interface.  This is MPIR_File_call_cxx_errhandler.
-             * See file_call_errhandler.c */
-#ifdef HAVE_CXX_BINDING
-            if (e_ptr->language == MPIR_LANG__CXX)
-                *kind = 3;
-#endif
-        }
-    }
-  fn_fail:
-    return;
-}
-
-/* This is a glue routine that can be used by ROMIO
-   (see mpi-io/glue/mpich/mpio_err.c) to properly invoke the C++
-   error handler */
-int MPIR_File_call_cxx_errhandler(MPI_File * fh, int *errorcode,
-                                  void (*c_errhandler) (MPI_File *, int *, ...))
-{
-    /* ROMIO will contain a reference to this routine, so if there is
-     * no C++ support, it will never be called but it must be available. */
-#ifdef HAVE_CXX_BINDING
-    void *fh1 = (void *) fh;
-    (*MPIR_Process.cxx_call_errfn) (1, fh1, errorcode, (void (*)(void)) c_errhandler);
-    /* The C++ code throws an exception if the error handler
-     * returns something other than MPI_SUCCESS. There is no "return"
-     * of an error code. This code mirrors that in errutil.c */
-    *errorcode = MPI_SUCCESS;
-#endif
-    return *errorcode;
 }
 
 int MPIR_Errhandler_free_impl(MPIR_Errhandler * errhan_ptr)

--- a/src/mpi/romio/mpi-io/open.c
+++ b/src/mpi/romio/mpi-io/open.c
@@ -27,6 +27,13 @@ int MPI_File_open(MPI_Comm comm, const char *filename, int amode, MPI_Info info,
 /* for user-definde reduce operator */
 #include "adio_extern.h"
 
+/* */
+#if !defined(HAVE_WEAK_SYMBOLS) && !defined(MPIO_BUILD_PROFILING)
+void *dummy_refs_MPI_File_open[] = {
+    (void *) ADIO_ImmediateOpen,
+    (void *) MPIU_datatype_full_size,
+};
+#endif
 
 extern int ADIO_Init_keyval;
 

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1280,6 +1280,48 @@ if test "$enable_fc" = yes ; then
     AC_LANG_POP([Fortran])
 fi
 
+# The f77/profile tests will failed to link if we are doing static linking and using
+# libmpi+libpmpi. The compiler will complain of multiple definition of the profiled
+# profiled routines. It still can be built if we pass the -Wl,--allow-multiple-definition
+# flag. For simplicity, we disable the test for this case.
+#
+f77profile=
+AC_SUBST(f77profile)
+if test "$f77dir" = "f77" ; then
+    AC_MSG_CHECKING([that f77/profile tests can be built])
+    AC_LANG_PUSH([Fortran])
+    AC_LINK_IFELSE([
+        AC_LANG_SOURCE([
+            program main
+            integer ierr
+            integer msg(1)
+            call mpi_init(ierr)
+            call mpi_send(msg, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, ierr)
+            call mpi_finalize(ierr)
+            end
+
+            subroutine mpi_send(msg, count, dtype, dest, tag, comm, ierr)
+            include "mpif.h"
+            integer count, dtype, dest, tag, comm, ierr
+            integer msg(count)
+            call pmpi_send(msg, count, dtype, dest, tag, comm, ierr)
+            return
+            end
+        ])
+    ],[
+        AC_MSG_RESULT(yes)
+        f77profile="profile"
+    ],[
+        AC_MSG_RESULT(no)
+    ])
+    AC_LANG_POP([Fortran])
+fi
+
+# The f90/profile tests uses the mechanism of e.g. "use mpi, skip_mpi_send => mpi_send".
+# If mpi.mod doesn't contain the routine interface, for example, when ignore TKR isn't
+# available, it need use the f77 mechanism of direct linking. For simplicity, here we
+# disable the profile test if that's the case.
+#
 f90profile=
 AC_SUBST(f90profile)
 if test "$f90dir" = "f90" ; then

--- a/test/mpi/f77/Makefile.am
+++ b/test/mpi/f77/Makefile.am
@@ -7,6 +7,6 @@ include $(top_srcdir)/Makefile_f77.mtest
 
 EXTRA_DIST = testlist.in
 
-static_subdirs = attr datatype coll pt2pt info init comm topo ext profile
+static_subdirs = attr datatype coll pt2pt info init comm topo ext @f77profile@
 SUBDIRS = $(static_subdirs) $(spawndir) $(iodir) $(rmadir)
 DIST_SUBDIRS = $(static_subdirs) spawn io rma

--- a/test/mpi/f77/testlist.in
+++ b/test/mpi/f77/testlist.in
@@ -10,4 +10,4 @@ init
 comm
 ext
 topo
-profile
+@f77profile@


### PR DESCRIPTION
## Pull Request Description
A few routines, `MPIR_ROMIO_Get_file_errhand`, `MPIR_ROMIO_Set_file_errhand`, and `MPIR_Comm_split_filesystem` are defined in `libromio.la`, part of `libmpi.la`, but referenced from `libpmpi.la`. This causes an issue when static linking + no weak symbols + ROMIO enabled.

Work-around this issue by adding references in files where we define `MPI_Init`, `MPI_Initthread`, and `MPI_Get_library_version`, which should be referenced for any application that uses MPI, thus forcing the inclusion of those ROMIO routines at the `libmpi.a` scanning stage.


## TODO
A root fix needs to rewrite how ROMIO profiling mechanism, to use the same mechanism as MPICH.
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
