### PR TITLE
Fix crashes while performing RMA operations with the CXI provider

### DIFF
--- a/src/mpid/ch4/netmod/ofi/errnames.txt
+++ b/src/mpid/ch4/netmod/ofi/errnames.txt
@@ -107,3 +107,4 @@
 **ofi_max_conn %d:OFI dynamic process reaches maximum connection (%d)
 **ofi_num_nics:OFI has a different number of nics available on different notes
 **ofi_num_nics %d %d:OFI has a different number of nics available on different notes (%d on this node and %d elsewhere)
+**ofid_mr_key:OFI MR key invalid

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -267,6 +267,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
     if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
         lmt_info->rma_key =
             MPIDI_OFI_mr_key_alloc(MPIDI_OFI_LOCAL_MR_KEY, MPIDI_OFI_INVALID_MR_KEY);
+        MPIR_ERR_CHKANDJUMP(lmt_info->rma_key == MPIDI_OFI_INVALID_MR_KEY, mpi_errno,
+                            MPI_ERR_OTHER, "**ofid_mr_key");
     } else {
         lmt_info->rma_key = 0;
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -289,10 +289,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_mr_bind(struct fi_info *prov, struct fid_
     if (prov->domain_attr->mr_mode == FI_MR_ENDPOINT) {
         /* Bind the memory region to the endpoint */
         MPIDI_OFI_CALL(fi_mr_bind(mr, &ep->fid, 0ULL), mr_bind);
-        /* Bind the memory region to the counter */
-        if (cntr != NULL) {
-            MPIDI_OFI_CALL(fi_mr_bind(mr, &cntr->fid, 0ULL), mr_bind);
-        }
         MPIDI_OFI_CALL(fi_mr_enable(mr), mr_enable);
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -306,6 +306,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
             for (int i = 0; i < num_nics; i++) {
                 rma_keys[i] =
                     MPIDI_OFI_mr_key_alloc(MPIDI_OFI_LOCAL_MR_KEY, MPIDI_OFI_INVALID_MR_KEY);
+                MPIR_ERR_CHKANDJUMP(rma_keys[i] == MPIDI_OFI_INVALID_MR_KEY, mpi_errno,
+                                    MPI_ERR_OTHER, "**ofid_mr_key");
             }
         } else {
             /* zero them to avoid warnings */

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -7,8 +7,6 @@
 #include "ofi_impl.h"
 #include "ofi_events.h"
 
-#define MPIDI_OFI_MR_KEY_PREFIX_SHIFT 63
-
 int MPIDI_OFI_retry_progress(void)
 {
     /* We do not call progress on hooks form netmod level
@@ -62,11 +60,15 @@ int MPIDI_OFI_mr_key_allocator_init(void)
  * pass a collectively unique key as requested_key and mr key allocator will mark
  * coll bit of the key and return to user.
  * we use highest bit of key to distinguish coll (user-specific key) and local
- * (auto-generated) 64-bits key; since the highest bit is reserved for key type,
- * a valid key has maximal 63 bits. */
+ * (auto-generated) (max_mr_key_size * 8) bit key; since the highest bit is reserved
+ * for key type, a valid key has maximal (max_mr_key_size * 8 - 1) bits. For example,
+ * when the max_mr_key_size is 8 bytes, a valid key has 63 bits. */
 uint64_t MPIDI_OFI_mr_key_alloc(int key_type, uint64_t requested_key)
 {
     uint64_t ret_key = MPIDI_OFI_INVALID_MR_KEY;
+
+    // Shift key by number of bits - 1
+    uint64_t key_mask = 1ULL << (MPIDI_OFI_global.max_mr_key_size * 8 - 1);
 
     switch (key_type) {
         case MPIDI_OFI_LOCAL_MR_KEY:
@@ -87,7 +89,8 @@ uint64_t MPIDI_OFI_mr_key_alloc(int key_type, uint64_t requested_key)
                         mr_key_allocator.last_free_mr_key = i;
                         ret_key = i * sizeof(uint64_t) * 8 + (nval - 1);
                         /* assert local key does not exceed its range */
-                        MPIR_Assert((ret_key & (1ULL << MPIDI_OFI_MR_KEY_PREFIX_SHIFT)) == 0);
+                        if ((ret_key & key_mask) != 0)
+                            return MPIDI_OFI_INVALID_MR_KEY;
                         break;
                     }
                     if (i == mr_key_allocator.num_ints - 1) {
@@ -108,7 +111,7 @@ uint64_t MPIDI_OFI_mr_key_alloc(int key_type, uint64_t requested_key)
         case MPIDI_OFI_COLL_MR_KEY:
             {
                 MPIR_Assert(requested_key != MPIDI_OFI_INVALID_MR_KEY);
-                ret_key = requested_key | (1ULL << MPIDI_OFI_MR_KEY_PREFIX_SHIFT);
+                ret_key = requested_key | key_mask;
                 break;
             }
 


### PR DESCRIPTION
## Pull Request Description
This PR fixes the crashes seen with all RMA tests on the CXI provider . With these fixes, most RMA + CXI tests are passing, I'm still investigating the remaining failures. 

There two RMA + CXI bugs fixed in this PR are: 

1. The fi_mr_bind call which bound the local counter to the memory region was causing a failure because of incorrectly using the API. fi_mr_bind is only required for remote counters and is only supported for FI_REMOTE_WRITE as per the API (https://manpages.debian.org/testing/libfabric-dev/fi_mr_bind.3.en.html). Since our rma counter is a local counter FI_READ | FI_WRITE, there is no need to bind it. The fix here was to remote that call altogether.


2. CXI only supported a mr key of 2 bytes, whereas the libfabric api used an 8 byte key. For that reason, our requested key passed into fi_mr_key was overflowing and that was causing assertion failures/hangs when running RMA tests. The fix here was to pass a valid requested key by prefixing it only by (mr key size in bits - 1) bits. 


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
