### PR TITLE
test: lower the test size for pt2pt/sendrecv1

### DIFF
--- a/test/mpi/maint/dtp-test-config.txt
+++ b/test/mpi/maint/dtp-test-config.txt
@@ -25,7 +25,8 @@ cxx/attr/fkeyvaltypex::1::1:1024::0
 cxx/datatype/packsizex::1::1:1024::0
 pt2pt/pingping::1 512 262144 17 1018 65530::2:8:32:0
 pt2pt/pingping_barrier::1::2:8:32:0
-pt2pt/sendrecv1::1 512 262144 17 1018 65530::2:32:1024:0
+pt2pt/sendrecv1::1 512 17 1018 65530::2:32:1024:0
+pt2pt/sendrecv1::262144::2:20::0
 pt2pt/sendself::1 512 262144 17 1018 65530::1:32:1024:0
 part/pingping::1 512 262144 17 1018 65530::2:8:32:0
 rma/accfence1::1 512 17 1018::4:16:1024:0


### PR DESCRIPTION
## Pull Request Description
We effectively double the test size for pt2pt/sendrecv1 in PR#6015 and
now the test start to time out on Solaris when count is 262144. Lower
the testsize for this test to avoid timeout. Solaris+solstudio seems run
particularly slow for the dtp tests.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
