### PR TITLE
ch4/ofi: free mr key before MPIDI_OFI_mr_key_free

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -97,15 +97,12 @@ static int send_huge_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request 
         huge_send_mrs = MPIDI_OFI_REQUEST(sreq, huge.send_mrs);
 
         /* Clean up the memory region */
-        if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
-            for (int i = 0; i < num_nics; i++) {
-                uint64_t key = fi_mr_key(huge_send_mrs[i]);
+        for (int i = 0; i < num_nics; i++) {
+            uint64_t key = fi_mr_key(huge_send_mrs[i]);
+            MPIDI_OFI_CALL(fi_close(&huge_send_mrs[i]->fid), mr_unreg);
+            if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
                 MPIDI_OFI_mr_key_free(MPIDI_OFI_LOCAL_MR_KEY, key);
             }
-        }
-
-        for (int i = 0; i < num_nics; i++) {
-            MPIDI_OFI_CALL(fi_close(&huge_send_mrs[i]->fid), mr_unreg);
         }
         MPL_free(huge_send_mrs);
 


### PR DESCRIPTION
## Pull Request Description
In the send huge path, we need unregister the mr key first before we
call MPIDI_OFI_mr_key_free. Otherwise, another thread may snatch the key
before libfabric frees it, resulting in key not available error.

This affects when we are not using MPIDI_OFI_VNI_USE_DOMAIN, in particular, with `psm3`.

## reference
`multivci-ofi-sepctx - ./threads/pt2pt/mt_probe_sendrecv_huge 2 -iter=64 -count=4096 MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=1638`
```
not ok 2637 - ./threads/pt2pt/mt_probe_sendrecv_huge 2
  ---
  Directory: ./threads/pt2pt
  File: mt_probe_sendrecv_huge
  Num-procs: 2
  Timeout: 180
  Date: "Sat May 21 09:21:26 2022"
  ...
## Test output (expected 'No Errors'):
## Abort(269110799) on node 0 (rank 0 in comm 0): Fatal error in internal_Send: Other MPI error, error stack:
## internal_Send(120)........: MPI_Send(buf=0x29a53c0, count=4096, MPI_INT, 1, 0, comm=0x84000003) failed
## MPID_Isend(74)............: 
## MPIDI_isend(45)...........: 
## MPIDI_OFI_send_normal(325): OFI memory registration failed (ofi_send.h:325:MPIDI_OFI_send_normal:Required key not available)
## 
## mt_probe_sendrecv_huge:351646 terminated with signal 11 at PC=7f68139776f3 SP=7ffd6cbef6f0.  Backtrace:
    
```

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
