### PR TITLE
xfail: pt2pt/rqfreeb for ch4:ofi and config=debug

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -73,6 +73,9 @@
 # freebsd failures
 * * debug ch3:tcp freebsd64     /^comm_create_group_threads/     xfail=issue4372        threads/comm/testlist
 
+# currently there is no mechanism in ofi to wait for pending freed request objects
+* * debug ch4:ofi *     /^rqfreeb/        xfail=issue3469        pt2pt/testlist
+
 # timeout due to lack of passive progress
 * * vci ch4:ofi *       /^rma_contig.*iter=10000/        xfail=issue5565        rma/testlist
 


### PR DESCRIPTION
## Pull Request Description
I believe this has always been an issue for ch4:ofi since there is no mechanism to make sure pending freed requests to complete at finalize.

I am marking this as xfail since it is very low priority to fix it. When user use `MPI_Request_free` and all the way reach `MPI_Finalize`, very likely the user does not care about completing the underlying communication. Or they should just `MPI_Wait` for the requests. So, xfail until there are support request.

Reference https://github.com/pmodels/mpich/issues/3469#issuecomment-1136256569

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
