### PR TITLE
ch4: call MPIDI_Self_cancel early

### DIFF
--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -63,26 +63,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_unsafe(MPIR_Request * rreq)
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    if (rreq->comm && MPIDI_is_self_comm(rreq->comm)) {
-        mpi_errno = MPIDI_Self_cancel(rreq);
-    } else {
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno = MPIDI_NM_mpi_cancel_recv(rreq);
+    mpi_errno = MPIDI_NM_mpi_cancel_recv(rreq);
 #else
-        if (MPIDI_REQUEST(rreq, is_local)) {
-            MPIR_Request *partner_rreq = MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq);
-            if (unlikely(partner_rreq)) {
-                /* Canceling MPI_ANY_SOURCE receive -- first cancel NM recv, then SHM */
-                mpi_errno = MPIDI_NM_mpi_cancel_recv(partner_rreq);
-                MPIR_ERR_CHECK(mpi_errno);
-                MPIDI_CH4_REQUEST_FREE(partner_rreq);
-            }
-            mpi_errno = MPIDI_SHM_mpi_cancel_recv(rreq);
-        } else {
-            mpi_errno = MPIDI_NM_mpi_cancel_recv(rreq);
+    if (MPIDI_REQUEST(rreq, is_local)) {
+        MPIR_Request *partner_rreq = MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq);
+        if (unlikely(partner_rreq)) {
+            /* Canceling MPI_ANY_SOURCE receive -- first cancel NM recv, then SHM */
+            mpi_errno = MPIDI_NM_mpi_cancel_recv(partner_rreq);
+            MPIR_ERR_CHECK(mpi_errno);
+            MPIDI_CH4_REQUEST_FREE(partner_rreq);
         }
-#endif
+        mpi_errno = MPIDI_SHM_mpi_cancel_recv(rreq);
+    } else {
+        mpi_errno = MPIDI_NM_mpi_cancel_recv(rreq);
     }
+#endif
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -326,7 +322,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Cancel_recv(MPIR_Request * rreq)
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIDI_cancel_recv_safe(rreq);
+    if (rreq->comm && MPIDI_is_self_comm(rreq->comm)) {
+        mpi_errno = MPIDI_Self_cancel(rreq);
+    } else {
+        mpi_errno = MPIDI_cancel_recv_safe(rreq);
+    }
 
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:


### PR DESCRIPTION
## Pull Request Description
MPIDI_Self_cancel will apply its own crtical section, thus we need call
it before entering vci lock.

Fixes follow failure with `per-vci + async` configuration:
```
not ok 2385 - ./f77/ext/c2f2cf 1
  ---
  Directory: ./f77/ext
  File: c2f2cf
  Num-procs: 1
  Timeout: 180
  Date: "Wed May 25 03:09:05 2022"
  ...
## Test output (expected 'No Errors'):
## Assertion failed in file ./src/include/mpir_request.h at line 514: 0
## /var/lib/jenkins-slave/workspace/mpich-main-async/compiler/gnu/jenkins_configure/async/label/centos64/netmod/ch4-ofi-vci/mpich-main/_inst/lib/libmpi.so.0(+0x580f73) [0x7f1330042f73]
## /var/lib/jenkins-slave/workspace/mpich-main-async/compiler/gnu/jenkins_configure/async/label/centos64/netmod/ch4-ofi-vci/mpich-main/_inst/lib/libmpi.so.0(+0x4976a4) [0x7f132ff596a4]
## /var/lib/jenkins-slave/workspace/mpich-main-async/compiler/gnu/jenkins_configure/async/label/centos64/netmod/ch4-ofi-vci/mpich-main/_inst/lib/libmpi.so.0(+0x4e441a) [0x7f132ffa641a]
## /var/lib/jenkins-slave/workspace/mpich-main-async/compiler/gnu/jenkins_configure/async/label/centos64/netmod/ch4-ofi-vci/mpich-main/_inst/lib/libmpi.so.0(+0x46ad55) [0x7f132ff2cd55]
## /var/lib/jenkins-slave/workspace/mpich-main-async/compiler/gnu/jenkins_configure/async/label/centos64/netmod/ch4-ofi-vci/mpich-main/_inst/lib/libmpi.so.0(PMPI_Cancel+0x138) [0x7f132fce5fb8]
## /var/lib/jenkins-slave/workspace/mpich-main-async/compiler/gnu/jenkins_configure/async/label/centos64/netmod/ch4-ofi-vci/mpich-main/_inst/lib/libmpifort.so.0(pmpi_cancel+0x30) [0x7f13327a91f0]
## ./c2f2cf() [0x401b7f]
## ./c2f2cf() [0x40151d]
## /lib64/libc.so.6(__libc_start_main+0xf5) [0x7f132eca0505]
## ./c2f2cf() [0x40154d]
## Abort(1) on node 0: Internal error
```
It is a recursive lock entrance error. The reason the `async` triggers the failure is due to switching on the `MPI_THREAD_MULTIPLE`, which activates the critical sections.
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
