### PR TITLE
ch4: fix anysource receive

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -380,6 +380,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq, bool 
                         (MPL_DBG_FDEST, "Request not found. Assuming already cancelled"));
         goto fn_exit;
     } else if (ret < 0) {
+        /* Some provider, e.g. psm3, return -FI_EAGAIN when they should return -FI_ENOENT.
+         * work around until they fix it */
+        if (ret == -FI_EAGAIN) {
+            goto fn_exit;
+        }
         MPIR_ERR_CHKANDJUMP4(ret < 0, mpi_errno, MPI_ERR_OTHER, "**ofid_cancel",
                              "**ofid_cancel %s %d %s %s", __SHORT_FILE__, __LINE__, __func__,
                              fi_strerror(-ret));

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -15,20 +15,24 @@ MPL_STATIC_INLINE_PREFIX int anysource_irecv(void *buf, MPI_Aint count, MPI_Data
                                              MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
-    int need_unlock = 0;
+
+    /* Need critical section to prevent shmmem progress in-between
+     * 1. Enter VCI lock and pre-allocate request for shm receive.
+     * 2. MPIDI_SHM_mpi_irecv with pre-allocated request
+     * 3. MPIDI_NM_mpi_irecv need use recursive locking in case it share the shm vci lock
+     */
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
+    int vsi;
+    MPIDI_POSIX_RECV_VSI(vsi);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
+
+    *request = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, vsi, 1);
+    MPIR_Assert(*request);
+#endif
 
     mpi_errno = MPIDI_SHM_mpi_irecv(buf, count, datatype, rank, tag, comm, attr, request);
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_Assert(*request);
-    /* 1. hold shm vci lock to prevent shm progress while we establish netmod request.
-     * 2. MPIDI_NM_mpi_irecv need use recursive locking in case it share the shm vci lock
-     */
-#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
-    int shm_vci = MPIDI_Request_get_vci(*request);
-#endif
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(shm_vci).lock);
-    need_unlock = 1;
     if (!MPIR_Request_is_complete(*request) && !MPIDIG_REQUEST_IN_PROGRESS(*request)) {
         MPIR_Request *nm_rreq = NULL;
         mpi_errno = MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, attr,
@@ -49,9 +53,9 @@ MPL_STATIC_INLINE_PREFIX int anysource_irecv(void *buf, MPI_Aint count, MPI_Data
         }
     }
   fn_exit:
-    if (need_unlock) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(shm_vci).lock);
-    }
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi).lock);
+#endif
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/src/mpidig_recv.h
+++ b/src/mpid/ch4/src/mpidig_recv.h
@@ -256,14 +256,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
         }
     }
 
-    if (*request != NULL) {
-        rreq = *request;
-        MPIDIG_request_init(rreq, MPIR_REQUEST_KIND__RECV);
-    } else {
+    if (*request == NULL) {
         rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2, vci, -1);
         MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         rreq->comm = comm;
         MPIR_Comm_add_ref(comm);
+    } else {
+        rreq = *request;
+        MPIDIG_request_init(rreq, vci, -1);
+        if (!rreq->comm) {
+            rreq->comm = comm;
+            MPIR_Comm_add_ref(comm);
+        }
     }
 
     *request = rreq;

--- a/src/mpid/ch4/src/mpidig_recv.h
+++ b/src/mpid/ch4/src/mpidig_recv.h
@@ -192,7 +192,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexp_mrecv(MPIR_Request * rreq)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                              int rank, int tag, MPIR_Comm * comm,
                                              int context_offset, int vci, MPIR_Request ** request,
-                                             int alloc_req, uint64_t flags)
+                                             uint64_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL, *unexp_req = NULL;
@@ -259,14 +259,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
     if (*request != NULL) {
         rreq = *request;
         MPIDIG_request_init(rreq, MPIR_REQUEST_KIND__RECV);
-    } else if (alloc_req) {
+    } else {
         rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2, vci, -1);
         MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         rreq->comm = comm;
         MPIR_Comm_add_ref(comm);
-    } else {
-        rreq = *request;
-        MPIR_Assert(0);
     }
 
     *request = rreq;
@@ -336,7 +333,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irecv(void *buf,
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIDIG_do_irecv(buf, count, datatype, rank, tag, comm, context_offset, vci,
-                                request, 1, 0ULL);
+                                request, 0ULL);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIDI_REQUEST_SET_LOCAL(*request, is_local, partner);

--- a/src/mpid/ch4/src/mpidig_request.h
+++ b/src/mpid/ch4/src/mpidig_request.h
@@ -9,17 +9,11 @@
 #include "ch4_types.h"
 #include "mpidu_genq.h"
 
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_request_create(MPIR_Request_kind_t kind,
-                                                             int ref_count,
-                                                             int local_vci, int remote_vci)
+MPL_STATIC_INLINE_PREFIX int MPIDIG_request_init_internal(MPIR_Request * req,
+                                                          int local_vci, int remote_vci)
 {
-    MPIR_Request *req;
-
+    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
-
-    MPIDI_CH4_REQUEST_CREATE(req, kind, local_vci, ref_count);
-    if (req == NULL)
-        goto fn_fail;
 
     MPIDI_NM_am_request_init(req);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
@@ -36,6 +30,23 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_request_create(MPIR_Request_kind_t
     MPIDIG_REQUEST(req, req->recv_async).data_copy_cb = NULL;
     MPIDIG_REQUEST(req, req->recv_async).recv_type = MPIDIG_RECV_NONE;
 
+    return mpi_errno;
+}
+
+MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_request_create(MPIR_Request_kind_t kind,
+                                                             int ref_count,
+                                                             int local_vci, int remote_vci)
+{
+    MPIR_Request *req;
+
+    MPIR_FUNC_ENTER;
+
+    MPIDI_CH4_REQUEST_CREATE(req, kind, local_vci, ref_count);
+    if (req == NULL)
+        goto fn_fail;
+
+    MPIDIG_request_init_internal(req, local_vci, remote_vci);
+
   fn_exit:
     MPIR_FUNC_EXIT;
     return req;
@@ -43,31 +54,19 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_request_create(MPIR_Request_kind_t
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_request_init(MPIR_Request * req,
-                                                           MPIR_Request_kind_t kind)
+MPL_STATIC_INLINE_PREFIX int MPIDIG_request_init(MPIR_Request * req, int local_vci, int remote_vci)
 {
+    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
     MPIR_Assert(req != NULL);
     /* Increment the refcount by one to account for the MPIDIG layer */
     MPIR_Request_add_ref(req);
 
-    MPIDI_NM_am_request_init(req);
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    MPIDI_SHM_am_request_init(req);
-#endif
-
-    MPL_COMPILE_TIME_ASSERT(sizeof(MPIDIG_req_ext_t) <= MPIDIU_REQUEST_POOL_CELL_SIZE);
-    int vci = MPIDI_Request_get_vci(req);
-    MPIDU_genq_private_pool_alloc_cell(MPIDI_global.per_vci[vci].request_pool,
-                                       (void **) &MPIDIG_REQUEST(req, req));
-    MPIR_Assert(MPIDIG_REQUEST(req, req));
-    MPIDIG_REQUEST(req, req->status) = 0;
-    MPIDIG_REQUEST(req, req->recv_async).data_copy_cb = NULL;
-    MPIDIG_REQUEST(req, req->recv_async).recv_type = MPIDIG_RECV_NONE;
+    mpi_errno = MPIDIG_request_init_internal(req, local_vci, remote_vci);
 
     MPIR_FUNC_EXIT;
-    return req;
+    return mpi_errno;
 }
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD


### PR DESCRIPTION
## Pull Request Description
The current code has a gap between posting a anysource SHM receive and its partner NM receive, allows a progress thread to complete the SHM receive before the partner request is set. It causes issue when SHM progress tries to cancel a non-existent netmod partner request.

We fix this by entering SHM vci critical section at ch4-layer and passing down to posix a pre-allocated request.

This fixes the following test failure (ch4:ofi + async + vci):
```
not ok 2258 - ./topo/distgraph1 4
  ---
  Directory: ./topo
  File: distgraph1
  Num-procs: 4
  Timeout: 180
  Date: "Wed May 25 05:12:03 2022"
  ...
## Test output (expected 'No Errors'):
## [mpiexec@pmrs-centos64-240-03.cels.anl.gov] APPLICATION TIMED OUT, TIMEOUT = 
```
`MPIR_Dist_graph_create_impl` internally uses anysource receives to exchange node edges.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
