### PR TITLE
errhan: fix MPIR_ERRHANDLER_N_BUILTIN

### DIFF
--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -422,12 +422,12 @@ typedef MPI_Session_errhandler_function MPI_Session_errhandler_fn;
    in 22-25), index in the low bits */
 #define MPI_ERRORS_ARE_FATAL ((MPI_Errhandler)0x54000000)
 #define MPI_ERRORS_RETURN    ((MPI_Errhandler)0x54000001)
-#define MPI_ERRORS_ABORT     ((MPI_Errhandler)0x54000003)
 /* MPIR_ERRORS_THROW_EXCEPTIONS is not part of the MPI standard, it is here to
    facilitate the c++ binding which has MPI::ERRORS_THROW_EXCEPTIONS. 
    Using the MPIR prefix preserved the MPI_ names for objects defined by
    the standard. */
 #define MPIR_ERRORS_THROW_EXCEPTIONS ((MPI_Errhandler)0x54000002)
+#define MPI_ERRORS_ABORT     ((MPI_Errhandler)0x54000003)
 typedef int MPI_Errhandler;
 
 /* Make the C names for the dup function mixed case.

--- a/src/include/mpir_errhandler.h
+++ b/src/include/mpir_errhandler.h
@@ -66,7 +66,7 @@ typedef struct MPIR_Errhandler {
 } MPIR_Errhandler;
 extern MPIR_Object_alloc_t MPIR_Errhandler_mem;
 /* Preallocated errhandler objects */
-#define MPIR_ERRHANDLER_N_BUILTIN 3
+#define MPIR_ERRHANDLER_N_BUILTIN 4
 extern MPIR_Errhandler MPIR_Errhandler_builtin[];
 extern MPIR_Errhandler MPIR_Errhandler_direct[];
 

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -153,6 +153,7 @@ void MPIR_Err_init(void)
     MPIR_Errhandler_builtin[0].handle = MPI_ERRORS_ARE_FATAL;
     MPIR_Errhandler_builtin[1].handle = MPI_ERRORS_RETURN;
     MPIR_Errhandler_builtin[2].handle = MPIR_ERRORS_THROW_EXCEPTIONS;
+    MPIR_Errhandler_builtin[3].handle = MPI_ERRORS_ABORT;
 
 #if MPICH_ERROR_MSG_LEVEL >= MPICH_ERROR_MSG__ALL
     MPIR_Err_stack_init();


### PR DESCRIPTION
## Pull Request Description
When we added MPI_ERRORS_ABORT, we forgot to raise
MPIR_ERRHANDLER_N_BUILTIN, resulting in errorchecking failures.

This patch also rearranges the lines in mpi.h that defines
MPI_ERRORS_ constants to make the bit space more obvious.

Fixes #6028
## Work-In-Progress
* [x] Fix the semantics of `MPI_ERRORS_ABORT`
       - what's missing is to handle `MPI_Comm_call_errhandler` for the `MPI_ERRORS_ABORT` case. `MPIR_Err_return_comm` and `MPIR_Handle_fatal_error` and `MPID_Abort` already handles on the per-communicator basis.
* [ ] Add tests

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
