### PR TITLE
finalize: allow non-collective finalizing

### DIFF
--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -45,6 +45,19 @@ cvars:
         in order to allow the process to continue (e.g., in gdb, "set
         hold=0").
 
+    - name        : MPIR_CVAR_NO_COLLECTIVE_FINALIZE
+      category    : COLLECTIVE
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If true, prevent MPI_Finalize to invoke collective behavior such as
+        barrier or communicating to other processes. Consequently, it may result
+        in leaking memory or losing messages due to pre-mature exiting. The
+        default is false, which may invoke collective behaviors at finalize.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -409,6 +409,8 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
 
     mpi_errno = MPIDI_CH3_SHM_Init();
     MPIR_ERR_CHECK(mpi_errno);
+    mpi_errno = MPIDU_Init_shm_barrier();
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifdef PAPI_MONITOR
     my_papi_start( pg_rank );

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -822,6 +822,7 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     } else if (MPIR_CVAR_NO_COLLECTIVE_FINALIZE) {
         /* skip collective work arounds */
     } else if (strcmp("verbs;ofi_rxm", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0
+               || strcmp("psm2", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0
                || strcmp("psm3", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0) {
         /* verbs;ofi_rxm provider need barrier to prevent message loss */
         mpi_errno = MPIR_pmi_barrier();

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -819,6 +819,8 @@ int MPIDI_OFI_mpi_finalize_hook(void)
             mpi_errno = flush_send_queue();
             MPIR_ERR_CHECK(mpi_errno);
         }
+    } else if (MPIR_CVAR_NO_COLLECTIVE_FINALIZE) {
+        /* skip collective work arounds */
     } else if (strcmp("verbs;ofi_rxm", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0
                || strcmp("psm3", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0) {
         /* verbs;ofi_rxm provider need barrier to prevent message loss */

--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -223,9 +223,6 @@ int MPIDU_Init_shm_finalize(void)
         goto fn_exit;
     }
 
-    mpi_errno = Init_shm_barrier();
-    MPIR_ERR_CHECK(mpi_errno);
-
     if (local_size == 1)
         MPL_free(memory.base_addr);
     else {

--- a/test/mpi/errors/comm/testlist
+++ b/test/mpi/errors/comm/testlist
@@ -15,6 +15,6 @@ comm_size_nullarg 1
 comm_split_nullarg 1
 comm_split_type_nullarg 1
 intercomm_create_nullarg 1
-subcomm_abort 4 mpiexecarg=-disable-auto-cleanup strict=false resultTest=TestStatus
-subcomm_abort2 6 mpiexecarg=-disable-auto-cleanup strict=false resultTest=TestStatus
+subcomm_abort 4 mpiexecarg=-disable-auto-cleanup env=MPIR_CVAR_NO_COLLECTIVE_FINALIZE strict=false resultTest=TestStatus
+subcomm_abort2 6 mpiexecarg=-disable-auto-cleanup env=MPIR_CVAR_NO_COLLECTIVE_FINALIZE strict=false resultTest=TestStatus
 intercomm_abort 6 mpiexecarg=-disable-auto-cleanup strict=false resultTest=TestStatus


### PR DESCRIPTION

## Pull Request Description
While posing a barrier at finalize is convenient, it is not always desirable or will work. Some process may need exit early or even call MPI_Abort without MPI_Finalize. Only some applications may need cater to this behavior but it is a sufficient reason for us to at least provide a mechanism allow non-collective finalizing.

## Work in progress
* [x] Init_shm_barrier in MPIDU_Init_shm_finalize
* [x] add MPIR_CVAR_NO_COLLECTIVE_FINALIZE
* [x] Avoid barriers in ofi_finalzie
* [x] Add `psm2` to the list of providers that require `MPIR_pmi_barrier` at finalize
       Fixes #5553
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
