### PR TITLE
hydra: fix valgrind warning by freeing string test_loc

### DIFF
--- a/src/pm/hydra/lib/utils/args.c
+++ b/src/pm/hydra/lib/utils/args.c
@@ -28,7 +28,7 @@ static HYD_status get_abs_wd(const char *wd, char **abs_wd)
     }
 
     if (wd[0] != '.') {
-        *abs_wd = (char *) wd;
+        *abs_wd = MPL_strdup(wd);
         goto fn_exit;
     }
 
@@ -91,15 +91,18 @@ HYD_status HYDU_find_in_path(const char *execname, char **path)
                 HYDU_ERR_POP(status, "unable to join strings\n");
                 HYDU_free_strlist(tmp);
 
+                MPL_free(test_loc);
                 goto fn_exit;   /* We are done */
             }
 
             MPL_free(path_loc);
             path_loc = NULL;
 
+            MPL_free(test_loc);
             status = get_abs_wd(strtok(NULL, ";:"), &test_loc);
             HYDU_ERR_POP(status, "error getting absolute working dir\n");
         }
+        MPL_free(test_loc);
     }
 
     /* There is either no PATH environment or we could not find the


### PR DESCRIPTION
valgrind --leak-check=full --quiet Github/bin/mpiexec -n 1 ./a.out
==1712644== 20 bytes in 1 blocks are definitely lost in loss record 8 of 19
==1712644==    at 0x4C3708B: malloc (vg_replace_malloc.c:381)
==1712644==    by 0x548B4ED: strdup (strdup.c:42)
==1712644==    by 0x42195C: HYDU_getcwd (args.c:244)
==1712644==    by 0x42198E: get_abs_wd.part.1 (args.c:43)
==1712644==    by 0x421C39: get_abs_wd (args.c:52)
==1712644==    by 0x421C39: HYDU_find_in_path (args.c:100)
==1712644==    by 0x4223EB: HYDU_find_full_path (args.c:370)
==1712644==    by 0x431CBB: ssh_get_path (external_common_launch.c:21)
==1712644==    by 0x431CBB: HYDT_bscd_common_launch_procs (external_common_launch.c:112)
==1712644==    by 0x42745F: HYDT_bsci_launch_procs (bsci_launch.c:16)
==1712644==    by 0x419C13: HYD_pmci_launch_procs (pmiserv_pmci.c:97)
==1712644==    by 0x403BF9: main (mpiexec.c:320)

## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
