### PR TITLE
test: reduce LOOPS for threads/rma/multirma

### DIFF
--- a/test/mpi/threads/rma/multirma.c
+++ b/test/mpi/threads/rma/multirma.c
@@ -11,7 +11,7 @@
 
 #define COUNT 1
 #define NUM_THREADS 4
-#define LOOPS 100000
+#define LOOPS 50000
 
 MPI_Win win;
 int errs = 0, dummy;


### PR DESCRIPTION
## Pull Request Description
This test currently runs close to 3 min timeout on Solaris and often
fail during oversubscribed nightly tests. Lower LOOPS so the test is
more stable. The slow testing is due to thread contention and unfair
mutex. LOOPS=50000 is sufficient to reveal threading errors.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
