### PR TITLE
datatype: remove global cs in MPI_Type_get_envelope

### DIFF
--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -251,7 +251,7 @@ MPI_Type_get_contents:
 
 MPI_Type_get_envelope:
     .desc: get type envelope
-    .skip: ThreadSafe
+    .skip: global_cs
 
 MPI_Type_get_extent:
     .desc: Get the lower bound and extent for a Datatype


### PR DESCRIPTION

## Pull Request Description
It only retrieves the data that are set during datatype creation.

Fixes #6034 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
