### PR TITLE
ch4: fix unexp receiv with preallocated request

### DIFF
--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -26,7 +26,7 @@ MPL_STATIC_INLINE_PREFIX int anysource_irecv(void *buf, MPI_Aint count, MPI_Data
     MPIDI_POSIX_RECV_VSI(vsi);
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
 
-    *request = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, vsi, 1);
+    MPIDI_CH4_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__RECV, vsi, 1);
     MPIR_Assert(*request);
 #endif
 

--- a/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
@@ -140,7 +140,6 @@ static int recv_target_cmpl_cb(MPIR_Request * rreq)
          * that came from CH4 (e.g. MPIDI_recv_safe) */
         MPIR_Request *sigreq = MPIDIG_REQUEST(rreq, req->rreq.match_req);
         sigreq->status = rreq->status;
-        MPIR_Request_add_ref(sigreq);
         MPID_Request_complete(sigreq);
         /* Free the unexpected request on behalf of the user */
         MPIDI_CH4_REQUEST_FREE(rreq);

--- a/src/mpid/ch4/src/mpidig_recv.h
+++ b/src/mpid/ch4/src/mpidig_recv.h
@@ -199,6 +199,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
     MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
     MPIR_FUNC_ENTER;
 
+    if (*request) {
+        /* ch4-layer pass down a pre-allocated request, let's initialize the mpidig part */
+        MPIDIG_request_init(*request, vci, -1);
+        if (!(*request)->comm) {
+            (*request)->comm = comm;
+            MPIR_Comm_add_ref(comm);
+        }
+    }
+
     unexp_req =
         MPIDIG_rreq_dequeue(rank, tag, context_id, &MPIDI_global.per_vci[vci].unexp_list,
                             MPIDIG_PT2PT_UNEXP);
@@ -207,8 +216,28 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
         MPII_UNEXPQ_FORGET(unexp_req);
         unexp_req->comm = comm;
         MPIR_Comm_add_ref(comm);
+
+        bool has_request = (*request != NULL);
+        if (!has_request) {
+            /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating
+             * a request. Here we simply return `unexp_req` */
+            *request = unexp_req;
+            /* Mark `match_req` as NULL so that we know nothing else to complete when
+             * `unexp_req` finally completes. (See below) */
+            MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = NULL;
+        } else {
+            /* Enqueuing path: CH4 already allocated a request.
+             * Record the passed `*request` to `match_req` so that we can complete it
+             * later when `unexp_req` completes.
+             * See MPIDI_recv_target_cmpl_cb for actual completion handler. */
+            MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = *request;
+            MPIDIG_REQUEST(*request, req->remote_vci) = MPIDIG_REQUEST(unexp_req, req->remote_vci);
+        }
+        MPIDIG_REQUEST(unexp_req, req->status) |= MPIDIG_REQ_MATCHED;
+        MPIDIG_REQUEST(*request, req->status) |= MPIDIG_REQ_IN_PROGRESS;
+
         if (MPIDIG_REQUEST(unexp_req, req->status) & MPIDIG_REQ_BUSY) {
-            MPIDIG_REQUEST(unexp_req, req->status) |= MPIDIG_REQ_MATCHED;
+            /* Nothing to do here. MPIDIG_handle_unexpected etc. in mpidig_pt2pt_callbacks.c */
         } else if (MPIDIG_REQUEST(unexp_req, req->status) & MPIDIG_REQ_RTS) {
             /* the count for unexpected long message is the data size */
             MPI_Aint data_sz = MPIDIG_REQUEST(unexp_req, count);
@@ -217,81 +246,38 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
             MPIDIG_REQUEST(unexp_req, datatype) = datatype;
             MPIDIG_REQUEST(unexp_req, buffer) = buf;
             MPIDIG_REQUEST(unexp_req, count) = count;
-            if (*request == NULL) {
-                /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating
-                 * a request. Here we simply return `unexp_req` */
-                *request = unexp_req;
-                /* Mark `match_req` as NULL so that we know nothing else to complete when
-                 * `unexp_req` finally completes. (See below) */
-                MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = NULL;
-            } else {
-                /* Enqueuing path: CH4 already allocated a request.
-                 * Record the passed `*request` to `match_req` so that we can complete it
-                 * later when `unexp_req` completes.
-                 * See MPIDI_recv_target_cmpl_cb for actual completion handler. */
-                MPIDIG_request_init(*request, vci, -1);
-                if (!(*request)->comm) {
-                    (*request)->comm = comm;
-                    MPIR_Comm_add_ref(comm);
-                }
-                MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = *request;
-            }
             MPIDIG_REQUEST(unexp_req, req->status) &= ~MPIDIG_REQ_UNEXPECTED;
             /* MPIDIG_recv_type_init will call the callback to finish the rndv protocol */
             mpi_errno = MPIDIG_recv_type_init(data_sz, unexp_req);
-            goto fn_exit;
         } else {
             mpi_errno = MPIDIG_handle_unexpected(buf, count, datatype, unexp_req);
             MPIR_ERR_CHECK(mpi_errno);
-            if (*request == NULL) {
-                /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating
-                 * a request. Here we simply return `unexp_req`, which is already completed. */
-                *request = unexp_req;
-            } else {
-                /* Enqueuing path: CH4 already allocated request as `*request`.
-                 * Since the real operations has completed in `unexp_req`, here we
-                 * simply copy the status to `*request` and complete it. */
-                MPIDIG_request_init(*request, vci, -1);
-                if (!(*request)->comm) {
-                    (*request)->comm = comm;
-                    MPIR_Comm_add_ref(comm);
-                }
+
+            if (has_request) {
                 (*request)->status = unexp_req->status;
-                MPIR_Request_add_ref(*request);
                 MPID_Request_complete(*request);
                 /* Need to free here because we don't return this to user */
                 MPIDI_CH4_REQUEST_FREE(unexp_req);
             }
-            goto fn_exit;
         }
-    }
-
-    if (*request == NULL) {
-        rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2, vci, -1);
-        MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        rreq->comm = comm;
-        MPIR_Comm_add_ref(comm);
     } else {
-        rreq = *request;
-        MPIDIG_request_init(rreq, vci, -1);
-        if (!rreq->comm) {
+        if (*request == NULL) {
+            rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2, vci, -1);
+            MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
+                                "**nomemreq");
             rreq->comm = comm;
             MPIR_Comm_add_ref(comm);
+        } else {
+            rreq = *request;
         }
-    }
 
-    *request = rreq;
+        *request = rreq;
 
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    MPIDIG_prepare_recv_req(rank, tag, context_id, buf, count, datatype, rreq);
-
-    if (!unexp_req) {
+        MPIR_Datatype_add_ref_if_not_builtin(datatype);
+        MPIDIG_prepare_recv_req(rank, tag, context_id, buf, count, datatype, rreq);
         MPIDIG_enqueue_request(rreq, &MPIDI_global.per_vci[vci].posted_list, MPIDIG_PT2PT_POSTED);
-    } else {
-        MPIDIG_REQUEST(rreq, req->remote_vci) = MPIDIG_REQUEST(unexp_req, req->remote_vci);
-        MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = rreq;
-        MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_IN_PROGRESS;
     }
+
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/src/mpidig_recv.h
+++ b/src/mpid/ch4/src/mpidig_recv.h
@@ -229,6 +229,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
                  * Record the passed `*request` to `match_req` so that we can complete it
                  * later when `unexp_req` completes.
                  * See MPIDI_recv_target_cmpl_cb for actual completion handler. */
+                MPIDIG_request_init(*request, vci, -1);
+                if (!(*request)->comm) {
+                    (*request)->comm = comm;
+                    MPIR_Comm_add_ref(comm);
+                }
                 MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = *request;
             }
             MPIDIG_REQUEST(unexp_req, req->status) &= ~MPIDIG_REQ_UNEXPECTED;
@@ -246,6 +251,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
                 /* Enqueuing path: CH4 already allocated request as `*request`.
                  * Since the real operations has completed in `unexp_req`, here we
                  * simply copy the status to `*request` and complete it. */
+                MPIDIG_request_init(*request, vci, -1);
+                if (!(*request)->comm) {
+                    (*request)->comm = comm;
+                    MPIR_Comm_add_ref(comm);
+                }
                 (*request)->status = unexp_req->status;
                 MPIR_Request_add_ref(*request);
                 MPID_Request_complete(*request);


### PR DESCRIPTION
## Pull Request Description
The active message with unexpected receiv and pre-allocated request was
not working correctly. Refactor to make the branches cleaner and fix the
test failure in pt2pt/precv_anysrc.


## Background
PR https://github.com/pmodels/mpich/pull/6027 activates the paths where ch4-layer preallocates request and passing down to `MPIDIG_do_irecv`. This path was not tested before and was not clean. The PR triggers the test failure of
```
[shm]
./pt2pt/precv_anysrc 2
---> 
Segmentation fault
```


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
