### PR TITLE
make: remove mpi as SUBDIRS from test/Makefile.am

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -6,7 +6,7 @@
 ## FIXME: commented out temporarily, really just want "mpi" to be dealt with at
 ## distclean time for now
 ##SUBDIRS = mpi util basic commands .
-SUBDIRS = mpi commands .
+SUBDIRS = commands .
 
 # Test both the MPI routines and the MPICH command scripts
 testing: mpi/Makefile


### PR DESCRIPTION
## Pull Request Description
Having mpi as a SUBDIR in test/Makefile.am asks make to descend into
test/mpi when making targets such as distclean. This fails since test/mpi
is no longer configured during the main mpich configure and
test/mpi/Makefile may not exist.

Fixes #6038
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
