### PR TITLE
ch4: request cleanup

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -184,12 +184,6 @@ struct MPIR_Request {
      * 32 bytes and 32-bit integers */
     MPIR_cc_t cc;
 
-    /* completion notification counter: this must be decremented by
-     * the request completion routine, when the completion count hits
-     * zero.  this counter allows us to keep track of the completion
-     * of multiple requests in a single place. */
-    MPIR_cc_t *completion_notification;
-
     /* A comm is needed to find the proper error handler */
     MPIR_Comm *comm;
     /* Status is needed for wait/test/recv */
@@ -414,8 +408,6 @@ static inline MPIR_Request *MPIR_Request_create_from_pool(MPIR_Request_kind_t ki
     req->kind = kind;
     MPIR_cc_set(&req->cc, 1);
     req->cc_ptr = &req->cc;
-
-    req->completion_notification = NULL;
 
     req->status.MPI_ERROR = MPI_SUCCESS;
     MPIR_STATUS_SET_CANCEL_BIT(req->status, FALSE);

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -17,7 +17,6 @@ static void init_builtin_request(MPIR_Request * req, int handle, MPIR_Request_ki
     req->kind = kind;
     MPIR_cc_set(&req->cc, 0);
     req->cc_ptr = &req->cc;
-    req->completion_notification = NULL;
     req->status.MPI_ERROR = MPI_SUCCESS;
     MPIR_STATUS_SET_CANCEL_BIT(req->status, FALSE);
     req->comm = NULL;

--- a/src/mpid/ch3/src/ch3u_request.c
+++ b/src/mpid/ch3/src/ch3u_request.c
@@ -545,10 +545,6 @@ int MPID_Request_complete(MPIR_Request *req)
 
     MPIDI_CH3U_Request_decrement_cc(req, &incomplete);
     if (!incomplete) {
-        /* decrement completion_notification counter */
-        if (req->completion_notification)
-            MPIR_cc_dec(req->completion_notification);
-
 	MPIR_Request_free(req);
     }
 

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -16,7 +16,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_create_hook(MPIR_Request * req)
     req->dev.completion_notification = NULL;
     MPIDIG_REQUEST(req, req) = NULL;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    MPIDI_REQUEST_ANYSOURCE_PARTNER(req) = NULL;
+    req->dev.anysrc_partner = NULL;
 #endif
 
     MPIR_FUNC_EXIT;
@@ -31,11 +31,13 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_free_hook(MPIR_Request * req)
     int count = MPL_atomic_relaxed_load_int(&MPIDI_VCI(vci).progress_count);
     MPL_atomic_relaxed_store_int(&MPIDI_VCI(vci).progress_count, count + 1);
 
-    /* This is tricky. I think the only solution is to expose partner
-     * to the upper layer */
-    if (req->kind == MPIR_REQUEST_KIND__PREQUEST_RECV &&
-        NULL != MPIDI_REQUEST_ANYSOURCE_PARTNER(req))
-        MPIR_Request_free(MPIDI_REQUEST_ANYSOURCE_PARTNER(req));
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    /* FIXME: I don't think persistent request will ever need anysrc_partner. It is
+     * handled by its real_request. Add assertion for now. Remove once confirmed. */
+    MPIR_Assert(req->kind != MPIR_REQUEST_KIND__PREQUEST_RECV || req->dev.anysrc_partner == NULL);
+    if (req->kind == MPIR_REQUEST_KIND__PREQUEST_RECV && NULL != req->dev.anysrc_partner)
+        MPIR_Request_free(req->dev.anysrc_partner);
+#endif
 
     MPIR_FUNC_EXIT;
     return;

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -31,14 +31,6 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_free_hook(MPIR_Request * req)
     int count = MPL_atomic_relaxed_load_int(&MPIDI_VCI(vci).progress_count);
     MPL_atomic_relaxed_store_int(&MPIDI_VCI(vci).progress_count, count + 1);
 
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    /* FIXME: I don't think persistent request will ever need anysrc_partner. It is
-     * handled by its real_request. Add assertion for now. Remove once confirmed. */
-    MPIR_Assert(req->kind != MPIR_REQUEST_KIND__PREQUEST_RECV || req->dev.anysrc_partner == NULL);
-    if (req->kind == MPIR_REQUEST_KIND__PREQUEST_RECV && NULL != req->dev.anysrc_partner)
-        MPIR_Request_free(req->dev.anysrc_partner);
-#endif
-
     MPIR_FUNC_EXIT;
     return;
 }

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -13,6 +13,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_create_hook(MPIR_Request * req)
 {
     MPIR_FUNC_ENTER;
 
+    req->dev.completion_notification = NULL;
     MPIDIG_REQUEST(req, req) = NULL;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIDI_REQUEST_ANYSOURCE_PARTNER(req) = NULL;

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -14,7 +14,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_create_hook(MPIR_Request * req)
     MPIR_FUNC_ENTER;
 
     req->dev.completion_notification = NULL;
-    MPIDIG_REQUEST(req, req) = NULL;
+    req->dev.type = MPIDI_REQ_TYPE_NONE;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     req->dev.anysrc_partner = NULL;
 #endif

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -273,6 +273,12 @@ typedef struct {
 } MPIDI_self_request_t;
 
 typedef struct MPIDI_Devreq_t {
+    /* completion notification counter: this must be decremented by
+     * the request completion routine, when the completion count hits
+     * zero.  this counter allows us to keep track of the completion
+     * of multiple requests in a single place. */
+    MPIR_cc_t *completion_notification;
+
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     int is_local;
     /* Anysource handling. Netmod and shm specific requests are cross

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -284,7 +284,7 @@ typedef struct MPIDI_Devreq_t {
     /* Anysource handling. Netmod and shm specific requests are cross
      * referenced. This must be present all of the time to avoid lots of extra
      * ifdefs in the code. */
-    struct MPIR_Request *anysource_partner_request;
+    struct MPIR_Request *anysrc_partner;
 #endif
 
     union {
@@ -320,14 +320,12 @@ typedef struct MPIDI_Devreq_t {
 #define MPIDIG_REQUEST_IN_PROGRESS(r)   ((r)->dev.ch4.am.req->status & MPIDIG_REQ_IN_PROGRESS)
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-#define MPIDI_REQUEST_ANYSOURCE_PARTNER(req)  (((req)->dev).anysource_partner_request)
 #define MPIDI_REQUEST_SET_LOCAL(req, is_local_, partner_) \
     do { \
         (req)->dev.is_local = is_local_; \
-        (req)->dev.anysource_partner_request = partner_; \
+        (req)->dev.anysrc_partner = partner_; \
     } while (0)
 #else
-#define MPIDI_REQUEST_ANYSOURCE_PARTNER(req)  NULL
 #define MPIDI_REQUEST_SET_LOCAL(req, is_local_, partner_)  do { } while (0)
 #endif
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -272,6 +272,11 @@ typedef struct {
     MPIR_Request *match_req;    /* for mrecv */
 } MPIDI_self_request_t;
 
+typedef enum {
+    MPIDI_REQ_TYPE_NONE = 0,
+    MPIDI_REQ_TYPE_AM,
+} MPIDI_REQ_TYPE;
+
 typedef struct MPIDI_Devreq_t {
     /* completion notification counter: this must be decremented by
      * the request completion routine, when the completion count hits
@@ -287,6 +292,8 @@ typedef struct MPIDI_Devreq_t {
     struct MPIR_Request *anysrc_partner;
 #endif
 
+    /* initialized to MPIDI_REQ_TYPE_NONE, set when one of the union field is set */
+    MPIDI_REQ_TYPE type;
     union {
         /* The first fields are used by the MPIDIG apis */
         MPIDIG_req_t am;
@@ -309,6 +316,7 @@ typedef struct MPIDI_Devreq_t {
 #endif
     } ch4;
 } MPIDI_Devreq_t;
+
 #define MPIDI_REQUEST_HDR_SIZE              offsetof(struct MPIR_Request, dev.ch4.netmod)
 #define MPIDI_REQUEST(req,field)       (((req)->dev).field)
 #define MPIDIG_REQUEST(req,field)       (((req)->dev.ch4.am).field)

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -596,7 +596,7 @@ int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret)
                     MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(req, datatype));
                     MPIR_STATUS_SET_CANCEL_BIT(req->status, TRUE);
                     MPIR_STATUS_SET_COUNT(req->status, 0);
-                    MPIDIU_request_complete(req);
+                    MPIDI_Request_complete_fast(req);
                     break;
 
                 case FI_ENOMSG:

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -133,7 +133,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vni, struct fi_cq_tagged_e
                                             ss_bits), vni_local, tinjectdata, FALSE /* eagain */);
     }
 
-    MPIDIU_request_complete(rreq);
+    MPIDI_Request_complete_fast(rreq);
 
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -948,10 +948,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
   null_op_exit:
     mpi_errno = MPI_SUCCESS;
     if (sigreq) {
+        /* FIXME: shouldn't this be a lightweight completed request? */
         MPIDI_CH4_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0, 2);
         MPIR_ERR_CHKANDSTMT((*sigreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
                             "**nomemreq");
-        MPIDIU_request_complete(*sigreq);
+        MPIDI_Request_complete_fast(*sigreq);
     }
     goto fn_exit;
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -31,7 +31,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_recv_cmpl_cb(void *request, ucs_status_t
         MPIR_STATUS_SET_COUNT(rreq->status, count);
     }
 
-    MPIDIU_request_complete(rreq);
+    MPIDI_Request_complete_fast(rreq);
     ucp_request->req = NULL;
     ucp_request_release(ucp_request);
 
@@ -58,7 +58,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_mrecv_cmpl_cb(void *request, ucs_status_
     rreq->status.MPI_TAG = MPIDI_UCX_get_tag(info->sender_tag);
 
     /* complete the request */
-    MPIDIU_request_complete(rreq);
+    MPIDI_Request_complete_fast(rreq);
     ucp_request->req = NULL;
     ucp_request_release(ucp_request);
 

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -20,7 +20,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_send_cmpl_cb(void *request, ucs_status_t
 
     if (unlikely(status == UCS_ERR_CANCELED))
         MPIR_STATUS_SET_CANCEL_BIT(req->status, TRUE);
-    MPIDIU_request_complete(req);
+    MPIDI_Request_complete_fast(req);
     ucp_request->req = NULL;
     ucp_request_release(ucp_request);
 

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -99,20 +99,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Context_id_t MPIDIG_win_to_context(const MPIR_Win 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDIU_request_complete(MPIR_Request * req)
-{
-    int incomplete;
-
-    MPIR_FUNC_ENTER;
-
-    MPIR_cc_decr(req->cc_ptr, &incomplete);
-    if (!incomplete) {
-        MPIDI_CH4_REQUEST_FREE(req);
-    }
-
-    MPIR_FUNC_EXIT;
-}
-
 MPL_STATIC_INLINE_PREFIX MPIDIG_win_target_t *MPIDIG_win_target_add(MPIR_Win * win, int rank)
 {
     MPIR_FUNC_ENTER;

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -38,7 +38,7 @@ MPL_STATIC_INLINE_PREFIX int anysource_irecv(void *buf, MPI_Aint count, MPI_Data
         mpi_errno = MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, attr,
                                        av, &nm_rreq, *request);
         MPIR_ERR_CHECK(mpi_errno);
-        MPIDI_REQUEST_ANYSOURCE_PARTNER(*request) = nm_rreq;
+        (*request)->dev.anysrc_partner = nm_rreq;
 
         /* cancel the shm request if netmod/am handles the request from unexpected queue. */
         if (MPIR_Request_is_complete(nm_rreq)) {
@@ -71,7 +71,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_unsafe(MPIR_Request * rreq)
     mpi_errno = MPIDI_NM_mpi_cancel_recv(rreq, false);
 #else
     if (MPIDI_REQUEST(rreq, is_local)) {
-        MPIR_Request *partner_rreq = MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq);
+        MPIR_Request *partner_rreq = rreq->dev.anysrc_partner;
         if (unlikely(partner_rreq)) {
             /* Canceling MPI_ANY_SOURCE receive -- first cancel NM recv, then SHM */
             mpi_errno = MPIDI_NM_mpi_cancel_recv(partner_rreq, false);

--- a/src/mpid/ch4/src/ch4_request.h
+++ b/src/mpid/ch4/src/ch4_request.h
@@ -103,6 +103,15 @@ MPL_STATIC_INLINE_PREFIX int MPID_Request_complete(MPIR_Request * req)
     return MPI_SUCCESS;
 }
 
+MPL_STATIC_INLINE_PREFIX void MPIDI_Request_complete_fast(MPIR_Request * req)
+{
+    int incomplete;
+    MPIR_cc_decr(req->cc_ptr, &incomplete);
+    if (!incomplete) {
+        MPIDI_CH4_REQUEST_FREE(req);
+    }
+}
+
 MPL_STATIC_INLINE_PREFIX void MPID_Prequest_free_hook(MPIR_Request * req)
 {
     MPIR_FUNC_ENTER;

--- a/src/mpid/ch4/src/ch4_request.h
+++ b/src/mpid/ch4/src/ch4_request.h
@@ -85,7 +85,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Request_complete(MPIR_Request * req)
             MPIR_cc_dec(req->dev.completion_notification);
         }
 
-        if (MPIDIG_REQUEST(req, req)) {
+        if (req->dev.type == MPIDI_REQ_TYPE_AM) {
             /* FIXME: refactor mpidig code into ch4r_request.h */
             int vci = MPIDI_Request_get_vci(req);
             MPIDU_genq_private_pool_free_cell(MPIDI_global.per_vci[vci].request_pool,

--- a/src/mpid/ch4/src/ch4_request.h
+++ b/src/mpid/ch4/src/ch4_request.h
@@ -81,9 +81,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Request_complete(MPIR_Request * req)
     /* if we hit a zero completion count, free up AM-related
      * objects */
     if (!incomplete) {
-        /* decrement completion_notification counter */
-        if (req->completion_notification)
-            MPIR_cc_dec(req->completion_notification);
+        if (req->dev.completion_notification) {
+            MPIR_cc_dec(req->dev.completion_notification);
+        }
 
         if (MPIDIG_REQUEST(req, req)) {
             /* FIXME: refactor mpidig code into ch4r_request.h */

--- a/src/mpid/ch4/src/mpidig_part_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_part_callbacks.c
@@ -149,7 +149,7 @@ int MPIDIG_part_send_data_target_msg_cb(void *am_hdr, void *data,
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = part_send_data_target_cmpl_cb;
 
     /* Set part_rreq complete when am request completes but not decrease part_rreq refcnt */
-    rreq->completion_notification = &part_rreq->cc;
+    rreq->dev.completion_notification = &part_rreq->cc;
     /* Will update part_sreq status when the AM request completes.
      * TODO: can we get rid of the pointer? */
     MPIDIG_REQUEST(rreq, req->part_am_req.part_req_ptr) = part_rreq;

--- a/src/mpid/ch4/src/mpidig_part_utils.h
+++ b/src/mpid/ch4/src/mpidig_part_utils.h
@@ -48,7 +48,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_issue_data(MPIR_Request * part_sreq,
     am_hdr.rreq_ptr = MPIDIG_PART_REQUEST(part_sreq, peer_req_ptr);
 
     /* Complete partitioned req at am request completes */
-    sreq->completion_notification = &part_sreq->cc;
+    sreq->dev.completion_notification = &part_sreq->cc;
     /* Will update part_sreq status when the AM request completes
      * TODO: can we get rid of the pointer? */
     MPIDIG_REQUEST(sreq, req->part_am_req.part_req_ptr) = part_sreq;

--- a/src/mpid/ch4/src/mpidig_request.h
+++ b/src/mpid/ch4/src/mpidig_request.h
@@ -15,6 +15,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_request_init_internal(MPIR_Request * req,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
+    req->dev.type = MPIDI_REQ_TYPE_AM;
     MPIDI_NM_am_request_init(req);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIDI_SHM_am_request_init(req);

--- a/src/mpid/ch4/src/mpidig_request.h
+++ b/src/mpid/ch4/src/mpidig_request.h
@@ -88,7 +88,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_anysrc_try_cancel_partner(MPIR_Request * rreq
 
     *is_cancelled = 1;  /* overwrite if cancel fails */
 
-    MPIR_Request *anysrc_partner = MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq);
+    MPIR_Request *anysrc_partner = rreq->dev.anysrc_partner;
     if (unlikely(anysrc_partner)) {
         if (!MPIR_STATUS_GET_CANCEL_BIT(anysrc_partner->status)) {
             if (MPIDI_REQUEST(rreq, is_local)) {
@@ -116,8 +116,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_anysrc_try_cancel_partner(MPIR_Request * rreq
                     /* NM partner is not user-visible, free it now, which means
                      * explicit SHM code can skip MPIDI_anysrc_free_partner
                      */
-                    MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq) = NULL;
-                    MPIDI_REQUEST_ANYSOURCE_PARTNER(anysrc_partner) = NULL;
+                    rreq->dev.anysrc_partner = NULL;
+                    anysrc_partner->dev.anysrc_partner = NULL;
                     /* cancel freed it once, freed once more on behalf of mpi-layer */
                     MPIDI_CH4_REQUEST_FREE(anysrc_partner);
                 }
@@ -145,12 +145,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_anysrc_try_cancel_partner(MPIR_Request * rreq
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_anysrc_free_partner(MPIR_Request * rreq)
 {
-    MPIR_Request *anysrc_partner = MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq);
+    MPIR_Request *anysrc_partner = rreq->dev.anysrc_partner;
     if (unlikely(anysrc_partner)) {
         if (!MPIDI_REQUEST(rreq, is_local)) {
             /* NM, complete and free SHM partner */
-            MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq) = NULL;
-            MPIDI_REQUEST_ANYSOURCE_PARTNER(anysrc_partner) = NULL;
+            rreq->dev.anysrc_partner = NULL;
+            anysrc_partner->dev.anysrc_partner = NULL;
             /* copy status to SHM partner */
             anysrc_partner->status = rreq->status;
             MPID_Request_complete(anysrc_partner);

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -69,7 +69,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
 
     /* Increase local and remote completion counters and set the local completion
      * counter in request, thus it can be decreased at request completion. */
-    MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
+    MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->dev.completion_notification);
     MPIDIG_REQUEST(sreq, u.origin.target_rank) = target_rank;
 
     int is_contig;
@@ -218,7 +218,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
 
     /* Increase local and remote completion counters and set the local completion
      * counter in request, thus it can be decreased at request completion. */
-    MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
+    MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->dev.completion_notification);
 
     int is_contig;
     MPIR_Datatype_is_contig(target_datatype, &is_contig);
@@ -319,7 +319,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
 
     /* Increase local and remote completion counters and set the local completion
      * counter in request, thus it can be decreased at request completion. */
-    MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
+    MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->dev.completion_notification);
     /* Increase remote completion counter for acc. */
     MPIDIG_win_remote_acc_cmpl_cnt_incr(win, target_rank);
 
@@ -473,7 +473,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
 
     /* Increase local and remote completion counters and set the local completion
      * counter in request, thus it can be decreased at request completion. */
-    MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
+    MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->dev.completion_notification);
     /* Increase remote completion counter for acc. */
     MPIDIG_win_remote_acc_cmpl_cnt_incr(win, target_rank);
 
@@ -803,7 +803,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
     am_hdr.src_rank = win->comm_ptr->rank;
     MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
 
-    MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
+    MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->dev.completion_notification);
     /* Increase remote completion counter for acc. */
     MPIDIG_win_remote_acc_cmpl_cnt_incr(win, target_rank);
 


### PR DESCRIPTION
## Pull Request Description
Misc cleanup related to the request object in ch4
* Move completion_notification inside ch4
* remove macro `MPIDI_REQUEST_ANYSOURCE_PARTNER`
* use `req->dev.type` to check whether it's a am request
* rename `MPIDIU_request_complete` into `MPIDI_Request_complete_fast`


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
