### PR TITLE
config: use AC_SEARCH_LIBS and fix checking pbs

### DIFF
--- a/confdb/aclocal_libs.m4
+++ b/confdb/aclocal_libs.m4
@@ -113,13 +113,16 @@ AC_DEFUN([PAC_CHECK_HEADER_LIB_OPTIONAL],[
         pac_have_$1=no
     else
         dnl Other than "embedded" or "no", we check ...
-        PAC_CHECK_HEADER_LIB($2,$3,$4,pac_have_$1=yes,pac_have_$1=no,$5)
+        for a in $3 ; do
+            PAC_CHECK_HEADER_LIB($2,$a,$4,pac_have_$1=yes,pac_have_$1=no,$5)
+            if test "$pac_have_$1" = "yes"; then
+                PAC_LIBS_ADD(-l$a)
+                break
+            fi
+        done
         if test "${pac_have_$1}" = "no" -a -n "${with_$1}" ; then
             dnl user asks for it, so missing is an error
             AC_MSG_ERROR([--with-$1 is given but not found])
-        fi
-        if test "${pac_have_$1}" = "yes" ; then
-            PAC_LIBS_ADD(-l$3)
         fi
     fi
 ])

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -253,7 +253,7 @@ for hydra_bss_name in ${hydra_bss_names}; do
 	pbs)
 		hydra_bss_external=true
 		# Check if TM library support is available
-		PAC_CHECK_HEADER_LIB_OPTIONAL(pbs, tm.h, torque, tm_init)
+		PAC_CHECK_HEADER_LIB_OPTIONAL(pbs, tm.h, [torque pbs], tm_init)
                 if test "$pac_have_pbs" = "yes" ; then
 		    available_launchers="$available_launchers pbs"
                 fi


### PR DESCRIPTION

## Pull Request Description
Some libraries may use different lib names for different forks. Use
AC_SEARCH_LIBS instead of AC_CHECK_LIB allows checking for multiple
alternatives.

Fixes #6049 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
