### PR TITLE
hydra: fix hwloc paths and move them to modules dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,9 +113,7 @@ apply-xfail.sh
 /src/mpi/romio/confdb
 /src/mpl/confdb
 /src/pm/hydra/confdb
-/src/pm/hydra/mpl
-/src/pm/hydra/mpl/confdb
-/src/pm/hydra/tools/topo/hwloc/hwloc
+/src/pm/hydra/modules
 /src/pm/hydra2/confdb
 /src/pm/hydra2/mpl
 /src/pm/hydra2/mpl/confdb

--- a/README.vin
+++ b/README.vin
@@ -267,7 +267,6 @@ exist.
     mpich-%VERSION%/config.log (generated in step 1(d) above)
     mpich-%VERSION%/src/mpl/config.log (generated in step 1(d) above)
     mpich-%VERSION%/src/pm/hydra/config.log (generated in step 1(d) above)
-    mpich-%VERSION%/src/pm/hydra/tools/topo/hwloc/hwloc/config.log (generated in step 1(d) above)
 
     DID WE MENTION? DO NOT FORGET TO COMPRESS THESE FILES!
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -314,11 +314,12 @@ fn_copy_confdb_etc() {
     if test "$do_hydra" = "yes" ; then
         confdb_dirs="${confdb_dirs} src/pm/hydra/confdb"
         if test "$do_quick" = "no" ; then
-            sync_external src/mpl src/pm/hydra/mpl
-            sync_external modules/hwloc src/pm/hydra/tools/topo/hwloc/hwloc
+            mkdir -p src/pm/hydra/modules
+            sync_external src/mpl src/pm/hydra/modules/mpl
+            sync_external modules/hwloc src/pm/hydra/modules/hwloc
             # remove .git directories to avoid confusing git clean
-            rm -rf src/pm/hydra/tools/topo/hwloc/hwloc/.git
-            confdb_dirs="${confdb_dirs} src/pm/hydra/mpl/confdb"
+            rm -rf src/pm/hydra/modules/hwloc/.git
+            confdb_dirs="${confdb_dirs} src/pm/hydra/modules/mpl/confdb"
         fi
     fi
     if test "$do_hydra2" = "yes" ; then

--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -13,7 +13,7 @@ AC_DEFUN([PAC_CONFIG_MPL_EMBEDDED],[
 
 AC_DEFUN([PAC_CONFIG_MPL],[
     dnl NOTE: we only support embedded mpl
-    m4_if(mpl_embedded_dir, [src/mpl], [
+    m4_ifdef([MPICH_CONFIGURE], [
         dnl ---- the main MPICH configure ----
         PAC_CONFIG_MPL_EMBEDDED
         PAC_APPEND_FLAG([-I${main_top_builddir}/src/mpl/include], [CPPFLAGS])
@@ -84,7 +84,7 @@ AC_DEFUN([PAC_CONFIG_HWLOC],[
     fi
 
     if test "$with_hwloc" = "embedded" ; then
-        m4_if(hwloc_embedded_dir, [modules/hwloc], [
+        m4_ifdef([MPICH_CONFIGURE], [
             dnl ---- the main MPICH configure ----
             hwloclib="modules/hwloc/hwloc/libhwloc_embedded.la"
             if test -e "${use_top_srcdir}/modules/PREBUILT" -a -e "$hwloclib"; then

--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,7 @@ dnl
 dnl Note that no executable statements are allowed (and any are silently
 dnl dropped) before AC_INIT.
 
+m4_define([MPICH_CONFIGURE], 1)
 m4_include([maint/version.m4])
 dnl 2nd arg is intentionally underquoted
 AC_INIT([MPICH],

--- a/src/pm/hydra/.gitignore
+++ b/src/pm/hydra/.gitignore
@@ -111,27 +111,4 @@ configure
 /tools/rmk/src/rmki_init.c
 
 # hwloc in hydra
-/tools/topo/hwloc/hwloc/config/ar-lib
-/tools/topo/hwloc/hwloc/config/argz.m4
-/tools/topo/hwloc/hwloc/config/compile
-/tools/topo/hwloc/hwloc/config/config.guess
-/tools/topo/hwloc/hwloc/config/config.sub
-/tools/topo/hwloc/hwloc/config/depcomp
-/tools/topo/hwloc/hwloc/config/install-sh
-/tools/topo/hwloc/hwloc/config/libtool.m4
-/tools/topo/hwloc/hwloc/config/ltdl.m4
-/tools/topo/hwloc/hwloc/config/ltmain.sh
-/tools/topo/hwloc/hwloc/config/ltoptions.m4
-/tools/topo/hwloc/hwloc/config/ltsugar.m4
-/tools/topo/hwloc/hwloc/config/ltversion.m4
-/tools/topo/hwloc/hwloc/config/lt~obsolete.m4
-/tools/topo/hwloc/hwloc/config/missing
-/tools/topo/hwloc/hwloc/config/test-driver
-/tools/topo/hwloc/hwloc/include/hwloc/autogen/config.h
-/tools/topo/hwloc/hwloc/include/hwloc/autogen/stamp-h2
-/tools/topo/hwloc/hwloc/include/hwloc/autogen/stamp-h3
-/tools/topo/hwloc/hwloc/include/private/autogen/config.h
-/tools/topo/hwloc/hwloc/include/private/autogen/stamp-h2
-/tools/topo/hwloc/hwloc/src/libltdl/
-/tools/topo/hwloc/hwloc/src/static-components.h
-
+/modules

--- a/src/pm/hydra/autogen.sh
+++ b/src/pm/hydra/autogen.sh
@@ -6,14 +6,14 @@
 
 autoreconf=${AUTORECONF:-autoreconf}
 
-if test -d "mpl" ; then
-    echo "=== running autoreconf in 'mpl' ==="
-    (cd mpl && $autoreconf ${autoreconf_args:-"-vif"}) || exit 1
+if test -d "modules/mpl" ; then
+    echo "=== running autoreconf in 'modules/mpl' ==="
+    (cd modules/mpl && $autoreconf ${autoreconf_args:-"-vif"}) || exit 1
 fi
 
-if test -d "tools/topo/hwloc/hwloc" ; then
-    echo "=== running autoreconf in 'tools/topo/hwloc/hwloc' ==="
-    (cd tools/topo/hwloc/hwloc && ./autogen.sh) || exit 1
+if test -d "modules/hwloc" ; then
+    echo "=== running autoreconf in 'modules/hwloc' ==="
+    (cd modules/hwloc && ./autogen.sh) || exit 1
 fi
 
 echo "=== running autoreconf in '.' ==="

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -123,7 +123,7 @@ mpl_includedir=""
 AC_SUBST([mpl_includedir])
 mpl_lib=""
 AC_SUBST([mpl_lib])
-m4_define([mpl_embedded_dir],[mpl])
+m4_define([mpl_embedded_dir],[modules/mpl])
 PAC_CONFIG_MPL
 
 # Documentation
@@ -374,7 +374,7 @@ AC_SUBST([hwloc_lib])
 for hydra_topolib in ${hydra_topolibs}; do
     case "$hydra_topolib" in
 	hwloc)
-                m4_define([hwloc_embedded_dir],[tools/topo/hwloc/hwloc])
+                m4_define([hwloc_embedded_dir],[modules/hwloc])
                 PAC_CONFIG_HWLOC
 
 		if test "$pac_have_hwloc" = "yes" ; then


### PR DESCRIPTION
## Pull Request Description

It is unnecessary to put embedded library to deep nested paths. Put them
all in modules dir, similar to how mpich does it.

The hwloc path was previously broken when we rearranged the source tree.
It didn't show in our testing because by default, we reuse the hwloc
compiled by main mpich.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
