### PR TITLE
ch4/ofi: fix memory leak in the cancel path

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -596,6 +596,17 @@ int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret)
                     MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(req, datatype));
                     MPIR_STATUS_SET_CANCEL_BIT(req->status, TRUE);
                     MPIR_STATUS_SET_COUNT(req->status, 0);
+                    /* NOTE: assuming only the receive request can be cancelled and reach here */
+                    int event_id = MPIDI_OFI_REQUEST(req, event_id);
+                    if ((event_id == MPIDI_OFI_EVENT_RECV_PACK ||
+                         event_id == MPIDI_OFI_EVENT_GET_HUGE) &&
+                        MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer)) {
+                        MPIR_gpu_free_host(MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer));
+                    } else if (MPIDI_OFI_ENABLE_PT2PT_NOPACK &&
+                               event_id == MPIDI_OFI_EVENT_RECV_NOPACK &&
+                               MPIDI_OFI_REQUEST(req, noncontig.nopack)) {
+                        MPL_free(MPIDI_OFI_REQUEST(req, noncontig.nopack));
+                    }
                     MPIDI_Request_complete_fast(req);
                     break;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -593,10 +593,11 @@ int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret)
 
                 case FI_ECANCELED:
                     req = MPIDI_OFI_context_to_request(e.op_context);
-                    MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(req, datatype));
                     MPIR_STATUS_SET_CANCEL_BIT(req->status, TRUE);
                     MPIR_STATUS_SET_COUNT(req->status, 0);
-                    /* NOTE: assuming only the receive request can be cancelled and reach here */
+                    /* Clean up the request. Reference MPIDI_OFI_recv_event.
+                     * NOTE: assuming only the receive request can be cancelled and reach here
+                     */
                     int event_id = MPIDI_OFI_REQUEST(req, event_id);
                     if ((event_id == MPIDI_OFI_EVENT_RECV_PACK ||
                          event_id == MPIDI_OFI_EVENT_GET_HUGE) &&
@@ -607,6 +608,7 @@ int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret)
                                MPIDI_OFI_REQUEST(req, noncontig.nopack)) {
                         MPL_free(MPIDI_OFI_REQUEST(req, noncontig.nopack));
                     }
+                    MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(req, datatype));
                     MPIDI_Request_complete_fast(req);
                     break;
 


### PR DESCRIPTION
## Pull Request Description
When we cancel an ofi receive request, we need to do the same clean-ups as the normal receive completion.

Fixes #6056

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
