### PR TITLE
hcoll: fix HAVE_LIBCOLL

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -6,7 +6,7 @@
 #ifndef MPIR_COMM_H_INCLUDED
 #define MPIR_COMM_H_INCLUDED
 
-#if defined HAVE_LIBHCOLL
+#if defined HAVE_HCOLL
 #include "../mpid/common/hcoll/hcollpre.h"
 #endif
 
@@ -234,9 +234,9 @@ struct MPIR_Comm {
     } coll;
 
     void *csel_comm;            /* collective selector handle */
-#if defined HAVE_LIBHCOLL
+#if defined HAVE_HCOLL
     hcoll_comm_priv_t hcoll_priv;
-#endif                          /* HAVE_LIBHCOLL */
+#endif                          /* HAVE_HCOLL */
 
     /* the mapper is temporarily filled out in order to allow the
      * device to setup its network addresses.  it will be freed after

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -7,13 +7,13 @@
 #define MPID_COLL_H_INCLUDED
 
 #include "mpiimpl.h"
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
 #include "../../common/hcoll/hcoll.h"
 #endif
 
 static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Barrier(comm, errflag))
         return MPI_SUCCESS;
 #endif
@@ -23,7 +23,7 @@ static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 static inline int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                              MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Bcast(buffer, count, datatype, root, comm, errflag))
         return MPI_SUCCESS;
 #endif
@@ -34,7 +34,7 @@ static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint co
                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                  MPIR_Errflag_t * errflag)
 {
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag))
         return MPI_SUCCESS;
 #endif
@@ -45,7 +45,7 @@ static inline int MPID_Allgather(const void *sendbuf, MPI_Aint sendcount, MPI_Da
                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcount, recvtype, comm, errflag))
         return MPI_SUCCESS;

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -16,12 +16,12 @@ struct MPIR_Request;
 #include <sys/types.h>
 #endif
 
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
 #include "hcoll/api/hcoll_dte.h"
 #endif
 
 typedef struct {
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     hcoll_datatype_t hcoll_datatype;
 #endif
     int foo; /* Shut up the compiler */

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -5,7 +5,7 @@
 
 #include "mpidimpl.h"
 #include "utlist.h"
-#if defined HAVE_LIBHCOLL
+#if defined HAVE_HCOLL
 #include "../../common/hcoll/hcoll.h"
 #endif
 
@@ -52,7 +52,7 @@ static hook_elt *destroy_hooks_tail = NULL;
 int MPIDI_CH3I_Comm_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
-#if defined HAVE_LIBHCOLL && MPID_CH3I_CH_HCOLL_BCOL
+#if defined HAVE_HCOLL && MPID_CH3I_CH_HCOLL_BCOL
     MPIR_CHKLMEM_DECL(1);
 #endif
 
@@ -64,7 +64,7 @@ int MPIDI_CH3I_Comm_init(void)
     mpi_errno = MPIDI_CH3U_Comm_register_create_hook(comm_created, NULL);
     MPIR_ERR_CHECK(mpi_errno);
 
-#if defined HAVE_LIBHCOLL
+#if defined HAVE_HCOLL
     {
         int r;
 
@@ -103,7 +103,7 @@ int MPIDI_CH3I_Comm_init(void)
     
  fn_exit:
     MPIR_FUNC_EXIT;
-#if defined HAVE_LIBHCOLL && MPID_CH3I_CH_HCOLL_BCOL
+#if defined HAVE_HCOLL && MPID_CH3I_CH_HCOLL_BCOL
     MPIR_CHKLMEM_FREEALL();
 #endif
     return mpi_errno;

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -10,7 +10,7 @@
 #include <sys/types.h>
 #endif
 
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
 #include "hcoll/api/hcoll_dte.h"
 #endif
 
@@ -41,7 +41,7 @@ enum {
 #endif
 
 typedef struct {
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     hcoll_datatype_t hcoll_datatype;
 #endif
     union {

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -7,7 +7,7 @@
 #define UCX_COLL_H_INCLUDED
 
 #include "ucx_impl.h"
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
 #include "../../../common/hcoll/hcoll.h"
 #endif
 
@@ -16,7 +16,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Err
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     mpi_errno = hcoll_Barrier(comm_ptr, errflag);
     if (mpi_errno != MPI_SUCCESS)
 #endif
@@ -35,7 +35,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     mpi_errno = hcoll_Bcast(buffer, count, datatype, root, comm_ptr, errflag);
     if (mpi_errno != MPI_SUCCESS)
 #endif
@@ -55,7 +55,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     mpi_errno = hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
     if (mpi_errno != MPI_SUCCESS)
 #endif
@@ -75,7 +75,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Ain
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     mpi_errno = hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcount, recvtype, comm_ptr, errflag);
     if (mpi_errno != MPI_SUCCESS)
@@ -178,7 +178,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     mpi_errno = hcoll_Alltoall(sendbuf, sendcount, sendtype, recvbuf,
                                recvcount, recvtype, comm_ptr, errflag);
     if (mpi_errno != MPI_SUCCESS)
@@ -201,7 +201,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     mpi_errno = hcoll_Alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
                                 recvcounts, rdispls, recvtype, comm_ptr, errflag);
     if (mpi_errno != MPI_SUCCESS)
@@ -240,7 +240,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     mpi_errno = hcoll_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
     if (mpi_errno != MPI_SUCCESS)
 #endif

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.c
@@ -6,7 +6,7 @@
 #include "mpidimpl.h"
 #include "ucx_impl.h"
 #include "mpidu_bc.h"
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
 #include "../../common/hcoll/hcoll.h"
 #endif
 
@@ -15,7 +15,7 @@ int MPIDI_UCX_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-#if defined HAVE_LIBHCOLL
+#if defined HAVE_HCOLL
     hcoll_comm_create(comm, NULL);
 #endif
 
@@ -38,7 +38,7 @@ int MPIDI_UCX_mpi_comm_free_hook(MPIR_Comm * comm)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     hcoll_comm_destroy(comm, NULL);
 #endif
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.c
@@ -6,7 +6,7 @@
 #include "mpidimpl.h"
 #include "ucx_impl.h"
 #include <ucp/api/ucp.h>
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
 #include "../../../common/hcoll/hcoll.h"
 #endif
 
@@ -108,7 +108,7 @@ int MPIDI_UCX_mpi_type_free_hook(MPIR_Datatype * datatype_p)
         ucp_dt_destroy(datatype_p->dev.netmod.ucx.ucp_datatype);
         datatype_p->dev.netmod.ucx.ucp_datatype = -1;
     }
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     hcoll_type_free_hook(datatype_p);
 #endif
 
@@ -139,7 +139,7 @@ int MPIDI_UCX_mpi_type_commit_hook(MPIR_Datatype * datatype_p)
         datatype_p->dev.netmod.ucx.ucp_datatype = ucp_datatype;
 
     }
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
     hcoll_type_commit_hook(datatype_p);
 #endif
 

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -221,7 +221,7 @@ typedef struct {
 
 #define MPIDIU_THREAD_SCHED_LIST_MUTEX    MPIDI_global.m[3]
 #define MPIDIU_THREAD_TSP_QUEUE_MUTEX     MPIDI_global.m[4]
-#ifdef HAVE_LIBHCOLL
+#ifdef HAVE_HCOLL
 #define MPIDIU_THREAD_HCOLL_MUTEX         MPIDI_global.m[5]
 #endif
 

--- a/src/mpid/common/hcoll/subconfigure.m4
+++ b/src/mpid/common/hcoll/subconfigure.m4
@@ -2,6 +2,9 @@
 
 AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
     PAC_CHECK_HEADER_LIB_OPTIONAL(hcoll,[hcoll/api/hcoll_api.h],[hcoll],[hcoll_init])
+    if test "$pac_have_hcoll" = "yes" ; then
+        AC_DEFINE([HAVE_HCOLL],1,[Define if building hcoll])
+    fi
     AM_CONDITIONAL([BUILD_HCOLL],[test "$pac_have_hcoll" = "yes"])
 ])dnl end PREREQ
 


### PR DESCRIPTION
## Pull Request Description
The macros `HAVE_LIBHCOLL` is implicitly defined by `AC_CHECK_LIB`, and it is unreliable when we change the mechanism of detecting libraries. Rather, define `HAVE_HCOLL` explicitly instead.

## Background
The hcoll build is broken by https://github.com/pmodels/mpich/pull/6050

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
