### PR TITLE
ch4/ipc: Implement IPC support for ze

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -938,6 +938,7 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **gpu_get_global_dev_ids: gpu_get_global_dev_ids failed
 **gpu_get_buffer_info: gpu_get_buffer_info failed
 **gpu_get_dev_count: gpu_get_dev_count failed
+**gpu_compare_pointer_attr: gpu_compare_pointer_attr failed
 
 ## GAVL tree related error messages
 **mpl_gavl_search: mpl_gavl_search failed

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -211,11 +211,11 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     /* Initialize gpu in mpl in order to support shm gpu module initialization
      * inside MPID_Init */
     if (MPIR_CVAR_ENABLE_GPU) {
-        int debug_summary = 0;
+        MPL_gpu_info_t info = { 0 };
         if (MPIR_CVAR_DEBUG_SUMMARY) {
-            debug_summary = (MPIR_Process.rank == 0);
+            info.debug_summary = (MPIR_Process.rank == 0);
         }
-        int mpl_errno = MPL_gpu_init(debug_summary);
+        int mpl_errno = MPL_gpu_init(&info);
         MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_init");
 
         int device_count, max_dev_id;
@@ -224,6 +224,11 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
 
         if (device_count <= 0) {
             MPIR_CVAR_ENABLE_GPU = 0;
+        } else {
+            /* If the MPL backend doesn't support IPC, disable it for the upper layer */
+            if (!info.enable_ipc) {
+                MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD = -1;
+            }
         }
     }
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -165,6 +165,7 @@ int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
                             "**gpu_ipc_handle_create");
         ipc_attr->ipc_handle.gpu.handle_status = MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED;
     } else {
+        ipc_attr->ipc_handle.gpu.ipc_handle = handle_obj->ipc_handle;
         ipc_attr->ipc_handle.gpu.handle_status = MPIDI_GPU_IPC_HANDLE_VALID;
     }
 
@@ -179,6 +180,11 @@ int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
     ipc_attr->ipc_handle.gpu.offset = (uintptr_t) vaddr - (uintptr_t) pbase;
 
     ipc_attr->ipc_handle.gpu.global_dev_id = global_dev_id;
+
+    if (handle_obj == NULL) {
+        mpi_errno = MPIDI_GPU_ipc_handle_cache_insert(rank, comm, ipc_attr->ipc_handle.gpu);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
   fn_fail:
 #else
     /* Do not support IPC data transfer */

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -139,12 +139,20 @@ int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
 
     recv_lrank = MPIDI_GPUI_global.local_ranks[MPIDIU_rank_to_lpid(rank, comm)];
     ipc_attr->ipc_type = MPIDI_IPCI_TYPE__GPU;
+    ipc_attr->threshold.send_lmt_sz = MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD;
 
     local_dev_id = MPL_gpu_get_dev_id_from_attr(&ipc_attr->gpu_attr);
     int global_dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
 
     mpl_err = MPL_gpu_get_buffer_bounds(vaddr, &pbase, &len);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_get_buffer_info");
+
+    /* Don't create or search for an ipc handle if the buffer doesn't meet the threshold
+     * requirement */
+    if (ipc_attr->threshold.send_lmt_sz > len) {
+        ipc_attr->ipc_handle.gpu.handle_status = MPIDI_GPU_IPC_HANDLE_INVALID;
+        goto fn_fail;
+    }
 
     MPL_gavl_tree_t track_tree =
         MPIDI_GPUI_global.ipc_handle_track_trees[recv_lrank][global_dev_id];
@@ -171,7 +179,6 @@ int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
     ipc_attr->ipc_handle.gpu.offset = (uintptr_t) vaddr - (uintptr_t) pbase;
 
     ipc_attr->ipc_handle.gpu.global_dev_id = global_dev_id;
-    ipc_attr->threshold.send_lmt_sz = MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD;
   fn_fail:
 #else
     /* Do not support IPC data transfer */

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -11,6 +11,7 @@
 enum {
     MPIDI_GPU_IPC_HANDLE_VALID,
     MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED,
+    MPIDI_GPU_IPC_HANDLE_INVALID,
 };
 
 typedef struct MPIDI_GPU_ipc_handle {

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -16,6 +16,7 @@ enum {
 
 typedef struct MPIDI_GPU_ipc_handle {
     MPL_gpu_ipc_mem_handle_t ipc_handle;
+    MPL_pointer_attr_t gpu_attr;
     int global_dev_id;
     uintptr_t remote_base_addr;
     uintptr_t len;

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -42,6 +42,11 @@ typedef enum {
     MPL_GPU_TYPE_HIP,
 } MPL_gpu_type_t;
 
+typedef struct {
+    bool enable_ipc;
+    int debug_summary;
+} MPL_gpu_info_t;
+
 #ifndef MPL_HAVE_GPU
 /* inline the query function in the fallback path to provide compiler optimization opportunity */
 static inline int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
@@ -69,7 +74,7 @@ int MPL_gpu_unregister_host(const void *ptr);
 int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device);
 int MPL_gpu_free(void *ptr);
 
-int MPL_gpu_init(int debug_summary);
+int MPL_gpu_init(MPL_gpu_info_t * info);
 int MPL_gpu_finalize(void);
 
 int MPL_gpu_global_to_local_dev_id(int global_dev_id);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -61,6 +61,7 @@ static inline int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t
 
 int MPL_gpu_query_support(MPL_gpu_type_t * type);
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
+int MPL_gpu_compare_pointer_attr(MPL_pointer_attr_t attr1, MPL_pointer_attr_t attr2, bool * same);
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle);
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr);

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -32,10 +32,6 @@ static int gpu_mem_hook_init();
 int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 {
     int ret = MPL_SUCCESS;
-    if (!gpu_initialized) {
-        ret = MPL_gpu_init(0);
-    }
-
     *dev_cnt = device_count;
     *dev_id = max_dev_id;
     return ret;
@@ -215,7 +211,7 @@ int MPL_gpu_free(void *ptr)
     goto fn_exit;
 }
 
-int MPL_gpu_init(int debug_summary)
+int MPL_gpu_init(MPL_gpu_info_t * info)
 {
     int mpl_err = MPL_SUCCESS;
     if (gpu_initialized) {
@@ -229,6 +225,8 @@ int MPL_gpu_init(int debug_summary)
         gpu_initialized = 1;
         goto fn_exit;
     }
+
+    info->enable_ipc = true;
 
     char *visible_devices = getenv("CUDA_VISIBLE_DEVICES");
     if (visible_devices) {
@@ -274,7 +272,7 @@ int MPL_gpu_init(int debug_summary)
     gpu_mem_hook_init();
     gpu_initialized = 1;
 
-    if (debug_summary) {
+    if (info->debug_summary) {
         printf("==== GPU Init (CUDA) ====\n");
         printf("device_count: %d\n", device_count);
         if (visible_devices) {

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -75,6 +75,15 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
+int MPL_gpu_compare_pointer_attr(MPL_pointer_attr_t attr1, MPL_pointer_attr_t attr2, bool * same)
+{
+    int mpl_err = MPL_SUCCESS;
+    *same = (attr1.device_attr.device == attr2.device_attr.device &&
+             attr1.device_attr.devicePointer == attr2.device_attr.devicePointer &&
+             attr1.device_attr.hostPointer == attr2.device_attr.hostPointer);
+    return mpl_err;
+}
+
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -12,6 +12,12 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
     return MPL_SUCCESS;
 }
 
+int MPL_gpu_compare_pointer_attr(MPL_pointer_attr_t attr1, MPL_pointer_attr_t attr2, bool * same)
+{
+    abort();
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     abort();

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -64,8 +64,9 @@ int MPL_gpu_free(void *ptr)
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_init(int debug_summary)
+int MPL_gpu_init(MPL_gpu_info_t * info)
 {
+    info->enable_ipc = false;
     return MPL_SUCCESS;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -69,6 +69,15 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
+int MPL_gpu_compare_pointer_attr(MPL_pointer_attr_t attr1, MPL_pointer_attr_t attr2, bool * same)
+{
+    int mpl_err = MPL_SUCCESS;
+    *same = (attr1.device_attr.device == attr2.device_attr.device &&
+             attr1.device_attr.devicePointer == attr2.device_attr.devicePointer &&
+             attr1.device_attr.hostPointer == attr2.device_attr.hostPointer);
+    return mpl_err;
+}
+
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -31,10 +31,6 @@ static int gpu_mem_hook_init();
 int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 {
     int ret = MPL_SUCCESS;
-    if (!gpu_initialized) {
-        ret = MPL_gpu_init(0);
-    }
-
     *dev_cnt = device_count;
     *dev_id = max_dev_id;
     return ret;
@@ -209,11 +205,13 @@ int MPL_gpu_free(void *ptr)
     goto fn_exit;
 }
 
-int MPL_gpu_init(int debug_summary)
+int MPL_gpu_init(MPL_gpu_info_t * info)
 {
     int mpl_err = MPL_SUCCESS;
     hipError_t ret = hipGetDeviceCount(&device_count);
     HIP_ERR_CHECK(ret);
+
+    info->enable_ipc = true;
 
     char *visible_devices = getenv("HIP_VISIBLE_DEVICES");
     if (visible_devices) {
@@ -260,7 +258,7 @@ int MPL_gpu_init(int debug_summary)
     gpu_mem_hook_init();
     gpu_initialized = 1;
 
-    if (debug_summary) {
+    if (info->debug_summary) {
         printf("==== GPU Init (HIP) ====\n");
         printf("device_count: %d\n", device_count);
         if (visible_devices) {

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -35,21 +35,19 @@ static int gpu_ze_init_driver(void);
 int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 {
     int ret = MPL_SUCCESS;
-    if (!gpu_initialized) {
-        ret = MPL_gpu_init(0);
-    }
-
     *dev_cnt = device_count;
     *dev_id = max_dev_id;
     return ret;
 }
 
-int MPL_gpu_init(int debug_summary)
+int MPL_gpu_init(MPL_gpu_info_t * info)
 {
     int mpl_err;
     mpl_err = gpu_ze_init_driver();
     if (mpl_err != MPL_SUCCESS)
         goto fn_fail;
+
+    info->enable_ipc = false;
 
     device_count = global_ze_device_count;
     max_dev_id = device_count - 1;
@@ -63,7 +61,7 @@ int MPL_gpu_init(int debug_summary)
 
     gpu_initialized = 1;
 
-    if (debug_summary) {
+    if (info->debug_summary) {
         printf("==== GPU Init (ZE) ====\n");
         printf("device_count: %d\n", device_count);
         printf("=========================\n");

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -374,6 +374,13 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
+int MPL_gpu_compare_pointer_attr(MPL_pointer_attr_t attr1, MPL_pointer_attr_t attr2, bool * same)
+{
+    int mpl_err = MPL_SUCCESS;
+    *same = (attr1.device_attr.prop.id == attr2.device_attr.prop.id);
+    return mpl_err;
+}
+
 int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -5,6 +5,7 @@
 
 #include "mpl.h"
 #include <assert.h>
+#include <dlfcn.h>
 
 MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 
@@ -32,6 +33,11 @@ typedef struct {
     int dev_id;
 } fd_pid_t;
 
+typedef struct gpu_free_hook {
+    void (*free_hook) (void *dptr);
+    struct gpu_free_hook *next;
+} gpu_free_hook_s;
+
 pid_t mypid;
 
 /* Level-zero API v1.0:
@@ -42,6 +48,12 @@ ze_device_handle_t *global_ze_devices_handle = NULL;
 ze_context_handle_t global_ze_context;
 uint32_t global_ze_device_count;
 static int gpu_ze_init_driver(void);
+
+static gpu_free_hook_s *free_hook_chain = NULL;
+
+static ze_result_t ZE_APICALL(*sys_zeMemFree) (ze_context_handle_t hContext, void *dptr) = NULL;
+
+static int gpu_mem_hook_init(void);
 
 #define ZE_ERR_CHECK(ret) \
     do { \
@@ -82,6 +94,7 @@ int MPL_gpu_init(MPL_gpu_info_t * info)
 
     mypid = getpid();
 
+    gpu_mem_hook_init();
     gpu_initialized = 1;
 
     /* Test if ipc can be supported via pidfd_open/pidfd_get */
@@ -205,6 +218,14 @@ int MPL_gpu_finalize(void)
     MPL_free(local_to_global_map);
     MPL_free(global_to_local_map);
     MPL_free(global_ze_devices_handle);
+
+    gpu_free_hook_s *prev;
+    while (free_hook_chain) {
+        prev = free_hook_chain;
+        free_hook_chain = free_hook_chain->next;
+        MPL_free(prev);
+    }
+
     return MPL_SUCCESS;
 }
 
@@ -464,9 +485,57 @@ int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
     goto fn_exit;
 }
 
+static void gpu_free_hooks_cb(void *dptr)
+{
+    gpu_free_hook_s *current = free_hook_chain;
+    if (dptr != NULL) {
+        /* we call gpu hook only when dptr != NULL */
+        while (current) {
+            current->free_hook(dptr);
+            current = current->next;
+        }
+    }
+    return;
+}
+
+static int gpu_mem_hook_init(void)
+{
+    if (sys_zeMemFree)
+        return MPL_SUCCESS;
+
+    void *libze_handle = dlopen("libze_loader.so", RTLD_LAZY | RTLD_GLOBAL);
+    assert(libze_handle);
+
+    sys_zeMemFree = (void *) dlsym(libze_handle, "zeMemFree");
+    assert(sys_zeMemFree);
+
+    return MPL_SUCCESS;
+}
+
 int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr))
 {
+    gpu_free_hook_s *hook_obj = MPL_malloc(sizeof(gpu_free_hook_s), MPL_MEM_OTHER);
+    assert(hook_obj);
+    hook_obj->free_hook = free_hook;
+    hook_obj->next = NULL;
+    if (!free_hook_chain)
+        free_hook_chain = hook_obj;
+    else {
+        hook_obj->next = free_hook_chain;
+        free_hook_chain = hook_obj;
+    }
+
     return MPL_SUCCESS;
+}
+
+ze_result_t ZE_APICALL zeMemFree(ze_context_handle_t hContext, void *dptr)
+{
+    ze_result_t result;
+    /* in case when MPI_Init was skipped */
+    gpu_mem_hook_init();
+    gpu_free_hooks_cb(dptr);
+    result = sys_zeMemFree(hContext, dptr);
+    return (result);
 }
 
 int MPL_gpu_launch_hostfn(int stream, MPL_gpu_hostfn fn, void *data)


### PR DESCRIPTION
## Pull Request Description

This PR implements IPC support for the ze backend in MPL.

Level zero uses file descriptors for IPC handles, so they cannot be directly transmitted between processes in a generic approach. As a result, we use `pidfd_open` and `pidfd_getfd` to duplicate the underlying fd of the handles to support generic transmission. Thus the protocol doesn't have to rely on UNIX sockets in order to share IPC handles with other processes.

This approach requires Linux Kernel version 5.6.0 or newer (`pidfd_getfd` is not implemented until this kernel version). The support for this method is checked at runtime, and silently disables IPC if it does not exist.

Additionally, in cases where `zeMemFree` cannot be captured by the MPI library (i.e. due to link ordering), there can be false hits where subsequent virtual addresses are the same, but are actually distinct allocations. In this scenario, the cached IPC handle is invalid and will cause failures. As a result, a check against the unique ID of allocations is added in the gavl cache to prevent this issue.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
