### PR TITLE
ch4: replace MPIR_gpu_malloc_host with MPL_malloc

### DIFF
--- a/src/include/mpir_gpu.h
+++ b/src/include/mpir_gpu.h
@@ -79,6 +79,10 @@ MPL_STATIC_INLINE_PREFIX bool MPIR_GPU_query_pointer_is_dev(const void *ptr)
     return false;
 }
 
+/* gpu registration or pinning has huge latency (~500us), thus the following
+ * functions should be avoided at all critical paths. Use unregistered buffer
+ * (MPL_malloc) instead. */
+
 MPL_STATIC_INLINE_PREFIX int MPIR_gpu_register_host(const void *ptr, size_t size)
 {
     if (ENABLE_GPU) {

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.c
@@ -27,7 +27,7 @@ int MPIDI_OFI_am_rdma_read_ack_handler(void *am_hdr, void *data,
     MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_AM_SREQ_HDR(sreq, lmt_mr)->fid), mr_unreg);
     MPIDI_OFI_global.per_vni[vni_local].am_inflight_rma_send_mrs -= 1;
 
-    MPIR_gpu_free_host(MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer));
+    MPL_free(MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer));
 
     /* retrieve the handler_id of the original send request for origin cb. Note the handler_id
      * parameter is MPIDI_OFI_AM_RDMA_READ_ACK and should never be called with origin_cbs */

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -308,7 +308,7 @@ MPL_STATIC_INLINE_PREFIX int do_long_am_recv_unpack(MPI_Aint in_data_sz, MPIR_Re
     p->context_id = lmt_msg->context_id;
     p->src_offset = lmt_msg->src_offset;
 
-    mpi_errno = MPIR_gpu_malloc_host(&p->unpack_buffer, pack_size);
+    p->unpack_buffer = MPL_malloc(pack_size, MPL_MEM_OTHER);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPI_Aint remain = MPIDIG_REQUEST(rreq, req->recv_async).in_data_sz;
@@ -345,7 +345,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_lmt_unpack_event(MPIR_Request * rreq)
         return FALSE;
     } else {
         /* all done. */
-        MPIR_gpu_free_host(p->unpack_buffer);
+        MPL_free(p->unpack_buffer);
         return TRUE;
     }
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -765,7 +765,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_rdma_read(int rank, MPIR_Comm
         /* FIXME: currently always allocate pack buffer for any size. This should be removed in next
          * step when we work on ZCOPY protocol support. Basically, if the src buf and datatype needs
          * packing, we should not be doing RDMA read. */
-        MPIR_gpu_malloc_host((void **) &send_buf, data_sz);
+        send_buf = MPL_malloc(data_sz, MPL_MEM_OTHER);
         mpi_errno = MPIR_Typerep_pack(buf, count, datatype, 0, send_buf, data_sz, &last,
                                       MPIR_TYPEREP_FLAG_NONE);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -107,7 +107,7 @@ static int send_huge_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request 
         MPL_free(huge_send_mrs);
 
         if (MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer)) {
-            MPIR_gpu_free_host(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer));
+            MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer));
         }
 
         MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(sreq, datatype));
@@ -602,7 +602,7 @@ int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret)
                     if ((event_id == MPIDI_OFI_EVENT_RECV_PACK ||
                          event_id == MPIDI_OFI_EVENT_GET_HUGE) &&
                         MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer)) {
-                        MPIR_gpu_free_host(MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer));
+                        MPL_free(MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer));
                     } else if (MPIDI_OFI_ENABLE_PT2PT_NOPACK &&
                                event_id == MPIDI_OFI_EVENT_RECV_NOPACK &&
                                MPIDI_OFI_REQUEST(req, noncontig.nopack)) {

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -34,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(int vni,
     if (c == 0) {
         if ((event_id == MPIDI_OFI_EVENT_SEND_PACK) &&
             (MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer))) {
-            MPIR_gpu_free_host(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer));
+            MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer));
         } else if (MPIDI_OFI_ENABLE_PT2PT_NOPACK && (event_id == MPIDI_OFI_EVENT_SEND_NOPACK))
             MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.nopack));
 
@@ -86,7 +86,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vni, struct fi_cq_tagged_e
                             MPIDI_OFI_REQUEST(rreq, noncontig.pack.count),
                             MPIDI_OFI_REQUEST(rreq, noncontig.pack.datatype), 0,
                             &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
-        MPIR_gpu_free_host(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer));
+        MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer));
         if (actual_unpack_bytes != (MPI_Aint) count) {
             rreq->status.MPI_ERROR =
                 MPIR_Err_create_code(MPI_SUCCESS,

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -199,12 +199,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         }
         /* Unpack */
         MPIDI_OFI_REQUEST(rreq, event_id) = MPIDI_OFI_EVENT_RECV_PACK;
-        /* FIXME: allocating a GPU registered host buffer adds some additional overhead.
-         * However, once the new buffer pool infrastructure is setup, we would simply be
-         * allocating a buffer from the pool, so whether it's a regular malloc buffer or a GPU
-         * registered buffer should be equivalent with respect to performance. */
-        MPIR_gpu_malloc_host((void **) &MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer),
-                             data_sz);
+        MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer) = MPL_malloc(data_sz, MPL_MEM_OTHER);
         MPIR_ERR_CHKANDJUMP1(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer) == NULL, mpi_errno,
                              MPI_ERR_OTHER, "**nomem", "**nomem %s", "Recv Pack Buffer alloc");
         recv_buf = MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -242,12 +242,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         /* Pack */
         MPIDI_OFI_REQUEST(sreq, event_id) = MPIDI_OFI_EVENT_SEND_PACK;
 
-        /* FIXME: allocating a GPU registered host buffer adds some additional overhead.
-         * However, once the new buffer pool infrastructure is setup, we would simply be
-         * allocating a buffer from the pool, so whether it's a regular malloc buffer or a GPU
-         * registered buffer should be equivalent with respect to performance. */
-        MPIR_gpu_malloc_host((void **) &MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer),
-                             data_sz);
+        MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer) = MPL_malloc(data_sz, MPL_MEM_OTHER);
         MPIR_ERR_CHKANDJUMP1(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer) == NULL, mpi_errno,
                              MPI_ERR_OTHER, "**nomem", "**nomem %s", "Send Pack buffer alloc");
 
@@ -409,7 +404,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
             if (!MPIDI_OFI_ENABLE_HMEM) {
                 /* Force pack for GPU buffer. */
                 void *host_buf = NULL;
-                MPIR_gpu_malloc_host(&host_buf, data_sz);
+                host_buf = MPL_malloc(data_sz, MPL_MEM_OTHER);
                 MPIR_Typerep_pack(buf, count, datatype, 0, host_buf, data_sz, &actual_pack_bytes,
                                   MPIR_TYPEREP_FLAG_NONE);
                 MPIR_Assert(actual_pack_bytes == data_sz);
@@ -421,7 +416,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         if (actual_pack_bytes > 0) {
             /* Free stage host buf (assigned to send_buf already) after
              * lightweight_send. */
-            MPIR_gpu_free_host(send_buf);
+            MPL_free(send_buf);
         }
         if (!noreq) {
             *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -16,7 +16,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_am_isend_callback(void *request, ucs_sta
 
     MPIR_FUNC_ENTER;
 
-    MPIR_gpu_free_host(req->dev.ch4.am.netmod_am.ucx.pack_buffer);
+    MPL_free(req->dev.ch4.am.netmod_am.ucx.pack_buffer);
     req->dev.ch4.am.netmod_am.ucx.pack_buffer = NULL;
     MPIDIG_global.origin_cbs[handler_id] (req);
     ucp_request->req = NULL;
@@ -84,7 +84,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
     size_t total_sz;
     ucp_datatype_t dt;
     if (dt_contig) {
-        MPIR_gpu_malloc_host((void **) &send_buf, sizeof(ucx_hdr) + am_hdr_sz);
+        send_buf = MPL_malloc(sizeof(ucx_hdr) + am_hdr_sz, MPL_MEM_OTHER);
         MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
         MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
 
@@ -98,7 +98,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
         dt = ucp_dt_make_iov();
         total_sz = 2;
     } else {
-        MPIR_gpu_malloc_host((void **) &send_buf, data_sz + am_hdr_sz + sizeof(ucx_hdr));
+        send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_OTHER);
         MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
         MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
 
@@ -121,7 +121,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
 
     /* send is done. free all resources and complete the request */
     if (ucp_request == NULL) {
-        MPIR_gpu_free_host(send_buf);
+        MPL_free(send_buf);
         MPIDIG_global.origin_cbs[handler_id] (sreq);
         goto fn_exit;
     }

--- a/src/mpid/ch4/netmod/ucx/ucx_request.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_request.h
@@ -15,7 +15,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req)
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
 {
-    MPIR_gpu_free_host((req)->dev.ch4.am.netmod_am.ucx.pack_buffer);
+    MPL_free((req)->dev.ch4.am.netmod_am.ucx.pack_buffer);
     /* MPIR_Request_free(req); */
 }
 


### PR DESCRIPTION
## Pull Request Description

The overhead of gpu registration is huge and will perform worse than
using unregistered buffers directly in most cases. Thus it doesn't make sense to allocate registered host buffer for single-use temporary buffers.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
