### PR TITLE
hcoll: fix wrong condition to add datatype ref_count

### DIFF
--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -377,7 +377,7 @@ int MPII_Finalize(MPIR_Session * session_ptr)
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Call the low-priority (post Finalize) callbacks */
-    MPII_Call_finalize_callbacks(0, MPIR_FINALIZE_CALLBACK_PRIO - 1);
+    MPII_Call_finalize_callbacks(0, MPIR_FINALIZE_CALLBACK_PRIO);
 
     MPII_hwtopo_finalize();
     MPII_nettopo_finalize();

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -357,11 +357,11 @@ int MPII_Finalize(MPIR_Session * session_ptr)
     MPIR_ThreadInfo.isThreaded = 0;
 #endif
 
-    mpi_errno = MPIR_finalize_builtin_comms();
-    MPIR_ERR_CHECK(mpi_errno);
-
     /* Call the high-priority callbacks */
     MPII_Call_finalize_callbacks(MPIR_FINALIZE_CALLBACK_PRIO + 1, MPIR_FINALIZE_CALLBACK_MAX_PRIO);
+
+    mpi_errno = MPIR_finalize_builtin_comms();
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Signal the debugger that we are about to exit. */
     MPIR_Debugger_set_aborting(NULL);

--- a/src/mpid/common/hcoll/hcoll_dtypes.c
+++ b/src/mpid/common/hcoll/hcoll_dtypes.c
@@ -129,7 +129,7 @@ int hcoll_type_commit_hook(MPIR_Datatype * dtype_p)
         return MPI_ERR_OTHER;
     }
 
-    if (HCOL_DTE_IS_ZERO(dtype_p->dev.hcoll_datatype))
+    if (!HCOL_DTE_IS_ZERO(dtype_p->dev.hcoll_datatype))
         MPIR_Datatype_add_ref_if_not_builtin(dtype_p->handle);
 
     return MPI_SUCCESS;
@@ -141,7 +141,7 @@ int hcoll_type_free_hook(MPIR_Datatype * dtype_p)
         return MPI_SUCCESS;
     }
 
-    if (HCOL_DTE_IS_ZERO(dtype_p->dev.hcoll_datatype))
+    if (!HCOL_DTE_IS_ZERO(dtype_p->dev.hcoll_datatype))
         MPIR_Datatype_release_if_not_builtin(dtype_p->handle);
 
     int rc = hcoll_dt_destroy(dtype_p->dev.hcoll_datatype);

--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -102,7 +102,8 @@ int hcoll_initialize(void)
 
         MPIR_Progress_hook_activate(hcoll_progress_hook_id);
     }
-    MPIR_Add_finalize(hcoll_destroy, 0, 0);
+    /* set priority to finalize before finalizing world comm */
+    MPIR_Add_finalize(hcoll_destroy, 0, MPIR_FINALIZE_CALLBACK_PRIO + 1);
 
     CHECK_ENABLE_ENV_VARS(BARRIER, barrier);
     CHECK_ENABLE_ENV_VARS(BCAST, bcast);


### PR DESCRIPTION
## Pull Request Description

Two bugs:
1. Need to make sure to call hcoll_finalize before we finalize built-in communicators since it needs to access `MPIR_Process.comm_world`.
2. The condition of adding datatype reference count was flipped.

Fixes #6075
[skip warnings]



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
