### PR TITLE
Fixes for multi-NIC support

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -82,10 +82,10 @@ static int update_nic_preferences(MPIR_Comm * comm)
          * it in the communciator object. If this happens while traffic is outstanding, it will
          * cause problems so the user needs to quiesce traffic first. */
         if (comm->hints[MPIR_COMM_HINT_MULTI_NIC_PREF_NIC] != -1) {
-            if (MPIDI_OFI_COMM(comm).pref_nic == NULL) {
-                MPIDI_OFI_COMM(comm).pref_nic = MPL_malloc(sizeof(int) * comm->remote_size,
-                                                           MPL_MEM_ADDRESS);
-            }
+            /* comm is used to exchange its pref_nic hints. So, to avoid its behavior change while it is
+             * under use, exchange pref_nic using a local copy first, then copy it to comm.pref_nic */
+            int *pref_nic_copy = MPL_malloc(sizeof(int) * comm->remote_size, MPL_MEM_ADDRESS);
+            MPIR_ERR_CHKANDJUMP(pref_nic_copy == NULL, mpi_errno, MPI_ERR_NO_MEM, "**nomem");
 
             /* Make sure the NIC id is in a valid range. If the user went over the number of NICs,
              * loop back around to the first NIC. */
@@ -98,7 +98,7 @@ static int update_nic_preferences(MPIR_Comm * comm)
             for (int i = 0; i < MPIDI_OFI_global.num_nics; ++i) {
                 if (MPIDI_OFI_global.nic_info[i].id ==
                     comm->hints[MPIR_COMM_HINT_MULTI_NIC_PREF_NIC]) {
-                    MPIDI_OFI_COMM(comm).pref_nic[comm->rank] = i;
+                    pref_nic_copy[comm->rank] = i;
                     break;
                 }
             }
@@ -107,9 +107,21 @@ static int update_nic_preferences(MPIR_Comm * comm)
             /* Collect the NIC IDs set for the other ranks. We always expect to receive a single
              * NIC id from each rank, i.e., one MPI_INT. */
             mpi_errno = MPIR_Allgather_allcomm_auto(MPI_IN_PLACE, 0, MPI_INT,
-                                                    MPIDI_OFI_COMM(comm).pref_nic,
-                                                    1, MPI_INT, comm, &errflag);
+                                                    pref_nic_copy, 1, MPI_INT, comm, &errflag);
             MPIR_ERR_CHECK(mpi_errno);
+
+            if (MPIDI_OFI_COMM(comm).pref_nic == NULL) {
+                MPIDI_OFI_COMM(comm).pref_nic = MPL_malloc(sizeof(int) * comm->remote_size,
+                                                           MPL_MEM_ADDRESS);
+                MPIR_ERR_CHKANDJUMP(MPIDI_OFI_COMM(comm).pref_nic == NULL, mpi_errno,
+                                    MPI_ERR_NO_MEM, "**nomem");
+            }
+
+            /* Update comm.pref_nic */
+            for (int i = 0; i < comm->remote_size; ++i) {
+                MPIDI_OFI_COMM(comm).pref_nic[i] = pref_nic_copy[i];
+            }
+            MPL_free(pref_nic_copy);
         }
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -578,12 +578,13 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_OFI_count_iov(int dt_count,       /* numbe
  */
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_multx_sender_nic_index(MPIR_Comm * comm,
                                                               MPIR_Context_id_t ctxid_in_effect,
-                                                              int receiver_rank, int tag)
+                                                              int sender_rank, int receiver_rank,
+                                                              int tag)
 {
     int nic_idx = 0;
 
     if (MPIDI_OFI_COMM(comm).pref_nic) {
-        nic_idx = MPIDI_OFI_COMM(comm).pref_nic[comm->rank];
+        nic_idx = MPIDI_OFI_COMM(comm).pref_nic[sender_rank];
     } else if (MPIDI_OFI_COMM(comm).enable_hashing) {
         /* TODO - We should use the per-communicator value for the maximum number of NICs in this
          *        calculation once we have a per-communicator value for it. */
@@ -605,12 +606,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_multx_sender_nic_index(MPIR_Comm * comm,
  */
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_multx_receiver_nic_index(MPIR_Comm * comm,
                                                                 MPIR_Context_id_t ctxid_in_effect,
-                                                                int sender_rank, int tag)
+                                                                int sender_rank, int receiver_rank,
+                                                                int tag)
 {
     int nic_idx = 0;
 
     if (MPIDI_OFI_COMM(comm).pref_nic) {
-        nic_idx = MPIDI_OFI_COMM(comm).pref_nic[comm->rank];
+        nic_idx = MPIDI_OFI_COMM(comm).pref_nic[receiver_rank];
     } else if (MPIDI_OFI_COMM(comm).enable_hashing) {
         /* TODO - We should use the per-communicator value for the maximum number of NICs in this
          *        calculation once we have a per-communicator value for it. */

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -47,10 +47,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
         goto unpack;
 
     /* Calculate the correct NICs. */
-    sender_nic = MPIDI_OFI_multx_sender_nic_index(comm, comm->recvcontext_id, MPIR_Process.rank,
-                                                  MPIDI_OFI_init_get_tag(match_bits));
-    receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->recvcontext_id, rank,
-                                                      MPIDI_OFI_init_get_tag(match_bits));
+    sender_nic =
+        MPIDI_OFI_multx_sender_nic_index(comm, comm->recvcontext_id, rank, comm->rank,
+                                         MPIDI_OFI_init_get_tag(match_bits));
+    receiver_nic =
+        MPIDI_OFI_multx_receiver_nic_index(comm, comm->recvcontext_id, rank, comm->rank,
+                                           MPIDI_OFI_init_get_tag(match_bits));
     MPIDI_OFI_REQUEST(rreq, nic_num) = receiver_nic;
     ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
 
@@ -154,9 +156,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
     }
 
     /* Calculate the correct NICs. */
-    sender_nic = MPIDI_OFI_multx_sender_nic_index(comm, comm->recvcontext_id, MPIR_Process.rank,
-                                                  tag);
-    receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->recvcontext_id, rank, tag);
+    sender_nic =
+        MPIDI_OFI_multx_sender_nic_index(comm, comm->recvcontext_id, rank, comm->rank, tag);
+    receiver_nic =
+        MPIDI_OFI_multx_receiver_nic_index(comm, comm->recvcontext_id, rank, comm->rank, tag);
     MPIDI_OFI_REQUEST(rreq, nic_num) = receiver_nic;
     ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
 

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -27,9 +27,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
     MPIR_FUNC_ENTER;
 
     /* Calculate the correct NICs. */
-    sender_nic = MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, dst_rank, tag);
-    receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, MPIR_Process.rank,
-                                                      tag);
+    sender_nic =
+        MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, comm->rank, dst_rank, tag);
+    receiver_nic =
+        MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, comm->rank, dst_rank, tag);
     ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_local, sender_nic);
 
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, tag, 0);
@@ -88,10 +89,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
         goto pack;
 
     /* Calculate the correct NICs. */
-    sender_nic = MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, dst_rank,
+    sender_nic = MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, comm->rank, dst_rank,
                                                   MPIDI_OFI_init_get_tag(match_bits));
-    receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, MPIR_Process.rank,
-                                                      MPIDI_OFI_init_get_tag(match_bits));
+    receiver_nic =
+        MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, comm->rank, dst_rank,
+                                           MPIDI_OFI_init_get_tag(match_bits));
     MPIDI_OFI_REQUEST(sreq, nic_num) = sender_nic;
     ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_local, MPIDI_OFI_REQUEST(sreq, nic_num));
 
@@ -181,9 +183,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
 
     /* Calculate the correct NICs. */
-    sender_nic = MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, dst_rank, tag);
-    receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, MPIR_Process.rank,
-                                                      tag);
+    sender_nic =
+        MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, comm->rank, dst_rank, tag);
+    receiver_nic =
+        MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, comm->rank, dst_rank, tag);
     MPIDI_OFI_REQUEST(sreq, nic_num) = sender_nic;
     ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_local, MPIDI_OFI_REQUEST(sreq, nic_num));
 


### PR DESCRIPTION
## Pull Request Description
This PR contains patches to:
* Correctly exchange the comm.pref_nic hints list between the processes
* Use correct ranks and fix failures when using multi-NICs with multi-ppn.

These changes address issues that were identified during scale-out experiments with oneCCL and MPICH.


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
