### PR TITLE
typerep: skip unsigned integer type for yaksa reduce

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -203,6 +203,20 @@ int MPIR_Typerep_reduce_is_supported(MPI_Op op, MPI_Datatype datatype)
     if (!MPIR_CVAR_ENABLE_YAKSA_REDUCTION)
         return 0;
 
+    /* yaksa pup code currently treat unsigned integer type the same as
+     * the corresponding signed integer type, which will not work with
+     * most op other than REPLACE.
+     */
+    if (datatype == MPI_UNSIGNED_CHAR ||
+        datatype == MPI_UNSIGNED_SHORT ||
+        datatype == MPI_UNSIGNED ||
+        datatype == MPI_UNSIGNED_LONG ||
+        datatype == MPI_UNSIGNED_LONG_LONG ||
+        datatype == MPI_UINT8_T ||
+        datatype == MPI_UINT16_T || datatype == MPI_UINT32_T || datatype == MPI_UINT64_T) {
+        return 0;
+    }
+
     if ((datatype == MPI_DOUBLE || datatype == MPI_C_DOUBLE_COMPLEX) &&
         (!MPIR_CVAR_GPU_DOUBLE_SUPPORT))
         return 0;


### PR DESCRIPTION
## Pull Request Description

Yaksa currently treat unsigned integer type the same as its
corresponding signed type. This will not work in general. To fix, yaksa
need generate additional pup code for unsigned datatypes, which will
further bloating up the build time and resulting binary size.

Because yaksa reduce is an optimization path and unsigned integer
computation is not common in HPC applications, we opt for simply skip
yakda reduce in this case.

Fixes #6083 
Note: the issue may be hidden by https://github.com/pmodels/mpich/pull/6017/commits/b93801d90597e137314c74a98aa539afb5ad4663

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
