### PR TITLE
init: fix error checking in  MPI_Session_get_nth_pset

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -10,6 +10,7 @@
 **finalized:MPI has already called MPI_Finalize
 **inittwice:Cannot call MPI_INIT or MPI_INIT_THREAD more than once
 **psetinvalidn:Invalid pset number
+**psetinvalidn %d:Invalid pset number - %d
 **psetinvalidname:Invalid pset name
 **session:Invalid MPI_Session handle
 **sessionnull: NULL MPI_Session

--- a/src/mpi/init/init_impl.c
+++ b/src/mpi/init/init_impl.c
@@ -195,7 +195,8 @@ int MPIR_Session_get_nth_pset_impl(MPIR_Session * session_ptr, MPIR_Info * info_
     }
 
     if (!MPIR_pset_list[i]) {
-        MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_ARG, goto fn_fail, "**psetinvalidn");
+        MPIR_ERR_SETANDSTMT1(mpi_errno, MPI_ERR_ARG, goto fn_fail, "**psetinvalidn",
+                             "**psetinvalidn %d", n);
     }
 
     int len = strlen(MPIR_pset_list[i]);

--- a/src/mpi/init/init_impl.c
+++ b/src/mpi/init/init_impl.c
@@ -194,7 +194,7 @@ int MPIR_Session_get_nth_pset_impl(MPIR_Session * session_ptr, MPIR_Info * info_
         i++;
     }
 
-    if (i != n) {
+    if (!MPIR_pset_list[i]) {
         MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_ARG, goto fn_fail, "**psetinvalidn");
     }
 


### PR DESCRIPTION
## Pull Request Description
The old range check was insufficient and misses the case when `n` is equal the total number of psets. This PR fixes the check and enhances the error message by adding the index argument to the error message.

Fixes #6086
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
