### PR TITLE
misc: fix error check in nonblocking localcopy

### DIFF
--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -65,9 +65,9 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
             MPIR_Typerep_unpack(MPIR_get_contig_ptr(sendbuf, sendtype_true_lb), copy_sz, recvbuf,
                                 recvcount, recvtype, 0, &actual_unpack_bytes,
                                 MPIR_TYPEREP_FLAG_NONE);
+            MPIR_ERR_CHKANDJUMP(actual_unpack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
+                                "**dtypemismatch");
         }
-        MPIR_ERR_CHKANDJUMP(actual_unpack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
-                            "**dtypemismatch");
     } else if (recvtype_iscontig) {
         MPI_Aint actual_pack_bytes;
         if (typereq_req) {
@@ -78,9 +78,9 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
             MPIR_Typerep_pack(sendbuf, sendcount, sendtype, 0,
                               MPIR_get_contig_ptr(recvbuf, recvtype_true_lb), copy_sz,
                               &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
+            MPIR_ERR_CHKANDJUMP(actual_pack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
+                                "**dtypemismatch");
         }
-        MPIR_ERR_CHKANDJUMP(actual_pack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
-                            "**dtypemismatch");
     } else {
         /* For multi-step pack/unpack, using only blocking version for simplicity. */
 


### PR DESCRIPTION
## Pull Request Description
When we call MPIR_Typerep_ipack or MPIR_Typerep_iunpack, the
actual_unpack_bytes won't be correctly updated until the request is
complete. Thus, we shouldn't do the error checking after issuing the
operation.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
