### PR TITLE
mpl: fix hip and add GPU debug summary

### DIFF
--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -214,7 +214,11 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     /* Initialize gpu in mpl in order to support shm gpu module initialization
      * inside MPID_Init */
     if (MPIR_CVAR_ENABLE_GPU) {
-        int mpl_errno = MPL_gpu_init();
+        int debug_summary = 0;
+        if (MPIR_CVAR_DEBUG_SUMMARY) {
+            debug_summary = (MPIR_Process.rank == 0);
+        }
+        int mpl_errno = MPL_gpu_init(debug_summary);
         MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_init");
     }
 

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -1082,16 +1082,16 @@ AM_CONDITIONAL([MPL_HAVE_ZE],[test "X${pac_have_ze}" = "Xyes"])
 
 # Check HIP availability
 if test "$have_gpu" = "no" ; then
+    PAC_PUSH_FLAG(CPPFLAGS)
     PAC_APPEND_FLAG([-D__HIP_PLATFORM_AMD__], [CPPFLAGS])
     PAC_CHECK_HEADER_LIB_OPTIONAL([hip],[hip/hip_runtime_api.h],[amdhip64],[hipStreamSynchronize])
+    PAC_POP_FLAG(CPPFLAGS)
 fi
 
 if test "X${pac_have_hip}" = "Xyes" ; then
-    have_gpu="yes"
     AC_DEFINE([HAVE_HIP],[1],[Define if HIP is available])
+    have_gpu="yes"
     GPU_SUPPORT="HIP"
-else
-    CPPFLAGS=`echo $CPPFLAGS | sed 's/-D__HIP_PLATFORM_AMD__)//g'`
 fi
 AM_CONDITIONAL([MPL_HAVE_HIP],[test "X${pac_have_hip}" = "Xyes"])
 

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -69,7 +69,7 @@ int MPL_gpu_unregister_host(const void *ptr);
 int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device);
 int MPL_gpu_free(void *ptr);
 
-int MPL_gpu_init(void);
+int MPL_gpu_init(int debug_summary);
 int MPL_gpu_finalize(void);
 
 int MPL_gpu_global_to_local_dev_id(int global_dev_id);

--- a/src/mpl/include/mpl_gpu_hip.h
+++ b/src/mpl/include/mpl_gpu_hip.h
@@ -6,6 +6,10 @@
 #ifndef MPL_GPU_HIP_H_INCLUDED
 #define MPL_GPU_HIP_H_INCLUDED
 
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIP_PLATFORM_NVIDIA__)
+#define __HIP_PLATFORM_AMD__
+#endif
+
 #include "hip/hip_runtime.h"
 #include "hip/hip_runtime_api.h"
 

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -33,7 +33,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 {
     int ret = MPL_SUCCESS;
     if (!gpu_initialized) {
-        ret = MPL_gpu_init();
+        ret = MPL_gpu_init(0);
     }
 
     *dev_cnt = device_count;
@@ -215,7 +215,7 @@ int MPL_gpu_free(void *ptr)
     goto fn_exit;
 }
 
-int MPL_gpu_init(void)
+int MPL_gpu_init(int debug_summary)
 {
     int mpl_err = MPL_SUCCESS;
     if (gpu_initialized) {
@@ -273,6 +273,15 @@ int MPL_gpu_init(void)
      * for result correctness. */
     gpu_mem_hook_init();
     gpu_initialized = 1;
+
+    if (debug_summary) {
+        printf("==== GPU Init (CUDA) ====\n");
+        printf("device_count: %d\n", device_count);
+        if (visible_devices) {
+            printf("CUDA_VISIBLE_DEVICES: %s\n", visible_devices);
+        }
+        printf("=========================\n");
+    }
 
   fn_exit:
     return mpl_err;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -63,7 +63,7 @@ int MPL_gpu_free(void *ptr)
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_init(void)
+int MPL_gpu_init(int debug_summary)
 {
     return MPL_SUCCESS;
 }

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -32,7 +32,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 {
     int ret = MPL_SUCCESS;
     if (!gpu_initialized) {
-        ret = MPL_gpu_init();
+        ret = MPL_gpu_init(0);
     }
 
     *dev_cnt = device_count;
@@ -209,7 +209,7 @@ int MPL_gpu_free(void *ptr)
     goto fn_exit;
 }
 
-int MPL_gpu_init(void)
+int MPL_gpu_init(int debug_summary)
 {
     int mpl_err = MPL_SUCCESS;
     hipError_t ret = hipGetDeviceCount(&device_count);
@@ -259,6 +259,15 @@ int MPL_gpu_init(void)
      * for result correctness. */
     gpu_mem_hook_init();
     gpu_initialized = 1;
+
+    if (debug_summary) {
+        printf("==== GPU Init (HIP) ====\n");
+        printf("device_count: %d\n", device_count);
+        if (visible_devices) {
+            printf("HIP_VISIBLE_DEVICES: %s\n", visible_devices);
+        }
+        printf("=========================\n");
+    }
 
   fn_exit:
     return mpl_err;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -36,7 +36,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 {
     int ret = MPL_SUCCESS;
     if (!gpu_initialized) {
-        ret = MPL_gpu_init();
+        ret = MPL_gpu_init(0);
     }
 
     *dev_cnt = device_count;
@@ -44,7 +44,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
     return ret;
 }
 
-int MPL_gpu_init(void)
+int MPL_gpu_init(int debug_summary)
 {
     int mpl_err;
     mpl_err = gpu_ze_init_driver();
@@ -62,6 +62,12 @@ int MPL_gpu_init(void)
     }
 
     gpu_initialized = 1;
+
+    if (debug_summary) {
+        printf("==== GPU Init (ZE) ====\n");
+        printf("device_count: %d\n", device_count);
+        printf("=========================\n");
+    }
 
   fn_exit:
     return mpl_err;


### PR DESCRIPTION
## Pull Request Description
Defining __HIP_PLATFORM_AMD__ only in CPPFLAGS in MPL is not sufficient
since we also include mpl_gpu_hip.h when compiling mpich. Define it in
mpl_gpu_hip.h right before we include hip/hip_runtime.h instead.

User should be able to pass CPPFLAGS=-D__HIP_PLATFORM_NVIDIA__ to build
hip on NVIDIA GPU as well.

It may be useful to dump runtime gpu information when
MPIR_CVAR_DEBUG_SUMMARY is on.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
