### PR TITLE
test: do not expect white spaces for successful tests

### DIFF
--- a/test/mpi/checktests.in
+++ b/test/mpi/checktests.in
@@ -54,7 +54,7 @@ while (<RESULTS>) {
 	while (<RFD>) {
 	    chop;
 	    $outLine = $_;
-	    if ($outLine =~ /^\s+No [Ee]rrors\s*$/) {
+	    if ($outLine =~ /^\s*No [Ee]rrors\s*$/) {
 		$sawNoerrors = 1;
 	    }
 	    else {


### PR DESCRIPTION
The `checktests` script expected to have at least one white space before the "No Errors" output in case of successful tests. This patch removes this requirement.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
