### PR TITLE
hydra: add -hybrid-hosts option

### DIFF
--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -281,7 +281,7 @@ static HYD_status add_exec_to_proxy(struct HYD_exec *exec, struct HYD_proxy *pro
             proxy->exec_list->exec[i] = MPL_strdup(exec->exec[i]);
         proxy->exec_list->exec[i] = NULL;
 
-        proxy->exec_list->wdir = MPL_strdup(exec->wdir);
+        proxy->exec_list->wdir = exec->wdir ? MPL_strdup(exec->wdir) : NULL;
         proxy->exec_list->proc_count = num_procs;
         proxy->exec_list->env_prop = exec->env_prop ? MPL_strdup(exec->env_prop) : NULL;
         proxy->exec_list->user_env = HYDU_env_list_dup(exec->user_env);
@@ -297,7 +297,7 @@ static HYD_status add_exec_to_proxy(struct HYD_exec *exec, struct HYD_proxy *pro
             texec->exec[i] = MPL_strdup(exec->exec[i]);
         texec->exec[i] = NULL;
 
-        texec->wdir = MPL_strdup(exec->wdir);
+        texec->wdir = exec->wdir ? MPL_strdup(exec->wdir) : NULL;
         texec->proc_count = num_procs;
         texec->env_prop = exec->env_prop ? MPL_strdup(exec->env_prop) : NULL;
         texec->user_env = HYDU_env_list_dup(exec->user_env);

--- a/src/pm/hydra/mpiexec/get_parameters.c
+++ b/src/pm/hydra/mpiexec/get_parameters.c
@@ -344,8 +344,12 @@ static HYD_status post_process(void)
     HYD_status status = HYD_SUCCESS;
 
     for (struct HYD_exec * exec = HYD_uii_mpx_exec_list; exec; exec = exec->next) {
-        status = HYDU_correct_wdir(&exec->wdir);
-        HYDU_ERR_POP(status, "unable to correct wdir\n");
+        if (HYD_server_info.hybrid_hosts) {
+            /* Do not convert to abs path when hybrid_hosts option is set */
+        } else {
+            status = HYDU_correct_wdir(&exec->wdir);
+            HYDU_ERR_POP(status, "unable to correct wdir\n");
+        }
     }
 
     /* If an interface is provided, set that */

--- a/src/pm/hydra/mpiexec/hydra_server.h
+++ b/src/pm/hydra/mpiexec/hydra_server.h
@@ -22,6 +22,7 @@ struct HYD_cmd {
 struct HYD_server_info_s {
     struct HYD_user_global user_global;
 
+    bool hybrid_hosts;
     char *base_path;
     char *port_range;
     char *iface_ip_env_name;

--- a/src/pm/hydra/mpiexec/options.c
+++ b/src/pm/hydra/mpiexec/options.c
@@ -1573,7 +1573,6 @@ struct HYD_arg_match_table HYD_mpiexec_match_table[] = {
     {"demux", demux_fn, demux_help_fn},
 
     /* Other hydra options */
-    {"dac", auto_cleanup_fn, auto_cleanup_help_fn},
     {"debug", verbose_fn, verbose_help_fn},
     {"disable-auto-cleanup", auto_cleanup_fn, auto_cleanup_help_fn},
     {"disable-hostname-propagation", hostname_propagation_fn, hostname_propagation_help_fn},

--- a/src/pm/hydra/mpiexec/options.c
+++ b/src/pm/hydra/mpiexec/options.c
@@ -91,25 +91,25 @@ static void help_help_fn(void)
 
     printf("\n");
     printf("  Other Hydra options:\n");
-    printf("    -verbose                         verbose mode\n");
-    printf("    -info                            build information\n");
-    printf("    -print-all-exitcodes             print exit codes of all processes\n");
-    printf("    -iface                           network interface to use\n");
-    printf("    -ppn                             processes per node\n");
-    printf("    -profile                         turn on internal profiling\n");
-    printf("    -prepend-rank                    prepend rank to output\n");
-    printf("    -prepend-pattern                 prepend pattern to output\n");
-    printf("    -outfile-pattern                 direct stdout to file\n");
-    printf("    -errfile-pattern                 direct stderr to file\n");
-    printf("    -nameserver                      name server information (host:port format)\n");
     printf("    -disable-auto-cleanup            don't cleanup processes on error\n");
     printf("    -disable-hostname-propagation    let MPICH auto-detect the hostname\n");
-    printf("    -order-nodes                     order nodes as ascending/descending cores\n");
-    printf("    -localhost                       local hostname for the launching node\n");
-    printf("    -usize                           universe size (SYSTEM, INFINITE, <value>)\n");
-    printf("    -pmi-port                        use the PMI_PORT model\n");
-    printf("    -skip-launch-node                do not run MPI processes on the launch node\n");
+    printf("    -errfile-pattern                 direct stderr to file\n");
     printf("    -gpus-per-proc                   number of GPUs per process (default: auto)\n");
+    printf("    -iface                           network interface to use\n");
+    printf("    -info                            build information\n");
+    printf("    -localhost                       local hostname for the launching node\n");
+    printf("    -nameserver                      name server information (host:port format)\n");
+    printf("    -order-nodes                     order nodes as ascending/descending cores\n");
+    printf("    -outfile-pattern                 direct stdout to file\n");
+    printf("    -pmi-port                        use the PMI_PORT model\n");
+    printf("    -ppn                             processes per node\n");
+    printf("    -prepend-pattern                 prepend pattern to output\n");
+    printf("    -prepend-rank                    prepend rank to output\n");
+    printf("    -print-all-exitcodes             print exit codes of all processes\n");
+    printf("    -profile                         turn on internal profiling\n");
+    printf("    -skip-launch-node                do not run MPI processes on the launch node\n");
+    printf("    -usize                           universe size (SYSTEM, INFINITE, <value>)\n");
+    printf("    -verbose                         verbose mode\n");
 
     printf("\n");
     printf("Please see the instructions provided at\n");
@@ -1573,26 +1573,26 @@ struct HYD_arg_match_table HYD_mpiexec_match_table[] = {
     {"demux", demux_fn, demux_help_fn},
 
     /* Other hydra options */
-    {"verbose", verbose_fn, verbose_help_fn},
-    {"v", verbose_fn, verbose_help_fn},
-    {"debug", verbose_fn, verbose_help_fn},
-    {"info", info_fn, info_help_fn},
-    {"version", info_fn, info_help_fn},
-    {"print-all-exitcodes", print_all_exitcodes_fn, print_all_exitcodes_help_fn},
-    {"iface", iface_fn, iface_help_fn},
-    {"nameserver", nameserver_fn, nameserver_help_fn},
-    {"disable-auto-cleanup", auto_cleanup_fn, auto_cleanup_help_fn},
     {"dac", auto_cleanup_fn, auto_cleanup_help_fn},
-    {"enable-auto-cleanup", auto_cleanup_fn, auto_cleanup_help_fn},
+    {"debug", verbose_fn, verbose_help_fn},
+    {"disable-auto-cleanup", auto_cleanup_fn, auto_cleanup_help_fn},
     {"disable-hostname-propagation", hostname_propagation_fn, hostname_propagation_help_fn},
+    {"enable-auto-cleanup", auto_cleanup_fn, auto_cleanup_help_fn},
     {"enable-hostname-propagation", hostname_propagation_fn, hostname_propagation_help_fn},
-    {"order-nodes", order_nodes_fn, order_nodes_help_fn},
-    {"localhost", localhost_fn, localhost_help_fn},
-    {"usize", usize_fn, usize_help_fn},
-    {"pmi-port", pmi_port_fn, pmi_port_help_fn},
-    {"skip-launch-node", skip_launch_node_fn, skip_launch_node_help_fn},
-    {"gpus-per-proc", gpus_per_proc_fn, gpus_per_proc_help_fn},
     {"g", gpus_per_proc_fn, gpus_per_proc_help_fn},
+    {"gpus-per-proc", gpus_per_proc_fn, gpus_per_proc_help_fn},
+    {"iface", iface_fn, iface_help_fn},
+    {"info", info_fn, info_help_fn},
+    {"localhost", localhost_fn, localhost_help_fn},
+    {"nameserver", nameserver_fn, nameserver_help_fn},
+    {"order-nodes", order_nodes_fn, order_nodes_help_fn},
+    {"pmi-port", pmi_port_fn, pmi_port_help_fn},
+    {"print-all-exitcodes", print_all_exitcodes_fn, print_all_exitcodes_help_fn},
+    {"skip-launch-node", skip_launch_node_fn, skip_launch_node_help_fn},
+    {"usize", usize_fn, usize_help_fn},
+    {"v", verbose_fn, verbose_help_fn},
+    {"verbose", verbose_fn, verbose_help_fn},
+    {"version", info_fn, info_help_fn},
 
     /* Singleton init */
     {"pmi_args", pmi_args_fn, pmi_args_help_fn},

--- a/src/pm/hydra/mpiexec/options.c
+++ b/src/pm/hydra/mpiexec/options.c
@@ -95,6 +95,7 @@ static void help_help_fn(void)
     printf("    -disable-hostname-propagation    let MPICH auto-detect the hostname\n");
     printf("    -errfile-pattern                 direct stderr to file\n");
     printf("    -gpus-per-proc                   number of GPUs per process (default: auto)\n");
+    printf("    -hybrid-hosts                    assume hosts do not share paths\n");
     printf("    -iface                           network interface to use\n");
     printf("    -info                            build information\n");
     printf("    -localhost                       local hostname for the launching node\n");
@@ -1505,6 +1506,24 @@ static HYD_status gpus_per_proc_fn(char *arg, char ***argv)
     goto fn_exit;
 }
 
+static void hybrid_hosts_help_fn(void)
+{
+    printf("\n");
+    printf("-hybrid_hosts:\n");
+    printf("   Assume hosts do not share PATH and working directories. For it\n");
+    printf("   to work, hydra need be installed to PATH on individual hosts.\n");
+    printf("   Working directory will not be set by default.\n");
+}
+
+static HYD_status hybrid_hosts_fn(char *arg, char ***argv)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    HYD_server_info.hybrid_hosts = true;
+
+    return status;
+}
+
 struct HYD_arg_match_table HYD_mpiexec_match_table[] = {
     /* help options */
     {"help", help_fn, help_help_fn},
@@ -1580,6 +1599,7 @@ struct HYD_arg_match_table HYD_mpiexec_match_table[] = {
     {"enable-hostname-propagation", hostname_propagation_fn, hostname_propagation_help_fn},
     {"g", gpus_per_proc_fn, gpus_per_proc_help_fn},
     {"gpus-per-proc", gpus_per_proc_fn, gpus_per_proc_help_fn},
+    {"hybrid-hosts", hybrid_hosts_fn, hybrid_hosts_help_fn},
     {"iface", iface_fn, iface_help_fn},
     {"info", info_fn, info_help_fn},
     {"localhost", localhost_fn, localhost_help_fn},

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -46,7 +46,10 @@ HYD_status HYD_pmcd_pmi_fill_in_proxy_args(struct HYD_string_stash *proxy_stash,
     }
 
     HYD_STRING_STASH_INIT(stash);
-    HYD_STRING_STASH(stash, MPL_strdup(HYD_server_info.base_path), status);
+    if (!HYD_server_info.hybrid_hosts) {
+        /* use abs path unless hybrid_hosts option is given */
+        HYD_STRING_STASH(stash, MPL_strdup(HYD_server_info.base_path), status);
+    }
     HYD_STRING_STASH(stash, MPL_strdup(HYDRA_PMI_PROXY), status);
     HYD_STRING_SPIT(stash, str, status);
 

--- a/src/pm/hydra/mpiexec/uiu.c
+++ b/src/pm/hydra/mpiexec/uiu.c
@@ -18,6 +18,7 @@ void HYD_uiu_init_params(void)
 {
     HYDU_init_user_global(&HYD_server_info.user_global);
 
+    HYD_server_info.hybrid_hosts = false;
     HYD_server_info.base_path = NULL;
 
     HYD_server_info.port_range = NULL;


### PR DESCRIPTION
## Pull Request Description
By default, hydra only works when each host share common paths to both the `hydra` and the current working directory. On hybrid hosts, paths on the launching host may not exist on the other hosts. By assuming hydra is installed to each host's PATH and executable commands work with the default working directory (typically `$HOME`), this PR makes it work by using `-hybrid-hosts` option. Users still can use `-wdir` option and use either relative or absolute command paths to further specify the commands.

NOTE:
Ideally, each hosts should install the latest `hydra` version. In particular, https://github.com/pmodels/mpich/pull/5900 altered the handshake, so older `hydra` before that PR will not work with the latest `mpiexec`. 

However, since this option only apply to `mpiexec`, not `hydra_pmi_proxy`, different hosts do not require strictly the same `hydra` version.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
