### PR TITLE
mpir_pmi: fix typo in checking error return

### DIFF
--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -1016,7 +1016,7 @@ int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
                                (const INFO_TYPE **) info_keyval_vectors,
                                num_preput_keyval, preput_vector, NULL, 0, pmi_errcodes);
     MPL_free(argcs);
-    MPIR_ERR_CHKANDJUMP1(mpi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                          "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
 #elif defined(USE_PMIX_API)
     /* not supported yet */


### PR DESCRIPTION
## Pull Request Description
We should check against pmi_errno, but mistyped as mpi_errno.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
