### PR TITLE
stream: reimplement MPIR_Allreduce_enqueue_impl

### DIFF
--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -64,7 +64,7 @@ int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtyp
                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype);
 int MPIR_Ilocalcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                    MPIR_Typerep_req * typereq_req);
+                    MPIR_Typerep_req * typerep_req);
 
 /* Contiguous datatype calculates buffer address with `(char *) buf + dt_true_lb`.
  * However, dt_true_lb is treated as ptrdiff_t (signed), and when buf is MPI_BOTTOM

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -65,6 +65,8 @@ int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtyp
 int MPIR_Ilocalcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
                     MPIR_Typerep_req * typerep_req);
+int MPIR_Localcopy_stream(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                          void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, void *stream);
 
 /* Contiguous datatype calculates buffer address with `(char *) buf + dt_true_lb`.
  * However, dt_true_lb is treated as ptrdiff_t (signed), and when buf is MPI_BOTTOM

--- a/src/include/mpir_typerep.h
+++ b/src/include/mpir_typerep.h
@@ -67,15 +67,15 @@ int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize,
                         void *outbuf, MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
                         MPI_Aint * actual_unpack_bytes, uint32_t flags);
 int MPIR_Typerep_icopy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
-                       MPIR_Typerep_req * typereq_req, uint32_t flags);
+                       MPIR_Typerep_req * typerep_req, uint32_t flags);
 int MPIR_Typerep_ipack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                        MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
-                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typereq_req,
+                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typerep_req,
                        uint32_t flags);
 int MPIR_Typerep_iunpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_Aint outcount,
                          MPI_Datatype datatype, MPI_Aint outoffset, MPI_Aint * actual_unpack_bytes,
-                         MPIR_Typerep_req * typereq_req, uint32_t flags);
-int MPIR_Typerep_wait(MPIR_Typerep_req typereq_req);
+                         MPIR_Typerep_req * typerep_req, uint32_t flags);
+int MPIR_Typerep_wait(MPIR_Typerep_req typerep_req);
 
 int MPIR_Typerep_size_external32(MPI_Datatype type);
 int MPIR_Typerep_pack_external(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
@@ -9,7 +9,7 @@
 #include "typerep_internal.h"
 
 int MPIR_Typerep_icopy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
-                       MPIR_Typerep_req * typereq_req, uint32_t flags)
+                       MPIR_Typerep_req * typerep_req, uint32_t flags)
 {
     MPIR_FUNC_ENTER;
 
@@ -30,7 +30,7 @@ int MPIR_Typerep_copy(void *outbuf, const void *inbuf, MPI_Aint num_bytes, uint3
 
 int MPIR_Typerep_ipack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                        MPI_Aint inoffset, void *outbuf, MPI_Aint max_pack_bytes,
-                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typereq_req, uint32_t flags)
+                       MPI_Aint * actual_pack_bytes, MPIR_Typerep_req * typerep_req, uint32_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Segment *segp;
@@ -96,7 +96,7 @@ int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype
 
 int MPIR_Typerep_iunpack(const void *inbuf, MPI_Aint insize,
                          void *outbuf, MPI_Aint outcount, MPI_Datatype datatype, MPI_Aint outoffset,
-                         MPI_Aint * actual_unpack_bytes, MPIR_Typerep_req * typereq_req,
+                         MPI_Aint * actual_unpack_bytes, MPIR_Typerep_req * typerep_req,
                          uint32_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -161,7 +161,7 @@ int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize,
                                 actual_unpack_bytes, NULL, flags);
 }
 
-int MPIR_Typerep_wait(MPIR_Typerep_req typereq_req)
+int MPIR_Typerep_wait(MPIR_Typerep_req typerep_req)
 {
     /* All nonblocking operations are actually blocking. Thus, do nothing in wait. */
     return MPI_SUCCESS;

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -65,9 +65,9 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
             MPIR_Typerep_unpack(MPIR_get_contig_ptr(sendbuf, sendtype_true_lb), copy_sz, recvbuf,
                                 recvcount, recvtype, 0, &actual_unpack_bytes,
                                 MPIR_TYPEREP_FLAG_NONE);
-            MPIR_ERR_CHKANDJUMP(actual_unpack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
-                                "**dtypemismatch");
         }
+        MPIR_ERR_CHKANDJUMP(actual_unpack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
+                            "**dtypemismatch");
     } else if (recvtype_iscontig) {
         MPI_Aint actual_pack_bytes;
         if (typereq_req) {
@@ -78,9 +78,9 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
             MPIR_Typerep_pack(sendbuf, sendcount, sendtype, 0,
                               MPIR_get_contig_ptr(recvbuf, recvtype_true_lb), copy_sz,
                               &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
-            MPIR_ERR_CHKANDJUMP(actual_pack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
-                                "**dtypemismatch");
         }
+        MPIR_ERR_CHKANDJUMP(actual_pack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
+                            "**dtypemismatch");
     } else {
         /* For multi-step pack/unpack, using only blocking version for simplicity. */
 

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -59,30 +59,28 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
 
     if (sendtype_iscontig) {
         MPI_Aint actual_unpack_bytes;
+        const void *bufptr = MPIR_get_contig_ptr(sendbuf, sendtype_true_lb);
         if (localcopy_kind == LOCALCOPY_NONBLOCKING) {
             MPIR_Typerep_req *typerep_req = extra_param;
-            MPIR_Typerep_iunpack(MPIR_get_contig_ptr(sendbuf, sendtype_true_lb), copy_sz, recvbuf,
-                                 recvcount, recvtype, 0, &actual_unpack_bytes, typerep_req,
-                                 MPIR_TYPEREP_FLAG_NONE);
+            MPIR_Typerep_iunpack(bufptr, copy_sz, recvbuf, recvcount, recvtype, 0,
+                                 &actual_unpack_bytes, typerep_req, MPIR_TYPEREP_FLAG_NONE);
         } else {
             /* LOCALCOPY_BLOCKING */
-            MPIR_Typerep_unpack(MPIR_get_contig_ptr(sendbuf, sendtype_true_lb), copy_sz, recvbuf,
-                                recvcount, recvtype, 0, &actual_unpack_bytes,
-                                MPIR_TYPEREP_FLAG_NONE);
+            MPIR_Typerep_unpack(bufptr, copy_sz, recvbuf, recvcount, recvtype, 0,
+                                &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
         }
         MPIR_ERR_CHKANDJUMP(actual_unpack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,
                             "**dtypemismatch");
     } else if (recvtype_iscontig) {
+        void *bufptr = MPIR_get_contig_ptr(recvbuf, recvtype_true_lb);
         MPI_Aint actual_pack_bytes;
         if (localcopy_kind == LOCALCOPY_NONBLOCKING) {
             MPIR_Typerep_req *typerep_req = extra_param;
-            MPIR_Typerep_ipack(sendbuf, sendcount, sendtype, 0,
-                               MPIR_get_contig_ptr(recvbuf, recvtype_true_lb), copy_sz,
+            MPIR_Typerep_ipack(sendbuf, sendcount, sendtype, 0, bufptr, copy_sz,
                                &actual_pack_bytes, typerep_req, MPIR_TYPEREP_FLAG_NONE);
         } else {
             /* LOCALCOPY_BLOCKING */
-            MPIR_Typerep_pack(sendbuf, sendcount, sendtype, 0,
-                              MPIR_get_contig_ptr(recvbuf, recvtype_true_lb), copy_sz,
+            MPIR_Typerep_pack(sendbuf, sendcount, sendtype, 0, bufptr, copy_sz,
                               &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
         }
         MPIR_ERR_CHKANDJUMP(actual_pack_bytes != copy_sz, mpi_errno, MPI_ERR_TYPE,

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -60,9 +60,9 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
     if (sendtype_iscontig) {
         MPI_Aint actual_unpack_bytes;
         if (localcopy_kind == LOCALCOPY_NONBLOCKING) {
-            MPIR_Typerep_req *typereq_req = extra_param;
+            MPIR_Typerep_req *typerep_req = extra_param;
             MPIR_Typerep_iunpack(MPIR_get_contig_ptr(sendbuf, sendtype_true_lb), copy_sz, recvbuf,
-                                 recvcount, recvtype, 0, &actual_unpack_bytes, typereq_req,
+                                 recvcount, recvtype, 0, &actual_unpack_bytes, typerep_req,
                                  MPIR_TYPEREP_FLAG_NONE);
         } else {
             /* LOCALCOPY_BLOCKING */
@@ -75,10 +75,10 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
     } else if (recvtype_iscontig) {
         MPI_Aint actual_pack_bytes;
         if (localcopy_kind == LOCALCOPY_NONBLOCKING) {
-            MPIR_Typerep_req *typereq_req = extra_param;
+            MPIR_Typerep_req *typerep_req = extra_param;
             MPIR_Typerep_ipack(sendbuf, sendcount, sendtype, 0,
                                MPIR_get_contig_ptr(recvbuf, recvtype_true_lb), copy_sz,
-                               &actual_pack_bytes, typereq_req, MPIR_TYPEREP_FLAG_NONE);
+                               &actual_pack_bytes, typerep_req, MPIR_TYPEREP_FLAG_NONE);
         } else {
             /* LOCALCOPY_BLOCKING */
             MPIR_Typerep_pack(sendbuf, sendcount, sendtype, 0,
@@ -183,14 +183,14 @@ int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtyp
 
 int MPIR_Ilocalcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                    MPIR_Typerep_req * typereq_req)
+                    MPIR_Typerep_req * typerep_req)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = do_localcopy(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                             LOCALCOPY_NONBLOCKING, typereq_req);
+                             LOCALCOPY_NONBLOCKING, typerep_req);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:


### PR DESCRIPTION
## Pull Request Description

Add stream versions of MPIR_Localcopy and using similar buffer swapping pattern as in gpu fallback collectives to simplify the implementation of `MPIR_Allreduce_enqueue`.

Previously splitting the allocation of host buffer and the intermediary temporary buffer between the enqueue function and the callback function is problematic.

Handle `MPI_IN_PLACE`.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
