### PR TITLE
configure: support C++ datatypes when CXX is available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3188,6 +3188,9 @@ if test -n "$CXX" ; then
     AC_MSG_RESULT([$pac_retval])
     AC_DEFINE_UNQUOTED([MPIR_CXX_BOOL_CTYPE],[$pac_retval],
 			[a C type used to compute C++ bool reductions])
+    if test "$ac_cv_sizeof_bool" != 0 ; then
+        AC_DEFINE(HAVE_CXX_BOOL,1,[Define is C++ supports bool types])
+    fi
 
     AC_CHECK_HEADER(complex)
     if test "$ac_cv_header_complex" = "yes" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -683,6 +683,24 @@ dnl lead to weird AM_CONDITIONAL errors and potentially other problems.
 # suppress default "-g -O2" from AC_PROG_CXX
 : ${CXXFLAGS=""}
 AC_PROG_CXX
+AC_CACHE_CHECK([whether the C++ compiler $CXX can build an executable],
+    pac_cv_cxx_builds_exe,[
+    AC_LANG_PUSH([C++])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+        class mytest {
+            int a;
+        public:
+            mytest(void) : a(1) {}
+            ~mytest(void) {}
+        };
+        ]],[[mytest a;]])],
+        pac_cv_cxx_builds_exe=yes, pac_cv_cxx_builds_exe=no)
+    AC_LANG_POP([C++])
+])
+if test "$pac_cv_cxx_builds_exe" = "no" ; then
+    # clear $CXX if C++ compiler does not work
+    CXX=
+fi
 
 if test "$enable_fortran" = "no" ; then
     enable_f77=no
@@ -2246,21 +2264,7 @@ if test "$enable_cxx" = "yes" ; then
     # to link programs that are really C++.  For that reason,
     # we've added a test to see if the C++ compiler can produce
     # an executable.
-    AC_CACHE_CHECK([whether the C++ compiler $CXX can build an executable],
-    pac_cv_cxx_builds_exe,[
- AC_LANG_PUSH([C++])
- AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-    class mytest {
-        int a;
-      public:
-        mytest(void) : a(1) {}
-        ~mytest(void) {}
-    };
-    ]],[[mytest a;]])],
-    pac_cv_cxx_builds_exe=yes, pac_cv_cxx_builds_exe=no)
- AC_LANG_POP([C++])
-])
-    if test "$pac_cv_cxx_builds_exe" != yes ; then
+    if test -z "$CXX" ; then
         AC_MSG_ERROR([Aborting because C++ compiler does not work.  If you do not need a C++ compiler, configure with --disable-cxx])
     fi
     # Recent failures have come when a standard header is loaded
@@ -3173,9 +3177,9 @@ else
     AC_DEFINE(HAVE_NO_FORTRAN_MPI_TYPES_IN_C,1,[Define if the Fortran types are not available in C])
 fi
 # ----------------------------------------------------------------------------
-# C++ types
+# C++ types - we support CXX datatypes if there is a working CXX compiler
 
-if test "$enable_cxx" = "yes" ; then
+if test -n "$CXX" ; then
     AC_LANG([C++])
     AC_CHECK_SIZEOF(bool)
 

--- a/src/include/mpir_op_util.h
+++ b/src/include/mpir_op_util.h
@@ -72,7 +72,7 @@ MPIR_OP_TYPE_GROUP(C_INTEGER)
 #define MPIR_OP_TYPE_MACRO_HAVE_REAL4_CTYPE(mpi_type_,c_type_,type_name_)
 #define MPIR_OP_TYPE_MACRO_HAVE_REAL8_CTYPE(mpi_type_,c_type_,type_name_)
 #define MPIR_OP_TYPE_MACRO_HAVE_REAL16_CTYPE(mpi_type_,c_type_,type_name_)
-#define MPIR_OP_TYPE_MACRO_HAVE_CXX(mpi_type_,c_type_,type_name_)
+#define MPIR_OP_TYPE_MACRO_HAVE_CXX_BOOL(mpi_type_,c_type_,type_name_)
 #define MPIR_OP_TYPE_MACRO_HAVE_CXX_COMPLEX(mpi_type_,c_type_,type_name_)
 #define MPIR_OP_TYPE_MACRO_HAVE_CXX_LONG_DOUBLE_COMPLEX(mpi_type_,c_type_,type_name_)
 #define MPIR_OP_TYPE_MACRO_HAVE_INT8_T(mpi_type_,c_type_,type_name_)
@@ -145,9 +145,9 @@ MPIR_OP_TYPE_GROUP(C_INTEGER)
 #define MPIR_OP_TYPE_MACRO_HAVE_REAL16_CTYPE(mpi_type_,c_type_,type_name_) MPIR_OP_TYPE_MACRO(mpi_type_,c_type_,type_name_)
 #endif
 /* general C++ types */
-#if defined(HAVE_CXX_BINDING)
-#undef MPIR_OP_TYPE_MACRO_HAVE_CXX
-#define MPIR_OP_TYPE_MACRO_HAVE_CXX(mpi_type_,c_type_,type_name_) MPIR_OP_TYPE_MACRO(mpi_type_,c_type_,type_name_)
+#if defined(HAVE_CXX_BOOL)
+#undef MPIR_OP_TYPE_MACRO_HAVE_CXX_BOOL
+#define MPIR_OP_TYPE_MACRO_HAVE_CXX_BOOL(mpi_type_,c_type_,type_name_) MPIR_OP_TYPE_MACRO(mpi_type_,c_type_,type_name_)
 #endif
 /* C++ complex types */
 #if defined(HAVE_CXX_COMPLEX)
@@ -321,7 +321,7 @@ typedef struct {
 #define MPIR_OP_TYPE_GROUP_LOGICAL                                                    \
     MPIR_OP_TYPE_MACRO_HAVE_FORTRAN(MPI_LOGICAL, MPI_Fint, mpir_typename_logical)     \
     MPIR_OP_TYPE_MACRO_HAVE_C_BOOL(MPI_C_BOOL, _Bool, mpir_typename_c_bool)           \
-    MPIR_OP_TYPE_MACRO_HAVE_CXX(MPI_CXX_BOOL, MPIR_CXX_BOOL_CTYPE, mpir_typename_cxx_bool_value)
+    MPIR_OP_TYPE_MACRO_HAVE_CXX_BOOL(MPI_CXX_BOOL, MPIR_CXX_BOOL_CTYPE, mpir_typename_cxx_bool_value)
 #define MPIR_OP_TYPE_GROUP_LOGICAL_EXTRA        /* empty, provided for consistency */
 
 /* complex group */

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_init.c
@@ -153,9 +153,9 @@ yaksa_type_t MPII_Typerep_get_yaksa_type(MPI_Datatype type)
         case MPI_INTEGER4:
         case MPI_INTEGER8:
 #endif /* HAVE_FORTRAN_BINDING */
-#ifdef HAVE_CXX_BINDING
+#ifdef HAVE_CXX_BOOL
         case MPI_CXX_BOOL:
-#endif /* HAVE_CXX_BINDING */
+#endif /* HAVE_CXX_BOOL */
             switch (basic_type_size) {
                 case 1:
                     yaksa_type = YAKSA_TYPE__INT8_T;

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -315,7 +315,6 @@ int MPIR_Datatype_builtintype_alignment(MPI_Datatype type)
             return ALIGNOF_LONG_DOUBLE;
 #endif /* HAVE_FORTRAN_BINDING */
 
-#ifdef HAVE_CXX_BINDING
     } else if (type == MPI_CXX_BOOL) {
         return ALIGNOF_BOOL;
     } else if (type == MPI_CXX_FLOAT_COMPLEX) {
@@ -324,7 +323,6 @@ int MPIR_Datatype_builtintype_alignment(MPI_Datatype type)
         return ALIGNOF_DOUBLE;
     } else if (type == MPI_CXX_LONG_DOUBLE_COMPLEX) {
         return ALIGNOF_LONG_DOUBLE;
-#endif /* HAVE_CXX_BINDING */
     }
 
     return 1;


### PR DESCRIPTION
## Pull Request Description
Support C++ datatypes when there is a working c++ compiler rather than
depending on whether C++ binding is enabled.


Fixes #6094 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
