### PR TITLE
pmi: fix MPIR_pmi_barrier using PMI2_KVS_Fence

### DIFF
--- a/src/pm/hydra/mpiexec/pmiserv_pmi.h
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi.h
@@ -22,7 +22,11 @@ struct HYD_pmcd_token_segment {
 };
 
 struct HYD_pmcd_pmi_pg_scratch {
+    /* PMI-1's PMI_Barrier is blocking, thus a single barrier_count works */
     int barrier_count;
+    /* PMI-2's PMI2_KVS_Fence is non-blocking, thus need track epoch */
+    int epoch;
+    int fence_count;
     struct HYD_pmcd_pmi_ecount {
         int fd;
         int pid;

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -517,6 +517,8 @@ HYD_status HYD_pmcd_pmi_alloc_pg_scratch(struct HYD_pg *pg)
     pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
 
     pg_scratch->barrier_count = 0;
+    pg_scratch->epoch = 0;
+    pg_scratch->fence_count = 0;
 
     HYDU_MALLOC_OR_JUMP(pg_scratch->ecount, struct HYD_pmcd_pmi_ecount *,
                         pg->pg_process_count * sizeof(struct HYD_pmcd_pmi_ecount), status);

--- a/src/pmi/include/pmi2.h
+++ b/src/pmi/include/pmi2.h
@@ -294,16 +294,17 @@ S*/
   Returns 'MPI_SUCCESS' on success and an MPI error code on failure.
 
   Notes:
-  This is a collective call across the job.  It has semantics that are
-  similar to those for MPI_Win_fence and hence is most easily
-  implemented as a barrier across all of the processes in the job.
-  Specifically, all PMI2_KVS_Put operations performed by any process in
-  the same job must be visible to all processes (by using PMI2_KVS_Get)
-  after PMI2_KVS_Fence completes.  However, a PMI implementation could
-  make this a lazy operation by not waiting for all processes to enter
-  their corresponding PMI2_KVS_Fence until some process issues a
-  PMI2_KVS_Get. This might be appropriate for some wide-area
-  implementations.
+  This is a collective call across the job.  All PMI2_KVS_Put operations
+  performed by any process in the same job must be visible to all
+  processes (by using PMI2_KVS_Get) after PMI2_KVS_Fence completes.
+  However, a PMI implementation could make this a lazy operation by not
+  waiting for all processes to enter their corresponding PMI2_KVS_Fence
+  until some process issues a PMI2_KVS_Get. Thus PMI2_KVS_Fence alone
+  may not serve as a barrier.  Using PMI2_KVS_GET for a non-existent key
+  after PMI2_KVS_Fence will have the same effect as an barrier since
+  PMI2_KVS_GET will not return until all processes posted PMI2_KVS_Fence,
+  even though PMI2_KVS_Get will return error since the key does not
+  exist.
 
 @*/
     int PMI2_KVS_Fence(void);

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -407,6 +407,9 @@ int MPIR_pmi_barrier(void)
     pmi_errno = PMI2_KVS_Fence();
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                          "**pmi_kvsfence", "**pmi_kvsfence %d", pmi_errno);
+    /* Get a non-existent key, it only returns after every process called fence */
+    int out_len;
+    PMI2_KVS_Get(pmi_jobid, PMI2_ID_NULL, "-NONEXIST-KEY", NULL, 0, &out_len);
 #elif defined(USE_PMIX_API)
     pmix_info_t *info;
     PMIX_INFO_CREATE(info, 1);


### PR DESCRIPTION
## Pull Request Description
Split from https://github.com/pmodels/mpich/pull/6107

`PMI2_KVS_Fence` alone is insufficient to serve as a PMI barrier. It needs to be combined with `PMI2_KVS_Get` to get the barrier effect.

Hydra implementation of kvs_fence uses a single global `fence_count`. This may be corrupted from `PMI2_KVS_Fence` posted across multiple epochs or from multiple process groups. Fix it by attaching the count to each process group and tracking epoch number.

Amend the notes on `PMI2_KVS_Fence` for clarification.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
