### PR TITLE
romio: change internal int count type to MPI_Aint

### DIFF
--- a/src/mpi/romio/adio/ad_daos/ad_daos.h
+++ b/src/mpi/romio/adio/ad_daos/ad_daos.h
@@ -100,7 +100,8 @@ void adio_daos_coh_release(struct adio_daos_hdl *hdl);
 
 int ADIOI_DAOS_aio_free_fn(void *extra_state);
 int ADIOI_DAOS_aio_poll_fn(void *extra_state, MPI_Status * status);
-int ADIOI_DAOS_aio_wait_fn(int count, void **array_of_states, double timeout, MPI_Status * status);
+int ADIOI_DAOS_aio_wait_fn(MPI_Aint count, void **array_of_states, double timeout,
+                           MPI_Status * status);
 int ADIOI_DAOS_err(const char *myname, const char *filename, int line, int rc);
 
 void ADIOI_DAOS_Open(ADIO_File fd, int *error_code);
@@ -112,28 +113,28 @@ void ADIOI_DAOS_Close(ADIO_File fd, int *error_code);
 void ADIOI_DAOS_Delete(const char *filename, int *error_code);
 void ADIOI_DAOS_Fcntl(ADIO_File fd, int flag, ADIO_Fcntl_t * fcntl_struct, int *error_code);
 void ADIOI_DAOS_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code);
-void ADIOI_DAOS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_DAOS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_DAOS_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_DAOS_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_DAOS_IReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_DAOS_IReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, MPI_Request * request, int *error_code);
-void ADIOI_DAOS_IWriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_DAOS_IWriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, MPI_Request * request, int *error_code);
-void ADIOI_DAOS_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_DAOS_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_DAOS_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_DAOS_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_DAOS_IreadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_DAOS_IreadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Request * request, int *error_code);
-void ADIOI_DAOS_IwriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_DAOS_IwriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, MPI_Request * request, int *error_code);
 #endif /* AD_DAOS_H_INCLUDED */

--- a/src/mpi/romio/adio/ad_daos/ad_daos_io.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_io.c
@@ -18,7 +18,7 @@ enum {
 
 static MPIX_Grequest_class ADIOI_DAOS_greq_class = 0;
 
-static void DAOS_IOContig(ADIO_File fd, void *buf, int count,
+static void DAOS_IOContig(ADIO_File fd, void *buf, MPI_Aint count,
                           MPI_Datatype datatype, int file_ptr_type,
                           ADIO_Offset offset, ADIO_Status * status,
                           MPI_Request * request, int flag, int *error_code)
@@ -116,7 +116,7 @@ static void DAOS_IOContig(ADIO_File fd, void *buf, int count,
     *error_code = MPI_SUCCESS;
 }
 
-void ADIOI_DAOS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_DAOS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -124,7 +124,7 @@ void ADIOI_DAOS_ReadContig(ADIO_File fd, void *buf, int count,
                   offset, status, NULL, DAOS_READ, error_code);
 }
 
-void ADIOI_DAOS_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_DAOS_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -132,7 +132,7 @@ void ADIOI_DAOS_WriteContig(ADIO_File fd, const void *buf, int count,
                   offset, status, NULL, DAOS_WRITE, error_code);
 }
 
-void ADIOI_DAOS_IReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_DAOS_IReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, MPI_Request * request, int *error_code)
 {
@@ -140,7 +140,7 @@ void ADIOI_DAOS_IReadContig(ADIO_File fd, void *buf, int count,
                   offset, NULL, request, DAOS_READ, error_code);
 }
 
-void ADIOI_DAOS_IWriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_DAOS_IWriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, MPI_Request * request, int *error_code)
 {
@@ -187,7 +187,8 @@ int ADIOI_DAOS_aio_poll_fn(void *extra_state, MPI_Status * status)
 }
 
 /* wait for multiple requests to complete */
-int ADIOI_DAOS_aio_wait_fn(int count, void **array_of_states, double timeout, MPI_Status * status)
+int ADIOI_DAOS_aio_wait_fn(MPI_Aint count, void **array_of_states, double timeout,
+                           MPI_Status * status)
 {
 
     struct ADIO_DAOS_req **aio_reqlist;

--- a/src/mpi/romio/adio/ad_daos/ad_daos_io_str.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_io_str.c
@@ -19,7 +19,7 @@ enum {
 };
 
 static void
-ADIOI_DAOS_StridedListIO(ADIO_File fd, const void *buf, int count,
+ADIOI_DAOS_StridedListIO(ADIO_File fd, const void *buf, MPI_Aint count,
                          MPI_Datatype datatype, int file_ptr_type,
                          ADIO_Offset offset, ADIO_Status * status,
                          MPI_Request * request, int rw_type, int *error_code);
@@ -29,7 +29,7 @@ int ADIOI_DAOS_aio_free_fn(void *extra_state);
 int ADIOI_DAOS_aio_poll_fn(void *extra_state, MPI_Status * status);
 int ADIOI_DAOS_aio_wait_fn(int count, void **array_of_states, double timeout, MPI_Status * status);
 
-void ADIOI_DAOS_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_DAOS_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -38,7 +38,7 @@ void ADIOI_DAOS_ReadStrided(ADIO_File fd, void *buf, int count,
     return;
 }
 
-void ADIOI_DAOS_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_DAOS_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -47,7 +47,7 @@ void ADIOI_DAOS_WriteStrided(ADIO_File fd, const void *buf, int count,
     return;
 }
 
-void ADIOI_DAOS_IreadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_DAOS_IreadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Request * request, int *error_code)
 {
@@ -56,7 +56,7 @@ void ADIOI_DAOS_IreadStrided(ADIO_File fd, void *buf, int count,
     return;
 }
 
-void ADIOI_DAOS_IwriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_DAOS_IwriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, MPI_Request * request, int *error_code)
 {
@@ -67,7 +67,7 @@ void ADIOI_DAOS_IwriteStrided(ADIO_File fd, const void *buf, int count,
 
 
 static void
-ADIOI_DAOS_StridedListIO(ADIO_File fd, const void *buf, int count,
+ADIOI_DAOS_StridedListIO(ADIO_File fd, const void *buf, MPI_Aint count,
                          MPI_Datatype datatype, int file_ptr_type,
                          ADIO_Offset offset, ADIO_Status * status,
                          MPI_Request * request, int rw_type, int *error_code)

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs.h
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs.h
@@ -31,32 +31,32 @@ void ADIOI_GPFS_Open(ADIO_File fd, int *error_code);
 
 void ADIOI_GPFS_Close(ADIO_File fd, int *error_code);
 
-void ADIOI_GPFS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_GPFS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int
                            *error_code);
-void ADIOI_GPFS_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_GPFS_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int
                             *error_code);
 
 void ADIOI_GPFS_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code);
 
-void ADIOI_GPFS_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_GPFS_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int
                              *error_code);
-void ADIOI_GPFS_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_GPFS_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int
                             *error_code);
 
-void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
+void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, ADIO_Status * status, int
                                 *error_code);
 
-void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
+void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
                                  MPI_Datatype datatype, int file_ptr_type,
                                  ADIO_Offset offset, ADIO_Status * status, int
                                  *error_code);

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -71,7 +71,7 @@ static void ADIOI_Fill_user_buffer(ADIO_File fd, void *buf, ADIOI_Flatlist_node
                                    ADIO_Offset fd_size, ADIO_Offset * fd_start,
                                    ADIO_Offset * fd_end, MPI_Aint buftype_extent);
 
-extern void ADIOI_Calc_my_off_len(ADIO_File fd, int bufcount, MPI_Datatype
+extern void ADIOI_Calc_my_off_len(ADIO_File fd, MPI_Aint bufcount, MPI_Datatype
                                   datatype, int file_ptr_type, ADIO_Offset
                                   offset, ADIO_Offset ** offset_list_ptr, ADIO_Offset
                                   ** len_list_ptr, ADIO_Offset * start_offset_ptr,
@@ -80,7 +80,7 @@ extern void ADIOI_Calc_my_off_len(ADIO_File fd, int bufcount, MPI_Datatype
 
 
 
-void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
+void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, ADIO_Status * status, int
                                 *error_code)

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -476,7 +476,7 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
     MPI_Status status;
     ADIOI_Flatlist_node *flat_buf = NULL;
     MPI_Aint lb, buftype_extent;
-    int coll_bufsize;
+    MPI_Aint coll_bufsize;
 #ifdef RDCOLL_DEBUG
     int iii;
 #endif
@@ -608,7 +608,7 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
 #ifdef PROFILE
         MPE_Log_event(13, 0, "start computation");
 #endif
-        size = MPL_MIN((unsigned) coll_bufsize, end_loc - st_loc + 1 - done);
+        size = MPL_MIN(coll_bufsize, end_loc - st_loc + 1 - done);
         real_off = off - for_curr_iter;
         real_size = size + for_curr_iter;
 

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -88,7 +88,7 @@ static void ADIOI_Heap_merge(ADIOI_Access * others_req, int *count,
                              int nprocs, int nprocs_recv, int total_elements);
 
 
-void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
+void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
                                  MPI_Datatype datatype, int file_ptr_type,
                                  ADIO_Offset offset, ADIO_Status * status, int
                                  *error_code)

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -607,7 +607,8 @@ static void ADIOI_Exch_and_write(ADIO_File fd, const void *buf, MPI_Datatype
     MPI_Status status;
     ADIOI_Flatlist_node *flat_buf = NULL;
     MPI_Aint lb, buftype_extent;
-    int info_flag, coll_bufsize;
+    int info_flag;
+    MPI_Aint coll_bufsize;
     char *value;
     static char myname[] = "ADIOI_EXCH_AND_WRITE";
     pthread_t io_thread;
@@ -767,7 +768,7 @@ static void ADIOI_Exch_and_write(ADIO_File fd, const void *buf, MPI_Datatype
         for (i = 0; i < nprocs; i++)
             count[i] = recv_size[i] = 0;
 
-        size = MPL_MIN((unsigned) coll_bufsize, end_loc - st_loc + 1 - done);
+        size = MPL_MIN(coll_bufsize, end_loc - st_loc + 1 - done);
 
         for (i = 0; i < nprocs; i++) {
             if (others_req[i].count) {

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre.h
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre.h
@@ -52,22 +52,22 @@
 
 void ADIOI_LUSTRE_Open(ADIO_File fd, int *error_code);
 void ADIOI_LUSTRE_Close(ADIO_File fd, int *error_code);
-void ADIOI_LUSTRE_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_LUSTRE_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_LUSTRE_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_LUSTRE_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
+void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
                                    MPI_Datatype datatype, int file_ptr_type,
                                    ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_LUSTRE_ReadStridedColl(ADIO_File fd, void *buf, int count,
+void ADIOI_LUSTRE_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                                   MPI_Datatype datatype, int file_ptr_type,
                                   ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_LUSTRE_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_LUSTRE_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Status * status, int *error_code);
 void ADIOI_LUSTRE_Fcntl(ADIO_File fd, int flag, ADIO_Fcntl_t * fcntl_struct, int *error_code);

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
@@ -136,11 +136,11 @@ static ssize_t ADIOI_LUSTRE_Directio(ADIO_File fd, const void *buf, MPI_Count le
     return nbytes;
 }
 
-static void ADIOI_LUSTRE_IOContig(ADIO_File fd, const void *buf, int count,
+static void ADIOI_LUSTRE_IOContig(ADIO_File fd, const void *buf, MPI_Aint count,
                                   MPI_Datatype datatype, int file_ptr_type,
                                   ADIO_Offset offset, ADIO_Status * status,
                                   int io_mode, int *error_code);
-static void ADIOI_LUSTRE_IOContig(ADIO_File fd, const void *buf, int count,
+static void ADIOI_LUSTRE_IOContig(ADIO_File fd, const void *buf, MPI_Aint count,
                                   MPI_Datatype datatype, int file_ptr_type,
                                   ADIO_Offset offset, ADIO_Status * status,
                                   int io_mode, int *error_code)
@@ -235,14 +235,14 @@ static void ADIOI_LUSTRE_IOContig(ADIO_File fd, const void *buf, int count,
     /* --END ERROR HANDLING-- */
 }
 
-void ADIOI_LUSTRE_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_LUSTRE_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
     ADIOI_LUSTRE_IOContig(fd, buf, count, datatype, file_ptr_type, offset, status, 1, error_code);
 }
 
-void ADIOI_LUSTRE_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_LUSTRE_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -83,7 +83,7 @@ static void ADIOI_LUSTRE_IterateOneSided(ADIO_File fd, const void *buf, int *str
                                          ADIO_Offset firstFileOffset, ADIO_Offset lastFileOffset,
                                          MPI_Datatype datatype, int myrank, int *error_code);
 
-void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
+void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
                                    MPI_Datatype datatype,
                                    int file_ptr_type, ADIO_Offset offset,
                                    ADIO_Status * status, int *error_code)

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrstr.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrstr.c
@@ -139,7 +139,7 @@
         }                                                               \
     }
 
-void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs.h
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs.h
@@ -43,19 +43,19 @@ int ADIOI_NFS_aio(ADIO_File fd, void *buf, int len, ADIO_Offset offset,
 #endif
 
 void ADIOI_NFS_Open(ADIO_File fd, int *error_code);
-void ADIOI_NFS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_NFS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                           MPI_Datatype datatype, int file_ptr_type,
                           ADIO_Offset offset, ADIO_Status * status, int
                           *error_code);
-void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int
                            *error_code);
-void ADIOI_NFS_IwriteContig(ADIO_File fd, void *buf, int count,
+void ADIOI_NFS_IwriteContig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Request * request, int
                             *error_code);
-void ADIOI_NFS_IreadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_NFS_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Request * request, int
                            *error_code);
@@ -68,11 +68,11 @@ void ADIOI_NFS_ReadComplete(ADIO_Request * request, ADIO_Status * status, int
 void ADIOI_NFS_WriteComplete(ADIO_Request * request, ADIO_Status * status, int *error_code);
 void ADIOI_NFS_Fcntl(ADIO_File fd, int flag, ADIO_Fcntl_t * fcntl_struct, int
                      *error_code);
-void ADIOI_NFS_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_NFS_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int
                             *error_code);
-void ADIOI_NFS_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_NFS_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int
                            *error_code);

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_iread.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_iread.c
@@ -7,7 +7,7 @@
 
 #ifdef ROMIO_HAVE_WORKING_AIO
 /* nearly identical to ADIOI_GEN_IreadContig, except we lock around I/O */
-void ADIOI_NFS_IreadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_NFS_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Request * request, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_iwrite.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_iwrite.c
@@ -17,7 +17,7 @@
 static MPIX_Grequest_class ADIOI_GEN_greq_class = 0;
 /* this routine is nearly identical to ADIOI_GEN_IwriteContig, except we lock
  * around I/O */
-void ADIOI_NFS_IwriteContig(ADIO_File fd, void *buf, int count,
+void ADIOI_NFS_IwriteContig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Request * request, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_read.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_read.c
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #endif
 
-void ADIOI_NFS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_NFS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                           MPI_Datatype datatype, int file_ptr_type,
                           ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -154,7 +154,7 @@ void ADIOI_NFS_ReadContig(ADIO_File fd, void *buf, int count,
 #endif
 
 
-void ADIOI_NFS_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_NFS_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int
                            *error_code)

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_write.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_write.c
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #endif
 
-void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -258,7 +258,7 @@ void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
 #endif
 
 
-void ADIOI_NFS_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_NFS_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int
                             *error_code)

--- a/src/mpi/romio/adio/ad_panfs/ad_panfs.h
+++ b/src/mpi/romio/adio/ad_panfs/ad_panfs.h
@@ -32,11 +32,11 @@ void ADIOI_PANFS_Open(ADIO_File fd, int *error_code);
 /* Panasas 6 introduced some new features */
 void ADIOI_PANFS_Open6(ADIO_File fd, int *error_code);
 void ADIOI_PANFS_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code);
-void ADIOI_PANFS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_PANFS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int *error_code);
 void ADIOI_PANFS_Resize(ADIO_File fd, ADIO_Offset size, int *error_code);
-void ADIOI_PANFS_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_PANFS_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int *error_code);
 

--- a/src/mpi/romio/adio/ad_panfs/ad_panfs_read.c
+++ b/src/mpi/romio/adio/ad_panfs/ad_panfs_read.c
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #endif
 
-void ADIOI_PANFS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_PANFS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_panfs/ad_panfs_write.c
+++ b/src/mpi/romio/adio/ad_panfs/ad_panfs_write.c
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #endif
 
-void ADIOI_PANFS_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_PANFS_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2.h
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2.h
@@ -17,21 +17,21 @@
 
 void ADIOI_PVFS2_Open(ADIO_File fd, int *error_code);
 void ADIOI_PVFS2_Close(ADIO_File fd, int *error_code);
-void ADIOI_PVFS2_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_PVFS2_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int
                             *error_code);
-void ADIOI_PVFS2_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_PVFS2_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int
                              *error_code);
 void ADIOI_PVFS2_Fcntl(ADIO_File fd, int flag, ADIO_Fcntl_t * fcntl_struct, int
                        *error_code);
-void ADIOI_PVFS2_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_PVFS2_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Status * status, int
                               *error_code);
-void ADIOI_PVFS2_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_PVFS2_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int
                              *error_code);
@@ -41,28 +41,28 @@ void ADIOI_PVFS2_Resize(ADIO_File fd, ADIO_Offset size, int *error_code);
 void ADIOI_PVFS2_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code);
 int ADIOI_PVFS2_Feature(ADIO_File fd, int flag);
 
-void ADIOI_PVFS2_IReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_PVFS2_IReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, MPI_Request * request, int *error_code);
-void ADIOI_PVFS2_IWriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_PVFS2_IWriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, MPI_Request * request, int *error_code);
-void ADIOI_PVFS2_AIO_contig(ADIO_File fd, void *buf, int count,
+void ADIOI_PVFS2_AIO_contig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, MPI_Request * request, int flag, int *error_code);
-void ADIOI_PVFS2_OldWriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_PVFS2_OldWriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                                  MPI_Datatype datatype, int file_ptr_type,
                                  ADIO_Offset offset, ADIO_Status * status, int
                                  *error_code);
-void ADIOI_PVFS2_OldReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_PVFS2_OldReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, ADIO_Status * status, int
                                 *error_code);
 
-int ADIOI_PVFS2_WriteStridedListIO(ADIO_File fd, const void *buf, int count,
+int ADIOI_PVFS2_WriteStridedListIO(ADIO_File fd, const void *buf, MPI_Aint count,
                                    MPI_Datatype datatype, int file_ptr_type,
                                    ADIO_Offset offset, ADIO_Status * status, int *error_code);
-int ADIOI_PVFS2_WriteStridedDtypeIO(ADIO_File fd, const void *buf, int count,
+int ADIOI_PVFS2_WriteStridedDtypeIO(ADIO_File fd, const void *buf, MPI_Aint count,
                                     MPI_Datatype datatype, int file_ptr_type,
                                     ADIO_Offset offset, ADIO_Status * status, int *error_code);
 

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_aio.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_aio.c
@@ -20,7 +20,7 @@ int ADIOI_PVFS2_aio_free_fn(void *extra_state);
 int ADIOI_PVFS2_aio_poll_fn(void *extra_state, MPI_Status * status);
 int ADIOI_PVFS2_aio_wait_fn(int count, void **array_of_states, double timeout, MPI_Status * status);
 
-void ADIOI_PVFS2_IReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_PVFS2_IReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, MPI_Request * request, int *error_code)
 {
@@ -28,7 +28,7 @@ void ADIOI_PVFS2_IReadContig(ADIO_File fd, void *buf, int count,
                            offset, request, READ, error_code);
 }
 
-void ADIOI_PVFS2_IWriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_PVFS2_IWriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, MPI_Request * request, int *error_code)
 {
@@ -36,7 +36,7 @@ void ADIOI_PVFS2_IWriteContig(ADIO_File fd, const void *buf, int count,
                            offset, request, WRITE, error_code);
 }
 
-void ADIOI_PVFS2_AIO_contig(ADIO_File fd, void *buf, int count,
+void ADIOI_PVFS2_AIO_contig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, MPI_Request * request, int flag, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io.h
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io.h
@@ -16,12 +16,12 @@
 /* #define DEBUG_DTYPE */
 
 /* Contig I/O helper prototypes */
-int ADIOI_PVFS2_Contig(ADIO_File fd, void *buf, int count,
+int ADIOI_PVFS2_Contig(ADIO_File fd, void *buf, MPI_Aint count,
                        MPI_Datatype datatype, int file_ptr_type,
                        ADIO_Offset offset, ADIO_Status * status, int *error_code, int rw_type);
 
 /* List I/O helper prototypes */
-int ADIOI_PVFS2_StridedListIO(ADIO_File fd, void *buf, int count,
+int ADIOI_PVFS2_StridedListIO(ADIO_File fd, void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Status * status,
                               int *error_code, int rw_type);
@@ -53,7 +53,7 @@ void print_buf_file_ol_pairs(int64_t buf_off_arr[],
                              int32_t file_len_arr[], int32_t file_ol_count, void *buf, int rw_type);
 
 /* Datatype I/O helper prototypes */
-int ADIOI_PVFS2_StridedDtypeIO(ADIO_File fd, void *buf, int count,
+int ADIOI_PVFS2_StridedDtypeIO(ADIO_File fd, void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Status * status,
                                int *error_code, int rw_type);

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io_dtype.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io_dtype.c
@@ -10,7 +10,7 @@
 #include "ad_pvfs2_io.h"
 #include "ad_pvfs2_common.h"
 
-int ADIOI_PVFS2_StridedDtypeIO(ADIO_File fd, void *buf, int count,
+int ADIOI_PVFS2_StridedDtypeIO(ADIO_File fd, void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Status * status, int
                                *error_code, int rw_type)

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io_list.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_io_list.c
@@ -12,7 +12,7 @@
 
 #define COALESCE_REGIONS        /* TODO: would we ever want to *not* coalesce? */
 #define MAX_OL_COUNT 64
-int ADIOI_PVFS2_StridedListIO(ADIO_File fd, void *buf, int count,
+int ADIOI_PVFS2_StridedListIO(ADIO_File fd, void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Status * status,
                               int *error_code, int rw_type)

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_read.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_read.c
@@ -9,7 +9,7 @@
 #include "ad_pvfs2_io.h"
 #include "ad_pvfs2_common.h"
 
-void ADIOI_PVFS2_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_PVFS2_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -99,7 +99,7 @@ void ADIOI_PVFS2_ReadContig(ADIO_File fd, void *buf, int count,
     return;
 }
 
-static int ADIOI_PVFS2_ReadStridedListIO(ADIO_File fd, void *buf, int count,
+static int ADIOI_PVFS2_ReadStridedListIO(ADIO_File fd, void *buf, MPI_Aint count,
                                          MPI_Datatype datatype, int file_ptr_type,
                                          ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -107,7 +107,7 @@ static int ADIOI_PVFS2_ReadStridedListIO(ADIO_File fd, void *buf, int count,
                                      datatype, file_ptr_type, offset, status, error_code, READ);
 }
 
-static int ADIOI_PVFS2_ReadStridedDtypeIO(ADIO_File fd, void *buf, int count,
+static int ADIOI_PVFS2_ReadStridedDtypeIO(ADIO_File fd, void *buf, MPI_Aint count,
                                           MPI_Datatype datatype, int file_ptr_type,
                                           ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -115,7 +115,7 @@ static int ADIOI_PVFS2_ReadStridedDtypeIO(ADIO_File fd, void *buf, int count,
                                       datatype, file_ptr_type, offset, status, error_code, READ);
 }
 
-void ADIOI_PVFS2_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_PVFS2_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int
                              *error_code)

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_read_list_classic.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_read_list_classic.c
@@ -9,7 +9,7 @@
 
 #include "ad_pvfs2_common.h"
 
-void ADIOI_PVFS2_OldReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_PVFS2_OldReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, ADIO_Status * status, int
                                 *error_code)

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_write.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_write.c
@@ -8,7 +8,7 @@
 #include "ad_pvfs2_io.h"
 #include "ad_pvfs2_common.h"
 
-void ADIOI_PVFS2_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_PVFS2_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -111,7 +111,7 @@ void ADIOI_PVFS2_WriteContig(ADIO_File fd, const void *buf, int count,
     return;
 }
 
-int ADIOI_PVFS2_WriteStridedListIO(ADIO_File fd, const void *buf, int count,
+int ADIOI_PVFS2_WriteStridedListIO(ADIO_File fd, const void *buf, MPI_Aint count,
                                    MPI_Datatype datatype, int file_ptr_type,
                                    ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -119,7 +119,7 @@ int ADIOI_PVFS2_WriteStridedListIO(ADIO_File fd, const void *buf, int count,
                                      datatype, file_ptr_type, offset, status, error_code, WRITE);
 }
 
-int ADIOI_PVFS2_WriteStridedDtypeIO(ADIO_File fd, const void *buf, int count,
+int ADIOI_PVFS2_WriteStridedDtypeIO(ADIO_File fd, const void *buf, MPI_Aint count,
                                     MPI_Datatype datatype, int file_ptr_type,
                                     ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -128,7 +128,7 @@ int ADIOI_PVFS2_WriteStridedDtypeIO(ADIO_File fd, const void *buf, int count,
 }
 
 
-void ADIOI_PVFS2_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_PVFS2_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_write_list_classic.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_write_list_classic.c
@@ -9,7 +9,7 @@
 
 #include "ad_pvfs2_common.h"
 
-void ADIOI_PVFS2_OldWriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_PVFS2_OldWriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                                  MPI_Datatype datatype, int file_ptr_type,
                                  ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_quobytefs/ad_quobytefs.h
+++ b/src/mpi/romio/adio/ad_quobytefs/ad_quobytefs.h
@@ -40,10 +40,10 @@ void ADIOI_QUOBYTEFS_CreateAdapter(const char *registry, int *error_code);
 void ADIOI_QUOBYTEFS_DestroyAdapter(void) __attribute__ ((destructor));
 
 void ADIOI_QUOBYTEFS_Open(ADIO_File fd, int *error_code);
-void ADIOI_QUOBYTEFS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_QUOBYTEFS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_QUOBYTEFS_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_QUOBYTEFS_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                                  MPI_Datatype datatype, int file_ptr_type,
                                  ADIO_Offset offset, ADIO_Status * status, int *error_code);
 void ADIOI_QUOBYTEFS_Fcntl(ADIO_File fd, int flag, ADIO_Fcntl_t * fcntl_struct, int
@@ -54,16 +54,16 @@ void ADIOI_QUOBYTEFS_Resize(ADIO_File fd, ADIO_Offset size, int *error_code);
 void ADIOI_QUOBYTEFS_Delete(const char *path, int *error_code);
 int ADIOI_QUOBYTEFS_SetLock(ADIO_File fd, int cmd, int type, ADIO_Offset offset, int whence,
                             ADIO_Offset len);
-int ADIOI_QUOBYTEFS_aio(ADIO_File fd, void *buf, int count, MPI_Datatype type,
+int ADIOI_QUOBYTEFS_aio(ADIO_File fd, void *buf, MPI_Aint count, MPI_Datatype type,
                         ADIO_Offset offset, int wr, MPI_Request * request);
 int ADIOI_QUOBYTEFS_aio_free_fn(void *extra_state);
 int ADIOI_QUOBYTEFS_aio_poll_fn(void *extra_state, MPI_Status * status);
-int ADIOI_QUOBYTEFS_aio_wait_fn(int count, void **array_of_states, double timeout,
+int ADIOI_QUOBYTEFS_aio_wait_fn(MPI_Aint count, void **array_of_states, double timeout,
                                 MPI_Status * status);
-void ADIOI_QUOBYTEFS_IreadContig(ADIO_File fd, void *buf, int count, MPI_Datatype datatype,
+void ADIOI_QUOBYTEFS_IreadContig(ADIO_File fd, void *buf, MPI_Aint count, MPI_Datatype datatype,
                                  int file_ptr_type, ADIO_Offset offset, MPI_Request * request,
                                  int *error_code);
-void ADIOI_QUOBYTEFS_IwriteContig(ADIO_File fd, const void *buf, int count, MPI_Datatype datatype,
-                                  int file_ptr_type, ADIO_Offset offset, ADIO_Request * request,
-                                  int *error_code);
+void ADIOI_QUOBYTEFS_IwriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
+                                  MPI_Datatype datatype, int file_ptr_type, ADIO_Offset offset,
+                                  ADIO_Request * request, int *error_code);
 #endif /* AD_QUOBYTEFS_H_INCLUDED */

--- a/src/mpi/romio/adio/ad_quobytefs/ad_quobytefs_aio.c
+++ b/src/mpi/romio/adio/ad_quobytefs/ad_quobytefs_aio.c
@@ -30,7 +30,7 @@ static void quobyte_io_event_finished(void *event, int ret)
     }
 }
 
-int ADIOI_QUOBYTEFS_aio(ADIO_File fd, void *buf, int count, MPI_Datatype type,
+int ADIOI_QUOBYTEFS_aio(ADIO_File fd, void *buf, MPI_Aint count, MPI_Datatype type,
                         ADIO_Offset offset, int wr, MPI_Request * request)
 {
 
@@ -86,7 +86,7 @@ int ADIOI_QUOBYTEFS_aio(ADIO_File fd, void *buf, int count, MPI_Datatype type,
     return 0;
 }
 
-void ADIOI_QUOBYTEFS_IreadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_QUOBYTEFS_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
                                  MPI_Datatype datatype, int file_ptr_type,
                                  ADIO_Offset offset, MPI_Request * request, int *error_code)
 {
@@ -116,7 +116,7 @@ void ADIOI_QUOBYTEFS_IreadContig(ADIO_File fd, void *buf, int count,
     *error_code = MPI_SUCCESS;
 }
 
-void ADIOI_QUOBYTEFS_IwriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_QUOBYTEFS_IwriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                                   MPI_Datatype datatype, int file_ptr_type,
                                   ADIO_Offset offset, ADIO_Request * request, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_quobytefs/ad_quobytefs_read.c
+++ b/src/mpi/romio/adio/ad_quobytefs/ad_quobytefs_read.c
@@ -8,7 +8,7 @@
 
 #include "ad_quobytefs.h"
 
-void ADIOI_QUOBYTEFS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_QUOBYTEFS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_quobytefs/ad_quobytefs_write.c
+++ b/src/mpi/romio/adio/ad_quobytefs/ad_quobytefs_write.c
@@ -12,7 +12,7 @@
 
 #include "ad_quobytefs.h"
 
-void ADIOI_QUOBYTEFS_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_QUOBYTEFS_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                                  MPI_Datatype datatype, int file_ptr_type,
                                  ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_testfs/ad_testfs.h
+++ b/src/mpi/romio/adio/ad_testfs/ad_testfs.h
@@ -14,19 +14,19 @@
 
 void ADIOI_TESTFS_Open(ADIO_File fd, int *error_code);
 void ADIOI_TESTFS_Close(ADIO_File fd, int *error_code);
-void ADIOI_TESTFS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_TESTFS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int
                              *error_code);
-void ADIOI_TESTFS_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_TESTFS_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Status * status, int
                               *error_code);
-void ADIOI_TESTFS_IwriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_TESTFS_IwriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Request * request, int
                                *error_code);
-void ADIOI_TESTFS_IreadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_TESTFS_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Request * request, int
                               *error_code);
@@ -38,26 +38,26 @@ void ADIOI_TESTFS_ReadComplete(ADIO_Request * request, ADIO_Status * status, int
                                *error_code);
 void ADIOI_TESTFS_WriteComplete(ADIO_Request * request, ADIO_Status * status, int *error_code);
 void ADIOI_TESTFS_Fcntl(ADIO_File fd, int flag, ADIO_Fcntl_t * fcntl_struct, int *error_code);
-void ADIOI_TESTFS_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_TESTFS_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_TESTFS_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_TESTFS_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Status * status, int
                               *error_code);
-void ADIOI_TESTFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
+void ADIOI_TESTFS_WriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
                                    MPI_Datatype datatype, int file_ptr_type,
                                    ADIO_Offset offset, ADIO_Status * status, int
                                    *error_code);
-void ADIOI_TESTFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
+void ADIOI_TESTFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                                   MPI_Datatype datatype, int file_ptr_type,
                                   ADIO_Offset offset, ADIO_Status * status, int
                                   *error_code);
-void ADIOI_TESTFS_IreadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_TESTFS_IreadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Request * request, int
                                *error_code);
-void ADIOI_TESTFS_IwriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_TESTFS_IwriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, ADIO_Request * request, int
                                 *error_code);

--- a/src/mpi/romio/adio/ad_testfs/ad_testfs_iread.c
+++ b/src/mpi/romio/adio/ad_testfs/ad_testfs_iread.c
@@ -10,7 +10,7 @@
  *
  * Implemented by immediately calling ReadContig()
  */
-void ADIOI_TESTFS_IreadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_TESTFS_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Request * request, int
                               *error_code)
@@ -34,7 +34,7 @@ void ADIOI_TESTFS_IreadContig(ADIO_File fd, void *buf, int count,
     MPIO_Completed_request_create(&fd, len, error_code, request);
 }
 
-void ADIOI_TESTFS_IreadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_TESTFS_IreadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Request * request, int
                                *error_code)

--- a/src/mpi/romio/adio/ad_testfs/ad_testfs_iwrite.c
+++ b/src/mpi/romio/adio/ad_testfs/ad_testfs_iwrite.c
@@ -13,7 +13,7 @@
  *
  * Implemented by immediately calling WriteContig()
  */
-void ADIOI_TESTFS_IwriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_TESTFS_IwriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Request * request, int
                                *error_code)
@@ -37,7 +37,7 @@ void ADIOI_TESTFS_IwriteContig(ADIO_File fd, const void *buf, int count,
 
 }
 
-void ADIOI_TESTFS_IwriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_TESTFS_IwriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, ADIO_Request * request, int
                                 *error_code)

--- a/src/mpi/romio/adio/ad_testfs/ad_testfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_testfs/ad_testfs_rdcoll.c
@@ -6,7 +6,7 @@
 #include "ad_testfs.h"
 #include "adioi.h"
 
-void ADIOI_TESTFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
+void ADIOI_TESTFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                                   MPI_Datatype datatype, int file_ptr_type,
                                   ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_testfs/ad_testfs_read.c
+++ b/src/mpi/romio/adio/ad_testfs/ad_testfs_read.c
@@ -6,7 +6,7 @@
 #include "ad_testfs.h"
 #include "adioi.h"
 
-void ADIOI_TESTFS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_TESTFS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Status * status, int
                              *error_code)
@@ -36,7 +36,7 @@ void ADIOI_TESTFS_ReadContig(ADIO_File fd, void *buf, int count,
 #endif
 }
 
-void ADIOI_TESTFS_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_TESTFS_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Status * status, int
                               *error_code)

--- a/src/mpi/romio/adio/ad_testfs/ad_testfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_testfs/ad_testfs_wrcoll.c
@@ -6,7 +6,7 @@
 #include "ad_testfs.h"
 #include "adioi.h"
 
-void ADIOI_TESTFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
+void ADIOI_TESTFS_WriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
                                    MPI_Datatype datatype, int file_ptr_type,
                                    ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_testfs/ad_testfs_write.c
+++ b/src/mpi/romio/adio/ad_testfs/ad_testfs_write.c
@@ -6,7 +6,7 @@
 #include "ad_testfs.h"
 #include "adioi.h"
 
-void ADIOI_TESTFS_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_TESTFS_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Status * status, int
                               *error_code)
@@ -38,7 +38,7 @@ void ADIOI_TESTFS_WriteContig(ADIO_File fd, const void *buf, int count,
 #endif
 }
 
-void ADIOI_TESTFS_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_TESTFS_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_ufs/ad_ufs.h
+++ b/src/mpi/romio/adio/ad_ufs/ad_ufs.h
@@ -38,11 +38,11 @@
 int ADIOI_UFS_aio(ADIO_File fd, void *buf, int len, ADIO_Offset offset, int wr, void *handle);
 
 void ADIOI_UFS_Open(ADIO_File fd, int *error_code);
-void ADIOI_UFS_IwriteContig(ADIO_File fd, void *buf, int count,
+void ADIOI_UFS_IwriteContig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Request * request, int
                             *error_code);
-void ADIOI_UFS_IreadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_UFS_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Request * request, int
                            *error_code);

--- a/src/mpi/romio/adio/ad_xfs/ad_xfs.h
+++ b/src/mpi/romio/adio/ad_xfs/ad_xfs.h
@@ -21,11 +21,11 @@ typedef struct aiocb64 aiocb64_t;
 
 void ADIOI_XFS_Open(ADIO_File fd, int *error_code);
 void ADIOI_XFS_Close(ADIO_File fd, int *error_code);
-void ADIOI_XFS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_XFS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                           MPI_Datatype datatype, int file_ptr_type,
                           ADIO_Offset offset, ADIO_Status * status, int
                           *error_code);
-void ADIOI_XFS_WriteContig(ADIO_File fd, void *buf, int count,
+void ADIOI_XFS_WriteContig(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int
                            *error_code);

--- a/src/mpi/romio/adio/ad_xfs/ad_xfs_read.c
+++ b/src/mpi/romio/adio/ad_xfs/ad_xfs_read.c
@@ -13,7 +13,7 @@
 static void ADIOI_XFS_Aligned_Mem_File_Read(ADIO_File fd, void *buf, int len,
                                             ADIO_Offset offset, int *err);
 
-void ADIOI_XFS_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_XFS_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                           MPI_Datatype datatype, int file_ptr_type,
                           ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/ad_xfs/ad_xfs_write.c
+++ b/src/mpi/romio/adio/ad_xfs/ad_xfs_write.c
@@ -14,7 +14,7 @@
 static int ADIOI_XFS_Aligned_Mem_File_Write(ADIO_File fd, void *buf,
                                             ADIO_Offset len, ADIO_Offset offset);
 
-void ADIOI_XFS_WriteContig(ADIO_File fd, void *buf, int count,
+void ADIOI_XFS_WriteContig(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/common/ad_coll_exch_new.c
+++ b/src/mpi/romio/adio/common/ad_coll_exch_new.c
@@ -60,7 +60,7 @@ void ADIOI_Print_flatlist_node(ADIOI_Flatlist_node * flatlist_node_p)
  * agg_file_view_state for all clients, which is the view for each
  * aggregator of a client's filetype. */
 void ADIOI_Exch_file_views(int myrank, int nprocs, int file_ptr_type,
-                           ADIO_File fd, int count,
+                           ADIO_File fd, MPI_Aint count,
                            MPI_Datatype datatype, ADIO_Offset off,
                            view_state * my_mem_view_state_arr,
                            view_state * agg_file_view_state_arr,

--- a/src/mpi/romio/adio/common/ad_io_coll.c
+++ b/src/mpi/romio/adio/common/ad_io_coll.c
@@ -37,7 +37,7 @@ static void post_client_comm(ADIO_File fd, int rw_type,
  * - persistent file domains
  * - an option to use alltoall instead of point-to-point
  */
-void ADIOI_IOStridedColl(ADIO_File fd, void *buf, int count, int rdwr,
+void ADIOI_IOStridedColl(ADIO_File fd, void *buf, MPI_Aint count, int rdwr,
                          MPI_Datatype datatype, int file_ptr_type,
                          ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {
@@ -663,7 +663,7 @@ void ADIOI_IOStridedColl(ADIO_File fd, void *buf, int count, int rdwr,
 
 /* Some of this code is from the old Calc_my_off_len() function.
  * It calculates the 1st and last byte accessed */
-void ADIOI_Calc_bounds(ADIO_File fd, int count, MPI_Datatype buftype,
+void ADIOI_Calc_bounds(ADIO_File fd, MPI_Aint count, MPI_Datatype buftype,
                        int file_ptr_type, ADIO_Offset offset,
                        ADIO_Offset * st_offset, ADIO_Offset * end_offset)
 {
@@ -833,7 +833,7 @@ void ADIOI_Calc_bounds(ADIO_File fd, int count, MPI_Datatype buftype,
  * WriteStrided call without affecting existing code.  For the new 2
  * phase code, we really only need to set a custom_ftype, and we can
  * assume that this uses MPI_BYTE for the etype, and disp is 0 */
-void ADIOI_IOFiletype(ADIO_File fd, void *buf, int count,
+void ADIOI_IOFiletype(ADIO_File fd, void *buf, MPI_Aint count,
                       MPI_Datatype datatype, int file_ptr_type,
                       ADIO_Offset offset, MPI_Datatype custom_ftype,
                       int rdwr, ADIO_Status * status, int *error_code)

--- a/src/mpi/romio/adio/common/ad_iread.c
+++ b/src/mpi/romio/adio/common/ad_iread.c
@@ -33,7 +33,7 @@
  * In the aio case we rely on ADIOI_GEN_aio(), which is implemented in
  * common/ad_iwrite.c.
  */
-void ADIOI_GEN_IreadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, MPI_Request * request, int *error_code)
 {
@@ -66,7 +66,7 @@ void ADIOI_GEN_IreadContig(ADIO_File fd, void *buf, int count,
 /* Generic implementation of IreadStrided calls the blocking ReadStrided
  * immediately.
  */
-void ADIOI_GEN_IreadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_IreadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Request * request, int *error_code)
 {

--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -107,7 +107,7 @@ struct ADIOI_Iread_and_exch_vars {
     ADIO_Offset for_next_iter;
     ADIOI_Flatlist_node *flat_buf;
     MPI_Aint buftype_extent;
-    int coll_bufsize;
+    MPI_Aint coll_bufsize;
 
     /* next function to be called */
     void (*next_fn) (ADIOI_NBC_Request *, int *);
@@ -545,7 +545,7 @@ static void ADIOI_Iread_and_exch(ADIOI_NBC_Request * nbc_req, int *error_code)
 
     int i, j;
     ADIO_Offset st_loc = -1, end_loc = -1;
-    int coll_bufsize;
+    MPI_Aint coll_bufsize;
 
     *error_code = MPI_SUCCESS;  /* changed below if error */
     /* only I/O errors are currently reported */
@@ -708,7 +708,7 @@ static void ADIOI_Iread_and_exch_l1_begin(ADIOI_NBC_Request * nbc_req, int *erro
      * minus what was satisfied in previous iteration
      * req_size = size corresponding to req_off */
 
-    size = MPL_MIN((unsigned) vars->coll_bufsize, vars->end_loc - vars->st_loc + 1 - vars->done);
+    size = MPL_MIN(vars->coll_bufsize, vars->end_loc - vars->st_loc + 1 - vars->done);
     real_off = vars->off - vars->for_curr_iter;
     real_size = size + vars->for_curr_iter;
 

--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -24,7 +24,7 @@ struct ADIOI_GEN_IreadStridedColl_vars {
     /* parameters */
     ADIO_File fd;
     void *buf;
-    int count;
+    MPI_Aint count;
     MPI_Datatype datatype;
     int file_ptr_type;
     ADIO_Offset offset;
@@ -194,7 +194,7 @@ static int ADIOI_GEN_irc_wait_fn(int count, void **array_of_states,
 
 
 /* Nonblocking version of ADIOI_GEN_ReadStridedColl() */
-void ADIOI_GEN_IreadStridedColl(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_IreadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, MPI_Request * request, int *error_code)
 {
@@ -324,7 +324,8 @@ static void ADIOI_GEN_IreadStridedColl_indio(ADIOI_NBC_Request * nbc_req, int *e
     ADIOI_Icalc_others_req_vars *cor_vars = NULL;
     ADIO_File fd = vars->fd;
     void *buf;
-    int count, file_ptr_type;
+    MPI_Aint count;
+    int file_ptr_type;
     MPI_Datatype datatype = vars->datatype;
     ADIO_Offset offset;
     int filetype_is_contig;

--- a/src/mpi/romio/adio/common/ad_iread_fake.c
+++ b/src/mpi/romio/adio/common/ad_iread_fake.c
@@ -9,7 +9,7 @@
 /* Generic implementation of IreadContig calls the blocking ReadContig
  * immediately.
  */
-void ADIOI_FAKE_IreadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_FAKE_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Request * request, int *error_code)
 {
@@ -36,7 +36,7 @@ void ADIOI_FAKE_IreadContig(ADIO_File fd, void *buf, int count,
 /* Generic implementation of IreadStrided calls the blocking ReadStrided
  * immediately.
  */
-void ADIOI_FAKE_IreadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_FAKE_IreadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Request * request, int *error_code)
 {

--- a/src/mpi/romio/adio/common/ad_iwrite.c
+++ b/src/mpi/romio/adio/common/ad_iwrite.c
@@ -44,7 +44,7 @@ static MPIX_Grequest_class ADIOI_GEN_greq_class = 0;
  * routines.  Otherwise, the ADIOI_Fns_struct will point to the FAKE
  * version.
  */
-void ADIOI_GEN_IwriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_IwriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Request * request, int *error_code)
 {
@@ -81,7 +81,7 @@ void ADIOI_GEN_IwriteContig(ADIO_File fd, const void *buf, int count,
  *
  * Returns 0 on success, -errno on failure.
  */
-int ADIOI_GEN_aio(ADIO_File fd, void *buf, int count, MPI_Datatype type,
+int ADIOI_GEN_aio(ADIO_File fd, void *buf, MPI_Aint count, MPI_Datatype type,
                   ADIO_Offset offset, int wr, MPI_Request * request)
 {
     int err = -1, fd_sys;
@@ -195,7 +195,7 @@ int ADIOI_GEN_aio(ADIO_File fd, void *buf, int count, MPI_Datatype type,
 /* Generic implementation of IwriteStrided calls the blocking WriteStrided
  * immediately.
  */
-void ADIOI_GEN_IwriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_IwriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, MPI_Request * request, int *error_code)
 {

--- a/src/mpi/romio/adio/common/ad_iwrite_coll.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_coll.c
@@ -22,7 +22,7 @@ struct ADIOI_GEN_IwriteStridedColl_vars {
     /* parameters */
     ADIO_File fd;
     const void *buf;
-    int count;
+    MPI_Aint count;
     MPI_Datatype datatype;
     int file_ptr_type;
     ADIO_Offset offset;
@@ -217,7 +217,7 @@ static int ADIOI_GEN_iwc_wait_fn(int count, void **array_of_states,
 
 
 /* Non-blocking version of ADIOI_GEN_WriteStridedColl() */
-void ADIOI_GEN_IwriteStridedColl(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_IwriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
                                  MPI_Datatype datatype, int file_ptr_type,
                                  ADIO_Offset offset, MPI_Request * request, int *error_code)
 {
@@ -342,7 +342,8 @@ static void ADIOI_GEN_IwriteStridedColl_indio(ADIOI_NBC_Request * nbc_req, int *
     ADIOI_Icalc_others_req_vars *cor_vars = NULL;
     ADIO_File fd = vars->fd;
     const void *buf;
-    int count, file_ptr_type;
+    MPI_Aint count;
+    int file_ptr_type;
     MPI_Datatype datatype = vars->datatype;
     ADIO_Offset offset;
     int filetype_is_contig;

--- a/src/mpi/romio/adio/common/ad_iwrite_coll.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_coll.c
@@ -109,7 +109,7 @@ struct ADIOI_Iexch_and_write_vars {
     int *done_to_proc;
     ADIOI_Flatlist_node *flat_buf;
     MPI_Aint buftype_extent;
-    int coll_bufsize;
+    MPI_Aint coll_bufsize;
 
     /* next function to be called */
     void (*next_fn) (ADIOI_NBC_Request *, int *);
@@ -590,7 +590,8 @@ static void ADIOI_Iexch_and_write(ADIOI_NBC_Request * nbc_req, int *error_code)
 
     int i, j;
     ADIO_Offset st_loc = -1, end_loc = -1;
-    int info_flag, coll_bufsize;
+    int info_flag;
+    MPI_Aint coll_bufsize;
     char *value;
 
     *error_code = MPI_SUCCESS;  /* changed below if error */
@@ -747,7 +748,7 @@ static void ADIOI_Iexch_and_write_l1_begin(ADIOI_NBC_Request * nbc_req, int *err
     for (i = 0; i < nprocs; i++)
         count[i] = recv_size[i] = 0;
 
-    size = MPL_MIN((unsigned) vars->coll_bufsize, vars->end_loc - vars->st_loc + 1 - vars->done);
+    size = MPL_MIN(vars->coll_bufsize, vars->end_loc - vars->st_loc + 1 - vars->done);
     vars->size = size;
 
     for (i = 0; i < nprocs; i++) {

--- a/src/mpi/romio/adio/common/ad_iwrite_fake.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_fake.c
@@ -10,7 +10,7 @@
 /* Generic implementation of IwriteContig calls the blocking WriteContig
  * immediately.
  */
-void ADIOI_FAKE_IwriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_FAKE_IwriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Request * request, int *error_code)
 {
@@ -38,7 +38,7 @@ void ADIOI_FAKE_IwriteContig(ADIO_File fd, const void *buf, int count,
 /* Generic implementation of IwriteStrided calls the blocking WriteStrided
  * immediately.
  */
-void ADIOI_FAKE_IwriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_FAKE_IwriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Request * request, int *error_code)
 {

--- a/src/mpi/romio/adio/common/ad_read.c
+++ b/src/mpi/romio/adio/common/ad_read.c
@@ -18,7 +18,7 @@
 #include <limits.h>
 #endif
 
-void ADIOI_GEN_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                           MPI_Datatype datatype, int file_ptr_type,
                           ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -68,7 +68,7 @@ if ((fd->file_system == ADIO_LUSTRE) && (fd->hints->fs_hints.lustre.lock_ahead_r
 #define ADIOI_LUSTRE_RD_LOCK_AHEAD(fd,cb_nodes,offset,error_code)
 #endif
 
-void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Status * status, int
                                *error_code)
@@ -256,7 +256,7 @@ void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
     fd->fp_sys_posn = -1;       /* set it to null. */
 }
 
-void ADIOI_Calc_my_off_len(ADIO_File fd, int bufcount, MPI_Datatype
+void ADIOI_Calc_my_off_len(ADIO_File fd, MPI_Aint bufcount, MPI_Datatype
                            datatype, int file_ptr_type, ADIO_Offset
                            offset, ADIO_Offset ** offset_list_ptr, ADIO_Offset
                            ** len_list_ptr, ADIO_Offset * start_offset_ptr,

--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -504,7 +504,7 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
     MPI_Status status;
     ADIOI_Flatlist_node *flat_buf = NULL;
     MPI_Aint lb, buftype_extent;
-    int coll_bufsize;
+    MPI_Aint coll_bufsize;
 
     *error_code = MPI_SUCCESS;  /* changed below if error */
     /* only I/O errors are currently reported */
@@ -627,7 +627,7 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
          * minus what was satisfied in previous iteration
          * req_size = size corresponding to req_off */
 
-        size = MPL_MIN((unsigned) coll_bufsize, end_loc - st_loc + 1 - done);
+        size = MPL_MIN(coll_bufsize, end_loc - st_loc + 1 - done);
         real_off = off - for_curr_iter;
         real_size = size + for_curr_iter;
 

--- a/src/mpi/romio/adio/common/ad_read_str.c
+++ b/src/mpi/romio/adio/common/ad_read_str.c
@@ -49,7 +49,7 @@
     }
 
 
-void ADIOI_GEN_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int
                            *error_code)

--- a/src/mpi/romio/adio/common/ad_read_str_naive.c
+++ b/src/mpi/romio/adio/common/ad_read_str_naive.c
@@ -6,7 +6,7 @@
 #include "adio.h"
 #include "adio_extern.h"
 
-void ADIOI_GEN_ReadStrided_naive(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_ReadStrided_naive(ADIO_File fd, void *buf, MPI_Aint count,
                                  MPI_Datatype buftype, int file_ptr_type,
                                  ADIO_Offset offset, ADIO_Status * status, int
                                  *error_code)

--- a/src/mpi/romio/adio/common/ad_write.c
+++ b/src/mpi/romio/adio/common/ad_write.c
@@ -20,7 +20,7 @@
 #endif
 
 
-void ADIOI_GEN_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int *error_code)
 {

--- a/src/mpi/romio/adio/common/ad_write_coll.c
+++ b/src/mpi/romio/adio/common/ad_write_coll.c
@@ -284,7 +284,8 @@ static void ADIOI_Exch_and_write(ADIO_File fd, void *buf, MPI_Datatype
     MPI_Status status;
     ADIOI_Flatlist_node *flat_buf = NULL;
     MPI_Aint lb, buftype_extent;
-    int info_flag, coll_bufsize;
+    int info_flag;
+    MPI_Aint coll_bufsize;
     char *value;
     static char myname[] = "ADIOI_EXCH_AND_WRITE";
 
@@ -402,7 +403,7 @@ static void ADIOI_Exch_and_write(ADIO_File fd, void *buf, MPI_Datatype
         for (i = 0; i < nprocs; i++)
             count[i] = recv_size[i] = 0;
 
-        size = MPL_MIN((unsigned) coll_bufsize, end_loc - st_loc + 1 - done);
+        size = MPL_MIN(coll_bufsize, end_loc - st_loc + 1 - done);
 
         for (i = 0; i < nprocs; i++) {
             if (others_req[i].count) {

--- a/src/mpi/romio/adio/common/ad_write_coll.c
+++ b/src/mpi/romio/adio/common/ad_write_coll.c
@@ -48,7 +48,7 @@ void ADIOI_Heap_merge(ADIOI_Access * others_req, int *count,
                       int nprocs, int nprocs_recv, int total_elements);
 
 
-void ADIOI_GEN_WriteStridedColl(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_WriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, ADIO_Status * status, int
                                 *error_code)

--- a/src/mpi/romio/adio/common/ad_write_nolock.c
+++ b/src/mpi/romio/adio/common/ad_write_nolock.c
@@ -10,7 +10,7 @@
 
 
 /* #define IO_DEBUG 1 */
-void ADIOI_NOLOCK_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_NOLOCK_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Status * status, int
                                *error_code)

--- a/src/mpi/romio/adio/common/ad_write_str.c
+++ b/src/mpi/romio/adio/common/ad_write_str.c
@@ -110,7 +110,7 @@
             memcpy(writebuf, (char *)buf + userbuf_off, write_sz);      \
         }                                                               \
     }
-void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int
                             *error_code)

--- a/src/mpi/romio/adio/common/ad_write_str_naive.c
+++ b/src/mpi/romio/adio/common/ad_write_str_naive.c
@@ -6,7 +6,7 @@
 #include "adio.h"
 #include "adio_extern.h"
 
-void ADIOI_GEN_WriteStrided_naive(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_WriteStrided_naive(ADIO_File fd, const void *buf, MPI_Aint count,
                                   MPI_Datatype buftype, int file_ptr_type,
                                   ADIO_Offset offset, ADIO_Status * status, int
                                   *error_code)

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -352,17 +352,17 @@ MPI_File ADIO_Open(MPI_Comm orig_comm, MPI_Comm comm, const char *filename,
 void ADIOI_OpenColl(ADIO_File fd, int rank, int acces_mode, int *error_code);
 void ADIO_ImmediateOpen(ADIO_File fd, int *error_code);
 void ADIO_Close(ADIO_File fd, int *error_code);
-void ADIO_ReadContig(ADIO_File fd, void *buf, int count, MPI_Datatype datatype,
+void ADIO_ReadContig(ADIO_File fd, void *buf, MPI_Aint count, MPI_Datatype datatype,
                      int file_ptr_type, ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIO_WriteContig(ADIO_File fd, void *buf, int count,
+void ADIO_WriteContig(ADIO_File fd, void *buf, MPI_Aint count,
                       MPI_Datatype datatype, int file_ptr_type,
                       ADIO_Offset offset, int *bytes_written, int
                       *error_code);
-void ADIO_IwriteContig(ADIO_File fd, void *buf, int count,
+void ADIO_IwriteContig(ADIO_File fd, void *buf, MPI_Aint count,
                        MPI_Datatype datatype, int file_ptr_type,
                        ADIO_Offset offset, ADIO_Request * request, int
                        *error_code);
-void ADIO_IreadContig(ADIO_File fd, void *buf, int count,
+void ADIO_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
                       MPI_Datatype datatype, int file_ptr_type,
                       ADIO_Offset offset, ADIO_Request * request, int
                       *error_code);
@@ -376,34 +376,34 @@ void ADIO_ReadComplete(ADIO_Request * request, ADIO_Status * status, int
 void ADIO_WriteComplete(ADIO_Request * request, ADIO_Status * status, int *error_code);
 void ADIO_Fcntl(ADIO_File fd, int flag, ADIO_Fcntl_t * fcntl_struct, int
                 *error_code);
-void ADIO_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIO_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                       MPI_Datatype datatype, int file_ptr_type,
                       ADIO_Offset offset, ADIO_Status * status, int
                       *error_code);
-void ADIO_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIO_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                        MPI_Datatype datatype, int file_ptr_type,
                        ADIO_Offset offset, ADIO_Status * status, int
                        *error_code);
-void ADIO_ReadStridedColl(ADIO_File fd, void *buf, int count,
+void ADIO_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                           MPI_Datatype datatype, int file_ptr_type,
                           ADIO_Offset offset, ADIO_Status * status, int
                           *error_code);
-void ADIO_WriteStridedColl(ADIO_File fd, void *buf, int count,
+void ADIO_WriteStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int
                            *error_code);
-void ADIO_IreadStrided(ADIO_File fd, void *buf, int count,
+void ADIO_IreadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                        MPI_Datatype datatype, int file_ptr_type,
                        ADIO_Offset offset, ADIO_Request * request, int
                        *error_code);
-void ADIO_IwriteStrided(ADIO_File fd, void *buf, int count,
+void ADIO_IwriteStrided(ADIO_File fd, void *buf, MPI_Aint count,
                         MPI_Datatype datatype, int file_ptr_type,
                         ADIO_Offset offset, ADIO_Request * request, int
                         *error_code);
-void ADIO_IreadStridedColl(ADIO_File fd, void *buf, int count,
+void ADIO_IreadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Request * request, int *error_code);
-void ADIO_IwriteStridedColl(ADIO_File fd, void *buf, int count,
+void ADIO_IwriteStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Request * request, int *error_code);
 ADIO_Offset ADIO_SeekIndividual(ADIO_File fd, ADIO_Offset offset, int whence, int *error_code);

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -187,43 +187,43 @@ typedef struct ADIOI_AIO_req_str {
 struct ADIOI_Fns_struct {
     void (*ADIOI_xxx_Open) (ADIO_File fd, int *error_code);
     void (*ADIOI_xxx_OpenColl) (ADIO_File fd, int rank, int access_mode, int *error_code);
-    void (*ADIOI_xxx_ReadContig) (ADIO_File fd, void *buf, int count,
+    void (*ADIOI_xxx_ReadContig) (ADIO_File fd, void *buf, MPI_Aint count,
                                   MPI_Datatype datatype, int file_ptr_type,
                                   ADIO_Offset offset, ADIO_Status * status, int *error_code);
-    void (*ADIOI_xxx_WriteContig) (ADIO_File fd, const void *buf, int count,
+    void (*ADIOI_xxx_WriteContig) (ADIO_File fd, const void *buf, MPI_Aint count,
                                    MPI_Datatype datatype, int file_ptr_type,
                                    ADIO_Offset offset, ADIO_Status * status, int *error_code);
-    void (*ADIOI_xxx_ReadStridedColl) (ADIO_File fd, void *buf, int count,
+    void (*ADIOI_xxx_ReadStridedColl) (ADIO_File fd, void *buf, MPI_Aint count,
                                        MPI_Datatype datatype, int file_ptr_type,
                                        ADIO_Offset offset, ADIO_Status * status, int *error_code);
-    void (*ADIOI_xxx_WriteStridedColl) (ADIO_File fd, const void *buf, int count,
+    void (*ADIOI_xxx_WriteStridedColl) (ADIO_File fd, const void *buf, MPI_Aint count,
                                         MPI_Datatype datatype, int file_ptr_type,
                                         ADIO_Offset offset, ADIO_Status * status, int *error_code);
      ADIO_Offset(*ADIOI_xxx_SeekIndividual) (ADIO_File fd, ADIO_Offset offset,
                                              int whence, int *error_code);
     void (*ADIOI_xxx_Fcntl) (ADIO_File fd, int flag, ADIO_Fcntl_t * fcntl_struct, int *error_code);
     void (*ADIOI_xxx_SetInfo) (ADIO_File fd, MPI_Info users_info, int *error_code);
-    void (*ADIOI_xxx_ReadStrided) (ADIO_File fd, void *buf, int count,
+    void (*ADIOI_xxx_ReadStrided) (ADIO_File fd, void *buf, MPI_Aint count,
                                    MPI_Datatype datatype, int file_ptr_type,
                                    ADIO_Offset offset, ADIO_Status * status, int *error_code);
-    void (*ADIOI_xxx_WriteStrided) (ADIO_File fd, const void *buf, int count,
+    void (*ADIOI_xxx_WriteStrided) (ADIO_File fd, const void *buf, MPI_Aint count,
                                     MPI_Datatype datatype, int file_ptr_type,
                                     ADIO_Offset offset, ADIO_Status * status, int *error_code);
     void (*ADIOI_xxx_Close) (ADIO_File fd, int *error_code);
-    void (*ADIOI_xxx_IreadContig) (ADIO_File fd, void *buf, int count,
+    void (*ADIOI_xxx_IreadContig) (ADIO_File fd, void *buf, MPI_Aint count,
                                    MPI_Datatype datatype, int file_ptr_type,
                                    ADIO_Offset offset, ADIO_Request * request, int *error_code);
-    void (*ADIOI_xxx_IwriteContig) (ADIO_File fd, const void *buf, int count,
+    void (*ADIOI_xxx_IwriteContig) (ADIO_File fd, const void *buf, MPI_Aint count,
                                     MPI_Datatype datatype, int file_ptr_type,
                                     ADIO_Offset offset, ADIO_Request * request, int *error_code);
     int (*ADIOI_xxx_ReadDone) (ADIO_Request * request, ADIO_Status * status, int *error_code);
     int (*ADIOI_xxx_WriteDone) (ADIO_Request * request, ADIO_Status * status, int *error_code);
     void (*ADIOI_xxx_ReadComplete) (ADIO_Request * request, ADIO_Status * status, int *error_code);
     void (*ADIOI_xxx_WriteComplete) (ADIO_Request * request, ADIO_Status * status, int *error_code);
-    void (*ADIOI_xxx_IreadStrided) (ADIO_File fd, void *buf, int count,
+    void (*ADIOI_xxx_IreadStrided) (ADIO_File fd, void *buf, MPI_Aint count,
                                     MPI_Datatype datatype, int file_ptr_type,
                                     ADIO_Offset offset, ADIO_Request * request, int *error_code);
-    void (*ADIOI_xxx_IwriteStrided) (ADIO_File fd, const void *buf, int count,
+    void (*ADIOI_xxx_IwriteStrided) (ADIO_File fd, const void *buf, MPI_Aint count,
                                      MPI_Datatype datatype, int file_ptr_type,
                                      ADIO_Offset offset, ADIO_Request * request, int *error_code);
     void (*ADIOI_xxx_Flush) (ADIO_File fd, int *error_code);
@@ -231,11 +231,11 @@ struct ADIOI_Fns_struct {
     void (*ADIOI_xxx_Delete) (const char *filename, int *error_code);
     int (*ADIOI_xxx_Feature) (ADIO_File fd, int flag);
     const char *fsname;
-    void (*ADIOI_xxx_IreadStridedColl) (ADIO_File fd, void *buf, int count,
+    void (*ADIOI_xxx_IreadStridedColl) (ADIO_File fd, void *buf, MPI_Aint count,
                                         MPI_Datatype datatype, int file_ptr_type,
                                         ADIO_Offset offset, ADIO_Request * request,
                                         int *error_code);
-    void (*ADIOI_xxx_IwriteStridedColl) (ADIO_File fd, const void *buf, int count,
+    void (*ADIOI_xxx_IwriteStridedColl) (ADIO_File fd, const void *buf, MPI_Aint count,
                                          MPI_Datatype datatype, int file_ptr_type,
                                          ADIO_Offset offset, ADIO_Request * request,
                                          int *error_code);
@@ -400,29 +400,29 @@ void ADIOI_GEN_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code
 void ADIOI_SCALEABLE_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code);
 void ADIOI_FAILSAFE_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code);
 void ADIOI_GEN_Delete(const char *filename, int *error_code);
-void ADIOI_GEN_ReadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_ReadContig(ADIO_File fd, void *buf, MPI_Aint count,
                           MPI_Datatype datatype, int file_ptr_type,
                           ADIO_Offset offset, ADIO_Status * status, int *error_code);
-int ADIOI_GEN_aio(ADIO_File fd, void *buf, int count, MPI_Datatype type,
+int ADIOI_GEN_aio(ADIO_File fd, void *buf, MPI_Aint count, MPI_Datatype type,
                   ADIO_Offset offset, int wr, MPI_Request * request);
-void ADIOI_GEN_IreadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Request * request, int *error_code);
-void ADIOI_GEN_WriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_WriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int *error_code);
-void ADIOI_GEN_IwriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_IwriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Request * request, int *error_code);
-void ADIOI_GEN_ReadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Status * status, int
                            *error_code);
-void ADIOI_GEN_IreadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_IreadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Request * request, int
                             *error_code);
-void ADIOI_GEN_IwriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_IwriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Request * request, int
                              *error_code);
@@ -434,37 +434,37 @@ int ADIOI_GEN_aio_query_fn(void *extra_state, ADIO_Status * status);
 int ADIOI_GEN_aio_free_fn(void *extra_state);
 int ADIOI_GEN_Feature(ADIO_File fd, int feature);
 
-void ADIOI_GEN_ReadStrided_naive(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_ReadStrided_naive(ADIO_File fd, void *buf, MPI_Aint count,
                                  MPI_Datatype buftype, int file_ptr_type,
                                  ADIO_Offset offset, ADIO_Status * status, int
                                  *error_code);
-void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Status * status, int
                             *error_code);
-void ADIOI_GEN_WriteStrided_naive(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_WriteStrided_naive(ADIO_File fd, const void *buf, MPI_Aint count,
                                   MPI_Datatype datatype, int file_ptr_type,
                                   ADIO_Offset offset, ADIO_Status * status, int
                                   *error_code);
-void ADIOI_NOLOCK_WriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_NOLOCK_WriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Status * status, int
                                *error_code);
-void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                                MPI_Datatype datatype, int file_ptr_type,
                                ADIO_Offset offset, ADIO_Status * status, int
                                *error_code);
-void ADIOI_GEN_IreadStridedColl(ADIO_File fd, void *buf, int count,
+void ADIOI_GEN_IreadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, MPI_Request * request, int *error_code);
-void ADIOI_GEN_WriteStridedColl(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_WriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
                                 MPI_Datatype datatype, int file_ptr_type,
                                 ADIO_Offset offset, ADIO_Status * status, int
                                 *error_code);
-void ADIOI_GEN_IwriteStridedColl(ADIO_File fd, const void *buf, int count,
+void ADIOI_GEN_IwriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
                                  MPI_Datatype datatype, int file_ptr_type,
                                  ADIO_Offset offset, MPI_Request * request, int *error_code);
-void ADIOI_Calc_my_off_len(ADIO_File fd, int bufcount, MPI_Datatype
+void ADIOI_Calc_my_off_len(ADIO_File fd, MPI_Aint bufcount, MPI_Datatype
                            datatype, int file_ptr_type, ADIO_Offset
                            offset, ADIO_Offset ** offset_list_ptr, ADIO_Offset
                            ** len_list_ptr, ADIO_Offset * start_offset_ptr,
@@ -636,24 +636,24 @@ typedef struct view_state {
     ADIOI_Flatlist_node *flat_type_p;
 } view_state;
 
-void ADIOI_Calc_bounds(ADIO_File fd, int count, MPI_Datatype buftype,
+void ADIOI_Calc_bounds(ADIO_File fd, MPI_Aint count, MPI_Datatype buftype,
                        int file_ptr_type, ADIO_Offset offset,
                        ADIO_Offset * st_offset, ADIO_Offset * end_offset);
 int ADIOI_Agg_idx(int rank, ADIO_File fd);
 void ADIOI_Calc_file_realms(ADIO_File fd, ADIO_Offset min_st_offset, ADIO_Offset max_end_offset);
-void ADIOI_IOFiletype(ADIO_File fd, void *buf, int count,
+void ADIOI_IOFiletype(ADIO_File fd, void *buf, MPI_Aint count,
                       MPI_Datatype datatype, int file_ptr_type,
                       ADIO_Offset offset, MPI_Datatype custom_ftype,
                       int rdwr, ADIO_Status * status, int
                       *error_code);
-void ADIOI_IOStridedColl(ADIO_File fd, void *buf, int count, int rdwr,
+void ADIOI_IOStridedColl(ADIO_File fd, void *buf, MPI_Aint count, int rdwr,
                          MPI_Datatype datatype, int file_ptr_type,
                          ADIO_Offset offset, ADIO_Status * status, int
                          *error_code);
 void ADIOI_Print_flatlist_node(ADIOI_Flatlist_node * flatlist_node_p);
 ADIOI_Flatlist_node *ADIOI_Add_contig_flattened(MPI_Datatype contig_type);
 void ADIOI_Exch_file_views(int myrank, int nprocs, int file_ptr_type,
-                           ADIO_File fd, int count,
+                           ADIO_File fd, MPI_Aint count,
                            MPI_Datatype datatype, ADIO_Offset off,
                            view_state * my_mem_view_state_arr,
                            view_state * agg_file_view_state_arr,
@@ -776,16 +776,16 @@ int ADIOI_Type_create_hindexed_x(int count,
 
 
 int ADIOI_FAKE_IODone(ADIO_Request * request, ADIO_Status * status, int *error_code);
-void ADIOI_FAKE_IreadContig(ADIO_File fd, void *buf, int count,
+void ADIOI_FAKE_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,
                             ADIO_Offset offset, ADIO_Request * request, int *error_code);
-void ADIOI_FAKE_IreadStrided(ADIO_File fd, void *buf, int count,
+void ADIOI_FAKE_IreadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Request * request, int *error_code);
-void ADIOI_FAKE_IwriteContig(ADIO_File fd, const void *buf, int count,
+void ADIOI_FAKE_IwriteContig(ADIO_File fd, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, int file_ptr_type,
                              ADIO_Offset offset, ADIO_Request * request, int *error_code);
-void ADIOI_FAKE_IwriteStrided(ADIO_File fd, const void *buf, int count,
+void ADIOI_FAKE_IwriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Request * request, int *error_code);
 void ADIOI_FAKE_IOComplete(ADIO_Request * request, ADIO_Status * status, int *error_code);
@@ -795,67 +795,55 @@ void ADIOI_FAKE_IOComplete(ADIO_Request * request, ADIO_Status * status, int *er
 int MPIOI_File_read(MPI_File fh,
                     MPI_Offset offset,
                     int file_ptr_type,
-                    void *buf, int count, MPI_Datatype datatype, char *myname, MPI_Status * status);
-int MPIOI_File_write(MPI_File fh,
-                     MPI_Offset offset,
-                     int file_ptr_type,
-                     const void *buf,
-                     int count, MPI_Datatype datatype, char *myname, MPI_Status * status);
-int MPIOI_File_read_all(MPI_File fh,
-                        MPI_Offset offset,
-                        int file_ptr_type,
-                        void *buf,
-                        int count, MPI_Datatype datatype, char *myname, MPI_Status * status);
-int MPIOI_File_write_all(MPI_File fh,
-                         MPI_Offset offset,
-                         int file_ptr_type,
-                         const void *buf,
-                         int count, MPI_Datatype datatype, char *myname, MPI_Status * status);
-int MPIOI_File_read_all_begin(MPI_File fh,
-                              MPI_Offset offset,
-                              int file_ptr_type,
-                              void *buf, int count, MPI_Datatype datatype, char *myname);
-int MPIOI_File_write_all_begin(MPI_File fh,
-                               MPI_Offset offset,
-                               int file_ptr_type,
-                               const void *buf, int count, MPI_Datatype datatype, char *myname);
+                    void *buf, MPI_Aint count, MPI_Datatype datatype, char *myname,
+                    MPI_Status * status);
+int MPIOI_File_write(MPI_File fh, MPI_Offset offset, int file_ptr_type, const void *buf,
+                     MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status);
+int MPIOI_File_read_all(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf,
+                        MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status);
+int MPIOI_File_write_all(MPI_File fh, MPI_Offset offset, int file_ptr_type, const void *buf,
+                         MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status);
+int MPIOI_File_read_all_begin(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf,
+                              MPI_Aint count, MPI_Datatype datatype, char *myname);
+int MPIOI_File_write_all_begin(MPI_File fh, MPI_Offset offset, int file_ptr_type, const void *buf,
+                               MPI_Aint count, MPI_Datatype datatype, char *myname);
 int MPIOI_File_read_all_end(MPI_File fh, void *buf, char *myname, MPI_Status * status);
 int MPIOI_File_write_all_end(MPI_File fh, const void *buf, char *myname, MPI_Status * status);
 int MPIOI_File_iwrite(MPI_File fh,
                       MPI_Offset offset,
                       int file_ptr_type,
                       const void *buf,
-                      int count, MPI_Datatype datatype, char *myname, MPI_Request * request);
+                      MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Request * request);
 int MPIOI_File_iread(MPI_File fh,
                      MPI_Offset offset,
                      int file_ptr_type,
                      void *buf,
-                     int count, MPI_Datatype datatype, char *myname, MPI_Request * request);
+                     MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Request * request);
 int MPIOI_File_iwrite_all(MPI_File fh,
                           MPI_Offset offset,
                           int file_ptr_type,
                           const void *buf,
-                          int count, MPI_Datatype datatype, char *myname, MPI_Request * request);
-int MPIOI_File_iread_all(MPI_File fh,
-                         MPI_Offset offset,
-                         int file_ptr_type,
-                         void *buf,
-                         int count, MPI_Datatype datatype, char *myname, MPI_Request * request);
+                          MPI_Aint count, MPI_Datatype datatype, char *myname,
+                          MPI_Request * request);
+int MPIOI_File_iread_all(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf,
+                         MPI_Aint count, MPI_Datatype datatype, char *myname,
+                         MPI_Request * request);
 
-int MPIOI_File_read_ordered(MPI_File fh, void *buf, int count,
+int MPIOI_File_read_ordered(MPI_File fh, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, MPI_Status * status);
-int MPIOI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype);
-int MPIOI_File_read_shared(MPI_File fh, void *buf, int count,
+int MPIOI_File_read_ordered_begin(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype);
+int MPIOI_File_read_shared(MPI_File fh, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, MPI_Status * status);
-int MPIOI_File_iread_shared(MPI_File fh, void *buf, int count,
+int MPIOI_File_iread_shared(MPI_File fh, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, MPI_Request * request);
-int MPIOI_File_write_ordered(MPI_File fh, const void *buf, int count,
+int MPIOI_File_write_ordered(MPI_File fh, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, MPI_Status * status);
-int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype);
-int MPIOI_File_write_shared(MPI_File fh, const void *buf, int count,
-                            MPI_Datatype datatype, MPI_Status * status);
-int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, int count,
-                             MPI_Datatype datatype, MPIO_Request * request);
+int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, MPI_Aint count,
+                                   MPI_Datatype datatype);
+int MPIOI_File_write_shared(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                            MPI_Status * status);
+int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                             MPIO_Request * request);
 
 typedef void (*MPIOI_VOID_FN) (void *);
 int MPIOI_Register_datarep(const char *datarep,

--- a/src/mpi/romio/adio/include/adioi_error.h
+++ b/src/mpi/romio/adio/include/adioi_error.h
@@ -50,7 +50,7 @@
     }
 
 #define MPIO_CHECK_COUNT_SIZE(fh, count, datatype_size, myname, error_code) \
-    if (count*datatype_size != (ADIO_Offset)(unsigned)count*(ADIO_Offset)datatype_size) { \
+    if (count*datatype_size != (ADIO_Offset)count*(ADIO_Offset)datatype_size) { \
         error_code = MPIO_Err_create_code(MPI_SUCCESS,                  \
                                           MPIR_ERR_RECOVERABLE,         \
                                           myname, __LINE__,             \

--- a/src/mpi/romio/adio/include/mpiu_external32.h
+++ b/src/mpi/romio/adio/include/mpiu_external32.h
@@ -15,6 +15,6 @@ int MPIU_datatype_full_size(MPI_Datatype datatype, MPI_Aint * size);
 /* given a buffer, count, and datatype, return an appropriately sized and
  *  * external32-formatted buffer, suitable for handing off to a subsequent write
  *   * routine */
-int MPIU_external32_buffer_setup(const void *buf, int count, MPI_Datatype type, void **newbuf);
+int MPIU_external32_buffer_setup(const void *buf, MPI_Aint count, MPI_Datatype type, void **newbuf);
 
 #endif /* MPIU_EXTERNAL32_H_INCLUDED */

--- a/src/mpi/romio/doc/source-guide.tex
+++ b/src/mpi/romio/doc/source-guide.tex
@@ -393,7 +393,7 @@ call Open at MPI\_File\_open time, but instead call open if they perform
 independent I/O.  This can result in somewhat unusual error returns to
 processes (e.g. learning that a file is not accessible at write time).
 
-ADIOI\_ReadContig(ADIO\_File fd, void *buf, int count, MPI\_Datatype datatype,
+ADIOI\_ReadContig(ADIO\_File fd, void *buf, MPI\_Aint count, MPI\_Datatype datatype,
 int file\_ptr\_type, ADIO\_Offset offset, ADIO\_Status *status, int *error\_code)
 
 ReadContig is used to read a contiguous region from a file into a contiguous
@@ -405,7 +405,7 @@ file\_ptr\_type.  Open has been called by this process prior to the call to
 ReadContig.  There is no guarantee that any other processes will call this
 function at the same time.
 
-ADIOI\_WriteContig(ADIO\_File fd, void *buf, int count, MPI\_Datatype datatype,
+ADIOI\_WriteContig(ADIO\_File fd, void *buf, MPI\_Aint count, MPI\_Datatype datatype,
 int file\_ptr\_type, ADIO\_Offset offset, ADIO\_Status *status, int *error\_code)
 
 WriteContig is used to write a contiguous region to a file from a contiguous

--- a/src/mpi/romio/mpi-io/iread.c
+++ b/src/mpi/romio/mpi-io/iread.c
@@ -107,7 +107,6 @@ Output Parameters:
 int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
                      MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code = MPI_SUCCESS;
     static char myname[] = "MPI_FILE_IREAD";
 #ifdef MPI_hpux
@@ -134,10 +133,9 @@ int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datat
 
 /* prevent multiple definitions of this routine */
 #ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf, int count,
+int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf, MPI_Aint count,
                      MPI_Datatype datatype, char *myname, MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     MPI_Count datatype_size;
     ADIO_Status status;

--- a/src/mpi/romio/mpi-io/iread_all.c
+++ b/src/mpi/romio/mpi-io/iread_all.c
@@ -109,7 +109,6 @@ Output Parameters:
 int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count,
                          MPI_Datatype datatype, MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_ALL";
 #ifdef MPI_hpux
@@ -141,9 +140,8 @@ int MPIOI_File_iread_all(MPI_File fh,
                          MPI_Offset offset,
                          int file_ptr_type,
                          void *buf,
-                         int count, MPI_Datatype datatype, char *myname, MPI_Request * request)
+                         MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/iread_at.c
+++ b/src/mpi/romio/mpi-io/iread_at.c
@@ -111,7 +111,6 @@ Output Parameters:
 int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count,
                         MPI_Datatype datatype, MPIO_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT";
 

--- a/src/mpi/romio/mpi-io/iread_atall.c
+++ b/src/mpi/romio/mpi-io/iread_atall.c
@@ -110,7 +110,6 @@ Output Parameters:
 int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
                             MPI_Count count, MPI_Datatype datatype, MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT_ALL";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/iread_sh.c
+++ b/src/mpi/romio/mpi-io/iread_sh.c
@@ -84,15 +84,13 @@ Output Parameters:
 int MPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count,
                             MPI_Datatype datatype, MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     return MPIOI_File_iread_shared(fh, buf, count, datatype, request);
 }
 
 #ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iread_shared(MPI_File fh, void *buf, int count,
+int MPIOI_File_iread_shared(MPI_File fh, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     ADIO_Offset bufsize;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/iwrite.c
+++ b/src/mpi/romio/mpi-io/iwrite.c
@@ -107,7 +107,6 @@ Output Parameters:
 int MPI_File_iwrite_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                       MPI_Datatype datatype, MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code = MPI_SUCCESS;
     static char myname[] = "MPI_FILE_IWRITE";
 #ifdef MPI_hpux
@@ -138,9 +137,8 @@ int MPIOI_File_iwrite(MPI_File fh,
                       MPI_Offset offset,
                       int file_ptr_type,
                       const void *buf,
-                      int count, MPI_Datatype datatype, char *myname, MPI_Request * request)
+                      MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     MPI_Count datatype_size;
     ADIO_Status status;

--- a/src/mpi/romio/mpi-io/iwrite_all.c
+++ b/src/mpi/romio/mpi-io/iwrite_all.c
@@ -103,7 +103,6 @@ Output Parameters:
 int MPI_File_iwrite_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                           MPI_Datatype datatype, MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IWRITE_ALL";
 #ifdef MPI_hpux
@@ -129,9 +128,9 @@ int MPIOI_File_iwrite_all(MPI_File fh,
                           MPI_Offset offset,
                           int file_ptr_type,
                           const void *buf,
-                          int count, MPI_Datatype datatype, char *myname, MPI_Request * request)
+                          MPI_Aint count, MPI_Datatype datatype, char *myname,
+                          MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/iwrite_at.c
+++ b/src/mpi/romio/mpi-io/iwrite_at.c
@@ -114,7 +114,6 @@ Output Parameters:
 int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                          MPI_Count count, MPI_Datatype datatype, MPIO_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code;
     ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_IWRITE_AT";

--- a/src/mpi/romio/mpi-io/iwrite_atall.c
+++ b/src/mpi/romio/mpi-io/iwrite_atall.c
@@ -104,7 +104,6 @@ Output Parameters:
 int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                              MPI_Count count, MPI_Datatype datatype, MPI_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IWRITE_AT_ALL";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/iwrite_sh.c
+++ b/src/mpi/romio/mpi-io/iwrite_sh.c
@@ -88,15 +88,13 @@ Output Parameters:
 int MPI_File_iwrite_shared_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                              MPI_Datatype datatype, MPIO_Request * request)
 {
-    assert(count <= INT_MAX);
     return MPIOI_File_iwrite_shared(fh, buf, count, datatype, request);
 }
 
 #ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, int count,
+int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, MPIO_Request * request)
 {
-    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     ADIO_File adio_fh;
     ADIO_Offset incr, bufsize;

--- a/src/mpi/romio/mpi-io/mpiu_external32.c
+++ b/src/mpi/romio/mpi-io/mpiu_external32.c
@@ -132,7 +132,7 @@ int MPIU_datatype_full_size(MPI_Datatype datatype, MPI_Aint * size)
 /* given a buffer, count, and datatype, return an appropriately allocated, sized
  * and external32-formatted buffer, suitable for handing off to a subsequent
  * write routine.  Caller is responsible for freeing 'newbuf' */
-int MPIU_external32_buffer_setup(const void *buf, int count, MPI_Datatype type, void **newbuf)
+int MPIU_external32_buffer_setup(const void *buf, MPI_Aint count, MPI_Datatype type, void **newbuf)
 {
 
     MPI_Aint datatype_size = 0, bytes = 0;

--- a/src/mpi/romio/mpi-io/rd_atallb.c
+++ b/src/mpi/romio/mpi-io/rd_atallb.c
@@ -86,7 +86,6 @@ Output Parameters:
 int MPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf,
                                  MPI_Count count, MPI_Datatype datatype)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_READ_AT_ALL_BEGIN";
 

--- a/src/mpi/romio/mpi-io/read.c
+++ b/src/mpi/romio/mpi-io/read.c
@@ -97,7 +97,6 @@ Output Parameters:
 int MPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
                     MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_READ";
 #ifdef MPI_hpux
@@ -121,9 +120,9 @@ int MPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype dataty
 int MPIOI_File_read(MPI_File fh,
                     MPI_Offset offset,
                     int file_ptr_type,
-                    void *buf, int count, MPI_Datatype datatype, char *myname, MPI_Status * status)
+                    void *buf, MPI_Aint count, MPI_Datatype datatype, char *myname,
+                    MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/read_all.c
+++ b/src/mpi/romio/mpi-io/read_all.c
@@ -97,7 +97,6 @@ Output Parameters:
 int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
                         MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_READ_ALL";
 #ifdef MPI_hpux
@@ -123,9 +122,8 @@ int MPIOI_File_read_all(MPI_File fh,
                         MPI_Offset offset,
                         int file_ptr_type,
                         void *buf,
-                        int count, MPI_Datatype datatype, char *myname, MPI_Status * status)
+                        MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/read_allb.c
+++ b/src/mpi/romio/mpi-io/read_allb.c
@@ -80,7 +80,6 @@ Output Parameters:
 @*/
 int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_READ_ALL_BEGIN";
 
@@ -95,9 +94,8 @@ int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datat
 int MPIOI_File_read_all_begin(MPI_File fh,
                               MPI_Offset offset,
                               int file_ptr_type,
-                              void *buf, int count, MPI_Datatype datatype, char *myname)
+                              void *buf, MPI_Aint count, MPI_Datatype datatype, char *myname)
 {
-    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/read_at.c
+++ b/src/mpi/romio/mpi-io/read_at.c
@@ -100,7 +100,6 @@ Output Parameters:
 int MPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf,
                        MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_READ_AT";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/read_atall.c
+++ b/src/mpi/romio/mpi-io/read_atall.c
@@ -100,7 +100,6 @@ Output Parameters:
 int MPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
                            MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/read_ord.c
+++ b/src/mpi/romio/mpi-io/read_ord.c
@@ -83,15 +83,13 @@ Output Parameters:
 int MPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count,
                             MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     return MPIOI_File_read_ordered(fh, buf, count, datatype, status);
 }
 
 #ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_read_ordered(MPI_File fh, void *buf, int count,
+int MPIOI_File_read_ordered(MPI_File fh, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code, nprocs, myrank;
     ADIO_Offset incr;
     MPI_Count datatype_size;

--- a/src/mpi/romio/mpi-io/read_ordb.c
+++ b/src/mpi/romio/mpi-io/read_ordb.c
@@ -74,12 +74,11 @@ Output Parameters:
 @*/
 int MPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
 {
-    assert(count <= INT_MAX);
     return MPIOI_File_read_ordered_begin(fh, buf, count, datatype);
 }
 
 #ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype)
+int MPIOI_File_read_ordered_begin(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype)
 {
     int error_code, nprocs, myrank;
     MPI_Count datatype_size;

--- a/src/mpi/romio/mpi-io/read_sh.c
+++ b/src/mpi/romio/mpi-io/read_sh.c
@@ -83,15 +83,13 @@ Output Parameters:
 int MPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count,
                            MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     return MPIOI_File_read_shared(fh, buf, count, datatype, status);
 }
 
 #ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_read_shared(MPI_File fh, void *buf, int count,
+int MPIOI_File_read_shared(MPI_File fh, void *buf, MPI_Aint count,
                            MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     static char myname[] = "MPI_FILE_READ_SHARED";
     MPI_Count datatype_size;

--- a/src/mpi/romio/mpi-io/wr_atallb.c
+++ b/src/mpi/romio/mpi-io/wr_atallb.c
@@ -84,7 +84,6 @@ Input Parameters:
 int MPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                                   MPI_Count count, MPI_Datatype datatype)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_AT_ALL_BEGIN";
 

--- a/src/mpi/romio/mpi-io/write.c
+++ b/src/mpi/romio/mpi-io/write.c
@@ -96,7 +96,6 @@ Output Parameters:
 int MPI_File_write_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                      MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE";
 #ifdef MPI_hpux
@@ -121,9 +120,8 @@ int MPIOI_File_write(MPI_File fh,
                      MPI_Offset offset,
                      int file_ptr_type,
                      const void *buf,
-                     int count, MPI_Datatype datatype, char *myname, MPI_Status * status)
+                     MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code, buftype_is_contig, filetype_is_contig;
     MPI_Count datatype_size;
     ADIO_Offset off, bufsize;

--- a/src/mpi/romio/mpi-io/write_all.c
+++ b/src/mpi/romio/mpi-io/write_all.c
@@ -97,7 +97,6 @@ Output Parameters:
 int MPI_File_write_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                          MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_ALL";
 #ifdef MPI_hpux
@@ -122,9 +121,8 @@ int MPIOI_File_write_all(MPI_File fh,
                          MPI_Offset offset,
                          int file_ptr_type,
                          const void *buf,
-                         int count, MPI_Datatype datatype, char *myname, MPI_Status * status)
+                         MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/write_allb.c
+++ b/src/mpi/romio/mpi-io/write_allb.c
@@ -79,7 +79,6 @@ Input Parameters:
 int MPI_File_write_all_begin_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                                MPI_Datatype datatype)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_ALL_BEGIN";
 
@@ -94,9 +93,8 @@ int MPI_File_write_all_begin_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count cou
 int MPIOI_File_write_all_begin(MPI_File fh,
                                MPI_Offset offset,
                                int file_ptr_type,
-                               const void *buf, int count, MPI_Datatype datatype, char *myname)
+                               const void *buf, MPI_Aint count, MPI_Datatype datatype, char *myname)
 {
-    assert(count <= INT_MAX);
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;

--- a/src/mpi/romio/mpi-io/write_at.c
+++ b/src/mpi/romio/mpi-io/write_at.c
@@ -101,7 +101,6 @@ Output Parameters:
 int MPI_File_write_at_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                         MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_AT";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/write_atall.c
+++ b/src/mpi/romio/mpi-io/write_atall.c
@@ -99,7 +99,6 @@ Output Parameters:
 int MPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                             MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_AT_ALL";
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/write_ord.c
+++ b/src/mpi/romio/mpi-io/write_ord.c
@@ -83,15 +83,13 @@ Output Parameters:
 int MPI_File_write_ordered_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                              MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     return MPIOI_File_write_ordered(fh, buf, count, datatype, status);
 }
 
 #ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_write_ordered(MPI_File fh, const void *buf, int count,
+int MPIOI_File_write_ordered(MPI_File fh, const void *buf, MPI_Aint count,
                              MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     int error_code, nprocs, myrank;
     ADIO_Offset incr;
     MPI_Count datatype_size;

--- a/src/mpi/romio/mpi-io/write_ordb.c
+++ b/src/mpi/romio/mpi-io/write_ordb.c
@@ -77,14 +77,13 @@ Output Parameters:
 int MPI_File_write_ordered_begin_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                                    MPI_Datatype datatype)
 {
-    assert(count <= INT_MAX);
     return MPIOI_File_write_ordered_begin(fh, buf, count, datatype);
 }
 
 #ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype)
+int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, MPI_Aint count,
+                                   MPI_Datatype datatype)
 {
-    assert(count <= INT_MAX);
     int error_code, nprocs, myrank;
     ADIO_Offset incr;
     MPI_Count datatype_size;

--- a/src/mpi/romio/mpi-io/write_sh.c
+++ b/src/mpi/romio/mpi-io/write_sh.c
@@ -83,12 +83,11 @@ Output Parameters:
 int MPI_File_write_shared_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                             MPI_Datatype datatype, MPI_Status * status)
 {
-    assert(count <= INT_MAX);
     return MPIOI_File_write_shared(fh, buf, count, datatype, status);
 }
 
 #ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_write_shared(MPI_File fh, const void *buf, int count,
+int MPIOI_File_write_shared(MPI_File fh, const void *buf, MPI_Aint count,
                             MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code, buftype_is_contig, filetype_is_contig;

--- a/test/mpi/io/rdwrord.c
+++ b/test/mpi/io/rdwrord.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "mpitest.h"
+#include <limits.h>
 
 /*
 static char MTEST_Descrip[] = "Test reading and writing ordered output";
@@ -19,7 +20,18 @@ int main(int argc, char *argv[])
     MPI_File fh;
     MPI_Comm comm;
     MPI_Status status;
+    int do_large_count = 0;
+    MPI_Count count, total_count;
 
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-large-count") == 0) {
+            do_large_count = 1;
+#if MPI_VERSION < 4
+            printf("Large count test only available with MPI_VERSION >= 4\n");
+            return 1;
+#endif
+        }
+    }
     MTest_Init(&argc, &argv);
 
     comm = MPI_COMM_WORLD;
@@ -28,9 +40,19 @@ int main(int argc, char *argv[])
 
     MPI_Comm_size(comm, &size);
     MPI_Comm_rank(comm, &rank);
-    buf = (int *) malloc(size * sizeof(int));
-    buf[0] = rank;
-    rc = MPI_File_write_ordered(fh, buf, 1, MPI_INT, &status);
+
+    if (!do_large_count) {
+        buf = (int *) malloc(size * sizeof(int));
+        buf[0] = rank;
+        rc = MPI_File_write_ordered(fh, buf, 1, MPI_INT, &status);
+    } else {
+        count = (MPI_Count) INT_MAX + 100;
+        total_count = count * size;
+        buf[0] = rank;
+#if MPI_VERSION >= 4
+        rc = MPI_File_write_ordered_c(fh, buf, count, MPI_INT, &status);
+#endif
+    }
     if (rc) {
         MTestPrintErrorMsg("File_write_ordered", rc);
         errs++;
@@ -40,19 +62,36 @@ int main(int argc, char *argv[])
 
     /* Set the individual pointer to 0, since we want to use a read_all */
     MPI_File_seek(fh, 0, MPI_SEEK_SET);
-    MPI_File_read_all(fh, buf, size, MPI_INT, &status);
+    if (!do_large_count) {
+        MPI_File_read_all(fh, buf, size, MPI_INT, &status);
+    } else {
+#if MPI_VERSION >= 4
+        MPI_File_read_all_c(fh, buf, total_count, MPI_INT, &status);
+#endif
+    }
 
     for (i = 0; i < size; i++) {
-        if (buf[i] != i) {
+        size_t pos;
+        if (!do_large_count) {
+            pos = (size_t) (1 * i);
+        } else {
+            pos = (size_t) (count * i);
+        }
+        if (buf[pos] != i) {
             errs++;
-            fprintf(stderr, "%d: buf[%d] = %d\n", rank, i, buf[i]);
+            fprintf(stderr, "%d: buf[%zd] = %d, expect %d\n", rank, pos, buf[pos], i);
         }
     }
 
     MPI_File_seek_shared(fh, 0, MPI_SEEK_SET);
-    for (i = 0; i < size; i++)
-        buf[i] = -1;
-    MPI_File_read_ordered(fh, buf, 1, MPI_INT, &status);
+    buf[0] = -1;
+    if (!do_large_count) {
+        MPI_File_read_ordered(fh, buf, 1, MPI_INT, &status);
+    } else {
+#if MPI_VERSION >= 4
+        MPI_File_read_ordered_c(fh, buf, count, MPI_INT, &status);
+#endif
+    }
     if (buf[0] != rank) {
         errs++;
         fprintf(stderr, "%d: buf[0] = %d\n", rank, buf[0]);

--- a/test/mpi/io/testlist.in
+++ b/test/mpi/io/testlist.in
@@ -1,4 +1,5 @@
 rdwrord 4
+rdwrord 2 -large-count
 rdwrzero 4
 getextent 2
 setinfo 4


### PR DESCRIPTION
## Pull Request Description
Change internal int count type to MPI_Aint to enable large count
functions.

[skip warnings]
Fixes #5866


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
