### PR TITLE
romio: actually set status in MPI_File_read_all

### DIFF
--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -826,7 +826,7 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
     for (i = 0; i < nprocs; i++) {
         if (send_size[i]) {
             /* take care if the last off-len pair is a partial send */
-            ADIO_Offset tmp;
+            ADIO_Offset tmp = 0;
             if (partial_send[i]) {
                 k = start_pos[i] + count[i] - 1;
                 tmp = others_req[i].lens[k];

--- a/test/mpi/io/Makefile.am
+++ b/test/mpi/io/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST = testlist.in
 noinst_PROGRAMS = \
     rdwrord       \
     rdwrzero      \
+    rd_end	  \
     getextent     \
     setinfo       \
     setviewcur    \

--- a/test/mpi/io/rd_end.c
+++ b/test/mpi/io/rd_end.c
@@ -1,0 +1,79 @@
+#include "mpitest.h"
+#include "mpi.h"
+#include <stdio.h>
+
+/* Test case contributed by Pascal Deveze <Pascal.Deveze@bull.net>
+ *
+ * This test uses MPI_File_read_all to read a file with less data than requested.
+ * Run with two processors.
+ */
+
+#define IO_SIZE 10
+static const char *filename = "test.ord";
+
+int main(int argc, char **argv)
+{
+    int errs = 0;
+    MPI_File fh;
+    MPI_Status status;
+    unsigned char buffer[IO_SIZE];
+    unsigned char cmp[IO_SIZE];
+
+    int rank, size;
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size != 2) {
+        printf("This test require 2 processes\n");
+        goto fn_exit;
+    }
+
+    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
+    MPI_File_set_errhandler(fh, MPI_ERRORS_ARE_FATAL);
+    for (int i = 0; i < IO_SIZE; i++) {
+        buffer[i] = i;
+        cmp[i] = i;
+    }
+    if (rank == 0) {
+        MPI_File_write(fh, buffer, IO_SIZE - 5, MPI_CHAR, &status);
+    }
+
+    for (int i = 0; i < IO_SIZE; i++) {
+        buffer[i] = 99;
+    }
+    for (int i = IO_SIZE - 5; i < IO_SIZE; i++) {
+        cmp[i] = 99;
+    }
+
+    /* strictly speaking, this sync/barrier/sync closes one write access and
+     * ensures subsequent read access sees latest data */
+    MPI_File_sync(fh);
+    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_File_sync(fh);
+
+    MPI_File_seek(fh, 0, MPI_SEEK_SET);
+    /* everybody reads the first IO_SIZE bytes from the file, but the file is
+     * only IO_SIZE-5 bytes big.  */
+    MPI_File_read_all(fh, buffer, IO_SIZE, MPI_BYTE, &status);
+
+    int count;
+    MPI_Get_count(&status, MPI_CHAR, &count);
+    if (count != IO_SIZE - 5) {
+        fprintf(stderr, "%d: count was %d; expected %d\n", rank, count, IO_SIZE - 5);
+        errs++;
+    }
+
+    for (int i = 0; i < IO_SIZE; i++) {
+        if (buffer[i] != cmp[i]) {
+            fprintf(stderr, "%d: buffer[%d] = %d; expected %d\n", rank, i, buffer[i], cmp[i]);
+            errs++;
+        }
+    }
+
+    MPI_File_close(&fh);
+
+  fn_exit:
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/io/testlist.in
+++ b/test/mpi/io/testlist.in
@@ -1,6 +1,7 @@
 rdwrord 4
 rdwrord 2 -large-count
 rdwrzero 4
+rd_end 2
 getextent 2
 setinfo 4
 setviewcur 4


### PR DESCRIPTION
## Pull Request Description

The old code blindly sets status of MPI_File_read_all with the input
data size. This ignore the cases when the actual file is too short or
have issues of actually getting the requested data. This patch updates
the status with actual number of bytes received.

Fixes #1085



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
