### PR TITLE
ADI: fix large count support for RMA and pt2pt

### DIFF
--- a/src/binding/c/rma_api.txt
+++ b/src/binding/c/rma_api.txt
@@ -526,25 +526,12 @@ MPI_Win_set_name:
 MPI_Win_shared_query:
     .desc: Query the size and base pointer for a patch of a shared memory window
     .seealso: MPI_Win_allocate_shared
+    .poly_impl: use_aint
 /*
     Notes:
     The returned baseptr points to the calling process' address space of the
     shared segment belonging to the target rank.
 */
-{
-    mpi_errno = MPID_Win_shared_query(win_ptr, rank, size, disp_unit, baseptr);
-    if (mpi_errno) {
-        goto fn_fail;
-    }
-}
-{ -- large_count --
-    int disp_unit_c;
-    mpi_errno = MPID_Win_shared_query(win_ptr, rank, size, &disp_unit_c, baseptr);
-    if (mpi_errno) {
-        goto fn_fail;
-    }
-    *disp_unit = disp_unit_c;
-}
 
 MPI_Win_start:
     .desc: Start an RMA access epoch for MPI

--- a/src/mpi/rma/rma_impl.c
+++ b/src/mpi/rma/rma_impl.c
@@ -23,5 +23,11 @@ int MPIR_Win_set_name_impl(MPIR_Win * win_ptr, const char *win_name)
 int MPIR_Win_shared_query_impl(MPIR_Win * win_ptr, int rank, MPI_Aint * size, MPI_Aint * disp_unit,
                                void *baseptr)
 {
-    return MPID_Win_shared_query(win_ptr, rank, size, disp_unit, baseptr);
+    int mpi_errno;
+    int my_disp_unit;
+
+    mpi_errno = MPID_Win_shared_query(win_ptr, rank, size, &my_disp_unit, baseptr);
+    *disp_unit = my_disp_unit;
+
+    return mpi_errno;
 }

--- a/src/mpi/rma/rma_impl.c
+++ b/src/mpi/rma/rma_impl.c
@@ -19,3 +19,9 @@ int MPIR_Win_set_name_impl(MPIR_Win * win_ptr, const char *win_name)
 
     return MPI_SUCCESS;
 }
+
+int MPIR_Win_shared_query_impl(MPIR_Win * win_ptr, int rank, MPI_Aint * size, MPI_Aint * disp_unit,
+                               void *baseptr)
+{
+    return MPID_Win_shared_query(win_ptr, rank, size, disp_unit, baseptr);
+}

--- a/src/mpid/ch3/include/mpid_rma_shm.h
+++ b/src/mpid/ch3/include/mpid_rma_shm.h
@@ -9,8 +9,8 @@
 #include "utlist.h"
 #include "mpid_rma_types.h"
 
-static inline int do_accumulate_op(void *source_buf, int source_count, MPI_Datatype source_dtp,
-                                   void *target_buf, int target_count, MPI_Datatype target_dtp,
+static inline int do_accumulate_op(void *source_buf, MPI_Aint source_count, MPI_Datatype source_dtp,
+                                   void *target_buf, MPI_Aint target_count, MPI_Datatype target_dtp,
                                    MPI_Aint stream_offset, MPI_Op acc_op,
                                    MPIDI_RMA_Acc_srcbuf_kind_t srckind);
 
@@ -240,9 +240,9 @@ static inline int shm_copy(const void *src, int scount, MPI_Datatype stype,
     /* --END ERROR HANDLING-- */
 }
 
-static inline int MPIDI_CH3I_Shm_put_op(const void *origin_addr, int origin_count, MPI_Datatype
+static inline int MPIDI_CH3I_Shm_put_op(const void *origin_addr, MPI_Aint origin_count, MPI_Datatype
                                         origin_datatype, int target_rank, MPI_Aint target_disp,
-                                        int target_count, MPI_Datatype target_datatype,
+                                        MPI_Aint target_count, MPI_Datatype target_datatype,
                                         MPIR_Win * win_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -276,9 +276,9 @@ static inline int MPIDI_CH3I_Shm_put_op(const void *origin_addr, int origin_coun
 }
 
 
-static inline int MPIDI_CH3I_Shm_acc_op(const void *origin_addr, int origin_count, MPI_Datatype
+static inline int MPIDI_CH3I_Shm_acc_op(const void *origin_addr, MPI_Aint origin_count, MPI_Datatype
                                         origin_datatype, int target_rank, MPI_Aint target_disp,
-                                        int target_count, MPI_Datatype target_datatype, MPI_Op op,
+                                        MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op,
                                         MPIR_Win * win_ptr)
 {
     void *base = NULL;
@@ -386,10 +386,10 @@ static inline int MPIDI_CH3I_Shm_acc_op(const void *origin_addr, int origin_coun
 }
 
 
-static inline int MPIDI_CH3I_Shm_get_acc_op(const void *origin_addr, int origin_count, MPI_Datatype
-                                            origin_datatype, void *result_addr, int result_count,
+static inline int MPIDI_CH3I_Shm_get_acc_op(const void *origin_addr, MPI_Aint origin_count, MPI_Datatype
+                                            origin_datatype, void *result_addr, MPI_Aint result_count,
                                             MPI_Datatype result_datatype, int target_rank, MPI_Aint
-                                            target_disp, int target_count,
+                                            target_disp, MPI_Aint target_count,
                                             MPI_Datatype target_datatype, MPI_Op op,
                                             MPIR_Win * win_ptr)
 {
@@ -507,9 +507,9 @@ static inline int MPIDI_CH3I_Shm_get_acc_op(const void *origin_addr, int origin_
 }
 
 
-static inline int MPIDI_CH3I_Shm_get_op(void *origin_addr, int origin_count,
+static inline int MPIDI_CH3I_Shm_get_op(void *origin_addr, MPI_Aint origin_count,
                                         MPI_Datatype origin_datatype, int target_rank,
-                                        MPI_Aint target_disp, int target_count,
+                                        MPI_Aint target_disp, MPI_Aint target_count,
                                         MPI_Datatype target_datatype, MPIR_Win * win_ptr)
 {
     void *base = NULL;

--- a/src/mpid/ch3/include/mpid_rma_types.h
+++ b/src/mpid/ch3/include/mpid_rma_types.h
@@ -38,14 +38,14 @@ typedef struct MPIDI_RMA_Op {
     struct MPIDI_RMA_Op *prev;  /* pointer to prev element in list */
 
     void *origin_addr;
-    int origin_count;
+    MPI_Aint origin_count;
     MPI_Datatype origin_datatype;
 
     void *compare_addr;
     MPI_Datatype compare_datatype;
 
     void *result_addr;
-    int result_count;
+    MPI_Aint result_count;
     MPI_Datatype result_datatype;
 
     struct MPIR_Request *single_req;    /* used for unstreamed RMA ops */

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -601,7 +601,7 @@ typedef struct MPIDI_Comm_ops
     int (*send_init)(struct MPIDI_VC *vc, const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		     int dest, int tag, MPIR_Comm *comm, int context_offset,
 		     struct MPIR_Request **request );
-    int (*bsend_init)(struct MPIDI_VC *vc, const void *buf, int count, MPI_Datatype datatype,
+    int (*bsend_init)(struct MPIDI_VC *vc, const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		      int dest, int tag, MPIR_Comm *comm, int context_offset,
 		      struct MPIR_Request **request);
     int (*rsend_init)(struct MPIDI_VC *vc, const void *buf, MPI_Aint count, MPI_Datatype datatype,
@@ -1104,22 +1104,22 @@ int MPIDI_CH3I_Progress_finalize(void);
 
 /* Internal RMA operation routines.
  * Called by normal RMA operations and request-based RMA operations . */
-int MPIDI_CH3I_Put(const void *origin_addr, int origin_count, MPI_Datatype
+int MPIDI_CH3I_Put(const void *origin_addr, MPI_Aint origin_count, MPI_Datatype
                    origin_datatype, int target_rank, MPI_Aint target_disp,
-                   int target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
+                   MPI_Aint target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
                    MPIR_Request * ureq);
-int MPIDI_CH3I_Get(void *origin_addr, int origin_count, MPI_Datatype
+int MPIDI_CH3I_Get(void *origin_addr, MPI_Aint origin_count, MPI_Datatype
                    origin_datatype, int target_rank, MPI_Aint target_disp,
-                   int target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
+                   MPI_Aint target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
                    MPIR_Request * ureq);
-int MPIDI_CH3I_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype
+int MPIDI_CH3I_Accumulate(const void *origin_addr, MPI_Aint origin_count, MPI_Datatype
                           origin_datatype, int target_rank, MPI_Aint target_disp,
-                          int target_count, MPI_Datatype target_datatype, MPI_Op op,
+                          MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op,
                           MPIR_Win * win_ptr, MPIR_Request * ureq);
-int MPIDI_CH3I_Get_accumulate(const void *origin_addr, int origin_count,
-                              MPI_Datatype origin_datatype, void *result_addr, int result_count,
+int MPIDI_CH3I_Get_accumulate(const void *origin_addr, MPI_Aint origin_count,
+                              MPI_Datatype origin_datatype, void *result_addr, MPI_Aint result_count,
                               MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp,
-                              int target_count, MPI_Datatype target_datatype, MPI_Op op,
+                              MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op,
                               MPIR_Win * win_ptr, MPIR_Request * ureq);
 
 /*@

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -744,7 +744,7 @@ MPI_Aint MPID_Aint_add(MPI_Aint base, MPI_Aint disp);
 
 MPI_Aint MPID_Aint_diff(MPI_Aint addr1, MPI_Aint addr2);
 
-int MPID_Win_create(void *, MPI_Aint, int, MPIR_Info *, MPIR_Comm *,
+int MPID_Win_create(void *, MPI_Aint, MPI_Aint, MPIR_Info *, MPIR_Comm *,
                     MPIR_Win **);
 int MPID_Win_free(MPIR_Win **);
 
@@ -765,9 +765,9 @@ int MPID_Win_complete(MPIR_Win *win_ptr);
 int MPID_Win_lock(int lock_type, int dest, int assert, MPIR_Win *win_ptr);
 int MPID_Win_unlock(int dest, MPIR_Win *win_ptr);
 
-int MPID_Win_allocate(MPI_Aint size, int disp_unit, MPIR_Info *info,
+int MPID_Win_allocate(MPI_Aint size, MPI_Aint disp_unit, MPIR_Info *info,
                       MPIR_Comm *comm, void *baseptr, MPIR_Win **win);
-int MPID_Win_allocate_shared(MPI_Aint size, int disp_unit, MPIR_Info *info_ptr, MPIR_Comm *comm_ptr,
+int MPID_Win_allocate_shared(MPI_Aint size, MPI_Aint disp_unit, MPIR_Info *info_ptr, MPIR_Comm *comm_ptr,
                              void *base_ptr, MPIR_Win **win_ptr);
 int MPID_Win_shared_query(MPIR_Win *win, int rank, MPI_Aint *size, int *disp_unit,
                           void *baseptr);

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -567,7 +567,7 @@ int MPID_Send_coll( const void *buf, MPI_Aint count, MPI_Datatype datatype,
                     int dest, int tag, MPIR_Comm *comm, int attr,
                     MPIR_Request **request, MPIR_Errflag_t * errflag );
 
-int MPID_Rsend( const void *buf, int count, MPI_Datatype datatype,
+int MPID_Rsend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		int dest, int tag, MPIR_Comm *comm, int attr,
 		MPIR_Request **request );
 
@@ -583,11 +583,11 @@ int MPID_Isend_coll( const void *buf, MPI_Aint count, MPI_Datatype datatype,
                      int dest, int tag, MPIR_Comm *comm, int attr,
                      MPIR_Request **request, MPIR_Errflag_t * errflag );
 
-int MPID_Irsend( const void *buf, int count, MPI_Datatype datatype,
+int MPID_Irsend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		 int dest, int tag, MPIR_Comm *comm, int attr,
 		 MPIR_Request **request );
 
-int MPID_Issend( const void *buf, int count, MPI_Datatype datatype,
+int MPID_Issend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		 int dest, int tag, MPIR_Comm *comm, int attr,
 		 MPIR_Request **request );
 
@@ -599,20 +599,20 @@ int MPID_Irecv( void *buf, MPI_Aint count, MPI_Datatype datatype,
 		int source, int tag, MPIR_Comm *comm, int attr,
 		MPIR_Request **request );
 
-int MPID_Send_init( const void *buf, int count, MPI_Datatype datatype,
+int MPID_Send_init( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		    int dest, int tag, MPIR_Comm *comm, int attr,
 		    MPIR_Request **request );
 
-int MPID_Bsend_init(const void *, int, MPI_Datatype, int, int, MPIR_Comm *,
+int MPID_Bsend_init(const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *,
 		   int, MPIR_Request **);
-int MPID_Rsend_init( const void *buf, int count, MPI_Datatype datatype,
+int MPID_Rsend_init( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		     int dest, int tag, MPIR_Comm *comm, int attr,
 		     MPIR_Request **request );
-int MPID_Ssend_init( const void *buf, int count, MPI_Datatype datatype,
+int MPID_Ssend_init( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		     int dest, int tag, MPIR_Comm *comm, int attr,
 		     MPIR_Request **request );
 
-int MPID_Recv_init( void *buf, int count, MPI_Datatype datatype,
+int MPID_Recv_init( void *buf, MPI_Aint count, MPI_Datatype datatype,
 		    int source, int tag, MPIR_Comm *comm, int attr,
 		    MPIR_Request **request );
 
@@ -720,10 +720,10 @@ int MPID_Mprobe(int source, int tag, MPIR_Comm *comm, int attr,
 int MPID_Improbe(int source, int tag, MPIR_Comm *comm, int attr,
                  int *flag, MPIR_Request **message, MPI_Status *status);
 
-int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
+int MPID_Imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                 MPIR_Request *message, MPIR_Request **rreqp);
 
-int MPID_Mrecv(void *buf, int count, MPI_Datatype datatype,
+int MPID_Mrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                MPIR_Request *message, MPI_Status *status, MPIR_Request **rreq);
 
 int MPID_Cancel_send(MPIR_Request *);
@@ -748,11 +748,11 @@ int MPID_Win_create(void *, MPI_Aint, MPI_Aint, MPIR_Info *, MPIR_Comm *,
                     MPIR_Win **);
 int MPID_Win_free(MPIR_Win **);
 
-int MPID_Put(const void *, int, MPI_Datatype, int, MPI_Aint, int,
+int MPID_Put(const void *, MPI_Aint, MPI_Datatype, int, MPI_Aint, MPI_Aint,
              MPI_Datatype, MPIR_Win *);
-int MPID_Get(void *, int, MPI_Datatype, int, MPI_Aint, int,
+int MPID_Get(void *, MPI_Aint, MPI_Datatype, int, MPI_Aint, MPI_Aint,
              MPI_Datatype, MPIR_Win *);
-int MPID_Accumulate(const void *, int, MPI_Datatype, int, MPI_Aint, int,
+int MPID_Accumulate(const void *, MPI_Aint, MPI_Datatype, int, MPI_Aint, MPI_Aint,
                     MPI_Datatype, MPI_Op, MPIR_Win *);
 
 int MPID_Win_fence(int, MPIR_Win *);
@@ -777,32 +777,32 @@ int MPID_Win_detach(MPIR_Win *win, const void *base);
 int MPID_Win_get_info(MPIR_Win *win, MPIR_Info **info_used);
 int MPID_Win_set_info(MPIR_Win *win, MPIR_Info *info);
 
-int MPID_Get_accumulate(const void *origin_addr, int origin_count,
-                        MPI_Datatype origin_datatype, void *result_addr, int result_count,
+int MPID_Get_accumulate(const void *origin_addr, MPI_Aint origin_count,
+                        MPI_Datatype origin_datatype, void *result_addr, MPI_Aint result_count,
                         MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp,
-                        int target_count, MPI_Datatype target_datatype, MPI_Op op, MPIR_Win *win);
+                        MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op, MPIR_Win *win);
 int MPID_Fetch_and_op(const void *origin_addr, void *result_addr,
                       MPI_Datatype datatype, int target_rank, MPI_Aint target_disp,
                       MPI_Op op, MPIR_Win *win);
 int MPID_Compare_and_swap(const void *origin_addr, const void *compare_addr,
                           void *result_addr, MPI_Datatype datatype, int target_rank,
                           MPI_Aint target_disp, MPIR_Win *win);
-int MPID_Rput(const void *origin_addr, int origin_count,
+int MPID_Rput(const void *origin_addr, MPI_Aint origin_count,
               MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp,
-              int target_count, MPI_Datatype target_datatype, MPIR_Win *win,
+              MPI_Aint target_count, MPI_Datatype target_datatype, MPIR_Win *win,
               MPIR_Request **request);
-int MPID_Rget(void *origin_addr, int origin_count,
+int MPID_Rget(void *origin_addr, MPI_Aint origin_count,
               MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp,
-              int target_count, MPI_Datatype target_datatype, MPIR_Win *win,
+              MPI_Aint target_count, MPI_Datatype target_datatype, MPIR_Win *win,
               MPIR_Request **request);
-int MPID_Raccumulate(const void *origin_addr, int origin_count,
+int MPID_Raccumulate(const void *origin_addr, MPI_Aint origin_count,
                      MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp,
-                     int target_count, MPI_Datatype target_datatype, MPI_Op op, MPIR_Win *win,
+                     MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op, MPIR_Win *win,
                      MPIR_Request **request);
-int MPID_Rget_accumulate(const void *origin_addr, int origin_count,
-                         MPI_Datatype origin_datatype, void *result_addr, int result_count,
+int MPID_Rget_accumulate(const void *origin_addr, MPI_Aint origin_count,
+                         MPI_Datatype origin_datatype, void *result_addr, MPI_Aint result_count,
                          MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp,
-                         int target_count, MPI_Datatype target_datatype, MPI_Op op, MPIR_Win *win,
+                         MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op, MPIR_Win *win,
                          MPIR_Request **request);
 
 int MPID_Win_lock_all(int assert, MPIR_Win *win);

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -323,7 +323,7 @@ static inline int enqueue_lock_origin(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
         intptr_t buf_size = 0;
         MPIR_Request *req = NULL;
         MPI_Datatype target_dtp;
-        int target_count;
+        MPI_Aint target_count;
         int complete = 0;
         intptr_t data_len;
         int pkt_flags;
@@ -803,8 +803,8 @@ static inline int MPIDI_CH3I_RMA_Handle_ack(MPIR_Win * win_ptr, int target_rank)
 }
 
 
-static inline int do_accumulate_op(void *source_buf, int source_count, MPI_Datatype source_dtp,
-                                   void *target_buf, int target_count, MPI_Datatype target_dtp,
+static inline int do_accumulate_op(void *source_buf, MPI_Aint source_count, MPI_Datatype source_dtp,
+                                   void *target_buf, MPI_Aint target_count, MPI_Datatype target_dtp,
                                    MPI_Aint stream_offset, MPI_Op acc_op,
                                    MPIDI_RMA_Acc_srcbuf_kind_t srckind)
 {
@@ -866,7 +866,7 @@ static inline int do_accumulate_op(void *source_buf, int source_count, MPI_Datat
         MPIR_Datatype*dtp;
         MPI_Aint curr_len;
         void *curr_loc;
-        int accumulated_count;
+        MPI_Aint accumulated_count;
 
         MPIR_Datatype_get_ptr(target_dtp, dtp);
         vec_len = dtp->typerep.num_contig_blocks * target_count + 1;

--- a/src/mpid/ch3/src/ch3u_rma_ops.c
+++ b/src/mpid/ch3/src/ch3u_rma_ops.c
@@ -33,9 +33,9 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-int MPIDI_CH3I_Put(const void *origin_addr, int origin_count, MPI_Datatype
+int MPIDI_CH3I_Put(const void *origin_addr, MPI_Aint origin_count, MPI_Datatype
                    origin_datatype, int target_rank, MPI_Aint target_disp,
-                   int target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
+                   MPI_Aint target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
                    MPIR_Request * ureq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -193,9 +193,9 @@ int MPIDI_CH3I_Put(const void *origin_addr, int origin_count, MPI_Datatype
     /* --END ERROR HANDLING-- */
 }
 
-int MPIDI_CH3I_Get(void *origin_addr, int origin_count, MPI_Datatype
+int MPIDI_CH3I_Get(void *origin_addr, MPI_Aint origin_count, MPI_Datatype
                    origin_datatype, int target_rank, MPI_Aint target_disp,
-                   int target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
+                   MPI_Aint target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
                    MPIR_Request * ureq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -347,9 +347,9 @@ int MPIDI_CH3I_Get(void *origin_addr, int origin_count, MPI_Datatype
 }
 
 
-int MPIDI_CH3I_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype
+int MPIDI_CH3I_Accumulate(const void *origin_addr, MPI_Aint origin_count, MPI_Datatype
                           origin_datatype, int target_rank, MPI_Aint target_disp,
-                          int target_count, MPI_Datatype target_datatype, MPI_Op op,
+                          MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op,
                           MPIR_Win * win_ptr, MPIR_Request * ureq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -541,10 +541,10 @@ int MPIDI_CH3I_Accumulate(const void *origin_addr, int origin_count, MPI_Datatyp
 }
 
 
-int MPIDI_CH3I_Get_accumulate(const void *origin_addr, int origin_count,
-                              MPI_Datatype origin_datatype, void *result_addr, int result_count,
+int MPIDI_CH3I_Get_accumulate(const void *origin_addr, MPI_Aint origin_count,
+                              MPI_Datatype origin_datatype, void *result_addr, MPI_Aint result_count,
                               MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp,
-                              int target_count, MPI_Datatype target_datatype, MPI_Op op,
+                              MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op,
                               MPIR_Win * win_ptr, MPIR_Request * ureq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -776,9 +776,9 @@ int MPIDI_CH3I_Get_accumulate(const void *origin_addr, int origin_count,
 }
 
 
-int MPID_Put(const void *origin_addr, int origin_count, MPI_Datatype
+int MPID_Put(const void *origin_addr, MPI_Aint origin_count, MPI_Datatype
              origin_datatype, int target_rank, MPI_Aint target_disp,
-             int target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr)
+             MPI_Aint target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -792,9 +792,9 @@ int MPID_Put(const void *origin_addr, int origin_count, MPI_Datatype
     return mpi_errno;
 }
 
-int MPID_Get(void *origin_addr, int origin_count, MPI_Datatype
+int MPID_Get(void *origin_addr, MPI_Aint origin_count, MPI_Datatype
              origin_datatype, int target_rank, MPI_Aint target_disp,
-             int target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr)
+             MPI_Aint target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -808,9 +808,9 @@ int MPID_Get(void *origin_addr, int origin_count, MPI_Datatype
     return mpi_errno;
 }
 
-int MPID_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype
+int MPID_Accumulate(const void *origin_addr, MPI_Aint origin_count, MPI_Datatype
                     origin_datatype, int target_rank, MPI_Aint target_disp,
-                    int target_count, MPI_Datatype target_datatype, MPI_Op op, MPIR_Win * win_ptr)
+                    MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op, MPIR_Win * win_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -824,10 +824,10 @@ int MPID_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype
     return mpi_errno;
 }
 
-int MPID_Get_accumulate(const void *origin_addr, int origin_count,
-                        MPI_Datatype origin_datatype, void *result_addr, int result_count,
+int MPID_Get_accumulate(const void *origin_addr, MPI_Aint origin_count,
+                        MPI_Datatype origin_datatype, void *result_addr, MPI_Aint result_count,
                         MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp,
-                        int target_count, MPI_Datatype target_datatype, MPI_Op op,
+                        MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op,
                         MPIR_Win * win_ptr)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch3/src/ch3u_rma_reqops.c
+++ b/src/mpid/ch3/src/ch3u_rma_reqops.c
@@ -6,9 +6,9 @@
 #include "mpidi_ch3_impl.h"
 #include "mpidrma.h"
 
-int MPID_Rput(const void *origin_addr, int origin_count,
+int MPID_Rput(const void *origin_addr, MPI_Aint origin_count,
               MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp,
-              int target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
+              MPI_Aint target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
               MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -59,9 +59,9 @@ int MPID_Rput(const void *origin_addr, int origin_count,
 }
 
 
-int MPID_Rget(void *origin_addr, int origin_count,
+int MPID_Rget(void *origin_addr, MPI_Aint origin_count,
               MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp,
-              int target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
+              MPI_Aint target_count, MPI_Datatype target_datatype, MPIR_Win * win_ptr,
               MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -112,9 +112,9 @@ int MPID_Rget(void *origin_addr, int origin_count,
 }
 
 
-int MPID_Raccumulate(const void *origin_addr, int origin_count,
+int MPID_Raccumulate(const void *origin_addr, MPI_Aint origin_count,
                      MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp,
-                     int target_count, MPI_Datatype target_datatype, MPI_Op op, MPIR_Win * win_ptr,
+                     MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op, MPIR_Win * win_ptr,
                      MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -165,10 +165,10 @@ int MPID_Raccumulate(const void *origin_addr, int origin_count,
 }
 
 
-int MPID_Rget_accumulate(const void *origin_addr, int origin_count,
-                         MPI_Datatype origin_datatype, void *result_addr, int result_count,
+int MPID_Rget_accumulate(const void *origin_addr, MPI_Aint origin_count,
+                         MPI_Datatype origin_datatype, void *result_addr, MPI_Aint result_count,
                          MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp,
-                         int target_count, MPI_Datatype target_datatype, MPI_Op op,
+                         MPI_Aint target_count, MPI_Datatype target_datatype, MPI_Op op,
                          MPIR_Win * win_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch3/src/mpid_imrecv.c
+++ b/src/mpid/ch3/src/mpid_imrecv.c
@@ -5,7 +5,7 @@
 
 #include "mpidimpl.h"
 
-int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
+int MPID_Imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                 MPIR_Request *message, MPIR_Request **rreqp)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch3/src/mpid_irsend.c
+++ b/src/mpid/ch3/src/mpid_irsend.c
@@ -8,7 +8,7 @@
 /*
  * MPID_Irsend()
  */
-int MPID_Irsend(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
+int MPID_Irsend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		MPIR_Request ** request)
 {
     MPIDI_CH3_Pkt_t upkt;

--- a/src/mpid/ch3/src/mpid_issend.c
+++ b/src/mpid/ch3/src/mpid_issend.c
@@ -8,7 +8,7 @@
 /*
  * MPID_Issend()
  */
-int MPID_Issend(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
+int MPID_Issend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		MPIR_Request ** request)
 {
     intptr_t data_sz;

--- a/src/mpid/ch3/src/mpid_mrecv.c
+++ b/src/mpid/ch3/src/mpid_mrecv.c
@@ -5,7 +5,7 @@
 
 #include "mpidimpl.h"
 
-int MPID_Mrecv(void *buf, int count, MPI_Datatype datatype,
+int MPID_Mrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                MPIR_Request *message, MPI_Status *status, MPIR_Request **rreq)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch3/src/mpid_rma.c
+++ b/src/mpid/ch3/src/mpid_rma.c
@@ -53,7 +53,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
                     MPIR_Comm * comm_ptr, MPIR_Win ** win_ptr);
 
 
-int MPID_Win_create(void *base, MPI_Aint size, int disp_unit, MPIR_Info * info,
+int MPID_Win_create(void *base, MPI_Aint size, MPI_Aint disp_unit, MPIR_Info * info,
                     MPIR_Comm * comm_ptr, MPIR_Win ** win_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -66,13 +66,15 @@ int MPID_Win_create(void *base, MPI_Aint size, int disp_unit, MPIR_Info * info,
         MPIR_ERR_SETANDJUMP(mpi_errno, MPIX_ERR_REVOKED, "**revoked");
     }
 
-    mpi_errno =
-        win_init(size, disp_unit, MPI_WIN_FLAVOR_CREATE, MPI_WIN_UNIFIED, info, comm_ptr, win_ptr);
+    MPIR_Assert(disp_unit <= INT_MAX);
+    int my_disp_unit = (int) disp_unit;
+    mpi_errno = win_init(size, my_disp_unit, MPI_WIN_FLAVOR_CREATE, MPI_WIN_UNIFIED,
+                         info, comm_ptr, win_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     (*win_ptr)->base = base;
 
-    mpi_errno = MPIDI_CH3U_Win_fns.create(base, size, disp_unit, info, comm_ptr, win_ptr);
+    mpi_errno = MPIDI_CH3U_Win_fns.create(base, size, my_disp_unit, info, comm_ptr, win_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:
@@ -81,19 +83,20 @@ int MPID_Win_create(void *base, MPI_Aint size, int disp_unit, MPIR_Info * info,
 }
 
 
-int MPID_Win_allocate(MPI_Aint size, int disp_unit, MPIR_Info * info,
+int MPID_Win_allocate(MPI_Aint size, MPI_Aint disp_unit, MPIR_Info * info,
                       MPIR_Comm * comm_ptr, void *baseptr, MPIR_Win ** win_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno =
-        win_init(size, disp_unit, MPI_WIN_FLAVOR_ALLOCATE, MPI_WIN_UNIFIED, info, comm_ptr,
-                 win_ptr);
+    MPIR_Assert(disp_unit <= INT_MAX);
+    int my_disp_unit = (int) disp_unit;
+    mpi_errno = win_init(size, my_disp_unit, MPI_WIN_FLAVOR_ALLOCATE, MPI_WIN_UNIFIED,
+                         info, comm_ptr, win_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIDI_CH3U_Win_fns.allocate(size, disp_unit, info, comm_ptr, baseptr, win_ptr);
+    mpi_errno = MPIDI_CH3U_Win_fns.allocate(size, my_disp_unit, info, comm_ptr, baseptr, win_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:
@@ -153,20 +156,21 @@ int MPID_Free_mem(void *ptr)
 }
 
 
-int MPID_Win_allocate_shared(MPI_Aint size, int disp_unit, MPIR_Info * info, MPIR_Comm * comm_ptr,
+int MPID_Win_allocate_shared(MPI_Aint size, MPI_Aint disp_unit, MPIR_Info * info, MPIR_Comm * comm_ptr,
                              void *base_ptr, MPIR_Win ** win_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
-
     MPIR_FUNC_ENTER;
 
-    mpi_errno =
-        win_init(size, disp_unit, MPI_WIN_FLAVOR_SHARED, MPI_WIN_UNIFIED, info, comm_ptr, win_ptr);
+    MPIR_Assert(disp_unit <= INT_MAX);
+    int my_disp_unit = (int) disp_unit;
+    mpi_errno = win_init(size, my_disp_unit, MPI_WIN_FLAVOR_SHARED, MPI_WIN_UNIFIED,
+                         info, comm_ptr, win_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
-        MPIDI_CH3U_Win_fns.allocate_shared(size, disp_unit, info, comm_ptr, base_ptr, win_ptr);
+        MPIDI_CH3U_Win_fns.allocate_shared(size, my_disp_unit, info, comm_ptr, base_ptr, win_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:

--- a/src/mpid/ch3/src/mpid_rsend.c
+++ b/src/mpid/ch3/src/mpid_rsend.c
@@ -12,7 +12,7 @@
 /*
  * MPID_Rsend()
  */
-int MPID_Rsend(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
+int MPID_Rsend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 	       MPIR_Request ** request)
 {
     intptr_t data_sz;

--- a/src/mpid/ch3/src/mpid_startall.c
+++ b/src/mpid/ch3/src/mpid_startall.c
@@ -161,7 +161,7 @@ int MPID_Startall(int count, MPIR_Request * requests[])
 /*
  * MPID_Send_init()
  */
-int MPID_Send_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
+int MPID_Send_init(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		   MPIR_Request ** request)
 {
     MPIR_Request * sreq;
@@ -187,7 +187,7 @@ int MPID_Send_init(const void * buf, int count, MPI_Datatype datatype, int rank,
 /*
  * MPID_Ssend_init()
  */
-int MPID_Ssend_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
+int MPID_Ssend_init(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		    MPIR_Request ** request)
 {
     MPIR_Request * sreq;
@@ -213,7 +213,7 @@ int MPID_Ssend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 /*
  * MPID_Rsend_init()
  */
-int MPID_Rsend_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
+int MPID_Rsend_init(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		    MPIR_Request ** request)
 {
     MPIR_Request * sreq;
@@ -239,7 +239,7 @@ int MPID_Rsend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 /*
  * MPID_Bsend_init()
  */
-int MPID_Bsend_init(const void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
+int MPID_Bsend_init(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int attr,
 		    MPIR_Request ** request)
 {
     MPIR_Request * sreq;
@@ -273,7 +273,7 @@ int MPID_Bsend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 /*
  * MPID_Recv_init()
  */
-int MPID_Recv_init(void * buf, int count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int context_offset,
+int MPID_Recv_init(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag, MPIR_Comm * comm, int context_offset,
 		   MPIR_Request ** request)
 {
     MPIR_Request * rreq;

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -475,7 +475,7 @@ PARAM:
     op_p: MPIR_Op *
     origin_addr: const void *
     origin_addr-2: void *
-    origin_count: int
+    origin_count: MPI_Aint
     origin_datatype: MPI_Datatype
     partner: MPIR_Request *
     port_name: const char *
@@ -496,7 +496,7 @@ PARAM:
     req: MPIR_Request *
     req_p: MPIR_Request **
     result_addr: void *
-    result_count: int
+    result_count: MPI_Aint
     result_datatype: MPI_Datatype
     root: int
     rreq: MPIR_Request *
@@ -518,7 +518,7 @@ PARAM:
     tag: int
     tag_bits: int *
     target: int
-    target_count: int
+    target_count: MPI_Aint
     target_datatype: MPI_Datatype
     target_disp: MPI_Aint
     target_rank: int

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -106,7 +106,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Parrived(MPIR_Request * rreq, int partition, i
 MPL_STATIC_INLINE_PREFIX int MPID_Accumulate(const void *, int, MPI_Datatype, int, MPI_Aint, int,
                                              MPI_Datatype, MPI_Op,
                                              MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
-int MPID_Win_create(void *, MPI_Aint, int, MPIR_Info *, MPIR_Comm *, MPIR_Win **);
+int MPID_Win_create(void *, MPI_Aint, MPI_Aint, MPIR_Info *, MPIR_Comm *, MPIR_Win **);
 MPL_STATIC_INLINE_PREFIX int MPID_Win_fence(int, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Win_free(MPIR_Win **);
 MPL_STATIC_INLINE_PREFIX int MPID_Get(void *, int, MPI_Datatype, int, MPI_Aint, int, MPI_Datatype,
@@ -126,9 +126,9 @@ int MPID_Comm_reenable_anysource(MPIR_Comm *, MPIR_Group **);
 int MPID_Comm_remote_group_failed(MPIR_Comm *, MPIR_Group **);
 int MPID_Comm_group_failed(MPIR_Comm *, MPIR_Group **);
 int MPID_Win_attach(MPIR_Win *, void *, MPI_Aint);
-int MPID_Win_allocate_shared(MPI_Aint, int, MPIR_Info *, MPIR_Comm *, void **, MPIR_Win **);
-MPL_STATIC_INLINE_PREFIX int MPID_Rput(const void *, int, MPI_Datatype, int, MPI_Aint, int,
-                                       MPI_Datatype, MPIR_Win *,
+int MPID_Win_allocate_shared(MPI_Aint, MPI_Aint, MPIR_Info *, MPIR_Comm *, void **, MPIR_Win **);
+MPL_STATIC_INLINE_PREFIX int MPID_Rput(const void *, MPI_Aint, MPI_Datatype, int, MPI_Aint,
+                                       MPI_Aint, MPI_Datatype, MPIR_Win *,
                                        MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local(int, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Win_detach(MPIR_Win *, const void *);
@@ -146,7 +146,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Fetch_and_op(const void *, void *, MPI_Datatyp
                                                MPI_Op, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_shared_query(MPIR_Win *, int, MPI_Aint *, int *,
                                                    void *) MPL_STATIC_INLINE_SUFFIX;
-int MPID_Win_allocate(MPI_Aint, int, MPIR_Info *, MPIR_Comm *, void *, MPIR_Win **);
+int MPID_Win_allocate(MPI_Aint, MPI_Aint, MPIR_Info *, MPIR_Comm *, void *, MPIR_Win **);
 MPL_STATIC_INLINE_PREFIX int MPID_Win_flush(int, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local_all(MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock_all(MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -103,14 +103,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Pready_range(int, int, MPIR_Request *) MPL_STA
 MPL_STATIC_INLINE_PREFIX int MPID_Pready_list(int, int[], MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Parrived(MPIR_Request * rreq, int partition, int *flag);
 
-MPL_STATIC_INLINE_PREFIX int MPID_Accumulate(const void *, int, MPI_Datatype, int, MPI_Aint, int,
-                                             MPI_Datatype, MPI_Op,
+MPL_STATIC_INLINE_PREFIX int MPID_Accumulate(const void *, MPI_Aint, MPI_Datatype, int,
+                                             MPI_Aint, MPI_Aint, MPI_Datatype, MPI_Op,
                                              MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Win_create(void *, MPI_Aint, MPI_Aint, MPIR_Info *, MPIR_Comm *, MPIR_Win **);
 MPL_STATIC_INLINE_PREFIX int MPID_Win_fence(int, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Win_free(MPIR_Win **);
-MPL_STATIC_INLINE_PREFIX int MPID_Get(void *, int, MPI_Datatype, int, MPI_Aint, int, MPI_Datatype,
-                                      MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Get(void *, MPI_Aint, MPI_Datatype, int, MPI_Aint, MPI_Aint,
+                                      MPI_Datatype, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Win_get_info(MPIR_Win *, MPIR_Info **);
 MPL_STATIC_INLINE_PREFIX int MPID_Win_lock(int, int, int, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock(int, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
@@ -119,7 +119,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_complete(MPIR_Win *) MPL_STATIC_INLINE_SUF
 MPL_STATIC_INLINE_PREFIX int MPID_Win_post(MPIR_Group *, int, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_wait(MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_test(MPIR_Win *, int *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Put(const void *, int, MPI_Datatype, int, MPI_Aint, int,
+MPL_STATIC_INLINE_PREFIX int MPID_Put(const void *, MPI_Aint, MPI_Datatype, int, MPI_Aint, MPI_Aint,
                                       MPI_Datatype, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Win_set_info(MPIR_Win *, MPIR_Info *);
 int MPID_Comm_reenable_anysource(MPIR_Comm *, MPIR_Group **);
@@ -135,12 +135,12 @@ int MPID_Win_detach(MPIR_Win *, const void *);
 MPL_STATIC_INLINE_PREFIX int MPID_Compare_and_swap(const void *, const void *, void *, MPI_Datatype,
                                                    int, MPI_Aint,
                                                    MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Raccumulate(const void *, int, MPI_Datatype, int, MPI_Aint, int,
-                                              MPI_Datatype, MPI_Op, MPIR_Win *,
+MPL_STATIC_INLINE_PREFIX int MPID_Raccumulate(const void *, MPI_Aint, MPI_Datatype, int, MPI_Aint,
+                                              MPI_Aint, MPI_Datatype, MPI_Op, MPIR_Win *,
                                               MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Rget_accumulate(const void *, int, MPI_Datatype, void *, int,
-                                                  MPI_Datatype, int, MPI_Aint, int, MPI_Datatype,
-                                                  MPI_Op, MPIR_Win *,
+MPL_STATIC_INLINE_PREFIX int MPID_Rget_accumulate(const void *, MPI_Aint, MPI_Datatype, void *,
+                                                  MPI_Aint, MPI_Datatype, int, MPI_Aint, MPI_Aint,
+                                                  MPI_Datatype, MPI_Op, MPIR_Win *,
                                                   MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Fetch_and_op(const void *, void *, MPI_Datatype, int, MPI_Aint,
                                                MPI_Op, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
@@ -151,13 +151,15 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush(int, MPIR_Win *) MPL_STATIC_INLINE_S
 MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local_all(MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock_all(MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Win_create_dynamic(MPIR_Info *, MPIR_Comm *, MPIR_Win **);
-MPL_STATIC_INLINE_PREFIX int MPID_Rget(void *, int, MPI_Datatype, int, MPI_Aint, int, MPI_Datatype,
-                                       MPIR_Win *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Rget(void *, MPI_Aint, MPI_Datatype, int, MPI_Aint, MPI_Aint,
+                                       MPI_Datatype, MPIR_Win *,
+                                       MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_sync(MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_all(MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Get_accumulate(const void *, int, MPI_Datatype, void *, int,
-                                                 MPI_Datatype, int, MPI_Aint, int, MPI_Datatype,
-                                                 MPI_Op, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Get_accumulate(const void *, MPI_Aint, MPI_Datatype, void *,
+                                                 MPI_Aint, MPI_Datatype, int, MPI_Aint, MPI_Aint,
+                                                 MPI_Datatype, MPI_Op,
+                                                 MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Win_lock_all(int, MPIR_Win *) MPL_STATIC_INLINE_SUFFIX;
 void *MPID_Alloc_mem(MPI_Aint, MPIR_Info *);
 int MPID_Free_mem(void *);

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -111,8 +111,8 @@ typedef struct MPIDIG_acc_req_t {
     MPIR_Request *req_ptr;
     MPI_Datatype origin_datatype;
     MPI_Datatype target_datatype;
-    int origin_count;
-    int target_count;
+    MPI_Aint origin_count;
+    MPI_Aint target_count;
     void *target_addr;
     void *flattened_dt;
     void *data;                 /* for origin_data received and result_data being sent (in GET_ACC).
@@ -121,7 +121,7 @@ typedef struct MPIDIG_acc_req_t {
     MPI_Aint result_data_sz;    /* only used in GET_ACC */
     MPI_Op op;
     void *result_addr;
-    int result_count;
+    MPI_Aint result_count;
     void *origin_addr;
     MPI_Datatype result_datatype;
 } MPIDIG_acc_req_t;

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_rma.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_rma.h
@@ -115,11 +115,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
+                                              MPI_Aint target_count, MPI_Datatype target_datatype,
                                               MPIR_Win * win, MPIDI_av_entry_t * addr,
                                               MPIDI_winattr_t winattr)
 {
@@ -128,11 +128,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
+                                              MPI_Aint target_count, MPI_Datatype target_datatype,
                                               MPIR_Win * win, MPIDI_av_entry_t * addr,
                                               MPIDI_winattr_t winattr)
 {
@@ -141,11 +141,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rput(const void *origin_addr,
-                                               int origin_count,
+                                               MPI_Aint origin_count,
                                                MPI_Datatype origin_datatype,
                                                int target_rank,
                                                MPI_Aint target_disp,
-                                               int target_count,
+                                               MPI_Aint target_count,
                                                MPI_Datatype target_datatype,
                                                MPIR_Win * win,
                                                MPIDI_av_entry_t * addr, MPIDI_winattr_t winattr,
@@ -169,11 +169,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr,
-                                                      int origin_count,
+                                                      MPI_Aint origin_count,
                                                       MPI_Datatype origin_datatype,
                                                       int target_rank,
                                                       MPI_Aint target_disp,
-                                                      int target_count,
+                                                      MPI_Aint target_count,
                                                       MPI_Datatype target_datatype,
                                                       MPI_Op op, MPIR_Win * win,
                                                       MPIDI_av_entry_t * addr,
@@ -185,14 +185,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget_accumulate(const void *origin_addr,
-                                                          int origin_count,
+                                                          MPI_Aint origin_count,
                                                           MPI_Datatype origin_datatype,
                                                           void *result_addr,
-                                                          int result_count,
+                                                          MPI_Aint result_count,
                                                           MPI_Datatype result_datatype,
                                                           int target_rank,
                                                           MPI_Aint target_disp,
-                                                          int target_count,
+                                                          MPI_Aint target_count,
                                                           MPI_Datatype target_datatype,
                                                           MPI_Op op, MPIR_Win * win,
                                                           MPIDI_av_entry_t * addr,
@@ -218,11 +218,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr,
-                                               int origin_count,
+                                               MPI_Aint origin_count,
                                                MPI_Datatype origin_datatype,
                                                int target_rank,
                                                MPI_Aint target_disp,
-                                               int target_count,
+                                               MPI_Aint target_count,
                                                MPI_Datatype target_datatype,
                                                MPIR_Win * win,
                                                MPIDI_av_entry_t * addr, MPIDI_winattr_t winattr,
@@ -234,14 +234,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr,
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr,
-                                                         int origin_count,
+                                                         MPI_Aint origin_count,
                                                          MPI_Datatype origin_datatype,
                                                          void *result_addr,
-                                                         int result_count,
+                                                         MPI_Aint result_count,
                                                          MPI_Datatype result_datatype,
                                                          int target_rank,
                                                          MPI_Aint target_disp,
-                                                         int target_count,
+                                                         MPI_Aint target_count,
                                                          MPI_Datatype target_datatype, MPI_Op op,
                                                          MPIR_Win * win, MPIDI_av_entry_t * addr,
                                                          MPIDI_winattr_t winattr)
@@ -252,11 +252,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_accumulate(const void *origin_addr,
-                                                     int origin_count,
+                                                     MPI_Aint origin_count,
                                                      MPI_Datatype origin_datatype,
                                                      int target_rank,
                                                      MPI_Aint target_disp,
-                                                     int target_count,
+                                                     MPI_Aint target_count,
                                                      MPI_Datatype target_datatype, MPI_Op op,
                                                      MPIR_Win * win, MPIDI_av_entry_t * addr,
                                                      MPIDI_winattr_t winattr)

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -374,19 +374,19 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_load_iov(const void *buffer, int count,
 
 int MPIDI_OFI_issue_deferred_rma(MPIR_Win * win);
 void MPIDI_OFI_complete_chunks(MPIDI_OFI_win_request_t * winreq);
-int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
+int MPIDI_OFI_nopack_putget(const void *origin_addr, MPI_Aint origin_count,
                             MPI_Datatype origin_datatype, int target_rank,
-                            int target_count, MPI_Datatype target_datatype,
+                            MPI_Aint target_count, MPI_Datatype target_datatype,
                             MPIDI_OFI_target_mr_t target_mr, MPIR_Win * win,
                             MPIDI_av_entry_t * addr, int rma_type, MPIR_Request ** sigreq);
-int MPIDI_OFI_pack_put(const void *origin_addr, int origin_count,
+int MPIDI_OFI_pack_put(const void *origin_addr, MPI_Aint origin_count,
                        MPI_Datatype origin_datatype, int target_rank,
-                       int target_count, MPI_Datatype target_datatype,
+                       MPI_Aint target_count, MPI_Datatype target_datatype,
                        MPIDI_OFI_target_mr_t target_mr, MPIR_Win * win,
                        MPIDI_av_entry_t * addr, MPIR_Request ** sigreq);
-int MPIDI_OFI_pack_get(void *origin_addr, int origin_count,
+int MPIDI_OFI_pack_get(void *origin_addr, MPI_Aint origin_count,
                        MPI_Datatype origin_datatype, int target_rank,
-                       int target_count, MPI_Datatype target_datatype,
+                       MPI_Aint target_count, MPI_Datatype target_datatype,
                        MPIDI_OFI_target_mr_t target_mr, MPIR_Win * win,
                        MPIDI_av_entry_t * addr, MPIR_Request ** sigreq);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -51,9 +51,9 @@ void MPIDI_OFI_complete_chunks(MPIDI_OFI_win_request_t * winreq)
     winreq->chunks = NULL;
 }
 
-int MPIDI_OFI_nopack_putget(const void *origin_addr, int origin_count,
+int MPIDI_OFI_nopack_putget(const void *origin_addr, MPI_Aint origin_count,
                             MPI_Datatype origin_datatype, int target_rank,
-                            int target_count, MPI_Datatype target_datatype,
+                            MPI_Aint target_count, MPI_Datatype target_datatype,
                             MPIDI_OFI_target_mr_t target_mr, MPIR_Win * win,
                             MPIDI_av_entry_t * addr, int rma_type, MPIR_Request ** sigreq)
 {
@@ -351,9 +351,9 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
     goto fn_exit;
 }
 
-int MPIDI_OFI_pack_put(const void *origin_addr, int origin_count,
+int MPIDI_OFI_pack_put(const void *origin_addr, MPI_Aint origin_count,
                        MPI_Datatype origin_datatype, int target_rank,
-                       int target_count, MPI_Datatype target_datatype,
+                       MPI_Aint target_count, MPI_Datatype target_datatype,
                        MPIDI_OFI_target_mr_t target_mr, MPIR_Win * win,
                        MPIDI_av_entry_t * addr, MPIR_Request ** sigreq)
 {
@@ -412,9 +412,9 @@ int MPIDI_OFI_pack_put(const void *origin_addr, int origin_count,
     goto fn_exit;
 }
 
-int MPIDI_OFI_pack_get(void *origin_addr, int origin_count,
+int MPIDI_OFI_pack_get(void *origin_addr, MPI_Aint origin_count,
                        MPI_Datatype origin_datatype, int target_rank,
-                       int target_count, MPI_Datatype target_datatype,
+                       MPI_Aint target_count, MPI_Datatype target_datatype,
                        MPIDI_OFI_target_mr_t target_mr, MPIR_Win * win,
                        MPIDI_av_entry_t * addr, MPIR_Request ** sigreq)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -169,11 +169,11 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_prepare_target_mr(int target_rank,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count,
+                                              MPI_Aint target_count,
                                               MPI_Datatype target_datatype,
                                               MPIR_Win * win, MPIDI_av_entry_t * addr,
                                               MPIDI_winattr_t winattr, MPIR_Request ** sigreq)
@@ -323,11 +323,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
+                                              MPI_Aint target_count, MPI_Datatype target_datatype,
                                               MPIR_Win * win, MPIDI_av_entry_t * av,
                                               MPIDI_winattr_t winattr)
 {
@@ -354,11 +354,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count,
+                                              MPI_Aint target_count,
                                               MPI_Datatype target_datatype,
                                               MPIR_Win * win, MPIDI_av_entry_t * addr,
                                               MPIDI_winattr_t winattr, MPIR_Request ** sigreq)
@@ -491,11 +491,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
+                                              MPI_Aint target_count, MPI_Datatype target_datatype,
                                               MPIR_Win * win, MPIDI_av_entry_t * av,
                                               MPIDI_winattr_t winattr)
 {
@@ -523,11 +523,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rput(const void *origin_addr,
-                                               int origin_count,
+                                               MPI_Aint origin_count,
                                                MPI_Datatype origin_datatype,
                                                int target_rank,
                                                MPI_Aint target_disp,
-                                               int target_count,
+                                               MPI_Aint target_count,
                                                MPI_Datatype target_datatype,
                                                MPIR_Win * win, MPIDI_av_entry_t * av,
                                                MPIDI_winattr_t winattr, MPIR_Request ** request)
@@ -675,11 +675,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
-                                                     int origin_count,
+                                                     MPI_Aint origin_count,
                                                      MPI_Datatype origin_datatype,
                                                      int target_rank,
                                                      MPI_Aint target_disp,
-                                                     int target_count,
+                                                     MPI_Aint target_count,
                                                      MPI_Datatype target_datatype,
                                                      MPI_Op op, MPIR_Win * win,
                                                      MPIDI_av_entry_t * addr,
@@ -810,14 +810,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
-                                                         int origin_count,
+                                                         MPI_Aint origin_count,
                                                          MPI_Datatype origin_datatype,
                                                          void *result_addr,
-                                                         int result_count,
+                                                         MPI_Aint result_count,
                                                          MPI_Datatype result_datatype,
                                                          int target_rank,
                                                          MPI_Aint target_disp,
-                                                         int target_count,
+                                                         MPI_Aint target_count,
                                                          MPI_Datatype target_datatype,
                                                          MPI_Op op, MPIR_Win * win,
                                                          MPIDI_av_entry_t * addr,
@@ -959,11 +959,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr,
-                                                      int origin_count,
+                                                      MPI_Aint origin_count,
                                                       MPI_Datatype origin_datatype,
                                                       int target_rank,
                                                       MPI_Aint target_disp,
-                                                      int target_count,
+                                                      MPI_Aint target_count,
                                                       MPI_Datatype target_datatype,
                                                       MPI_Op op, MPIR_Win * win,
                                                       MPIDI_av_entry_t * av,
@@ -1004,14 +1004,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget_accumulate(const void *origin_addr,
-                                                          int origin_count,
+                                                          MPI_Aint origin_count,
                                                           MPI_Datatype origin_datatype,
                                                           void *result_addr,
-                                                          int result_count,
+                                                          MPI_Aint result_count,
                                                           MPI_Datatype result_datatype,
                                                           int target_rank,
                                                           MPI_Aint target_disp,
-                                                          int target_count,
+                                                          MPI_Aint target_count,
                                                           MPI_Datatype target_datatype,
                                                           MPI_Op op, MPIR_Win * win,
                                                           MPIDI_av_entry_t * av,
@@ -1166,11 +1166,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr,
-                                               int origin_count,
+                                               MPI_Aint origin_count,
                                                MPI_Datatype origin_datatype,
                                                int target_rank,
                                                MPI_Aint target_disp,
-                                               int target_count,
+                                               MPI_Aint target_count,
                                                MPI_Datatype target_datatype,
                                                MPIR_Win * win, MPIDI_av_entry_t * av,
                                                MPIDI_winattr_t winattr, MPIR_Request ** request)
@@ -1199,14 +1199,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr,
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr,
-                                                         int origin_count,
+                                                         MPI_Aint origin_count,
                                                          MPI_Datatype origin_datatype,
                                                          void *result_addr,
-                                                         int result_count,
+                                                         MPI_Aint result_count,
                                                          MPI_Datatype result_datatype,
                                                          int target_rank,
                                                          MPI_Aint target_disp,
-                                                         int target_count,
+                                                         MPI_Aint target_count,
                                                          MPI_Datatype target_datatype, MPI_Op op,
                                                          MPIR_Win * win, MPIDI_av_entry_t * av,
                                                          MPIDI_winattr_t winattr)
@@ -1244,11 +1244,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_accumulate(const void *origin_addr,
-                                                     int origin_count,
+                                                     MPI_Aint origin_count,
                                                      MPI_Datatype origin_datatype,
                                                      int target_rank,
                                                      MPI_Aint target_disp,
-                                                     int target_count,
+                                                     MPI_Aint target_count,
                                                      MPI_Datatype target_datatype, MPI_Op op,
                                                      MPIR_Win * win, MPIDI_av_entry_t * av,
                                                      MPIDI_winattr_t winattr)

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -86,10 +86,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_noncontig_put(const void *origin_addr,
-                                                     int origin_count, MPI_Datatype origin_datatype,
-                                                     int target_rank, size_t size,
-                                                     MPI_Aint target_disp, MPI_Aint true_lb,
-                                                     MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                                     MPI_Aint origin_count,
+                                                     MPI_Datatype origin_datatype, int target_rank,
+                                                     size_t size, MPI_Aint target_disp,
+                                                     MPI_Aint true_lb, MPIR_Win * win,
+                                                     MPIDI_av_entry_t * addr,
                                                      MPIR_Request ** reqptr ATTRIBUTE((unused)),
                                                      int vni, int vni_target)
 {
@@ -179,11 +180,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_put(const void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
+                                              MPI_Aint target_count, MPI_Datatype target_datatype,
                                               MPIR_Win * win, MPIDI_av_entry_t * addr,
                                               MPIDI_winattr_t winattr, MPIR_Request ** reqptr)
 {
@@ -247,11 +248,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_put(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_get(void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
+                                              MPI_Aint target_count, MPI_Datatype target_datatype,
                                               MPIR_Win * win, MPIDI_av_entry_t * addr,
                                               MPIDI_winattr_t winattr, MPIR_Request ** reqptr)
 {
@@ -303,11 +304,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_get(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
+                                              MPI_Aint target_count, MPI_Datatype target_datatype,
                                               MPIR_Win * win, MPIDI_av_entry_t * addr,
                                               MPIDI_winattr_t winattr)
 {
@@ -329,11 +330,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count, MPI_Datatype target_datatype,
+                                              MPI_Aint target_count, MPI_Datatype target_datatype,
                                               MPIR_Win * win, MPIDI_av_entry_t * addr,
                                               MPIDI_winattr_t winattr)
 {
@@ -355,11 +356,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rput(const void *origin_addr,
-                                               int origin_count,
+                                               MPI_Aint origin_count,
                                                MPI_Datatype origin_datatype,
                                                int target_rank,
                                                MPI_Aint target_disp,
-                                               int target_count,
+                                               MPI_Aint target_count,
                                                MPI_Datatype target_datatype,
                                                MPIR_Win * win,
                                                MPIDI_av_entry_t * addr, MPIDI_winattr_t winattr,
@@ -410,11 +411,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr,
-                                                      int origin_count,
+                                                      MPI_Aint origin_count,
                                                       MPI_Datatype origin_datatype,
                                                       int target_rank,
                                                       MPI_Aint target_disp,
-                                                      int target_count,
+                                                      MPI_Aint target_count,
                                                       MPI_Datatype target_datatype,
                                                       MPI_Op op, MPIR_Win * win,
                                                       MPIDI_av_entry_t * addr,
@@ -426,14 +427,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget_accumulate(const void *origin_addr,
-                                                          int origin_count,
+                                                          MPI_Aint origin_count,
                                                           MPI_Datatype origin_datatype,
                                                           void *result_addr,
-                                                          int result_count,
+                                                          MPI_Aint result_count,
                                                           MPI_Datatype result_datatype,
                                                           int target_rank,
                                                           MPI_Aint target_disp,
-                                                          int target_count,
+                                                          MPI_Aint target_count,
                                                           MPI_Datatype target_datatype,
                                                           MPI_Op op, MPIR_Win * win,
                                                           MPIDI_av_entry_t * addr,
@@ -459,11 +460,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr,
-                                               int origin_count,
+                                               MPI_Aint origin_count,
                                                MPI_Datatype origin_datatype,
                                                int target_rank,
                                                MPI_Aint target_disp,
-                                               int target_count,
+                                               MPI_Aint target_count,
                                                MPI_Datatype target_datatype,
                                                MPIR_Win * win,
                                                MPIDI_av_entry_t * addr, MPIDI_winattr_t winattr,
@@ -502,14 +503,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr,
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr,
-                                                         int origin_count,
+                                                         MPI_Aint origin_count,
                                                          MPI_Datatype origin_datatype,
                                                          void *result_addr,
-                                                         int result_count,
+                                                         MPI_Aint result_count,
                                                          MPI_Datatype result_datatype,
                                                          int target_rank,
                                                          MPI_Aint target_disp,
-                                                         int target_count,
+                                                         MPI_Aint target_count,
                                                          MPI_Datatype target_datatype, MPI_Op op,
                                                          MPIR_Win * win, MPIDI_av_entry_t * addr,
                                                          MPIDI_winattr_t winattr)
@@ -520,11 +521,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_accumulate(const void *origin_addr,
-                                                     int origin_count,
+                                                     MPI_Aint origin_count,
                                                      MPI_Datatype origin_datatype,
                                                      int target_rank,
                                                      MPI_Aint target_disp,
-                                                     int target_count,
+                                                     MPI_Aint target_count,
                                                      MPI_Datatype target_datatype, MPI_Op op,
                                                      MPIR_Win * win, MPIDI_av_entry_t * addr,
                                                      MPIDI_winattr_t winattr)

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -10,10 +10,10 @@
 #include "posix_impl.h"
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_compute_accumulate(void *origin_addr,
-                                                            int origin_count,
+                                                            MPI_Aint origin_count,
                                                             MPI_Datatype origin_datatype,
                                                             void *target_addr,
-                                                            int target_count,
+                                                            MPI_Aint target_count,
                                                             MPI_Datatype target_datatype, MPI_Op op,
                                                             int mapped_device)
 {
@@ -82,11 +82,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_compute_accumulate(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
-                                                int origin_count,
+                                                MPI_Aint origin_count,
                                                 MPI_Datatype origin_datatype,
                                                 int target_rank,
                                                 MPI_Aint target_disp,
-                                                int target_count, MPI_Datatype target_datatype,
+                                                MPI_Aint target_count, MPI_Datatype target_datatype,
                                                 MPIR_Win * win, MPIDI_winattr_t winattr)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -136,11 +136,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
-                                                int origin_count,
+                                                MPI_Aint origin_count,
                                                 MPI_Datatype origin_datatype,
                                                 int target_rank,
                                                 MPI_Aint target_disp,
-                                                int target_count, MPI_Datatype target_datatype,
+                                                MPI_Aint target_count, MPI_Datatype target_datatype,
                                                 MPIR_Win * win, MPIDI_winattr_t winattr)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -189,14 +189,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get_accumulate(const void *origin_addr,
-                                                           int origin_count,
+                                                           MPI_Aint origin_count,
                                                            MPI_Datatype origin_datatype,
                                                            void *result_addr,
-                                                           int result_count,
+                                                           MPI_Aint result_count,
                                                            MPI_Datatype result_datatype,
                                                            int target_rank,
                                                            MPI_Aint target_disp,
-                                                           int target_count,
+                                                           MPI_Aint target_count,
                                                            MPI_Datatype target_datatype, MPI_Op op,
                                                            MPIR_Win * win, MPIDI_winattr_t winattr)
 {
@@ -261,11 +261,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get_accumulate(const void *origin_ad
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_accumulate(const void *origin_addr,
-                                                       int origin_count,
+                                                       MPI_Aint origin_count,
                                                        MPI_Datatype origin_datatype,
                                                        int target_rank,
                                                        MPI_Aint target_disp,
-                                                       int target_count,
+                                                       MPI_Aint target_count,
                                                        MPI_Datatype target_datatype, MPI_Op op,
                                                        MPIR_Win * win, MPIDI_winattr_t winattr)
 {
@@ -321,12 +321,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_accumulate(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_put(const void *origin_addr,
-                                                 int origin_count,
+                                                 MPI_Aint origin_count,
                                                  MPI_Datatype origin_datatype,
                                                  int target_rank,
                                                  MPI_Aint target_disp,
-                                                 int target_count, MPI_Datatype target_datatype,
-                                                 MPIR_Win * win, MPIDI_winattr_t winattr)
+                                                 MPI_Aint target_count,
+                                                 MPI_Datatype target_datatype, MPIR_Win * win,
+                                                 MPIDI_winattr_t winattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
@@ -352,12 +353,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_put(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_get(void *origin_addr,
-                                                 int origin_count,
+                                                 MPI_Aint origin_count,
                                                  MPI_Datatype origin_datatype,
                                                  int target_rank,
                                                  MPI_Aint target_disp,
-                                                 int target_count, MPI_Datatype target_datatype,
-                                                 MPIR_Win * win, MPIDI_winattr_t winattr)
+                                                 MPI_Aint target_count,
+                                                 MPI_Datatype target_datatype, MPIR_Win * win,
+                                                 MPIDI_winattr_t winattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
@@ -383,11 +385,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_get(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rput(const void *origin_addr,
-                                                  int origin_count,
+                                                  MPI_Aint origin_count,
                                                   MPI_Datatype origin_datatype,
                                                   int target_rank,
                                                   MPI_Aint target_disp,
-                                                  int target_count,
+                                                  MPI_Aint target_count,
                                                   MPI_Datatype target_datatype,
                                                   MPIR_Win * win, MPIDI_winattr_t winattr,
                                                   MPIR_Request ** request)
@@ -498,11 +500,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_compare_and_swap(const void *origin
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_raccumulate(const void *origin_addr,
-                                                         int origin_count,
+                                                         MPI_Aint origin_count,
                                                          MPI_Datatype origin_datatype,
                                                          int target_rank,
                                                          MPI_Aint target_disp,
-                                                         int target_count,
+                                                         MPI_Aint target_count,
                                                          MPI_Datatype target_datatype,
                                                          MPI_Op op, MPIR_Win * win,
                                                          MPIDI_winattr_t winattr,
@@ -545,14 +547,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_raccumulate(const void *origin_addr
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget_accumulate(const void *origin_addr,
-                                                             int origin_count,
+                                                             MPI_Aint origin_count,
                                                              MPI_Datatype origin_datatype,
                                                              void *result_addr,
-                                                             int result_count,
+                                                             MPI_Aint result_count,
                                                              MPI_Datatype result_datatype,
                                                              int target_rank,
                                                              MPI_Aint target_disp,
-                                                             int target_count,
+                                                             MPI_Aint target_count,
                                                              MPI_Datatype target_datatype,
                                                              MPI_Op op, MPIR_Win * win,
                                                              MPIDI_winattr_t winattr,
@@ -676,11 +678,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_fetch_and_op(const void *origin_add
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget(void *origin_addr,
-                                                  int origin_count,
+                                                  MPI_Aint origin_count,
                                                   MPI_Datatype origin_datatype,
                                                   int target_rank,
                                                   MPI_Aint target_disp,
-                                                  int target_count,
+                                                  MPI_Aint target_count,
                                                   MPI_Datatype target_datatype,
                                                   MPIR_Win * win, MPIDI_winattr_t winattr,
                                                   MPIR_Request ** request)
@@ -720,14 +722,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_get_accumulate(const void *origin_addr,
-                                                            int origin_count,
+                                                            MPI_Aint origin_count,
                                                             MPI_Datatype origin_datatype,
                                                             void *result_addr,
-                                                            int result_count,
+                                                            MPI_Aint result_count,
                                                             MPI_Datatype result_datatype,
                                                             int target_rank,
                                                             MPI_Aint target_disp,
-                                                            int target_count,
+                                                            MPI_Aint target_count,
                                                             MPI_Datatype target_datatype, MPI_Op op,
                                                             MPIR_Win * win, MPIDI_winattr_t winattr)
 {
@@ -754,11 +756,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_get_accumulate(const void *origin_a
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_accumulate(const void *origin_addr,
-                                                        int origin_count,
+                                                        MPI_Aint origin_count,
                                                         MPI_Datatype origin_datatype,
                                                         int target_rank,
                                                         MPI_Aint target_disp,
-                                                        int target_count,
+                                                        MPI_Aint target_count,
                                                         MPI_Datatype target_datatype, MPI_Op op,
                                                         MPIR_Win * win, MPIDI_winattr_t winattr)
 {

--- a/src/mpid/ch4/shm/src/shm_am_fallback_rma.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_rma.h
@@ -27,11 +27,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_rma_target_local_cmpl_hook(int rank, MPIR
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_put(const void *origin_addr,
-                                               int origin_count,
+                                               MPI_Aint origin_count,
                                                MPI_Datatype origin_datatype,
                                                int target_rank,
                                                MPI_Aint target_disp,
-                                               int target_count, MPI_Datatype target_datatype,
+                                               MPI_Aint target_count, MPI_Datatype target_datatype,
                                                MPIR_Win * win, MPIDI_winattr_t winattr)
 {
     return MPIDIG_mpi_put(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
@@ -39,11 +39,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_put(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get(void *origin_addr,
-                                               int origin_count,
+                                               MPI_Aint origin_count,
                                                MPI_Datatype origin_datatype,
                                                int target_rank,
                                                MPI_Aint target_disp,
-                                               int target_count, MPI_Datatype target_datatype,
+                                               MPI_Aint target_count, MPI_Datatype target_datatype,
                                                MPIR_Win * win, MPIDI_winattr_t winattr)
 {
     return MPIDIG_mpi_get(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
@@ -51,11 +51,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rput(const void *origin_addr,
-                                                int origin_count,
+                                                MPI_Aint origin_count,
                                                 MPI_Datatype origin_datatype,
                                                 int target_rank,
                                                 MPI_Aint target_disp,
-                                                int target_count,
+                                                MPI_Aint target_count,
                                                 MPI_Datatype target_datatype,
                                                 MPIR_Win * win, MPIDI_winattr_t winattr,
                                                 MPIR_Request ** request)
@@ -77,11 +77,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_compare_and_swap(const void *origin_a
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_raccumulate(const void *origin_addr,
-                                                       int origin_count,
+                                                       MPI_Aint origin_count,
                                                        MPI_Datatype origin_datatype,
                                                        int target_rank,
                                                        MPI_Aint target_disp,
-                                                       int target_count,
+                                                       MPI_Aint target_count,
                                                        MPI_Datatype target_datatype,
                                                        MPI_Op op, MPIR_Win * win,
                                                        MPIDI_winattr_t winattr,
@@ -92,14 +92,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_raccumulate(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget_accumulate(const void *origin_addr,
-                                                           int origin_count,
+                                                           MPI_Aint origin_count,
                                                            MPI_Datatype origin_datatype,
                                                            void *result_addr,
-                                                           int result_count,
+                                                           MPI_Aint result_count,
                                                            MPI_Datatype result_datatype,
                                                            int target_rank,
                                                            MPI_Aint target_disp,
-                                                           int target_count,
+                                                           MPI_Aint target_count,
                                                            MPI_Datatype target_datatype,
                                                            MPI_Op op, MPIR_Win * win,
                                                            MPIDI_winattr_t winattr,
@@ -123,11 +123,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_fetch_and_op(const void *origin_addr,
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget(void *origin_addr,
-                                                int origin_count,
+                                                MPI_Aint origin_count,
                                                 MPI_Datatype origin_datatype,
                                                 int target_rank,
                                                 MPI_Aint target_disp,
-                                                int target_count,
+                                                MPI_Aint target_count,
                                                 MPI_Datatype target_datatype,
                                                 MPIR_Win * win, MPIDI_winattr_t winattr,
                                                 MPIR_Request ** request)
@@ -138,14 +138,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget(void *origin_addr,
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get_accumulate(const void *origin_addr,
-                                                          int origin_count,
+                                                          MPI_Aint origin_count,
                                                           MPI_Datatype origin_datatype,
                                                           void *result_addr,
-                                                          int result_count,
+                                                          MPI_Aint result_count,
                                                           MPI_Datatype result_datatype,
                                                           int target_rank,
                                                           MPI_Aint target_disp,
-                                                          int target_count,
+                                                          MPI_Aint target_count,
                                                           MPI_Datatype target_datatype, MPI_Op op,
                                                           MPIR_Win * win, MPIDI_winattr_t winattr)
 {
@@ -155,11 +155,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get_accumulate(const void *origin_add
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_accumulate(const void *origin_addr,
-                                                      int origin_count,
+                                                      MPI_Aint origin_count,
                                                       MPI_Datatype origin_datatype,
                                                       int target_rank,
                                                       MPI_Aint target_disp,
-                                                      int target_count,
+                                                      MPI_Aint target_count,
                                                       MPI_Datatype target_datatype, MPI_Op op,
                                                       MPIR_Win * win, MPIDI_winattr_t winattr)
 {

--- a/src/mpid/ch4/shm/src/shm_rma.h
+++ b/src/mpid/ch4/shm/src/shm_rma.h
@@ -9,9 +9,9 @@
 #include <shm.h>
 #include "../posix/shm_inline.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_put(const void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_put(const void *origin_addr, MPI_Aint origin_count,
                                                MPI_Datatype origin_datatype, int target_rank,
-                                               MPI_Aint target_disp, int target_count,
+                                               MPI_Aint target_disp, MPI_Aint target_count,
                                                MPI_Datatype target_datatype, MPIR_Win * win,
                                                MPIDI_winattr_t winattr)
 {
@@ -26,9 +26,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_put(const void *origin_addr, int orig
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get(void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get(void *origin_addr, MPI_Aint origin_count,
                                                MPI_Datatype origin_datatype, int target_rank,
-                                               MPI_Aint target_disp, int target_count,
+                                               MPI_Aint target_disp, MPI_Aint target_count,
                                                MPI_Datatype target_datatype, MPIR_Win * win,
                                                MPIDI_winattr_t winattr)
 {
@@ -43,9 +43,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get(void *origin_addr, int origin_cou
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_accumulate(const void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_accumulate(const void *origin_addr,
+                                                      MPI_Aint origin_count,
                                                       MPI_Datatype origin_datatype, int target_rank,
-                                                      MPI_Aint target_disp, int target_count,
+                                                      MPI_Aint target_disp, MPI_Aint target_count,
                                                       MPI_Datatype target_datatype, MPI_Op op,
                                                       MPIR_Win * win, MPIDI_winattr_t winattr)
 {
@@ -61,9 +62,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_accumulate(const void *origin_addr, i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rput(const void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rput(const void *origin_addr, MPI_Aint origin_count,
                                                 MPI_Datatype origin_datatype, int target_rank,
-                                                MPI_Aint target_disp, int target_count,
+                                                MPI_Aint target_disp, MPI_Aint target_count,
                                                 MPI_Datatype target_datatype, MPIR_Win * win,
                                                 MPIDI_winattr_t winattr, MPIR_Request ** request)
 {
@@ -96,10 +97,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_compare_and_swap(const void *origin_a
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_raccumulate(const void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_raccumulate(const void *origin_addr,
+                                                       MPI_Aint origin_count,
                                                        MPI_Datatype origin_datatype,
                                                        int target_rank, MPI_Aint target_disp,
-                                                       int target_count,
+                                                       MPI_Aint target_count,
                                                        MPI_Datatype target_datatype, MPI_Op op,
                                                        MPIR_Win * win, MPIDI_winattr_t winattr,
                                                        MPIR_Request ** request)
@@ -117,12 +119,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_raccumulate(const void *origin_addr, 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget_accumulate(const void *origin_addr,
-                                                           int origin_count,
+                                                           MPI_Aint origin_count,
                                                            MPI_Datatype origin_datatype,
-                                                           void *result_addr, int result_count,
+                                                           void *result_addr, MPI_Aint result_count,
                                                            MPI_Datatype result_datatype,
                                                            int target_rank, MPI_Aint target_disp,
-                                                           int target_count,
+                                                           MPI_Aint target_count,
                                                            MPI_Datatype target_datatype, MPI_Op op,
                                                            MPIR_Win * win, MPIDI_winattr_t winattr,
                                                            MPIR_Request ** request)
@@ -157,9 +159,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_fetch_and_op(const void *origin_addr,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget(void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget(void *origin_addr, MPI_Aint origin_count,
                                                 MPI_Datatype origin_datatype, int target_rank,
-                                                MPI_Aint target_disp, int target_count,
+                                                MPI_Aint target_disp, MPI_Aint target_count,
                                                 MPI_Datatype target_datatype, MPIR_Win * win,
                                                 MPIDI_winattr_t winattr, MPIR_Request ** request)
 {
@@ -175,12 +177,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget(void *origin_addr, int origin_co
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get_accumulate(const void *origin_addr,
-                                                          int origin_count,
+                                                          MPI_Aint origin_count,
                                                           MPI_Datatype origin_datatype,
-                                                          void *result_addr, int result_count,
+                                                          void *result_addr, MPI_Aint result_count,
                                                           MPI_Datatype result_datatype,
                                                           int target_rank, MPI_Aint target_disp,
-                                                          int target_count,
+                                                          MPI_Aint target_count,
                                                           MPI_Datatype target_datatype, MPI_Op op,
                                                           MPIR_Win * win, MPIDI_winattr_t winattr)
 {

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -961,9 +961,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_wait_am_acc(MPIR_Win * win, int target_rank)
  * The source datatype can be only predefined; the target datatype can be
  * predefined or derived. If the source buffer has been packed by the caller,
  * src_kind must be set to MPIDIG_ACC_SRCBUF_PACKED.*/
-MPL_STATIC_INLINE_PREFIX int MPIDIG_compute_acc_op(void *source_buf, int source_count,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_compute_acc_op(void *source_buf, MPI_Aint source_count,
                                                    MPI_Datatype source_dtp, void *target_buf,
-                                                   int target_count, MPI_Datatype target_dtp,
+                                                   MPI_Aint target_count, MPI_Datatype target_dtp,
                                                    MPI_Op acc_op, int src_kind)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/src/ch4_rma.h
+++ b/src/mpid/ch4/src/ch4_rma.h
@@ -27,11 +27,11 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_dbg_dump_winattr(MPIDI_winattr_t winattr)
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_put(const void *origin_addr,
-                                       int origin_count,
+                                       MPI_Aint origin_count,
                                        MPI_Datatype origin_datatype,
                                        int target_rank,
                                        MPI_Aint target_disp,
-                                       int target_count, MPI_Datatype target_datatype,
+                                       MPI_Aint target_count, MPI_Datatype target_datatype,
                                        MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -65,11 +65,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_put(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_get(void *origin_addr,
-                                       int origin_count,
+                                       MPI_Aint origin_count,
                                        MPI_Datatype origin_datatype,
                                        int target_rank,
                                        MPI_Aint target_disp,
-                                       int target_count, MPI_Datatype target_datatype,
+                                       MPI_Aint target_count, MPI_Datatype target_datatype,
                                        MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -103,11 +103,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate(const void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count,
+                                              MPI_Aint target_count,
                                               MPI_Datatype target_datatype, MPI_Op op,
                                               MPIR_Win * win)
 {
@@ -179,11 +179,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap(const void *origin_addr,
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate(const void *origin_addr,
-                                               int origin_count,
+                                               MPI_Aint origin_count,
                                                MPI_Datatype origin_datatype,
                                                int target_rank,
                                                MPI_Aint target_disp,
-                                               int target_count,
+                                               MPI_Aint target_count,
                                                MPI_Datatype target_datatype,
                                                MPI_Op op, MPIR_Win * win, MPIR_Request ** request)
 {
@@ -217,14 +217,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate(const void *origin_addr,
-                                                   int origin_count,
+                                                   MPI_Aint origin_count,
                                                    MPI_Datatype origin_datatype,
                                                    void *result_addr,
-                                                   int result_count,
+                                                   MPI_Aint result_count,
                                                    MPI_Datatype result_datatype,
                                                    int target_rank,
                                                    MPI_Aint target_disp,
-                                                   int target_count,
+                                                   MPI_Aint target_count,
                                                    MPI_Datatype target_datatype,
                                                    MPI_Op op, MPIR_Win * win,
                                                    MPIR_Request ** request)
@@ -298,11 +298,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_rget(void *origin_addr,
-                                        int origin_count,
+                                        MPI_Aint origin_count,
                                         MPI_Datatype origin_datatype,
                                         int target_rank,
                                         MPI_Aint target_disp,
-                                        int target_count,
+                                        MPI_Aint target_count,
                                         MPI_Datatype target_datatype, MPIR_Win * win,
                                         MPIR_Request ** request)
 {
@@ -337,11 +337,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_rput(const void *origin_addr,
-                                        int origin_count,
+                                        MPI_Aint origin_count,
                                         MPI_Datatype origin_datatype,
                                         int target_rank,
                                         MPI_Aint target_disp,
-                                        int target_count,
+                                        MPI_Aint target_count,
                                         MPI_Datatype target_datatype, MPIR_Win * win,
                                         MPIR_Request ** request)
 {
@@ -376,14 +376,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rput(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate(const void *origin_addr,
-                                                  int origin_count,
+                                                  MPI_Aint origin_count,
                                                   MPI_Datatype origin_datatype,
                                                   void *result_addr,
-                                                  int result_count,
+                                                  MPI_Aint result_count,
                                                   MPI_Datatype result_datatype,
                                                   int target_rank,
                                                   MPI_Aint target_disp,
-                                                  int target_count,
+                                                  MPI_Aint target_count,
                                                   MPI_Datatype target_datatype, MPI_Op op,
                                                   MPIR_Win * win)
 {
@@ -422,11 +422,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate(const void *origin_addr,
 
 
 MPL_STATIC_INLINE_PREFIX int MPID_Put(const void *origin_addr,
-                                      int origin_count,
+                                      MPI_Aint origin_count,
                                       MPI_Datatype origin_datatype,
                                       int target_rank,
                                       MPI_Aint target_disp,
-                                      int target_count, MPI_Datatype target_datatype,
+                                      MPI_Aint target_count, MPI_Datatype target_datatype,
                                       MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -443,11 +443,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Put(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Get(void *origin_addr,
-                                      int origin_count,
+                                      MPI_Aint origin_count,
                                       MPI_Datatype origin_datatype,
                                       int target_rank,
                                       MPI_Aint target_disp,
-                                      int target_count, MPI_Datatype target_datatype,
+                                      MPI_Aint target_count, MPI_Datatype target_datatype,
                                       MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -464,11 +464,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Accumulate(const void *origin_addr,
-                                             int origin_count,
+                                             MPI_Aint origin_count,
                                              MPI_Datatype origin_datatype,
                                              int target_rank,
                                              MPI_Aint target_disp,
-                                             int target_count,
+                                             MPI_Aint target_count,
                                              MPI_Datatype target_datatype, MPI_Op op,
                                              MPIR_Win * win)
 {
@@ -506,11 +506,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Compare_and_swap(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Raccumulate(const void *origin_addr,
-                                              int origin_count,
+                                              MPI_Aint origin_count,
                                               MPI_Datatype origin_datatype,
                                               int target_rank,
                                               MPI_Aint target_disp,
-                                              int target_count,
+                                              MPI_Aint target_count,
                                               MPI_Datatype target_datatype,
                                               MPI_Op op, MPIR_Win * win, MPIR_Request ** request)
 {
@@ -529,14 +529,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Raccumulate(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Rget_accumulate(const void *origin_addr,
-                                                  int origin_count,
+                                                  MPI_Aint origin_count,
                                                   MPI_Datatype origin_datatype,
                                                   void *result_addr,
-                                                  int result_count,
+                                                  MPI_Aint result_count,
                                                   MPI_Datatype result_datatype,
                                                   int target_rank,
                                                   MPI_Aint target_disp,
-                                                  int target_count,
+                                                  MPI_Aint target_count,
                                                   MPI_Datatype target_datatype,
                                                   MPI_Op op, MPIR_Win * win,
                                                   MPIR_Request ** request)
@@ -576,11 +576,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Fetch_and_op(const void *origin_addr,
 
 
 MPL_STATIC_INLINE_PREFIX int MPID_Rget(void *origin_addr,
-                                       int origin_count,
+                                       MPI_Aint origin_count,
                                        MPI_Datatype origin_datatype,
                                        int target_rank,
                                        MPI_Aint target_disp,
-                                       int target_count,
+                                       MPI_Aint target_count,
                                        MPI_Datatype target_datatype, MPIR_Win * win,
                                        MPIR_Request ** request)
 {
@@ -598,11 +598,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rget(void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Rput(const void *origin_addr,
-                                       int origin_count,
+                                       MPI_Aint origin_count,
                                        MPI_Datatype origin_datatype,
                                        int target_rank,
                                        MPI_Aint target_disp,
-                                       int target_count,
+                                       MPI_Aint target_count,
                                        MPI_Datatype target_datatype, MPIR_Win * win,
                                        MPIR_Request ** request)
 {
@@ -621,14 +621,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rput(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Get_accumulate(const void *origin_addr,
-                                                 int origin_count,
+                                                 MPI_Aint origin_count,
                                                  MPI_Datatype origin_datatype,
                                                  void *result_addr,
-                                                 int result_count,
+                                                 MPI_Aint result_count,
                                                  MPI_Datatype result_datatype,
                                                  int target_rank,
                                                  MPI_Aint target_disp,
-                                                 int target_count,
+                                                 MPI_Aint target_count,
                                                  MPI_Datatype target_datatype, MPI_Op op,
                                                  MPIR_Win * win)
 {

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -15,7 +15,7 @@
 #define MPIDIU_MAP_NOT_FOUND      ((void*)(-1UL))
 
 #define MPIDIU_REQUEST_POOL_NUM_CELLS_PER_CHUNK (1024)
-#define MPIDIU_REQUEST_POOL_CELL_SIZE (256)
+#define MPIDIU_REQUEST_POOL_CELL_SIZE (512)
 
 /* Flags for MPIDI_Progress_test
  *

--- a/src/mpid/ch4/src/ch4_win.c
+++ b/src/mpid/ch4/src/ch4_win.c
@@ -66,16 +66,20 @@ int MPID_Win_free(MPIR_Win ** win_ptr)
     goto fn_exit;
 }
 
-int MPID_Win_create(void *base, MPI_Aint length, int disp_unit, MPIR_Info * info,
+int MPID_Win_create(void *base, MPI_Aint length, MPI_Aint disp_unit, MPIR_Info * info,
                     MPIR_Comm * comm_ptr, MPIR_Win ** win_ptr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
+
+    MPIR_Assert(disp_unit <= INT_MAX);
+    int my_disp_unit = (int) disp_unit;
+
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_win_create(base, length, disp_unit, info, comm_ptr, win_ptr);
+    mpi_errno = MPIDI_NM_mpi_win_create(base, length, my_disp_unit, info, comm_ptr, win_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 #else
-    mpi_errno = MPIDIG_mpi_win_create(base, length, disp_unit, info, comm_ptr, win_ptr);
+    mpi_errno = MPIDIG_mpi_win_create(base, length, my_disp_unit, info, comm_ptr, win_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
@@ -106,17 +110,21 @@ int MPID_Win_attach(MPIR_Win * win, void *base, MPI_Aint size)
     goto fn_exit;
 }
 
-int MPID_Win_allocate_shared(MPI_Aint size, int disp_unit, MPIR_Info * info_ptr,
+int MPID_Win_allocate_shared(MPI_Aint size, MPI_Aint disp_unit, MPIR_Info * info_ptr,
                              MPIR_Comm * comm_ptr, void **base_ptr, MPIR_Win ** win_ptr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
+
+    MPIR_Assert(disp_unit <= INT_MAX);
+    int my_disp_unit = (int) disp_unit;
+
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_win_allocate_shared(size, disp_unit,
+    mpi_errno = MPIDI_NM_mpi_win_allocate_shared(size, my_disp_unit,
                                                  info_ptr, comm_ptr, base_ptr, win_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 #else
-    mpi_errno = MPIDIG_mpi_win_allocate_shared(size, disp_unit, info_ptr, comm_ptr, base_ptr,
+    mpi_errno = MPIDIG_mpi_win_allocate_shared(size, my_disp_unit, info_ptr, comm_ptr, base_ptr,
                                                win_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
@@ -146,16 +154,20 @@ int MPID_Win_detach(MPIR_Win * win, const void *base)
     goto fn_exit;
 }
 
-int MPID_Win_allocate(MPI_Aint size, int disp_unit, MPIR_Info * info, MPIR_Comm * comm,
+int MPID_Win_allocate(MPI_Aint size, MPI_Aint disp_unit, MPIR_Info * info, MPIR_Comm * comm,
                       void *baseptr, MPIR_Win ** win)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
+
+    MPIR_Assert(disp_unit <= INT_MAX);
+    int my_disp_unit = (int) disp_unit;
+
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_win_allocate(size, disp_unit, info, comm, baseptr, win);
+    mpi_errno = MPIDI_NM_mpi_win_allocate(size, my_disp_unit, info, comm, baseptr, win);
     MPIR_ERR_CHECK(mpi_errno);
 #else
-    mpi_errno = MPIDIG_mpi_win_allocate(size, disp_unit, info, comm, baseptr, win);
+    mpi_errno = MPIDIG_mpi_win_allocate(size, my_disp_unit, info, comm, baseptr, win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
   fn_exit:

--- a/src/mpid/ch4/src/mpidig_part.c
+++ b/src/mpid/ch4/src/mpidig_part.c
@@ -131,7 +131,7 @@ int MPIDIG_mpi_psend_init(const void *buf, int partitions, MPI_Aint count,
     goto fn_exit;
 }
 
-int MPIDIG_mpi_precv_init(void *buf, int partitions, int count,
+int MPIDIG_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
                           MPI_Datatype datatype, int source, int tag,
                           MPIR_Comm * comm, MPIR_Info * info, MPIR_Request ** request)
 {

--- a/src/mpid/ch4/src/mpidig_part.h
+++ b/src/mpid/ch4/src/mpidig_part.h
@@ -13,7 +13,7 @@ void MPIDIG_precv_matched(MPIR_Request * part_req);
 int MPIDIG_mpi_psend_init(const void *buf, int partitions, MPI_Aint count,
                           MPI_Datatype datatype, int dest, int tag,
                           MPIR_Comm * comm, MPIR_Info * info, MPIR_Request ** request);
-int MPIDIG_mpi_precv_init(void *buf, int partitions, int count,
+int MPIDIG_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
                           MPI_Datatype datatype, int source, int tag,
                           MPIR_Comm * comm, MPIR_Info * info, MPIR_Request ** request);
 

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -20,9 +20,9 @@ extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_amhdr_set ATTRIBUTE((unused));
                             goto fn_fail, "**nomemreq");                \
     } while (0)
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, MPI_Aint origin_count,
                                            MPI_Datatype origin_datatype, int target_rank,
-                                           MPI_Aint target_disp, int target_count,
+                                           MPI_Aint target_disp, MPI_Aint target_count,
                                            MPI_Datatype target_datatype, MPIR_Win * win,
                                            int vci, MPIR_Request ** sreq_ptr)
 {
@@ -157,9 +157,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, int origin_c
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, MPI_Aint origin_count,
                                            MPI_Datatype origin_datatype, int target_rank,
-                                           MPI_Aint target_disp, int target_count,
+                                           MPI_Aint target_disp, MPI_Aint target_count,
                                            MPI_Datatype target_datatype, MPIR_Win * win,
                                            int vci, MPIR_Request ** sreq_ptr)
 {
@@ -264,9 +264,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, int origin_count,
 }
 
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, MPI_Aint origin_count,
                                                   MPI_Datatype origin_datatype, int target_rank,
-                                                  MPI_Aint target_disp, int target_count,
+                                                  MPI_Aint target_disp, MPI_Aint target_count,
                                                   MPI_Datatype target_datatype,
                                                   MPI_Op op, MPIR_Win * win,
                                                   int vci, MPIR_Request ** sreq_ptr)
@@ -395,14 +395,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
-                                                      int origin_count_,
+                                                      MPI_Aint origin_count_,
                                                       MPI_Datatype origin_datatype_,
                                                       void *result_addr,
-                                                      int result_count,
+                                                      MPI_Aint result_count,
                                                       MPI_Datatype result_datatype,
                                                       int target_rank,
                                                       MPI_Aint target_disp,
-                                                      int target_count,
+                                                      MPI_Aint target_count,
                                                       MPI_Datatype target_datatype,
                                                       MPI_Op op, MPIR_Win * win,
                                                       int vci, MPIR_Request ** sreq_ptr)
@@ -413,7 +413,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
     MPIDIG_get_acc_req_msg_t am_hdr;
     MPI_Aint origin_data_sz, result_data_sz, target_data_sz;
     MPIR_Datatype *dt_ptr;
-    int origin_count = origin_count_;
+    MPI_Aint origin_count = origin_count_;
     MPI_Datatype origin_datatype = origin_datatype_;
 
     MPIR_FUNC_ENTER;
@@ -548,9 +548,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_put(const void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_put(const void *origin_addr, MPI_Aint origin_count,
                                             MPI_Datatype origin_datatype, int target_rank,
-                                            MPI_Aint target_disp, int target_count,
+                                            MPI_Aint target_disp, MPI_Aint target_count,
                                             MPI_Datatype target_datatype, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -571,9 +571,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_put(const void *origin_addr, int origin_
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rput(const void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rput(const void *origin_addr, MPI_Aint origin_count,
                                              MPI_Datatype origin_datatype, int target_rank,
-                                             MPI_Aint target_disp, int target_count,
+                                             MPI_Aint target_disp, MPI_Aint target_count,
                                              MPI_Datatype target_datatype, MPIR_Win * win,
                                              MPIR_Request ** request)
 {
@@ -597,9 +597,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rput(const void *origin_addr, int origin
 }
 
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_get(void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_get(void *origin_addr, MPI_Aint origin_count,
                                             MPI_Datatype origin_datatype, int target_rank,
-                                            MPI_Aint target_disp, int target_count,
+                                            MPI_Aint target_disp, MPI_Aint target_count,
                                             MPI_Datatype target_datatype, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -620,9 +620,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_get(void *origin_addr, int origin_count,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rget(void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rget(void *origin_addr, MPI_Aint origin_count,
                                              MPI_Datatype origin_datatype, int target_rank,
-                                             MPI_Aint target_disp, int target_count,
+                                             MPI_Aint target_disp, MPI_Aint target_count,
                                              MPI_Datatype target_datatype, MPIR_Win * win,
                                              MPIR_Request ** request)
 {
@@ -646,9 +646,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rget(void *origin_addr, int origin_count
 }
 
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_raccumulate(const void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_raccumulate(const void *origin_addr, MPI_Aint origin_count,
                                                     MPI_Datatype origin_datatype, int target_rank,
-                                                    MPI_Aint target_disp, int target_count,
+                                                    MPI_Aint target_disp, MPI_Aint target_count,
                                                     MPI_Datatype target_datatype, MPI_Op op,
                                                     MPIR_Win * win, MPIR_Request ** request)
 {
@@ -672,9 +672,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_raccumulate(const void *origin_addr, int
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_accumulate(const void *origin_addr, int origin_count,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_accumulate(const void *origin_addr, MPI_Aint origin_count,
                                                    MPI_Datatype origin_datatype, int target_rank,
-                                                   MPI_Aint target_disp, int target_count,
+                                                   MPI_Aint target_disp, MPI_Aint target_count,
                                                    MPI_Datatype target_datatype, MPI_Op op,
                                                    MPIR_Win * win)
 {
@@ -698,12 +698,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_accumulate(const void *origin_addr, int 
 
 
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rget_accumulate(const void *origin_addr,
-                                                        int origin_count,
+                                                        MPI_Aint origin_count,
                                                         MPI_Datatype origin_datatype,
-                                                        void *result_addr, int result_count,
+                                                        void *result_addr, MPI_Aint result_count,
                                                         MPI_Datatype result_datatype,
                                                         int target_rank, MPI_Aint target_disp,
-                                                        int target_count,
+                                                        MPI_Aint target_count,
                                                         MPI_Datatype target_datatype, MPI_Op op,
                                                         MPIR_Win * win, MPIR_Request ** request)
 {
@@ -728,12 +728,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rget_accumulate(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_get_accumulate(const void *origin_addr,
-                                                       int origin_count,
+                                                       MPI_Aint origin_count,
                                                        MPI_Datatype origin_datatype,
-                                                       void *result_addr, int result_count,
+                                                       void *result_addr, MPI_Aint result_count,
                                                        MPI_Datatype result_datatype,
                                                        int target_rank, MPI_Aint target_disp,
-                                                       int target_count,
+                                                       MPI_Aint target_count,
                                                        MPI_Datatype target_datatype,
                                                        MPI_Op op, MPIR_Win * win)
 {


### PR DESCRIPTION
## Pull Request Description
Split from https://github.com/pmodels/mpich/pull/5069

Some ADI functions are not updated to support large count operations. We need use MPI_Aint for all count parameters and variables to support large count.

Following functions are fixed:
```   
    MPID_Get
    MPID_Put
    MPID_Accumulate
    MPID_Get_accumulate
    MPID_Rget
    MPID_Rput
    MPID_Raccumulate
    MPID_Rget_accumulate

    MPID_Rsend
    MPID_Irsend
    MPID_Issend
    MPID_Send_init
    MPID_Bsend_init
    MPID_Rsend_init
    MPID_Ssend_init
    MPID_Recv_init
    MPID_Mrecv
    MPID_Imrecv
```
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
