### PR TITLE
stream/gpu: remove the synchronize requirement

### DIFF
--- a/src/mpi/stream/stream_impl.c
+++ b/src/mpi/stream/stream_impl.c
@@ -73,8 +73,7 @@ void MPIR_stream_comm_free(MPIR_Comm * comm)
 {
     if (comm->stream_comm_type == MPIR_STREAM_COMM_SINGLE) {
         if (comm->stream_comm.single.stream) {
-            int cnt;
-            MPIR_Object_release_ref_always(comm->stream_comm.single.stream, &cnt);
+            MPIR_Stream_free_impl(comm->stream_comm.single.stream);
         }
         MPL_free(comm->stream_comm.single.vci_table);
     } else if (comm->stream_comm_type == MPIR_STREAM_COMM_MULTIPLEX) {
@@ -83,8 +82,7 @@ void MPIR_stream_comm_free(MPIR_Comm * comm)
             comm->stream_comm.multiplex.vci_displs[rank];
         for (int i = 0; i < num_local_streams; i++) {
             if (comm->stream_comm.multiplex.local_streams[i]) {
-                int cnt;
-                MPIR_Object_release_ref_always(comm->stream_comm.multiplex.local_streams[i], &cnt);
+                MPIR_Stream_free_impl(comm->stream_comm.multiplex.local_streams[i]);
             }
         }
         MPL_free(comm->stream_comm.multiplex.local_streams);

--- a/test/mpi/impls/mpich/cuda/stream.cu
+++ b/test/mpi/impls/mpich/cuda/stream.cu
@@ -83,8 +83,6 @@ int main(void)
 
         mpi_errno = MPIX_Send_enqueue(d_x, N, MPI_FLOAT, 1, 0, stream_comm);
         assert(mpi_errno == MPI_SUCCESS);
-
-        cudaStreamSynchronize(stream);
     } else if (rank == 1) {
         for (int i = 0; i < N; i++) {
             y[i] = y_val;
@@ -114,8 +112,6 @@ int main(void)
         /* req won't reset to MPI_REQUEST_NULL, but user shouldn't use it afterward */
         mpi_errno = MPIX_Wait_enqueue(&req, MPI_STATUS_IGNORE);
         assert(mpi_errno == MPI_SUCCESS);
-
-        cudaStreamSynchronize(stream);
     } else if (rank == 1) {
         /* reset d_x, d_y */
         for (int i = 0; i < N; i++) {


### PR DESCRIPTION
## Pull Request Description
We can avoid the synchronize requirement (e.g. `cudaStreamSynchronize` before `MPI_Comm_free` or `MPIX_Stream_free` if we reference count the usage and lazily free the actual object.

Having `cudaStreamSynchronize` requirement, even in non-performance critical APIs, may raise suspicion.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
