### PR TITLE
hydra: use struct PMIU_cmd from pmi_wire.h

### DIFF
--- a/src/pm/hydra/lib/pmi_v2_common.c
+++ b/src/pm/hydra/lib/pmi_v2_common.c
@@ -5,10 +5,11 @@
 
 #include "hydra.h"
 #include "bsci.h"
+#include "pmiserv_common.h"
 #include "pmi_v2_common.h"
 
-HYD_status HYD_pmcd_pmi_v2_queue_req(int fd, int pid, int pgid, char *args[], char *key,
-                                     struct HYD_pmcd_pmi_v2_reqs **pending_reqs)
+HYD_status HYD_pmcd_pmi_v2_queue_req(int fd, int pid, int pgid, struct PMIU_cmd *pmi,
+                                     const char *key, struct HYD_pmcd_pmi_v2_reqs **pending_reqs)
 {
     struct HYD_pmcd_pmi_v2_reqs *req, *tmp;
     HYD_status status = HYD_SUCCESS;
@@ -21,9 +22,7 @@ HYD_status HYD_pmcd_pmi_v2_queue_req(int fd, int pid, int pgid, char *args[], ch
     req->prev = NULL;
     req->next = NULL;
 
-    status = HYDU_strdup_list(args, &req->args);
-    HYDU_ERR_POP(status, "unable to dup args\n");
-
+    req->pmi = PMIU_cmd_dup(pmi);
     req->key = MPL_strdup(key);
 
     if (*pending_reqs == NULL)

--- a/src/pm/hydra/lib/pmi_v2_common.h
+++ b/src/pm/hydra/lib/pmi_v2_common.h
@@ -7,21 +7,21 @@
 #define PMI_V2_COMMON_H_INCLUDED
 
 #include "hydra.h"
+#include "pmi_wire.h"
 
 struct HYD_pmcd_pmi_v2_reqs {
     int fd;
     int pid;
     int pgid;
-    char *thrid;
-    char **args;
-    char *key;
+    const char *thrid;
+    struct PMIU_cmd *pmi;
+    const char *key;
 
     struct HYD_pmcd_pmi_v2_reqs *prev;
     struct HYD_pmcd_pmi_v2_reqs *next;
 };
 
-HYD_status HYD_pmcd_pmi_v2_queue_req(int fd, int pid, int pgid, char *args[], char *key,
-                                     struct HYD_pmcd_pmi_v2_reqs **pending_reqs);
-void HYD_pmcd_pmi_v2_print_req_list(struct HYD_pmcd_pmi_v2_reqs *pending_reqs);
+HYD_status HYD_pmcd_pmi_v2_queue_req(int fd, int pid, int pgid, struct PMIU_cmd *pmi,
+                                     const char *key, struct HYD_pmcd_pmi_v2_reqs **pending_reqs);
 
 #endif /* PMI_V2_COMMON_H_INCLUDED */

--- a/src/pm/hydra/lib/pmiserv_common.h
+++ b/src/pm/hydra/lib/pmiserv_common.h
@@ -32,6 +32,13 @@ struct HYD_pmcd_init_hdr {
     int proxy_id;
 };
 
+HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_pmcd_pmi_kvs **kvs, int pgid);
+void HYD_pmcd_free_pmi_kvs_list(struct HYD_pmcd_pmi_kvs *kvs_list);
+HYD_status HYD_pmcd_pmi_add_kvs(const char *key, const char *val, struct HYD_pmcd_pmi_kvs *kvs,
+                                int *ret);
+
+/* ---- struct HYD_pmcd_hdr ---- */
+
 /* The set of commands supported */
 enum HYD_pmcd_cmd {
     CMD_INVALID = 0,            /* for sanity testing */
@@ -75,13 +82,8 @@ struct HYD_pmcd_hdr {
 };
 
 void HYD_pmcd_init_header(struct HYD_pmcd_hdr *hdr);
-HYD_status HYD_pmcd_pmi_parse_pmi_cmd(char *buf, int pmi_version, char **pmi_cmd, char *args[]);
-HYD_status HYD_pmcd_pmi_args_to_tokens(char *args[], struct PMIU_token **tokens, int *count);
-void HYD_pmcd_pmi_free_tokens(struct PMIU_token *tokens, int token_count);
-char *HYD_pmcd_pmi_find_token_keyval(struct PMIU_token *tokens, int count, const char *key);
-HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_pmcd_pmi_kvs **kvs, int pgid);
-void HYD_pmcd_free_pmi_kvs_list(struct HYD_pmcd_pmi_kvs *kvs_list);
-HYD_status HYD_pmcd_pmi_add_kvs(const char *key, char *val, struct HYD_pmcd_pmi_kvs *kvs, int *ret);
+void HYD_pmcd_pmi_dump(struct PMIU_cmd *pmi);
+HYD_status HYD_pmcd_pmi_send(int fd, struct PMIU_cmd *pmi, struct HYD_pmcd_hdr *hdr, int debug);
 
 /* macros for retrieving key/val from struct PMIU_cmd */
 #define HYD_PMI_GET_STRVAL(pmi, key, val) \

--- a/src/pm/hydra/mpiexec/name_service.c
+++ b/src/pm/hydra/mpiexec/name_service.c
@@ -7,14 +7,14 @@
 #include "pmiserv_pmi.h"
 #include "pmiserv_utils.h"
 
-static HYD_status builtin_publish(char *name, char *port, int *success);
-static HYD_status builtin_unpublish(char *name, int *success);
-static HYD_status builtin_lookup(char *name, char **value);
-static HYD_status server_publish(char *name, char *port, int *success);
-static HYD_status server_unpublish(char *name, int *success);
-static HYD_status server_lookup(char *name, char **value);
+static HYD_status builtin_publish(const char *name, const char *port, int *success);
+static HYD_status builtin_unpublish(const char *name, int *success);
+static HYD_status builtin_lookup(const char *name, const char **value);
+static HYD_status server_publish(const char *name, const char *port, int *success);
+static HYD_status server_unpublish(const char *name, int *success);
+static HYD_status server_lookup(const char *name, const char **value);
 
-HYD_status HYD_pmcd_pmi_publish(char *name, char *port, int *success)
+HYD_status HYD_pmcd_pmi_publish(const char *name, const char *port, int *success)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -30,7 +30,7 @@ HYD_status HYD_pmcd_pmi_publish(char *name, char *port, int *success)
     return status;
 }
 
-HYD_status HYD_pmcd_pmi_unpublish(char *name, int *success)
+HYD_status HYD_pmcd_pmi_unpublish(const char *name, int *success)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -46,7 +46,7 @@ HYD_status HYD_pmcd_pmi_unpublish(char *name, int *success)
     return status;
 }
 
-HYD_status HYD_pmcd_pmi_lookup(char *name, char **value)
+HYD_status HYD_pmcd_pmi_lookup(const char *name, const char **value)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -99,7 +99,7 @@ static HYD_status builtin_free_publish(struct builtin_publish *publish)
     return status;
 }
 
-static HYD_status builtin_publish(char *name, char *port, int *success)
+static HYD_status builtin_publish(const char *name, const char *port, int *success)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -139,7 +139,7 @@ static HYD_status builtin_publish(char *name, char *port, int *success)
     goto fn_exit;
 }
 
-static HYD_status builtin_unpublish(char *name, int *success)
+static HYD_status builtin_unpublish(const char *name, int *success)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -183,7 +183,7 @@ static HYD_status builtin_unpublish(char *name, int *success)
     return status;
 }
 
-static HYD_status builtin_lookup(char *name, char **value)
+static HYD_status builtin_lookup(const char *name, const char **value)
 {
     HYDU_FUNC_ENTER();
 
@@ -202,7 +202,7 @@ static HYD_status builtin_lookup(char *name, char **value)
 
 /* ---- internal routines using name server ---- */
 
-static HYD_status server_publish(char *name, char *port, int *success)
+static HYD_status server_publish(const char *name, const char *port, int *success)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -266,7 +266,7 @@ static HYD_status server_publish(char *name, char *port, int *success)
     goto fn_exit;
 }
 
-static HYD_status server_unpublish(char *name, int *success)
+static HYD_status server_unpublish(const char *name, int *success)
 {
     HYD_status status = HYD_SUCCESS;
 
@@ -329,7 +329,7 @@ static HYD_status server_unpublish(char *name, int *success)
     goto fn_exit;
 }
 
-static HYD_status server_lookup(char *name, char **value)
+static HYD_status server_lookup(const char *name, const char **value)
 {
     HYD_status status = HYD_SUCCESS;
 

--- a/src/pm/hydra/mpiexec/pmiserv_pmi.h
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi.h
@@ -16,11 +16,6 @@ extern struct HYD_pmcd_pmi_handle *HYD_pmcd_pmi_v1;
 /* PMI-2 specific definitions */
 extern struct HYD_pmcd_pmi_handle *HYD_pmcd_pmi_v2;
 
-struct HYD_pmcd_token_segment {
-    int start_idx;
-    int token_count;
-};
-
 struct HYD_pmcd_pmi_pg_scratch {
     /* PMI-1's PMI_Barrier is blocking, thus a single barrier_count works */
     int barrier_count;
@@ -45,13 +40,13 @@ struct HYD_pmcd_pmi_pg_scratch {
 
 struct HYD_proxy *HYD_pmcd_pmi_find_proxy(int fd);
 HYD_status HYD_pmcd_pmi_finalize(void);
-HYD_status HYD_pmcd_pmi_publish(char *name, char *port, int *success);
-HYD_status HYD_pmcd_pmi_unpublish(char *name, int *success);
-HYD_status HYD_pmcd_pmi_lookup(char *name, char **value);
+HYD_status HYD_pmcd_pmi_publish(const char *name, const char *port, int *success);
+HYD_status HYD_pmcd_pmi_unpublish(const char *name, int *success);
+HYD_status HYD_pmcd_pmi_lookup(const char *name, const char **value);
 
 struct HYD_pmcd_pmi_handle {
     const char *cmd;
-     HYD_status(*handler) (int fd, int pid, int pgid, char *args[]);
+     HYD_status(*handler) (int fd, int pid, int pgid, struct PMIU_cmd * pmi);
 };
 
 extern struct HYD_pmcd_pmi_handle *HYD_pmcd_pmi_handle;

--- a/src/pm/hydra/mpiexec/pmiserv_pmi_v1.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi_v1.c
@@ -10,43 +10,18 @@
 #include "pmiserv_pmi.h"
 #include "pmiserv_utils.h"
 
-static HYD_status cmd_response(int fd, int pid, const char *cmd)
+static HYD_status cmd_response(int fd, int pid, struct PMIU_cmd *pmi)
 {
     struct HYD_pmcd_hdr hdr;
-    int sent, closed;
-    HYD_status status = HYD_SUCCESS;
-
-    HYDU_FUNC_ENTER();
-
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = CMD_PMI_RESPONSE;
     hdr.u.pmi.pid = pid;
-    hdr.u.pmi.pmi_version = 1;
-    hdr.buflen = strlen(cmd);
-    status = HYDU_sock_write(fd, &hdr, sizeof(hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
-    HYDU_ERR_POP(status, "unable to send CMD_PMI_RESPONSE header to proxy\n");
-    HYDU_ASSERT(!closed, status);
-
-    if (HYD_server_info.user_global.debug) {
-        HYDU_dump(stdout, "PMI response to fd %d pid %d: %s", fd, pid, cmd);
-    }
-
-    status = HYDU_sock_write(fd, cmd, strlen(cmd), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
-    HYDU_ERR_POP(status, "unable to send response to command\n");
-    HYDU_ASSERT(!closed, status);
-
-  fn_exit:
-    HYDU_FUNC_EXIT();
-    return status;
-
-  fn_fail:
-    goto fn_exit;
+    return HYD_pmcd_pmi_send(fd, pmi, &hdr, HYD_server_info.user_global.debug);
 }
 
 static HYD_status bcast_keyvals(int fd, int pid)
 {
-    int keyval_count, arg_count, i, j;
-    char **tmp = NULL, *cmd;
+    int keyval_count, arg_count, j;
     struct HYD_pmcd_pmi_kvs_pair *run;
     struct HYD_proxy *proxy, *tproxy;
     struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
@@ -65,66 +40,39 @@ static HYD_status bcast_keyvals(int fd, int pid)
 
     keyval_count -= pg_scratch->keyval_dist_count;
 
-    /* Each keyval has the following four items: 'key' '=' 'val'
-     * '<space>'.  Two additional items for the command at the start
-     * and the NULL at the end. */
-    HYDU_MALLOC_OR_JUMP(tmp, char **, (4 * keyval_count + 3) * sizeof(char *), status);
-
-    /* send all available keyvals downstream */
+    struct PMIU_cmd pmi;
     if (keyval_count) {
+        PMIU_cmd_init(&pmi, 1, "keyval_cache");
         arg_count = 1;
-        i = 0;
-        tmp[i++] = MPL_strdup("cmd=keyval_cache ");
         for (run = pg_scratch->kvs->key_pair, j = 0; run; run = run->next, j++) {
             if (j < pg_scratch->keyval_dist_count)
                 continue;
 
-            tmp[i++] = MPL_strdup(run->key);
-            tmp[i++] = MPL_strdup("=");
-            tmp[i++] = MPL_strdup(run->val);
-            tmp[i++] = MPL_strdup(" ");
+            PMIU_cmd_add_str(&pmi, run->key, run->val);
 
             arg_count++;
             if (arg_count >= MAX_PMI_ARGS) {
-                tmp[i++] = MPL_strdup("\n");
-                tmp[i++] = NULL;
-
-                status = HYDU_str_alloc_and_join(tmp, &cmd);
-                HYDU_ERR_POP(status, "unable to join strings\n");
-                HYDU_free_strlist(tmp);
-
                 pg_scratch->keyval_dist_count += (arg_count - 1);
                 for (tproxy = proxy->pg->proxy_list; tproxy; tproxy = tproxy->next) {
-                    status = cmd_response(tproxy->control_fd, pid, cmd);
+                    status = cmd_response(tproxy->control_fd, pid, &pmi);
                     HYDU_ERR_POP(status, "error writing PMI line\n");
                 }
-                MPL_free(cmd);
 
-                i = 0;
-                tmp[i++] = MPL_strdup("cmd=keyval_cache ");
+                PMIU_cmd_init(&pmi, 1, "keyval_cache");
                 arg_count = 1;
             }
         }
-        tmp[i++] = MPL_strdup("\n");
-        tmp[i++] = NULL;
 
         if (arg_count > 1) {
-            status = HYDU_str_alloc_and_join(tmp, &cmd);
-            HYDU_ERR_POP(status, "unable to join strings\n");
-
             pg_scratch->keyval_dist_count += (arg_count - 1);
             for (tproxy = proxy->pg->proxy_list; tproxy; tproxy = tproxy->next) {
-                status = cmd_response(tproxy->control_fd, pid, cmd);
+                status = cmd_response(tproxy->control_fd, pid, &pmi);
                 HYDU_ERR_POP(status, "error writing PMI line\n");
             }
-            MPL_free(cmd);
         }
-        HYDU_free_strlist(tmp);
     }
 
   fn_exit:
-    if (tmp)
-        MPL_free(tmp);
     HYDU_FUNC_EXIT();
     return status;
 
@@ -132,7 +80,7 @@ static HYD_status bcast_keyvals(int fd, int pid)
     goto fn_exit;
 }
 
-static HYD_status fn_barrier_in(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_barrier_in(int fd, int pid, int pgid, struct PMIU_cmd *pmi)
 {
     struct HYD_proxy *proxy, *tproxy;
     HYD_status status = HYD_SUCCESS;
@@ -148,8 +96,10 @@ static HYD_status fn_barrier_in(int fd, int pid, int pgid, char *args[])
 
         bcast_keyvals(fd, pid);
 
+        struct PMIU_cmd pmi_response;
+        PMIU_cmd_init(&pmi_response, 1, "barrier_out");
         for (tproxy = proxy->pg->proxy_list; tproxy; tproxy = tproxy->next) {
-            status = cmd_response(tproxy->control_fd, pid, "cmd=barrier_out\n");
+            status = cmd_response(tproxy->control_fd, pid, &pmi_response);
             HYDU_ERR_POP(status, "error writing PMI line\n");
         }
     }
@@ -162,30 +112,28 @@ static HYD_status fn_barrier_in(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_put(int fd, int pid, int pgid, char *args[])
+/* NOTE: this is an aggregate put from proxy with multiple key=val pairs */
+static HYD_status fn_put(int fd, int pid, int pgid, struct PMIU_cmd *pmi)
 {
     struct HYD_proxy *proxy;
     struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
-    struct PMIU_token *tokens;
-    int token_count, i, ret;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
-
-    status = HYD_pmcd_pmi_args_to_tokens(args, &tokens, &token_count);
-    HYDU_ERR_POP(status, "unable to convert args to tokens\n");
 
     proxy = HYD_pmcd_pmi_find_proxy(fd);
     HYDU_ASSERT(proxy, status);
     pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) proxy->pg->pg_scratch;
 
-    for (i = 0; i < token_count; i++) {
-        status = HYD_pmcd_pmi_add_kvs(tokens[i].key, (char *) tokens[i].val, pg_scratch->kvs, &ret);
+    /* FIXME: leak of pmi's abstraction */
+    for (int i = 0; i < pmi->num_tokens; i++) {
+        int ret;
+        status = HYD_pmcd_pmi_add_kvs(pmi->tokens[i].key, pmi->tokens[i].val,
+                                      pg_scratch->kvs, &ret);
         HYDU_ERR_POP(status, "unable to add key pair to kvs\n");
     }
 
   fn_exit:
-    HYD_pmcd_pmi_free_tokens(tokens, token_count);
     HYDU_FUNC_EXIT();
     return status;
 
@@ -193,28 +141,21 @@ static HYD_status fn_put(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_get(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_get(int fd, int pid, int pgid, struct PMIU_cmd *pmi)
 {
-    int i;
     struct HYD_proxy *proxy;
     struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
     struct HYD_pmcd_pmi_kvs_pair *run;
-    char *kvsname, *key, *val;
-    char *tmp[HYD_NUM_TMP_STRINGS], *cmd;
-    struct PMIU_token *tokens;
-    int token_count;
+    const char *kvsname, *key, *val;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
-    status = HYD_pmcd_pmi_args_to_tokens(args, &tokens, &token_count);
-    HYDU_ERR_POP(status, "unable to convert args to tokens\n");
-
-    kvsname = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "kvsname");
+    kvsname = PMIU_cmd_find_keyval(pmi, "kvsname");
     HYDU_ERR_CHKANDJUMP(status, kvsname == NULL, HYD_INTERNAL_ERROR,
                         "unable to find token: kvsname\n");
 
-    key = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "key");
+    key = PMIU_cmd_find_keyval(pmi, "key");
     HYDU_ERR_CHKANDJUMP(status, key == NULL, HYD_INTERNAL_ERROR, "unable to find token: key\n");
 
     proxy = HYD_pmcd_pmi_find_proxy(fd);
@@ -241,30 +182,26 @@ static HYD_status fn_get(int fd, int pid, int pgid, char *args[])
         }
     }
 
+    struct PMIU_cmd pmi_response;
   found_val:
-    i = 0;
-    tmp[i++] = MPL_strdup("cmd=get_result rc=");
+    PMIU_cmd_init(&pmi_response, 1, "get_result");
     if (val) {
-        tmp[i++] = MPL_strdup("0 msg=success value=");
-        tmp[i++] = MPL_strdup(val);
+        PMIU_cmd_add_str(&pmi_response, "rc", "0");
+        PMIU_cmd_add_str(&pmi_response, "msg", "success");
+        PMIU_cmd_add_str(&pmi_response, "value", val);
     } else {
-        tmp[i++] = MPL_strdup("-1 msg=key_");
-        tmp[i++] = MPL_strdup(key);
-        tmp[i++] = MPL_strdup("_not_found value=unknown");
+        static char tmp[100];
+        MPL_snprintf(tmp, 100, "key_%s_not_found", key);
+
+        PMIU_cmd_add_str(&pmi_response, "rc", "-1");
+        PMIU_cmd_add_str(&pmi_response, "msg", tmp);
+        PMIU_cmd_add_str(&pmi_response, "value", "unknown");
     }
-    tmp[i++] = MPL_strdup("\n");
-    tmp[i++] = NULL;
 
-    status = HYDU_str_alloc_and_join(tmp, &cmd);
-    HYDU_ERR_POP(status, "unable to join strings\n");
-    HYDU_free_strlist(tmp);
-
-    status = cmd_response(fd, pid, cmd);
+    status = cmd_response(fd, pid, &pmi_response);
     HYDU_ERR_POP(status, "error writing PMI line\n");
-    MPL_free(cmd);
 
   fn_exit:
-    HYD_pmcd_pmi_free_tokens(tokens, token_count);
     HYDU_FUNC_EXIT();
     return status;
 
@@ -272,48 +209,22 @@ static HYD_status fn_get(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static char *mcmd_args[MAX_PMI_ARGS] = { NULL };
-
-static int mcmd_num_args = 0;
-
-static void segment_tokens(struct PMIU_token *tokens, int token_count,
-                           struct HYD_pmcd_token_segment *segment_list, int *num_segments)
-{
-    int i, j;
-
-    j = 0;
-    segment_list[j].start_idx = 0;
-    segment_list[j].token_count = 0;
-    for (i = 0; i < token_count; i++) {
-        if (!strcmp(tokens[i].key, "endcmd") && (i < token_count - 1)) {
-            j++;
-            segment_list[j].start_idx = i + 1;
-            segment_list[j].token_count = 0;
-        } else {
-            segment_list[j].token_count++;
-        }
-    }
-    *num_segments = j + 1;
-}
-
-static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_spawn(int fd, int pid, int pgid, struct PMIU_cmd *pmi)
 {
     struct HYD_pg *pg;
     struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
     struct HYD_proxy *proxy;
-    struct PMIU_token *tokens;
     struct HYD_exec *exec_list = NULL, *exec;
     struct HYD_env *env;
     struct HYD_node *node;
 
-    char key[PMI_MAXKEYLEN], *val;
+    char key[PMI_MAXKEYLEN];
+    const char *val;
     int nprocs, preput_num, info_num, ret;
     char *execname, *path = NULL;
 
-    struct HYD_pmcd_token_segment *segment_list = NULL;
-
-    int token_count, i, j, k, new_pgid, total_spawns;
-    int argcnt, num_segments;
+    int i, k, new_pgid;
+    int argcnt;
     struct HYD_string_stash proxy_stash;
     char *control_port;
     struct HYD_string_stash stash;
@@ -321,120 +232,99 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
 
     HYDU_FUNC_ENTER();
 
-    for (i = 0; args[i]; i++)
-        mcmd_args[mcmd_num_args++] = MPL_strdup(args[i]);
-    mcmd_args[mcmd_num_args] = NULL;
-
     /* Initialize the proxy stash, so it can be freed if we jump to
      * exit */
     HYD_STRING_STASH_INIT(proxy_stash);
 
-    status = HYD_pmcd_pmi_args_to_tokens(mcmd_args, &tokens, &token_count);
-    HYDU_ERR_POP(status, "unable to convert args to tokens\n");
 
-
-    /* Here's the order of things we do:
-     *
-     *   1. Break the token list into multiple segments, each segment
-     *      corresponding to a command. Each command represents
-     *      information for one executable.
-     *
-     *   2. Allocate a process group for the new set of spawned
-     *      processes
-     *
-     *   3. Get all the common keys and deal with them
-     *
-     *   4. Create an executable list based on the segments.
-     *
-     *   5. Create a proxy list using the created executable list and
-     *      spawn it.
+    /* With PMI-v1, PMI_Spawn_multiple comes as separate mcmd=spawn
+     * commands. We use static variables (pg, execlist) to sync between
+     * segments.
+     *   * In the first segment, we allocate pg and execlist.
+     *   * For each segment, we allocate, parse, and enqueue the exec object.
+     *   * In the last segment, we execute the spawn.
      */
 
-    /* Break the token list into multiple segments and create an
-     * executable list based on the segments. */
-    val = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "totspawns");
+    int total_spawns, spawnssofar;
+    val = PMIU_cmd_find_keyval(pmi, "totspawns");
     HYDU_ERR_CHKANDJUMP(status, val == NULL, HYD_INTERNAL_ERROR,
                         "unable to find token: totspawns\n");
     total_spawns = atoi(val);
 
-    HYDU_MALLOC_OR_JUMP(segment_list, struct HYD_pmcd_token_segment *,
-                        total_spawns * sizeof(struct HYD_pmcd_token_segment), status);
+    val = PMIU_cmd_find_keyval(pmi, "spawnssofar");
+    HYDU_ERR_CHKANDJUMP(status, val == NULL, HYD_INTERNAL_ERROR,
+                        "unable to find token: totspawns\n");
+    spawnssofar = atoi(val);
 
-    segment_tokens(tokens, token_count, segment_list, &num_segments);
+    static struct HYD_pg *spawn_pg = NULL;
+    static struct HYD_exec *spawn_exec_list = NULL;
 
-    if (num_segments != total_spawns) {
-        /* We didn't read the entire PMI string; wait for the rest to
-         * arrive */
-        goto fn_exit;
+    if (spawnssofar == 1) {
+        /* Allocate a new process group */
+        for (pg = &HYD_server_info.pg_list; pg->next; pg = pg->next);
+        new_pgid = pg->pgid + 1;
+
+        status = HYDU_alloc_pg(&pg->next, new_pgid);
+        HYDU_ERR_POP(status, "unable to allocate process group\n");
+
+        pg = pg->next;
+        spawn_pg = pg;
+
+        proxy = HYD_pmcd_pmi_find_proxy(fd);
+        HYDU_ASSERT(proxy, status);
+
+        pg->spawner_pg = proxy->pg;
+
+        status = HYDU_alloc_exec(&exec_list);
+        HYDU_ERR_POP(status, "unable to allocate exec\n");
+        exec_list->appnum = 0;
+        spawn_exec_list = exec_list;
+
+        exec = exec_list;
     } else {
-        /* Got the entire PMI string; free the arguments and reset */
-        HYDU_free_strlist(mcmd_args);
-        mcmd_num_args = 0;
+        pg = spawn_pg;
+        new_pgid = pg->pgid;
+        exec_list = spawn_exec_list;
+
+        for (exec = exec_list; exec->next; exec = exec->next);
+        status = HYDU_alloc_exec(&exec->next);
+        HYDU_ERR_POP(status, "unable to allocate exec\n");
+        exec->next->appnum = exec->appnum + 1;
+        exec = exec->next;
     }
+    HYDU_ASSERT(pg, status);
 
-    /* Allocate a new process group */
-    for (pg = &HYD_server_info.pg_list; pg->next; pg = pg->next);
-    new_pgid = pg->pgid + 1;
-
-    status = HYDU_alloc_pg(&pg->next, new_pgid);
-    HYDU_ERR_POP(status, "unable to allocate process group\n");
-
-    pg = pg->next;
-
-    proxy = HYD_pmcd_pmi_find_proxy(fd);
-    HYDU_ASSERT(proxy, status);
-
-    pg->spawner_pg = proxy->pg;
-
-    for (j = 0; j < total_spawns; j++) {
+    {
         /* For each segment, we create an exec structure */
-        val = HYD_pmcd_pmi_find_token_keyval(&tokens[segment_list[j].start_idx],
-                                             segment_list[j].token_count, "nprocs");
+        val = PMIU_cmd_find_keyval(pmi, "nprocs");
         HYDU_ERR_CHKANDJUMP(status, val == NULL, HYD_INTERNAL_ERROR,
                             "unable to find token: nprocs\n");
         nprocs = atoi(val);
         pg->pg_process_count += nprocs;
 
-        val = HYD_pmcd_pmi_find_token_keyval(&tokens[segment_list[j].start_idx],
-                                             segment_list[j].token_count, "argcnt");
+        val = PMIU_cmd_find_keyval(pmi, "argcnt");
         HYDU_ERR_CHKANDJUMP(status, val == NULL, HYD_INTERNAL_ERROR,
                             "unable to find token: argcnt\n");
         argcnt = atoi(val);
 
-        val = HYD_pmcd_pmi_find_token_keyval(&tokens[segment_list[j].start_idx],
-                                             segment_list[j].token_count, "info_num");
+        val = PMIU_cmd_find_keyval(pmi, "info_num");
         if (val)
             info_num = atoi(val);
         else
             info_num = 0;
 
-        if (exec_list == NULL) {
-            status = HYDU_alloc_exec(&exec_list);
-            HYDU_ERR_POP(status, "unable to allocate exec\n");
-            exec_list->appnum = 0;
-            exec = exec_list;
-        } else {
-            for (exec = exec_list; exec->next; exec = exec->next);
-            status = HYDU_alloc_exec(&exec->next);
-            HYDU_ERR_POP(status, "unable to allocate exec\n");
-            exec->next->appnum = exec->appnum + 1;
-            exec = exec->next;
-        }
-
         /* Info keys */
         for (i = 0; i < info_num; i++) {
-            char *info_key, *info_val;
+            const char *info_key, *info_val;
 
             MPL_snprintf(key, PMI_MAXKEYLEN, "info_key_%d", i);
-            val = HYD_pmcd_pmi_find_token_keyval(&tokens[segment_list[j].start_idx],
-                                                 segment_list[j].token_count, key);
+            val = PMIU_cmd_find_keyval(pmi, key);
             HYDU_ERR_CHKANDJUMP(status, val == NULL, HYD_INTERNAL_ERROR,
                                 "unable to find token: %s\n", key);
             info_key = val;
 
             MPL_snprintf(key, PMI_MAXKEYLEN, "info_val_%d", i);
-            val = HYD_pmcd_pmi_find_token_keyval(&tokens[segment_list[j].start_idx],
-                                                 segment_list[j].token_count, key);
+            val = PMIU_cmd_find_keyval(pmi, key);
             HYDU_ERR_CHKANDJUMP(status, val == NULL, HYD_INTERNAL_ERROR,
                                 "unable to find token: %s\n", key);
             info_val = val;
@@ -444,13 +334,15 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
             } else if (!strcmp(info_key, "wdir")) {
                 exec->wdir = MPL_strdup(info_val);
             } else if (!strcmp(info_key, "host") || !strcmp(info_key, "hosts")) {
+                char *val_copy = MPL_strdup(info_val);
                 char *saveptr;
-                char *host = strtok_r(info_val, ",", &saveptr);
+                char *host = strtok_r(val_copy, ",", &saveptr);
                 while (host) {
                     status = HYDU_process_mfile_token(host, 1, &pg->user_node_list);
                     HYDU_ERR_POP(status, "error creating node list\n");
                     host = strtok_r(NULL, ",", &saveptr);
                 }
+                MPL_free(val_copy);
             } else if (!strcmp(info_key, "hostfile")) {
                 pg->user_node_list = NULL;
                 status = HYDU_parse_hostfile(info_val, &pg->user_node_list,
@@ -464,8 +356,7 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
         status = HYDU_correct_wdir(&exec->wdir);
         HYDU_ERR_POP(status, "unable to correct wdir\n");
 
-        val = HYD_pmcd_pmi_find_token_keyval(&tokens[segment_list[j].start_idx],
-                                             segment_list[j].token_count, "execname");
+        val = PMIU_cmd_find_keyval(pmi, "execname");
         HYDU_ERR_CHKANDJUMP(status, val == NULL, HYD_INTERNAL_ERROR,
                             "unable to find token: execname\n");
         if (path == NULL)
@@ -483,8 +374,7 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
         exec->exec[i++] = execname;
         for (k = 0; k < argcnt; k++) {
             MPL_snprintf(key, PMI_MAXKEYLEN, "arg%d", k + 1);
-            val = HYD_pmcd_pmi_find_token_keyval(&tokens[segment_list[j].start_idx],
-                                                 segment_list[j].token_count, key);
+            val = PMIU_cmd_find_keyval(pmi, key);
             HYDU_ERR_CHKANDJUMP(status, val == NULL, HYD_INTERNAL_ERROR,
                                 "unable to find token: %s\n", key);
             exec->exec[i++] = MPL_strdup(val);
@@ -503,6 +393,10 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
         exec->user_env = env;
     }
 
+    if (spawnssofar < total_spawns) {
+        goto fn_exit;
+    }
+
     status = HYD_pmcd_pmi_alloc_pg_scratch(pg);
     HYDU_ERR_POP(status, "unable to allocate pg scratch space\n");
 
@@ -513,23 +407,26 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
     pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
 
     /* Get the common keys and deal with them */
-    val = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "preput_num");
+    /* NOTE: with PMI-v1, common keys are repeated in each exec segment;
+     *       here we take it from the last segment and ignore from others.
+     */
+    val = PMIU_cmd_find_keyval(pmi, "preput_num");
     if (val)
         preput_num = atoi(val);
     else
         preput_num = 0;
 
     for (i = 0; i < preput_num; i++) {
-        char *preput_key, *preput_val;
+        const char *preput_key, *preput_val;
 
         MPL_snprintf(key, PMI_MAXKEYLEN, "preput_key_%d", i);
-        val = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, key);
+        val = PMIU_cmd_find_keyval(pmi, key);
         HYDU_ERR_CHKANDJUMP(status, val == NULL, HYD_INTERNAL_ERROR,
                             "unable to find token: %s\n", key);
         preput_key = val;
 
         MPL_snprintf(key, PMI_MAXKEYLEN, "preput_val_%d", i);
-        val = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, key);
+        val = PMIU_cmd_find_keyval(pmi, key);
         HYDU_ERR_CHKANDJUMP(status, val == NULL, HYD_INTERNAL_ERROR,
                             "unable to find token: %s\n", key);
         preput_val = val;
@@ -581,17 +478,12 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
     HYDU_ERR_POP(status, "launcher cannot launch processes\n");
 
     {
-        char *cmd;
+        struct PMIU_cmd pmi_response;
+        PMIU_cmd_init(&pmi_response, 1, "spawn_result");
+        PMIU_cmd_add_str(&pmi_response, "rc", "0");
 
-        HYD_STRING_STASH_INIT(stash);
-        HYD_STRING_STASH(stash, MPL_strdup("cmd=spawn_result rc=0"), status);
-        HYD_STRING_STASH(stash, MPL_strdup("\n"), status);
-
-        HYD_STRING_SPIT(stash, cmd, status);
-
-        status = cmd_response(fd, pid, cmd);
+        status = cmd_response(fd, pid, &pmi_response);
         HYDU_ERR_POP(status, "error writing PMI line\n");
-        MPL_free(cmd);
     }
 
     /* Cache the pre-initialized keyvals on the new proxies */
@@ -599,10 +491,7 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
         bcast_keyvals(fd, pid);
 
   fn_exit:
-    HYD_pmcd_pmi_free_tokens(tokens, token_count);
     HYD_STRING_STASH_FREE(proxy_stash);
-    if (segment_list)
-        MPL_free(segment_list);
     HYDU_FUNC_EXIT();
     return status;
 
@@ -610,50 +499,42 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_publish_name(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_publish_name(int fd, int pid, int pgid, struct PMIU_cmd *pmi)
 {
-    struct HYD_string_stash stash;
-    char *cmd, *val;
-    int token_count;
-    struct PMIU_token *tokens = NULL;
+    const char *val;
     char *name = NULL, *port = NULL;
     int success = 0;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
-    status = HYD_pmcd_pmi_args_to_tokens(args, &tokens, &token_count);
-    HYDU_ERR_POP(status, "unable to convert args to tokens\n");
-
-    if ((val = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "service")) == NULL)
+    if ((val = PMIU_cmd_find_keyval(pmi, "service")) == NULL)
         HYDU_ERR_POP(status, "cannot find token: service\n");
     name = MPL_strdup(val);
 
-    if ((val = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "port")) == NULL)
+    if ((val = PMIU_cmd_find_keyval(pmi, "port")) == NULL)
         HYDU_ERR_POP(status, "cannot find token: port\n");
     port = MPL_strdup(val);
 
     status = HYD_pmcd_pmi_publish(name, port, &success);
     HYDU_ERR_POP(status, "error publishing service\n");
 
-    HYD_STRING_STASH_INIT(stash);
-    if (success)
-        HYD_STRING_STASH(stash, MPL_strdup("cmd=publish_result info=ok rc=0 msg=success\n"),
-                         status);
-    else
-        HYD_STRING_STASH(stash,
-                         MPL_strdup("cmd=publish_result info=ok rc=1 msg=key_already_present\n"),
-                         status);
+    struct PMIU_cmd pmi_response;
+    PMIU_cmd_init(&pmi_response, 1, "publish_result");
+    if (success) {
+        PMIU_cmd_add_str(&pmi_response, "info", "ok");
+        PMIU_cmd_add_str(&pmi_response, "rc", "0");
+        PMIU_cmd_add_str(&pmi_response, "msg", "success");
+    } else {
+        PMIU_cmd_add_str(&pmi_response, "info", "ok");
+        PMIU_cmd_add_str(&pmi_response, "rc", "1");
+        PMIU_cmd_add_str(&pmi_response, "msg", "key_already_present");
+    }
 
-    HYD_STRING_SPIT(stash, cmd, status);
-
-    status = cmd_response(fd, pid, cmd);
+    status = cmd_response(fd, pid, &pmi_response);
     HYDU_ERR_POP(status, "send command failed\n");
-    MPL_free(cmd);
 
   fn_exit:
-    if (tokens)
-        HYD_pmcd_pmi_free_tokens(tokens, token_count);
     if (name)
         MPL_free(name);
     if (port)
@@ -666,44 +547,36 @@ static HYD_status fn_publish_name(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_unpublish_name(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_unpublish_name(int fd, int pid, int pgid, struct PMIU_cmd *pmi)
 {
-    struct HYD_string_stash stash;
-    char *cmd, *name;
-    int token_count;
-    struct PMIU_token *tokens = NULL;
+    const char *name;
     int success = 0;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
-    status = HYD_pmcd_pmi_args_to_tokens(args, &tokens, &token_count);
-    HYDU_ERR_POP(status, "unable to convert args to tokens\n");
-
-    if ((name = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "service")) == NULL)
+    if ((name = PMIU_cmd_find_keyval(pmi, "service")) == NULL)
         HYDU_ERR_POP(status, "cannot find token: service\n");
 
     status = HYD_pmcd_pmi_unpublish(name, &success);
     HYDU_ERR_POP(status, "error unpublishing service\n");
 
-    HYD_STRING_STASH_INIT(stash);
-    if (success)
-        HYD_STRING_STASH(stash, MPL_strdup("cmd=unpublish_result info=ok rc=0 msg=success\n"),
-                         status);
-    else
-        HYD_STRING_STASH(stash,
-                         MPL_strdup("cmd=unpublish_result info=ok rc=1 msg=service_not_found\n"),
-                         status);
+    struct PMIU_cmd pmi_response;
+    PMIU_cmd_init(&pmi_response, 1, "unpublish_result");
+    if (success) {
+        PMIU_cmd_add_str(&pmi_response, "info", "ok");
+        PMIU_cmd_add_str(&pmi_response, "rc", "0");
+        PMIU_cmd_add_str(&pmi_response, "msg", "success");
+    } else {
+        PMIU_cmd_add_str(&pmi_response, "info", "ok");
+        PMIU_cmd_add_str(&pmi_response, "rc", "1");
+        PMIU_cmd_add_str(&pmi_response, "msg", "service_not_found");
+    }
 
-    HYD_STRING_SPIT(stash, cmd, status);
-
-    status = cmd_response(fd, pid, cmd);
+    status = cmd_response(fd, pid, &pmi_response);
     HYDU_ERR_POP(status, "send command failed\n");
-    MPL_free(cmd);
 
   fn_exit:
-    if (tokens)
-        HYD_pmcd_pmi_free_tokens(tokens, token_count);
     HYDU_FUNC_EXIT();
     return status;
 
@@ -711,44 +584,34 @@ static HYD_status fn_unpublish_name(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_lookup_name(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_lookup_name(int fd, int pid, int pgid, struct PMIU_cmd *pmi)
 {
-    struct HYD_string_stash stash;
-    char *cmd, *name, *value = NULL;
-    int token_count;
-    struct PMIU_token *tokens = NULL;
+    const char *name, *value = NULL;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
-    status = HYD_pmcd_pmi_args_to_tokens(args, &tokens, &token_count);
-    HYDU_ERR_POP(status, "unable to convert args to tokens\n");
-
-    if ((name = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "service")) == NULL)
+    if ((name = PMIU_cmd_find_keyval(pmi, "service")) == NULL)
         HYDU_ERR_POP(status, "cannot find token: service\n");
 
     status = HYD_pmcd_pmi_lookup(name, &value);
     HYDU_ERR_POP(status, "error while looking up service\n");
 
-    HYD_STRING_STASH_INIT(stash);
-    HYD_STRING_STASH(stash, MPL_strdup("cmd=lookup_result"), status);
+    struct PMIU_cmd pmi_response;
+    PMIU_cmd_init(&pmi_response, 1, "lookup_result");
     if (value) {
-        HYD_STRING_STASH(stash, MPL_strdup(" port="), status);
-        HYD_STRING_STASH(stash, MPL_strdup(value), status);
-        HYD_STRING_STASH(stash, MPL_strdup(" info=ok rc=0 msg=success\n"), status);
+        PMIU_cmd_add_str(&pmi_response, "port", value);
+        PMIU_cmd_add_str(&pmi_response, "rc", "0");
+        PMIU_cmd_add_str(&pmi_response, "msg", "success");
     } else {
-        HYD_STRING_STASH(stash, MPL_strdup(" rc=1 msg=service_not_found\n"), status);
+        PMIU_cmd_add_str(&pmi_response, "rc", "1");
+        PMIU_cmd_add_str(&pmi_response, "msg", "service_not_found");
     }
 
-    HYD_STRING_SPIT(stash, cmd, status);
-
-    status = cmd_response(fd, pid, cmd);
+    status = cmd_response(fd, pid, &pmi_response);
     HYDU_ERR_POP(status, "send command failed\n");
-    MPL_free(cmd);
 
   fn_exit:
-    if (tokens)
-        HYD_pmcd_pmi_free_tokens(tokens, token_count);
     if (value)
         MPL_free(value);
     HYDU_FUNC_EXIT();
@@ -758,23 +621,18 @@ static HYD_status fn_lookup_name(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_abort(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_abort(int fd, int pid, int pgid, struct PMIU_cmd *pmi)
 {
-    int token_count;
-    struct PMIU_token *tokens;
     /* set a default exit code of 1 */
     int exitcode = 1;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
-    status = HYD_pmcd_pmi_args_to_tokens(args, &tokens, &token_count);
-    HYDU_ERR_POP(status, "unable to convert args to tokens\n");
-
-    if (HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "exitcode") == NULL)
+    if (PMIU_cmd_find_keyval(pmi, "exitcode") == NULL)
         HYDU_ERR_POP(status, "cannot find token: exitcode\n");
 
-    exitcode = strtol(HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "exitcode"), NULL, 10);
+    exitcode = strtol(PMIU_cmd_find_keyval(pmi, "exitcode"), NULL, 10);
 
   fn_exit:
     /* clean everything up and exit */

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -90,7 +90,6 @@ HYD_status HYD_pmcd_pmip_get_params(char **t_argv);
 void HYD_pmcd_pmip_send_signal(int sig);
 
 HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp);
-HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v1(char **response);
-HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v2(char *thrid, char **response);
+const char *HYD_pmip_get_hwloc_xmlfile(void);
 
 #endif /* PMIP_H_INCLUDED */

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -93,11 +93,8 @@ static HYD_status stdoe_cb(int fd, HYD_event_t events, void *userp)
     goto fn_exit;
 }
 
-static HYD_status handle_pmi_cmd(int fd, char *buf, struct HYD_pmcd_hdr hdr)
+static HYD_status handle_pmi_cmd(int fd, char *buf, int buflen, struct HYD_pmcd_hdr hdr)
 {
-    struct HYD_pmcd_pmip_pmi_handle *h;
-    char *pmi_cmd = NULL, **args = NULL;
-    int sent, closed;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
@@ -107,22 +104,22 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, struct HYD_pmcd_hdr hdr)
     else
         HYD_pmcd_pmip_pmi_handle = HYD_pmcd_pmip_pmi_v2;
 
-    HYDU_MALLOC_OR_JUMP(args, char **, MAX_PMI_ARGS * sizeof(char *), status);
-    for (int i = 0; i < MAX_PMI_ARGS; i++)
-        args[i] = NULL;
+    char *cmd = PMIU_wire_get_cmd(buf, hdr.buflen, hdr.u.pmi.pmi_version);
 
-    status = HYD_pmcd_pmi_parse_pmi_cmd(buf, hdr.u.pmi.pmi_version, &pmi_cmd, args);
-    HYDU_ERR_POP(status, "unable to parse PMI command\n");
-
-    if (HYD_pmcd_pmip.user_global.debug) {
-        HYDU_dump(stdout, "got pmi command (from %d): %s\n", fd, pmi_cmd);
-        HYDU_print_strlist(args);
-    }
-
+    struct HYD_pmcd_pmip_pmi_handle *h;
     h = HYD_pmcd_pmip_pmi_handle;
     while (h->handler) {
-        if (!strcmp(pmi_cmd, h->cmd)) {
-            status = h->handler(fd, args);
+        if (strcmp(cmd, h->cmd) == 0) {
+            struct PMIU_cmd pmi;
+            status = PMIU_cmd_parse(buf, buflen, hdr.u.pmi.pmi_version, &pmi);
+            HYDU_ERR_POP(status, "unable to parse PMI command\n");
+
+            if (HYD_pmcd_pmip.user_global.debug) {
+                HYDU_dump(stdout, "got pmi command\n    ");
+                HYD_pmcd_pmi_dump(&pmi);
+            }
+
+            status = h->handler(fd, &pmi);
             HYDU_ERR_POP(status, "PMI handler returned error\n");
             goto fn_exit;
         }
@@ -130,10 +127,13 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, struct HYD_pmcd_hdr hdr)
     }
 
     if (HYD_pmcd_pmip.user_global.debug) {
-        HYDU_dump(stdout, "we don't understand this command %s; forwarding upstream\n", pmi_cmd);
+        HYDU_dump(stdout, "we don't understand this command, forwarding upstream\n");
+        HYDU_dump(stdout, "    %s\n", buf);
     }
 
     /* We don't understand the command; forward it upstream */
+    int sent, closed;
+
     hdr.cmd = CMD_PMI;
     hdr.u.pmi.pid = fd;
     hdr.buflen = strlen(buf);
@@ -150,12 +150,6 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, struct HYD_pmcd_hdr hdr)
     HYDU_ASSERT(!closed, status);
 
   fn_exit:
-    MPL_free(pmi_cmd);
-    if (args) {
-        HYDU_free_strlist(args);
-        MPL_free(args);
-    }
-
     HYDU_FUNC_EXIT();
     return status;
 
@@ -163,10 +157,9 @@ static HYD_status handle_pmi_cmd(int fd, char *buf, struct HYD_pmcd_hdr hdr)
     goto fn_exit;
 }
 
-static HYD_status check_pmi_cmd(char **buf, int *pmi_version, int *repeat)
+static HYD_status check_pmi_cmd(char **buf, int *buflen_out, int *pmi_version, int *repeat)
 {
     HYD_status status = HYD_SUCCESS;
-
     HYDU_FUNC_ENTER();
 
     *repeat = 0;
@@ -241,6 +234,7 @@ static HYD_status check_pmi_cmd(char **buf, int *pmi_version, int *repeat)
     if (full_command) {
         /* We have a full command */
         *buf = sptr;
+        *buflen_out = buflen;
         sptr += buflen;
         pmi_storage_len -= buflen;
 
@@ -345,8 +339,9 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
         pmi_storage[pmi_storage_len] = 0;
     }
 
+    int buflen;
   check_cmd:
-    status = check_pmi_cmd(&buf, &hdr.u.pmi.pmi_version, &repeat);
+    status = check_pmi_cmd(&buf, &buflen, &hdr.u.pmi.pmi_version, &repeat);
     HYDU_ERR_POP(status, "error checking the PMI command\n");
 
     if (buf == NULL)
@@ -360,7 +355,7 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
     if (pid != -1 && !HYD_pmcd_pmip.downstream.pmi_fd_active[pid])
         HYD_pmcd_pmip.downstream.pmi_fd_active[pid] = 1;
 
-    status = handle_pmi_cmd(fd, buf, hdr);
+    status = handle_pmi_cmd(fd, buf, buflen, hdr);
     HYDU_ERR_POP(status, "unable to handle PMI command\n");
 
     if (repeat)
@@ -377,8 +372,8 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
 
 static HYD_status handle_pmi_response(int fd, struct HYD_pmcd_hdr hdr)
 {
-    int count, closed, sent, i;
-    char *buf = NULL, *pmi_cmd = NULL, **args = NULL;
+    int count, closed, sent;
+    char *buf = NULL;
     struct HYD_pmcd_pmip_pmi_handle *h;
     HYD_status status = HYD_SUCCESS;
 
@@ -394,17 +389,18 @@ static HYD_status handle_pmi_response(int fd, struct HYD_pmcd_hdr hdr)
 
     int pmi_version = hdr.u.pmi.pmi_version;
     int pmi_rank = hdr.u.pmi.pid;
-    HYDU_MALLOC_OR_JUMP(args, char **, MAX_PMI_ARGS * sizeof(char *), status);
-    for (i = 0; i < MAX_PMI_ARGS; i++)
-        args[i] = NULL;
 
-    status = HYD_pmcd_pmi_parse_pmi_cmd(buf, pmi_version, &pmi_cmd, args);
-    HYDU_ERR_POP(status, "unable to parse PMI command\n");
+    char *cmd = PMIU_wire_get_cmd(buf, hdr.buflen, pmi_version);
 
     h = HYD_pmcd_pmip_pmi_handle;
     while (h->handler) {
-        if (!strcmp(pmi_cmd, h->cmd)) {
-            status = h->handler(fd, args);
+        if (strcmp(cmd, h->cmd) == 0) {
+            struct PMIU_cmd pmi;
+            /* note: buf is modified during parsing; make sure do not forward */
+            status = PMIU_cmd_parse(buf, hdr.buflen, pmi_version, &pmi);
+            HYDU_ERR_POP(status, "unable to parse PMI command\n");
+
+            status = h->handler(fd, &pmi);
             HYDU_ERR_POP(status, "PMI handler returned error\n");
             goto fn_exit;
         }
@@ -412,7 +408,7 @@ static HYD_status handle_pmi_response(int fd, struct HYD_pmcd_hdr hdr)
     }
 
     if (HYD_pmcd_pmip.user_global.debug) {
-        HYDU_dump(stdout, "we don't understand the response %s; forwarding downstream\n", pmi_cmd);
+        HYDU_dump(stdout, "we don't understand the response %s; forwarding downstream\n", cmd);
     }
 
     status = HYDU_sock_write(pmi_rank, buf, hdr.buflen, &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
@@ -425,11 +421,6 @@ static HYD_status handle_pmi_response(int fd, struct HYD_pmcd_hdr hdr)
     }
 
   fn_exit:
-    MPL_free(pmi_cmd);
-    if (args) {
-        HYDU_free_strlist(args);
-        MPL_free(args);
-    }
     MPL_free(buf);
     HYDU_FUNC_EXIT();
     return status;

--- a/src/pm/hydra/proxy/pmip_pmi.h
+++ b/src/pm/hydra/proxy/pmip_pmi.h
@@ -17,7 +17,7 @@ extern struct HYD_pmcd_pmip_pmi_handle *HYD_pmcd_pmip_pmi_v2;
 
 struct HYD_pmcd_pmip_pmi_handle {
     const char *cmd;
-     HYD_status(*handler) (int fd, char *args[]);
+     HYD_status(*handler) (int fd, struct PMIU_cmd * pmi);
 };
 
 extern struct HYD_pmcd_pmip_pmi_handle *HYD_pmcd_pmip_pmi_handle;

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -723,115 +723,20 @@ HYD_status HYD_pmcd_pmip_get_params(char **t_argv)
 #ifdef HAVE_HWLOC
 #include "topo_hwloc.h"
 
-HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v1(char **response)
+const char *HYD_pmip_get_hwloc_xmlfile(void)
 {
-    HYD_status status = HYD_SUCCESS;
-    char *xmlfile;
-
     HYDU_FUNC_ENTER();
 
-    *response = NULL;
-
     /* lazy init */
-    status = HYDT_topo_hwloc_init(NULL, NULL, NULL);
-    HYDU_ERR_POP(status, "unable to initialize hwloc\n");
-    xmlfile = HYDT_topo_hwloc_info.xml_topology_file;
-    if (xmlfile != NULL) {
-        int strlen = MPL_snprintf(NULL, 0, "cmd=get_result rc=0 msg=success value=%s\n", xmlfile);
-        ++strlen;       /* for null char */
-        HYDU_MALLOC_OR_JUMP(*response, char *, strlen, status);
-        MPL_snprintf(*response, strlen, "cmd=get_result rc=0 msg=success value=%s\n", xmlfile);
-    } else {
-        /* we know about the key but no file is available */
-        *response = MPL_strdup("cmd=get_result rc=0 msg=success value=unavailable\n");
-    }
+    HYD_status status = HYDT_topo_hwloc_init(NULL, NULL, NULL);
+    assert(status == HYD_SUCCESS);
 
-  fn_exit:
     HYDU_FUNC_EXIT();
-    return status;
-
-  fn_fail:
-    MPL_free(*response);
-    *response = NULL;
-    goto fn_exit;
-}
-
-HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v2(char *thrid, char **response)
-{
-    HYD_status status = HYD_SUCCESS;
-    char *xmlfile;
-    struct HYD_string_stash stash;
-
-    HYDU_FUNC_ENTER();
-
-    *response = NULL;
-
-    /* lazy init */
-    status = HYDT_topo_hwloc_init(NULL, NULL, NULL);
-    HYDU_ERR_POP(status, "unable to initialize hwloc\n");
-    xmlfile = HYDT_topo_hwloc_info.xml_topology_file;
-
-    HYD_STRING_STASH_INIT(stash);
-    HYD_STRING_STASH(stash, MPL_strdup("cmd=info-getjobattr-response;"), status);
-    if (thrid) {
-        HYD_STRING_STASH(stash, MPL_strdup("thrid="), status);
-        HYD_STRING_STASH(stash, MPL_strdup(thrid), status);
-        HYD_STRING_STASH(stash, MPL_strdup(";"), status);
-    }
-
-    if (xmlfile != NULL) {
-        HYD_STRING_STASH(stash, MPL_strdup("found=TRUE;value="), status);
-        HYD_STRING_STASH(stash, MPL_strdup(HYDT_topo_hwloc_info.xml_topology_file), status);
-        HYD_STRING_STASH(stash, MPL_strdup(";rc=0;"), status);
-    } else {
-        HYD_STRING_STASH(stash, MPL_strdup("found=FALSE;rc=0;"), status);
-    }
-
-    HYD_STRING_SPIT(stash, *response, status);
-
-  fn_exit:
-    HYDU_FUNC_EXIT();
-    return status;
-
-  fn_fail:
-    MPL_free(*response);
-    *response = NULL;
-    goto fn_exit;
+    return (const char *) HYDT_topo_hwloc_info.xml_topology_file;
 }
 #else
-HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v1(char **response)
+const char *HYD_pmip_get_hwloc_xmlfile(void)
 {
-    HYDU_FUNC_ENTER();
-
-    *response = MPL_strdup("cmd=get_result rc=0 msg=success value=unavailable\n");
-
-    HYDU_FUNC_EXIT();
-    return HYD_SUCCESS;
-}
-
-HYD_status HYD_pmip_get_hwloc_xmlfile_resp_v2(char *thrid, char **response)
-{
-    HYD_status status = HYD_SUCCESS;
-    struct HYD_string_stash stash;
-
-    HYDU_FUNC_ENTER();
-
-    *response = NULL;
-
-    HYD_STRING_STASH_INIT(stash);
-    HYD_STRING_STASH(stash, MPL_strdup("cmd=info-getjobattr-response;"), status);
-    if (thrid) {
-        HYD_STRING_STASH(stash, MPL_strdup("thrid="), status);
-        HYD_STRING_STASH(stash, MPL_strdup(thrid), status);
-        HYD_STRING_STASH(stash, MPL_strdup(";"), status);
-    }
-    HYD_STRING_STASH(stash, MPL_strdup("found=FALSE;rc=0;"), status);
-    HYD_STRING_SPIT(stash, *response, status);
-
-  fn_exit:
-    HYDU_FUNC_EXIT();
-    return status;
-  fn_fail:
-    goto fn_exit;
+    return NULL;
 }
 #endif


### PR DESCRIPTION
## Pull Request Description
Another split from https://github.com/pmodels/mpich/pull/5860. This is a single commit with many lines of changes, but hopefully straightforward to review.

Use `struct PMIU_cmd` from `pmi_wire.h` to wrap the internal parsing and handling of PMI
commands.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
