### PR TITLE
test/mpi: Remove runtime configure check for MPI_Publish_name

### DIFF
--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -552,22 +552,6 @@ MPILIBLOC=""
 AC_SUBST(MPILIBLOC)
 
 namepub_tests="#"
-if test "$enable_namepub" != "no" ; then
-    AC_MSG_CHECKING([whether MPI_Publish_name is supported])
-    AC_RUN_IFELSE([
-            AC_LANG_PROGRAM([#include "mpi.h"],[
-                int rc;
-                MPI_Init(0,0);
-                rc = MPI_Publish_name("servname", MPI_INFO_NULL, "otherhost:122");
-                MPI_Finalize();
-                if (rc) {
-                    exit(1);
-                }
-            ])
-        ],[enable_namepub=yes],[enable_namepub=no])
-    AC_MSG_RESULT($enable_namepub)
-fi
-
 if test "$enable_namepub" = "yes" ; then
     namepub_tests=""
 fi


### PR DESCRIPTION
## Pull Request Description

This check did not compile with a C99 compiler due to implicit
declaration of exit(), leading to name publishing tests being disabled
more often than they should. Additionally, a singleton test may not be
an accurate check, since publishing is often supported by the process
manager.

Remove this check and let the user enable/disable testing with the
provided switch or xfail infrastructure.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
