### PR TITLE
mpir/pmi: Fix singleton init with PMI-2 and PMIx

### DIFF
--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -164,7 +164,8 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     MPIR_Typerep_init();
     MPII_thread_mutex_create();
     MPII_init_request();
-    MPIR_pmi_init();
+    mpi_errno = MPIR_pmi_init();
+    MPIR_ERR_CHECK(mpi_errno);
     MPII_hwtopo_init();
     MPII_nettopo_init();
     MPII_init_windows();

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -554,7 +554,7 @@ static int getConnInfoKVS( int rank, char *buf, int bufsize, MPIDI_PG_t *pg )
     MPIR_ERR_CHKANDJUMP1(len < 0 || len > sizeof(key), mpi_errno, MPI_ERR_OTHER, "**snprintf", "**snprintf %d", len);
 
     MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_PMI_MUTEX);
-    mpi_errno = MPIR_pmi_kvs_get(-1, key, buf, bufsize);
+    mpi_errno = MPIR_pmi_kvs_get(rank, key, buf, bufsize);
     MPIR_ERR_CHECK(mpi_errno);
     MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_PMI_MUTEX);
 

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -172,6 +172,12 @@ int MPIR_pmi_init(void)
     pmix_value_t *pvalue = NULL;
 
     pmi_errno = PMIx_Init(&pmix_proc, NULL, 0);
+    if (pmi_errno == PMIX_ERR_UNREACH) {
+        /* no pmi server, assume we are a singleton */
+        rank = 0;
+        size = 1;
+        goto singleton_out;
+    }
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                          "**pmix_init", "**pmix_init %d", pmi_errno);
 
@@ -187,6 +193,7 @@ int MPIR_pmi_init(void)
     PMIX_VALUE_RELEASE(pvalue);
 
     /* appnum, has_parent is not set for now */
+  singleton_out:
     appnum = 0;
     has_parent = 0;
 


### PR DESCRIPTION
## Pull Request Description

Allow simple programs to run without a PMI-2 or PMIx server (e.g. `./examples/cpi`). Full-fledged singleton init that starts a server is not yet supported with PMI-2 or PMIx.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
