### PR TITLE
ch4/ucx: Only set window base pointer when allocating

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -70,7 +70,9 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
         status = ucp_mem_query(mem_h, &mem_attr);
         MPIDI_UCX_CHK_STATUS(status);
 
-        *base_ptr = mem_attr.address;
+        if (mem_map_params.flags & UCP_MEM_MAP_ALLOCATE) {
+            *base_ptr = mem_attr.address;
+        }
         MPIR_Assert(mem_attr.length >= length);
 
         /* pack the key */


### PR DESCRIPTION
## Pull Request Description

Fix a bug in ch4/ucx window creation. A number of RMA tests were failing with UCX 1.13.0 and newer releases.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
