### PR TITLE
binding/c: Update short descriptions for MPI_COMM_DUP[_WITH_INFO]

### DIFF
--- a/src/binding/c/comm_api.txt
+++ b/src/binding/c/comm_api.txt
@@ -21,7 +21,7 @@ MPI_Comm_create_group:
     .extra: errtest_comm_intra
 
 MPI_Comm_dup:
-    .desc: Duplicates an existing communicator with all its cached information
+    .desc: Duplicates an existing communicator
     .seealso: MPI_Comm_free, MPI_Keyval_create, MPI_Attr_put, MPI_Attr_delete, MPI_Comm_create_keyval, MPI_Comm_set_attr, MPI_Comm_delete_attr
 /*
     Notes:
@@ -48,7 +48,7 @@ MPI_Comm_dup:
 */
 
 MPI_Comm_dup_with_info:
-    .desc: Duplicates an existing communicator with all its cached information
+    .desc: Duplicates an existing communicator using the supplied info hints
     .seealso: MPI_Comm_dup, MPI_Comm_free, MPI_Keyval_create, MPI_Attr_put, MPI_Attr_delete, MPI_Comm_create_keyval, MPI_Comm_set_attr, MPI_Comm_delete_attr
 /*
     Notes:


### PR DESCRIPTION
## Pull Request Description

Avoid using the phrase "all its cached information" since it is
ambiguous. The note for MPI_COMM_DUP is specific about what happens with
attributes and topology information. MPI-4.0, page 346 lines 1-2 states
that info hints are not propagated from one communicator to
another. Fixes pmodels/mpich#2262.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
