### PR TITLE
mpir: add safe type casting to int and MPI_Aint

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3268,11 +3268,13 @@ case $MPI_AINT in
         MPI_AINT_FMT_DEC_SPEC="%d"
         MPI_AINT_FMT_HEX_SPEC="%x"
         MPIR_AINT_MAX="INT_MAX"
+        MPIR_AINT_MIN="INT_MIN"
         ;;
     long)
         MPI_AINT_FMT_DEC_SPEC="%ld"
         MPI_AINT_FMT_HEX_SPEC="%lx"
         MPIR_AINT_MAX="LONG_MAX"
+        MPIR_AINT_MIN="LONG_MIN"
         ;;
     long_long)
         MPI_AINT_FMT_DEC_SPEC="%lld"
@@ -3280,17 +3282,20 @@ case $MPI_AINT in
         # tt#1776: if LLONG_MAX is missing, we fix it up in C, b/c it's
         # easier there.  See mpiiimpl.h.
         MPIR_AINT_MAX="LLONG_MAX"
+        MPIR_AINT_MIN="LLONG_MIN"
         ;;
     short)
         MPI_AINT_FMT_DEC_SPEC="%hd"
         MPI_AINT_FMT_HEX_SPEC="%hx"
         MPIR_AINT_MAX="SHRT_MAX"
+        MPIR_AINT_MIN="SHRT_MIN"
         ;;
     *)
         AC_MSG_WARN([unable to determine format specifiers for MPI_Aint, defaulting to int])
         MPI_AINT_FMT_DEC_SPEC="%d"
         MPI_AINT_FMT_HEX_SPEC="%x"
         MPIR_AINT_MAX="INT_MAX"
+        MPIR_AINT_MIN="INT_MIN"
     ;;
 esac
 export MPI_AINT_FMT_DEC_SPEC MPI_AINT_FMT_HEX_SPEC
@@ -3299,6 +3304,7 @@ AC_SUBST(MPI_AINT)
 AC_SUBST(MPI_AINT_FMT_DEC_SPEC)
 AC_SUBST(MPI_AINT_FMT_HEX_SPEC)
 AC_DEFINE_UNQUOTED([MPIR_AINT_MAX],[$MPIR_AINT_MAX],[limits.h _MAX constant for MPI_Aint])
+AC_DEFINE_UNQUOTED([MPIR_AINT_MIN],[$MPIR_AINT_MIN],[limits.h _MIN constant for MPI_Aint])
 
 # ------------
 # MPI_OFFSET

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -89,4 +89,16 @@ int MPIR_Find_external(struct MPIR_Comm *comm, int *external_size_p, int *extern
 int MPIR_Get_internode_rank(MPIR_Comm * comm_ptr, int r);
 int MPIR_Get_intranode_rank(MPIR_Comm * comm_ptr, int r);
 
+#define MPIR_CAST(T, val) CAST_##T((val))
+#ifdef NDEBUG
+#define MPIR_CAST_int(val) ((int) (val))
+#define MPIR_CAST_Aint(val) ((MPI_Aint) (val))
+#else
+#define MPIR_CAST_int(val) \
+    (((val) > INT_MAX || ((val) < 0 && (val) < INT_MIN)) ? (assert(0), 0) : (int) (val))
+#define MPIR_CAST_Aint(val) \
+    (((val) > MPIR_AINT_MAX || ((val) < 0 && (val) < MPIR_AINT_MIN)) ? (assert(0), 0) \
+     : (MPI_Aint) (val))
+#endif
+
 #endif /* MPIR_MISC_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

Adding safe casting to int and MPI_Aint type. It will abort if overflow happens at casting.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
