### PR TITLE
mpi4: Add large count MPI_STATUS_SET_ELEMENTS

### DIFF
--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -163,6 +163,12 @@ MPI_Status_set_elements:
         goto fn_fail;
     }
 }
+{ -- large_count --
+    mpi_errno = MPIR_Status_set_elements_x_impl(status, datatype, count);
+    if (mpi_errno) {
+        goto fn_fail;
+    }
+}
 
 MPI_Status_set_elements_x:
     .desc: Set the number of elements in a status

--- a/src/binding/mpi_standard_api.txt
+++ b/src/binding/mpi_standard_api.txt
@@ -2021,7 +2021,7 @@ MPI_Status_set_cancelled:
 MPI_Status_set_elements:
     status: STATUS, direction=inout, [status with which to associate count]
     datatype: DATATYPE, [datatype associated with count]
-    count: XFER_NUM_ELEM_SMALL, [number of elements to associate with status]
+    count: POLYXFER_NUM_ELEM, [number of elements to associate with status]
 MPI_Status_set_elements_x:
     status: STATUS, direction=inout, [status with which to associate count]
     datatype: DATATYPE, [datatype associated with count]

--- a/test/mpi/datatype/large_count.c
+++ b/test/mpi/datatype/large_count.c
@@ -13,6 +13,8 @@
 #include <mpi.h>
 #include "mpitest.h"
 
+static int errs;
+
 /* assert-like macro that bumps the err count and emits a message */
 #define check(x_)                                                                 \
     do {                                                                          \
@@ -24,9 +26,44 @@
         }                                                                         \
     } while (0)
 
+/* Sets elements corresponding to count=1 of the given MPI datatype, using
+ * set_elements and set_elements_x.  Checks expected values are returned by
+ * get_elements, get_elements_x, and get_count (including MPI_UNDEFINED
+ * clipping) */
+static void check_set_elements(MPI_Status status, MPI_Datatype type, MPI_Count expected)
+{
+    MPI_Count elements_x;
+    int elements;
+    int count;
+
+    elements = elements_x = count = 0xfeedface;
+    /* can't use legacy "set" for large element counts */
+    if (expected <= INT_MAX) {
+        MPI_Status_set_elements(&status, type, 1);
+        MPI_Get_elements(&status, type, &elements);
+        MPI_Get_elements_x(&status, type, &elements_x);
+        MPI_Get_count(&status, type, &count);
+        check(elements == (int) expected);
+        check(elements_x == expected);
+        check(count == 1);
+    }
+
+    elements = elements_x = count = 0xfeedface;
+    MPI_Status_set_elements_x(&status, type, 1);
+    MPI_Get_elements(&status, type, &elements);
+    MPI_Get_elements_x(&status, type, &elements_x);
+    MPI_Get_count(&status, type, &count);
+    if (expected > INT_MAX) {
+        check(elements == MPI_UNDEFINED);
+    } else {
+        check(elements == (int) expected);
+    }
+    check(elements_x == expected);
+    check(count == 1);
+}
+
 int main(int argc, char *argv[])
 {
-    int errs = 0;
     int wrank, wsize;
     int size, elements, count;
     MPI_Aint lb, extent;
@@ -186,43 +223,10 @@ int main(int argc, char *argv[])
     check(elements_x == 10);
     check(count == 10);
 
-    /* Sets elements corresponding to count=1 of the given MPI datatype, using
-     * set_elements and set_elements_x.  Checks expected values are returned by
-     * get_elements, get_elements_x, and get_count (including MPI_UNDEFINED
-     * clipping) */
-#define check_set_elements(type_, elts_)                          \
-    do {                                                          \
-        elements = elements_x = count = 0xfeedface;               \
-        /* can't use legacy "set" for large element counts */     \
-        if ((elts_) <= INT_MAX) {                                 \
-            MPI_Status_set_elements(&status, (type_), 1);         \
-            MPI_Get_elements(&status, (type_), &elements);        \
-            MPI_Get_elements_x(&status, (type_), &elements_x);    \
-            MPI_Get_count(&status, (type_), &count);              \
-            check(elements == (int) (elts_));                     \
-            check(elements_x == (elts_));                         \
-            check(count == 1);                                    \
-        }                                                         \
-                                                                  \
-        elements = elements_x = count = 0xfeedface;               \
-        MPI_Status_set_elements_x(&status, (type_), 1);           \
-        MPI_Get_elements(&status, (type_), &elements);            \
-        MPI_Get_elements_x(&status, (type_), &elements_x);        \
-        MPI_Get_count(&status, (type_), &count);                  \
-        if ((elts_) > INT_MAX) {                                  \
-            check(elements == MPI_UNDEFINED);                     \
-        }                                                         \
-        else {                                                    \
-            check(elements == (int) (elts_));                           \
-        }                                                         \
-        check(elements_x == (elts_));                             \
-        check(count == 1);                                        \
-    } while (0)                                                   \
-
-    check_set_elements(imax_contig, INT_MAX);
-    check_set_elements(four_ints, 4);
-    check_set_elements(imx4i, 4LL * (INT_MAX / 2));
-    check_set_elements(imx4i_rsz, 4LL * (INT_MAX / 2));
+    check_set_elements(status, imax_contig, INT_MAX);
+    check_set_elements(status, four_ints, 4);
+    check_set_elements(status, imx4i, 4LL * (INT_MAX / 2));
+    check_set_elements(status, imx4i_rsz, 4LL * (INT_MAX / 2));
 
   epilogue:
     if (imax_contig != MPI_DATATYPE_NULL)

--- a/test/mpi/datatype/large_count.c
+++ b/test/mpi/datatype/large_count.c
@@ -28,8 +28,8 @@ static int errs;
 
 /* Sets elements corresponding to count=1 of the given MPI datatype, using
  * set_elements and set_elements_x.  Checks expected values are returned by
- * get_elements, get_elements_x, and get_count (including MPI_UNDEFINED
- * clipping) */
+ * get_elements, get_elements_x, get_elements_c, and get_count (including
+ * MPI_UNDEFINED clipping) */
 static void check_set_elements(MPI_Status status, MPI_Datatype type, MPI_Count expected)
 {
     MPI_Count elements_x;
@@ -60,6 +60,21 @@ static void check_set_elements(MPI_Status status, MPI_Datatype type, MPI_Count e
     }
     check(elements_x == expected);
     check(count == 1);
+
+#if MTEST_HAVE_MIN_MPI_VERSION(4,0)
+    elements = elements_x = count = 0xfeedface;
+    MPI_Status_set_elements_c(&status, type, 1);
+    MPI_Get_elements(&status, type, &elements);
+    MPI_Get_elements_c(&status, type, &elements_x);
+    MPI_Get_count(&status, type, &count);
+    if (expected > INT_MAX) {
+        check(elements == MPI_UNDEFINED);
+    } else {
+        check(elements == (int) expected);
+    }
+    check(elements_x == expected);
+    check(count == 1);
+#endif
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
## Pull Request Description

This function was missed when "embiggening" the MPI standard. It was
later added in mpi-forum/mpi-standard#620. Fixes pmodels/mpich#5413.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
