### PR TITLE
debugger: fix typo in dll_mpich.c

### DIFF
--- a/src/mpi/debugger/dll_mpich.c
+++ b/src/mpi/debugger/dll_mpich.c
@@ -1005,7 +1005,7 @@ static mqs_tword_t fetch_int(mqs_process * proc, mqs_taddr_t addr, mpich_process
 static mqs_tword_t fetch_int16(mqs_process * proc, mqs_taddr_t addr, mpich_process_info * p_info)
 {
     char buffer[8];             /* ASSUME an integer fits in 8 bytes */
-    int16_t res = 0;
+    mqs_tword_t res = 0;
 
     if (mqs_ok == dbgr_fetch_data(proc, addr, 2, buffer))
         dbgr_target_to_host(proc, buffer,


### PR DESCRIPTION

## Pull Request Description
A nice compiler warning from an old issue pointed out this typo. Address
a few bytes pass an int16_t is suspicious. I believe it is trying to
address into a mqs_tword_t.

Fixes #2230


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
