### PR TITLE
romio: Dev romio visibility hint

### DIFF
--- a/src/mpi/romio/adio/ad_nfs/Makefile.mk
+++ b/src/mpi/romio/adio/ad_nfs/Makefile.mk
@@ -20,6 +20,7 @@ romio_other_sources +=            \
     adio/ad_nfs/ad_nfs_getsh.c    \
     adio/ad_nfs/ad_nfs.c          \
     adio/ad_nfs/ad_nfs_resize.c   \
-    adio/ad_nfs/ad_nfs_features.c
+    adio/ad_nfs/ad_nfs_features.c \
+    adio/ad_nfs/ad_nfs_hints.c
 
 endif BUILD_AD_NFS

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs.c
@@ -17,7 +17,7 @@ struct ADIOI_Fns_struct ADIO_NFS_operations = {
     ADIOI_GEN_WriteStridedColl, /* WriteStridedColl */
     ADIOI_GEN_SeekIndividual,   /* SeekIndividual */
     ADIOI_NFS_Fcntl,    /* Fcntl */
-    ADIOI_GEN_SetInfo,  /* SetInfo */
+    ADIOI_NFS_SetInfo,  /* SetInfo */
     ADIOI_NFS_ReadStrided,      /* ReadStrided */
     ADIOI_NFS_WriteStrided,     /* WriteStrided */
     ADIOI_GEN_Close,    /* Close */

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_hints.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_hints.c
@@ -8,4 +8,6 @@
 void ADIOI_NFS_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
 {
     ADIOI_GEN_SetInfo(fd, users_info, error_code);
+    ADIOI_Info_set(fd->info, "romio_visibility_immediate", "false");
+    fd->hints->visibility_immediate = 0;
 }

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_hints.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_hints.c
@@ -113,5 +113,8 @@ void ADIOI_PVFS2_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
     /* set the values for collective I/O and data sieving parameters */
     ADIOI_GEN_SetInfo(fd, users_info, error_code);
 
+    ADIOI_Info_set(info, "romio_visibility_immediate", "false");
+    fd->hints->visibility_immediate = 0;
+
     *error_code = MPI_SUCCESS;
 }

--- a/src/mpi/romio/adio/common/ad_hints.c
+++ b/src/mpi/romio/adio/common/ad_hints.c
@@ -132,6 +132,14 @@ void ADIOI_GEN_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
         ADIOI_Info_set(info, "romio_synchronized_flush", "disabled");
         fd->hints->synchronizing_flush = 0;
 
+        /* While MPI-IO rules say a write from one process is not visible until
+         * sync or close, many file systems implement the more restrictive
+         * POSIX semantics:  under POSIX semantics a write from one process is
+         * visible to everyone.  For counter-example, Unify, NFS and PVFS do
+         * not support this semantic */
+        ADIOI_Info_set(info, "romio_visibility_immediate", "true");
+        fd->hints->visibility_immediate = 1;
+
         fd->hints->initialized = 1;
 
         /* ADIO_Open sets up collective buffering arrays.  If we are in this

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -48,6 +48,7 @@ struct ADIOI_Hints_struct {
     int start_iodevice;
     int min_fdomain_size;
     int synchronizing_flush;    /* "romio_synchronized_flush" hint */
+    int visibility_immediate;   /* "romio_visibility_immediate" hint */
     char *cb_config_list;
     int *ranklist;
     union {


### PR DESCRIPTION
## Pull Request Description
romio: user can determine "visibility" of writes

Lots of file systems implement POSIX semantics: once a process writes
data, other processes can see that data.  It's more strict than MPI-IO
semantics.  If a file system implements POSIX semantics, though, the
caller can skip the strict (and expensive) "make this write visible"
calls.

Fixes:  pmodels/mpich#5902
 
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
