### PR TITLE
datatype: Fix MPI_GET_ELEMENTS error case

### DIFF
--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -67,12 +67,20 @@ MPI_Get_elements:
 
     /* clip the value if it cannot be correctly returned to the user */
     *count = (count_x > INT_MAX) ? MPI_UNDEFINED : (int) count_x;
+
+    if (byte_count != 0) {
+        *count = MPI_UNDEFINED;
+    }
 }
 { -- large_count --
     MPI_Count byte_count = MPIR_STATUS_GET_COUNT(*status);
     mpi_errno = MPIR_Get_elements_x_impl(&byte_count, datatype, count);
     if (mpi_errno) {
         goto fn_fail;
+    }
+
+    if (byte_count != 0) {
+        *count = MPI_UNDEFINED;
     }
 }
 
@@ -83,6 +91,10 @@ MPI_Get_elements_x:
     MPI_Count byte_count = MPIR_STATUS_GET_COUNT(*status);
     mpi_errno = MPIR_Get_elements_x_impl(&byte_count, datatype, count);
     MPIR_ERR_CHECK(mpi_errno);
+
+    if (byte_count != 0) {
+        *count = MPI_UNDEFINED;
+    }
 }
 
 MPI_Pack:

--- a/test/mpi/errors/datatype/testlist
+++ b/test/mpi/errors/datatype/testlist
@@ -1,4 +1,4 @@
-getcnterr 1 xfail=ticket2715
+getcnterr 1
 type_contiguous_nullarg 1
 type_extent_nullarg 1 strict=FALSE
 type_get_extent_nullarg 1


### PR DESCRIPTION
## Pull Request Description

When getting the number of elements received from a status object,
leftover bytes indicate that the user-provided datatype signature does
not match the one used to receive the data. Return MPI_UNDEFINED to the
user to indicate the error.

Fixes pmodels/mpich#2715.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
