### PR TITLE
test/mpi: Silence output during python3 check

### DIFF
--- a/test/mpi/autogen.sh
+++ b/test/mpi/autogen.sh
@@ -13,11 +13,11 @@ PYTHON=
 check_python3() {
     echo_n "Checking for Python 3... "
     PYTHON=
-    if test 3 = `python -c 'import sys; print(sys.version_info[0])'`; then
+    if test 3 = `python -c 'import sys; print(sys.version_info[0])' 2> /dev/null || echo "0"`; then
         PYTHON=python
     fi
 
-    if test -z "$PYTHON" -a 3 = `python3 -c 'import sys; print(sys.version_info[0])'`; then
+    if test -z "$PYTHON" -a 3 = `python3 -c 'import sys; print(sys.version_info[0])' 2> /dev/null || echo "0"`; then
         PYTHON=python3
     fi
 


### PR DESCRIPTION
## Pull Request Description

Send any error output to /dev/null and echo a dummy value to avoid
"unary operator expected" warnings. Same fix as [fd14090d].

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
