### PR TITLE
test/configure: Improve runtime check for MPI_THREAD_MULTIPLE

### DIFF
--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -520,7 +520,7 @@ if test "$enable_threads" != "no" ; then
                 MPI_Init_thread(0,0, MPI_THREAD_MULTIPLE, &provided);
                 MPI_Finalize();
                 if (provided != MPI_THREAD_MULTIPLE) {
-                    exit(1);
+                    return 1;
                 }
             ])
         ],[enable_threads=yes],[enable_threads=no])


### PR DESCRIPTION
## Pull Request Description

This AC_RUN_IFELSE program will fail to compile with a strict C99
compiler, since there is no declaration for the exit function. Returning
1 achieves the same result and should not have compilation issues.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
