### PR TITLE
romio: implementation using MPIX_Type_iov extensions

### DIFF
--- a/src/mpi/romio/adio/common/ad_aggregate_new.c
+++ b/src/mpi/romio/adio/common/ad_aggregate_new.c
@@ -70,7 +70,7 @@ void ADIOI_Calc_file_realms(ADIO_File fd, ADIO_Offset min_st_offset, ADIO_Offset
         *file_realm_st_offs = min_st_offset;
         MPI_Type_contiguous((max_end_offset - min_st_offset + 1), MPI_BYTE, file_realm_types);
         MPI_Type_commit(file_realm_types);
-        ADIOI_Flatten_datatype(*file_realm_types);
+        ADIOI_Flatten_and_find(*file_realm_types);
     } else if (fd->file_realm_st_offs == NULL) {
         file_realm_st_offs = (ADIO_Offset *)
             ADIOI_Malloc(nprocs_for_coll * sizeof(ADIO_Offset));
@@ -84,13 +84,13 @@ void ADIOI_Calc_file_realms(ADIO_File fd, ADIO_Offset min_st_offset, ADIO_Offset
                                        file_realm_st_offs, file_realm_types);
             /* flatten file realm datatype for future use - only one
              * because all are the same*/
-            ADIOI_Flatten_datatype(file_realm_types[0]);
+            ADIOI_Flatten_and_find(file_realm_types[0]);
         } else if (file_realm_calc_type == ADIOI_FR_FSZ) {
             ADIOI_Calc_file_realms_fsize(fd, nprocs_for_coll, max_end_offset,
                                          file_realm_st_offs, file_realm_types);
             /* flatten file realm datatype for future use - only one
              * because all are the same*/
-            ADIOI_Flatten_datatype(file_realm_types[0]);
+            ADIOI_Flatten_and_find(file_realm_types[0]);
         } else if (file_realm_calc_type == ADIOI_FR_USR_REALMS) {
             /* copy user provided realm datatypes and realm offsets in
              * hints to file descriptor. may also want to verify that
@@ -101,7 +101,7 @@ void ADIOI_Calc_file_realms(ADIO_File fd, ADIO_Offset min_st_offset, ADIO_Offset
                                              nprocs_for_coll, file_realm_st_offs, file_realm_types);
             /* flatten file realm datatype for future use - only one
              * because all are the same */
-            ADIOI_Flatten_datatype(file_realm_types[0]);
+            ADIOI_Flatten_and_find(file_realm_types[0]);
         }
     }
     fd->file_realm_st_offs = file_realm_st_offs;

--- a/src/mpi/romio/adio/common/ad_io_coll.c
+++ b/src/mpi/romio/adio/common/ad_io_coll.c
@@ -895,7 +895,7 @@ void ADIOI_IOFiletype(ADIO_File fd, void *buf, MPI_Aint count,
     ADIOI_Datatype_iscontig(custom_ftype, &f_is_contig);
     ADIOI_Datatype_iscontig(datatype, &m_is_contig);
     if (!f_is_contig)
-        ADIOI_Flatten_datatype(custom_ftype);
+        ADIOI_Flatten_and_find(custom_ftype);
 
     /* make appropriate Read/Write calls.  Let ROMIO figure out file
      * system specific stuff. */

--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -39,7 +39,7 @@ static int ADIOI_Flattened_type_delete(MPI_Datatype datatype,
     return MPI_SUCCESS;
 }
 
-ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype datatype);
+static ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype datatype);
 
 ADIOI_Flatlist_node *ADIOI_Flatten_and_find(MPI_Datatype datatype)
 {
@@ -107,28 +107,11 @@ static void flatlist_node_grow(ADIOI_Flatlist_node * flat, int idx)
 
 static void ADIOI_Optimize_flattened(ADIOI_Flatlist_node * flat_type);
 /* flatten datatype and add it to Flatlist */
-ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype datatype)
+static ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype datatype)
 {
     MPI_Count flat_count, curr_index = 0;
-    int is_contig, flag;
+    int is_contig;
     ADIOI_Flatlist_node *flat;
-
-    if (ADIOI_Flattened_type_keyval == MPI_KEYVAL_INVALID) {
-        /* ADIOI_End_call will take care of cleanup */
-        MPI_Type_create_keyval(ADIOI_Flattened_type_copy,
-                               ADIOI_Flattened_type_delete, &ADIOI_Flattened_type_keyval, NULL);
-    }
-
-    /* check if necessary to flatten. */
-
-    /* has it already been flattened? */
-    MPI_Type_get_attr(datatype, ADIOI_Flattened_type_keyval, &flat, &flag);
-    if (flag) {
-#ifdef FLATTEN_DEBUG
-        DBG_FPRINTF(stderr, "ADIOI_Flatten_datatype:: found datatype %#X\n", datatype);
-#endif
-        return flat;
-    }
 
     /* is it entirely contiguous? */
     ADIOI_Datatype_iscontig(datatype, &is_contig);

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -371,16 +371,7 @@ typedef struct {
 
 void ADIOI_SetFunctions(ADIO_File fd);
 ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype type);
-void ADIOI_Flatten(MPI_Datatype type, ADIOI_Flatlist_node * flat,
-                   ADIO_Offset st_offset, MPI_Count * curr_index);
-/* callbacks for attribute-style flattened tracking */
-int ADIOI_Flattened_type_copy(MPI_Datatype oldtype,
-                              int type_keyval, void *extra_state, void *attribute_val_in,
-                              void *attribute_val_out, int *flag);
-int ADIOI_Flattened_type_delete(MPI_Datatype datatype,
-                                int type_keyval, void *attribute_val, void *extra_state);
 ADIOI_Flatlist_node *ADIOI_Flatten_and_find(MPI_Datatype);
-MPI_Count ADIOI_Count_contiguous_blocks(MPI_Datatype type, MPI_Count * curr_index);
 void ADIOI_Complete_async(int *error_code);
 void *ADIOI_Malloc_fn(size_t size, int lineno, const char *fname);
 void *ADIOI_Calloc_fn(size_t nelem, size_t elsize, int lineno, const char *fname);

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -370,7 +370,6 @@ typedef struct {
 /* prototypes for ADIO internal functions */
 
 void ADIOI_SetFunctions(ADIO_File fd);
-ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype type);
 ADIOI_Flatlist_node *ADIOI_Flatten_and_find(MPI_Datatype);
 void ADIOI_Complete_async(int *error_code);
 void *ADIOI_Malloc_fn(size_t size, int lineno, const char *fname);

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1464,6 +1464,7 @@ elif test $FROM_MPICH = yes ; then
    AC_DEFINE(HAVE_MPI_TYPE_SIZE_X, 1, [Define if MPI library provides MPI_TYPE_SIZE_X])
    AC_DEFINE(HAVE_MPI_STATUS_SET_ELEMENTS_X, 1, [Define if MPI library provides MPI_STATUS_SET_ELEMENTS_X])
    AC_DEFINE(HAVE_DECL_MPI_COMBINER_HINDEXED_BLOCK, 1, [Define if MPI library provides HINDEXED_BLOCK datatype])
+   AC_DEFINE(HAVE_MPIX_TYPE_IOV, 1, [Define if MPI library provides MPIX_Type_iov and MPIX_Type_iov_len])
 fi
 #
 #


### PR DESCRIPTION
## Pull Request Description
The current romio code has to recursively query a datatype and maintain a flat_list (iovs) as a datatype attribute. It is not only messy but also inefficient when the datatype contains a large number of non-contig segments. And in some cases (e.g. https://github.com/pmodels/mpich/issues/2182) it may run out of memory.

Using the newly added MPIX iov extension, we can utilize the datatype engine from the MPI implementation, which is simpler and more efficient.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
