### PR TITLE
hydra: fix initack under PMI-1 -pmi-port

### DIFF
--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -262,11 +262,18 @@ HYD_status fn_fullinit(int fd, struct PMIU_cmd *pmi)
 
         PMIU_cmd_init_static(&pmi_response, pmi->version, "set");
         PMIU_cmd_add_int(&pmi_response, "size", size);
-        PMIU_cmd_add_int(&pmi_response, "rank", rank);
-        PMIU_cmd_add_int(&pmi_response, "debug", debug);
-
         status = send_cmd_downstream(fd, &pmi_response);
-        HYDU_ERR_POP(status, "error sending PMI response\n");
+        HYDU_ERR_POP(status, "error sending PMI set size\n");
+
+        PMIU_cmd_init_static(&pmi_response, pmi->version, "set");
+        PMIU_cmd_add_int(&pmi_response, "rank", rank);
+        status = send_cmd_downstream(fd, &pmi_response);
+        HYDU_ERR_POP(status, "error sending PMI set rank\n");
+
+        PMIU_cmd_init_static(&pmi_response, pmi->version, "set");
+        PMIU_cmd_add_int(&pmi_response, "debug", debug);
+        status = send_cmd_downstream(fd, &pmi_response);
+        HYDU_ERR_POP(status, "error sending PMI set debug\n");
     } else {
         PMIU_cmd_init_static(&pmi_response, 2, "fullinit-response");
         PMIU_cmd_add_str(&pmi_response, "pmi-version", "2");


### PR DESCRIPTION
## Pull Request Description
With hydra -pmi-port, it goes through the initack handshake and require server to send 3 separate set command. This was broken in commit 3eefc26c681a8fe13b8944ec06f977204d8a196e.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
