### PR TITLE
ch4/config: Fix VCI help text

### DIFF
--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -311,7 +311,7 @@ dnl Note: the maximum of 64 is due to the fact that we use 6 bits in the
 dnl request handle to encode pool index
 AC_ARG_WITH(ch4-max-vcis,
     [--with-ch4-max-vcis=<N>
-       Select max number of VCIs to configure (default is 1; minimum is 1; maximum is 64)],
+       Select max number of VCIs to configure (default is 64; minimum is 1; maximum is 64)],
     [], [with_ch4_max_vcis=64])
 
 if test $with_ch4_max_vcis -lt 1 -o $with_ch4_max_vcis -gt 64; then


### PR DESCRIPTION
## Pull Request Description

A maximum of 64 VCIs is the current default.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
