### PR TITLE
shm/ipc: change the check for self messages

### DIFF
--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -31,7 +31,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
 
     MPIDI_POSIX_THREAD_CS_ENTER_VCI(vsi_src);
 
-    if (rank == comm->rank) {
+    if (comm->local_size == 1) {
         goto fn_exit;
     }
 


### PR DESCRIPTION
## Pull Request Description
The MPIDI_IPCI_try_lmt_isend function checks if the local rank is the same as the recv rank, and if it is, the IPC P2P falls back to POSIX P2P, which slows down the collective operations that use isend to send data within the same rank. The intention of the check in MPIDI_IPCI_try_lmt_isend is to handle messages within "self"-comms (i.e. MPI_COMM_SELF and all communicators with size of 1) and the IPC P2P can handle the data copy within the same rank. So we need to change if (rank == comm->rank) to if (comm->local_size == 1).

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
