### PR TITLE
ch4/progress: Avoid explicit vcis during global progress

### DIFF
--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -136,8 +136,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_progress_test(MPID_Progress_state * state, in
     }
 #else
     /* multiple vci */
-    if (MPIDI_do_global_progress()) {
-        for (int vci = 0; vci < MPIDI_global.n_total_vcis; vci++) {
+    bool is_explicit_vci = (state->vci_count == 1 && MPIDI_VCI_IS_EXPLICIT(state->vci[0]));
+    if (!is_explicit_vci && MPIDI_do_global_progress()) {
+        for (int vci = 0; vci < MPIDI_global.n_vcis; vci++) {
             MPIDI_PROGRESS(vci);
             if (wait) {
                 MPIDI_check_progress_made_vci(state, vci);
@@ -221,7 +222,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_progress_test_vci(int vci)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    if (MPIDI_do_global_progress()) {
+    if (!MPIDI_VCI_IS_EXPLICIT(vci) && MPIDI_do_global_progress()) {
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
         mpi_errno = MPID_Progress_test(NULL);
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);


### PR DESCRIPTION
## Pull Request Description

Reserved vcis should only be progressed explicitly by the user. Otherwise multiple threads may attempt to progress an explicit vci without sufficient lock protection, resulting in crashes or other bad behavior. Fixes pmodels/mpich#6173.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
