### PR TITLE
pmi: use const in PMI_keyval_t and PMI2_keyval_t

### DIFF
--- a/src/pmi/include/pmi.h
+++ b/src/pmi/include/pmi.h
@@ -419,7 +419,7 @@ Fields:
 S*/
     typedef struct PMI_keyval_t {
         const char *key;
-        char *val;
+        const char *val;
     } PMI_keyval_t;
 
 /*@

--- a/src/pmi/include/pmi2.h
+++ b/src/pmi/include/pmi2.h
@@ -66,8 +66,8 @@ Fields:
 
 S*/
     typedef struct PMI2_keyval_t {
-        char *key;
-        char *val;
+        const char *key;
+        const char *val;
     } PMI2_keyval_t;
 
 /*@


### PR DESCRIPTION
## Pull Request Description

The libpmi should not modify the both the key and val strings. Adding const fixes the -Wdiscarded-qualifiers warnings.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
