### PR TITLE
hydra: fix singleton exit

### DIFF
--- a/src/pm/hydra/lib/tools/topo/topo.c
+++ b/src/pm/hydra/lib/tools/topo/topo.c
@@ -105,6 +105,10 @@ HYD_status HYDT_topo_finalize(void)
 
     HYDU_FUNC_ENTER();
 
+    if (!HYDT_topo_info.topolib) {
+        goto fn_exit;
+    }
+
     /* Finalize the topology library requested by the user */
 #if defined HAVE_HWLOC
     if (!strcmp(HYDT_topo_info.topolib, "hwloc")) {

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -130,6 +130,11 @@ int main(int argc, char **argv)
     status = init_params();
     HYDU_ERR_POP(status, "Error initializing proxy params\n");
 
+    status = HYDT_topo_init(HYD_pmcd_pmip.user_global.topolib,
+                            HYD_pmcd_pmip.user_global.binding,
+                            HYD_pmcd_pmip.user_global.mapping, HYD_pmcd_pmip.user_global.membind);
+    HYDU_ERR_POP(status, "unable to initialize process topology\n");
+
     status = HYD_pmcd_pmip_get_params(argv);
     HYDU_ERR_POP(status, "bad parameters passed to the proxy\n");
 

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -200,30 +200,41 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Now wait for the processes to finish */
-    while (1) {
-        pid = waitpid(-1, &ret_status, 0);
+    /* collect exit_status unless it is a singleton */
+    if (HYD_pmcd_pmip.user_global.singleton_pid > 0) {
+        HYDU_ASSERT(HYD_pmcd_pmip.local.proxy_process_count == 1, status);
+        HYDU_ASSERT(HYD_pmcd_pmip.downstream.pid[0] == HYD_pmcd_pmip.user_global.singleton_pid,
+                    status);
+        /* We won't get the singleton's exit status. Assume it's 0. */
+        if (HYD_pmcd_pmip.downstream.exit_status[0] == PMIP_EXIT_STATUS_UNSET) {
+            HYD_pmcd_pmip.downstream.exit_status[0] = 0;
+        }
+    } else {
+        /* Wait for the processes to finish */
+        while (1) {
+            pid = waitpid(-1, &ret_status, 0);
 
-        /* Find the pid and mark it as complete. */
-        if (pid > 0) {
-            for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
-                if (HYD_pmcd_pmip.downstream.pid[i] == pid) {
-                    if (HYD_pmcd_pmip.downstream.exit_status[i] == PMIP_EXIT_STATUS_UNSET) {
-                        HYD_pmcd_pmip.downstream.exit_status[i] = ret_status;
+            /* Find the pid and mark it as complete. */
+            if (pid > 0) {
+                for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
+                    if (HYD_pmcd_pmip.downstream.pid[i] == pid) {
+                        if (HYD_pmcd_pmip.downstream.exit_status[i] == PMIP_EXIT_STATUS_UNSET) {
+                            HYD_pmcd_pmip.downstream.exit_status[i] = ret_status;
+                        }
+                        done++;
                     }
-                    done++;
                 }
             }
+
+            /* If no more processes are pending, break out */
+            if (done == HYD_pmcd_pmip.local.proxy_process_count)
+                break;
+
+            /* Check if there are any messages from the launcher */
+            status = HYDT_dmx_wait_for_event(0);
+            HYDU_IGNORE_TIMEOUT(status);
+            HYDU_ERR_POP(status, "demux engine error waiting for event\n");
         }
-
-        /* If no more processes are pending, break out */
-        if (done == HYD_pmcd_pmip.local.proxy_process_count)
-            break;
-
-        /* Check if there are any messages from the launcher */
-        status = HYDT_dmx_wait_for_event(0);
-        HYDU_IGNORE_TIMEOUT(status);
-        HYDU_ERR_POP(status, "demux engine error waiting for event\n");
     }
 
     /* Send the exit status upstream */

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -612,11 +612,6 @@ static HYD_status launch_procs(void)
         HYD_pmcd_pmip.downstream.pmi_rank[i] = local_to_global_id(i);
     }
 
-    status = HYDT_topo_init(HYD_pmcd_pmip.user_global.topolib,
-                            HYD_pmcd_pmip.user_global.binding,
-                            HYD_pmcd_pmip.user_global.mapping, HYD_pmcd_pmip.user_global.membind);
-    HYDU_ERR_POP(status, "unable to initialize process topology\n");
-
     if (HYD_pmcd_pmip.user_global.pmi_port) {
         status = HYDU_sock_create_and_listen_portstr(HYD_pmcd_pmip.user_global.iface,
                                                      NULL, NULL, &pmi_port, pmi_listen_cb, NULL);

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -617,6 +617,13 @@ HYD_status fn_finalize(int fd, struct PMIU_cmd *pmi)
 
     finalize_count++;
 
+    /* mark singleton's stdio sockets as closed */
+    if (HYD_pmcd_pmip.user_global.singleton_pid > 0) {
+        HYDU_ASSERT(HYD_pmcd_pmip.local.proxy_process_count == 1, status);
+        HYD_pmcd_pmip.downstream.out[0] = HYD_FD_CLOSED;
+        HYD_pmcd_pmip.downstream.err[0] = HYD_FD_CLOSED;
+    }
+
     if (finalize_count == HYD_pmcd_pmip.local.proxy_process_count) {
         /* All processes have finalized */
         internal_finalize();

--- a/test/mpi/runtests
+++ b/test/mpi/runtests
@@ -211,6 +211,9 @@ if (defined($ENV{'MPIEXEC'})) {
 if (defined($ENV{'MPITEST_MPIEXECARG'})) {
     $g_opt{mpiexecargs} = $ENV{'MPITEST_MPIEXECARG'};
 }
+if (defined($ENV{'MPITEST_SINGLETON'})) {
+    $g_opt{mpitest_singleton} = $ENV{'MPITEST_SINGLETON'};
+}
 
 #---------------------------------------------------------------------------
 # Process arguments and override any defaults
@@ -408,6 +411,11 @@ sub LoadTests {
             my $requiresStrict = "";
 
             if ($#args >= 1) { $np = $args[1]; }
+
+            if ($g_opt{mpitest_singleton} and $np != 1) {
+                # skip multiple process tests if we need test singleton init
+                next;
+            }
             # Process the key=value arguments
             for (my $i=2; $i <= $#args; $i++) {
                 if ($args[$i] =~ /([^=]+)=(.*)/) {
@@ -608,6 +616,10 @@ sub LoadImplicitTests {
 
 sub get_mpiexec_wrapper {
     my ($np, $test_opt) = @_;
+
+    if ($g_opt{mpitest_singleton}) {
+        return $g_opt{program_wrapper};
+    }
 
     my $mpiexecArgs;
     if ($test_opt->{mpiexecargs} and @{$test_opt->{mpiexecargs}}) {


### PR DESCRIPTION
## Pull Request Description
The singleton init will have hydra_pmi_proxy hang in the loop of HYDT_dmx_wait_for_event because the singleton's stdio are never connected. Detect singleton case in finalize handler and set both the out and err sockets to HYD_FD_CLOSED so that the main loop can exit.

We also need to skip the collecting of exit_status because the singleton process was never the child of the proxy process.

* [x] TODO: add a singleton init test


Fixes #6181 
Fixes #6154
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
