### PR TITLE
comm: Check for unmatched messages before releasing context_id

### DIFF
--- a/src/mpi/comm/builtin_comms.c
+++ b/src/mpi/comm/builtin_comms.c
@@ -127,7 +127,7 @@ static int finalize_builtin_comm(MPIR_Comm * comm)
         comm->errhandler = NULL;
     }
 
-    MPIR_Comm_release_always(comm);
+    mpi_errno = MPIR_Comm_release_always(comm);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -486,6 +486,8 @@ unexpected messages queued.
 **failure_pending:Request pending due to failure
 **revoked:Communication object revoked
 **eagain:Operation could not be issued (EAGAIN)
+**commhasunmatched:Communicator being freed has unmatched message(s)
+**commhasunmatched %x %d:Communicator (handle=%x) being freed has %d unmatched message(s)
 # Duplicates?
 #**argnull:Invalid null parameter
 #**argnull %s:Invalid null parameter %s

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -73,18 +73,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 }
 
 
-#define MPIDI_OFI_PROTOCOL_BITS (3)     /* This is set to 3 even though we actually use 4. The ssend
-                                         * ack bit needs to live outside the protocol bit space to avoid
-                                         * accidentally matching unintended messages. Because of this,
-                                         * we shift the PROTOCOL_MASK one extra bit to the left to take
-                                         * the place of the empty SSEND_ACK bit. */
+#define MPIDI_OFI_PROTOCOL_BITS (2)     /* This is set to 2 even though we actually use 4. The ssend
+                                         * ack bit and dynproc bit need to live outside the protocol
+                                         * bit space to avoid accidentally matching unintended
+                                         * messages. Because of this, we shift the PROTOCOL_MASK
+                                         * two extra bits to the left. */
 
 #if MPIDI_OFI_ENABLE_RUNTIME_CHECKS == MPIDI_OFI_ON
 #define MPIDI_OFI_SYNC_SEND_ACK      (1ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
-#define MPIDI_OFI_SYNC_SEND          (2ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
-#define MPIDI_OFI_DYNPROC_SEND       (4ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
+#define MPIDI_OFI_DYNPROC_SEND       (2ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
+#define MPIDI_OFI_SYNC_SEND          (4ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_HUGE_SEND          (8ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
-#define MPIDI_OFI_PROTOCOL_MASK      (((1ULL << MPIDI_OFI_PROTOCOL_BITS) - 1) << 1 << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
+#define MPIDI_OFI_PROTOCOL_MASK      (((1ULL << MPIDI_OFI_PROTOCOL_BITS) - 1) << 2 << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_CONTEXT_MASK       (((1ULL << MPIDI_OFI_CONTEXT_BITS) - 1) << (MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_SOURCE_MASK        (((1ULL << MPIDI_OFI_SOURCE_BITS) - 1) << MPIDI_OFI_TAG_BITS)
 #define MPIDI_OFI_TAG_MASK           ((1ULL << MPIDI_OFI_TAG_BITS) - 1)

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -73,18 +73,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 }
 
 
-#define MPIDI_OFI_PROTOCOL_BITS (2)     /* This is set to 2 even though we actually use 4. The ssend
-                                         * ack bit and dynproc bit need to live outside the protocol
-                                         * bit space to avoid accidentally matching unintended
-                                         * messages. Because of this, we shift the PROTOCOL_MASK
-                                         * two extra bits to the left. */
+/* There are 4 protocol bits:
+ * - MPIDI_DYNPROC_SEND
+ * - MPIDI_OFI_HUGE_SEND
+ * - MPIDI_OFI_SYNC_SEND
+ * - MPIDI_OFI_SYNC_SEND_ACK
+ * The ssend ack and dynproc send bits need to be included in matching
+ * to avoid matching with user messages. Because of this, we only mask
+ * the ssend and huge bits. */
+#define MPIDI_OFI_PROTOCOL_BITS (4)
+#define MPIDI_OFI_PROTOCOL_MASK_BITS (2)
 
 #if MPIDI_OFI_ENABLE_RUNTIME_CHECKS == MPIDI_OFI_ON
 #define MPIDI_OFI_SYNC_SEND_ACK      (1ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_DYNPROC_SEND       (2ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_SYNC_SEND          (4ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_HUGE_SEND          (8ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
-#define MPIDI_OFI_PROTOCOL_MASK      (((1ULL << MPIDI_OFI_PROTOCOL_BITS) - 1) << 2 << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
+#define MPIDI_OFI_PROTOCOL_MASK      (((1ULL << MPIDI_OFI_PROTOCOL_MASK_BITS) - 1) << (MPIDI_OFI_PROTOCOL_BITS - MPIDI_OFI_PROTOCOL_MASK_BITS) << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_CONTEXT_MASK       (((1ULL << MPIDI_OFI_CONTEXT_BITS) - 1) << (MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_SOURCE_MASK        (((1ULL << MPIDI_OFI_SOURCE_BITS) - 1) << MPIDI_OFI_TAG_BITS)
 #define MPIDI_OFI_TAG_MASK           ((1ULL << MPIDI_OFI_TAG_BITS) - 1)

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -481,6 +481,7 @@
 /errors/comm/too_many_icomms
 /errors/comm/too_many_icomms2
 /errors/comm/userdup
+/errors/comm/unmatched
 /errors/cxx/errhan/commerrx
 /errors/cxx/errhan/errgetx
 /errors/cxx/errhan/errsetx

--- a/test/mpi/errors/comm/Makefile.am
+++ b/test/mpi/errors/comm/Makefile.am
@@ -29,4 +29,5 @@ noinst_PROGRAMS = cfree \
                   intercomm_create_nullarg \
                   subcomm_abort \
                   subcomm_abort2 \
-                  intercomm_abort
+                  intercomm_abort \
+                  unmatched

--- a/test/mpi/errors/comm/testlist
+++ b/test/mpi/errors/comm/testlist
@@ -18,3 +18,4 @@ intercomm_create_nullarg 1
 subcomm_abort 4 mpiexecarg=-disable-auto-cleanup env=MPIR_CVAR_NO_COLLECTIVE_FINALIZE=1 strict=false resultTest=TestStatus
 subcomm_abort2 6 mpiexecarg=-disable-auto-cleanup env=MPIR_CVAR_NO_COLLECTIVE_FINALIZE=1 strict=false resultTest=TestStatus
 intercomm_abort 6 mpiexecarg=-disable-auto-cleanup strict=false resultTest=TestStatus
+unmatched 2 strict=false

--- a/test/mpi/errors/comm/unmatched.c
+++ b/test/mpi/errors/comm/unmatched.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+
+int main(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int errs = 0;
+
+    MTest_Init(NULL, NULL);
+
+    MPI_Comm comm;
+    MPI_Comm_dup(MPI_COMM_WORLD, &comm);
+    MPI_Comm_set_errhandler(comm, MPI_ERRORS_RETURN);
+    /* The implementation may raise an error on the default handler
+     * since it will happen during MPI_Comm_free. The default,
+     * as of MPI-4.0, is the error handler for MPI_COMM_SELF.
+     * Prior to MPI-4.0, it was MPI_COMM_WORLD. */
+    MPI_Comm_set_errhandler(MPI_COMM_SELF, MPI_ERRORS_RETURN);
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    int rank;
+    MPI_Comm_rank(comm, &rank);
+
+    if (rank == 0) {
+        /* if an implementation does not use eager
+         * protocol, this send may hang */
+        MPI_Send(NULL, 0, MPI_INT, 1, 0, comm);
+    }
+
+    MPI_Barrier(comm);
+
+    mpi_errno = MPI_Comm_free(&comm);
+    /* unmatched message should be detected at rank 1 */
+    if (rank == 1 && mpi_errno == MPI_SUCCESS) {
+        errs++;
+    }
+
+    MTest_Finalize(errs);
+
+    return MTestReturnValue(errs);
+}


### PR DESCRIPTION
## Pull Request Description

If there are still messages using a communicator context_id in the unexpected queue at destruction time, they could disturb message matching if the context_id is reused. To prevent this, do not allow a communicator with unmatched messages to be freed, and therefore retain the context_id. See pmodels/mpich#6184.

Fixes #6184

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
