### PR TITLE
configure: Fix craypmi configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1668,9 +1668,19 @@ case "$with_pmilib" in
     PAC_PREPEND_FLAG([$CRAY_PMI_POST_LINK_OPTS], [LDFLAGS])
 
     AC_CHECK_HEADER([pmi.h], [], [AC_MSG_ERROR([could not find pmi.h.  Configure aborted])])
-    AC_CHECK_LIB([pmi], [PMI_Init], [], [AC_MSG_ERROR([could not find the cray libpmi.  Configure aborted])])
+    AC_CHECK_LIB([pmi], [PMI_Init], [craypmi_libpmi=yes], [craypmi_libpmi=no])
 
-    PAC_APPEND_FLAG([-lpmi], [WRAPPER_LIBS])
+    if test "X$craypmi_libpmi" = "Xyes"; then
+        PAC_APPEND_FLAG([-lpmi], [WRAPPER_LIBS])
+    else
+        AC_CHECK_LIB([pmi2], [PMI_Init], [craypmi_libpmi2=yes], [craypmi_libpmi2=no])
+        if test "X$craypmi_libpmi2" = "Xyes"; then
+            PAC_APPEND_FLAG([-lpmi2], [WRAPPER_LIBS])
+        else
+            AC_MSG_ERROR([could not find the cray libpmi.  Configure aborted])
+        fi
+    fi
+
     if test "$with_pmi" = "pmi2" ; then
         AC_DEFINE([USE_PMI2_CRAY], 1, [Define if using CRAY PMI 2])
     fi


### PR DESCRIPTION
## Pull Request Description

Fixes configure issue related to PMI library and Cray PMI. Tested on Crusher. Crusher has Cray PMI 6.0 which switched to `libpmi2.so`.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
