### PR TITLE
romio/daos: fix daos_common library dependency

### DIFF
--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -797,6 +797,7 @@ AS_IF([test "x$with_daos" != xno], [
     AC_CHECK_HEADERS(gurt/hash.h,, [unset DAOS])
     AC_CHECK_LIB([gurt], [d_hash_table_create],, [unset DAOS])
     AC_CHECK_LIB([uuid], [uuid_generate],, [unset DAOS])
+    AC_CHECK_LIB([daos_common], [daos_hhash_init_feats],, [unset DAOS])
     AC_CHECK_LIB([daos], [daos_init],, [unset DAOS])
     AC_CHECK_LIB([dfs], [dfs_mount],, [unset DAOS])
     AC_CHECK_LIB([duns], [duns_resolve_path],, [unset DAOS])


### PR DESCRIPTION
## Pull Request Description

Bunch of functions such as _daos_hhash_ ones have been moved into the _daos_common_ library.  Update the _romio_ configure script to add this new library.

