### PR TITLE
[4.0.x] backport message queue dumping revamp

### DIFF
--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -50,7 +50,7 @@ MPI_Bsend_init:
                                 MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
-    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id);
+    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id, buf, count);
 
     /* return the handle of the request to the user */
     MPIR_OBJ_PUBLISH_HANDLE(*request, request_ptr->handle);
@@ -245,7 +245,7 @@ MPI_Irsend:
                             MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
-    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id);
+    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id, buf, count);
 
     /* return the handle of the request to the user */
     /* MPIU_OBJ_HANDLE_PUBLISH is unnecessary for irsend, lower-level access is
@@ -265,7 +265,7 @@ MPI_Isend:
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
-    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id);
+    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id, buf, count);
 
     /* return the handle of the request to the user */
     /* MPIU_OBJ_HANDLE_PUBLISH is unnecessary for isend, lower-level access is
@@ -284,7 +284,7 @@ MPI_Issend:
                             MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
-    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id);
+    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id, buf, count);
 
     /* return the handle of the request to the user */
     /* MPIU_OBJ_HANDLE_PUBLISH is unnecessary for issend, lower-level access is
@@ -477,7 +477,7 @@ MPI_Send_init:
                                MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
-    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id);
+    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id, buf, count);
 
     /* return the handle of the request to the user */
     MPIR_OBJ_PUBLISH_HANDLE(*request, request_ptr->handle);

--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -50,7 +50,6 @@ MPI_Bsend_init:
                                 MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
-    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id, buf, count);
 
     /* return the handle of the request to the user */
     MPIR_OBJ_PUBLISH_HANDLE(*request, request_ptr->handle);
@@ -245,7 +244,6 @@ MPI_Irsend:
                             MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
-    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id, buf, count);
 
     /* return the handle of the request to the user */
     /* MPIU_OBJ_HANDLE_PUBLISH is unnecessary for irsend, lower-level access is
@@ -265,8 +263,6 @@ MPI_Isend:
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
-    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id, buf, count);
-
     /* return the handle of the request to the user */
     /* MPIU_OBJ_HANDLE_PUBLISH is unnecessary for isend, lower-level access is
      * responsible for its own consistency, while upper-level field access is
@@ -284,7 +280,6 @@ MPI_Issend:
                             MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
-    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id, buf, count);
 
     /* return the handle of the request to the user */
     /* MPIU_OBJ_HANDLE_PUBLISH is unnecessary for issend, lower-level access is
@@ -477,7 +472,6 @@ MPI_Send_init:
                                MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
-    MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id, buf, count);
 
     /* return the handle of the request to the user */
     MPIR_OBJ_PUBLISH_HANDLE(*request, request_ptr->handle);

--- a/src/include/mpir_debugger.h
+++ b/src/include/mpir_debugger.h
@@ -42,15 +42,9 @@ void MPII_CommL_forget(MPIR_Comm * comm);
 #define MPII_COMML_REMEMBER(_a) MPII_CommL_remember(_a)
 #define MPII_COMML_FORGET(_a) MPII_CommL_forget(_a)
 #define MPII_REQUEST_CLEAR_DBG(_r)                                      \
-    if ((_r)->kind == MPIR_REQUEST_KIND__SEND) {                        \
-        ((_r)->u.send.dbg = NULL);                                      \
-    } else if ((_r)->kind == MPIR_REQUEST_KIND__PREQUEST_SEND) {        \
-        ((_r)->u.persist.dbg = NULL);                                   \
-    } else if ((_r)->kind == MPIR_REQUEST_KIND__RECV || (_r)->kind == MPIR_REQUEST_KIND__MPROBE) { \
-        ((_r)->u.recv.dbg = NULL);                                      \
-    } else {                                                            \
-        MPIR_Assert(0);                                                 \
-    }
+    (_r)->send = NULL;                                                  \
+    (_r)->recv = NULL;                                                  \
+    (_r)->unexp = NULL;
 
 #else
 static inline void MPII_Wait_for_debugger(void)

--- a/src/include/mpir_debugger.h
+++ b/src/include/mpir_debugger.h
@@ -13,12 +13,12 @@
 
 #ifdef HAVE_DEBUGGER_SUPPORT
 void MPII_Wait_for_debugger(void);
-void MPIR_Debugger_set_aborting(const char *);
+void MPIR_Debugger_set_aborting(const char *msg);
 /* internal functions */
-void MPII_Debugq_remember(MPIR_Request *, int, int, int);
-void MPII_Debugq_forget(MPIR_Request *);
-void MPII_CommL_remember(MPIR_Comm *);
-void MPII_CommL_forget(MPIR_Comm *);
+void MPII_Debugq_remember(MPIR_Request * req, int rank, int tag, int context_id);
+void MPII_Debugq_forget(MPIR_Request * req);
+void MPII_CommL_remember(MPIR_Comm * comm);
+void MPII_CommL_forget(MPIR_Comm * comm);
 
 #define MPII_SENDQ_REMEMBER(_a,_b,_c,_d) MPII_Debugq_remember(_a,_b,_c,_d)
 #define MPII_SENDQ_FORGET(_a) MPII_Debugq_forget(_a)

--- a/src/include/mpir_debugger.h
+++ b/src/include/mpir_debugger.h
@@ -24,7 +24,7 @@ void MPII_CommL_forget(MPIR_Comm *);
 #define MPII_SENDQ_FORGET(_a) MPII_Sendq_forget(_a)
 #define MPII_COMML_REMEMBER(_a) MPII_CommL_remember(_a)
 #define MPII_COMML_FORGET(_a) MPII_CommL_forget(_a)
-#define MPII_REQUEST_CLEAR_DBG(_r) ((_r)->u.send.dbg_next = NULL)
+#define MPII_REQUEST_CLEAR_DBG(_r) ((_r)->u.send.dbg = NULL)
 #else
 static inline void MPII_Wait_for_debugger(void)
 {

--- a/src/include/mpir_debugger.h
+++ b/src/include/mpir_debugger.h
@@ -24,7 +24,15 @@ void MPII_CommL_forget(MPIR_Comm *);
 #define MPII_SENDQ_FORGET(_a) MPII_Sendq_forget(_a)
 #define MPII_COMML_REMEMBER(_a) MPII_CommL_remember(_a)
 #define MPII_COMML_FORGET(_a) MPII_CommL_forget(_a)
-#define MPII_REQUEST_CLEAR_DBG(_r) ((_r)->u.send.dbg = NULL)
+#define MPII_REQUEST_CLEAR_DBG(_r)                                      \
+    if ((_r)->kind == MPIR_REQUEST_KIND__SEND) {                        \
+        ((_r)->u.send.dbg = NULL);                                      \
+    } else if ((_r)->kind == MPIR_REQUEST_KIND__PREQUEST_SEND) {        \
+        ((_r)->u.persist.dbg = NULL);                                   \
+    } else {                                                            \
+        MPIR_Assert(0);                                                 \
+    }
+
 #else
 static inline void MPII_Wait_for_debugger(void)
 {

--- a/src/include/mpir_debugger.h
+++ b/src/include/mpir_debugger.h
@@ -15,13 +15,13 @@
 void MPII_Wait_for_debugger(void);
 void MPIR_Debugger_set_aborting(const char *);
 /* internal functions */
-void MPII_Sendq_remember(MPIR_Request *, int, int, int);
-void MPII_Sendq_forget(MPIR_Request *);
+void MPII_Debugq_remember(MPIR_Request *, int, int, int);
+void MPII_Debugq_forget(MPIR_Request *);
 void MPII_CommL_remember(MPIR_Comm *);
 void MPII_CommL_forget(MPIR_Comm *);
 
-#define MPII_SENDQ_REMEMBER(_a,_b,_c,_d) MPII_Sendq_remember(_a,_b,_c,_d)
-#define MPII_SENDQ_FORGET(_a) MPII_Sendq_forget(_a)
+#define MPII_SENDQ_REMEMBER(_a,_b,_c,_d) MPII_Debugq_remember(_a,_b,_c,_d)
+#define MPII_SENDQ_FORGET(_a) MPII_Debugq_forget(_a)
 #define MPII_COMML_REMEMBER(_a) MPII_CommL_remember(_a)
 #define MPII_COMML_FORGET(_a) MPII_CommL_forget(_a)
 #define MPII_REQUEST_CLEAR_DBG(_r)                                      \

--- a/src/include/mpir_debugger.h
+++ b/src/include/mpir_debugger.h
@@ -12,16 +12,31 @@
 */
 
 #ifdef HAVE_DEBUGGER_SUPPORT
+typedef struct MPIR_Debugq {
+    MPIR_Request *req;
+    int tag, rank, context_id;
+    struct MPIR_Debugq *next;
+    struct MPIR_Debugq *prev;
+} MPIR_Debugq;
+extern MPIR_Debugq *MPIR_Sendq_head;
+extern MPIR_Debugq *MPIR_Recvq_head;
+extern MPIR_Debugq *MPIR_Unexpq_head;
+
 void MPII_Wait_for_debugger(void);
 void MPIR_Debugger_set_aborting(const char *msg);
 /* internal functions */
-void MPII_Debugq_remember(MPIR_Request * req, int rank, int tag, int context_id);
-void MPII_Debugq_forget(MPIR_Request * req);
+void MPII_Debugq_remember(MPIR_Request * req, int rank, int tag, int context_id,
+                          MPIR_Debugq ** queue);
+void MPII_Debugq_forget(MPIR_Request * req, MPIR_Debugq ** queue);
 void MPII_CommL_remember(MPIR_Comm * comm);
 void MPII_CommL_forget(MPIR_Comm * comm);
 
-#define MPII_SENDQ_REMEMBER(_a,_b,_c,_d) MPII_Debugq_remember(_a,_b,_c,_d)
-#define MPII_SENDQ_FORGET(_a) MPII_Debugq_forget(_a)
+#define MPII_SENDQ_REMEMBER(_a,_b,_c,_d) MPII_Debugq_remember(_a,_b,_c,_d,&MPIR_Sendq_head)
+#define MPII_SENDQ_FORGET(_a) MPII_Debugq_forget(_a,&MPIR_Sendq_head)
+#define MPII_RECVQ_REMEMBER(_a,_b,_c,_d) MPII_Debugq_remember(_a,_b,_c,_d,&MPIR_Recvq_head)
+#define MPII_RECVQ_FORGET(_a) MPII_Debugq_forget(_a,&MPIR_Recvq_head)
+#define MPII_UNEXPQ_REMEMBER(_a,_b,_c,_d) MPII_Debugq_remember(_a,_b,_c,_d,&MPIR_Unexpq_head)
+#define MPII_UNEXPQ_FORGET(_a) MPII_Debugq_forget(_a,&MPIR_Unexpq_head)
 #define MPII_COMML_REMEMBER(_a) MPII_CommL_remember(_a)
 #define MPII_COMML_FORGET(_a) MPII_CommL_forget(_a)
 #define MPII_REQUEST_CLEAR_DBG(_r)                                      \
@@ -29,6 +44,8 @@ void MPII_CommL_forget(MPIR_Comm * comm);
         ((_r)->u.send.dbg = NULL);                                      \
     } else if ((_r)->kind == MPIR_REQUEST_KIND__PREQUEST_SEND) {        \
         ((_r)->u.persist.dbg = NULL);                                   \
+    } else if ((_r)->kind == MPIR_REQUEST_KIND__RECV || (_r)->kind == MPIR_REQUEST_KIND__MPROBE) { \
+        ((_r)->u.recv.dbg = NULL);                                      \
     } else {                                                            \
         MPIR_Assert(0);                                                 \
     }
@@ -44,6 +61,10 @@ static inline void MPIR_Debugger_set_aborting(const char *dummy)
 
 #define MPII_SENDQ_REMEMBER(a,b,c,d)
 #define MPII_SENDQ_FORGET(a)
+#define MPII_RECVQ_REMEMBER(a,b,c,d)
+#define MPII_RECVQ_FORGET(a)
+#define MPII_UNEXPQ_REMEMBER(a,b,c,d)
+#define MPII_UNEXPQ_FORGET(a)
 #define MPII_COMML_REMEMBER(_a)
 #define MPII_COMML_FORGET(_a)
 #define MPII_REQUEST_CLEAR_DBG(_r)

--- a/src/include/mpir_debugger.h
+++ b/src/include/mpir_debugger.h
@@ -15,6 +15,8 @@
 typedef struct MPIR_Debugq {
     MPIR_Request *req;
     int tag, rank, context_id;
+    const void *buf;
+    MPI_Aint count;
     struct MPIR_Debugq *next;
     struct MPIR_Debugq *prev;
 } MPIR_Debugq;
@@ -25,17 +27,17 @@ extern MPIR_Debugq *MPIR_Unexpq_head;
 void MPII_Wait_for_debugger(void);
 void MPIR_Debugger_set_aborting(const char *msg);
 /* internal functions */
-void MPII_Debugq_remember(MPIR_Request * req, int rank, int tag, int context_id,
-                          MPIR_Debugq ** queue);
+void MPII_Debugq_remember(MPIR_Request * req, int rank, int tag, int context_id, const void *buf,
+                          MPI_Aint count, MPIR_Debugq ** queue);
 void MPII_Debugq_forget(MPIR_Request * req, MPIR_Debugq ** queue);
 void MPII_CommL_remember(MPIR_Comm * comm);
 void MPII_CommL_forget(MPIR_Comm * comm);
 
-#define MPII_SENDQ_REMEMBER(_a,_b,_c,_d) MPII_Debugq_remember(_a,_b,_c,_d,&MPIR_Sendq_head)
+#define MPII_SENDQ_REMEMBER(_a,_b,_c,_d,_e,_f) MPII_Debugq_remember(_a,_b,_c,_d,_e,_f,&MPIR_Sendq_head)
 #define MPII_SENDQ_FORGET(_a) MPII_Debugq_forget(_a,&MPIR_Sendq_head)
-#define MPII_RECVQ_REMEMBER(_a,_b,_c,_d) MPII_Debugq_remember(_a,_b,_c,_d,&MPIR_Recvq_head)
+#define MPII_RECVQ_REMEMBER(_a,_b,_c,_d,_e,_f) MPII_Debugq_remember(_a,_b,_c,_d,_e,_f,&MPIR_Recvq_head)
 #define MPII_RECVQ_FORGET(_a) MPII_Debugq_forget(_a,&MPIR_Recvq_head)
-#define MPII_UNEXPQ_REMEMBER(_a,_b,_c,_d) MPII_Debugq_remember(_a,_b,_c,_d,&MPIR_Unexpq_head)
+#define MPII_UNEXPQ_REMEMBER(_a,_b,_c,_d) MPII_Debugq_remember(_a,_b,_c,_d,NULL,0,&MPIR_Unexpq_head)
 #define MPII_UNEXPQ_FORGET(_a) MPII_Debugq_forget(_a,&MPIR_Unexpq_head)
 #define MPII_COMML_REMEMBER(_a) MPII_CommL_remember(_a)
 #define MPII_COMML_FORGET(_a) MPII_CommL_forget(_a)
@@ -59,9 +61,9 @@ static inline void MPIR_Debugger_set_aborting(const char *dummy)
 {
 }
 
-#define MPII_SENDQ_REMEMBER(a,b,c,d)
+#define MPII_SENDQ_REMEMBER(a,b,c,d,e,f)
 #define MPII_SENDQ_FORGET(a)
-#define MPII_RECVQ_REMEMBER(a,b,c,d)
+#define MPII_RECVQ_REMEMBER(a,b,c,d,e,f)
 #define MPII_RECVQ_FORGET(a)
 #define MPII_UNEXPQ_REMEMBER(a,b,c,d)
 #define MPII_UNEXPQ_FORGET(a)

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -204,18 +204,7 @@ struct MPIR_Request {
             MPIR_Errflag_t errflag;
             MPII_Coll_req_t coll;
         } nbc;                  /* kind : MPIR_REQUEST_KIND__COLL */
-#if defined HAVE_DEBUGGER_SUPPORT
         struct {
-            struct MPIR_Debugq *dbg;
-        } send;                 /* kind : MPIR_REQUEST_KIND__SEND */
-        struct {
-            struct MPIR_Debugq *dbg;
-        } recv;                 /* kind : MPIR_REQUEST_KIND__RECV */
-#endif                          /* HAVE_DEBUGGER_SUPPORT */
-        struct {
-#if defined HAVE_DEBUGGER_SUPPORT
-            struct MPIR_Debugq *dbg;
-#endif                          /* HAVE_DEBUGGER_SUPPORT */
             /* Persistent requests have their own "real" requests */
             struct MPIR_Request *real_request;
             MPIR_TSP_sched_t sched;
@@ -235,6 +224,12 @@ struct MPIR_Request {
             MPIR_Win *win;
         } rma;                  /* kind : MPIR_REQUEST_KIND__RMA */
     } u;
+
+#if defined HAVE_DEBUGGER_SUPPORT
+    struct MPIR_Debugq *send;
+    struct MPIR_Debugq *recv;
+    struct MPIR_Debugq *unexp;
+#endif                          /* HAVE_DEBUGGER_SUPPORT */
 
     struct MPIR_Request *next, *prev;
 
@@ -424,12 +419,6 @@ static inline MPIR_Request *MPIR_Request_create_from_pool(MPIR_Request_kind_t ki
     req->comm = NULL;
 
     switch (kind) {
-        case MPIR_REQUEST_KIND__SEND:
-        case MPIR_REQUEST_KIND__PREQUEST_SEND:
-        case MPIR_REQUEST_KIND__RECV:
-        case MPIR_REQUEST_KIND__MPROBE:
-            MPII_REQUEST_CLEAR_DBG(req);
-            break;
         case MPIR_REQUEST_KIND__COLL:
             req->u.nbc.errflag = MPIR_ERR_NONE;
             req->u.nbc.coll.host_sendbuf = NULL;
@@ -443,6 +432,7 @@ static inline MPIR_Request *MPIR_Request_create_from_pool(MPIR_Request_kind_t ki
         default:
             break;
     }
+    MPII_REQUEST_CLEAR_DBG(req);
 
     MPID_Request_create_hook(req);
 

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -422,6 +422,7 @@ static inline MPIR_Request *MPIR_Request_create_from_pool(MPIR_Request_kind_t ki
 
     switch (kind) {
         case MPIR_REQUEST_KIND__SEND:
+        case MPIR_REQUEST_KIND__PREQUEST_SEND:
             MPII_REQUEST_CLEAR_DBG(req);
             break;
         case MPIR_REQUEST_KIND__COLL:

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -206,12 +206,12 @@ struct MPIR_Request {
         } nbc;                  /* kind : MPIR_REQUEST_KIND__COLL */
 #if defined HAVE_DEBUGGER_SUPPORT
         struct {
-            struct MPIR_Sendq *dbg;
+            struct MPIR_Debugq *dbg;
         } send;                 /* kind : MPIR_REQUEST_KIND__SEND */
 #endif                          /* HAVE_DEBUGGER_SUPPORT */
         struct {
 #if defined HAVE_DEBUGGER_SUPPORT
-            struct MPIR_Sendq *dbg;
+            struct MPIR_Debugq *dbg;
 #endif                          /* HAVE_DEBUGGER_SUPPORT */
             /* Persistent requests have their own "real" requests */
             struct MPIR_Request *real_request;

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -206,12 +206,12 @@ struct MPIR_Request {
         } nbc;                  /* kind : MPIR_REQUEST_KIND__COLL */
 #if defined HAVE_DEBUGGER_SUPPORT
         struct {
-            struct MPIR_Sendq *dbg_next;
+            struct MPIR_Sendq *dbg;
         } send;                 /* kind : MPID_REQUEST_SEND */
 #endif                          /* HAVE_DEBUGGER_SUPPORT */
         struct {
 #if defined HAVE_DEBUGGER_SUPPORT
-            struct MPIR_Sendq *dbg_next;
+            struct MPIR_Sendq *dbg;
 #endif                          /* HAVE_DEBUGGER_SUPPORT */
             /* Persistent requests have their own "real" requests */
             struct MPIR_Request *real_request;

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -207,7 +207,7 @@ struct MPIR_Request {
 #if defined HAVE_DEBUGGER_SUPPORT
         struct {
             struct MPIR_Sendq *dbg;
-        } send;                 /* kind : MPID_REQUEST_SEND */
+        } send;                 /* kind : MPIR_REQUEST_KIND__SEND */
 #endif                          /* HAVE_DEBUGGER_SUPPORT */
         struct {
 #if defined HAVE_DEBUGGER_SUPPORT
@@ -216,7 +216,7 @@ struct MPIR_Request {
             /* Persistent requests have their own "real" requests */
             struct MPIR_Request *real_request;
             MPIR_TSP_sched_t sched;
-        } persist;              /* kind : MPID_PREQUEST_SEND or MPID_PREQUEST_RECV */
+        } persist;              /* kind : MPIR_REQUEST_KIND__PREQUEST_SEND or MPIR_REQUEST_KIND__PREQUEST_RECV */
         struct {
             struct MPIR_Request *real_request;
             enum MPIR_sched_type sched_type;

--- a/src/mpi/debugger/Makefile.mk
+++ b/src/mpi/debugger/Makefile.mk
@@ -14,7 +14,7 @@ noinst_HEADERS += src/mpi/debugger/mpich_dll_defs.h
 noinst_LTLIBRARIES += src/mpi/debugger/libdbginitdummy.la
 src_mpi_debugger_libdbginitdummy_la_SOURCES = src/mpi/debugger/dbginit.c
 src_mpi_debugger_libdbginitdummy_la_CFLAGS = -g
-pmpi_convenience_libs += $(top_builddir)/src/mpi/debugger/libdbginitdummy.la
+pmpi_convenience_libs += src/mpi/debugger/libdbginitdummy.la
 
 lib_LTLIBRARIES += lib/libtvmpich.la
 # There is no static debugger interface library

--- a/src/mpi/debugger/dbginit.c
+++ b/src/mpi/debugger/dbginit.c
@@ -405,7 +405,7 @@ void MPII_Debugq_remember(MPIR_Request * req, int rank, int tag, int context_id,
 void MPII_Debugq_forget(MPIR_Request * req, MPIR_Debugq ** queue)
 {
 #if defined HAVE_DEBUGGER_SUPPORT
-    MPIR_Debugq *p = NULL, *prev = NULL;
+    MPIR_Debugq *p = NULL;
 
     MPID_THREAD_CS_ENTER(VCI, lock);
     MPID_THREAD_CS_ENTER(POBJ, lock);

--- a/src/mpi/debugger/dbginit.c
+++ b/src/mpi/debugger/dbginit.c
@@ -386,9 +386,9 @@ void MPII_Sendq_remember(MPIR_Request * req, int rank, int tag, int context_id)
         if (!p) {
             /* Just ignore it */
             if (MPIR_REQUEST_KIND__SEND == req->kind)
-                req->u.send.dbg_next = NULL;
+                req->u.send.dbg = NULL;
             else if (MPIR_REQUEST_KIND__PREQUEST_SEND == req->kind)
-                req->u.persist.dbg_next = NULL;
+                req->u.persist.dbg = NULL;
             goto fn_exit;
         }
     }
@@ -398,9 +398,9 @@ void MPII_Sendq_remember(MPIR_Request * req, int rank, int tag, int context_id)
     p->context_id = context_id;
     DL_PREPEND(MPIR_Sendq_head, p);
     if (MPIR_REQUEST_KIND__SEND == req->kind)
-        req->u.send.dbg_next = p;
+        req->u.send.dbg = p;
     else if (MPIR_REQUEST_KIND__PREQUEST_SEND == req->kind)
-        req->u.persist.dbg_next = p;
+        req->u.persist.dbg = p;
   fn_exit:
     MPID_THREAD_CS_EXIT(VCI, lock);
     MPID_THREAD_CS_EXIT(POBJ, lock);
@@ -415,9 +415,9 @@ void MPII_Sendq_forget(MPIR_Request * req)
     MPID_THREAD_CS_ENTER(VCI, lock);
     MPID_THREAD_CS_ENTER(POBJ, lock);
     if (MPIR_REQUEST_KIND__SEND == req->kind)
-        p = req->u.send.dbg_next;
+        p = req->u.send.dbg;
     else if (MPIR_REQUEST_KIND__PREQUEST_SEND == req->kind)
-        p = req->u.persist.dbg_next;
+        p = req->u.persist.dbg;
     if (!p) {
         /* Just ignore it */
         MPID_THREAD_CS_EXIT(VCI, lock);

--- a/src/mpi/debugger/dbginit.c
+++ b/src/mpi/debugger/dbginit.c
@@ -396,11 +396,7 @@ void MPII_Sendq_remember(MPIR_Request * req, int rank, int tag, int context_id)
     p->tag = tag;
     p->rank = rank;
     p->context_id = context_id;
-    p->next = MPIR_Sendq_head;
-    p->prev = NULL;
-    MPIR_Sendq_head = p;
-    if (p->next)
-        p->next->prev = p;
+    DL_PREPEND(MPIR_Sendq_head, p);
     if (MPIR_REQUEST_KIND__SEND == req->kind)
         req->u.send.dbg_next = p;
     else if (MPIR_REQUEST_KIND__PREQUEST_SEND == req->kind)
@@ -428,13 +424,7 @@ void MPII_Sendq_forget(MPIR_Request * req)
         MPID_THREAD_CS_EXIT(POBJ, lock);
         return;
     }
-    prev = p->prev;
-    if (prev != NULL)
-        prev->next = p->next;
-    else
-        MPIR_Sendq_head = p->next;
-    if (p->next != NULL)
-        p->next->prev = prev;
+    DL_DELETE(MPIR_Sendq_head, p);
     /* Return this element to the pool */
     p->next = pool;
     pool = p;

--- a/src/mpi/debugger/dbginit.c
+++ b/src/mpi/debugger/dbginit.c
@@ -350,8 +350,8 @@ static MPIR_Debugq *pool = 0;
 
 /* This routine is used to establish a queue of requests to allow the
    debugger easier access to the active requests. */
-void MPII_Debugq_remember(MPIR_Request * req, int rank, int tag, int context_id,
-                          MPIR_Debugq ** queue)
+void MPII_Debugq_remember(MPIR_Request * req, int rank, int tag, int context_id, const void *buf,
+                          MPI_Aint count, MPIR_Debugq ** queue)
 {
 #if defined HAVE_DEBUGGER_SUPPORT
     MPIR_Debugq *p;
@@ -383,6 +383,8 @@ void MPII_Debugq_remember(MPIR_Request * req, int rank, int tag, int context_id,
     p->tag = tag;
     p->rank = rank;
     p->context_id = context_id;
+    p->buf = buf;
+    p->count = count;
     DL_PREPEND(*queue, p);
 
     if (MPIR_REQUEST_KIND__SEND == req->kind) {

--- a/src/mpi/debugger/dbgstub.c
+++ b/src/mpi/debugger/dbgstub.c
@@ -15,13 +15,6 @@ extern MPIR_Request **const MPID_Recvq_posted_head_ptr, **const MPID_Recvq_unexp
 #include "mpi_interface.h"
 
 /* This is from dbginit.c; it is not exported to other files */
-typedef struct MPIR_Debugq {
-    MPIR_Request *req;
-    int tag, rank, context_id;
-    struct MPIR_Debugq *next;
-} MPIR_Debugq;
-extern MPIR_Debugq *MPIR_Sendq_head;
-/* This is from dbginit.c; it is not exported to other files */
 typedef struct MPIR_Comm_list {
     int sequence_number;        /* Used to detect changes in the list */
     MPIR_Comm *head;            /* Head of the list */

--- a/src/mpi/debugger/dbgstub.c
+++ b/src/mpi/debugger/dbgstub.c
@@ -244,6 +244,10 @@ int dbgrI_field_offset(mqs_type * type, char *name)
                     off = ((char *) &c.rank - (char *) &c);
                 } else if (strcmp(name, "context_id") == 0) {
                     off = ((char *) &c.context_id - (char *) &c);
+                } else if (strcmp(name, "buf") == 0) {
+                    off = ((char *) &c.buf - (char *) &c);
+                } else if (strcmp(name, "count") == 0) {
+                    off = ((char *) &c.count - (char *) &c);
                 } else if (strcmp(name, "req") == 0) {
                     off = ((char *) &c.req - (char *) &c);
                 } else {

--- a/src/mpi/debugger/dbgstub.c
+++ b/src/mpi/debugger/dbgstub.c
@@ -15,12 +15,12 @@ extern MPIR_Request **const MPID_Recvq_posted_head_ptr, **const MPID_Recvq_unexp
 #include "mpi_interface.h"
 
 /* This is from dbginit.c; it is not exported to other files */
-typedef struct MPIR_Sendq {
-    MPIR_Request *sreq;
+typedef struct MPIR_Debugq {
+    MPIR_Request *req;
     int tag, rank, context_id;
-    struct MPIR_Sendq *next;
-} MPIR_Sendq;
-extern MPIR_Sendq *MPIR_Sendq_head;
+    struct MPIR_Debugq *next;
+} MPIR_Debugq;
+extern MPIR_Debugq *MPIR_Sendq_head;
 /* This is from dbginit.c; it is not exported to other files */
 typedef struct MPIR_Comm_list {
     int sequence_number;        /* Used to detect changes in the list */
@@ -46,7 +46,7 @@ enum { TYPE_UNKNOWN = 0,
     TYPE_MPIDI_REQUEST = 3,
     TYPE_MPIDI_MESSAGE_MATCH = 4,
     TYPE_MPIR_REQUEST = 5,
-    TYPE_MPIR_SENDQ = 6,
+    TYPE_MPIR_DEBUGQ = 6,
     TYPE_MPIDI_MESSAGE_MATCH_PARTS = 7,
     TYPE_MPIDI_DEVREQ_T = 8,
     TYPE_MPIDIG_REQ_T = 9,
@@ -60,7 +60,7 @@ enum { TYPE_UNKNOWN = 0,
 static int knownTypesArray[] = { TYPE_UNKNOWN, TYPE_MPIR_COMM,
     TYPE_MPIR_COMM_LIST, TYPE_MPIDI_REQUEST,
     TYPE_MPIDI_MESSAGE_MATCH, TYPE_MPIR_REQUEST,
-    TYPE_MPIR_SENDQ,
+    TYPE_MPIR_DEBUGQ,
     TYPE_MPIDI_MESSAGE_MATCH_PARTS,
     TYPE_MPIDI_DEVREQ_T,
     TYPE_MPIDIG_REQ_T,
@@ -83,8 +83,8 @@ mqs_type *dbgrI_find_type(mqs_image * image, char *name, mqs_lang_code lang)
         curType = TYPE_MPIDI_MESSAGE_MATCH_PARTS;
     } else if (strcmp(name, "MPIR_Request") == 0) {
         curType = TYPE_MPIR_REQUEST;
-    } else if (strcmp(name, "MPIR_Sendq") == 0) {
-        curType = TYPE_MPIR_SENDQ;
+    } else if (strcmp(name, "MPIR_Debugq") == 0) {
+        curType = TYPE_MPIR_DEBUGQ;
     } else if (strcmp(name, "MPIDI_Devreq_t") == 0) {
         curType = TYPE_MPIDI_DEVREQ_T;
     } else if (strcmp(name, "MPIDIG_req_t") == 0) {
@@ -240,9 +240,9 @@ int dbgrI_field_offset(mqs_type * type, char *name)
                 }
             }
             break;
-        case TYPE_MPIR_SENDQ:
+        case TYPE_MPIR_DEBUGQ:
             {
-                struct MPIR_Sendq c;
+                struct MPIR_Debugq c;
                 if (strcmp(name, "next") == 0) {
                     off = ((char *) &c.next - (char *) &c);
                 } else if (strcmp(name, "tag") == 0) {
@@ -251,10 +251,10 @@ int dbgrI_field_offset(mqs_type * type, char *name)
                     off = ((char *) &c.rank - (char *) &c);
                 } else if (strcmp(name, "context_id") == 0) {
                     off = ((char *) &c.context_id - (char *) &c);
-                } else if (strcmp(name, "sreq") == 0) {
-                    off = ((char *) &c.sreq - (char *) &c);
+                } else if (strcmp(name, "req") == 0) {
+                    off = ((char *) &c.req - (char *) &c);
                 } else {
-                    printf("Panic! Unrecognized Sendq field %s\n", name);
+                    printf("Panic! Unrecognized request queue field %s\n", name);
                 }
             }
             break;

--- a/src/mpi/debugger/dbgstub.c
+++ b/src/mpi/debugger/dbgstub.c
@@ -7,11 +7,6 @@
 
 #include "mpiimpl.h"
 
-/* These are pointers to the static variables in ch3u_recvq.c or ch4r_recvq.c
-   that contains the *addresses* of the posted and unexpected queue head
-   pointers */
-extern MPIR_Request **const MPID_Recvq_posted_head_ptr, **const MPID_Recvq_unexpected_head_ptr;
-
 #include "mpi_interface.h"
 
 /* This is from dbginit.c; it is not exported to other files */
@@ -36,14 +31,9 @@ extern MPIR_Comm_list MPIR_All_communicators;
 enum { TYPE_UNKNOWN = 0,
     TYPE_MPIR_COMM = 1,
     TYPE_MPIR_COMM_LIST = 2,
-    TYPE_MPIDI_REQUEST = 3,
-    TYPE_MPIDI_MESSAGE_MATCH = 4,
-    TYPE_MPIR_REQUEST = 5,
-    TYPE_MPIR_DEBUGQ = 6,
-    TYPE_MPIDI_MESSAGE_MATCH_PARTS = 7,
-    TYPE_MPIDI_DEVREQ_T = 8,
-    TYPE_MPIDIG_REQ_T = 9,
-    TYPE_MPIDIG_COMM_T = 10,
+    TYPE_MPIR_REQUEST = 3,
+    TYPE_MPIR_DEBUGQ = 4,
+    TYPE_MPIDIG_COMM_T = 5,
 } KnownTypes;
 
 /* The dll_mpich.c has a few places where it doesn't always use the most
@@ -51,12 +41,9 @@ enum { TYPE_UNKNOWN = 0,
    have an example of each type, and return that value. */
 
 static int knownTypesArray[] = { TYPE_UNKNOWN, TYPE_MPIR_COMM,
-    TYPE_MPIR_COMM_LIST, TYPE_MPIDI_REQUEST,
-    TYPE_MPIDI_MESSAGE_MATCH, TYPE_MPIR_REQUEST,
+    TYPE_MPIR_COMM_LIST,
+    TYPE_MPIR_REQUEST,
     TYPE_MPIR_DEBUGQ,
-    TYPE_MPIDI_MESSAGE_MATCH_PARTS,
-    TYPE_MPIDI_DEVREQ_T,
-    TYPE_MPIDIG_REQ_T,
     TYPE_MPIDIG_COMM_T,
 };
 
@@ -68,20 +55,10 @@ mqs_type *dbgrI_find_type(mqs_image * image, char *name, mqs_lang_code lang)
         curType = TYPE_MPIR_COMM;
     } else if (strcmp(name, "MPIR_Comm_list") == 0) {
         curType = TYPE_MPIR_COMM_LIST;
-    } else if (strcmp(name, "MPIDI_Request") == 0) {
-        curType = TYPE_MPIDI_REQUEST;
-    } else if (strcmp(name, "MPIDI_Message_match") == 0) {
-        curType = TYPE_MPIDI_MESSAGE_MATCH;
-    } else if (strcmp(name, "MPIDI_Message_match_parts_t") == 0) {
-        curType = TYPE_MPIDI_MESSAGE_MATCH_PARTS;
     } else if (strcmp(name, "MPIR_Request") == 0) {
         curType = TYPE_MPIR_REQUEST;
     } else if (strcmp(name, "MPIR_Debugq") == 0) {
         curType = TYPE_MPIR_DEBUGQ;
-    } else if (strcmp(name, "MPIDI_Devreq_t") == 0) {
-        curType = TYPE_MPIDI_DEVREQ_T;
-    } else if (strcmp(name, "MPIDIG_req_t") == 0) {
-        curType = TYPE_MPIDIG_REQ_T;
     } else if (strcmp(name, "MPIDIG_comm_t") == 0) {
         curType = TYPE_MPIDIG_COMM_T;
     } else {
@@ -133,90 +110,6 @@ int dbgrI_field_offset(mqs_type * type, char *name)
                 }
             }
             break;
-#ifndef HAVE_CH4_DEBUGGER_SUPPORT
-        case TYPE_MPIDI_REQUEST:
-            {
-                struct MPIDI_Request c;
-                if (strcmp(name, "match") == 0) {
-                    off = ((char *) &c.match - (char *) &c);
-                } else if (strcmp(name, "user_buf") == 0) {
-                    off = ((char *) &c.user_buf - (char *) &c);
-                } else if (strcmp(name, "user_count") == 0) {
-                    off = ((char *) &c.user_count - (char *) &c);
-                } else if (strcmp(name, "datatype") == 0) {
-                    off = ((char *) &c.datatype - (char *) &c);
-                } else {
-                    printf("Panic! Unrecognized mpidi request field %s\n", name);
-                }
-            }
-            break;
-        case TYPE_MPIDI_MESSAGE_MATCH:
-            {
-                if (strcmp(name, "parts") == 0) {
-                    off = 0;
-                } else {
-                    printf("Panic: Unrecognized mpidi_match fields %s\n", name);
-                }
-            }
-            break;
-        case TYPE_MPIDI_MESSAGE_MATCH_PARTS:
-            {
-                MPIDI_Message_match c;
-                if (strcmp(name, "tag") == 0) {
-                    off = ((char *) &c.parts.tag - (char *) &c);
-                } else if (strcmp(name, "rank") == 0) {
-                    off = ((char *) &c.parts.rank - (char *) &c);
-                } else if (strcmp(name, "context_id") == 0) {
-                    off = ((char *) &c.parts.context_id - (char *) &c);
-                } else {
-                    printf("Panic! Unrecognized message match parts field %s\n", name);
-                }
-            }
-            break;
-#else
-        case TYPE_MPIDI_DEVREQ_T:
-            {
-                MPIDI_Devreq_t c;
-                if (strcmp(name, "am") == 0) {
-                    off = ((char *) &c.ch4.am - (char *) &c);
-                } else {
-                    printf("Panic! Unrecognized MPIDI_Devreq_t field %s\n", name);
-                }
-            }
-            break;
-        case TYPE_MPIDIG_REQ_T:
-            {
-                MPIDIG_req_t c;
-                if (strcmp(name, "buffer") == 0) {
-                    off = ((char *) &c.buffer - (char *) &c);
-                } else if (strcmp(name, "count") == 0) {
-                    off = ((char *) &c.count - (char *) &c);
-                } else if (strcmp(name, "rank") == 0) {
-                    off = ((char *) &c.u.recv.source - (char *) &c);
-                } else if (strcmp(name, "tag") == 0) {
-                    off = ((char *) &c.u.recv.tag - (char *) &c);
-                } else if (strcmp(name, "context_id") == 0) {
-                    off = ((char *) &c.u.recv.context_id - (char *) &c);
-                } else if (strcmp(name, "datatype") == 0) {
-                    off = ((char *) &c.datatype - (char *) &c);
-                } else {
-                    printf("Panic! Unrecognized MPIDIG_req_t field %s\n", name);
-                }
-            }
-            break;
-        case TYPE_MPIDIG_COMM_T:
-            {
-                MPIDIG_comm_t c;
-                if (strcmp(name, "posted_head_ptr") == 0) {
-                    off = ((char *) &c.posted_head_ptr - (char *) &c);
-                } else if (strcmp(name, "unexp_head_ptr") == 0) {
-                    off = ((char *) &c.unexp_head_ptr - (char *) &c);
-                } else {
-                    printf("Panic! Unrecognized MPIDIG_comm_t field %s\n", name);
-                }
-            }
-            break;
-#endif
         case TYPE_MPIR_REQUEST:
             {
                 MPIR_Request c;
@@ -277,13 +170,11 @@ int dbgrI_find_symbol(mqs_image * image, char *name, mqs_taddr_t * loc)
         printf("all communicators head as pointer %p\n", &MPIR_All_communicators);
         printf("head is %p\n", MPIR_All_communicators.head);
         return mqs_ok;
-    } else if (strcmp(name, "MPID_Recvq_posted_head_ptr") == 0) {
-        *loc = (mqs_taddr_t) & MPID_Recvq_posted_head_ptr;
-        printf("Address of ptr to posted head ptr = %p\n", &MPID_Recvq_posted_head_ptr);
-        printf("Address of posted head ptr = %p\n", MPID_Recvq_posted_head_ptr);
+    } else if (strcmp(name, "MPIR_Recvq_head") == 0) {
+        *loc = (mqs_taddr_t) & MPIR_Recvq_head;
         return mqs_ok;
-    } else if (strcmp(name, "MPID_Recvq_unexpected_head_ptr") == 0) {
-        *loc = (mqs_taddr_t) & MPID_Recvq_unexpected_head_ptr;
+    } else if (strcmp(name, "MPIR_Unexpq_head") == 0) {
+        *loc = (mqs_taddr_t) & MPIR_Unexpq_head;
         return mqs_ok;
     } else if (strcmp(name, "MPIR_Sendq_head") == 0) {
         *loc = (mqs_taddr_t) & MPIR_Sendq_head;

--- a/src/mpi/debugger/dll_mpich.c
+++ b/src/mpi/debugger/dll_mpich.c
@@ -287,87 +287,17 @@ int mqs_image_has_queues(mqs_image * image, const char **message)
         }
     }
 
-    /* Now the receive queues.  The receive queues contain MPIR_Request
-     * objects, and the various fields are within types in that object.
-     * To simplify the eventual access, we compute all offsets relative to the
-     * request.  This means diving into the types that make of the
-     * request definition */
+    /* Request queues */
     {
-        mqs_type *req_type = dbgr_find_type(image, (char *) "MPIR_Request", mqs_lang_c);
+        mqs_type *req_type = dbgr_find_type(image, (char *) "MPIR_Debugq", mqs_lang_c);
         if (req_type) {
-            int dev_offs;
-            dev_offs = dbgr_field_offset(req_type, (char *) "dev");
-            i_info->req_status_offs = dbgr_field_offset(req_type, (char *) "status");
-            i_info->req_cc_offs = dbgr_field_offset(req_type, (char *) "cc");
-            i_info->req_next_offs = dbgr_field_offset(req_type, (char *) "next");
-            if (dev_offs >= 0) {
-                i_info->req_dev_offs = dev_offs;
-#ifdef HAVE_CH4_DEBUGGER_SUPPORT
-                /* Only support CH4 active message */
-                /* buffer, count, rank, tag, context_id and datatype are stored in AM request */
-                mqs_type *dreq_type = dbgr_find_type(image, (char *) "MPIDI_Devreq_t", mqs_lang_c);
-
-                int am_offs = dev_offs + dbgr_field_offset(dreq_type, (char *) "am");
-                mqs_type *am_req_type = dbgr_find_type(image, (char *) "MPIDIG_req_t", mqs_lang_c);
-                i_info->req_user_buf_offs =
-                    am_offs + dbgr_field_offset(am_req_type, (char *) "buffer");
-                i_info->req_user_count_offs =
-                    am_offs + dbgr_field_offset(am_req_type, (char *) "count");
-                i_info->req_rank_offs = am_offs + dbgr_field_offset(am_req_type, (char *) "rank");
-                i_info->req_tag_offs = am_offs + dbgr_field_offset(am_req_type, (char *) "tag");
-                i_info->req_context_id_offs =
-                    am_offs + dbgr_field_offset(am_req_type, (char *) "context_id");
-                i_info->req_datatype_offs =
-                    am_offs + dbgr_field_offset(am_req_type, (char *) "datatype");
-#else
-                /* CH3 specific request definition */
-                mqs_type *dreq_type = dbgr_find_type(image, (char *) "MPIDI_Request",
-                                                     mqs_lang_c);
-                if (dreq_type) {
-                    int loff, match_offs;
-                    loff = dbgr_field_offset(dreq_type, (char *) "user_buf");
-                    i_info->req_user_buf_offs = dev_offs + loff;
-                    loff = dbgr_field_offset(dreq_type, (char *) "user_count");
-                    i_info->req_user_count_offs = dev_offs + loff;
-                    loff = dbgr_field_offset(dreq_type, (char *) "datatype");
-                    i_info->req_datatype_offs = dev_offs + loff;
-                    match_offs = dbgr_field_offset(dreq_type, (char *) "match");
-                    if (match_offs >= 0) {
-                        mqs_type *match_type =
-                            dbgr_find_type(image, (char *) "MPIDI_Message_match", mqs_lang_c);
-                        if (match_type) {
-                            int parts_offs = dbgr_field_offset(match_type, (char *) "parts");
-                            if (parts_offs >= 0) {
-                                mqs_type *parts_type =
-                                    dbgr_find_type(image, (char *) "MPIDI_Message_match_parts_t",
-                                                   mqs_lang_c);
-                                if (parts_type) {
-                                    int moff;
-                                    moff = dbgr_field_offset(parts_type, (char *) "tag");
-                                    i_info->req_tag_offs = dev_offs + match_offs + moff;
-                                    moff = dbgr_field_offset(parts_type, (char *) "rank");
-                                    i_info->req_rank_offs = dev_offs + match_offs + moff;
-                                    moff = dbgr_field_offset(parts_type, (char *) "context_id");
-                                    i_info->req_context_id_offs = dev_offs + match_offs + moff;
-                                }
-                            }
-                        }
-                    }
-                }
-#endif
-            }
-        }
-    }
-
-    /* Send queues use a separate system */
-    {
-        mqs_type *sreq_type = dbgr_find_type(image, (char *) "MPIR_Debugq", mqs_lang_c);
-        if (sreq_type) {
-            i_info->debugq_next_offs = dbgr_field_offset(sreq_type, (char *) "next");
-            i_info->debugq_tag_offs = dbgr_field_offset(sreq_type, (char *) "tag");
-            i_info->debugq_rank_offs = dbgr_field_offset(sreq_type, (char *) "rank");
-            i_info->debugq_context_id_offs = dbgr_field_offset(sreq_type, (char *) "context_id");
-            i_info->debugq_req_offs = dbgr_field_offset(sreq_type, (char *) "req");
+            i_info->debugq_next_offs = dbgr_field_offset(req_type, (char *) "next");
+            i_info->debugq_tag_offs = dbgr_field_offset(req_type, (char *) "tag");
+            i_info->debugq_rank_offs = dbgr_field_offset(req_type, (char *) "rank");
+            i_info->debugq_context_id_offs = dbgr_field_offset(req_type, (char *) "context_id");
+            i_info->debugq_user_buf_offs = dbgr_field_offset(req_type, (char *) "buf");
+            i_info->debugq_user_count_offs = dbgr_field_offset(req_type, (char *) "count");
+            i_info->debugq_req_offs = dbgr_field_offset(req_type, (char *) "req");
         }
     }
 
@@ -416,7 +346,6 @@ int mqs_process_has_queues(mqs_process * proc, char **msg)
     mpich_process_info *p_info = (mpich_process_info *) dbgr_get_process_info(proc);
     mqs_image *image = dbgr_get_image(proc);
     mpich_image_info *i_info = (mpich_image_info *) dbgr_get_image_info(image);
-    mqs_taddr_t head_ptr;
 
     /* Don't bother with a pop up here, it's unlikely to be helpful */
     *msg = 0;
@@ -427,13 +356,11 @@ int mqs_process_has_queues(mqs_process * proc, char **msg)
         return err_all_communicators;
 
     /* Check for the receive and send queues */
-    if (dbgr_find_symbol(image, (char *) "MPID_Recvq_posted_head_ptr", &head_ptr) != mqs_ok)
+    if (dbgr_find_symbol(image, (char *) "MPIR_Recvq_head", &p_info->posted_base) != mqs_ok)
         return err_posted;
-    p_info->posted_base = fetch_pointer(proc, head_ptr, p_info);
 
-    if (dbgr_find_symbol(image, (char *) "MPID_Recvq_unexpected_head_ptr", &head_ptr) != mqs_ok)
+    if (dbgr_find_symbol(image, (char *) "MPIR_Unexpq_head", &p_info->unexpected_base) != mqs_ok)
         return err_unexpected;
-    p_info->unexpected_base = fetch_pointer(proc, head_ptr, p_info);
 
     /* Send queues are optional */
     if (dbgr_find_symbol(image, (char *) "MPIR_Sendq_head", &p_info->sendq_base) == mqs_ok) {
@@ -462,9 +389,9 @@ const char *mqs_dll_error_string(int errcode)
             return
                 "Could not read a communicator's group from the process (probably a store corruption)";
         case err_unexpected:
-            return "Failed to find symbol MPID_Recvq_unexpected_head_ptr";
+            return "Failed to find symbol MPIR_Unexpq_head";
         case err_posted:
-            return "Failed to find symbol MPID_Recvq_posted_head_ptr";
+            return "Failed to find symbol MPIR_Recvq_head";
     }
     return "Unknown error code";
 }
@@ -636,7 +563,7 @@ static int fetch_receive(mqs_process * proc, mpich_process_info * p_info,
 #endif
     while (base != 0) {
         /* Check this entry to see if the context matches */
-        int16_t actual_context = fetch_int16(proc, base + i_info->req_context_id_offs, p_info);
+        int16_t actual_context = fetch_int16(proc, base + i_info->debugq_context_id_offs, p_info);
 
 #ifdef DEBUG_LIST_ITER
         initLogFile();
@@ -644,11 +571,13 @@ static int fetch_receive(mqs_process * proc, mpich_process_info * p_info,
 #endif
         if (actual_context == wanted_context) {
             /* Found a request for this communicator */
-            int tag = fetch_int(proc, base + i_info->req_tag_offs, p_info);
-            int rank = fetch_int16(proc, base + i_info->req_rank_offs, p_info);
-            int is_complete = fetch_int(proc, base + i_info->req_cc_offs, p_info);
-            mqs_tword_t user_buffer = fetch_pointer(proc, base + i_info->req_user_buf_offs, p_info);
-            int user_count = fetch_int(proc, base + i_info->req_user_count_offs, p_info);
+            int tag = fetch_int(proc, base + i_info->debugq_tag_offs, p_info);
+            int rank = fetch_int16(proc, base + i_info->debugq_rank_offs, p_info);
+            mqs_taddr_t rreq = fetch_pointer(proc, base + i_info->debugq_req_offs, p_info);
+            mqs_tword_t is_complete = fetch_int(proc, rreq + i_info->req_cc_offs, p_info);
+            mqs_tword_t user_buffer =
+                fetch_pointer(proc, base + i_info->debugq_user_buf_offs, p_info);
+            int user_count = fetch_int(proc, base + i_info->debugq_user_count_offs, p_info);
 
             /* Return -1 for ANY_TAG or ANY_SOURCE */
             res->desired_tag = (tag >= 0) ? tag : -1;
@@ -671,11 +600,11 @@ static int fetch_receive(mqs_process * proc, mpich_process_info * p_info,
             res->status = (is_complete != 0) ? mqs_st_pending : mqs_st_complete;
 
             /* Don't forget to step the queue ! */
-            p_info->next_msg = base + i_info->req_next_offs;
+            p_info->next_msg = base + i_info->debugq_next_offs;
             return mqs_ok;
         } else {
             /* Try the next one */
-            base = fetch_pointer(proc, base + i_info->req_next_offs, p_info);
+            base = fetch_pointer(proc, base + i_info->debugq_next_offs, p_info);
         }
     }
 #if 0
@@ -744,10 +673,10 @@ static int fetch_receive(mqs_process * proc, mpich_process_info * p_info,
             }
 
             /* Don't forget to step the queue ! */
-            p_info->next_msg = base + i_info->next_offs;
+            p_info->next_msg = base + i_info->debugq_next_offs;
             return mqs_ok;
         } else {        /* Try the next one */
-            base = fetch_pointer(proc, base + i_info->next_offs, p_info);
+            base = fetch_pointer(proc, base + i_info->debugq_next_offs, p_info);
         }
     }
 #endif
@@ -795,8 +724,8 @@ static int fetch_send(mqs_process * proc, mpich_process_info * p_info, mqs_pendi
             mqs_taddr_t data = 0;
             mqs_taddr_t sreq = fetch_pointer(proc, base + i_info->debugq_req_offs, p_info);
             mqs_tword_t is_complete = fetch_int(proc, sreq + i_info->req_cc_offs, p_info);
-            data = fetch_pointer(proc, sreq + i_info->req_user_buf_offs, p_info);
-            length = fetch_int(proc, sreq + i_info->req_user_count_offs, p_info);
+            data = fetch_pointer(proc, base + i_info->debugq_user_buf_offs, p_info);
+            length = fetch_int(proc, base + i_info->debugq_user_count_offs, p_info);
             /* mqs_tword_t complete=0; */
 
 #ifdef DEBUG_LIST_ITER

--- a/src/mpi/debugger/dll_mpich.c
+++ b/src/mpi/debugger/dll_mpich.c
@@ -361,13 +361,13 @@ int mqs_image_has_queues(mqs_image * image, const char **message)
 
     /* Send queues use a separate system */
     {
-        mqs_type *sreq_type = dbgr_find_type(image, (char *) "MPIR_Sendq", mqs_lang_c);
+        mqs_type *sreq_type = dbgr_find_type(image, (char *) "MPIR_Debugq", mqs_lang_c);
         if (sreq_type) {
-            i_info->sendq_next_offs = dbgr_field_offset(sreq_type, (char *) "next");
-            i_info->sendq_tag_offs = dbgr_field_offset(sreq_type, (char *) "tag");
-            i_info->sendq_rank_offs = dbgr_field_offset(sreq_type, (char *) "rank");
-            i_info->sendq_context_id_offs = dbgr_field_offset(sreq_type, (char *) "context_id");
-            i_info->sendq_req_offs = dbgr_field_offset(sreq_type, (char *) "sreq");
+            i_info->debugq_next_offs = dbgr_field_offset(sreq_type, (char *) "next");
+            i_info->debugq_tag_offs = dbgr_field_offset(sreq_type, (char *) "tag");
+            i_info->debugq_rank_offs = dbgr_field_offset(sreq_type, (char *) "rank");
+            i_info->debugq_context_id_offs = dbgr_field_offset(sreq_type, (char *) "context_id");
+            i_info->debugq_req_offs = dbgr_field_offset(sreq_type, (char *) "req");
         }
     }
 
@@ -785,15 +785,15 @@ static int fetch_send(mqs_process * proc, mpich_process_info * p_info, mqs_pendi
 
     while (base != 0) {
         /* Check this entry to see if the context matches */
-        int actual_context = fetch_int16(proc, base + i_info->sendq_context_id_offs, p_info);
+        int actual_context = fetch_int16(proc, base + i_info->debugq_context_id_offs, p_info);
 
         if (actual_context == wanted_context) {
             /* Fill in some of the fields */
-            mqs_tword_t target = fetch_int(proc, base + i_info->sendq_rank_offs, p_info);
-            mqs_tword_t tag = fetch_int(proc, base + i_info->sendq_tag_offs, p_info);
+            mqs_tword_t target = fetch_int(proc, base + i_info->debugq_rank_offs, p_info);
+            mqs_tword_t tag = fetch_int(proc, base + i_info->debugq_tag_offs, p_info);
             mqs_tword_t length = 0;
             mqs_taddr_t data = 0;
-            mqs_taddr_t sreq = fetch_pointer(proc, base + i_info->sendq_req_offs, p_info);
+            mqs_taddr_t sreq = fetch_pointer(proc, base + i_info->debugq_req_offs, p_info);
             mqs_tword_t is_complete = fetch_int(proc, sreq + i_info->req_cc_offs, p_info);
             data = fetch_pointer(proc, sreq + i_info->req_user_buf_offs, p_info);
             length = fetch_int(proc, sreq + i_info->req_user_count_offs, p_info);
@@ -802,7 +802,7 @@ static int fetch_send(mqs_process * proc, mpich_process_info * p_info, mqs_pendi
 #ifdef DEBUG_LIST_ITER
             initLogFile();
             fprintf(debugfp, "sendq entry = %p, rank off = %d, tag off = %d, context = %d\n",
-                    base, i_info->sendq_rank_offs, i_info->sendq_tag_offs, actual_context);
+                    base, i_info->debugq_rank_offs, i_info->debugq_tag_offs, actual_context);
 #endif
 
             /* Ok, fill in the results */
@@ -817,11 +817,11 @@ static int fetch_send(mqs_process * proc, mpich_process_info * p_info, mqs_pendi
 
 
             /* Don't forget to step the queue ! */
-            p_info->next_msg = base + i_info->sendq_next_offs;
+            p_info->next_msg = base + i_info->debugq_next_offs;
             return mqs_ok;
         } else {
             /* Try the next one */
-            base = fetch_pointer(proc, base + i_info->sendq_next_offs, p_info);
+            base = fetch_pointer(proc, base + i_info->debugq_next_offs, p_info);
         }
     }
 #if 0

--- a/src/mpi/debugger/mpich_dll_defs.h
+++ b/src/mpi/debugger/mpich_dll_defs.h
@@ -42,12 +42,12 @@ typedef struct {
     int req_datatype_offs;
     int req_next_offs;
 
-    /* Fields in MPIR_Sendq */
-    int sendq_next_offs;
-    int sendq_tag_offs;
-    int sendq_rank_offs;
-    int sendq_context_id_offs;
-    int sendq_req_offs;
+    /* Fields in MPIR_Debugq */
+    int debugq_next_offs;
+    int debugq_tag_offs;
+    int debugq_rank_offs;
+    int debugq_context_id_offs;
+    int debugq_req_offs;
 } mpich_image_info;
 
 /***********************************************************************

--- a/src/mpi/debugger/mpich_dll_defs.h
+++ b/src/mpi/debugger/mpich_dll_defs.h
@@ -33,14 +33,7 @@ typedef struct {
     /* Fields in MPIR_Request (including structures within the request) */
     int req_status_offs;
     int req_cc_offs;
-    int req_dev_offs;
-    int req_tag_offs;
-    int req_rank_offs;
-    int req_context_id_offs;
-    int req_user_buf_offs;
-    int req_user_count_offs;
     int req_datatype_offs;
-    int req_next_offs;
 
     /* Fields in MPIR_Debugq */
     int debugq_next_offs;

--- a/src/mpi/debugger/mpich_dll_defs.h
+++ b/src/mpi/debugger/mpich_dll_defs.h
@@ -47,6 +47,8 @@ typedef struct {
     int debugq_tag_offs;
     int debugq_rank_offs;
     int debugq_context_id_offs;
+    int debugq_user_buf_offs;
+    int debugq_user_count_offs;
     int debugq_req_offs;
 } mpich_image_info;
 

--- a/src/mpi/debugger/tvtest.c
+++ b/src/mpi/debugger/tvtest.c
@@ -241,17 +241,20 @@ int showQueues(int nComm, int expected)
         mqs_next_communicator(&process);
     }
 
+    int ret = 0;
     if (nFound < expected) {
         fprintf(stderr, "Error: expected to find %d queue entries but only saw %d\n", expected,
                 nFound);
+        ret = 1;
     }
     if (nCommFound < nComm) {
         fprintf(stderr, "Error: expected to find %d comms but only saw %d\n", nComm, nCommFound);
+        ret = 1;
     }
 
     fflush(stdout);
     fflush(stderr);
-    return 0;
+    return ret;
 }
 
 

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -56,12 +56,7 @@ void MPII_init_request(void)
     MPIR_Status_set_procnull(&req->status);
 }
 
-/* Complete a request, saving the status data if necessary.
-   If debugger information is being provided for pending (user-initiated)
-   send operations, the macros MPII_SENDQ_FORGET will be defined to
-   call the routine MPII_Sendq_forget; otherwise that macro will be a no-op.
-   The implementation of the MPIR_Sendq_xxx is in src/mpi/debugger/dbginit.c .
-*/
+/* Complete a request, saving the status data if necessary. */
 int MPIR_Request_completion_processing(MPIR_Request * request_ptr, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -72,7 +67,6 @@ int MPIR_Request_completion_processing(MPIR_Request * request_ptr, MPI_Status * 
             {
                 MPIR_Status_set_cancel_bit(status, MPIR_STATUS_GET_CANCEL_BIT(request_ptr->status));
                 mpi_errno = request_ptr->status.MPI_ERROR;
-                MPII_SENDQ_FORGET(request_ptr);
                 break;
             }
         case MPIR_REQUEST_KIND__COLL:

--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -113,8 +113,6 @@ int MPIR_Request_free_impl(MPIR_Request * request_ptr)
     MPID_Progress_poke();
     switch (request_ptr->kind) {
         case MPIR_REQUEST_KIND__SEND:
-            MPII_SENDQ_FORGET(request_ptr);
-            break;
         case MPIR_REQUEST_KIND__RECV:
             break;
         case MPIR_REQUEST_KIND__PREQUEST_SEND:

--- a/src/mpid/ch3/src/ch3u_recvq.c
+++ b/src/mpid/ch3/src/ch3u_recvq.c
@@ -337,6 +337,7 @@ MPIR_Request * MPIDI_CH3U_Recvq_FDU(MPI_Request sreq_id,
 	}
 
     MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
+    MPII_UNEXPQ_FORGET(matching_cur_rreq);
 	rreq = matching_cur_rreq;
 
         MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_buffer_size, rreq->dev.tmpbuf_sz);
@@ -396,6 +397,7 @@ MPIR_Request * MPIDI_CH3U_Recvq_FDU_matchonly(int source, int tag, int context_i
                     }
                     MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
                     MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_buffer_size, rreq->dev.tmpbuf_sz);
+                    MPII_UNEXPQ_FORGET(rreq);
 
                     rreq->comm = comm;
                     MPIR_Comm_add_ref(comm);
@@ -428,6 +430,7 @@ MPIR_Request * MPIDI_CH3U_Recvq_FDU_matchonly(int source, int tag, int context_i
                     }
                     MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
                     MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_buffer_size, rreq->dev.tmpbuf_sz);
+                    MPII_UNEXPQ_FORGET(rreq);
 
                     rreq->comm                 = comm;
                     MPIR_Comm_add_ref(comm);
@@ -510,6 +513,7 @@ MPIR_Request * MPIDI_CH3U_Recvq_FDU_or_AEP(int source, int tag,
 			recvq_unexpected_tail = prev_rreq;
 		    }
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
+            MPII_UNEXPQ_FORGET(rreq);
 
             if (MPIDI_Request_get_msg_type(rreq) == MPIDI_REQUEST_EAGER_MSG)
                 MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_buffer_size, rreq->dev.tmpbuf_sz);
@@ -546,6 +550,7 @@ MPIR_Request * MPIDI_CH3U_Recvq_FDU_or_AEP(int source, int tag,
                         recvq_unexpected_tail = prev_rreq;
                     }
                     MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
+                    MPII_UNEXPQ_FORGET(rreq);
 
                     if (MPIDI_Request_get_msg_type(rreq) == MPIDI_REQUEST_EAGER_MSG)
                         MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_buffer_size, rreq->dev.tmpbuf_sz);
@@ -794,6 +799,7 @@ MPIR_Request * MPIDI_CH3U_Recvq_FDP_or_AEU(MPIDI_Message_match * match,
 				   found=FALSE;goto lock_exit );
         MPIR_Assert(mpi_errno == 0);
         rreq->dev.recv_pending_count = 1;
+        MPII_UNEXPQ_REMEMBER(rreq, match->parts.rank, match->parts.tag, match->parts.context_id);
         /* Reset the error bits if we unset it earlier. */
         if (error_bit_masked) MPIR_TAG_SET_ERROR_BIT(match->parts.tag);
         if (proc_failure_bit_masked) MPIR_TAG_SET_PROC_FAILURE_BIT(match->parts.tag);

--- a/src/mpid/ch3/src/mpid_imrecv.c
+++ b/src/mpid/ch3/src/mpid_imrecv.c
@@ -28,6 +28,7 @@ int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
     rreq->dev.user_buf = buf;
     rreq->dev.user_count = count;
     rreq->dev.datatype = datatype;
+    MPII_RECVQ_REMEMBER(rreq, rreq->status.MPI_SOURCE, rreq->status.MPI_TAG, rreq->comm->recvcontext_id);
 
 #ifdef ENABLE_COMM_OVERRIDES
     MPIDI_Comm_get_vc(comm, rreq->status.MPI_SOURCE, &vc);

--- a/src/mpid/ch3/src/mpid_imrecv.c
+++ b/src/mpid/ch3/src/mpid_imrecv.c
@@ -28,7 +28,7 @@ int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
     rreq->dev.user_buf = buf;
     rreq->dev.user_count = count;
     rreq->dev.datatype = datatype;
-    MPII_RECVQ_REMEMBER(rreq, rreq->status.MPI_SOURCE, rreq->status.MPI_TAG, rreq->comm->recvcontext_id);
+    MPII_RECVQ_REMEMBER(rreq, rreq->status.MPI_SOURCE, rreq->status.MPI_TAG, rreq->comm->recvcontext_id, buf, count);
 
 #ifdef ENABLE_COMM_OVERRIDES
     MPIDI_Comm_get_vc(comm, rreq->status.MPI_SOURCE, &vc);

--- a/src/mpid/ch3/src/mpid_irecv.c
+++ b/src/mpid/ch3/src/mpid_irecv.c
@@ -155,6 +155,7 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
     *request = rreq;
     MPL_DBG_MSG_P(MPIDI_CH3_DBG_OTHER,VERBOSE,"request allocated, handle=0x%08x",
 		   rreq->handle);
+    MPII_RECVQ_REMEMBER(rreq, rank, tag, comm->recvcontext_id);
     MPIR_FUNC_EXIT;
     return mpi_errno;
 

--- a/src/mpid/ch3/src/mpid_irecv.c
+++ b/src/mpid/ch3/src/mpid_irecv.c
@@ -155,7 +155,7 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
     *request = rreq;
     MPL_DBG_MSG_P(MPIDI_CH3_DBG_OTHER,VERBOSE,"request allocated, handle=0x%08x",
 		   rreq->handle);
-    MPII_RECVQ_REMEMBER(rreq, rank, tag, comm->recvcontext_id);
+    MPII_RECVQ_REMEMBER(rreq, rank, tag, comm->recvcontext_id, buf, count);
     MPIR_FUNC_EXIT;
     return mpi_errno;
 

--- a/src/mpid/ch3/src/mpid_irsend.c
+++ b/src/mpid/ch3/src/mpid_irsend.c
@@ -128,6 +128,9 @@ int MPID_Irsend(const void * buf, int count, MPI_Datatype datatype, int rank, in
 
   fn_exit:
     *request = sreq;
+    if (sreq) {
+        MPII_SENDQ_REMEMBER(sreq, rank, tag, comm->recvcontext_id, buf, count);
+    }
 
     MPL_DBG_STMT(MPIDI_CH3_DBG_OTHER,VERBOSE,{
 	if (sreq != NULL)

--- a/src/mpid/ch3/src/mpid_isend.c
+++ b/src/mpid/ch3/src/mpid_isend.c
@@ -160,6 +160,9 @@ int MPID_Isend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
 
   fn_exit:
     *request = sreq;
+    if (sreq) {
+        MPII_SENDQ_REMEMBER(sreq, rank, tag, comm->recvcontext_id, buf, count);
+    }
 
     MPL_DBG_STMT(MPIDI_CH3_DBG_OTHER,VERBOSE,
     {

--- a/src/mpid/ch3/src/mpid_issend.c
+++ b/src/mpid/ch3/src/mpid_issend.c
@@ -104,6 +104,9 @@ int MPID_Issend(const void * buf, int count, MPI_Datatype datatype, int rank, in
 
   fn_exit:
     *request = sreq;
+    if (sreq) {
+        MPII_SENDQ_REMEMBER(sreq, rank, tag, comm->recvcontext_id, buf, count);
+    }
     
     MPL_DBG_STMT(MPIDI_CH3_DBG_OTHER,VERBOSE,
     {

--- a/src/mpid/ch3/src/mpid_recv.c
+++ b/src/mpid/ch3/src/mpid_recv.c
@@ -177,7 +177,7 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
     {
 	MPL_DBG_MSG_P(MPIDI_CH3_DBG_OTHER,VERBOSE,
 		       "request allocated, handle=0x%08x", rreq->handle);
-        MPII_RECVQ_REMEMBER(rreq, rank, tag, comm->recvcontext_id);
+        MPII_RECVQ_REMEMBER(rreq, rank, tag, comm->recvcontext_id, buf, count);
     }
     else
     {

--- a/src/mpid/ch3/src/mpid_recv.c
+++ b/src/mpid/ch3/src/mpid_recv.c
@@ -177,6 +177,7 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
     {
 	MPL_DBG_MSG_P(MPIDI_CH3_DBG_OTHER,VERBOSE,
 		       "request allocated, handle=0x%08x", rreq->handle);
+        MPII_RECVQ_REMEMBER(rreq, rank, tag, comm->recvcontext_id);
     }
     else
     {

--- a/src/mpid/ch3/src/mpid_rsend.c
+++ b/src/mpid/ch3/src/mpid_rsend.c
@@ -130,6 +130,9 @@ int MPID_Rsend(const void * buf, int count, MPI_Datatype datatype, int rank, int
 
   fn_exit:
     *request = sreq;
+    if (sreq) {
+        MPII_SENDQ_REMEMBER(sreq, rank, tag, comm->recvcontext_id, buf, count);
+    }
 
     MPL_DBG_STMT(MPIDI_CH3_DBG_OTHER,VERBOSE,
     {

--- a/src/mpid/ch3/src/mpid_send.c
+++ b/src/mpid/ch3/src/mpid_send.c
@@ -160,6 +160,9 @@ int MPID_Send(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank,
  fn_fail:
  fn_exit:
     *request = sreq;
+    if (sreq) {
+        MPII_SENDQ_REMEMBER(sreq, rank, tag, comm->recvcontext_id, buf, count);
+    }
 
     MPL_DBG_STMT(MPIDI_CH3_DBG_OTHER,VERBOSE,
     {

--- a/src/mpid/ch3/src/mpid_ssend.c
+++ b/src/mpid/ch3/src/mpid_ssend.c
@@ -106,6 +106,9 @@ int MPID_Ssend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
   fn_fail:
   fn_exit:
     *request = sreq;
+    if (sreq) {
+        MPII_SENDQ_REMEMBER(sreq, rank, tag, comm->recvcontext_id, buf, count);
+    }
     
     MPL_DBG_STMT(MPIDI_CH3_DBG_OTHER,VERBOSE,{if (sreq!=NULL) {
             MPL_DBG_MSG_P(MPIDI_CH3_DBG_OTHER,VERBOSE,

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -35,6 +35,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
         *flag = 1;
         req = (MPIR_Request *) MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__MPROBE, vni_dst, 2);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+        req->comm = comm;
+        MPIR_Comm_add_ref(comm);
         MPIDI_UCX_REQ(req).message_handler = message_h;
 
         if (status != MPI_STATUS_IGNORE) {

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -263,25 +263,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
                                         MPI_Datatype datatype, MPIR_Request * message,
                                         MPI_Status * status, MPIR_Request ** rreq)
 {
-    int mpi_errno;
-    MPIR_FUNC_ENTER;
-
-    MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
-    message->kind = MPIR_REQUEST_KIND__RECV;
-
-    if (message->comm && MPIDI_is_self_comm(message->comm)) {
-        mpi_errno = MPIDI_Self_imrecv(buf, count, datatype, message, rreq);
-    } else {
-        *rreq = message;
-        mpi_errno = MPIDI_imrecv(buf, count, datatype, message);
-    }
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
+    return MPID_Imrecv(buf, count, datatype, message, rreq);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -285,7 +285,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf, MPI_Aint count, MPI_Datatype
     MPIR_ERR_CHECK(mpi_errno);
 
     MPII_RECVQ_REMEMBER(message, message->status.MPI_SOURCE, message->status.MPI_TAG,
-                        message->comm->recvcontext_id);
+                        message->comm->recvcontext_id, buf, count);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -315,7 +315,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irecv(void *buf,
 
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPII_RECVQ_REMEMBER(*request, rank, tag, comm->recvcontext_id);
+    MPII_RECVQ_REMEMBER(*request, rank, tag, comm->recvcontext_id, buf, count);
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -283,6 +283,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf, MPI_Aint count, MPI_Datatype
         mpi_errno = MPIDI_imrecv(buf, count, datatype, message);
     }
     MPIR_ERR_CHECK(mpi_errno);
+
+    MPII_RECVQ_REMEMBER(message, message->status.MPI_SOURCE, message->status.MPI_TAG,
+                        message->comm->recvcontext_id);
+
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -310,6 +314,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irecv(void *buf,
     }
 
     MPIR_ERR_CHECK(mpi_errno);
+
+    MPII_RECVQ_REMEMBER(*request, rank, tag, comm->recvcontext_id);
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4_self.c
+++ b/src/mpid/ch4/src/ch4_self.c
@@ -232,6 +232,7 @@ int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int context_offset,
         *message = MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE);
         (*message)->dev.ch4.self.match_req = sreq;
         (*message)->comm = sreq->comm;  /* set so we can check it in MPI_{M,Im}recv */
+        MPIR_Comm_add_ref((*message)->comm);
         MPII_UNEXPQ_FORGET(sreq);
     } else {
         *flag = FALSE;
@@ -246,8 +247,6 @@ int MPIDI_Self_imrecv(char *buf, MPI_Aint count, MPI_Datatype datatype,
 {
     MPIR_FUNC_ENTER;
     MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SELF_MUTEX);
-
-    message->comm = NULL;       /* was set in MPIDI_Self_improbe */
 
     MPIR_Request *sreq = message->dev.ch4.self.match_req;
     MPIR_Request *rreq = message;

--- a/src/mpid/ch4/src/ch4_self.c
+++ b/src/mpid/ch4/src/ch4_self.c
@@ -136,6 +136,7 @@ int MPIDI_Self_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int
     } else {
         sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
         ENQUEUE_SELF_SEND(sreq, buf, count, datatype, tag, comm->context_id);
+        MPII_UNEXPQ_REMEMBER(sreq, rank, tag, comm->context_id);
         sreq->comm = comm;
         MPIR_Comm_add_ref(comm);
         MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -167,6 +168,7 @@ int MPIDI_Self_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
         MPIR_Datatype_release_if_not_builtin(sreq->dev.ch4.self.datatype);
         MPIR_Request_complete(sreq);
         MPIR_cc_set(&rreq->cc, 0);
+        MPII_UNEXPQ_FORGET(sreq);
     } else {
         ENQUEUE_SELF_RECV(rreq, buf, count, datatype, tag, comm->context_id);
         rreq->comm = comm;
@@ -230,6 +232,7 @@ int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int context_offset,
         *message = MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE);
         (*message)->dev.ch4.self.match_req = sreq;
         (*message)->comm = sreq->comm;  /* set so we can check it in MPI_{M,Im}recv */
+        MPII_UNEXPQ_FORGET(sreq);
     } else {
         *flag = FALSE;
     }

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -176,6 +176,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
     }
 
     MPIR_ERR_CHECK(mpi_errno);
+
+    if (*request) {
+        MPII_SENDQ_REMEMBER(*request, rank, tag, comm->recvcontext_id, buf, count);
+    }
+
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -273,6 +278,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
     }
 
     MPIR_ERR_CHECK(mpi_errno);
+
+    if (*request) {
+        MPII_SENDQ_REMEMBER(*request, rank, tag, comm->recvcontext_id, buf, count);
+    }
+
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/src/mpidig_probe.h
+++ b/src/mpid/ch4/src/mpidig_probe.h
@@ -57,6 +57,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
                             MPIDIG_PT2PT_UNEXP);
 
     if (unexp_req) {
+        MPII_UNEXPQ_FORGET(unexp_req);
         *flag = 1;
         *message = unexp_req;
 

--- a/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
@@ -389,6 +389,7 @@ int MPIDIG_send_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
 
         MPIDIG_enqueue_request(rreq, &MPIDI_global.per_vci[local_vci].unexp_list,
                                MPIDIG_PT2PT_UNEXP);
+        MPII_UNEXPQ_REMEMBER(rreq, hdr->src_rank, hdr->tag, hdr->context_id);
     } else {
         /* matched path */
         MPIDIG_REQUEST(rreq, req->remote_vci) = remote_vci;

--- a/src/mpid/ch4/src/mpidig_recv.h
+++ b/src/mpid/ch4/src/mpidig_recv.h
@@ -204,6 +204,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
                             MPIDIG_PT2PT_UNEXP);
 
     if (unexp_req) {
+        MPII_UNEXPQ_FORGET(unexp_req);
         unexp_req->comm = comm;
         MPIR_Comm_add_ref(comm);
         if (MPIDIG_REQUEST(unexp_req, req->status) & MPIDIG_REQ_BUSY) {


### PR DESCRIPTION
## Pull Request Description

This series backports the new message queue dumping interface support to the 4.0.x branch. The MQD interface is known to be broken for ch4 in 4.0.x. See #6131. All patches applied cleanly with `git cherry-pick`, so hopefully this isn't too much of a burden.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
