### PR TITLE
ch4: remove misleading comment

### DIFF
--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -524,10 +524,6 @@ static int win_shm_alloc_impl(MPI_Aint size, int disp_unit, MPIR_Comm * comm_ptr
         MPIR_CHKLMEM_MALLOC(shm_offsets, MPI_Aint *, shm_comm_ptr->local_size * sizeof(MPI_Aint),
                             mpi_errno, "shm offset", MPL_MEM_RMA);
 
-        /* No allreduce here because this is a shared memory domain
-         * and should be a relatively small number of processes
-         * and a non performance sensitive API.
-         */
         for (i = 0; i < shm_comm_ptr->local_size; i++) {
             shm_offsets[i] = (MPI_Aint) total_shm_size;
             if (MPIDIG_WIN(win, info_args).alloc_shared_noncontig)


### PR DESCRIPTION
## Pull Request Description
The comment doesn't make sense and probably should be deleted. The code it commented on is just adding up local sizes. It is likely the "allreduce" comment was meant on replacing the allgather of shared table. But it appears the shared table need to be allgathered anyway. The comment serves as a red herring.

Fixes https://github.com/pmodels/mpich/issues/6120

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
