### PR TITLE
ch4: optimize struct packing in MPIDIG_acc_req_t

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -119,11 +119,11 @@ typedef struct MPIDIG_acc_req_t {
                                  * Not to be confused with result_addr below which saves the
                                  * result_addr parameter. */
     MPI_Aint result_data_sz;    /* only used in GET_ACC */
-    MPI_Op op;
     void *result_addr;
     MPI_Aint result_count;
     void *origin_addr;
     MPI_Datatype result_datatype;
+    MPI_Op op;
 } MPIDIG_acc_req_t;
 
 typedef int (*MPIDIG_req_cmpl_cb) (MPIR_Request * req);

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -15,7 +15,7 @@
 #define MPIDIU_MAP_NOT_FOUND      ((void*)(-1UL))
 
 #define MPIDIU_REQUEST_POOL_NUM_CELLS_PER_CHUNK (1024)
-#define MPIDIU_REQUEST_POOL_CELL_SIZE (512)
+#define MPIDIU_REQUEST_POOL_CELL_SIZE (256)
 
 /* Flags for MPIDI_Progress_test
  *


### PR DESCRIPTION
## Pull Request Description

Put two 4-byte fields together allows the struct size to shrink by 8
bytes, just enough to get the size of `MPIDIG_req_ext_t` back to 256.

Fixes https://github.com/pmodels/mpich/issues/6136

## NOTES
Resulting sizes:
```
sizeof(MPIDIG_req_ext_t):      256
sizeof(MPIDIG_acc_req_t):      96 
```
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
