### PR TITLE
mpl/cuda: Avoid crash when global device id is not visible

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -358,7 +358,10 @@ int MPL_gpu_finalize(void)
 
 int MPL_gpu_global_to_local_dev_id(int global_dev_id)
 {
-    assert(global_dev_id <= max_dev_id);
+    if (global_dev_id > max_dev_id) {
+        return -1;
+    }
+
     return global_to_local_map[global_dev_id];
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -280,10 +280,8 @@ int MPL_gpu_init(int debug_summary)
     if (visible_devices) {
         local_to_global_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
 
-        uintptr_t len = strlen(visible_devices);
-        char *devices = MPL_malloc(len + 1, MPL_MEM_OTHER);
+        char *devices = MPL_strdup(visible_devices);
         char *free_ptr = devices;
-        memcpy(devices, visible_devices, len + 1);
         for (int i = 0; i < device_count; i++) {
             char *tmp = strtok(devices, ",");
             assert(tmp);


### PR DESCRIPTION
## Pull Request Description

If GPU visibility is enabled, some devices may have a higher global id
than the local max. Just return -1 to indicate we cannot see this
device. Fixes a crash in the IPC code when exclusive visibility is
used, e.g. `-gpus-per-proc <n>`.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
