### PR TITLE
ch3: fix dynamic message mixups

### DIFF
--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -501,11 +501,9 @@ static int MPIDI_CH3I_Initialize_tmp_comm(MPIR_Comm **comm_pptr,
     /* We use the second half of the context ID bits for dynamic
      * processes. This assumes that the context ID mask array is made
      * up of uint32_t's. */
-    /* FIXME: This code is still broken for the following case:
-     * If the same process opens connections to the multiple
-     * processes, this context ID might get out of sync.
-     */
-    tmp_comm->context_id     = MPIR_CONTEXT_SET_FIELD(DYNAMIC_PROC, context_id_offset, 1);
+    int context_id;
+    context_id = context_id_offset << MPIR_CONTEXT_PREFIX_SHIFT;
+    tmp_comm->context_id     = MPIR_CONTEXT_SET_FIELD(DYNAMIC_PROC, context_id, 1);
     tmp_comm->recvcontext_id = tmp_comm->context_id;
 
     /* sanity: the INVALID context ID value could potentially conflict with the

--- a/src/pm/hydra/lib/utils/sock.c
+++ b/src/pm/hydra/lib/utils/sock.c
@@ -241,7 +241,7 @@ HYD_status HYDU_sock_write(int fd, const void *buf, int maxlen, int *sent, int *
     while (1) {
         tmp = write(fd, (char *) buf + *sent, maxlen - *sent);
         if (tmp <= 0) {
-            if (errno == EAGAIN) {
+            if (errno == EAGAIN || errno == EINTR) {
                 if (flag == HYDU_SOCK_COMM_NONE)
                     goto fn_exit;
                 else


### PR DESCRIPTION
## Pull Request Description

In ch3, we create a temporary root-to-root intercomm during the connect/accept process. It uses a hacky context id system generated by the spawner when it creates the port. However, the context id was not properly shifted, resulting the collective messages mixed up with pt2pt messages from a neighbor comm.

This PR fixes the sporadic `threads/spawn/th_taskmanager 2` test in ch3. The test failure shows up after this commit https://github.com/pmodels/mpich/pull/6186/commits/9c30f178a67571e7dea8ef8c6882416e1222d424, since the clean-up of unmatched messages at comm release time removes the mixup messages from neighboring comm.

In addition, we fixed an issue in hydra that an interrupt such as SIGCHLD may cause a `write` to return `EINTR` and resulting in fatal failure.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
