### PR TITLE
hydra: fix proxy topolib init

### DIFF
--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -130,11 +130,6 @@ int main(int argc, char **argv)
     status = init_params();
     HYDU_ERR_POP(status, "Error initializing proxy params\n");
 
-    status = HYDT_topo_init(HYD_pmcd_pmip.user_global.topolib,
-                            HYD_pmcd_pmip.user_global.binding,
-                            HYD_pmcd_pmip.user_global.mapping, HYD_pmcd_pmip.user_global.membind);
-    HYDU_ERR_POP(status, "unable to initialize process topology\n");
-
     status = HYD_pmcd_pmip_get_params(argv);
     HYDU_ERR_POP(status, "bad parameters passed to the proxy\n");
 

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -973,6 +973,12 @@ HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
         status = procinfo(fd);
         HYDU_ERR_POP(status, "error parsing process info\n");
 
+        status = HYDT_topo_init(HYD_pmcd_pmip.user_global.topolib,
+                                HYD_pmcd_pmip.user_global.binding,
+                                HYD_pmcd_pmip.user_global.mapping,
+                                HYD_pmcd_pmip.user_global.membind);
+        HYDU_ERR_POP(status, "unable to initialize process topology\n");
+
         if (HYD_pmcd_pmip.user_global.singleton_port > 0) {
             status = singleton_init();
             HYDU_ERR_POP(status, "singleton_init returned error\n");


### PR DESCRIPTION
## Pull Request Description

The topolib cannot be initialized until the procinfo has been read, since it contains the binding information.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
