### PR TITLE
datatype: support packing/unpacking mixed memory types

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -53,3 +53,4 @@ Portions of this code have been contributed under the above license by:
  * Dolphin Interconnect Solutions Inc.
  * Institut Polytechnique de Bordeaux
  * Quobyte Corporation
+ * ParTec AG

--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -111,7 +111,8 @@ MPI_Pack:
     message.
 */
 { -- error_check -- inbuf, outbuf
-    if (incount > 0) {
+    /* MPI_BOTTOM cannot be used when count > 1 */
+    if (incount > 1) {
         MPIR_ERRTEST_ARGNULL(inbuf, "inbuf", mpi_errno);
     }
 }
@@ -151,7 +152,8 @@ MPI_Unpack:
     .seealso: MPI_Pack, MPI_Pack_size
     .poly_impl: use_aint
 { -- error_check -- inbuf, outbuf
-    if (outcount > 0) {
+    /* MPI_BOTTOM cannot be used when count > 1 */
+    if (outcount > 1) {
         MPIR_ERRTEST_ARGNULL(outbuf, "outbuf", mpi_errno);
     }
 }

--- a/test/mpi/datatype/Makefile.am
+++ b/test/mpi/datatype/Makefile.am
@@ -63,6 +63,8 @@ noinst_PROGRAMS =             \
     struct_no_real_types      \
     struct_pack               \
     structpack2               \
+    struct_pack_mpi_bottom    \
+    struct_unpack_mpi_bottom  \
     struct_verydeep           \
     struct_zero_count         \
     subarray                  \

--- a/test/mpi/datatype/struct_pack_mpi_bottom.c
+++ b/test/mpi/datatype/struct_pack_mpi_bottom.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <mpi.h>
+#include "mpitest.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+#define my_assert(cond_)                                                  \
+    do {                                                                  \
+        if (!(cond_)) {                                                   \
+            fprintf(stderr, "assertion (%s) failed, aborting\n", #cond_); \
+            MPI_Abort(MPI_COMM_WORLD, 1);                                 \
+        }                                                                 \
+    } while (0)
+
+static const int SQ_LIMIT = 10;
+static int SQ_COUNT = 0;
+static int SQ_VERBOSE = 0;
+
+#define SQUELCH(X) \
+    do { \
+        if (SQ_COUNT < SQ_LIMIT || SQ_VERBOSE) { \
+            SQ_COUNT++; \
+            X; \
+        } \
+    } while (0)
+
+#define BUF_LEN_ZERO  (64*1024)
+#define BUF_LEN_ONE   (4*1024)
+#define BUF_LEN_TOTAL (BUF_LEN_ZERO+BUF_LEN_ONE)
+#define BUF_VAL_ZERO  (0x42)
+#define BUF_VAL_ONE   (0x13)
+
+#define STAGE_BUF (0)
+#define MAIN_BUF  (1)
+
+static const char bufvals[2] = { BUF_VAL_ZERO, BUF_VAL_ONE };
+
+#if defined(HAVE_CUDA) || defined(HAVE_ZE) || defined(HAVE_HIP)
+#define MEMTYPE_COUNT (2)
+static mtest_mem_type_e memtypes[MEMTYPE_COUNT] = {
+    MTEST_MEM_TYPE__UNREGISTERED_HOST,
+    MTEST_MEM_TYPE__DEVICE
+};
+#else
+#define MEMTYPE_COUNT (1)
+static mtest_mem_type_e memtypes[MEMTYPE_COUNT] = {
+    MTEST_MEM_TYPE__UNREGISTERED_HOST,
+};
+#endif
+
+static void create_and_pack_datatype(void *outbuf, int blocks[2],
+                                     MPI_Aint displs[2], MPI_Datatype types[2])
+{
+    MPI_Datatype tmp_type;
+    int position = 0;
+    int packsize = 0;
+
+    /* create the datatype and verify the packsize */
+    MPI_Type_create_struct(2, blocks, displs, types, &tmp_type);
+    MPI_Type_commit(&tmp_type);
+    MPI_Pack_size(1, tmp_type, MPI_COMM_WORLD, &packsize);
+    my_assert(packsize == BUF_LEN_TOTAL);
+
+    /* do the actual packing */
+    MPI_Pack(MPI_BOTTOM, 1, tmp_type, outbuf, packsize, &position, MPI_COMM_WORLD);
+
+    /* free the datatype and the input buffers */
+    MPI_Type_free(&tmp_type);
+
+}
+
+
+static
+void alloc_and_init_buffers(void *inbufs[2][2], MPI_Aint displs[2], int blocks[2],
+                            mtest_mem_type_e memtypes[2])
+{
+    for (int inbuf = 0; inbuf < 2; ++inbuf) {
+        MTestCalloc(blocks[inbuf], memtypes[inbuf],
+                    (void **) &inbufs[inbuf][STAGE_BUF], (void **) &inbufs[inbuf][MAIN_BUF], 0);
+
+        memset(inbufs[inbuf][0], bufvals[inbuf], blocks[inbuf]);
+
+        MTestCopyContent(inbufs[inbuf][STAGE_BUF], inbufs[inbuf][MAIN_BUF],
+                         blocks[inbuf], memtypes[inbuf]);
+
+        MPI_Get_address(inbufs[inbuf][MAIN_BUF], &displs[inbuf]);
+    }
+}
+
+
+static
+void free_and_check_buffers(void *inbufs[2][2], mtest_mem_type_e memtypes[2],
+                            void *outbufs[2], mtest_mem_type_e outb_memtype, int *errs)
+{
+    char *check_buf = (char *) outbufs[STAGE_BUF];
+
+    /* check the output buffer */
+    MTestCopyContent(outbufs[MAIN_BUF], outbufs[STAGE_BUF], BUF_LEN_TOTAL, outb_memtype);
+
+    for (int i = 0; i < BUF_LEN_ZERO; ++i) {
+        if (check_buf[i] != BUF_VAL_ZERO) {
+            SQUELCH(printf("Error: check_buf[%d] = %x != %x\n", i, check_buf[i], BUF_VAL_ZERO));
+            ++(*errs);
+        }
+    }
+    SQ_COUNT = 0;
+
+    for (int i = 0; i < BUF_LEN_ONE; ++i) {
+        int buf_pos = BUF_LEN_ZERO + i;
+        if (check_buf[buf_pos] != BUF_VAL_ONE) {
+            SQUELCH(printf("Error: check_buf[%d] = %x != %x\n",
+                           buf_pos, check_buf[buf_pos], BUF_VAL_ONE));
+            ++errs;
+        }
+    }
+    SQ_COUNT = 0;
+
+    /* free the input buffers */
+    for (int cur_inbuf = 0; cur_inbuf < 2; ++cur_inbuf) {
+        MTestFree(memtypes[cur_inbuf], inbufs[cur_inbuf][STAGE_BUF], inbufs[cur_inbuf][MAIN_BUF]);
+    }
+
+    /* reset the output buffer */
+    memset(outbufs[STAGE_BUF], 0, BUF_LEN_TOTAL);
+    MTestCopyContent(outbufs[STAGE_BUF], outbufs[MAIN_BUF], BUF_LEN_TOTAL, outb_memtype);
+}
+
+
+static const char *memtype_str(mtest_mem_type_e memtype)
+{
+    static char buf[64];
+
+    switch (memtype) {
+        case MTEST_MEM_TYPE__UNREGISTERED_HOST:
+            return "host";
+#ifdef HAVE_CUDA
+        case MTEST_MEM_TYPE__DEVICE:
+            return "cuda";
+#elif HAVE_HIP
+        case MTEST_MEM_TYPE__DEVICE:
+            return "hip";
+#elif HAVE_ZE
+        case MTEST_MEM_TYPE__DEVICE:
+            return "ze";
+#endif
+    }
+
+    snprintf(buf, sizeof(buf), "%d", memtype);
+    return buf;
+}
+
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    int verbose = 0;
+
+    void *inbufs[2][2];
+    void *outbufs[2];
+
+    MPI_Datatype types[2] = { MPI_BYTE, MPI_BYTE };
+    int blocks[2] = { BUF_LEN_ZERO, BUF_LEN_ONE };
+    MPI_Aint displs[2] = { 0, 0 };
+    mtest_mem_type_e inbuf_mtypes[2];
+    mtest_mem_type_e outb_memtype;
+
+    MTest_Init(&argc, &argv);
+
+    mtest_mem_type_e memtypes[2] = {
+        MTEST_MEM_TYPE__UNREGISTERED_HOST,
+        MTEST_MEM_TYPE__DEVICE
+    };
+
+    /* iterate all combinations of input and output memory types */
+    for (int h = 0; h < MEMTYPE_COUNT; ++h) {
+        outb_memtype = memtypes[h];
+
+        /* allocate the output buffer */
+        MTestCalloc(BUF_LEN_TOTAL, outb_memtype, (void **) &outbufs[STAGE_BUF],
+                    (void **) &outbufs[MAIN_BUF], 0);
+
+        for (int i = 0; i < MEMTYPE_COUNT; ++i) {
+            inbuf_mtypes[0] = memtypes[i];
+
+            for (int j = 0; j < MEMTYPE_COUNT; ++j) {
+                inbuf_mtypes[1] = memtypes[j];
+
+                alloc_and_init_buffers(inbufs, displs, blocks, inbuf_mtypes);
+
+                if (verbose) {
+                    printf("Pack: { %s (%16p); %s (%16p) } -> %s (%16p)\n",
+                           memtype_str(inbuf_mtypes[0]), inbufs[0][MAIN_BUF],
+                           memtype_str(inbuf_mtypes[1]), inbufs[1][MAIN_BUF],
+                           memtype_str(outb_memtype), outbufs[MAIN_BUF]);
+                }
+
+                create_and_pack_datatype(outbufs[MAIN_BUF], blocks, displs, types);
+
+                free_and_check_buffers(inbufs, inbuf_mtypes, outbufs, outb_memtype, &errs);
+
+            }
+        }
+
+        MTestFree(memtypes[outb_memtype], outbufs[STAGE_BUF], outbufs[MAIN_BUF]);
+    }
+
+    MTest_Finalize(errs);
+
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/datatype/struct_unpack_mpi_bottom.c
+++ b/test/mpi/datatype/struct_unpack_mpi_bottom.c
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <mpi.h>
+#include "mpitest.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+#define my_assert(cond_)                                                  \
+    do {                                                                  \
+        if (!(cond_)) {                                                   \
+            fprintf(stderr, "assertion (%s) failed, aborting\n", #cond_); \
+            MPI_Abort(MPI_COMM_WORLD, 1);                                 \
+        }                                                                 \
+    } while (0)
+
+static const int SQ_LIMIT = 10;
+static int SQ_COUNT = 0;
+static int SQ_VERBOSE = 0;
+
+#define SQUELCH(X) \
+    do { \
+        if (SQ_COUNT < SQ_LIMIT || SQ_VERBOSE) { \
+            SQ_COUNT++; \
+            X; \
+        } \
+    } while (0)
+
+#define BUF_LEN_ZERO  (64*1024)
+#define BUF_LEN_ONE   (4*1024)
+#define BUF_LEN_TOTAL (BUF_LEN_ZERO+BUF_LEN_ONE)
+#define BUF_VAL_ZERO  (0x42)
+#define BUF_VAL_ONE   (0x13)
+
+#define STAGE_BUF (0)
+#define MAIN_BUF  (1)
+
+static const char bufvals[2] = { BUF_VAL_ZERO, BUF_VAL_ONE };
+
+#if defined(HAVE_CUDA) || defined(HAVE_ZE) || defined(HAVE_HIP)
+#define MEMTYPE_COUNT (2)
+static mtest_mem_type_e memtypes[MEMTYPE_COUNT] = {
+    MTEST_MEM_TYPE__UNREGISTERED_HOST,
+    MTEST_MEM_TYPE__DEVICE
+};
+#else
+#define MEMTYPE_COUNT (1)
+static mtest_mem_type_e memtypes[MEMTYPE_COUNT] = {
+    MTEST_MEM_TYPE__UNREGISTERED_HOST,
+};
+#endif
+
+static void create_and_unpack_datatype(void *inbuf, int blocks[2],
+                                       MPI_Aint displs[2], MPI_Datatype types[2])
+{
+    MPI_Datatype tmp_type;
+    int position = 0;
+    int packsize = 0;
+
+    /* create the datatype and verify the packsize */
+    MPI_Type_create_struct(2, blocks, displs, types, &tmp_type);
+    MPI_Type_commit(&tmp_type);
+    MPI_Pack_size(1, tmp_type, MPI_COMM_WORLD, &packsize);
+    my_assert(packsize == BUF_LEN_TOTAL);
+
+    /* do the actual packing */
+    MPI_Unpack(inbuf, packsize, &position, MPI_BOTTOM, 1, tmp_type, MPI_COMM_WORLD);
+
+    /* free the datatype and the input buffers */
+    MPI_Type_free(&tmp_type);
+
+}
+
+
+static
+void alloc_buffers(void *outbufs[2][2], MPI_Aint displs[2], int blocks[2],
+                   mtest_mem_type_e memtypes[2])
+{
+    for (int outbuf = 0; outbuf < 2; ++outbuf) {
+        MTestCalloc(blocks[outbuf], memtypes[outbuf],
+                    (void **) &outbufs[outbuf][STAGE_BUF], (void **) &outbufs[outbuf][MAIN_BUF], 0);
+
+        MPI_Get_address(outbufs[outbuf][MAIN_BUF], &displs[outbuf]);
+    }
+}
+
+
+static
+void free_and_check_buffers(void *outbufs[2][2], mtest_mem_type_e memtypes[2],
+                            int blocks[2], int *errs)
+{
+    /* check the output buffer */
+    for (int cur_outbuf = 0; cur_outbuf < 2; ++cur_outbuf) {
+        MTestCopyContent(outbufs[cur_outbuf][MAIN_BUF],
+                         outbufs[cur_outbuf][STAGE_BUF], blocks[cur_outbuf], memtypes[cur_outbuf]);
+
+        char *check_buf = (char *) outbufs[cur_outbuf][STAGE_BUF];
+
+        for (int i = 0; i < blocks[cur_outbuf]; ++i) {
+            if (check_buf[i] != bufvals[cur_outbuf]) {
+                SQUELCH(printf("Error: check_buf[%d] = %x != %x\n", i,
+                               check_buf[i], bufvals[cur_outbuf]));
+                ++(*errs);
+            }
+        }
+        SQ_COUNT = 0;
+
+        /* free the output buffers */
+        MTestFree(memtypes[cur_outbuf], outbufs[cur_outbuf][STAGE_BUF],
+                  outbufs[cur_outbuf][MAIN_BUF]);
+    }
+}
+
+
+static const char *memtype_str(mtest_mem_type_e memtype)
+{
+    static char buf[64];
+
+    switch (memtype) {
+        case MTEST_MEM_TYPE__UNREGISTERED_HOST:
+            return "host";
+#ifdef HAVE_CUDA
+        case MTEST_MEM_TYPE__DEVICE:
+            return "cuda";
+#elif HAVE_HIP
+        case MTEST_MEM_TYPE__DEVICE:
+            return "hip";
+#elif HAVE_ZE
+        case MTEST_MEM_TYPE__DEVICE:
+            return "ze";
+#endif
+    }
+
+    snprintf(buf, sizeof(buf), "%d", memtype);
+    return buf;
+}
+
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    int verbose = 0;
+
+    void *inbufs[2];
+    void *outbufs[2][2];
+
+    MPI_Datatype types[2] = { MPI_BYTE, MPI_BYTE };
+    int blocks[2] = { BUF_LEN_ZERO, BUF_LEN_ONE };
+    MPI_Aint displs[2] = { 0, 0 };
+    mtest_mem_type_e outbuf_mtypes[2];
+    mtest_mem_type_e inbuf_mtype;
+
+    MTest_Init(&argc, &argv);
+
+    /* iterate all combinations of input and output memory types */
+    for (int h = 0; h < MEMTYPE_COUNT; ++h) {
+        inbuf_mtype = memtypes[h];
+
+        /* allocate the input buffer */
+        MTestCalloc(BUF_LEN_TOTAL, inbuf_mtype, (void **) &inbufs[STAGE_BUF],
+                    (void **) &inbufs[1], 0);
+
+        /* initialize the input buffer */
+        memset(inbufs[STAGE_BUF], bufvals[0], BUF_LEN_ZERO);
+        memset(inbufs[STAGE_BUF] + BUF_LEN_ZERO, bufvals[1], BUF_LEN_ONE);
+        MTestCopyContent(inbufs[STAGE_BUF], inbufs[MAIN_BUF], BUF_LEN_TOTAL, inbuf_mtype);
+
+        for (int i = 0; i < MEMTYPE_COUNT; ++i) {
+            outbuf_mtypes[0] = memtypes[i];
+
+            for (int j = 0; j < MEMTYPE_COUNT; ++j) {
+                outbuf_mtypes[1] = memtypes[j];
+
+                alloc_buffers(outbufs, displs, blocks, outbuf_mtypes);
+
+                if (verbose) {
+                    printf("Unpack: { %s (%16p) -> %s (%16p); %s (%16p) }\n",
+                           memtype_str(inbuf_mtype), inbufs[1],
+                           memtype_str(outbuf_mtypes[0]), outbufs[0][MAIN_BUF],
+                           memtype_str(outbuf_mtypes[1]), outbufs[1][MAIN_BUF]);
+                }
+
+                create_and_unpack_datatype(inbufs[MAIN_BUF], blocks, displs, types);
+
+                free_and_check_buffers(outbufs, outbuf_mtypes, blocks, &errs);
+
+            }
+        }
+
+        MTestFree(inbuf_mtype, inbufs[STAGE_BUF], inbufs[MAIN_BUF]);
+    }
+
+    MTest_Finalize(errs);
+
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/datatype/testlist.in
+++ b/test/mpi/datatype/testlist.in
@@ -12,8 +12,8 @@ transpose_pack_oldapi 1 strict=FALSE
 slice_pack 1
 struct_pack 1
 structpack2 1
-struct_pack_mpi_bottom 1
-struct_unpack_mpi_bottom 1
+struct_pack_mpi_bottom 1 gpu=yes
+struct_unpack_mpi_bottom 1 gpu=yes
 typecommit 1
 typename 1
 typename_oldapi 1 strict=FALSE

--- a/test/mpi/datatype/testlist.in
+++ b/test/mpi/datatype/testlist.in
@@ -12,6 +12,8 @@ transpose_pack_oldapi 1 strict=FALSE
 slice_pack 1
 struct_pack 1
 structpack2 1
+struct_pack_mpi_bottom 1
+struct_unpack_mpi_bottom 1
 typecommit 1
 typename 1
 typename_oldapi 1 strict=FALSE

--- a/test/mpi/runtests
+++ b/test/mpi/runtests
@@ -399,13 +399,6 @@ sub LoadTests {
             }
 
             my $test_opt = {args=>[], envs=>[], mpiexecargs=>[]};
-            if ($g_opt{has_gpu_test}) {
-                if ($_f ne "testlist.gpu" and $curdir !~ /\bcuda$/) {
-                    push @{$test_opt->{envs}}, "MPIR_CVAR_ENABLE_GPU=0";
-                } else {
-                    push @{$test_opt->{envs}}, "MPIR_CVAR_ENABLE_GPU=1";
-                }
-            }
 
             my $np = "";
             my $requiresStrict = "";
@@ -421,7 +414,7 @@ sub LoadTests {
                 if ($args[$i] =~ /([^=]+)=(.*)/) {
                     my $key = $1;
                     my $value = $2;
-                    if ($key =~ /^(resultTest|init|timeLimit|xfail|lock|mem)$/) {
+                    if ($key =~ /^(resultTest|init|timeLimit|xfail|lock|mem|gpu)$/) {
                         $test_opt->{$key} = $value;
                     }
                     elsif ($key eq "arg") {
@@ -439,6 +432,16 @@ sub LoadTests {
                     else {
                         print STDERR "Unrecognized key $key in $listfileSource\n";
                     }
+                }
+            }
+
+            if ($g_opt{has_gpu_test}) {
+                if ($test_opt->{gpu}) {
+                    push @{$test_opt->{envs}}, "MPIR_CVAR_ENABLE_GPU=1";
+                } elsif ($_f eq "testlist.gpu" or $curdir =~ /\bcuda$/) {
+                    push @{$test_opt->{envs}}, "MPIR_CVAR_ENABLE_GPU=1";
+                } else {
+                    push @{$test_opt->{envs}}, "MPIR_CVAR_ENABLE_GPU=0";
                 }
             }
 


### PR DESCRIPTION
## Pull Request Description

Currently when using yaska, MPICH assumes all memory regions to have the same memory type. However, this is not necessarily true (e.g., [when using absolute addressing with `MPI_BOTTOM`](https://github.com/pmodels/mpich/blob/main/src/mpi/coll/gather/gather_intra_binomial.c#L276-L277)). These patches avoid querying the pointer attributes in case of absolute addressing on the MPICH level and let yaksa do the work. Additionally, two tests are added for testing the packing/unpacking in such cases across all combinations of host and device memory.

This PR corresponds to https://github.com/pmodels/yaksa/pull/234

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
