### PR TITLE
ch4/release_gather: fix dereference utarray_eltptr

### DIFF
--- a/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
@@ -285,9 +285,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_gather_completion(void *v, int *d
 
     /* Gather phase begins */
     for (i = 0; i < num_children; i++) {
+        int child_rank = *(int *) utarray_eltptr(children, i);
         child_gather_flag_addr =
-            MPIDI_POSIX_RELEASE_GATHER_NB_IBCAST_GATHER_FLAG_ADDR(*utarray_eltptr(children, i),
-                                                                  segment, num_ranks);
+            MPIDI_POSIX_RELEASE_GATHER_NB_IBCAST_GATHER_FLAG_ADDR(child_rank, segment, num_ranks);
         if (MPL_atomic_acquire_load_uint64(child_gather_flag_addr) != per_call_data->seq_no) {
             *done = 0;
             return MPI_SUCCESS;

--- a/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
@@ -169,9 +169,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_gather_step_completion(void *v, i
     /* Gather phase begins */
     /* Wait for all my children to arrive */
     for (i = 0; i < num_children; i++) {
+        int child_rank = *(int *) utarray_eltptr(children, i);
         child_gather_flag_addr =
-            MPIDI_POSIX_RELEASE_GATHER_NB_IREDUCE_GATHER_FLAG_ADDR(*utarray_eltptr(children, i),
-                                                                   segment, num_ranks);
+            MPIDI_POSIX_RELEASE_GATHER_NB_IREDUCE_GATHER_FLAG_ADDR(child_rank, segment, num_ranks);
         if (MPL_atomic_acquire_load_uint64(child_gather_flag_addr) != per_call_data->seq_no) {
             /* Set *done to 0 even if a single child has not arrived */
             *done = 0;

--- a/src/mpid/ch4/shm/posix/release_gather/nb_release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_release_gather.c
@@ -266,15 +266,13 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
         }
 
         /* Store address of each of the children's reduce buffer */
+        char *addr;
+        addr = NB_RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr);
         for (i = 0; i < NB_RELEASE_GATHER_FIELD(comm_ptr, reduce_tree.num_children); i++) {
-            MPIR_ERR_CHKANDJUMP(!utarray_eltptr
-                                (NB_RELEASE_GATHER_FIELD(comm_ptr, reduce_tree.children), i),
-                                mpi_errno, MPI_ERR_OTHER, "**nomem");
+            int child_rank =
+                *(int *) utarray_eltptr(NB_RELEASE_GATHER_FIELD(comm_ptr, reduce_tree).children, i);
             NB_RELEASE_GATHER_FIELD(comm_ptr, child_reduce_buf_addr[i]) =
-                (char *) NB_RELEASE_GATHER_FIELD(comm_ptr,
-                                                 reduce_buf_addr) +
-                ((*utarray_eltptr(NB_RELEASE_GATHER_FIELD(comm_ptr, reduce_tree.children), i))
-                 * MPIR_CVAR_REDUCE_INTRANODE_BUFFER_TOTAL_SIZE);
+                addr + (child_rank * MPIR_CVAR_REDUCE_INTRANODE_BUFFER_TOTAL_SIZE);
         }
     }
 

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -429,15 +429,13 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
         MPIR_ERR_CHECK(mpi_errno_ret);
 
         /* Store address of each of the children's reduce buffer */
+        char *addr;
+        addr = RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr);
         for (i = 0; i < RELEASE_GATHER_FIELD(comm_ptr, reduce_tree.num_children); i++) {
-            MPIR_ERR_CHKANDJUMP(!utarray_eltptr
-                                (RELEASE_GATHER_FIELD(comm_ptr, reduce_tree.children), i),
-                                mpi_errno, MPI_ERR_OTHER, "**nomem");
+            int child_rank =
+                *(int *) utarray_eltptr(RELEASE_GATHER_FIELD(comm_ptr, reduce_tree).children, i);
             RELEASE_GATHER_FIELD(comm_ptr, child_reduce_buf_addr[i]) =
-                (char *) RELEASE_GATHER_FIELD(comm_ptr,
-                                              reduce_buf_addr) +
-                ((*utarray_eltptr(RELEASE_GATHER_FIELD(comm_ptr, reduce_tree.children), i))
-                 * RELEASE_GATHER_FIELD(comm_ptr, reduce_shm_size));
+                addr + (child_rank * RELEASE_GATHER_FIELD(comm_ptr, reduce_shm_size));
         }
     }
 

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -317,9 +317,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_gather(const void *i
     /* Leaf nodes never skip checking */
     if (num_children == 0 || !skip_checking) {
         for (i = 0; i < num_children; i++) {
-            MPIR_ERR_CHKANDJUMP(!utarray_eltptr(children, i), mpi_errno, MPI_ERR_OTHER, "**nomem");
-            child_flag_addr =
-                MPIDI_POSIX_RELEASE_GATHER_GATHER_FLAG_ADDR(*utarray_eltptr(children, i));
+            int child_rank = *(int *) utarray_eltptr(children, i);
+            child_flag_addr = MPIDI_POSIX_RELEASE_GATHER_GATHER_FLAG_ADDR(child_rank);
             /* Wait until the child has arrived */
             MPIDI_POSIX_RELEASE_GATHER_WAIT_WHILE_LESS_THAN(child_flag_addr,
                                                             release_gather_info_ptr->gather_state -


### PR DESCRIPTION
## Pull Request Description

The utarray_eltptr returns a char * pointer and always need cast to properly dereference.

Remove the assertion on utarray_eltptr since the memory is already allocated by utarray.

Use local variables to reduce clutter.

[skip warnings]
Fixes https://github.com/pmodels/mpich/issues/6227

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
