### PR TITLE
Fix memory leak in ADIOI_GPFS_WriteStridedColl with ROMIO_TUNEGATHER=1

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -187,8 +187,8 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
                     count_sizes[ii] = gpfs_offsets[ii * 3 + 2];
                 }
             } else {
-                gpfs_offsets0 = (ADIO_Offset *) ADIOI_Malloc(2 * nprocs * sizeof(ADIO_Offset));
-                gpfs_offsets = (ADIO_Offset *) ADIOI_Malloc(2 * nprocs * sizeof(ADIO_Offset));
+                gpfs_offsets0 = (ADIO_Offset *) ADIOI_Malloc(4 * nprocs * sizeof(ADIO_Offset));
+                gpfs_offsets = gpfs_offsets0 + 2 * nprocs;
                 for (ii = 0; ii < nprocs; ii++) {
                     gpfs_offsets0[ii * 2] = 0;
                     gpfs_offsets0[ii * 2 + 1] = 0;


### PR DESCRIPTION
## Pull Request Description

* Fix memory leak in write collectives with `ROMIO_TUNEGATHER=1`
* The leak seems to be introduced in dce1b9e19cc04ffa566078406fa4f0fa18ecb8ff

## Context / Details

* with our long-running application we noticed that memory usage increases from a few GBs to hundreds of GBs.
* we noticed this with HPE MPI and thought this was a vendor library-related issue. HPE support suggested ROMIO_TUNEGATHER=0 as a temporary workaround.
* I started looking [ad_gpfs_wrcoll.c](https://github.com/pmodels/mpich/blob/ac869f20fb0d3feb0103ecc0cfdbbd58f30a83a0/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c#L190) and seems like there is a memory leak from one of the offset arrays being not freed. I believe this is introduced in dce1b9e19cc04ffa566078406fa4f0fa18ecb8ff where multiple malloc/callos were combined. (I assume this missed from the code review because [git diff](https://github.com/pmodels/mpich/commit/dce1b9e19cc04ffa566078406fa4f0fa18ecb8ff#diff-8313fb7fce6996a6c64931d5af684d49a7a46070e469e7887ec1eaa34884e29b) doesn't show the code section where multiple mallocs are used for offsets)
* In this tiny patch we combine two mallocs into one as it was done at other places in order to avoid memory leak.
* Valgrind with locally installed MPICH on GPFS shows:
```console
==105611==
==105611== 480,320 bytes in 3,002 blocks are definitely lost in loss record 17 of 17
==105611==    at 0x4044927: malloc (vg_replace_malloc.c:380)
==105611==    by 0x6C0D897: MPL_malloc (mpl_trmem.h:280)
==105611==    by 0x6C0D897: ADIOI_Malloc_fn (malloc.c:41)
==105611==    by 0x6BED020: ADIOI_GPFS_WriteStridedColl (ad_gpfs_wrcoll.c:191)
==105611==    by 0x6BE306B: MPIOI_File_write_all (write_all.c:168)
==105611==    by 0x6BE3730: PMPI_File_write_at_all (write_atall.c:71)
==105611==    by 0x401399: main (mpiio_reproducer.c:45)
==105611==
==105611== LEAK SUMMARY:
==105611==    definitely lost: 480,320 bytes in 3,002 blocks
==105611==    indirectly lost: 0 bytes in 0 blocks
==105611==      possibly lost: 0 bytes in 0 blocks
==105611==    still reachable: 695,251 bytes in 8,058 blocks
==105611==         suppressed: 0 bytes in 0 blocks
==105611==
```
* Without this patch and simple reproducer [posted here](https://gist.github.com/pramodk/73f330fdfbfcae717a700064d479e0de#file-mpiio_reproducer-c) shows memory usage is gradually increasing:
```console
$ ROMIO_TUNEGATHER=1 ROMIO_FSTYPE_FORCE="gpfs:" LD_LIBRARY_PATH=/gpfs/bbp.cscs.ch/home/kumbhar/spack_install_foo/software/install_gcc-11.2.0-skylake/mpich-develop-7rgatj/lib:/gpfs/bbp.cscs.ch/home/kumbhar/spack_install_foo/software/install_gcc-11.2.0-skylake/libfabric-1.13.2-yftaxa/lib/ /gpfs/bbp.cscs.ch/home/kumbhar/spack_install_foo/software/install_gcc-11.2.0-skylake/mpich-develop-7rgatj/bin/mpiexec -np 10 ./a.out
     0. Memusage [MB]: 9.88
  1000. Memusage [MB]: 13.18
  2000. Memusage [MB]: 13.50
  3000. Memusage [MB]: 13.68
  4000. Memusage [MB]: 13.88
  5000. Memusage [MB]: 14.06
  6000. Memusage [MB]: 14.23
  ...
240000. Memusage [MB]: 54.36
241000. Memusage [MB]: 54.53
242000. Memusage [MB]: 54.69
243000. Memusage [MB]: 54.86
244000. Memusage [MB]: 55.02
245000. Memusage [MB]: 55.18
246000. Memusage [MB]: 55.35
247000. Memusage [MB]: 55.51
248000. Memusage [MB]: 55.67
249000. Memusage [MB]: 55.84
250000. Memusage [MB]: 56.00
251000. Memusage [MB]: 56.17
252000. Memusage [MB]: 56.33
253000. Memusage [MB]: 56.41
254000. Memusage [MB]: 56.67
255000. Memusage [MB]: 56.84
256000. Memusage [MB]: 57.00
257000. Memusage [MB]: 57.16
258000. Memusage [MB]: 57.33
259000. Memusage [MB]: 57.49
260000. Memusage [MB]: 57.66
261000. Memusage [MB]: 57.83
262000. Memusage [MB]: 58.07
```
* With this patch, memory usage remains constant:

```console
$ ROMIO_TUNEGATHER=1 ROMIO_FSTYPE_FORCE="gpfs:" LD_LIBRARY_PATH=/gpfs/bbp.cscs.ch/home/kumbhar/spack_install_foo/software/install_gcc-11.2.0-skylake/mpich-develop-7rgatj/lib:/gpfs/bbp.cscs.ch/home/kumbhar/spack_install_foo/software/install_gcc-11.2.0-skylake/libfabric-1.13.2-yftaxa/lib/ /gpfs/bbp.cscs.ch/home/kumbhar/spack_install_foo/software/install_gcc-11.2.0-skylake/mpich-develop-7rgatj/bin/mpiexec -np 10 ./a.out
     0. Memusage [MB]: 9.88
  1000. Memusage [MB]: 12.99
  2000. Memusage [MB]: 13.46
  3000. Memusage [MB]: 13.72
  4000. Memusage [MB]: 13.73
  5000. Memusage [MB]: 13.74
  6000. Memusage [MB]: 13.75
  ...
224000. Memusage [MB]: 14.25
225000. Memusage [MB]: 14.25
226000. Memusage [MB]: 14.25
227000. Memusage [MB]: 14.25
228000. Memusage [MB]: 14.25
229000. Memusage [MB]: 14.25
230000. Memusage [MB]: 14.25
231000. Memusage [MB]: 14.25
232000. Memusage [MB]: 14.25
233000. Memusage [MB]: 14.25
234000. Memusage [MB]: 14.25
235000. Memusage [MB]: 14.25
236000. Memusage [MB]: 14.25
237000. Memusage [MB]: 14.25
238000. Memusage [MB]: 14.25
239000. Memusage [MB]: 14.25
240000. Memusage [MB]: 14.25
241000. Memusage [MB]: 14.25
242000. Memusage [MB]: 14.25
243000. Memusage [MB]: 14.25
244000. Memusage [MB]: 14.25
245000. Memusage [MB]: 14.25
246000. Memusage [MB]: 14.25
247000. Memusage [MB]: 14.25
248000. Memusage [MB]: 14.25
249000. Memusage [MB]: 14.25
250000. Memusage [MB]: 14.25
251000. Memusage [MB]: 14.25
252000. Memusage [MB]: 14.25
253000. Memusage [MB]: 14.25
254000. Memusage [MB]: 14.25
255000. Memusage [MB]: 14.25
256000. Memusage [MB]: 14.25
257000. Memusage [MB]: 14.25
258000. Memusage [MB]: 14.25
259000. Memusage [MB]: 14.25
260000. Memusage [MB]: 14.25
261000. Memusage [MB]: 14.25
262000. Memusage [MB]: 14.25
```


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement** (Sent today to cla@mpich.org)
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.

> TODO: I will look at the last two todos shortly.


