### PR TITLE
datatype: add early return for pack/unpack zerolen datatype

### DIFF
--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -115,6 +115,13 @@ MPI_Pack:
         MPIR_ERRTEST_ARGNULL(inbuf, "inbuf", mpi_errno);
     }
 }
+{ -- early_return --
+    MPI_Aint dt_size;
+    MPIR_Datatype_get_size_macro(datatype, dt_size);
+    if (dt_size == 0) {
+        goto fn_exit;
+    }
+}
 
 MPI_Pack_external:
     .desc: Packs a datatype into contiguous memory, using the external32 format
@@ -146,6 +153,13 @@ MPI_Unpack:
 { -- error_check -- inbuf, outbuf
     if (outcount > 0) {
         MPIR_ERRTEST_ARGNULL(outbuf, "outbuf", mpi_errno);
+    }
+}
+{ -- early_return --
+    MPI_Aint dt_size;
+    MPIR_Datatype_get_size_macro(datatype, dt_size);
+    if (dt_size == 0) {
+        goto fn_exit;
     }
 }
 


### PR DESCRIPTION
## Pull Request Description
Lower layer data engine may not handle zero-len datatype correctly. Since it is essentially a noop, check and return early when the datatype is zero length.

Fixes #6234
[skip warnings]



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
