### PR TITLE
init: only do async progress under world init

### DIFF
--- a/src/mpi/init/init_async.c
+++ b/src/mpi/init/init_async.c
@@ -323,7 +323,7 @@ int MPII_init_async(void)
 
     utarray_new(async_thread_list, &icd_async_thread_list, MPL_MEM_OTHER);
 
-    if (MPIR_CVAR_ASYNC_PROGRESS) {
+    if (MPIR_CVAR_ASYNC_PROGRESS && MPII_world_is_initialized()) {
         if (MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE) {
             mpi_errno = MPID_Init_async_thread();
             MPIR_ERR_CHECK(mpi_errno);

--- a/test/mpi/errors/comm/unmatched.c
+++ b/test/mpi/errors/comm/unmatched.c
@@ -12,6 +12,13 @@ int main(void)
 
     MTest_Init(NULL, NULL);
 
+    /* Current MPICH may not support thread multiple, especially with pervci */
+    int thread_level;
+    MPI_Query_thread(&thread_level);
+    if (thread_level == MPI_THREAD_MULTIPLE) {
+        goto fn_exit;
+    }
+
     MPI_Comm comm;
     MPI_Comm_dup(MPI_COMM_WORLD, &comm);
     MPI_Comm_set_errhandler(comm, MPI_ERRORS_RETURN);
@@ -39,6 +46,7 @@ int main(void)
         errs++;
     }
 
+  fn_exit:
     MTest_Finalize(errs);
 
     return MTestReturnValue(errs);

--- a/test/mpi/part/pingping.c
+++ b/test/mpi/part/pingping.c
@@ -13,6 +13,12 @@
 
 /* Extended from src/pt2pt/pingping.c with partitioned APIs. */
 
+/* the stress testing of unexpected message queue is covered by the pt2pt/pingping,
+ * test. Use barrier to simplify this test to focus on testing partitioned
+ * communications.
+ */
+#define USE_BARRIER 1
+
 /*
 static char MTEST_Descrip[] = "Pingping test with partitioned point-to-point routines";
 */


### PR DESCRIPTION
## Pull Request Description
With session init, the world part of initialization may not be ready and async progress cannot be started. The previous commit (0913836) moved MPII_init_async because we need to initialize the global states so the async progress can be launched on-demand by the user. But we should check the init state before we launch the ASYNC_PROGRESS.

Fixes the following tests (with async on)
```
init.01655 - ./init/session 4 | 0.35 sec | 7
init.01658 - ./init/session_psets 1 | 0.34 sec | 14
init.01659 - ./init/session_self 1

errors/spawn.02619 - ./errors/spawn/connect_timeout_no_accept

errors/comm.02574 - ./errors/comm/unmatched 2
```

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
