### PR TITLE
test: fix vecblklen to account char being unsigned

### DIFF
--- a/test/mpi/datatype/hvecblklen.c
+++ b/test/mpi/datatype/hvecblklen.c
@@ -3,11 +3,11 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include "mpi.h"
+#include "mpitest.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "mpitest.h"
+#include <limits.h>
 
 /* Inspired by the Intel MPI_Type_hvector_blklen test.
    Added to include a test of a typerep optimization that failed.
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
     outbuf = (char *) malloc(outsize);
     for (i = 0; i < outsize; i++) {
         inbuf[i] = i % 64;
-        outbuf[i] = -1;
+        outbuf[i] = CHAR_MAX;
     }
 
     MPI_Pack_size(1, newtype, MPI_COMM_WORLD, &psize);
@@ -61,14 +61,20 @@ int main(int argc, char *argv[])
             for (k = 0; k < 59; k++) {
                 if (*p != k % 64) {
                     errs++;
-                    fprintf(stderr, "[%d,%d,%d]expected %d but saw %d\n", i, j, k, (k % 64), *p);
+                    if (errs < 10) {
+                        fprintf(stderr, "[%d,%d,%d]expected %d but saw %d\n", i, j, k, (k % 64),
+                                *p);
+                    }
                 }
                 p++;
             }
             for (k = 59; k < 64; k++) {
-                if (*p != -1) {
+                if (*p != CHAR_MAX) {
                     errs++;
-                    fprintf(stderr, "[%d,%d,%d]expected -1 but saw %d\n", i, j, k, *p);
+                    if (errs < 10) {
+                        fprintf(stderr, "[%d,%d,%d]expected %c but saw %d\n",
+                                i, j, k, CHAR_MAX, *p);
+                    }
                 }
                 p++;
             }

--- a/test/mpi/datatype/vecblklen.c
+++ b/test/mpi/datatype/vecblklen.c
@@ -3,11 +3,11 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include "mpi.h"
+#include "mpitest.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "mpitest.h"
+#include <limits.h>
 
 /* Inspired by the Intel MPI_Type_vector_blklen test.
    Added to include a test of a typerep optimization that failed.
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
     outbuf = (char *) malloc(outsize);
     for (i = 0; i < outsize; i++) {
         inbuf[i] = i % 64;
-        outbuf[i] = -1;
+        outbuf[i] = CHAR_MAX;
     }
 
     MPI_Pack_size(1, newtype, MPI_COMM_WORLD, &psize);
@@ -61,14 +61,20 @@ int main(int argc, char *argv[])
             for (k = 0; k < 59; k++) {
                 if (*p != k % 64) {
                     errs++;
-                    fprintf(stderr, "[%d,%d,%d]expected %d but saw %d\n", i, j, k, (k % 64), *p);
+                    if (errs < 10) {
+                        fprintf(stderr, "[%d,%d,%d]expected %d but saw %d\n", i, j, k, (k % 64),
+                                *p);
+                    }
                 }
                 p++;
             }
             for (k = 59; k < 64; k++) {
-                if (*p != -1) {
+                if (*p != CHAR_MAX) {
                     errs++;
-                    fprintf(stderr, "[%d,%d,%d]expected -1 but saw %d\n", i, j, k, *p);
+                    if (errs < 10) {
+                        fprintf(stderr, "[%d,%d,%d]expected %c but saw %d\n",
+                                i, j, k, CHAR_MAX, *p);
+                    }
                 }
                 p++;
             }


### PR DESCRIPTION
## Pull Request Description
Apparently, `char` can be unsigned (allowed by C standard). We found this on `aarch64-suse-linux` `gcc-4.8`.

One explanation from the internet:

> Performance. Historically, ARM didn’t have a “load byte and sign extend” instruction making loading a signed char and promoting it to an int slower than loading an unsigned char and promoting it to an int.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
