### PR TITLE
coll: fix the case type_size greater than chunk size

### DIFF
--- a/src/mpi/coll/algorithms/common/algo_common.h
+++ b/src/mpi/coll/algorithms/common/algo_common.h
@@ -38,7 +38,7 @@ static inline int MPIR_Algo_calculate_pipeline_chunk_info(MPI_Aint chunk_size, M
     MPI_Aint maxelems;
     maxelems = chunk_size / type_size;
 
-    if (chunk_size <= 0 || maxelems >= count) { /* disable pipelining */
+    if (chunk_size <= 0 || maxelems >= count || maxelems < 1) { /* disable pipelining */
         *num_segments = 1;
         *segsize_floor = *segsize_ceil = count;
         goto fn_exit;

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -408,6 +408,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, 
 
     is_commutative = MPIR_Op_is_commutative(op);
 
+    /* FIXME: this fallback check assumes device algorithms are limited by release gather shm cell size */
+    MPI_Aint dt_size;
+    MPIR_Datatype_get_size_macro(datatype, dt_size);
+    if (dt_size >=
+        MPIR_CVAR_REDUCE_INTRANODE_BUFFER_TOTAL_SIZE / MPIR_CVAR_REDUCE_INTRANODE_NUM_CELLS) {
+        goto fallback;
+    }
+
     switch (MPIR_CVAR_ALLREDUCE_COMPOSITION) {
         case 1:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
@@ -1253,6 +1261,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
+
+    /* FIXME: this fallback check assumes device algorithms are limited by release gather shm cell size */
+    MPI_Aint dt_size;
+    MPIR_Datatype_get_size_macro(datatype, dt_size);
+    if (dt_size >=
+        MPIR_CVAR_REDUCE_INTRANODE_BUFFER_TOTAL_SIZE / MPIR_CVAR_REDUCE_INTRANODE_NUM_CELLS) {
+        goto fallback;
+    }
 
     switch (MPIR_CVAR_REDUCE_COMPOSITION) {
         case 1:

--- a/test/mpi/coll/Makefile.am
+++ b/test/mpi/coll/Makefile.am
@@ -23,6 +23,7 @@ noinst_PROGRAMS =      \
     allred4            \
     allred5            \
     allred6            \
+    allred_derived     \
     allredmany         \
     alltoall1          \
     alltoallv          \

--- a/test/mpi/coll/allred_derived.c
+++ b/test/mpi/coll/allred_derived.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "mpitest.h"
+#include <assert.h>
+
+/*
+static char MTEST_Descrip[] = "Test MPI_Allreduce with commutative user-defined operations";
+*/
+
+#define MAX_BLOCKLEN 10000
+#define IS_COMMUTATIVE 1
+
+/* We make the error count global so that we can easily control the output
+   of error information (in particular, limiting it after the first 10
+   errors */
+int errs = 0;
+
+/* parameter for a vector type of MPI_INT */
+int g_blocklen = 1;
+int g_stride = 1;
+
+void uop(void *, void *, int *, MPI_Datatype *);
+void uop(void *cinPtr, void *coutPtr, int *count, MPI_Datatype * dtype)
+{
+    const int *cin = (const int *) cinPtr;
+    int *cout = (int *) coutPtr;
+
+    int k = 0;
+    for (int i = 0; i < *count; i++) {
+        for (int j = 0; j < g_blocklen; j++) {
+            cout[k] += cin[k];
+            k += g_stride;
+        }
+    }
+}
+
+static void init_buf(void *buf, int count, int rank)
+{
+    int *p = buf;
+
+    int k = 0;
+    for (int i = 0; i < count; i++) {
+        for (int j = 0; j < g_blocklen; j++) {
+            p[k] = rank + i + j;
+            k += g_stride;
+        }
+    }
+}
+
+static int check_result(void *buf, int count, int size)
+{
+    int lerrs = 0;
+    int *p = buf;
+
+    int k = 0;
+    for (int i = 0; i < count; i++) {
+        for (int j = 0; j < g_blocklen; j++) {
+            int exp = size * (size - 1) / 2 + (i + j) * size;
+            if (p[k] != exp) {
+                lerrs++;
+                if (errs + lerrs < 10) {
+                    printf("[%d - %d] expected %d, got %d, %s\n",
+                           i, j, exp, p[k], MTestGetIntracommName());
+                }
+            }
+            k += g_stride;
+        }
+    }
+    return lerrs;
+}
+
+int main(int argc, char *argv[])
+{
+    MPI_Comm comm;
+    void *buf, *bufout;
+    MPI_Op op;
+    MPI_Datatype datatype;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Op_create(uop, IS_COMMUTATIVE, &op);
+
+    while (MTestGetIntracommGeneral(&comm, 2, 1)) {
+        if (comm == MPI_COMM_NULL) {
+            continue;
+        }
+
+        int rank, size;
+        MPI_Comm_rank(comm, &rank);
+        MPI_Comm_size(comm, &size);
+
+        int count = 10;
+        for (int n = 1; n < MAX_BLOCKLEN; n *= 2) {
+            g_blocklen = n;
+            int extent = g_blocklen * g_stride * sizeof(int);
+            MPI_Type_vector(g_blocklen, 1, g_stride, MPI_INT, &datatype);
+            MPI_Type_commit(&datatype);
+
+            buf = (int *) malloc(extent * count);
+            if (!buf) {
+                MPI_Abort(MPI_COMM_WORLD, 1);
+            }
+            bufout = (int *) malloc(extent * count);
+            if (!bufout) {
+                MPI_Abort(MPI_COMM_WORLD, 1);
+            }
+
+            init_buf(buf, count, rank);
+            MPI_Allreduce(buf, bufout, count, datatype, op, comm);
+            errs += check_result(bufout, count, size);
+
+            /* do it again using MPI_IN_PLACE */
+            init_buf(bufout, count, rank);
+            MPI_Allreduce(MPI_IN_PLACE, bufout, count, datatype, op, comm);
+            errs += check_result(bufout, count, size);
+
+            free(buf);
+            free(bufout);
+            MPI_Type_free(&datatype);
+        }
+
+        MTestFreeComm(&comm);
+    }
+
+    MPI_Op_free(&op);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/coll/testlist.in
+++ b/test/mpi/coll/testlist.in
@@ -9,6 +9,7 @@ allred5 5
 allred5 10
 allred6 4
 allred6 7
+allred_derived 4
 reduce 5
 reduce 10
 reduce_local 2


### PR DESCRIPTION
## Pull Request Description
It is missing check when type_size is bigger than chunk_size, which will result pipelining of zero-sized chunks, end up with divide-by-zero FPE.

Add a test that reproduces the bug.

Fixes #6239 
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
