### PR TITLE
romio: fix the cases when file_type is zero sized

### DIFF
--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -68,48 +68,50 @@ ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype datatype)
 
     MPI_Type_size_x(datatype, &type_size);
 
-    MPIX_Type_iov_len(datatype, type_size, &num_iovs, &actual);
-    assert(num_iovs > 0);
-    assert(actual == type_size);
+    {
+        MPIX_Type_iov_len(datatype, type_size, &num_iovs, &actual);
+        assert(num_iovs > 0);
+        assert(actual == type_size);
 
-    MPIX_Iov *iovs;
-    iovs = ADIOI_Malloc(num_iovs * sizeof(MPIX_Iov));
-    assert(iovs);
+        MPIX_Iov *iovs;
+        iovs = ADIOI_Malloc(num_iovs * sizeof(MPIX_Iov));
+        assert(iovs);
 
-    MPIX_Type_iov(datatype, 0, iovs, num_iovs, &actual);
-    assert(actual == num_iovs);
+        MPIX_Type_iov(datatype, 0, iovs, num_iovs, &actual);
+        assert(actual == num_iovs);
 
-    /* copy to flatlist */
-    ADIOI_Flatlist_node *flat;
-    flat = ADIOI_Malloc(sizeof(ADIOI_Flatlist_node));
-    flat->count = num_iovs;
-    flat->blocklens = (ADIO_Offset *) ADIOI_Malloc(flat->count * 2 * sizeof(ADIO_Offset));
-    flat->indices = flat->blocklens + flat->count;
-    flat->refct = 1;
+        /* copy to flatlist */
+        ADIOI_Flatlist_node *flat;
+        flat = ADIOI_Malloc(sizeof(ADIOI_Flatlist_node));
+        flat->count = num_iovs;
+        flat->blocklens = (ADIO_Offset *) ADIOI_Malloc(flat->count * 2 * sizeof(ADIO_Offset));
+        flat->indices = flat->blocklens + flat->count;
+        flat->refct = 1;
 
-    for (MPI_Count i = 0; i < num_iovs; i++) {
-        flat->indices[i] = (ADIO_Offset) iovs[i].iov_base;
-        flat->blocklens[i] = (ADIO_Offset) iovs[i].iov_len;
-    }
-
-    /* update flags */
-    flat->flag = 0;
-    for (MPI_Count i = 0; i < flat->count; i++) {
-        /* Check if any of the displacements is negative */
-        if (flat->indices[i] < 0) {
-            flat->flag |= ADIOI_TYPE_NEGATIVE;
+        for (MPI_Count i = 0; i < num_iovs; i++) {
+            flat->indices[i] = (ADIO_Offset) iovs[i].iov_base;
+            flat->blocklens[i] = (ADIO_Offset) iovs[i].iov_len;
         }
 
-        if (i > 0) {
-            MPI_Count j = i - 1;
-            /* Check if displacements are in a monotonic nondecreasing order */
-            if (flat->indices[j] > flat->indices[i]) {
-                flat->flag |= ADIOI_TYPE_DECREASE;
+        /* update flags */
+        flat->flag = 0;
+        for (MPI_Count i = 0; i < flat->count; i++) {
+            /* Check if any of the displacements is negative */
+            if (flat->indices[i] < 0) {
+                flat->flag |= ADIOI_TYPE_NEGATIVE;
             }
 
-            /* Check for overlapping regions */
-            if (flat->indices[j] + flat->blocklens[j] > flat->indices[i]) {
-                flat->flag |= ADIOI_TYPE_OVERLAP;
+            if (i > 0) {
+                MPI_Count j = i - 1;
+                /* Check if displacements are in a monotonic nondecreasing order */
+                if (flat->indices[j] > flat->indices[i]) {
+                    flat->flag |= ADIOI_TYPE_DECREASE;
+                }
+
+                /* Check for overlapping regions */
+                if (flat->indices[j] + flat->blocklens[j] > flat->indices[i]) {
+                    flat->flag |= ADIOI_TYPE_OVERLAP;
+                }
             }
         }
     }

--- a/src/mpi/romio/adio/common/get_fp_posn.c
+++ b/src/mpi/romio/adio/common/get_fp_posn.c
@@ -22,13 +22,15 @@ void ADIOI_Get_position(ADIO_File fd, ADIO_Offset * offset)
     ADIOI_Datatype_iscontig(fd->filetype, &filetype_is_contig);
     etype_size = fd->etype_size;
 
-    if (filetype_is_contig)
+    MPI_Type_size_x(fd->filetype, &filetype_size);
+    MPI_Type_get_extent(fd->filetype, &lb, &filetype_extent);
+
+    if (filetype_size == 0) {
+        *offset = 0;
+    } else if (filetype_is_contig)
         *offset = (fd->fp_ind - fd->disp) / etype_size;
     else {
         flat_file = ADIOI_Flatten_and_find(fd->filetype);
-
-        MPI_Type_size_x(fd->filetype, &filetype_size);
-        MPI_Type_get_extent(fd->filetype, &lb, &filetype_extent);
 
         disp = fd->disp;
         byte_offset = fd->fp_ind;

--- a/test/mpi/io/Makefile.am
+++ b/test/mpi/io/Makefile.am
@@ -17,6 +17,7 @@ noinst_PROGRAMS = \
     getextent     \
     setinfo       \
     setviewcur    \
+    setview_zero  \
     i_noncontig   \
     async         \
     async_any     \

--- a/test/mpi/io/setview_zero.c
+++ b/test/mpi/io/setview_zero.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Test MPI_File_set_view with zero-len filetype on some of the processes */
+
+/* The test is contributed Eric Chamberland. Reference issue #6222 */
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    MTest_Init(&argc, &argv);
+
+    int rank, size;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (size != 3) {
+        printf("Please run with 3 processes.\n");
+        MPI_Finalize();
+        return 1;
+    }
+
+    int displacement[3];
+    int *buffer = 0;
+
+    int lTailleBuf = 0;
+    if (rank == 0) {
+        lTailleBuf = 3;
+        displacement[0] = 0;
+        displacement[1] = 4;
+        displacement[2] = 5;
+        buffer = malloc(sizeof(int) * lTailleBuf);
+        for (int i = 0; i < lTailleBuf; i++) {
+            buffer[i] = 10 * (i + 1);
+        }
+    }
+    if (rank == 1) {
+        lTailleBuf = 3;
+        displacement[0] = 1;
+        displacement[1] = 2;
+        displacement[2] = 3;
+
+        buffer = malloc(sizeof(int) * lTailleBuf);
+        for (int i = 0; i < lTailleBuf; i++) {
+            buffer[i] = -(i + 1);
+        }
+    }
+    if (rank == 2) {
+        // A rank without any "element" is ok normally:
+        lTailleBuf = 0;
+    }
+
+    MPI_File lFile;
+    MPI_File_open(MPI_COMM_WORLD, "testfile", MPI_MODE_RDWR | MPI_MODE_CREATE, MPI_INFO_NULL,
+                  &lFile);
+
+    MPI_Datatype lTypeIndexIntWithExtent, lTypeIndexIntWithoutExtent;
+
+    MPI_Type_create_indexed_block(lTailleBuf, 1, displacement, MPI_INT,
+                                  &lTypeIndexIntWithoutExtent);
+    MPI_Type_commit(&lTypeIndexIntWithoutExtent);
+
+    // Here we compute the total number of int to write to resize the type:
+    int lTailleGlobale = 0;
+    MPI_Allreduce(&lTailleBuf, &lTailleGlobale, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+
+    //We now modify the extent of the type "type_without_extent"
+    MPI_Type_create_resized(lTypeIndexIntWithoutExtent, 0, lTailleGlobale * sizeof(int),
+                            &lTypeIndexIntWithExtent);
+    MPI_Type_commit(&lTypeIndexIntWithExtent);
+
+    MPI_File_set_view(lFile, 0, MPI_INT, lTypeIndexIntWithExtent, "native", MPI_INFO_NULL);
+
+    for (int i = 0; i < 2; ++i) {
+        MPI_File_write_all(lFile, buffer, lTailleBuf, MPI_INT, MPI_STATUS_IGNORE);
+        MPI_Offset lOffset, lSharedOffset;
+        MPI_File_get_position(lFile, &lOffset);
+        MPI_File_get_position_shared(lFile, &lSharedOffset);
+        MTestPrintfMsg(1, "[%d] Offset after write : %d int: Local: %lld Shared: %lld \n",
+                       rank, lTailleBuf, lOffset, lSharedOffset);
+    }
+
+    MPI_File_close(&lFile);
+
+    MPI_Type_free(&lTypeIndexIntWithExtent);
+    MPI_Type_free(&lTypeIndexIntWithoutExtent);
+
+    if (buffer) {
+        free(buffer);
+    }
+
+    if (rank == 0) {
+        MPI_File_delete((char *) "testfile", MPI_INFO_NULL);
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/io/testlist.in
+++ b/test/mpi/io/testlist.in
@@ -5,6 +5,7 @@ rd_end 2
 getextent 2
 setinfo 4
 setviewcur 4
+setview_zero 3
 i_noncontig 2
 async 4
 async_any 4


### PR DESCRIPTION
## Pull Request Description
It is permissible for some processes to have zero-sized file type if that
process does not need access to the file. This patch added missing
checks for zero length flatlist.

Fixes #6222

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
