### PR TITLE
hydra: fix singleton init

### DIFF
--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -380,8 +380,6 @@ struct HYD_user_global {
     int skip_launch_node;
     int gpus_per_proc;
     int gpu_subdevs_per_proc;
-    int singleton_port;
-    int singleton_pid;
 
     struct HYD_env_global global_env;
 };

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -255,6 +255,7 @@ HYD_status HYDU_create_proxy_list_singleton(struct HYD_node *node, int pgid,
 
     init_proxy(proxy, pgid, node);
 
+    proxy->proxy_id = 0;
     proxy->proxy_process_count = 1;
     proxy->node->active_processes = 1;
 

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -27,8 +27,6 @@ void HYDU_init_user_global(struct HYD_user_global *user_global)
     user_global->skip_launch_node = -1;
     user_global->gpus_per_proc = HYD_GPUS_PER_PROC_UNSET;
     user_global->gpu_subdevs_per_proc = HYD_GPUS_PER_PROC_UNSET;
-    user_global->singleton_port = 0;
-    user_global->singleton_pid = 0;
 
     HYDU_init_global_env(&user_global->global_env);
 }

--- a/src/pm/hydra/mpiexec/hydra_server.h
+++ b/src/pm/hydra/mpiexec/hydra_server.h
@@ -50,6 +50,7 @@ struct HYD_server_info_s {
     char *rankmap;
     time_t time_start;
 
+    bool is_singleton;
     int singleton_port;
     int singleton_pid;
 
@@ -84,8 +85,5 @@ void PMISERV_proxy_finalize(void);
 int PMISERV_proxy_alloc(void);  /* return proxy_id */
 int PMISERV_proxy_max_id(void);
 struct HYD_proxy *PMISERV_proxy_by_id(int proxy_id);
-
-HYD_status PMISERV_create_proxy_list(struct HYD_exec *exec_list, struct HYD_node *node_list,
-                                     int pgid, bool is_singleton);
 
 #endif /* HYDRA_SERVER_H_INCLUDED */

--- a/src/pm/hydra/mpiexec/options.c
+++ b/src/pm/hydra/mpiexec/options.c
@@ -1496,6 +1496,7 @@ static HYD_status pmi_args_fn(char *arg, char ***argv)
 
     HYD_server_info.singleton_port = atoi((*argv)[0]);
     HYD_server_info.singleton_pid = atoi((*argv)[3]);
+    HYD_server_info.is_singleton = true;
 
     (*argv) += 4;
 

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -232,9 +232,9 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
         HYDU_ERR_POP(status, "unable to read status from proxy\n");
         HYDU_ASSERT(!closed, status);
 
-        if (proxy->pgid != 0) {
+        if (proxy->pgid != 0 || HYD_server_info.singleton_port > 0) {
             /* We initialize the debugger code only for non-dynamically
-             * spawned processes */
+             * spawned processes and non-singleton */
             goto fn_exit;
         }
 

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -232,25 +232,23 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
         HYDU_ERR_POP(status, "unable to read status from proxy\n");
         HYDU_ASSERT(!closed, status);
 
-        if (proxy->pgid != 0 || HYD_server_info.singleton_port > 0) {
-            /* We initialize the debugger code only for non-dynamically
-             * spawned processes and non-singleton */
-            goto fn_exit;
-        }
+        /* We initialize the debugger code only for non-dynamically
+         * spawned processes and non-singleton */
+        if (proxy->pgid == 0 && !HYD_server_info.is_singleton) {
+            struct HYD_pg *pg;
+            pg = PMISERV_pg_by_id(proxy->pgid);
 
-        struct HYD_pg *pg;
-        pg = PMISERV_pg_by_id(proxy->pgid);
-
-        /* Check if all the PIDs have been received */
-        for (int i = 0; i < pg->proxy_count; i++) {
-            if (pg->proxy_list[i].pid == NULL) {
-                goto fn_exit;
+            /* Check if all the PIDs have been received */
+            for (int i = 0; i < pg->proxy_count; i++) {
+                if (pg->proxy_list[i].pid == NULL) {
+                    goto fn_exit;
+                }
             }
-        }
 
-        /* Call the debugger initialization */
-        status = HYDT_dbg_setup_procdesc(pg);
-        HYDU_ERR_POP(status, "debugger setup failed\n");
+            /* Call the debugger initialization */
+            status = HYDT_dbg_setup_procdesc(pg);
+            HYDU_ERR_POP(status, "debugger setup failed\n");
+        }
     } else if (hdr.cmd == CMD_EXIT_STATUS) {
         HYDU_MALLOC_OR_JUMP(proxy->exit_status, int *, proxy->proxy_process_count * sizeof(int),
                             status);

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -111,7 +111,7 @@ HYD_status HYD_pmcd_pmi_fill_in_proxy_args(struct HYD_string_stash *proxy_stash,
     HYD_STRING_STASH(*proxy_stash,
                      HYDU_int_to_str(HYD_server_info.user_global.gpu_subdevs_per_proc), status);
 
-    if (pgid == 0 && HYD_server_info.singleton_port > 0) {
+    if (pgid == 0 && HYD_server_info.is_singleton) {
         HYD_STRING_STASH(*proxy_stash, MPL_strdup("--singleton-port"), status);
         HYD_STRING_STASH(*proxy_stash, HYDU_int_to_str(HYD_server_info.singleton_port), status);
 

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -201,10 +201,8 @@ int main(int argc, char **argv)
     }
 
     /* collect exit_status unless it is a singleton */
-    if (HYD_pmcd_pmip.user_global.singleton_pid > 0) {
+    if (HYD_pmcd_pmip.is_singleton) {
         HYDU_ASSERT(HYD_pmcd_pmip.local.proxy_process_count == 1, status);
-        HYDU_ASSERT(HYD_pmcd_pmip.downstream.pid[0] == HYD_pmcd_pmip.user_global.singleton_pid,
-                    status);
         /* We won't get the singleton's exit status. Assume it's 0. */
         if (HYD_pmcd_pmip.downstream.exit_status[0] == PMIP_EXIT_STATUS_UNSET) {
             HYD_pmcd_pmip.downstream.exit_status[0] = 0;

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -19,6 +19,10 @@ struct HYD_pmcd_pmip_map {
 struct HYD_pmcd_pmip_s {
     struct HYD_user_global user_global;
 
+    bool is_singleton;
+    int singleton_port;
+    int singleton_pid;
+
     struct {
         struct {
             int local_filler;

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -476,16 +476,15 @@ static HYD_status singleton_init(void)
 
     HYD_pmcd_pmip.downstream.out[0] = 0;
     HYD_pmcd_pmip.downstream.err[0] = 0;
-    HYD_pmcd_pmip.downstream.pid[0] = HYD_pmcd_pmip.user_global.singleton_pid;
+    HYD_pmcd_pmip.downstream.pid[0] = HYD_pmcd_pmip.singleton_pid;
     HYD_pmcd_pmip.downstream.exit_status[0] = PMIP_EXIT_STATUS_UNSET;
     HYD_pmcd_pmip.downstream.pmi_rank[0] = 0;
     HYD_pmcd_pmip.downstream.pmi_fd[0] = HYD_FD_UNSET;
     HYD_pmcd_pmip.downstream.pmi_fd_active[0] = 1;
 
     int fd;
-    status =
-        HYDU_sock_connect("localhost", HYD_pmcd_pmip.user_global.singleton_port, &fd, 0,
-                          HYD_CONNECT_DELAY);
+    status = HYDU_sock_connect("localhost", HYD_pmcd_pmip.singleton_port, &fd, 0,
+                               HYD_CONNECT_DELAY);
     HYDU_ERR_POP(status, "unable to connect to singleton process\n");
     HYD_pmcd_pmip.downstream.pmi_fd[0] = fd;
 
@@ -979,7 +978,7 @@ HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
                                 HYD_pmcd_pmip.user_global.membind);
         HYDU_ERR_POP(status, "unable to initialize process topology\n");
 
-        if (HYD_pmcd_pmip.user_global.singleton_port > 0) {
+        if (HYD_pmcd_pmip.is_singleton) {
             status = singleton_init();
             HYDU_ERR_POP(status, "singleton_init returned error\n");
         } else {

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -630,7 +630,7 @@ HYD_status fn_finalize(int fd, struct PMIU_cmd *pmi)
     finalize_count++;
 
     /* mark singleton's stdio sockets as closed */
-    if (HYD_pmcd_pmip.user_global.singleton_pid > 0) {
+    if (HYD_pmcd_pmip.is_singleton) {
         HYDU_ASSERT(HYD_pmcd_pmip.local.proxy_process_count == 1, status);
         HYD_pmcd_pmip.downstream.out[0] = HYD_FD_CLOSED;
         HYD_pmcd_pmip.downstream.err[0] = HYD_FD_CLOSED;

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -131,7 +131,8 @@ static HYD_status singleton_port_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
 
-    HYD_pmcd_pmip.user_global.singleton_port = atoi(**argv);
+    HYD_pmcd_pmip.singleton_port = atoi(**argv);
+    HYD_pmcd_pmip.is_singleton = true;
 
     (*argv)++;
 
@@ -142,7 +143,7 @@ static HYD_status singleton_pid_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
 
-    HYD_pmcd_pmip.user_global.singleton_pid = atoi(**argv);
+    HYD_pmcd_pmip.singleton_pid = atoi(**argv);
 
     (*argv)++;
 

--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -857,16 +857,21 @@ static int PMII_singinit(void)
 
     if (pid == 0) {
         const char *newargv[8];
-        newargv[0] = "mpiexec";
-        newargv[1] = "-pmi_args";
-        newargv[2] = port_c;
+        int i = 0;
+        newargv[i++] = "mpiexec";
+        if (PMIU_verbose) {
+            newargv[i++] = "-v";
+        }
+        newargv[i++] = "-pmi_args";
+        newargv[i++] = port_c;
         /* FIXME: Use a valid hostname */
-        newargv[3] = "default_interface";       /* default interface name, for now */
-        newargv[4] = "default_key";     /* default authentication key, for now */
+        newargv[i++] = "default_interface";     /* default interface name, for now */
+        newargv[i++] = "default_key";   /* default authentication key, for now */
         char charpid[8];
         MPL_snprintf(charpid, 8, "%d", getpid());
-        newargv[5] = charpid;
-        newargv[6] = NULL;
+        newargv[i++] = charpid;
+        newargv[i++] = NULL;
+        PMIU_Assert(i <= 8);
         rc = execvp(newargv[0], (char **) newargv);
 
         /* never should return unless failed */


### PR DESCRIPTION
## Pull Request Description
The previous refactor broke the singleton init.
* pg->pg_process_count need be set without exec_list.
* proxy->proxy_id need be set. It is used as array index, so the default value of -1 will corrupt memory.
* need skip HYDT_dbg_setup_procdesc() since exec are NULL with singleton init.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
