### PR TITLE
init: add debug summary for config settings

### DIFF
--- a/src/mpi/init/init_util.c
+++ b/src/mpi/init/init_util.c
@@ -69,8 +69,50 @@ void MPII_Call_finalize_callbacks(int min_prio, int max_prio)
     }
 }
 
+static const char *threadlevel_name(int threadlevel)
+{
+    if (threadlevel == MPI_THREAD_SINGLE) {
+        return "MPI_THREAD_SINGLE";
+    } else if (threadlevel == MPI_THREAD_FUNNELED) {
+        return "MPI_THREAD_FUNNELED";
+    } else if (threadlevel == MPI_THREAD_SERIALIZED) {
+        return "MPI_THREAD_SERIALIZED";
+    } else if (threadlevel == MPI_THREAD_MULTIPLE) {
+        return "MPI_THREAD_MULTIPLE";
+    } else {
+        return "UNKNOWN";
+    }
+}
+
+static void print_setting(const char *label, const char *value)
+{
+    printf("%-18s: %s\n", label, value);
+}
+
 void MPII_dump_debug_summary(void)
 {
+#ifdef HAVE_ERROR_CHECKING
+    print_setting("error checking", "enabled");
+#else
+    print_setting("error checking", "disabled");
+#endif
+#ifdef ENABLE_QMPI
+    print_setting("QMPI", "enabled");
+#else
+    print_setting("QMPI", "disabled");
+#endif
+#ifdef HAVE_DEBUGGER_SUPPORT
+    print_setting("debugger support", "enabled");
+#else
+    print_setting("debugger support", "disabled");
+#endif
+    print_setting("thread level", threadlevel_name(MPIR_ThreadInfo.thread_provided));
+#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__GLOBAL
+    print_setting("thread CS", "global");
+#elif MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
+    print_setting("thread CS", "per-vci");
+#endif
+
     printf("==== data structure summary ====\n");
     printf("sizeof(MPIR_Comm): %ld\n", sizeof(MPIR_Comm));
     printf("sizeof(MPIR_Request): %ld\n", sizeof(MPIR_Request));


### PR DESCRIPTION
## Pull Request Description
Provide a way to check some config settings.

Example output:
```
$ MPIR_CVAR_DEBUG_SUMMARY=1 ./cpi
...
==== OFI dynamic settings ====                                       
num_vnis: 1                                                          
num_nics: 1                                                          
======================================                               
error checking    : enabled                                          
QMPI              : disabled                                         
debugger support  : disabled                                         
thread level      : MPI_THREAD_SINGLE                                
thread CS         : per-vci                                          
==== data structure summary ====                                     
sizeof(MPIR_Comm): 1712                                              
sizeof(MPIR_Request): 456                                            
sizeof(MPIR_Datatype): 280                                           
================================                                     
Process 0 of 1 is on tiger                                           
pi is approximately 3.1415926544231341, Error is 0.0000000008333410  
wall clock time = 0.000194                                           
```

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
