### PR TITLE
ch4/init_shm: increase size by one for broadcasting file name

### DIFF
--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -155,7 +155,7 @@ int MPIDU_Init_shm_init(void)
 
             mpl_err = MPL_shm_hnd_get_serialized_by_ref(memory.hnd, &serialized_hnd);
             MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
-            serialized_hnd_size = strlen(serialized_hnd);
+            serialized_hnd_size = strlen(serialized_hnd) + 1;
             MPIR_Assert(serialized_hnd_size < MPIR_pmi_max_val_size());
 
             mpi_errno = Init_shm_barrier_init(TRUE);


### PR DESCRIPTION
Increase size by 1 to include the trailing 0 for the file name string.
Otherwise the file name received on the receive buffer may contain garbage in the string, and open may file as a result.


## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
