### PR TITLE
coll: fix binding generation in MPI_Alltoallw

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1465,10 +1465,10 @@ def dump_coll_v_swap(func):
             replace_arg('rdispls', 'tmp_array + outdegree * 2 + indegree')
         else: # neighbor_alltoallw
             allocate_tmp_array("(outdegree + indegree)")
-            swap_one("indegree", "sendcounts")
-            swap_next("indegree", "outdegree", "recvcounts")
+            swap_one("outdegree", "sendcounts")
+            swap_next("outdegree", "indegree", "recvcounts")
             replace_arg('sendcounts', 'tmp_array')
-            replace_arg('recvcounts', 'tmp_array + indegree')
+            replace_arg('recvcounts', 'tmp_array + outdegree')
     # classical collectives
     elif RE.match(r'(mpi_i?reduce_scatter(_init)?\b)', func['name'], re.IGNORECASE):
         G.out.append("int n = comm_ptr->local_size;")

--- a/test/mpi/coll/Makefile.am
+++ b/test/mpi/coll/Makefile.am
@@ -149,6 +149,7 @@ noinst_PROGRAMS =      \
     neighb_alltoall    \
     neighb_alltoallv   \
     neighb_alltoallw   \
+    neighb_alltoallw2  \
     bcast              \
     bcast_comm_world_only \
     coll_large	       \

--- a/test/mpi/coll/neighb_alltoallw2.c
+++ b/test/mpi/coll/neighb_alltoallw2.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Test MPI_Neighbor_alltoallw with different indegree and outdegree */
+
+/* Reference issue #6233. Credit: tjahns */
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    int rank, size;
+
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size != 3) {
+        printf("This test require exactly 3 processes\n");
+        goto fn_exit;
+    }
+
+    /* build dist graph where rank 0 sends to rank 1 and 2 */
+    static const int indegree[3] = { 0, 1, 1 };
+    static const int sources[3][1] = { {-1}, {0}, {0} };
+    static const int outdegree[3] = { 2, 0, 0 };
+    static const int destinations[3][2] = { {1, 2}, {-1, -1}, {-1, -1} };
+    enum { reorder = 0 };
+    MPI_Comm neigh_comm;
+
+    MPI_Dist_graph_create_adjacent(MPI_COMM_WORLD,
+                                   indegree[rank], sources[rank], MPI_UNWEIGHTED,
+                                   outdegree[rank], destinations[rank], MPI_UNWEIGHTED,
+                                   MPI_INFO_NULL, reorder, &neigh_comm);
+
+    /* send single integer from rank 0 to rank 1 and 2 */
+    static const int send_buf[3][1] = { 0, -1, -2 };
+    static const int sendcounts[3][2] = { {1, 1}, {-1, -1}, {-1, -1} };
+    static const MPI_Aint sdispls[3][2] = { {0, 0}, {-1, -1}, {-1, -1} };
+    static const MPI_Datatype sendtypes[3][2] = {
+        {MPI_INT, MPI_INT},
+        {MPI_DATATYPE_NULL, MPI_DATATYPE_NULL},
+        {MPI_DATATYPE_NULL, MPI_DATATYPE_NULL}
+    };
+    int recv_buf[3][1] = { {-3}, {-4}, {-5} };
+    static const int recvcounts[3][1] = { {-1}, {1}, {1} };
+    static const MPI_Aint rdispls[3][1] = { {-1}, {0}, {0} };
+    static const MPI_Datatype recvtypes[3][2] = { {MPI_DATATYPE_NULL}, {MPI_INT}, {MPI_INT} };
+
+    MPI_Neighbor_alltoallw(send_buf[rank], sendcounts[rank], sdispls[rank], sendtypes[rank],
+                           recv_buf[rank], recvcounts[rank], rdispls[rank], recvtypes[rank],
+                           neigh_comm);
+
+    /* check receive buffer */
+    static const int ref_recv_buf[3][1] = { {-3}, {0}, {0} };
+
+    if (recv_buf[rank][0] != ref_recv_buf[rank][0]) {
+        errs++;
+        printf("rank: %d, expected: %d, actual value: %d\n",
+               rank, ref_recv_buf[rank][0], recv_buf[rank][0]);
+    }
+
+    MPI_Comm_free(&neigh_comm);
+
+  fn_exit:
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/coll/testlist.in
+++ b/test/mpi/coll/testlist.in
@@ -169,6 +169,7 @@ neighb_allgatherv 4
 neighb_alltoall 4
 neighb_alltoallv 4
 neighb_alltoallw 4
+neighb_alltoallw2 3
 ring_neighbor_alltoall 2
 ring_neighbor_alltoall 1
 


### PR DESCRIPTION
## Pull Request Description

We mixed up indegree and outdegree when performing sendcounts and
recvcounts swap from int array to MPI_Aint array.

Fixes #6233 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
