### PR TITLE
misc: fix async test failures

### DIFF
--- a/src/mpi/init/init_async.c
+++ b/src/mpi/init/init_async.c
@@ -93,6 +93,8 @@ static void progress_fn(void *data)
     }
 
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    /* The async thread should avoid monopolize the clock */
+    sleep(0);
 
     return;
 }

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -1187,9 +1187,14 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
                     break;
             }
 
+            /* NOTE: persistent sched s may get freed by MPI_Request_free as soon as we
+             *       complete the request. Access s->kind before we complete the request.
+             */
+            bool not_persistent = s->kind != MPIR_SCHED_KIND_PERSISTENT;
+
             MPIR_Request_complete(s->req);
 
-            if (s->kind != MPIR_SCHED_KIND_PERSISTENT) {
+            if (not_persistent) {
                 MPIDU_Sched_free(s);
             }
 


### PR DESCRIPTION
## Pull Request Description
* The async thread often negatively impact latency due to monopolizing the locks from the potentially latency sensitive main threads. Add sleep(0) to aggressively yield the lock.

  This may impact the latency of remote process when the communciation depends on the passive progress. I believe typical applications that use background threads are not latency sensitive. Alternatively, applications always can explicitly launch their own thread and run active progress using MPIX_Stream_progress.

* Fix a thread safety issue in persistent collectives with MPIR_Sched_progress
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
