### PR TITLE
[4.0.x] mpid/sched: race condition in freeing persistent sched

### DIFF
--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -1187,9 +1187,14 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
                     break;
             }
 
+            /* NOTE: persistent sched s may get freed by MPI_Request_free as soon as we
+             *       complete the request. Access s->kind before we complete the request.
+             */
+            bool not_persistent = s->kind != MPIR_SCHED_KIND_PERSISTENT;
+
             MPIR_Request_complete(s->req);
 
-            if (s->kind != MPIR_SCHED_KIND_PERSISTENT) {
+            if (not_persistent) {
                 MPIDU_Sched_free(s);
             }
 


### PR DESCRIPTION
## Pull Request Description

User may call MPI_Request_free as soon as we complete the internal request and concurrently freeing the sched as MPIDU_Sched_progress may still accessing its field.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
