### PR TITLE
ch4/part: race condition in MPIR_Part_request_activate

### DIFF
--- a/src/mpid/ch4/src/ch4_part.h
+++ b/src/mpid/ch4/src/ch4_part.h
@@ -25,8 +25,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_part_start(MPIR_Request * request)
 #endif
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_Part_request_activate(request);
-
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/src/mpidig_part.h
+++ b/src/mpid/ch4/src/mpidig_part.h
@@ -36,6 +36,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_start(MPIR_Request * request)
         mpi_errno = MPIDIG_part_issue_cts(request);
     }
 
+    MPIR_Part_request_activate(request);
+
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_FUNC_EXIT;
     return mpi_errno;


### PR DESCRIPTION
## Pull Request Description
There is a race condition if we call MPIR_Part_request_activate outside critical section, between MPIDIG_part_start and
MPIDIG_part_send_init_target_msg_cb. The latter may get in-between the former checking matched status and activate the flag, thus miss sending CTS.

Move MPIR_Part_request_activate before MPIDIG_part_start will also work. But it is cleaner to have the code together in MPIDIG_part_start.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
