### PR TITLE
test: split bcast gpu test

### DIFF
--- a/test/mpi/coll/testlist.gpu
+++ b/test/mpi/coll/testlist.gpu
@@ -10,4 +10,5 @@ op_coll 4 arg=-memtype=all
 # The dtp test will iterate over all typelist and counts, each time will repeat [repeat] times and select seed, testsize, memtypes accordingly
 # set MPITEST_VERBOSE=1 to the list of tests being run.
 
-bcast 4 arg=-typelist=MPI_INT,MPI_INT:4+MPI_DOUBLE:8 arg=-counts=1,17,50,100,512,65530 arg=-seed=100 arg=-testsizes=2,50 arg=-memtype=random timeLimit=600
+bcast 4 arg=-typelist=MPI_INT arg=-counts=1,17,50,100,512,65530 arg=-seed=100 arg=-testsizes=2,50 arg=-memtype=random timeLimit=600
+bcast 4 arg=-typelist=MPI_INT:4+MPI_DOUBLE:8 arg=-counts=1,17,50,100,512 arg=-seed=100 arg=-testsizes=10,50 arg=-memtype=random timeLimit=600


### PR DESCRIPTION
## Pull Request Description
The struct datatype goes through different yaksa path and require significantly more gpu resources. Split the test so we have better feedback. Currently, the count of 65530 struct bcast fails likely due to out-of resource. Omiting the large count for now.

NOTE: for pack and unpack, can yaksa simply treat contig datatype, struct or not, as simple memcpy rather than descend into it?


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
