### PR TITLE
datatype: fix builtin_element_size at MPIR_Typerep_unflatten

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_flatten.c
+++ b/src/mpi/datatype/typerep/src/typerep_flatten.c
@@ -118,6 +118,11 @@ int MPIR_Typerep_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     datatype_ptr->true_lb = flatten_hdr->true_lb;
     datatype_ptr->contents = NULL;
     datatype_ptr->flattened = NULL;
+    if (datatype_ptr->basic_type != MPI_DATATYPE_NULL) {
+        datatype_ptr->builtin_element_size = MPIR_Datatype_get_basic_size(datatype_ptr->basic_type);
+    } else {
+        datatype_ptr->builtin_element_size = 0;
+    }
 
 #if (MPICH_DATATYPE_ENGINE == MPICH_DATATYPE_ENGINE_YAKSA)
     int rc = yaksa_unflatten(&datatype_ptr->typerep.handle, flattened_typerep);

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -143,10 +143,7 @@ static int typerep_do_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype dat
         MPIR_Datatype *dtp;
         MPIR_Datatype_get_ptr(datatype, dtp);
         is_contig = dtp->is_contig;
-        /* NOTE: dtp->element_size may not be set if dtp is from a flattened type */
-        if (dtp->basic_type != MPI_DATATYPE_NULL) {
-            element_size = MPIR_Datatype_get_basic_size(datatype);
-        }
+        element_size = dtp->builtin_element_size;
         inbuf_ptr = MPIR_get_contig_ptr(inbuf, dtp->true_lb);
         total_size = incount * dtp->size;
     }


### PR DESCRIPTION
## Pull Request Description
The previous fix (commit a338d6a) contained type that gets the element_size from the datatype itself rather than its basic_type. This resulted all contig derived datatypes not to take the shortcut path.

Since the original bug was due to MPIR_Typerep_unflatten does not set builtin_element_size, this patch fixes the issue at its source.


[skip warnings]

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
