### PR TITLE
ch4/init: call MPIDI_Self_init in ch4_init

### DIFF
--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -416,6 +416,9 @@ int MPID_Init(int requested, int *provided)
         MPIDI_global.prev_sighandler = NULL;
 #endif
 
+    mpi_errno = MPIDI_Self_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
     choose_netmod();
 
     /* Create all ch4-layer granular locks.


### PR DESCRIPTION
## Pull Request Description
MPIDI_Self_init was never called, result in MPIDIU_THREAD_SELF_MUTEX never initialized. This is an issue for osx.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
