### PR TITLE
hydra: run autogen.sh in modules/pmi

### DIFF
--- a/src/pm/hydra/autogen.sh
+++ b/src/pm/hydra/autogen.sh
@@ -13,7 +13,7 @@ fi
 
 if test -d "modules/pmi" ; then
     echo "=== running autoreconf in 'modules/pmi' ==="
-    (cd modules/pmi && $autoreconf ${autoreconf_args:-"-vif"}) || exit 1
+    (cd modules/pmi && ./autogen.sh) || exit 1
 fi
 
 if test -d "modules/hwloc" ; then


### PR DESCRIPTION
## Pull Request Description
We need run autogen.sh in pmi to generate pmi_msg.c and pmi_msg.h.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
