### PR TITLE
test/xfail: add ch3:sock async io tests

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -60,6 +60,10 @@
 # pingping tests with large testsize currently fails async tests due to netmod handling of large message queue
 * * async * *           /^pingping .*testsize=32/        xfail=issue4474        pt2pt/testlist.dtp
 * * async * *           /^pingping .*testsize=32/        xfail=issue4474        part/testlist.dtp
+# ch3:sock sporadicly TIMEOUT on these async tests
+* * async ch3:sock *    /^nonblocking3 /                  xfail=issue6264        coll/testlist
+* * async ch3:sock *    /^i?write(sh|ord|ordbe|all|allbe)f /        xfail=issue6264        f77/io/testlist
+* * async ch3:sock *    /^i?write(sh|ord|ordbe|all|allbe)f90 /      xfail=issue6264        f90/io/testlist
 # dup_leak_test suffers from mutex unfairness issue under load for ch4:ofi
 * * * ch4:ofi *         /^dup_leak_test .*iter=12345.*/  xfail=issue4595        threads/comm/testlist
 # more mutex unfairness on freebsd64. note: check these after upgrading freebsd64 hardware


### PR DESCRIPTION
## Pull Request Description
Reference issue 6264, some of the async io tests with ch3:sock device routinely timeout. Xfail them now since it's not a priority fixing ch3:sock.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
