### PR TITLE
build: allow user to set PYTHON

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -234,7 +234,6 @@ set_externals() {
     fi
 }
 
-PYTHON=
 check_python3() {
     echo_n "Checking for Python 3... "
     PYTHON=

--- a/confdb/aclocal_misc.m4
+++ b/confdb/aclocal_misc.m4
@@ -1,16 +1,19 @@
 dnl PAC_CHECK_PYTHON check for python 3, sets PYTHON variable or abort
 dnl
 AC_DEFUN([PAC_CHECK_PYTHON],[
-    AC_MSG_CHECKING([Python 3])
-    PYTHON=
-    python_one_liner="import sys; print(sys.version_info[[0]])"
-    if test 3 = `python -c "$python_one_liner"`; then
-        PYTHON=python
-    elif test 3 = `python3 -c "$python_one_liner"`; then
-        PYTHON=python3
-    fi
-    AC_MSG_RESULT($PYTHON)
+    AC_ARG_VAR([PYTHON], [set to Python 3])
     if test -z "$PYTHON" ; then
-        AC_MSG_WARN([Python 3 not found! Bindings need to be generated before configure.])
+        AC_MSG_CHECKING([Python 3])
+        PYTHON=
+        python_one_liner="import sys; print(sys.version_info[[0]])"
+        if test 3 = `python -c "$python_one_liner"`; then
+            PYTHON=python
+        elif test 3 = `python3 -c "$python_one_liner"`; then
+            PYTHON=python3
+        fi
+        AC_MSG_RESULT($PYTHON)
+        if test -z "$PYTHON" ; then
+            AC_MSG_WARN([Python 3 not found! Bindings need to be generated before configure.])
+        fi
     fi
 ])

--- a/src/pmi/autogen.sh
+++ b/src/pmi/autogen.sh
@@ -11,7 +11,6 @@ if test -d mpl ; then
     (cd mpl && ${AUTORECONF:-autoreconf} ${autoreconf_args:-"-vif"}) || exit 1
 fi
 
-PYTHON=
 check_python3() {
     PYTHON=
     if test 3 = `python -c 'import sys; print(sys.version_info[0])' 2> /dev/null || echo "0"`; then

--- a/test/mpi/autogen.sh
+++ b/test/mpi/autogen.sh
@@ -9,7 +9,6 @@ echo_n() {
     printf "%s" "$*"
 }
 
-PYTHON=
 check_python3() {
     echo_n "Checking for Python 3... "
     PYTHON=
@@ -29,7 +28,9 @@ check_python3() {
     fi
 }
 
-check_python3
+if test -z "$PYTHON" ; then
+    check_python3
+fi
 echo "Generating collective cvar tests"
 $PYTHON maint/gen_coll_cvar.py
 


### PR DESCRIPTION
## Pull Request Description
Allow user to manually set environment variable PYTHON to the Python 3 executable in case we are not able to find it.

Fixes https://github.com/pmodels/mpich/issues/6266

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
