### PR TITLE
hydra: fix singleton init (again)

### DIFF
--- a/test/mpi/Makefile_common.mtest
+++ b/test/mpi/Makefile_common.mtest
@@ -21,8 +21,8 @@ LDADD = $(top_builddir)/dtpools/src/libdtpools.la
 $(top_builddir)/dtpools/src/libdtpools.la:
 	(cd $(top_builddir)/dtpools && $(MAKE))
 
-TESTDIRS ?= @TESTDIRS@
-TESTLIST ?= @TESTLIST@
+TESTDIRS ?= @default_testdirs@
+TESTLIST ?= @default_testlist@
 SUMMARY_BASENAME ?= summary
 
 testing:

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -812,26 +812,26 @@ PAC_POP_FLAG([LDFLAGS])
 PAC_POP_FLAG([LIBS])
 
 # setup which tests "make testing" will run
-TESTLIST=testlist
-TESTDIRS=
+default_testlist=testlist
+default_testdirs=
 if test $have_gpu = "yes" ; then
-    TESTLIST="${TESTLIST},testlist.gpu"
+    default_testlist="${default_testlist},testlist.gpu"
 fi
 if test $enable_dtpools = "yes" ; then
-    TESTLIST="${TESTLIST},testlist.dtp"
+    default_testlist="${default_testlist},testlist.dtp"
 fi
 if test $enable_collalgo_tests = "yes" ; then
-    TESTLIST="${TESTLIST},testlist.collalgo"
+    default_testlist="${default_testlist},testlist.collalgo"
 fi
 # handle --enable-gpu-tests-only
 if test $have_gpu = "no" -a $enable_gpu_tests_only = "yes" ; then
     AC_MSG_ERROR([GPU only test configuration requires GPU library (CUDA or LevelZero)])
 elif test $enable_gpu_tests_only = "yes" ; then
-    TESTDIRS=coll,pt2pt,rma
-    TESTLIST=testlist.gpu
+    default_testdirs=coll,pt2pt,rma
+    default_testlist=testlist.gpu
 fi
-AC_SUBST([TESTDIRS])
-AC_SUBST([TESTLIST])
+AC_SUBST([default_testdirs])
+AC_SUBST([default_testlist])
 
 # for tests that require large mem
 largetest="#"


### PR DESCRIPTION
## Pull Request Description
Try Fix the singleton init again.

Fixes #6269
## TODO
* [ ] Explain it.

## Notes
* The breaking commit was https://github.com/pmodels/mpich/pull/6231/commits/7d7823455ef2b128a4ebe4cfb6fb617d35e2cc41
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
