### PR TITLE
test: MPI_REAL16 and MPI_COMPLEX32 may not exist

### DIFF
--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1578,6 +1578,31 @@ if test "$pac_cv_have_mpi_integer16" = yes ; then
     AC_DEFINE(HAVE_MPI_INTEGER16,1,[Define if MPI_INTEGER16 is available])
 fi
 
+# Check if MPI_REAL16 and MPI_COMPLEX32 are defined. Tests handle the case
+# where they are defined, but the value is the same as MPI_DATATYPE_NULL.
+AC_CACHE_CHECK([whether MPI_REAL16 is available],
+pac_cv_have_mpi_real16,[
+    AC_COMPILE_IFELSE([
+        AC_LANG_PROGRAM([#include "mpi.h"],[
+            MPI_Datatype t = MPI_REAL16;
+        ])
+    ],[pac_cv_have_mpi_real16=yes],[pac_cv_have_mpi_real16=no])
+])
+if test "$pac_cv_have_mpi_real16" = yes ; then
+    AC_DEFINE(HAVE_MPI_REAL16,1,[Define if MPI_REAL16 is available])
+fi
+AC_CACHE_CHECK([whether MPI_COMPLEX32 is available],
+pac_cv_have_mpi_complex32,[
+    AC_COMPILE_IFELSE([
+        AC_LANG_PROGRAM([#include "mpi.h"],[
+            MPI_Datatype t = MPI_COMPLEX32;
+        ])
+    ],[pac_cv_have_mpi_complex32=yes],[pac_cv_have_mpi_complex32=no])
+])
+if test "$pac_cv_have_mpi_complex32" = yes ; then
+    AC_DEFINE(HAVE_MPI_COMPLEX32,1,[Define if MPI_COMPLEX32 is available])
+fi
+
 # MPI_Aint was intended as an address-sized int.  However, MPI didn't
 # specify this - MPI_Aint must be large enough to hold an address-sized
 # integer, but it can be larger.  To get clean compilation in some places,

--- a/test/mpi/datatype/sizedtypes.c
+++ b/test/mpi/datatype/sizedtypes.c
@@ -29,6 +29,7 @@ int main(int argc, char *argv[])
         errs++;
         printf("MPI_REAL8 has size %d\n", size);
     }
+#ifdef HAVE_MPI_REAL16
     if (MPI_REAL16 != MPI_DATATYPE_NULL) {
         MPI_Type_size(MPI_REAL16, &size);
         if (size != 16) {
@@ -36,6 +37,7 @@ int main(int argc, char *argv[])
             printf("MPI_REAL16 has size %d\n", size);
         }
     }
+#endif
 
     MPI_Type_size(MPI_COMPLEX8, &size);
     if (size != 8) {
@@ -47,6 +49,7 @@ int main(int argc, char *argv[])
         errs++;
         printf("MPI_COMPLEX16 has size %d\n", size);
     }
+#ifdef HAVE_MPI_COMPLEX32
     if (MPI_COMPLEX32 != MPI_DATATYPE_NULL) {
         MPI_Type_size(MPI_COMPLEX32, &size);
         if (size != 32) {
@@ -54,6 +57,7 @@ int main(int argc, char *argv[])
             printf("MPI_COMPLEX32 has size %d\n", size);
         }
     }
+#endif
 
     MPI_Type_size(MPI_INTEGER1, &size);
     if (size != 1) {

--- a/test/mpi/datatype/typename.c
+++ b/test/mpi/datatype/typename.c
@@ -83,10 +83,14 @@ static mpi_names_t mpi_names[] = {
      * compiler does not support it), the value may be MPI_DATATYPE_NULL */
     {MPI_REAL4, "MPI_REAL4"},
     {MPI_REAL8, "MPI_REAL8"},
+#ifdef HAVE_MPI_REAL16
     {MPI_REAL16, "MPI_REAL16"},
+#endif
     {MPI_COMPLEX8, "MPI_COMPLEX8"},
     {MPI_COMPLEX16, "MPI_COMPLEX16"},
+#ifdef HAVE_MPI_COMPLEX32
     {MPI_COMPLEX32, "MPI_COMPLEX32"},
+#endif
     {MPI_INTEGER1, "MPI_INTEGER1"},
     {MPI_INTEGER2, "MPI_INTEGER2"},
     {MPI_INTEGER4, "MPI_INTEGER4"},


### PR DESCRIPTION
macros to disable MPI_REAL16 and MPI_COMPLEX32.

TODO: needs configure.ac support.  Please help with this.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
