### PR TITLE
testsuite: workaround lack of deleted APIs

### DIFF
--- a/test/mpi/dtpools/src/dtpools_custom.c
+++ b/test/mpi/dtpools/src/dtpools_custom.c
@@ -220,8 +220,8 @@ static int custom_hvector(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * new
     n = sscanf(s, "numblks %d, blklen %d, stride %zd", &attr->u.hvector.numblks,
                &attr->u.hvector.blklen, &attr->u.hvector.stride);
     DTPI_ERR_ASSERT(n == 3, rc);
-    rc = MPI_Type_hvector(attr->u.hvector.numblks, attr->u.hvector.blklen, attr->u.hvector.stride,
-                          type, newtype);
+    rc = MPI_Type_create_hvector(attr->u.hvector.numblks, attr->u.hvector.blklen,
+                                 attr->u.hvector.stride, type, newtype);
     DTPI_ERR_CHK_MPI_RC(rc);
     DTPI_ERR_ASSERT(count % (attr->u.hvector.numblks * attr->u.hvector.blklen) == 0, rc);
     count /= attr->u.hvector.numblks * attr->u.hvector.blklen;
@@ -438,8 +438,8 @@ static int custom_hindexed(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * ne
         SKIP_DIGIT;
     }
 
-    rc = MPI_Type_hindexed(attr->u.hindexed.numblks, attr->u.hindexed.array_of_blklens,
-                           attr->u.hindexed.array_of_displs, type, newtype);
+    rc = MPI_Type_create_hindexed(attr->u.hindexed.numblks, attr->u.hindexed.array_of_blklens,
+                                  attr->u.hindexed.array_of_displs, type, newtype);
     DTPI_ERR_CHK_MPI_RC(rc);
 
     int total_blklen = 0;


### PR DESCRIPTION
conditionalize use of datatype functions that were deleted in MPI-3:
- MPI_Type_hvector
- MPI_Type_hindexed

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
