### PR TITLE
testsuite: fix compiler warning for format

### DIFF
--- a/test/mpi/part/parrived.c
+++ b/test/mpi/part/parrived.c
@@ -50,8 +50,8 @@ static int check_recv_partition(int rp, int iter)
         if (buf[index] != exp_val) {
             if (errs < 10) {
                 fprintf(stderr,
-                        "expected %.1f but received %.1f at buf[%d] (partition %d count %ld off %d), iteration %d\n",
-                        exp_val, buf[index], index, rp, rcount, i, iter);
+                        "expected %.1f but received %.1f at buf[%d] (partition %d count %lld off %d), iteration %d\n",
+                        exp_val, buf[index], index, rp, (long long) rcount, i, iter);
                 fflush(stderr);
             }
             errs++;
@@ -88,9 +88,9 @@ int main(int argc, char *argv[])
     scount = tot_count / spart;
     rcount = tot_count / rpart;
     if (spart * scount != rpart * rcount) {
-        fprintf(stderr, "Invalid partitions (%d, %d) or tot_count (%ld),"
+        fprintf(stderr, "Invalid partitions (%d, %d) or tot_count (%lld),"
                 "(tot_count / spart * spart) and (tot_count / rpart * rpart) "
-                "must be identical\n", spart, rpart, tot_count);
+                "must be identical\n", spart, rpart, (long long) tot_count);
         MPI_Abort(MPI_COMM_WORLD, 1);
     }
 

--- a/test/mpi/part/start_pready.c
+++ b/test/mpi/part/start_pready.c
@@ -173,9 +173,9 @@ int main(int argc, char *argv[])
     scount = tot_count / spart;
     rcount = tot_count / rpart;
     if (spart * scount != rpart * rcount) {
-        fprintf(stderr, "Invalid partitions (%d, %d) or tot_count (%ld),"
+        fprintf(stderr, "Invalid partitions (%d, %d) or tot_count (%lld),"
                 "(tot_count / spart * spart) and (tot_count / rpart * rpart) "
-                "must be identical\n", spart, rpart, tot_count);
+                "must be identical\n", spart, rpart, (long long) tot_count);
         MPI_Abort(MPI_COMM_WORLD, 1);
     }
 

--- a/test/mpi/threads/part/parrived_wait.c
+++ b/test/mpi/threads/part/parrived_wait.c
@@ -62,8 +62,8 @@ static int check_recv_partition(int tid, int rp, int iter)
         if (buf[index] != exp_val) {
             if (errs < 10) {
                 fprintf(stderr, "Rank %d tid %d expected %.1f but received %.1f "
-                        "at buf[%d] (partition %d count %ld off %d), iteration %d\n",
-                        rank, tid, exp_val, buf[index], index, rp, rcount, i, iter);
+                        "at buf[%d] (partition %d count %lld off %d), iteration %d\n",
+                        rank, tid, exp_val, buf[index], index, rp, (long long) rcount, i, iter);
                 fflush(stderr);
             }
             errs++;


### PR DESCRIPTION
printing MPI_Count should use a wider type. this isn't perfect, since MPI_Count can be anything, but long long is better than long.

```
parrived_wait.c:66:68: warning: format specifies type 'long' but the argument has type 'MPI_Count' (aka 'long long') [-Wformat]
                        rank, tid, exp_val, buf[index], index, rp, rcount, i, iter);
```

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
