### PR TITLE
test: avoid build ft tests when it is disabled

### DIFF
--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -9,7 +9,7 @@ include $(top_srcdir)/Makefile_single.mtest
 ACLOCAL_AMFLAGS = -I confdb
 
 static_subdirs = util attr basic datatype coll comm errhan group info init \
-                 pt2pt rma topo errors manual perf mpi_t impls ckpoint ft dtpools \
+                 pt2pt rma topo errors manual perf mpi_t impls ckpoint dtpools \
                  part
 all_lang_subdirs = f77 cxx f90 f08
 


### PR DESCRIPTION
## Pull Request Description
We neglected to remove ft target from the static list.

Fixes #6282

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
