### PR TITLE
testsuite: fix Waitany/Testany calls so F90 accepts them

### DIFF
--- a/test/mpi/f77/pt2pt/irsendf.f
+++ b/test/mpi/f77/pt2pt/irsendf.f
@@ -80,13 +80,13 @@ C
 C
          completed = 0
          do while (completed .lt. 2)
-            call MPI_Waitany(2, requests, index, statuses, ierr)
+            call MPI_Waitany(2, requests, index, status, ierr)
             completed = completed + 1
          end do
 C
          call rq_check( requests(1), 1, 'irsend and irecv' )
 C
-         call msg_check( recv_buf, next, tag, count, statuses,
+         call msg_check( recv_buf, next, tag, count, status,
      .           TEST_SIZE, 'irsend and irecv', errs )
 C
       else if (prev .eq. 0) then

--- a/test/mpi/f77/pt2pt/issendf.f
+++ b/test/mpi/f77/pt2pt/issendf.f
@@ -96,8 +96,8 @@ C
 C
          flag = .FALSE.
          do while (.not. flag)
-            call MPI_Testany(1, requests(1), index, flag,
-     .                       statuses(1,1), ierr)
+            call MPI_Testany(1, requests, index, flag,
+     .                       status, ierr)
          end do
 C
          call rq_check( requests, 1, 'issend and recv (testany)' )

--- a/test/mpi/f77/pt2pt/pssendf.f
+++ b/test/mpi/f77/pt2pt/pssendf.f
@@ -99,10 +99,10 @@ C
 C
          flag = .FALSE.
          do while (.not. flag)
-            call MPI_Testany(1, requests(1), index, flag,
-     .                       statuses(1,1), ierr)
+            call MPI_Testany(1, requests, index, flag,
+     .                       status, ierr)
          end do
-         call msg_check( recv_buf, prev, tag, count, statuses(1,1),
+         call msg_check( recv_buf, prev, tag, count, status,
      .           TEST_SIZE, 'testany', errs )
 
          do i = 1,count


### PR DESCRIPTION
F90 module is pickier about array dimension/reference matches. this fix works with both F77 and F90 compilers + header/module.

Resolves https://github.com/pmodels/mpich/issues/6287.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
