### PR TITLE
config: allow --with-pmi=path/to/libpmi

### DIFF
--- a/confdb/aclocal_libs.m4
+++ b/confdb/aclocal_libs.m4
@@ -18,7 +18,9 @@ dnl TODO as written, this macro cannot handle a "with_option" arg that has "-"
 dnl characters in it.  Use AS_TR_SH (and possibly AS_VAR_* macros) to handle
 dnl this case if it ever arises.
 AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
-    AC_ARG_WITH([$1], [AS_HELP_STRING([--with-$1=[[PATH]]],PAC_WITH_LIB_HELP_STRING($1))])
+    m4_ifdef([skip_ac_arg_with_$1], [], [
+        AC_ARG_WITH([$1], [AS_HELP_STRING([--with-$1=[[PATH]]],PAC_WITH_LIB_HELP_STRING($1))])
+    ])
 
     AC_ARG_WITH([$1-include],
                 [AS_HELP_STRING([--with-$1-include=PATH],

--- a/configure.ac
+++ b/configure.ac
@@ -1501,6 +1501,16 @@ case "$with_pmi" in
     with_pmi=pmi2
     with_pmilib=mpich
     ;;
+  pmi1|pmi2)
+    ;;
+  *)
+    # allow user to specify an external libpmi
+    m4_define([skip_ac_arg_with_pmi], 1)
+    PAC_CHECK_HEADER_LIB_FATAL([pmi], [pmi.h], [pmi], [PMI_Init])
+    # assume using PMI-1
+    with_pmi=pmi1
+    with_pmilib=no
+    ;;
 esac
 
 case "$with_pmilib" in
@@ -1689,6 +1699,9 @@ case "$with_pmilib" in
     ;;
   pmix)
     # taken care of by PAC_CHECK_HEADER_LIB_EXPLICIT
+    ;;
+  no)
+    # taken care of by --with-pmi=path
     ;;
   *)
     AC_MSG_ERROR([pmilib $with_pmilib not supported.])


### PR DESCRIPTION
## Pull Request Description
Allow linking with an externally installed `libpmi.so`. We'll assume using PMIv1, but eventually, we may allow runtime selections.

## Background

This will allow us to run nightly testing of `libpmi-main.tar.gz`.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
