### PR TITLE
dataloop: fix MPIR_Dataloop_iov

### DIFF
--- a/src/mpi/datatype/typerep/dataloop/dataloop_iov.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop_iov.c
@@ -164,7 +164,7 @@ int MPIR_Dataloop_iov(const void *buf, MPI_Aint count, void *dataloop, MPI_Aint 
                                     rem_skip, iov + idx, max_iov_len - idx, &tmp_len);
                     addr +=
                         dlp->loop_params.v_t.stride * (cnt - 1) +
-                        dlp->loop_params.v_t.blocksize * dt_extent;
+                        dlp->loop_params.v_t.blocksize * dlp->el_extent;
                     break;
                 case MPII_DATALOOP_KIND_BLOCKINDEXED:
                     fill_iov_blockindexed(addr, cnt, dlp->loop_params.bi_t.blocksize,
@@ -173,7 +173,7 @@ int MPIR_Dataloop_iov(const void *buf, MPI_Aint count, void *dataloop, MPI_Aint 
                                           rem_skip, iov + idx, max_iov_len - idx, &tmp_len);
                     addr = (void *) ((intptr_t) addr +
                                      dlp->loop_params.bi_t.offset_array[cnt - 1] +
-                                     dlp->loop_params.bi_t.blocksize * dt_extent);
+                                     dlp->loop_params.bi_t.blocksize * dlp->el_extent);
                     break;
                 case MPII_DATALOOP_KIND_INDEXED:
                     fill_iov_indexed(addr, cnt, dlp->loop_params.i_t.blocksize_array,
@@ -181,7 +181,7 @@ int MPIR_Dataloop_iov(const void *buf, MPI_Aint count, void *dataloop, MPI_Aint 
                                      child_dlp, dlp->el_extent, dlp->el_size,
                                      rem_skip, iov + idx, max_iov_len - idx, &tmp_len);
                     addr += dlp->loop_params.i_t.offset_array[cnt - 1] +
-                        dlp->loop_params.i_t.blocksize_array[cnt - 1] * dt_extent;
+                        dlp->loop_params.i_t.blocksize_array[cnt - 1] * dlp->el_extent;
                     break;
                 default:
                     MPIR_Assert(0);

--- a/src/mpi/datatype/typerep/dataloop/dataloop_iov.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop_iov.c
@@ -162,9 +162,9 @@ int MPIR_Dataloop_iov(const void *buf, MPI_Aint count, void *dataloop, MPI_Aint 
                                     dlp->loop_params.v_t.stride,
                                     child_dlp, dlp->el_extent, dlp->el_size,
                                     rem_skip, iov + idx, max_iov_len - idx, &tmp_len);
-                    addr +=
-                        dlp->loop_params.v_t.stride * (cnt - 1) +
-                        dlp->loop_params.v_t.blocksize * dlp->el_extent;
+                    addr = (void *) ((intptr_t) addr +
+                                     dlp->loop_params.v_t.stride * (cnt - 1) +
+                                     dlp->loop_params.v_t.blocksize * dlp->el_extent);
                     break;
                 case MPII_DATALOOP_KIND_BLOCKINDEXED:
                     fill_iov_blockindexed(addr, cnt, dlp->loop_params.bi_t.blocksize,
@@ -180,8 +180,10 @@ int MPIR_Dataloop_iov(const void *buf, MPI_Aint count, void *dataloop, MPI_Aint 
                                      dlp->loop_params.i_t.offset_array,
                                      child_dlp, dlp->el_extent, dlp->el_size,
                                      rem_skip, iov + idx, max_iov_len - idx, &tmp_len);
-                    addr += dlp->loop_params.i_t.offset_array[cnt - 1] +
-                        dlp->loop_params.i_t.blocksize_array[cnt - 1] * dlp->el_extent;
+                    addr = (void *) ((intptr_t) addr +
+                                     dlp->loop_params.i_t.offset_array[cnt - 1] +
+                                     dlp->loop_params.i_t.blocksize_array[cnt - 1] *
+                                     dlp->el_extent);
                     break;
                 default:
                     MPIR_Assert(0);


### PR DESCRIPTION
## Pull Request Description
Mistakingly multiplied dt_extent where it should be dlp->el_extent.

Caught by ubsan tests on 32-bit linux. Somehow the dtp test impls/mpich/misc/type_iov didn't catch this with regular 64-bit tests.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
