### PR TITLE
ch4/ofi: fix mt_mpicancel on 32-bit linux

### DIFF
--- a/src/mpi/init/init_util.c
+++ b/src/mpi/init/init_util.c
@@ -114,8 +114,8 @@ void MPII_dump_debug_summary(void)
 #endif
 
     printf("==== data structure summary ====\n");
-    printf("sizeof(MPIR_Comm): %ld\n", sizeof(MPIR_Comm));
-    printf("sizeof(MPIR_Request): %ld\n", sizeof(MPIR_Request));
-    printf("sizeof(MPIR_Datatype): %ld\n", sizeof(MPIR_Datatype));
+    printf("sizeof(MPIR_Comm): %zd\n", sizeof(MPIR_Comm));
+    printf("sizeof(MPIR_Request): %zd\n", sizeof(MPIR_Request));
+    printf("sizeof(MPIR_Datatype): %zd\n", sizeof(MPIR_Datatype));
     printf("================================\n");
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -368,6 +368,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq, bool 
             mpi_errno = MPIDI_OFI_progress_uninlined(vni);
             MPIR_ERR_CHECK(mpi_errno);
         }
+    } else {
+        /* run progress once to prevent accumulating cq errors. */
+        mpi_errno = MPIDI_OFI_progress_uninlined(vni);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:


### PR DESCRIPTION
## Pull Request Description
Run progress at least once to prevent accumulating entries in libfabric.
Some providers, e.g. the sockets provider, use finite cq_err space and
will silently throw away entries if we run out of space. This can be
easily triggered with threads/pt2pt/mt_mpicancel test on 32-bit os.

Poke progress at least once will clear the entries.

Also, fix a print fmt warning.

## Background
The 32-bit nightly tests sporadically fails the `./threads/pt2pt/mt_mpicancel 2` test. The test spawns 4 threads; each thread post and cancels 100 receive requests. On 32-bit linux with the sockets provider, there are only 16k cq error buffer, and it runs out-of-space after 292th `fi_cancel`. Since there are 4 threads and total 400 cancels, it may reach the limit depending on whether one of the thread issue `MPI_Wait_all` before the other threads issue 292th cancel.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
