### PR TITLE
coll: make errflag an input-only parameter

### DIFF
--- a/maint/gen_coll.py
+++ b/maint/gen_coll.py
@@ -665,7 +665,7 @@ def get_algo_params(params, algo):
     elif algo['func-commkind'].startswith('i'):
         algo_params += ", MPIR_Sched_t s"
     elif not algo['func-commkind'].startswith('neighbor_'):
-        algo_params += ", MPIR_Errflag_t *errflag"
+        algo_params += ", MPIR_Errflag_t errflag"
 
     return algo_params
 
@@ -682,7 +682,7 @@ def get_func_params(params, name, kind):
     func_params = params
     if kind == "blocking":
         if not name.startswith('neighbor_'):
-            func_params += ", MPIR_Errflag_t * errflag"
+            func_params += ", MPIR_Errflag_t errflag"
     elif kind == "nonblocking":
         func_params += ", MPIR_Request ** request"
     elif kind == "persistent":

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1368,7 +1368,7 @@ def push_impl_decl(func, impl_name=None):
         if func['dir'] == 'coll':
             # block collective use an extra errflag
             if not RE.match(r'MPI_(I.*|Neighbor.*|.*_init)$', func['name']):
-                params = params + ", MPIR_Errflag_t *errflag"
+                params = params + ", MPIR_Errflag_t errflag"
     else:
         params="void"
 
@@ -1416,8 +1416,7 @@ def dump_body_coll(func):
         dump_error_check("")
     else:
         # blocking collectives
-        G.out.append("MPIR_Errflag_t errflag = MPIR_ERR_NONE;")
-        dump_line_with_break("mpi_errno = %s(%s, &errflag);" % (mpir_name, args))
+        dump_line_with_break("mpi_errno = %s(%s, MPIR_ERR_NONE);" % (mpir_name, args))
         dump_error_check("")
 
 def dump_coll_v_swap(func):

--- a/src/binding/c/comm_api.txt
+++ b/src/binding/c/comm_api.txt
@@ -283,15 +283,13 @@ MPI_Intercomm_merge:
 }
 { -- error_check --
     int acthigh;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     /* Check for consistent valus of high in each local group.
      * The Intel test suite checks for this; it is also an easy
      * error to make */
     acthigh = high ? 1 : 0;     /* Clamp high into 1 or 0 */
     mpi_errno = MPIR_Allreduce(MPI_IN_PLACE, &acthigh, 1, MPI_INT,
-                                MPI_SUM, intercomm_ptr->local_comm, &errflag);
+                                MPI_SUM, intercomm_ptr->local_comm, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
     /* acthigh must either == 0 or the size of the local comm */
     if (acthigh != 0 && acthigh != intercomm_ptr->local_size) {
         mpi_errno = MPIR_Err_create_code(MPI_SUCCESS,

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -28,23 +28,23 @@ int MPIC_Wait(MPIR_Request * request_ptr);
 int MPIC_Probe(int source, int tag, MPI_Comm comm, MPI_Status * status);
 
 int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+              MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag);
 int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int tag,
               MPIR_Comm * comm_ptr, MPI_Status * status);
 int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag);
 int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                   int dest, int sendtag, void *recvbuf, MPI_Aint recvcount,
                   MPI_Datatype recvtype, int source, int recvtag,
-                  MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t * errflag);
+                  MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t errflag);
 int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
                           int dest, int sendtag,
                           int source, int recvtag,
-                          MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t * errflag);
+                          MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t errflag);
 int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t * errflag);
+               MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t errflag);
 int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-                MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t * errflag);
+                MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t errflag);
 int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
                int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[]);
@@ -52,7 +52,7 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[]);
 int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
                       MPI_Op op);
 
-int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag);
 
 /* TSP auto */
 int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -24,13 +24,13 @@
    other internal operations. They are wrappers around MPID send/recv
    functions. They do sends/receives by setting the context offset to
    MPIR_CONTEXT_INTRA(INTER)_COLL. */
-int MPIC_Wait(MPIR_Request * request_ptr, MPIR_Errflag_t * errflag);
+int MPIC_Wait(MPIR_Request * request_ptr);
 int MPIC_Probe(int source, int tag, MPI_Comm comm, MPI_Status * status);
 
 int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int tag,
-              MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t * errflag);
+              MPIR_Comm * comm_ptr, MPI_Status * status);
 int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
@@ -47,8 +47,7 @@ int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest
                 MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t * errflag);
 int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
                int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[],
-                 MPIR_Errflag_t * errflag);
+int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[]);
 
 int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
                       MPI_Op op);

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -876,12 +876,12 @@ cvars:
 /* For collective communication errors, record the error and continue */
 /* NOTE: this one assumes we are using mpi_errno and mpi_errno_ret */
 /* TODO: document the cases or criteria that we can safely do this */
-#define MPIR_ERR_COLL_CHECKANDCONT(err_, errflag_) \
+#define MPIR_ERR_COLL_CHECKANDCONT(err_, errflag_, err_ret_) \
     do { \
         if (err_) { \
             errflag_ = (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(err_)) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER; \
-            MPIR_ERR_SET(mpi_errno, errflag_, "**fail"); \
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno); \
+            MPIR_ERR_SET(err_, errflag_, "**fail"); \
+            MPIR_ERR_ADD(err_ret_, err_); \
         } \
     } while (0)
 
@@ -950,7 +950,7 @@ cvars:
             err_ = newerr_;                     \
     } while (0)
 
-#define MPIR_ERR_COLL_CHECKANDCONT(err_, errflag_) \
+#define MPIR_ERR_COLL_CHECKANDCONT(err_, errflag_, err_ret_) \
     do { \
         if (err_) { \
             errflag_ = (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(err_)) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER; \

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -873,14 +873,11 @@ cvars:
         (err_) = MPIR_Err_combine_codes((err_), (newerr_));     \
     } while (0)
 
-/* For collective communication errors, record the error and continue */
-/* NOTE: this one assumes we are using mpi_errno and mpi_errno_ret */
-/* TODO: document the cases or criteria that we can safely do this */
+/* For collective communication error, update errflag_ and err_ret_, do not abort */
 #define MPIR_ERR_COLL_CHECKANDCONT(err_, errflag_, err_ret_) \
     do { \
         if (err_) { \
-            errflag_ = (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(err_)) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER; \
-            MPIR_ERR_SET(err_, errflag_, "**fail"); \
+            errflag_ |= (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(err_)) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER; \
             MPIR_ERR_ADD(err_ret_, err_); \
         } \
     } while (0)

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -882,6 +882,17 @@ cvars:
         } \
     } while (0)
 
+/* Propagate the size mismatch error */
+#define MPIR_ERR_COLL_CHECK_SIZE(recv_sz, expect_sz, errflag_, err_ret_) \
+    do {                                                        \
+        if (recv_sz != expect_sz) { \
+            int err = MPI_SUCCESS; \
+            MPIR_ERR_SET2(err, MPI_ERR_OTHER, "**collective_size_mismatch", "**collective_size_mismatch %d %d", recv_sz, expect_sz); \
+            MPIR_ERR_ADD(err_ret_, err); \
+            errflag_ |= MPIR_ERR_OTHER; \
+        } \
+    } while (0)
+
 #else
 /* Simply set the class, being careful not to override a previously
    set class. */
@@ -953,6 +964,8 @@ cvars:
             errflag_ = (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(err_)) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER; \
         } \
     } while (0)
+
+#define MPIR_ERR_COLL_CHECK_SIZE(recv_sz, expect_sz, errflag_, err_ret_) do { } while (0)
 
 #endif
 

--- a/src/include/mpir_misc_post.h
+++ b/src/include/mpir_misc_post.h
@@ -6,24 +6,20 @@
 #ifndef MPIR_MISC_POST_H_INCLUDED
 #define MPIR_MISC_POST_H_INCLUDED
 
-/* Pull the error status out of the tag space and put it into an errflag. */
-static inline void MPIR_Process_status(MPI_Status * status, MPIR_Errflag_t * errflag)
+/* Pull the error status out of the tag space and return status->MPI_ERROR */
+static inline int MPIR_Process_status(MPI_Status * status)
 {
-    if (MPI_PROC_NULL != status->MPI_SOURCE &&
-        (MPIX_ERR_REVOKED == MPIR_ERR_GET_CLASS(status->MPI_ERROR) ||
-         MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(status->MPI_ERROR) ||
-         MPIR_TAG_CHECK_ERROR_BIT(status->MPI_TAG)) && !*errflag) {
-        /* If the receive was completed within the MPID_Recv, handle the
-         * errflag here. */
-        if (MPIR_TAG_CHECK_PROC_FAILURE_BIT(status->MPI_TAG) ||
-            MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(status->MPI_ERROR)) {
-            *errflag = MPIR_ERR_PROC_FAILED;
-            MPIR_TAG_CLEAR_ERROR_BITS(status->MPI_TAG);
+    if (MPI_PROC_NULL != status->MPI_SOURCE && MPIR_TAG_CHECK_ERROR_BIT(status->MPI_TAG)) {
+        int err = MPI_SUCCESS;
+        if (MPIR_TAG_CHECK_PROC_FAILURE_BIT(status->MPI_TAG)) {
+            MPIR_ERR_SET(err, MPIX_ERR_PROC_FAILED, "**fail");
         } else {
-            *errflag = MPIR_ERR_OTHER;
-            MPIR_TAG_CLEAR_ERROR_BITS(status->MPI_TAG);
+            MPIR_ERR_SET(err, MPI_ERR_OTHER, "**fail");
         }
+        MPIR_ERR_ADD(status->MPI_ERROR, err);
+        MPIR_TAG_CLEAR_ERROR_BITS(status->MPI_TAG);
     }
+    return status->MPI_ERROR;
 }
 
 #endif /* MPIR_MISC_POST_H_INCLUDED */

--- a/src/mpi/coll/allgather/allgather_allcomm_nb.c
+++ b/src/mpi/coll/allgather/allgather_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                              MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/allgather/allgather_allcomm_nb.c
+++ b/src/mpi/coll/allgather/allgather_allcomm_nb.c
@@ -18,7 +18,7 @@ int MPIR_Allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
                         &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
@@ -49,14 +49,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
     if (sendcount != 0) {
         mpi_errno = MPIR_Gather(sendbuf, sendcount, sendtype, tmp_buf, sendcount * sendtype_sz,
                                 MPI_BYTE, 0, newcomm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     /* first broadcast from left to right group, then from right to
@@ -67,14 +60,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Bcast(tmp_buf, sendcount * sendtype_sz * local_size,
                                    MPI_BYTE, root, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
 
         /* receive bcast from right */
@@ -82,14 +68,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
             root = 0;
             mpi_errno = MPIR_Bcast(recvbuf, recvcount * remote_size,
                                    recvtype, root, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     } else {
         /* receive bcast from left */
@@ -97,14 +76,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
             root = 0;
             mpi_errno = MPIR_Bcast(recvbuf, recvcount * remote_size,
                                    recvtype, root, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
 
         /* bcast to left */
@@ -112,14 +84,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Bcast(tmp_buf, sendcount * sendtype_sz * local_size,
                                    MPI_BYTE, root, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
@@ -15,7 +15,7 @@
 int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS, root;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -49,7 +49,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
     if (sendcount != 0) {
         mpi_errno = MPIR_Gather(sendbuf, sendcount, sendtype, tmp_buf, sendcount * sendtype_sz,
                                 MPI_BYTE, 0, newcomm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* first broadcast from left to right group, then from right to
@@ -60,7 +60,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Bcast(tmp_buf, sendcount * sendtype_sz * local_size,
                                    MPI_BYTE, root, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         /* receive bcast from right */
@@ -68,7 +68,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
             root = 0;
             mpi_errno = MPIR_Bcast(recvbuf, recvcount * remote_size,
                                    recvtype, root, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     } else {
         /* receive bcast from left */
@@ -76,7 +76,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
             root = 0;
             mpi_errno = MPIR_Bcast(recvbuf, recvcount * remote_size,
                                    recvtype, root, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         /* bcast to left */
@@ -84,7 +84,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Bcast(tmp_buf, sendcount * sendtype_sz * local_size,
                                    MPI_BYTE, root, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
@@ -125,13 +125,8 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -19,8 +19,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                 MPI_Datatype sendtype,
                                 void *recvbuf,
                                 MPI_Aint recvcount,
-                                MPI_Datatype recvtype,
-                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
@@ -70,7 +69,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   curr_cnt * recvtype_sz, MPI_BYTE,
                                   src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         curr_cnt *= 2;
         pof2 *= 2;
     }
@@ -87,7 +86,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   rem * recvcount * recvtype_sz, MPI_BYTE,
                                   src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Rotate blocks in tmp_buf down by (rank) blocks and store
@@ -103,7 +102,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                    (comm_size - rank) * recvcount * recvtype_sz,
                                    rank * recvcount * recvtype_sz, MPI_BYTE, recvbuf,
                                    rank * recvcount, recvtype);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -122,13 +122,8 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -70,14 +70,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   curr_cnt * recvtype_sz, MPI_BYTE,
                                   src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         curr_cnt *= 2;
         pof2 *= 2;
     }
@@ -94,14 +87,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   rem * recvcount * recvtype_sz, MPI_BYTE,
                                   src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     /* Rotate blocks in tmp_buf down by (rank) blocks and store
@@ -117,7 +103,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                    (comm_size - rank) * recvcount * recvtype_sz,
                                    rank * recvcount * recvtype_sz, MPI_BYTE, recvbuf,
                                    rank * recvcount, recvtype);
-        MPIR_ERR_CHECK(mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/allgather/allgather_intra_k_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_k_brucks.c
@@ -23,7 +23,7 @@ int
 MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
                               MPI_Datatype sendtype, void *recvbuf,
                               MPI_Aint recvcount, MPI_Datatype recvtype, MPIR_Comm * comm, int k,
-                              MPIR_Errflag_t * errflag)
+                              MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -143,7 +143,7 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
             mpi_errno = MPIC_Irecv((char *) tmp_recvbuf + j * recvcount * delta * recvtype_extent,
                                    count, recvtype, src, MPIR_ALLGATHER_TAG, comm,
                                    &reqs[num_reqs++]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
                                                      "Phase#%d:, k:%d Recv at:%p for count:%d", i,
@@ -155,7 +155,7 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
             mpi_errno =
                 MPIC_Isend(tmp_recvbuf, count, recvtype, dst, MPIR_ALLGATHER_TAG, comm,
                            &reqs[num_reqs++], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
                                                      "Phase#%d:, k:%d Send from:%p for count:%d",
@@ -163,7 +163,7 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
 
         }
         mpi_errno = MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         delta *= k;
     }
 

--- a/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
@@ -150,8 +150,7 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                          (rank >= tree_root + nprocs_completed)) {
                     mpi_errno = MPIC_Recv(((char *) recvbuf + offset),
                                           (comm_size - (my_tree_root + mask)) * recvcount,
-                                          recvtype, dst,
-                                          MPIR_ALLGATHER_TAG, comm_ptr, &status, errflag);
+                                          recvtype, dst, MPIR_ALLGATHER_TAG, comm_ptr, &status);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     /* nprocs_completed is also equal to the
                      * no. of processes whose data we don't have */

--- a/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
@@ -193,13 +193,8 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
     }
 
   fn_exit:
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
@@ -83,13 +83,8 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                                       (comm_size - dst_tree_root) * recvcount,
                                       recvtype, dst,
                                       MPIR_ALLGATHER_TAG, comm_ptr, &status, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                 last_recv_cnt = 0;
             } else {
                 MPIR_Get_count_impl(&status, recvtype, &last_recv_cnt);
@@ -146,17 +141,7 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                     mpi_errno = MPIC_Send(((char *) recvbuf + offset),
                                           last_recv_cnt,
                                           recvtype, dst, MPIR_ALLGATHER_TAG, comm_ptr, errflag);
-                    /* last_recv_cnt was set in the previous
-                     * receive. that's the amount of data to be
-                     * sent now. */
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -167,15 +152,10 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                                           (comm_size - (my_tree_root + mask)) * recvcount,
                                           recvtype, dst,
                                           MPIR_ALLGATHER_TAG, comm_ptr, &status, errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     /* nprocs_completed is also equal to the
                      * no. of processes whose data we don't have */
                     if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                         last_recv_cnt = 0;
                     } else {
                         MPIR_Get_count_impl(&status, recvtype, &last_recv_cnt);

--- a/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
@@ -23,7 +23,7 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                                             void *recvbuf,
                                             MPI_Aint recvcount,
                                             MPI_Datatype recvtype,
-                                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                            MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
@@ -83,7 +83,7 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                                       (comm_size - dst_tree_root) * recvcount,
                                       recvtype, dst,
                                       MPIR_ALLGATHER_TAG, comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (mpi_errno) {
                 last_recv_cnt = 0;
             } else {
@@ -141,7 +141,7 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                     mpi_errno = MPIC_Send(((char *) recvbuf + offset),
                                           last_recv_cnt,
                                           recvtype, dst, MPIR_ALLGATHER_TAG, comm_ptr, errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -151,7 +151,7 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                     mpi_errno = MPIC_Recv(((char *) recvbuf + offset),
                                           (comm_size - (my_tree_root + mask)) * recvcount,
                                           recvtype, dst, MPIR_ALLGATHER_TAG, comm_ptr, &status);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     /* nprocs_completed is also equal to the
                      * no. of processes whose data we don't have */
                     if (mpi_errno) {

--- a/src/mpi/coll/allgather/allgather_intra_ring.c
+++ b/src/mpi/coll/allgather/allgather_intra_ring.c
@@ -65,14 +65,7 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
                                    jnext * recvcount * recvtype_extent),
                                   recvcount, recvtype, left,
                                   MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         j = jnext;
         jnext = (comm_size + jnext - 1) % comm_size;
     }

--- a/src/mpi/coll/allgather/allgather_intra_ring.c
+++ b/src/mpi/coll/allgather/allgather_intra_ring.c
@@ -78,13 +78,8 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
     }
 
   fn_exit:
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allgather/allgather_intra_ring.c
+++ b/src/mpi/coll/allgather/allgather_intra_ring.c
@@ -25,7 +25,7 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
                               MPI_Datatype sendtype,
                               void *recvbuf,
                               MPI_Aint recvcount,
-                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
@@ -65,7 +65,7 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
                                    jnext * recvcount * recvtype_extent),
                                   recvcount, recvtype, left,
                                   MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         j = jnext;
         jnext = (comm_size + jnext - 1) % comm_size;
     }

--- a/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
@@ -7,8 +7,7 @@
 
 int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
-                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                               MPIR_Errflag_t * errflag)
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
@@ -19,7 +19,7 @@ int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                          comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
+++ b/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
@@ -113,17 +113,12 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Ain
     MPIR_Type_free_impl(&newtype);
 
   fn_exit:
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**coll_fail");
+    return mpi_errno_ret;
 
-    return mpi_errno;
   fn_fail:
-    /* --BEGIN ERROR HANDLING-- */
     if (newtype != MPI_DATATYPE_NULL)
         MPIR_Type_free_impl(&newtype);
 
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
-    /* --END ERROR HANDLING-- */
 }

--- a/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
+++ b/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
@@ -36,51 +36,23 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Ain
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
                                  recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         /* gatherv to right group */
         root = 0;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
                                  recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         /* gatherv to left group  */
         root = 0;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
                                  recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         /* gatherv from left group */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
                                  recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     /* now do an intracommunicator broadcast within each group. we use
@@ -101,20 +73,12 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Ain
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Bcast_allcomm_auto(recvbuf, 1, newtype, 0, newcomm_ptr, errflag);
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
     MPIR_Type_free_impl(&newtype);
 
   fn_exit:
     return mpi_errno_ret;
-
   fn_fail:
     if (newtype != MPI_DATATYPE_NULL)
         MPIR_Type_free_impl(&newtype);

--- a/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
+++ b/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
@@ -19,7 +19,7 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Ain
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const MPI_Aint * recvcounts, const MPI_Aint
                                                     * displs, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int remote_size, mpi_errno, root, rank;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -36,23 +36,23 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Ain
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
                                  recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* gatherv to right group */
         root = 0;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
                                  recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         /* gatherv to left group  */
         root = 0;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
                                  recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* gatherv from left group */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
                                  recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* now do an intracommunicator broadcast within each group. we use
@@ -73,7 +73,7 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Ain
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Bcast_allcomm_auto(recvbuf, 1, newtype, 0, newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     MPIR_Type_free_impl(&newtype);
 

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -146,12 +146,8 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -80,16 +80,12 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   (total_count - curr_cnt) * recvtype_sz, MPI_BYTE,
                                   src, MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
             recv_cnt = 0;
-        } else
+        } else {
             MPIR_Get_count_impl(&status, recvtype, &recv_cnt);
+        }
         curr_cnt += recv_cnt;
 
         pof2 *= 2;
@@ -111,14 +107,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   (total_count - curr_cnt) * recvtype_sz, MPI_BYTE,
                                   src, MPIR_ALLGATHERV_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     /* Rotate blocks in tmp_buf down by (rank) blocks and store

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -23,7 +23,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                  const MPI_Aint * recvcounts,
                                  const MPI_Aint * displs,
                                  MPI_Datatype recvtype,
-                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, rank, j, i;
     int mpi_errno = MPI_SUCCESS;
@@ -80,7 +80,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   (total_count - curr_cnt) * recvtype_sz, MPI_BYTE,
                                   src, MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         if (mpi_errno) {
             recv_cnt = 0;
         } else {
@@ -107,7 +107,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   (total_count - curr_cnt) * recvtype_sz, MPI_BYTE,
                                   src, MPIR_ALLGATHERV_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Rotate blocks in tmp_buf down by (rank) blocks and store

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -25,7 +25,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                                              const MPI_Aint * recvcounts,
                                              const MPI_Aint * displs,
                                              MPI_Datatype recvtype,
-                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, rank, j, i;
     int mpi_errno = MPI_SUCCESS;
@@ -114,7 +114,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                                       ((char *) tmp_buf + recv_offset * recvtype_sz),
                                       (total_count - recv_offset) * recvtype_sz, MPI_BYTE, dst,
                                       MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (mpi_errno) {
                 last_recv_cnt = 0;
             } else {
@@ -177,7 +177,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                     mpi_errno = MPIC_Send(((char *) tmp_buf + offset * recvtype_sz),
                                           last_recv_cnt * recvtype_sz,
                                           MPI_BYTE, dst, MPIR_ALLGATHERV_TAG, comm_ptr, errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     /* last_recv_cnt was set in the previous
                      * receive. that's the amount of data to be
                      * sent now. */
@@ -195,7 +195,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset * recvtype_sz),
                                           (total_count - offset) * recvtype_sz, MPI_BYTE,
                                           dst, MPIR_ALLGATHERV_TAG, comm_ptr, &status);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     if (mpi_errno) {
                         last_recv_cnt = 0;
                     } else

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -194,7 +194,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
 
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset * recvtype_sz),
                                           (total_count - offset) * recvtype_sz, MPI_BYTE,
-                                          dst, MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
+                                          dst, MPIR_ALLGATHERV_TAG, comm_ptr, &status);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     if (mpi_errno) {
                         last_recv_cnt = 0;

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -247,12 +247,8 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -114,18 +114,14 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                                       ((char *) tmp_buf + recv_offset * recvtype_sz),
                                       (total_count - recv_offset) * recvtype_sz, MPI_BYTE, dst,
                                       MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                 last_recv_cnt = 0;
-            } else
+            } else {
                 /* for convenience, recv is posted for a bigger amount
                  * than will be sent */
                 MPIR_Get_count_impl(&status, recvtype, &last_recv_cnt);
+            }
             curr_cnt += last_recv_cnt;
         }
 
@@ -181,14 +177,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                     mpi_errno = MPIC_Send(((char *) tmp_buf + offset * recvtype_sz),
                                           last_recv_cnt * recvtype_sz,
                                           MPI_BYTE, dst, MPIR_ALLGATHERV_TAG, comm_ptr, errflag);
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     /* last_recv_cnt was set in the previous
                      * receive. that's the amount of data to be
                      * sent now. */
@@ -206,13 +195,8 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset * recvtype_sz),
                                           (total_count - offset) * recvtype_sz, MPI_BYTE,
                                           dst, MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                         last_recv_cnt = 0;
                     } else
                         /* for convenience, recv is posted for a

--- a/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
@@ -113,39 +113,18 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
             mpi_errno =
                 MPIC_Recv(rbuf, recvnow, recvtype, left, MPIR_ALLGATHERV_TAG, comm_ptr, &status,
                           errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             torecv -= recvnow;
         } else if (!recvnow) {  /* If there's no data to receive, just do a send call */
             mpi_errno =
                 MPIC_Send(sbuf, sendnow, recvtype, right, MPIR_ALLGATHERV_TAG, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             tosend -= sendnow;
         } else {        /* There's data to be sent and received */
             mpi_errno = MPIC_Sendrecv(sbuf, sendnow, recvtype, right, MPIR_ALLGATHERV_TAG,
                                       rbuf, recvnow, recvtype, left, MPIR_ALLGATHERV_TAG,
                                       comm_ptr, &status, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             tosend -= sendnow;
             torecv -= recvnow;
         }

--- a/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
@@ -163,12 +163,8 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
     }
 
   fn_exit:
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
@@ -111,8 +111,7 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
              * consecutive processes contribute 0 bytes each. */
         } else if (!sendnow) {  /* If there's no data to send, just do a recv call */
             mpi_errno =
-                MPIC_Recv(rbuf, recvnow, recvtype, left, MPIR_ALLGATHERV_TAG, comm_ptr, &status,
-                          errflag);
+                MPIC_Recv(rbuf, recvnow, recvtype, left, MPIR_ALLGATHERV_TAG, comm_ptr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             torecv -= recvnow;
         } else if (!recvnow) {  /* If there's no data to receive, just do a send call */

--- a/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
@@ -28,8 +28,7 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
                                void *recvbuf,
                                const MPI_Aint * recvcounts,
                                const MPI_Aint * displs,
-                               MPI_Datatype recvtype,
-                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, rank, i, left, right;
     int mpi_errno = MPI_SUCCESS;
@@ -112,18 +111,18 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
         } else if (!sendnow) {  /* If there's no data to send, just do a recv call */
             mpi_errno =
                 MPIC_Recv(rbuf, recvnow, recvtype, left, MPIR_ALLGATHERV_TAG, comm_ptr, &status);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             torecv -= recvnow;
         } else if (!recvnow) {  /* If there's no data to receive, just do a send call */
             mpi_errno =
                 MPIC_Send(sbuf, sendnow, recvtype, right, MPIR_ALLGATHERV_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             tosend -= sendnow;
         } else {        /* There's data to be sent and received */
             mpi_errno = MPIC_Sendrecv(sbuf, sendnow, recvtype, right, MPIR_ALLGATHERV_TAG,
                                       rbuf, recvnow, recvtype, left, MPIR_ALLGATHERV_TAG,
                                       comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             tosend -= sendnow;
             torecv -= recvnow;
         }

--- a/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
+++ b/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
@@ -16,7 +16,7 @@ int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count
     mpi_errno = MPIR_Iallreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
+++ b/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t * errflag)
+                              MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
+++ b/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
@@ -15,7 +15,7 @@
 
 int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -41,19 +41,19 @@ int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbu
 
     /* Do a local reduce on this intracommunicator */
     mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype, op, 0, newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* Do a exchange between local and remote rank 0 on this intercommunicator */
     if (comm_ptr->rank == 0) {
         mpi_errno = MPIC_Sendrecv(tmp_buf, count, datatype, 0, MPIR_REDUCE_TAG,
                                   recvbuf, count, datatype, 0, MPIR_REDUCE_TAG,
                                   comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Do a local broadcast on this intracommunicator */
     mpi_errno = MPIR_Bcast(recvbuf, count, datatype, 0, newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
+++ b/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
@@ -41,40 +41,19 @@ int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbu
 
     /* Do a local reduce on this intracommunicator */
     mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype, op, 0, newcomm_ptr, errflag);
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
     /* Do a exchange between local and remote rank 0 on this intercommunicator */
     if (comm_ptr->rank == 0) {
         mpi_errno = MPIC_Sendrecv(tmp_buf, count, datatype, 0, MPIR_REDUCE_TAG,
                                   recvbuf, count, datatype, 0, MPIR_REDUCE_TAG,
                                   comm_ptr, MPI_STATUS_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     /* Do a local broadcast on this intracommunicator */
     mpi_errno = MPIR_Bcast(recvbuf, count, datatype, 0, newcomm_ptr, errflag);
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
+++ b/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
@@ -78,13 +78,8 @@ int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbu
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
@@ -15,7 +15,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                                                     MPI_Aint count,
                                                     MPI_Datatype datatype,
                                                     MPI_Op op, MPIR_Comm * comm, int k,
-                                                    int single_phase_recv, MPIR_Errflag_t * errflag)
+                                                    int single_phase_recv, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
     int rank, nranks, nbr;
@@ -107,16 +107,16 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
         /* non-participating rank sends the data to a participating rank */
         mpi_errno = MPIC_Send(recvbuf, count,
                               datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {    /* odd */
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
             mpi_errno =
                 MPIC_Recv(tmp_recvbuf, count, datatype, step1_recvfrom[i], MPIR_ALLREDUCE_TAG, comm,
                           MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             /* Do reduction of reduced data */
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, recvbuf, count, datatype, op);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 
@@ -164,7 +164,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                     MPIC_Isend((char *) recvbuf + send_offset, send_cnt,
                                datatype, dst, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++],
                                errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 rank_for_offset = MPII_Recexchalgo_reverse_digits_step2(rank, nranks, k);
                 MPII_Recexchalgo_get_count_and_offset(rank_for_offset, j, k, nranks,
@@ -177,14 +177,14 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                 mpi_errno =
                     MPIC_Irecv((char *) tmp_recvbuf + recv_offset, recv_cnt, datatype,
                                dst, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 mpi_errno = MPIC_Waitall(num_rreq, recv_reqs, MPI_STATUSES_IGNORE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 mpi_errno =
                     MPIR_Reduce_local((char *) tmp_recvbuf + recv_offset,
                                       (char *) recvbuf + recv_offset, recv_cnt, datatype, op);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
 
@@ -210,7 +210,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                         recv_count += cnts[offset + x];
                     mpi_errno = MPIC_Irecv(((char *) recvbuf + recv_offset), recv_count, datatype,
                                            nbr, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
                 recv_phase--;
             }
@@ -227,11 +227,11 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                 mpi_errno = MPIC_Isend(((char *) recvbuf + send_offset), send_count, datatype,
                                        nbr, MPIR_ALLREDUCE_TAG, comm, &send_reqs[num_sreq++],
                                        errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
             /* wait on prev recvs */
             mpi_errno = MPIC_Waitall((k - 1), recv_reqs, MPI_STATUSES_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             phase--;
             if (single_phase_recv == false) {
@@ -250,17 +250,17 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                         mpi_errno =
                             MPIC_Isend(((char *) recvbuf + send_offset), send_count, datatype, nbr,
                                        MPIR_ALLREDUCE_TAG, comm, &send_reqs[num_sreq++], errflag);
-                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     }
                     /* wait on prev recvs */
                     mpi_errno = MPIC_Waitall((k - 1), recv_reqs + (k - 1), MPI_STATUSES_IGNORE);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                     phase--;
                 }
             }
             mpi_errno = MPIC_Waitall(num_sreq, send_reqs, MPI_STATUSES_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 
@@ -269,18 +269,18 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm,
                               MPI_STATUS_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         if (step1_nrecvs > 0) {
             for (i = 0; i < step1_nrecvs; i++) {
                 mpi_errno =
                     MPIC_Isend(recvbuf, count, datatype, step1_recvfrom[i], MPIR_ALLREDUCE_TAG,
                                comm, &send_reqs[i], errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
 
             mpi_errno = MPIC_Waitall(i, send_reqs, MPI_STATUSES_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
@@ -107,38 +107,16 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
         /* non-participating rank sends the data to a participating rank */
         mpi_errno = MPIC_Send(recvbuf, count,
                               datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
-
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {    /* odd */
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
             mpi_errno =
                 MPIC_Recv(tmp_recvbuf, count, datatype, step1_recvfrom[i], MPIR_ALLREDUCE_TAG, comm,
                           MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             /* Do reduction of reduced data */
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, recvbuf, count, datatype, op);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }
 
@@ -186,14 +164,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                     MPIC_Isend((char *) recvbuf + send_offset, send_cnt,
                                datatype, dst, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++],
                                errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                 rank_for_offset = MPII_Recexchalgo_reverse_digits_step2(rank, nranks, k);
                 MPII_Recexchalgo_get_count_and_offset(rank_for_offset, j, k, nranks,
@@ -206,14 +177,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                 mpi_errno =
                     MPIC_Irecv((char *) tmp_recvbuf + recv_offset, recv_cnt, datatype,
                                dst, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++]);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                 mpi_errno = MPIC_Waitall(num_rreq, recv_reqs, MPI_STATUSES_IGNORE, errflag);
                 if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
@@ -221,14 +185,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                 mpi_errno =
                     MPIR_Reduce_local((char *) tmp_recvbuf + recv_offset,
                                       (char *) recvbuf + recv_offset, recv_cnt, datatype, op);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         }
 
@@ -254,14 +211,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                         recv_count += cnts[offset + x];
                     mpi_errno = MPIC_Irecv(((char *) recvbuf + recv_offset), recv_count, datatype,
                                            nbr, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++]);
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
                 recv_phase--;
             }
@@ -278,14 +228,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                 mpi_errno = MPIC_Isend(((char *) recvbuf + send_offset), send_count, datatype,
                                        nbr, MPIR_ALLREDUCE_TAG, comm, &send_reqs[num_sreq++],
                                        errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
             /* wait on prev recvs */
             mpi_errno = MPIC_Waitall((k - 1), recv_reqs, MPI_STATUSES_IGNORE, errflag);
@@ -309,15 +252,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                         mpi_errno =
                             MPIC_Isend(((char *) recvbuf + send_offset), send_count, datatype, nbr,
                                        MPIR_ALLREDUCE_TAG, comm, &send_reqs[num_sreq++], errflag);
-                        if (mpi_errno) {
-                            /* for communication errors, just record the error but continue */
-                            *errflag =
-                                MPIX_ERR_PROC_FAILED ==
-                                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED :
-                                MPIR_ERR_OTHER;
-                            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                        }
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     }
                     /* wait on prev recvs */
                     mpi_errno =
@@ -339,28 +274,14 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm,
                               MPI_STATUS_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         if (step1_nrecvs > 0) {
             for (i = 0; i < step1_nrecvs; i++) {
                 mpi_errno =
                     MPIC_Isend(recvbuf, count, datatype, step1_recvfrom[i], MPIR_ALLREDUCE_TAG,
                                comm, &send_reqs[i], errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
 
             mpi_errno = MPIC_Waitall(i, send_reqs, MPI_STATUSES_IGNORE, errflag);

--- a/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
@@ -112,7 +112,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
             mpi_errno =
                 MPIC_Recv(tmp_recvbuf, count, datatype, step1_recvfrom[i], MPIR_ALLREDUCE_TAG, comm,
-                          MPI_STATUS_IGNORE, errflag);
+                          MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             /* Do reduction of reduced data */
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, recvbuf, count, datatype, op);
@@ -179,9 +179,8 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                                dst, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
-                mpi_errno = MPIC_Waitall(num_rreq, recv_reqs, MPI_STATUSES_IGNORE, errflag);
-                if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-                    MPIR_ERR_POP(mpi_errno);
+                mpi_errno = MPIC_Waitall(num_rreq, recv_reqs, MPI_STATUSES_IGNORE);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 mpi_errno =
                     MPIR_Reduce_local((char *) tmp_recvbuf + recv_offset,
                                       (char *) recvbuf + recv_offset, recv_cnt, datatype, op);
@@ -231,9 +230,8 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
             /* wait on prev recvs */
-            mpi_errno = MPIC_Waitall((k - 1), recv_reqs, MPI_STATUSES_IGNORE, errflag);
-            if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-                MPIR_ERR_POP(mpi_errno);
+            mpi_errno = MPIC_Waitall((k - 1), recv_reqs, MPI_STATUSES_IGNORE);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             phase--;
             if (single_phase_recv == false) {
@@ -255,17 +253,14 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     }
                     /* wait on prev recvs */
-                    mpi_errno =
-                        MPIC_Waitall((k - 1), recv_reqs + (k - 1), MPI_STATUSES_IGNORE, errflag);
-                    if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-                        MPIR_ERR_POP(mpi_errno);
+                    mpi_errno = MPIC_Waitall((k - 1), recv_reqs + (k - 1), MPI_STATUSES_IGNORE);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                     phase--;
                 }
             }
-            mpi_errno = MPIC_Waitall(num_sreq, send_reqs, MPI_STATUSES_IGNORE, errflag);
-            if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-                MPIR_ERR_POP(mpi_errno);
+            mpi_errno = MPIC_Waitall(num_sreq, send_reqs, MPI_STATUSES_IGNORE);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }
 
@@ -273,7 +268,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
      * send the data to non-partcipating rans */
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm,
-                              MPI_STATUS_IGNORE, errflag);
+                              MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         if (step1_nrecvs > 0) {
@@ -284,9 +279,8 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
 
-            mpi_errno = MPIC_Waitall(i, send_reqs, MPI_STATUSES_IGNORE, errflag);
-            if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-                MPIR_ERR_POP(mpi_errno);
+            mpi_errno = MPIC_Waitall(i, send_reqs, MPI_STATUSES_IGNORE);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
@@ -383,11 +383,8 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
     MPL_free(tmp_recvbuf);
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allreduce/allreduce_intra_recexch.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recexch.c
@@ -158,9 +158,8 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                                        MPIR_ALLREDUCE_TAG, comm, &recv_reqs[recv_nreq++]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
-            mpi_errno = MPIC_Waitall(recv_nreq, recv_reqs, MPI_STATUSES_IGNORE, errflag);
-            if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-                MPIR_ERR_POP(mpi_errno);
+            mpi_errno = MPIC_Waitall(recv_nreq, recv_reqs, MPI_STATUSES_IGNORE);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* Do reduction of reduced data */
             for (i = 0; i < step1_nrecvs && count > 0; i++) {   /* participating rank gets data from non-partcipating ranks */
@@ -206,14 +205,12 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
             }
         }
 
-        mpi_errno = MPIC_Waitall(send_nreq, send_reqs, MPI_STATUSES_IGNORE, errflag);
-        if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-            MPIR_ERR_POP(mpi_errno);
+        mpi_errno = MPIC_Waitall(send_nreq, send_reqs, MPI_STATUSES_IGNORE);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         buf = myidx - 1;
-        mpi_errno = MPIC_Waitall((k - 1), recv_reqs, MPI_STATUSES_IGNORE, errflag);
-        if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-            MPIR_ERR_POP(mpi_errno);
+        mpi_errno = MPIC_Waitall((k - 1), recv_reqs, MPI_STATUSES_IGNORE);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         for (i = myidx - 1; i >= 0 && count > 0; i--, buf--) {
             mpi_errno = MPIR_Reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op);
@@ -253,14 +250,11 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                     }
                 }
 
-                mpi_errno = MPIC_Waitall(send_nreq, send_reqs, MPI_STATUSES_IGNORE, errflag);
-                if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-                    MPIR_ERR_POP(mpi_errno);
+                mpi_errno = MPIC_Waitall(send_nreq, send_reqs, MPI_STATUSES_IGNORE);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
-                mpi_errno =
-                    MPIC_Waitall((k - 1), recv_reqs + (k - 1), MPI_STATUSES_IGNORE, errflag);
-                if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-                    MPIR_ERR_POP(mpi_errno);
+                mpi_errno = MPIC_Waitall((k - 1), recv_reqs + (k - 1), MPI_STATUSES_IGNORE);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                 buf = (k - 1) + myidx - 1;
                 for (i = myidx - 1; i >= 0 && count > 0; i--, buf--) {
@@ -292,7 +286,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
      * send the data to non-partcipating rans */
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm,
-                              MPI_STATUS_IGNORE, errflag);
+                              MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {
@@ -302,9 +296,8 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
 
-        mpi_errno = MPIC_Waitall(i, send_reqs, MPI_STATUSES_IGNORE, errflag);
-        if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-            MPIR_ERR_POP(mpi_errno);
+        mpi_errno = MPIC_Waitall(i, send_reqs, MPI_STATUSES_IGNORE);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     if (in_step2 && (k > MAX_RADIX || count * extent > 8192)) {

--- a/src/mpi/coll/allreduce/allreduce_intra_recexch.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recexch.c
@@ -15,7 +15,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                                  MPI_Aint count,
                                  MPI_Datatype datatype,
                                  MPI_Op op, MPIR_Comm * comm, int k, int single_phase_recv,
-                                 MPIR_Errflag_t * errflag)
+                                 MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
     int is_commutative, rank, nranks, nbr, myidx;
@@ -149,22 +149,22 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
         /* non-participating rank sends the data to a participating rank */
         mpi_errno = MPIC_Send(recvbuf, count,
                               datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {    /* odd */
         if (step1_nrecvs) {
             for (i = 0; i < step1_nrecvs; i++) {        /* participating rank gets data from non-partcipating ranks */
                 mpi_errno = MPIC_Irecv(nbr_buffer[i], count,
                                        datatype, step1_recvfrom[i],
                                        MPIR_ALLREDUCE_TAG, comm, &recv_reqs[recv_nreq++]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
             mpi_errno = MPIC_Waitall(recv_nreq, recv_reqs, MPI_STATUSES_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* Do reduction of reduced data */
             for (i = 0; i < step1_nrecvs && count > 0; i++) {   /* participating rank gets data from non-partcipating ranks */
                 mpi_errno = MPIR_Reduce_local(nbr_buffer[i], recvbuf, count, datatype, op);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
     }
@@ -188,7 +188,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                 mpi_errno =
                     MPIC_Irecv(nbr_buffer[buf++], count, datatype, nbr, MPIR_ALLREDUCE_TAG,
                                comm, &recv_reqs[recv_nreq++]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
 
@@ -199,36 +199,36 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
             nbr = step2_nbrs[phase][i];
             mpi_errno = MPIC_Isend(recvbuf, count, datatype, nbr, MPIR_ALLREDUCE_TAG, comm,
                                    &send_reqs[send_nreq++], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (rank > nbr) {
                 myidx = i + 1;
             }
         }
 
         mpi_errno = MPIC_Waitall(send_nreq, send_reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         buf = myidx - 1;
         mpi_errno = MPIC_Waitall((k - 1), recv_reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         for (i = myidx - 1; i >= 0 && count > 0; i--, buf--) {
             mpi_errno = MPIR_Reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         buf = myidx;
         for (i = myidx; i < k - 1 && count > 0; i++, buf++) {
             if (is_commutative) {
                 mpi_errno = MPIR_Reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 mpi_errno = MPIR_Reduce_local(recvbuf, nbr_buffer[buf], count, datatype, op);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 mpi_errno =
                     MPIR_Localcopy(nbr_buffer[buf], count, datatype, recvbuf, count, datatype);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
 
@@ -244,22 +244,22 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                     mpi_errno =
                         MPIC_Isend(recvbuf, count, datatype, nbr, MPIR_ALLREDUCE_TAG, comm,
                                    &send_reqs[send_nreq++], errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     if (rank > nbr) {
                         myidx = i + 1;
                     }
                 }
 
                 mpi_errno = MPIC_Waitall(send_nreq, send_reqs, MPI_STATUSES_IGNORE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 mpi_errno = MPIC_Waitall((k - 1), recv_reqs + (k - 1), MPI_STATUSES_IGNORE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 buf = (k - 1) + myidx - 1;
                 for (i = myidx - 1; i >= 0 && count > 0; i--, buf--) {
                     mpi_errno = MPIR_Reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
 
                 buf = (k - 1) + myidx;
@@ -267,15 +267,15 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                     if (is_commutative) {
                         mpi_errno =
                             MPIR_Reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op);
-                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     } else {
                         mpi_errno =
                             MPIR_Reduce_local(recvbuf, nbr_buffer[buf], count, datatype, op);
-                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                         mpi_errno =
                             MPIR_Localcopy(nbr_buffer[buf], count, datatype, recvbuf, count,
                                            datatype);
-                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     }
                 }
             }
@@ -287,17 +287,17 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm,
                               MPI_STATUS_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {
             mpi_errno =
                 MPIC_Isend(recvbuf, count, datatype, step1_recvfrom[i], MPIR_ALLREDUCE_TAG,
                            comm, &send_reqs[i], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         mpi_errno = MPIC_Waitall(i, send_reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     if (in_step2 && (k > MAX_RADIX || count * extent > 8192)) {

--- a/src/mpi/coll/allreduce/allreduce_intra_recexch.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recexch.c
@@ -450,11 +450,8 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
         }
     }
   fn_exit:
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -21,8 +21,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
                                             void *recvbuf,
                                             MPI_Aint count,
                                             MPI_Datatype datatype,
-                                            MPI_Op op,
-                                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     MPIR_CHKLMEM_DECL(1);
     int comm_size, rank;
@@ -68,7 +67,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(recvbuf, count,
                                   datatype, rank + 1, MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -78,7 +77,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank - 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -114,7 +113,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
                                       dst, MPIR_ALLREDUCE_TAG, tmp_buf,
                                       count, datatype, dst,
                                       MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* tmp_buf contains data received in this step.
              * recvbuf contains data accumulated so far */
@@ -146,7 +145,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, rank + 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -77,7 +77,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
         } else {        /* odd */
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank - 1,
-                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -145,7 +145,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
         else    /* even */
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, rank + 1,
-                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
   fn_exit:

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -68,14 +68,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(recvbuf, count,
                                   datatype, rank + 1, MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -85,14 +78,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank - 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -128,14 +114,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
                                       dst, MPIR_ALLREDUCE_TAG, tmp_buf,
                                       count, datatype, dst,
                                       MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* tmp_buf contains data received in this step.
              * recvbuf contains data accumulated so far */
@@ -167,18 +146,11 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, rank + 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
     goto fn_exit;
 }

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -43,7 +43,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
                                                   MPI_Aint count,
                                                   MPI_Datatype datatype,
                                                   MPI_Op op,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     MPIR_CHKLMEM_DECL(3);
     int comm_size, rank;
@@ -87,7 +87,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(recvbuf, count,
                                   datatype, rank + 1, MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -97,7 +97,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank - 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -177,7 +177,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
                                       MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* tmp_buf contains data received in this step.
              * recvbuf contains data accumulated so far */
@@ -236,7 +236,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
                                       MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (newrank > newdst)
                 send_idx = recv_idx;
@@ -255,7 +255,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, rank + 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -87,14 +87,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(recvbuf, count,
                                   datatype, rank + 1, MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -104,14 +97,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank - 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -191,14 +177,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
                                       MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* tmp_buf contains data received in this step.
              * recvbuf contains data accumulated so far */
@@ -257,14 +236,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
                                       MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             if (newrank > newdst)
                 send_idx = recv_idx;
@@ -283,18 +255,11 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, rank + 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
     goto fn_exit;
 }

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -96,7 +96,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
         } else {        /* odd */
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank - 1,
-                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -254,7 +254,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
         else    /* even */
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, rank + 1,
-                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
   fn_exit:

--- a/src/mpi/coll/allreduce/allreduce_intra_ring.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_ring.c
@@ -76,56 +76,28 @@ int MPIR_Allreduce_intra_ring(const void *sendbuf, void *recvbuf, MPI_Aint count
 
         /* get a new tag to prevent out of order messages */
         mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIC_Irecv(tmpbuf, cnts[recv_rank], datatype, src, tag, comm, &reqs[0]);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag = MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
-
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         mpi_errno = MPIC_Isend((char *) recvbuf + displs[send_rank] * extent, cnts[send_rank],
                                datatype, dst, tag, comm, &reqs[1], errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag = MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         mpi_errno = MPIC_Waitall(2, reqs, MPI_STATUSES_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag = MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
-
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         mpi_errno =
             MPIR_Reduce_local(tmpbuf, (char *) recvbuf + displs[recv_rank] * extent,
                               cnts[recv_rank], datatype, op);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag = MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     /* Phase 3: Allgatherv ring, so everyone has the reduced data */
     mpi_errno = MPIR_Allgatherv_intra_ring(MPI_IN_PLACE, -1, MPI_DATATYPE_NULL, recvbuf, cnts,
                                            displs, datatype, comm, errflag);
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag = MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
     MPL_free(cnts);
     MPL_free(displs);

--- a/src/mpi/coll/allreduce/allreduce_intra_ring.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_ring.c
@@ -11,7 +11,7 @@
 
 int MPIR_Allreduce_intra_ring(const void *sendbuf, void *recvbuf, MPI_Aint count,
                               MPI_Datatype datatype, MPI_Op op,
-                              MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                              MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
     int i, src, dst;
@@ -79,25 +79,25 @@ int MPIR_Allreduce_intra_ring(const void *sendbuf, void *recvbuf, MPI_Aint count
         MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIC_Irecv(tmpbuf, cnts[recv_rank], datatype, src, tag, comm, &reqs[0]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         mpi_errno = MPIC_Isend((char *) recvbuf + displs[send_rank] * extent, cnts[send_rank],
                                datatype, dst, tag, comm, &reqs[1], errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         mpi_errno = MPIC_Waitall(2, reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         mpi_errno =
             MPIR_Reduce_local(tmpbuf, (char *) recvbuf + displs[recv_rank] * extent,
                               cnts[recv_rank], datatype, op);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Phase 3: Allgatherv ring, so everyone has the reduced data */
     mpi_errno = MPIR_Allgatherv_intra_ring(MPI_IN_PLACE, -1, MPI_DATATYPE_NULL, recvbuf, cnts,
                                            displs, datatype, comm, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     MPL_free(cnts);
     MPL_free(displs);

--- a/src/mpi/coll/allreduce/allreduce_intra_ring.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_ring.c
@@ -85,7 +85,7 @@ int MPIR_Allreduce_intra_ring(const void *sendbuf, void *recvbuf, MPI_Aint count
                                datatype, dst, tag, comm, &reqs[1], errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
-        mpi_errno = MPIC_Waitall(2, reqs, MPI_STATUSES_IGNORE, errflag);
+        mpi_errno = MPIC_Waitall(2, reqs, MPI_STATUSES_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         mpi_errno =

--- a/src/mpi/coll/allreduce/allreduce_intra_ring.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_ring.c
@@ -132,12 +132,8 @@ int MPIR_Allreduce_intra_ring(const void *sendbuf, void *recvbuf, MPI_Aint count
     MPL_free(tmpbuf);
 
   fn_exit:
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allreduce/allreduce_intra_smp.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_smp.c
@@ -7,7 +7,7 @@
 
 int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                             MPIR_Errflag_t * errflag)
+                             MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -24,11 +24,11 @@ int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
 
             mpi_errno =
                 MPIR_Reduce(recvbuf, NULL, count, datatype, op, 0, comm_ptr->node_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         } else {
             mpi_errno =
                 MPIR_Reduce(sendbuf, recvbuf, count, datatype, op, 0, comm_ptr->node_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     } else {
         /* only one process on the node. copy sendbuf to recvbuf */
@@ -43,13 +43,13 @@ int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
         mpi_errno =
             MPIR_Allreduce(MPI_IN_PLACE, recvbuf, count, datatype, op, comm_ptr->node_roots_comm,
                            errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* now broadcast the result among local processes */
     if (comm_ptr->node_comm != NULL) {
         mpi_errno = MPIR_Bcast(recvbuf, count, datatype, 0, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
     goto fn_exit;
 

--- a/src/mpi/coll/allreduce/allreduce_intra_tree.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_tree.c
@@ -177,11 +177,8 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
     MPIR_CHKLMEM_FREEALL();
 
   fn_exit:
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/allreduce/allreduce_intra_tree.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_tree.c
@@ -113,7 +113,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
 
             mpi_errno =
                 MPIC_Recv(recv_address, msgsize, datatype, child, MPIR_ALLREDUCE_TAG, comm_ptr,
-                          MPI_STATUS_IGNORE, errflag);
+                          MPI_STATUS_IGNORE);
             /* for communication errors, just record the error but continue */
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
@@ -142,7 +142,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
         if (my_tree.parent != -1) {
             mpi_errno = MPIC_Recv(reduce_address, msgsize,
                                   datatype, my_tree.parent, MPIR_ALLREDUCE_TAG, comm_ptr,
-                                  MPI_STATUS_IGNORE, errflag);
+                                  MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
         if (num_children) {
@@ -161,7 +161,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
     }
 
     if (num_reqs > 0) {
-        mpi_errno = MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE, errflag);
+        mpi_errno = MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/allreduce/allreduce_intra_tree.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_tree.c
@@ -16,7 +16,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
                               MPI_Datatype datatype,
                               MPI_Op op, MPIR_Comm * comm_ptr,
                               int tree_type, int k, int chunk_size,
-                              int buffer_per_child, MPIR_Errflag_t * errflag)
+                              int buffer_per_child, MPIR_Errflag_t errflag)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
@@ -115,7 +115,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
                 MPIC_Recv(recv_address, msgsize, datatype, child, MPIR_ALLREDUCE_TAG, comm_ptr,
                           MPI_STATUS_IGNORE);
             /* for communication errors, just record the error but continue */
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (is_commutative) {
                 mpi_errno = MPIR_Reduce_local(recv_address, reduce_address, msgsize, datatype, op);
@@ -136,14 +136,14 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
             mpi_errno =
                 MPIC_Isend(reduce_address, msgsize, datatype, my_tree.parent, MPIR_ALLREDUCE_TAG,
                            comm_ptr, &reqs[num_reqs++], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         if (my_tree.parent != -1) {
             mpi_errno = MPIC_Recv(reduce_address, msgsize,
                                   datatype, my_tree.parent, MPIR_ALLREDUCE_TAG, comm_ptr,
                                   MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         if (num_children) {
             for (i = 0; i < num_children; i++) {
@@ -153,7 +153,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
                 mpi_errno = MPIC_Isend(reduce_address, msgsize,
                                        datatype, child,
                                        MPIR_ALLREDUCE_TAG, comm_ptr, &reqs[num_reqs++], errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
 
@@ -162,7 +162,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
 
     if (num_reqs > 0) {
         mpi_errno = MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     if (!is_tree_leaf) {

--- a/src/mpi/coll/allreduce/allreduce_intra_tree.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_tree.c
@@ -115,7 +115,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
                 MPIC_Recv(recv_address, msgsize, datatype, child, MPIR_ALLREDUCE_TAG, comm_ptr,
                           MPI_STATUS_IGNORE, errflag);
             /* for communication errors, just record the error but continue */
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             if (is_commutative) {
                 mpi_errno = MPIR_Reduce_local(recv_address, reduce_address, msgsize, datatype, op);
@@ -136,14 +136,14 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
             mpi_errno =
                 MPIC_Isend(reduce_address, msgsize, datatype, my_tree.parent, MPIR_ALLREDUCE_TAG,
                            comm_ptr, &reqs[num_reqs++], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
 
         if (my_tree.parent != -1) {
             mpi_errno = MPIC_Recv(reduce_address, msgsize,
                                   datatype, my_tree.parent, MPIR_ALLREDUCE_TAG, comm_ptr,
                                   MPI_STATUS_IGNORE, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
         if (num_children) {
             for (i = 0; i < num_children; i++) {
@@ -153,7 +153,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
                 mpi_errno = MPIC_Isend(reduce_address, msgsize,
                                        datatype, child,
                                        MPIR_ALLREDUCE_TAG, comm_ptr, &reqs[num_reqs++], errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         }
 
@@ -162,7 +162,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
 
     if (num_reqs > 0) {
         mpi_errno = MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     if (!is_tree_leaf) {

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -77,8 +77,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
             newrank = -1;
         } else {        /* odd */
             to_comm_rank(csrc, group_rank - 1);
-            mpi_errno = MPIC_Recv(tmp_buf, count,
-                                  datatype, csrc, tag, comm_ptr, MPI_STATUS_IGNORE, errflag);
+            mpi_errno = MPIC_Recv(tmp_buf, count, datatype, csrc, tag, comm_ptr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -279,8 +278,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
             mpi_errno = MPIC_Send(recvbuf, count, datatype, cdst, tag, comm_ptr, errflag);
         } else {        /* even */
             to_comm_rank(csrc, group_rank + 1);
-            mpi_errno = MPIC_Recv(recvbuf, count,
-                                  datatype, csrc, tag, comm_ptr, MPI_STATUS_IGNORE, errflag);
+            mpi_errno = MPIC_Recv(recvbuf, count, datatype, csrc, tag, comm_ptr, MPI_STATUS_IGNORE);
         }
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -69,14 +69,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
         if (group_rank % 2 == 0) {      /* even */
             to_comm_rank(cdst, group_rank + 1);
             mpi_errno = MPIC_Send(recvbuf, count, datatype, cdst, tag, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -86,14 +79,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
             to_comm_rank(csrc, group_rank - 1);
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, csrc, tag, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -133,15 +119,8 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                           cdst, tag, tmp_buf,
                                           count, datatype, cdst,
                                           tag, comm_ptr, MPI_STATUS_IGNORE, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                } else {
-
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                if (!mpi_errno) {
                     /* tmp_buf contains data received in this step.
                      * recvbuf contains data accumulated so far */
 
@@ -221,14 +200,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                           disps[recv_idx] * extent,
                                           recv_cnt, datatype, cdst,
                                           tag, comm_ptr, MPI_STATUS_IGNORE, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                 /* tmp_buf contains data received in this step.
                  * recvbuf contains data accumulated so far */
@@ -288,14 +260,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                           disps[recv_idx] * extent,
                                           recv_cnt, datatype, cdst,
                                           tag, comm_ptr, MPI_STATUS_IGNORE, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                 if (newrank > newdst)
                     send_idx = recv_idx;
@@ -317,14 +282,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, csrc, tag, comm_ptr, MPI_STATUS_IGNORE, errflag);
         }
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -17,7 +17,7 @@
 
 int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Group * group_ptr, int tag, MPIR_Errflag_t * errflag)
+                               MPIR_Group * group_ptr, int tag, MPIR_Errflag_t errflag)
 {
     MPI_Aint type_size;
     int mpi_errno = MPI_SUCCESS;
@@ -69,7 +69,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
         if (group_rank % 2 == 0) {      /* even */
             to_comm_rank(cdst, group_rank + 1);
             mpi_errno = MPIC_Send(recvbuf, count, datatype, cdst, tag, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -78,7 +78,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
         } else {        /* odd */
             to_comm_rank(csrc, group_rank - 1);
             mpi_errno = MPIC_Recv(tmp_buf, count, datatype, csrc, tag, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -118,7 +118,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                           cdst, tag, tmp_buf,
                                           count, datatype, cdst,
                                           tag, comm_ptr, MPI_STATUS_IGNORE, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 if (!mpi_errno) {
                     /* tmp_buf contains data received in this step.
                      * recvbuf contains data accumulated so far */
@@ -199,7 +199,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                           disps[recv_idx] * extent,
                                           recv_cnt, datatype, cdst,
                                           tag, comm_ptr, MPI_STATUS_IGNORE, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 /* tmp_buf contains data received in this step.
                  * recvbuf contains data accumulated so far */
@@ -259,7 +259,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                           disps[recv_idx] * extent,
                                           recv_cnt, datatype, cdst,
                                           tag, comm_ptr, MPI_STATUS_IGNORE, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 if (newrank > newdst)
                     send_idx = recv_idx;
@@ -280,7 +280,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
             to_comm_rank(csrc, group_rank + 1);
             mpi_errno = MPIC_Recv(recvbuf, count, datatype, csrc, tag, comm_ptr, MPI_STATUS_IGNORE);
         }
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:
@@ -293,7 +293,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
 
 int MPII_Allreduce_group(void *sendbuf, void *recvbuf, MPI_Aint count,
                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                         MPIR_Group * group_ptr, int tag, MPIR_Errflag_t * errflag)
+                         MPIR_Group * group_ptr, int tag, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -329,13 +329,9 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return (mpi_errno);
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }
 

--- a/src/mpi/coll/allreduce_group/allreduce_group.h
+++ b/src/mpi/coll/allreduce_group/allreduce_group.h
@@ -10,9 +10,9 @@
 
 int MPII_Allreduce_group(void *sendbuf, void *recvbuf, MPI_Aint count,
                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                         MPIR_Group * group_ptr, int tag, MPIR_Errflag_t * errflag);
+                         MPIR_Group * group_ptr, int tag, MPIR_Errflag_t errflag);
 int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Group * group_ptr, int tag, MPIR_Errflag_t * errflag);
+                               MPIR_Group * group_ptr, int tag, MPIR_Errflag_t errflag);
 
 #endif /* ALLREDUCE_GROUP_H_INCLUDED */

--- a/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
+++ b/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
@@ -18,7 +18,7 @@ int MPIR_Alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
                        &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
+++ b/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
@@ -19,7 +19,7 @@
 int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                          MPIR_Errflag_t * errflag)
+                                          MPIR_Errflag_t errflag)
 {
     int local_size, remote_size, max_size, i;
     MPI_Aint sendtype_extent, recvtype_extent;
@@ -59,7 +59,7 @@ int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, MPI_Aint sendcoun
                                   MPIR_ALLTOALL_TAG, recvaddr,
                                   recvcount, recvtype, src,
                                   MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
@@ -59,14 +59,7 @@ int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, MPI_Aint sendcoun
                                   MPIR_ALLTOALL_TAG, recvaddr,
                                   recvcount, recvtype, src,
                                   MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
@@ -69,10 +69,5 @@ int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, MPI_Aint sendcoun
         }
     }
 
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -110,14 +110,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
         mpi_errno = MPIC_Sendrecv(tmp_buf, newtype_sz, MPI_BYTE, dst,
                                   MPIR_ALLTOALL_TAG, recvbuf, 1, newtype,
                                   src, MPIR_ALLTOALL_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         MPIR_Type_free_impl(&newtype);
 

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -149,14 +149,10 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
     if (newtype != MPI_DATATYPE_NULL)
         MPIR_Type_free_impl(&newtype);
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -23,8 +23,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
                                MPI_Datatype sendtype,
                                void *recvbuf,
                                MPI_Aint recvcount,
-                               MPI_Datatype recvtype,
-                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, i, pof2;
     MPI_Aint sendtype_extent, recvtype_extent;
@@ -110,7 +109,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
         mpi_errno = MPIC_Sendrecv(tmp_buf, newtype_sz, MPI_BYTE, dst,
                                   MPIR_ALLTOALL_TAG, recvbuf, 1, newtype,
                                   src, MPIR_ALLTOALL_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         MPIR_Type_free_impl(&newtype);
 

--- a/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
@@ -109,7 +109,7 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
                                  void *recvbuf,
                                  MPI_Aint recvcnt,
                                  MPI_Datatype recvtype, MPIR_Comm * comm, int k,
-                                 MPIR_Errflag_t * errflag)
+                                 MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -253,7 +253,7 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
             mpi_errno =
                 MPIC_Irecv(tmp_rbuf[j - 1], packsize, MPI_BYTE, src, MPIR_ALLTOALL_TAG, comm,
                            &reqs[num_reqs++]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             mpi_errno =
                 MPIC_Isend(tmp_sbuf[j - 1], packsize, MPI_BYTE, dst, MPIR_ALLTOALL_TAG, comm,
@@ -264,7 +264,7 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
         }
 
         MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         for (j = 1; j < k; j++) {
             if (delta * j >= size)      /* if the first location exceeds comm size, nothing is to be sent */

--- a/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
@@ -112,6 +112,7 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
                                  MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
     int i, j;
     int rank, size;
     int nphases, max;
@@ -252,9 +253,7 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
             mpi_errno =
                 MPIC_Irecv(tmp_rbuf[j - 1], packsize, MPI_BYTE, src, MPIR_ALLTOALL_TAG, comm,
                            &reqs[num_reqs++]);
-            if (mpi_errno) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             mpi_errno =
                 MPIC_Isend(tmp_sbuf[j - 1], packsize, MPI_BYTE, dst, MPIR_ALLTOALL_TAG, comm,
@@ -264,7 +263,8 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
             }
         }
 
-        MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE, errflag);
+        MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         for (j = 1; j < k; j++) {
             if (delta * j >= size)      /* if the first location exceeds comm size, nothing is to be sent */
@@ -328,7 +328,8 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
     MPIR_CHKLMEM_FREEALL();
 
   fn_exit:
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
@@ -88,12 +88,8 @@ int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
     }
 
   fn_exit:
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
@@ -77,14 +77,7 @@ int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
                                    src * recvcount * recvtype_extent),
                                   recvcount, recvtype, src,
                                   MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
@@ -28,7 +28,7 @@ int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
                                  void *recvbuf,
                                  MPI_Aint recvcount,
                                  MPI_Datatype recvtype,
-                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, i;
     MPI_Aint sendtype_extent, recvtype_extent;
@@ -77,7 +77,7 @@ int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
                                    src * recvcount * recvtype_extent),
                                   recvcount, recvtype, src,
                                   MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
@@ -57,28 +57,14 @@ int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf,
                     MPIC_Sendrecv_replace(((char *) recvbuf + j * recvcount * recvtype_extent),
                                           recvcount, recvtype, j, MPIR_ALLTOALL_TAG, j,
                                           MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             } else if (rank == j) {
                 /* same as above with i/j args reversed */
                 mpi_errno =
                     MPIC_Sendrecv_replace(((char *) recvbuf + i * recvcount * recvtype_extent),
                                           recvcount, recvtype, i, MPIR_ALLTOALL_TAG, i,
                                           MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
@@ -83,10 +83,5 @@ int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf,
         }
     }
 
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
@@ -25,7 +25,7 @@ int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf,
                                                   void *recvbuf,
                                                   MPI_Aint recvcount,
                                                   MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, i, j;
     MPI_Aint recvtype_extent;
@@ -57,14 +57,14 @@ int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf,
                     MPIC_Sendrecv_replace(((char *) recvbuf + j * recvcount * recvtype_extent),
                                           recvcount, recvtype, j, MPIR_ALLTOALL_TAG, j,
                                           MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else if (rank == j) {
                 /* same as above with i/j args reversed */
                 mpi_errno =
                     MPIC_Sendrecv_replace(((char *) recvbuf + i * recvcount * recvtype_extent),
                                           recvcount, recvtype, i, MPIR_ALLTOALL_TAG, i,
                                           MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/alltoall/alltoall_intra_scattered.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_scattered.c
@@ -112,12 +112,8 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/alltoall/alltoall_intra_scattered.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_scattered.c
@@ -96,14 +96,7 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
             for (j = 0; j < 2 * ss; j++) {
                 if (starray[j].MPI_ERROR != MPI_SUCCESS) {
                     mpi_errno = starray[j].MPI_ERROR;
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
             }
         }

--- a/src/mpi/coll/alltoall/alltoall_intra_scattered.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_scattered.c
@@ -33,9 +33,9 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
                                   void *recvbuf,
                                   MPI_Aint recvcount,
                                   MPI_Datatype recvtype,
-                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
-    int comm_size, i, j;
+    int comm_size, i;
     MPI_Aint sendtype_extent, recvtype_extent;
     int mpi_errno = MPI_SUCCESS, dst, rank;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -74,7 +74,7 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
                                    dst * recvcount * recvtype_extent,
                                    recvcount, recvtype, dst,
                                    MPIR_ALLTOALL_TAG, comm_ptr, &reqarray[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         for (i = 0; i < ss; i++) {
@@ -83,12 +83,12 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
                                    dst * sendcount * sendtype_extent,
                                    sendcount, sendtype, dst,
                                    MPIR_ALLTOALL_TAG, comm_ptr, &reqarray[i + ss], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         /* ... then wait for them to finish: */
         mpi_errno = MPIC_Waitall(2 * ss, reqarray, starray);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
@@ -8,7 +8,7 @@
 int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
                               const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
                               const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
-                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
@@ -19,7 +19,7 @@ int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
                         recvtype, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
@@ -23,7 +23,7 @@ int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint *
                                            const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                            void *recvbuf, const MPI_Aint * recvcounts,
                                            const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int local_size, remote_size, max_size, i;
     MPI_Aint send_extent, recv_extent;
@@ -67,7 +67,7 @@ int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint *
         mpi_errno = MPIC_Sendrecv(sendaddr, sendcount, sendtype, dst,
                                   MPIR_ALLTOALLV_TAG, recvaddr, recvcount,
                                   recvtype, src, MPIR_ALLTOALLV_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
@@ -77,9 +77,5 @@ int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint *
         }
     }
 
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
@@ -67,14 +67,7 @@ int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint *
         mpi_errno = MPIC_Sendrecv(sendaddr, sendcount, sendtype, dst,
                                   MPIR_ALLTOALLV_TAG, recvaddr, recvcount,
                                   recvtype, src, MPIR_ALLTOALLV_TAG, comm_ptr, &status, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
@@ -88,10 +88,5 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
         }
     }
 
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
@@ -60,14 +60,7 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   j, MPIR_ALLTOALLV_TAG,
                                                   j, MPIR_ALLTOALLV_TAG,
                                                   comm_ptr, &status, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             } else if (rank == j) {
                 /* same as above with i/j args reversed */
@@ -76,14 +69,7 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   i, MPIR_ALLTOALLV_TAG,
                                                   i, MPIR_ALLTOALLV_TAG,
                                                   comm_ptr, &status, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
@@ -22,7 +22,7 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                    const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                    void *recvbuf, const MPI_Aint * recvcounts,
                                                    const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, i, j;
     MPI_Aint recv_extent;
@@ -60,7 +60,7 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   j, MPIR_ALLTOALLV_TAG,
                                                   j, MPIR_ALLTOALLV_TAG,
                                                   comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             } else if (rank == j) {
                 /* same as above with i/j args reversed */
@@ -69,7 +69,7 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   i, MPIR_ALLTOALLV_TAG,
                                                   i, MPIR_ALLTOALLV_TAG,
                                                   comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -25,7 +25,7 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
                                    const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
                                    const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t * errflag)
+                                   MPIR_Errflag_t errflag)
 {
     int comm_size, i;
     MPI_Aint send_extent, recv_extent;
@@ -74,7 +74,7 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
                     mpi_errno = MPIC_Irecv((char *) recvbuf + rdispls[dst] * recv_extent,
                                            recvcounts[dst], recvtype, dst,
                                            MPIR_ALLTOALLV_TAG, comm_ptr, &reqarray[req_cnt]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     req_cnt++;
                 }
             }
@@ -90,21 +90,21 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
                                            sendcounts[dst], sendtype, dst,
                                            MPIR_ALLTOALLV_TAG, comm_ptr,
                                            &reqarray[req_cnt], errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     req_cnt++;
                 }
             }
         }
 
         mpi_errno = MPIC_Waitall(req_cnt, reqarray, starray);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* --BEGIN ERROR HANDLING-- */
         if (mpi_errno == MPI_ERR_IN_STATUS) {
             for (i = 0; i < req_cnt; i++) {
                 if (starray[i].MPI_ERROR != MPI_SUCCESS) {
                     mpi_errno = starray[i].MPI_ERROR;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
             }
         }

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -74,14 +74,7 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
                     mpi_errno = MPIC_Irecv((char *) recvbuf + rdispls[dst] * recv_extent,
                                            recvcounts[dst], recvtype, dst,
                                            MPIR_ALLTOALLV_TAG, comm_ptr, &reqarray[req_cnt]);
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     req_cnt++;
                 }
             }
@@ -97,14 +90,7 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
                                            sendcounts[dst], sendtype, dst,
                                            MPIR_ALLTOALLV_TAG, comm_ptr,
                                            &reqarray[req_cnt], errflag);
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     req_cnt++;
                 }
             }
@@ -119,14 +105,7 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
             for (i = 0; i < req_cnt; i++) {
                 if (starray[i].MPI_ERROR != MPI_SUCCESS) {
                     mpi_errno = starray[i].MPI_ERROR;
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
             }
         }

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -96,9 +96,8 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
             }
         }
 
-        mpi_errno = MPIC_Waitall(req_cnt, reqarray, starray, errflag);
-        if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-            MPIR_ERR_POP(mpi_errno);
+        mpi_errno = MPIC_Waitall(req_cnt, reqarray, starray);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         /* --BEGIN ERROR HANDLING-- */
         if (mpi_errno == MPI_ERR_IN_STATUS) {

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -135,14 +135,8 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
@@ -9,7 +9,7 @@ int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
                               const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                               void *recvbuf, const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t * errflag)
+                              MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
@@ -20,7 +20,7 @@ int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
                         recvtypes, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
@@ -68,14 +68,7 @@ int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint s
                                   dst, MPIR_ALLTOALLW_TAG, recvaddr,
                                   recvcount, recvtype, src,
                                   MPIR_ALLTOALLW_TAG, comm_ptr, &status, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
     return mpi_errno_ret;
 }

--- a/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
@@ -77,9 +77,5 @@ int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint s
             MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
         }
     }
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
@@ -23,7 +23,7 @@ int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint s
                                            const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                            void *recvbuf, const MPI_Aint recvcounts[],
                                            const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int local_size, remote_size, max_size, i;
     int mpi_errno = MPI_SUCCESS;
@@ -68,7 +68,7 @@ int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint s
                                   dst, MPIR_ALLTOALLW_TAG, recvaddr,
                                   recvcount, recvtype, src,
                                   MPIR_ALLTOALLW_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
     return mpi_errno_ret;
 }

--- a/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
@@ -84,9 +84,5 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
         }
     }
 
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
@@ -23,7 +23,7 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                    const MPI_Aint recvcounts[],
                                                    const MPI_Aint rdispls[],
                                                    const MPI_Datatype recvtypes[],
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, i, j;
     int mpi_errno = MPI_SUCCESS;
@@ -57,7 +57,7 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   j, MPIR_ALLTOALLW_TAG,
                                                   j, MPIR_ALLTOALLW_TAG,
                                                   comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else if (rank == j) {
                 /* same as above with i/j args reversed */
                 mpi_errno = MPIC_Sendrecv_replace(((char *) recvbuf + rdispls[i]),
@@ -65,7 +65,7 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   i, MPIR_ALLTOALLW_TAG,
                                                   i, MPIR_ALLTOALLW_TAG,
                                                   comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
@@ -57,14 +57,7 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   j, MPIR_ALLTOALLW_TAG,
                                                   j, MPIR_ALLTOALLW_TAG,
                                                   comm_ptr, &status, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             } else if (rank == j) {
                 /* same as above with i/j args reversed */
                 mpi_errno = MPIC_Sendrecv_replace(((char *) recvbuf + rdispls[i]),
@@ -72,14 +65,7 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   i, MPIR_ALLTOALLW_TAG,
                                                   i, MPIR_ALLTOALLW_TAG,
                                                   comm_ptr, &status, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -95,9 +95,8 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
             }
         }
 
-        mpi_errno = MPIC_Waitall(outstanding_requests, reqarray, starray, errflag);
-        if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-            MPIR_ERR_POP(mpi_errno);
+        mpi_errno = MPIC_Waitall(outstanding_requests, reqarray, starray);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         /* --BEGIN ERROR HANDLING-- */
         if (mpi_errno == MPI_ERR_IN_STATUS) {

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -23,7 +23,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
                                    const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                    void *recvbuf, const MPI_Aint recvcounts[],
                                    const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, i;
     int mpi_errno = MPI_SUCCESS;
@@ -96,14 +96,14 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
         }
 
         mpi_errno = MPIC_Waitall(outstanding_requests, reqarray, starray);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* --BEGIN ERROR HANDLING-- */
         if (mpi_errno == MPI_ERR_IN_STATUS) {
             for (i = 0; i < outstanding_requests; i++) {
                 if (starray[i].MPI_ERROR != MPI_SUCCESS) {
                     mpi_errno = starray[i].MPI_ERROR;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
             }
         }

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -104,14 +104,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
             for (i = 0; i < outstanding_requests; i++) {
                 if (starray[i].MPI_ERROR != MPI_SUCCESS) {
                     mpi_errno = starray[i].MPI_ERROR;
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
             }
         }

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -120,12 +120,8 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/barrier/barrier_allcomm_nb.c
+++ b/src/mpi/coll/barrier/barrier_allcomm_nb.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/barrier/barrier_allcomm_nb.c
+++ b/src/mpi/coll/barrier/barrier_allcomm_nb.c
@@ -14,7 +14,7 @@ int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
     mpi_errno = MPIR_Ibarrier(comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/barrier/barrier_inter_bcast.c
+++ b/src/mpi/coll/barrier/barrier_inter_bcast.c
@@ -36,63 +36,28 @@ int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 
     /* do a barrier on the local intracommunicator */
     mpi_errno = MPIR_Barrier(newcomm_ptr, errflag);
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
     if (comm_ptr->is_low_group) {
         /* bcast to right */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         /* receive bcast from right */
         root = 0;
         mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         /* receive bcast from left */
         root = 0;
         mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         /* bcast to left */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
   fn_exit:
     return mpi_errno_ret;

--- a/src/mpi/coll/barrier/barrier_inter_bcast.c
+++ b/src/mpi/coll/barrier/barrier_inter_bcast.c
@@ -17,7 +17,7 @@
  * group.
  */
 
-int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, mpi_errno = MPI_SUCCESS, root;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -36,28 +36,28 @@ int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 
     /* do a barrier on the local intracommunicator */
     mpi_errno = MPIR_Barrier(newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     if (comm_ptr->is_low_group) {
         /* bcast to right */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* receive bcast from right */
         root = 0;
         mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         /* receive bcast from left */
         root = 0;
         mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* bcast to left */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
   fn_exit:
     return mpi_errno_ret;

--- a/src/mpi/coll/barrier/barrier_inter_bcast.c
+++ b/src/mpi/coll/barrier/barrier_inter_bcast.c
@@ -95,11 +95,8 @@ int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
         }
     }
   fn_exit:
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
+++ b/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
@@ -35,11 +35,7 @@ int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errf
         mask <<= 1;
     }
 
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
 }
 
 /* Algorithm: high radix dissemination
@@ -134,11 +130,8 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t *
         MPL_free(recv_reqs);
         MPL_free(send_reqs);
     }
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
+++ b/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
@@ -102,10 +102,8 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t *
             /* wait on recvs from prev phase */
             if (i > 0 && j == 1) {
                 mpi_errno =
-                    MPIC_Waitall(k - 1, &recv_reqs[((k - 1) * ((i - 1) & 1))], MPI_STATUSES_IGNORE,
-                                 errflag);
-                if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-                    MPIR_ERR_POP(mpi_errno);
+                    MPIC_Waitall(k - 1, &recv_reqs[((k - 1) * ((i - 1) & 1))], MPI_STATUSES_IGNORE);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
 
             mpi_errno =
@@ -113,17 +111,14 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t *
                            errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
-        mpi_errno = MPIC_Waitall(k - 1, send_reqs, MPI_STATUSES_IGNORE, errflag);
-        if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-            MPIR_ERR_POP(mpi_errno);
+        mpi_errno = MPIC_Waitall(k - 1, send_reqs, MPI_STATUSES_IGNORE);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         shift *= k;
     }
 
     mpi_errno =
-        MPIC_Waitall(k - 1, recv_reqs + ((k - 1) * ((nphases - 1) & 1)), MPI_STATUSES_IGNORE,
-                     errflag);
-    if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-        MPIR_ERR_POP(mpi_errno);
+        MPIC_Waitall(k - 1, recv_reqs + ((k - 1) * ((nphases - 1) & 1)), MPI_STATUSES_IGNORE);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
   fn_exit:
     if (k > MAX_RADIX) {

--- a/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
+++ b/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
@@ -31,7 +31,7 @@ int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errf
         mpi_errno = MPIC_Sendrecv(NULL, 0, MPI_BYTE, dst,
                                   MPIR_BARRIER_TAG, NULL, 0, MPI_BYTE,
                                   src, MPIR_BARRIER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         mask <<= 1;
     }
 
@@ -102,7 +102,7 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t *
             mpi_errno =
                 MPIC_Irecv(NULL, 0, MPI_BYTE, from, MPIR_BARRIER_TAG, comm,
                            &recv_reqs[(j - 1) + ((k - 1) * (i & 1))]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             /* wait on recvs from prev phase */
             if (i > 0 && j == 1) {
                 mpi_errno =
@@ -115,7 +115,7 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t *
             mpi_errno =
                 MPIC_Isend(NULL, 0, MPI_BYTE, to, MPIR_BARRIER_TAG, comm, &send_reqs[j - 1],
                            errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
         mpi_errno = MPIC_Waitall(k - 1, send_reqs, MPI_STATUSES_IGNORE, errflag);
         if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)

--- a/src/mpi/coll/barrier/barrier_intra_recexch.c
+++ b/src/mpi/coll/barrier/barrier_intra_recexch.c
@@ -9,7 +9,7 @@
 /* Algorithm: call Allreduce's recursive exchange algorithm
  */
 int MPIR_Barrier_intra_recexch(MPIR_Comm * comm, int k, int single_phase_recv,
-                               MPIR_Errflag_t * errflag)
+                               MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/barrier/barrier_intra_smp.c
+++ b/src/mpi/coll/barrier/barrier_intra_smp.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -15,13 +15,13 @@ int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
     /* do the intranode barrier on all nodes */
     if (comm_ptr->node_comm != NULL) {
         mpi_errno = MPIR_Barrier(comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* do the barrier across roots of all nodes */
     if (comm_ptr->node_roots_comm != NULL) {
         mpi_errno = MPIR_Barrier(comm_ptr->node_roots_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* release the local processes on each node with a 1-byte
@@ -30,7 +30,7 @@ int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
     if (comm_ptr->node_comm != NULL) {
         int i = 0;
         mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, 0, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/barrier/barrier_intra_smp.c
+++ b/src/mpi/coll/barrier/barrier_intra_smp.c
@@ -54,9 +54,5 @@ int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
         }
     }
 
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/barrier/barrier_intra_smp.c
+++ b/src/mpi/coll/barrier/barrier_intra_smp.c
@@ -15,27 +15,13 @@ int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
     /* do the intranode barrier on all nodes */
     if (comm_ptr->node_comm != NULL) {
         mpi_errno = MPIR_Barrier(comm_ptr->node_comm, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     /* do the barrier across roots of all nodes */
     if (comm_ptr->node_roots_comm != NULL) {
         mpi_errno = MPIR_Barrier(comm_ptr->node_roots_comm, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     /* release the local processes on each node with a 1-byte
@@ -44,14 +30,7 @@ int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
     if (comm_ptr->node_comm != NULL) {
         int i = 0;
         mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, 0, comm_ptr->node_comm, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/bcast/bcast.h
+++ b/src/mpi/coll/bcast/bcast.h
@@ -10,6 +10,6 @@
 
 int MPII_Scatter_for_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                            int root, MPIR_Comm * comm_ptr, MPI_Aint nbytes, void *tmp_buf,
-                           int is_contig, MPIR_Errflag_t * errflag);
+                           int is_contig, MPIR_Errflag_t errflag);
 
 #endif /* BCAST_H_INCLUDED */

--- a/src/mpi/coll/bcast/bcast_allcomm_nb.c
+++ b/src/mpi/coll/bcast/bcast_allcomm_nb.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 int MPIR_Bcast_allcomm_nb(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                          MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                          MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/bcast/bcast_allcomm_nb.c
+++ b/src/mpi/coll/bcast/bcast_allcomm_nb.c
@@ -15,7 +15,7 @@ int MPIR_Bcast_allcomm_nb(void *buffer, MPI_Aint count, MPI_Datatype datatype, i
     mpi_errno = MPIR_Ibcast(buffer, count, datatype, root, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
+++ b/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
@@ -31,14 +31,7 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
     } else if (root == MPI_ROOT) {
         /* root sends to rank 0 on remote group and returns */
         mpi_errno = MPIC_Send(buffer, count, datatype, 0, MPIR_BCAST_TAG, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         /* remote group. rank 0 on remote group receives from root */
 
@@ -47,27 +40,13 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
         if (rank == 0) {
             mpi_errno = MPIC_Recv(buffer, count, datatype, root,
                                   MPIR_BCAST_TAG, comm_ptr, &status, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
 
         /* Get the local intracommunicator */
         if (!comm_ptr->local_comm) {
             mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
 
         newcomm_ptr = comm_ptr->local_comm;
@@ -75,14 +54,7 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
         /* now do the usual broadcast on this intracommunicator
          * with rank 0 as root. */
         mpi_errno = MPIR_Bcast_allcomm_auto(buffer, count, datatype, 0, newcomm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     MPIR_FUNC_EXIT;

--- a/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
+++ b/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
@@ -38,8 +38,7 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
         rank = comm_ptr->rank;
 
         if (rank == 0) {
-            mpi_errno = MPIC_Recv(buffer, count, datatype, root,
-                                  MPIR_BCAST_TAG, comm_ptr, &status, errflag);
+            mpi_errno = MPIC_Recv(buffer, count, datatype, root, MPIR_BCAST_TAG, comm_ptr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
 

--- a/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
+++ b/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
@@ -86,11 +86,5 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
     }
 
     MPIR_FUNC_EXIT;
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
+++ b/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
@@ -14,8 +14,7 @@
 int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
                                              MPI_Aint count,
                                              MPI_Datatype datatype,
-                                             int root,
-                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                             int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, mpi_errno;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -31,7 +30,7 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
     } else if (root == MPI_ROOT) {
         /* root sends to rank 0 on remote group and returns */
         mpi_errno = MPIC_Send(buffer, count, datatype, 0, MPIR_BCAST_TAG, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         /* remote group. rank 0 on remote group receives from root */
 
@@ -39,13 +38,13 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
 
         if (rank == 0) {
             mpi_errno = MPIC_Recv(buffer, count, datatype, root, MPIR_BCAST_TAG, comm_ptr, &status);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         /* Get the local intracommunicator */
         if (!comm_ptr->local_comm) {
             mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         newcomm_ptr = comm_ptr->local_comm;
@@ -53,7 +52,7 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
         /* now do the usual broadcast on this intracommunicator
          * with rank 0 as root. */
         mpi_errno = MPIR_Bcast_allcomm_auto(buffer, count, datatype, 0, newcomm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     MPIR_FUNC_EXIT;

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -167,13 +167,8 @@ int MPIR_Bcast_intra_binomial(void *buffer,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -97,14 +97,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
             else
                 mpi_errno = MPIC_Recv(buffer, count, datatype, src,
                                       MPIR_BCAST_TAG, comm_ptr, status_p, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 #ifdef HAVE_ERROR_CHECKING
             /* check that we received as much as we expected */
             MPIR_Get_count_impl(status_p, MPI_BYTE, &recvd_size);
@@ -138,14 +131,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
             else
                 mpi_errno = MPIC_Send(buffer, count, datatype, dst,
                                       MPIR_BCAST_TAG, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
         mask >>= 1;
     }

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -93,10 +93,10 @@ int MPIR_Bcast_intra_binomial(void *buffer,
                 src += comm_size;
             if (!is_contig)
                 mpi_errno = MPIC_Recv(tmp_buf, nbytes, MPI_BYTE, src,
-                                      MPIR_BCAST_TAG, comm_ptr, status_p, errflag);
+                                      MPIR_BCAST_TAG, comm_ptr, status_p);
             else
                 mpi_errno = MPIC_Recv(buffer, count, datatype, src,
-                                      MPIR_BCAST_TAG, comm_ptr, status_p, errflag);
+                                      MPIR_BCAST_TAG, comm_ptr, status_p);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 #ifdef HAVE_ERROR_CHECKING
             /* check that we received as much as we expected */

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -13,7 +13,7 @@
 int MPIR_Bcast_intra_binomial(void *buffer,
                               MPI_Aint count,
                               MPI_Datatype datatype,
-                              int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                              int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, comm_size, src, dst;
     int relative_rank, mask;
@@ -97,11 +97,11 @@ int MPIR_Bcast_intra_binomial(void *buffer,
             else
                 mpi_errno = MPIC_Recv(buffer, count, datatype, src,
                                       MPIR_BCAST_TAG, comm_ptr, status_p);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 #ifdef HAVE_ERROR_CHECKING
             /* check that we received as much as we expected */
             MPIR_Get_count_impl(status_p, MPI_BYTE, &recvd_size);
-            MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, errflag, mpi_errno_ret);
 #endif
             break;
         }
@@ -131,7 +131,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
             else
                 mpi_errno = MPIC_Send(buffer, count, datatype, dst,
                                       MPIR_BCAST_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         mask >>= 1;
     }

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -108,14 +108,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
 #ifdef HAVE_ERROR_CHECKING
             /* check that we received as much as we expected */
             MPIR_Get_count_impl(status_p, MPI_BYTE, &recvd_size);
-            if (recvd_size != nbytes) {
-                if (*errflag == MPIR_ERR_NONE)
-                    *errflag = MPIR_ERR_OTHER;
-                MPIR_ERR_SET2(mpi_errno, MPI_ERR_OTHER,
-                              "**collective_size_mismatch",
-                              "**collective_size_mismatch %d %d", recvd_size, nbytes);
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, *errflag, mpi_errno_ret);
 #endif
             break;
         }

--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -16,7 +16,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                                     MPI_Datatype datatype,
                                     int root, MPIR_Comm * comm_ptr, int tree_type,
                                     int branching_factor, int is_nb, int chunk_size,
-                                    int recv_pre_posted, MPIR_Errflag_t * errflag)
+                                    int recv_pre_posted, MPIR_Errflag_t errflag)
 {
     int rank, comm_size, i, j, k, *p, src = -1, dst, offset = 0;
     int is_contig;
@@ -104,7 +104,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                     mpi_errno =
                         MPIC_Irecv((char *) sendbuf + offset, msgsize, MPI_BYTE,
                                    src, MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
                 offset += msgsize;
             }
@@ -117,7 +117,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                     mpi_errno =
                         MPIC_Irecv((char *) sendbuf + offset, msgsize, MPI_BYTE,
                                    src, MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
                 offset += msgsize;
             }
@@ -132,17 +132,17 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
             /* Wait to receive the chunk before it can be sent to the children */
             if (src != -1) {
                 mpi_errno = MPIC_Wait(reqs[i]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
-                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, errflag, mpi_errno_ret);
             }
         } else if (num_chunks > 3 && is_nb && i < 3 && !recv_pre_posted) {
             /* Wait to receive the chunk before it can be sent to the children */
             if (src != -1) {
                 mpi_errno = MPIC_Wait(reqs[i]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
-                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, errflag, mpi_errno_ret);
             }
         } else {
             /* Receive message from parent */
@@ -150,9 +150,9 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                 mpi_errno =
                     MPIC_Recv((char *) sendbuf + offset, msgsize, MPI_BYTE,
                               src, MPIR_BCAST_TAG, comm_ptr, &status);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
-                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, errflag, mpi_errno_ret);
             }
         }
         if (tree_type == MPIR_TREE_TYPE_KARY) {
@@ -173,7 +173,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                         MPIC_Isend((char *) sendbuf + offset, msgsize, MPI_BYTE, dst,
                                    MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
                 }
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             }
         } else if (num_children) {
@@ -189,7 +189,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                         MPIC_Isend((char *) sendbuf + offset, msgsize, MPI_BYTE, dst,
                                    MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
                 }
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
         offset += msgsize;
@@ -197,7 +197,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
 
     if (is_nb) {
         mpi_errno = MPIC_Waitall(num_req, reqs, statuses);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     if (!is_contig) {

--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -131,7 +131,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
         if ((num_chunks <= 3 && is_nb) || (recv_pre_posted && is_nb)) {
             /* Wait to receive the chunk before it can be sent to the children */
             if (src != -1) {
-                mpi_errno = MPIC_Wait(reqs[i], errflag);
+                mpi_errno = MPIC_Wait(reqs[i]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
                 MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, *errflag, mpi_errno_ret);
@@ -139,7 +139,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
         } else if (num_chunks > 3 && is_nb && i < 3 && !recv_pre_posted) {
             /* Wait to receive the chunk before it can be sent to the children */
             if (src != -1) {
-                mpi_errno = MPIC_Wait(reqs[i], errflag);
+                mpi_errno = MPIC_Wait(reqs[i]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
                 MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, *errflag, mpi_errno_ret);
@@ -149,7 +149,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
             if (src != -1) {
                 mpi_errno =
                     MPIC_Recv((char *) sendbuf + offset, msgsize, MPI_BYTE,
-                              src, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
+                              src, MPIR_BCAST_TAG, comm_ptr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
                 MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, *errflag, mpi_errno_ret);
@@ -196,7 +196,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
     }
 
     if (is_nb) {
-        mpi_errno = MPIC_Waitall(num_req, reqs, statuses, errflag);
+        mpi_errno = MPIC_Waitall(num_req, reqs, statuses);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -104,7 +104,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                     mpi_errno =
                         MPIC_Irecv((char *) sendbuf + offset, msgsize, MPI_BYTE,
                                    src, MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
                 offset += msgsize;
             }
@@ -117,7 +117,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                     mpi_errno =
                         MPIC_Irecv((char *) sendbuf + offset, msgsize, MPI_BYTE,
                                    src, MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
                 offset += msgsize;
             }
@@ -132,7 +132,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
             /* Wait to receive the chunk before it can be sent to the children */
             if (src != -1) {
                 mpi_errno = MPIC_Wait(reqs[i], errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
                 if (recvd_size != msgsize) {
                     if (*errflag == MPIR_ERR_NONE)
@@ -147,7 +147,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
             /* Wait to receive the chunk before it can be sent to the children */
             if (src != -1) {
                 mpi_errno = MPIC_Wait(reqs[i], errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
                 if (recvd_size != msgsize) {
                     if (*errflag == MPIR_ERR_NONE)
@@ -164,7 +164,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                 mpi_errno =
                     MPIC_Recv((char *) sendbuf + offset, msgsize, MPI_BYTE,
                               src, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
                 if (recvd_size != msgsize) {
                     if (*errflag == MPIR_ERR_NONE)
@@ -195,7 +195,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                         MPIC_Isend((char *) sendbuf + offset, msgsize, MPI_BYTE, dst,
                                    MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
                 }
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             }
         } else if (num_children) {
@@ -211,7 +211,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                         MPIC_Isend((char *) sendbuf + offset, msgsize, MPI_BYTE, dst,
                                    MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
                 }
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         }
         offset += msgsize;
@@ -219,7 +219,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
 
     if (is_nb) {
         mpi_errno = MPIC_Waitall(num_req, reqs, statuses, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     if (!is_contig) {

--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -234,13 +234,8 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
         MPIR_Treealgo_tree_free(&my_tree);
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -134,14 +134,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                 mpi_errno = MPIC_Wait(reqs[i], errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
-                if (recvd_size != msgsize) {
-                    if (*errflag == MPIR_ERR_NONE)
-                        *errflag = MPIR_ERR_OTHER;
-                    MPIR_ERR_SET2(mpi_errno, MPI_ERR_OTHER,
-                                  "**collective_size_mismatch",
-                                  "**collective_size_mismatch %d %d", recvd_size, msgsize);
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, *errflag, mpi_errno_ret);
             }
         } else if (num_chunks > 3 && is_nb && i < 3 && !recv_pre_posted) {
             /* Wait to receive the chunk before it can be sent to the children */
@@ -149,14 +142,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                 mpi_errno = MPIC_Wait(reqs[i], errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
-                if (recvd_size != msgsize) {
-                    if (*errflag == MPIR_ERR_NONE)
-                        *errflag = MPIR_ERR_OTHER;
-                    MPIR_ERR_SET2(mpi_errno, MPI_ERR_OTHER,
-                                  "**collective_size_mismatch",
-                                  "**collective_size_mismatch %d %d", recvd_size, msgsize);
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, *errflag, mpi_errno_ret);
             }
         } else {
             /* Receive message from parent */
@@ -166,15 +152,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                               src, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
-                if (recvd_size != msgsize) {
-                    if (*errflag == MPIR_ERR_NONE)
-                        *errflag = MPIR_ERR_OTHER;
-                    MPIR_ERR_SET2(mpi_errno, MPI_ERR_OTHER,
-                                  "**collective_size_mismatch",
-                                  "**collective_size_mismatch %d %d", recvd_size, msgsize);
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
-
+                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, *errflag, mpi_errno_ret);
             }
         }
         if (tree_type == MPIR_TREE_TYPE_KARY) {

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -81,14 +81,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
     mpi_errno = MPII_Scatter_for_bcast(buffer, count, datatype, root, comm_ptr,
                                        nbytes, tmp_buf, is_contig, errflag);
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
     /* curr_size is the amount of data that this process now has stored in
      * buffer at byte offset (relative_rank*scatter_size) */
@@ -128,16 +121,9 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                                       ((char *) tmp_buf + recv_offset),
                                       (nbytes - recv_offset < 0 ? 0 : nbytes - recv_offset),
                                       MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             if (mpi_errno) {
-                /* --BEGIN ERROR HANDLING-- */
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                 recv_size = 0;
-                /* --END ERROR HANDLING-- */
             } else
                 MPIR_Get_count_impl(&status, MPI_BYTE, &recv_size);
             curr_size += recv_size;
@@ -203,14 +189,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                     /* recv_size was set in the previous
                      * receive. that's the amount of data to be
                      * sent now. */
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -225,16 +204,9 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                                           comm_ptr, &status, errflag);
                     /* nprocs_completed is also equal to the no. of processes
                      * whose data we don't have */
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     if (mpi_errno) {
-                        /* --BEGIN ERROR HANDLING-- */
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                         recv_size = 0;
-                        /* --END ERROR HANDLING-- */
                     } else
                         MPIR_Get_count_impl(&status, MPI_BYTE, &recv_size);
                     curr_size += recv_size;

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -30,7 +30,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                                                           MPI_Datatype datatype,
                                                           int root,
                                                           MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t * errflag)
+                                                          MPIR_Errflag_t errflag)
 {
     MPI_Status status;
     int rank, comm_size, dst;
@@ -81,7 +81,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
     mpi_errno = MPII_Scatter_for_bcast(buffer, count, datatype, root, comm_ptr,
                                        nbytes, tmp_buf, is_contig, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* curr_size is the amount of data that this process now has stored in
      * buffer at byte offset (relative_rank*scatter_size) */
@@ -121,7 +121,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                                       ((char *) tmp_buf + recv_offset),
                                       (nbytes - recv_offset < 0 ? 0 : nbytes - recv_offset),
                                       MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (mpi_errno) {
                 recv_size = 0;
             } else
@@ -189,7 +189,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                     /* recv_size was set in the previous
                      * receive. that's the amount of data to be
                      * sent now. */
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -203,7 +203,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                                           MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status);
                     /* nprocs_completed is also equal to the no. of processes
                      * whose data we don't have */
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     if (mpi_errno) {
                         recv_size = 0;
                     } else
@@ -224,7 +224,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
 #ifdef HAVE_ERROR_CHECKING
     /* check that we received as much as we expected */
-    MPIR_ERR_COLL_CHECK_SIZE(curr_size, nbytes, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECK_SIZE(curr_size, nbytes, errflag, mpi_errno_ret);
 #endif
 
     if (!is_contig) {

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -253,14 +253,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
 #ifdef HAVE_ERROR_CHECKING
     /* check that we received as much as we expected */
-    if (curr_size != nbytes) {
-        if (*errflag == MPIR_ERR_NONE)
-            *errflag = MPIR_ERR_OTHER;
-        MPIR_ERR_SET2(mpi_errno, MPI_ERR_OTHER,
-                      "**collective_size_mismatch",
-                      "**collective_size_mismatch %d %d", curr_size, nbytes);
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECK_SIZE(curr_size, nbytes, *errflag, mpi_errno_ret);
 #endif
 
     if (!is_contig) {

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -200,8 +200,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                      * relative_rank, dst); */
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
                                           nbytes - offset < 0 ? 0 : nbytes - offset,
-                                          MPI_BYTE, dst, MPIR_BCAST_TAG,
-                                          comm_ptr, &status, errflag);
+                                          MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status);
                     /* nprocs_completed is also equal to the no. of processes
                      * whose data we don't have */
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -272,13 +272,8 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -148,13 +148,8 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -24,8 +24,7 @@
 int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
                                             MPI_Aint count,
                                             MPI_Datatype datatype,
-                                            int root,
-                                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                            int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, comm_size;
     int mpi_errno = MPI_SUCCESS;
@@ -73,7 +72,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
 
     mpi_errno = MPII_Scatter_for_bcast(buffer, count, datatype, root, comm_ptr,
                                        nbytes, tmp_buf, is_contig, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* long-message allgather or medium-size but non-power-of-two. use ring algorithm. */
 
@@ -106,7 +105,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
                                   MPI_BYTE, right, MPIR_BCAST_TAG,
                                   (char *) tmp_buf + left_disp, left_count,
                                   MPI_BYTE, left, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
         curr_size += recvd_size;
         j = jnext;
@@ -115,7 +114,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
 
 #ifdef HAVE_ERROR_CHECKING
     /* check that we received as much as we expected */
-    MPIR_ERR_COLL_CHECK_SIZE(curr_size, nbytes, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECK_SIZE(curr_size, nbytes, errflag, mpi_errno_ret);
 #endif
 
     if (!is_contig) {

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -129,14 +129,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
 
 #ifdef HAVE_ERROR_CHECKING
     /* check that we received as much as we expected */
-    if (curr_size != nbytes) {
-        if (*errflag == MPIR_ERR_NONE)
-            *errflag = MPIR_ERR_OTHER;
-        MPIR_ERR_SET2(mpi_errno, MPI_ERR_OTHER,
-                      "**collective_size_mismatch",
-                      "**collective_size_mismatch %d %d", curr_size, nbytes);
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECK_SIZE(curr_size, nbytes, *errflag, mpi_errno_ret);
 #endif
 
     if (!is_contig) {

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -73,14 +73,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
 
     mpi_errno = MPII_Scatter_for_bcast(buffer, count, datatype, root, comm_ptr,
                                        nbytes, tmp_buf, is_contig, errflag);
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
     /* long-message allgather or medium-size but non-power-of-two. use ring algorithm. */
 
@@ -113,14 +106,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
                                   MPI_BYTE, right, MPIR_BCAST_TAG,
                                   (char *) tmp_buf + left_disp, left_count,
                                   MPI_BYTE, left, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
         curr_size += recvd_size;
         j = jnext;

--- a/src/mpi/coll/bcast/bcast_intra_smp.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp.c
@@ -65,14 +65,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
 #ifdef HAVE_ERROR_CHECKING
                 /* check that we received as much as we expected */
                 MPIR_Get_count_impl(status_p, MPI_BYTE, &recvd_size);
-                if (recvd_size != nbytes) {
-                    if (*errflag == MPIR_ERR_NONE)
-                        *errflag = MPIR_ERR_OTHER;
-                    MPIR_ERR_SET2(mpi_errno, MPI_ERR_OTHER,
-                                  "**collective_size_mismatch",
-                                  "**collective_size_mismatch %d %d", recvd_size, nbytes);
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, *errflag, mpi_errno_ret);
 #endif
             }
 

--- a/src/mpi/coll/bcast/bcast_intra_smp.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp.c
@@ -181,11 +181,5 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
     }
 
   fn_exit:
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/bcast/bcast_intra_smp.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp.c
@@ -11,7 +11,7 @@
  * be able to make changes along these lines almost exclusively in this function
  * and some new functions. [goodell@ 2008/01/07] */
 int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                         MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                         MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -42,16 +42,16 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
             if (root == comm_ptr->rank) {
                 mpi_errno = MPIC_Send(buffer, count, datatype, 0,
                                       MPIR_BCAST_TAG, comm_ptr->node_comm, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else if (0 == comm_ptr->node_comm->rank) {
                 mpi_errno =
                     MPIC_Recv(buffer, count, datatype, MPIR_Get_intranode_rank(comm_ptr, root),
                               MPIR_BCAST_TAG, comm_ptr->node_comm, status_p);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 #ifdef HAVE_ERROR_CHECKING
                 /* check that we received as much as we expected */
                 MPIR_Get_count_impl(status_p, MPI_BYTE, &recvd_size);
-                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, errflag, mpi_errno_ret);
 #endif
             }
 
@@ -62,13 +62,13 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
             mpi_errno = MPIR_Bcast(buffer, count, datatype,
                                    MPIR_Get_internode_rank(comm_ptr, root),
                                    comm_ptr->node_roots_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         /* perform the intranode broadcast on all except for the root's node */
         if (comm_ptr->node_comm != NULL) {
             mpi_errno = MPIR_Bcast(buffer, count, datatype, 0, comm_ptr->node_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     } else {    /* (nbytes > MPIR_CVAR_BCAST_SHORT_MSG_SIZE) && (comm_ptr->size >= MPIR_CVAR_BCAST_MIN_PROCS) */
 
@@ -86,7 +86,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
                 mpi_errno = MPIR_Bcast(buffer, count, datatype,
                                        MPIR_Get_intranode_rank(comm_ptr, root),
                                        comm_ptr->node_comm, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
 
             /* perform the internode broadcast */
@@ -94,7 +94,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
                 mpi_errno = MPIR_Bcast(buffer, count, datatype,
                                        MPIR_Get_internode_rank(comm_ptr, root),
                                        comm_ptr->node_roots_comm, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
 
             /* perform the intranode broadcast on all except for the root's node */
@@ -103,7 +103,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
                  * bcast.  We need a more comprehensive system for selecting the
                  * right algorithms here. */
                 mpi_errno = MPIR_Bcast(buffer, count, datatype, 0, comm_ptr->node_comm, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         } else {        /* large msg or non-pof2 */
 
@@ -113,7 +113,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
             mpi_errno =
                 MPIR_Bcast_intra_scatter_ring_allgather(buffer, count, datatype, root, comm_ptr,
                                                         errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/bcast/bcast_intra_smp.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp.c
@@ -46,7 +46,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
             } else if (0 == comm_ptr->node_comm->rank) {
                 mpi_errno =
                     MPIC_Recv(buffer, count, datatype, MPIR_Get_intranode_rank(comm_ptr, root),
-                              MPIR_BCAST_TAG, comm_ptr->node_comm, status_p, errflag);
+                              MPIR_BCAST_TAG, comm_ptr->node_comm, status_p);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 #ifdef HAVE_ERROR_CHECKING
                 /* check that we received as much as we expected */

--- a/src/mpi/coll/bcast/bcast_intra_smp.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp.c
@@ -42,26 +42,12 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
             if (root == comm_ptr->rank) {
                 mpi_errno = MPIC_Send(buffer, count, datatype, 0,
                                       MPIR_BCAST_TAG, comm_ptr->node_comm, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             } else if (0 == comm_ptr->node_comm->rank) {
                 mpi_errno =
                     MPIC_Recv(buffer, count, datatype, MPIR_Get_intranode_rank(comm_ptr, root),
                               MPIR_BCAST_TAG, comm_ptr->node_comm, status_p, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 #ifdef HAVE_ERROR_CHECKING
                 /* check that we received as much as we expected */
                 MPIR_Get_count_impl(status_p, MPI_BYTE, &recvd_size);
@@ -76,27 +62,13 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
             mpi_errno = MPIR_Bcast(buffer, count, datatype,
                                    MPIR_Get_internode_rank(comm_ptr, root),
                                    comm_ptr->node_roots_comm, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
 
         /* perform the intranode broadcast on all except for the root's node */
         if (comm_ptr->node_comm != NULL) {
             mpi_errno = MPIR_Bcast(buffer, count, datatype, 0, comm_ptr->node_comm, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     } else {    /* (nbytes > MPIR_CVAR_BCAST_SHORT_MSG_SIZE) && (comm_ptr->size >= MPIR_CVAR_BCAST_MIN_PROCS) */
 
@@ -114,14 +86,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
                 mpi_errno = MPIR_Bcast(buffer, count, datatype,
                                        MPIR_Get_intranode_rank(comm_ptr, root),
                                        comm_ptr->node_comm, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
 
             /* perform the internode broadcast */
@@ -129,14 +94,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
                 mpi_errno = MPIR_Bcast(buffer, count, datatype,
                                        MPIR_Get_internode_rank(comm_ptr, root),
                                        comm_ptr->node_roots_comm, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
 
             /* perform the intranode broadcast on all except for the root's node */
@@ -145,14 +103,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
                  * bcast.  We need a more comprehensive system for selecting the
                  * right algorithms here. */
                 mpi_errno = MPIR_Bcast(buffer, count, datatype, 0, comm_ptr->node_comm, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         } else {        /* large msg or non-pof2 */
 
@@ -162,14 +113,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
             mpi_errno =
                 MPIR_Bcast_intra_scatter_ring_allgather(buffer, count, datatype, root, comm_ptr,
                                                         errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -13,7 +13,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
                           MPI_Aint count,
                           MPI_Datatype datatype,
                           int root, MPIR_Comm * comm_ptr, int tree_type,
-                          int branching_factor, int is_nb, MPIR_Errflag_t * errflag)
+                          int branching_factor, int is_nb, MPIR_Errflag_t errflag)
 {
     int rank, comm_size, src, dst, *p, j, k, lrank, is_contig;
     int parent = -1, num_children = 0, num_req = 0, is_root = 0;
@@ -92,10 +92,10 @@ int MPIR_Bcast_intra_tree(void *buffer,
         || (!is_root && tree_type == MPIR_TREE_TYPE_KARY)) {
         src = parent;
         mpi_errno = MPIC_Recv(send_buf, count, dtype, src, MPIR_BCAST_TAG, comm_ptr, &status);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* check that we received as much as we expected */
         MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
-        MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, errflag, mpi_errno_ret);
     }
     if (tree_type == MPIR_TREE_TYPE_KARY) {
         for (k = 1; k <= branching_factor; k++) {       /* Send to children */
@@ -112,7 +112,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
                 mpi_errno = MPIC_Isend(send_buf, count, dtype, dst,
                                        MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     } else {
         for (j = 0; j < num_children; j++) {
@@ -126,12 +126,12 @@ int MPIR_Bcast_intra_tree(void *buffer,
                 mpi_errno = MPIC_Isend(send_buf, count, dtype, dst,
                                        MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
     if (is_nb) {
         mpi_errno = MPIC_Waitall(num_req, reqs, statuses);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     if (tree_type != MPIR_TREE_TYPE_KARY)

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -156,13 +156,8 @@ int MPIR_Bcast_intra_tree(void *buffer,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -93,7 +93,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
         src = parent;
         mpi_errno = MPIC_Recv(send_buf, count, dtype, src,
                               MPIR_BCAST_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         /* check that we received as much as we expected */
         MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
         if (recvd_size != nbytes) {
@@ -121,7 +121,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
                 mpi_errno = MPIC_Isend(send_buf, count, dtype, dst,
                                        MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     } else {
         for (j = 0; j < num_children; j++) {
@@ -135,12 +135,12 @@ int MPIR_Bcast_intra_tree(void *buffer,
                 mpi_errno = MPIC_Isend(send_buf, count, dtype, dst,
                                        MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }
     if (is_nb) {
         mpi_errno = MPIC_Waitall(num_req, reqs, statuses, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     if (tree_type != MPIR_TREE_TYPE_KARY)

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -96,15 +96,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         /* check that we received as much as we expected */
         MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
-        if (recvd_size != nbytes) {
-            if (*errflag == MPIR_ERR_NONE)
-                *errflag = MPIR_ERR_OTHER;
-            MPIR_ERR_SET2(mpi_errno, MPI_ERR_OTHER,
-                          "**collective_size_mismatch",
-                          "**collective_size_mismatch %d %d", recvd_size, nbytes);
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
-
+        MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, *errflag, mpi_errno_ret);
     }
     if (tree_type == MPIR_TREE_TYPE_KARY) {
         for (k = 1; k <= branching_factor; k++) {       /* Send to children */

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -91,8 +91,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
     if ((parent != -1 && tree_type != MPIR_TREE_TYPE_KARY)
         || (!is_root && tree_type == MPIR_TREE_TYPE_KARY)) {
         src = parent;
-        mpi_errno = MPIC_Recv(send_buf, count, dtype, src,
-                              MPIR_BCAST_TAG, comm_ptr, &status, errflag);
+        mpi_errno = MPIC_Recv(send_buf, count, dtype, src, MPIR_BCAST_TAG, comm_ptr, &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         /* check that we received as much as we expected */
         MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
@@ -131,7 +130,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
         }
     }
     if (is_nb) {
-        mpi_errno = MPIC_Waitall(num_req, reqs, statuses, errflag);
+        mpi_errno = MPIC_Waitall(num_req, reqs, statuses);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -119,11 +119,5 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
         mask >>= 1;
     }
 
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -69,13 +69,8 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                                        relative_rank * scatter_size),
                                       recv_size, MPI_BYTE, src,
                                       MPIR_BCAST_TAG, comm_ptr, &status, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                     curr_size = 0;
                 } else
                     /* query actual size of data received */
@@ -104,14 +99,7 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                 mpi_errno = MPIC_Send(((char *) tmp_buf +
                                        scatter_size * (relative_rank + mask)),
                                       send_size, MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                 curr_size -= send_size;
             }

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -67,8 +67,7 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
             } else {
                 mpi_errno = MPIC_Recv(((char *) tmp_buf +
                                        relative_rank * scatter_size),
-                                      recv_size, MPI_BYTE, src,
-                                      MPIR_BCAST_TAG, comm_ptr, &status, errflag);
+                                      recv_size, MPI_BYTE, src, MPIR_BCAST_TAG, comm_ptr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 if (mpi_errno) {
                     curr_size = 0;

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -21,7 +21,7 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                            MPI_Datatype datatype ATTRIBUTE((unused)),
                            int root,
                            MPIR_Comm * comm_ptr,
-                           MPI_Aint nbytes, void *tmp_buf, int is_contig, MPIR_Errflag_t * errflag)
+                           MPI_Aint nbytes, void *tmp_buf, int is_contig, MPIR_Errflag_t errflag)
 {
     MPI_Status status;
     int rank, comm_size, src, dst;
@@ -68,7 +68,7 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                 mpi_errno = MPIC_Recv(((char *) tmp_buf +
                                        relative_rank * scatter_size),
                                       recv_size, MPI_BYTE, src, MPIR_BCAST_TAG, comm_ptr, &status);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 if (mpi_errno) {
                     curr_size = 0;
                 } else
@@ -98,7 +98,7 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                 mpi_errno = MPIC_Send(((char *) tmp_buf +
                                        scatter_size * (relative_rank + mask)),
                                       send_size, MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 curr_size -= send_size;
             }

--- a/src/mpi/coll/exscan/exscan_allcomm_nb.c
+++ b/src/mpi/coll/exscan/exscan_allcomm_nb.c
@@ -16,7 +16,7 @@ int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
     mpi_errno = MPIR_Iexscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/exscan/exscan_allcomm_nb.c
+++ b/src/mpi/coll/exscan/exscan_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t * errflag)
+                           MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -95,14 +95,7 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
                                       dst, MPIR_EXSCAN_TAG, tmp_buf,
                                       count, datatype, dst,
                                       MPIR_EXSCAN_TAG, comm_ptr, &status, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             if (rank > dst) {
                 mpi_errno = MPIR_Reduce_local(tmp_buf, partial_scan, count, datatype, op);

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -146,11 +146,8 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -48,7 +48,7 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
                                          void *recvbuf,
                                          MPI_Aint count,
                                          MPI_Datatype datatype,
-                                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     MPI_Status status;
     int rank, comm_size;
@@ -95,7 +95,7 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
                                       dst, MPIR_EXSCAN_TAG, tmp_buf,
                                       count, datatype, dst,
                                       MPIR_EXSCAN_TAG, comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (rank > dst) {
                 mpi_errno = MPIR_Reduce_local(tmp_buf, partial_scan, count, datatype, op);

--- a/src/mpi/coll/gather/gather_allcomm_nb.c
+++ b/src/mpi/coll/gather/gather_allcomm_nb.c
@@ -17,7 +17,7 @@ int MPIR_Gather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype
         MPIR_Igather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr,
                      &req_ptr);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/gather/gather_allcomm_nb.c
+++ b/src/mpi/coll/gather/gather_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Gather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                            void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                           MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/gather/gather_inter_linear.c
+++ b/src/mpi/coll/gather/gather_inter_linear.c
@@ -37,26 +37,12 @@ int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
             mpi_errno =
                 MPIC_Recv(((char *) recvbuf + recvcount * i * extent), recvcount, recvtype, i,
                           MPIR_GATHER_TAG, comm_ptr, &status, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     } else {
         mpi_errno =
             MPIC_Send(sendbuf, sendcount, sendtype, root, MPIR_GATHER_TAG, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/gather/gather_inter_linear.c
+++ b/src/mpi/coll/gather/gather_inter_linear.c
@@ -36,7 +36,7 @@ int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
         for (i = 0; i < remote_size; i++) {
             mpi_errno =
                 MPIC_Recv(((char *) recvbuf + recvcount * i * extent), recvcount, recvtype, i,
-                          MPIR_GATHER_TAG, comm_ptr, &status, errflag);
+                          MPIR_GATHER_TAG, comm_ptr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     } else {

--- a/src/mpi/coll/gather/gather_inter_linear.c
+++ b/src/mpi/coll/gather/gather_inter_linear.c
@@ -15,7 +15,7 @@
 
 int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -37,12 +37,12 @@ int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
             mpi_errno =
                 MPIC_Recv(((char *) recvbuf + recvcount * i * extent), recvcount, recvtype, i,
                           MPIR_GATHER_TAG, comm_ptr, &status);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     } else {
         mpi_errno =
             MPIC_Send(sendbuf, sendcount, sendtype, root, MPIR_GATHER_TAG, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/gather/gather_inter_linear.c
+++ b/src/mpi/coll/gather/gather_inter_linear.c
@@ -59,9 +59,5 @@ int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
         }
     }
 
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -36,7 +36,7 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
         /* root receives data from rank 0 on remote group */
         mpi_errno =
             MPIC_Recv(recvbuf, recvcount * remote_size, recvtype, 0, MPIR_GATHER_TAG, comm_ptr,
-                      &status, errflag);
+                      &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -101,12 +101,8 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -16,7 +16,7 @@
 int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
                                                MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -37,7 +37,7 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
         mpi_errno =
             MPIC_Recv(recvbuf, recvcount * remote_size, recvtype, 0, MPIR_GATHER_TAG, comm_ptr,
                       &status);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does
          * local intracommunicator gather, and then sends the data
@@ -69,12 +69,12 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
         mpi_errno = MPIR_Gather(sendbuf, sendcount, sendtype,
                                 tmp_buf, sendcount * sendtype_sz, MPI_BYTE, 0, newcomm_ptr,
                                 errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         if (rank == 0) {
             mpi_errno = MPIC_Send(tmp_buf, sendcount * local_size * sendtype_sz, MPI_BYTE,
                                   root, MPIR_GATHER_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -37,14 +37,7 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
         mpi_errno =
             MPIC_Recv(recvbuf, recvcount * remote_size, recvtype, 0, MPIR_GATHER_TAG, comm_ptr,
                       &status, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does
          * local intracommunicator gather, and then sends the data
@@ -76,26 +69,12 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
         mpi_errno = MPIR_Gather(sendbuf, sendcount, sendtype,
                                 tmp_buf, sendcount * sendtype_sz, MPI_BYTE, 0, newcomm_ptr,
                                 errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         if (rank == 0) {
             mpi_errno = MPIC_Send(tmp_buf, sendcount * local_size * sendtype_sz, MPI_BYTE,
                                   root, MPIR_GATHER_TAG, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -139,15 +139,13 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                                                (((rank +
                                                   mask) % comm_size) * (MPI_Aint) recvcount *
                                                 extent)), (MPI_Aint) recvblks * recvcount,
-                                              recvtype, src, MPIR_GATHER_TAG, comm_ptr, &status,
-                                              errflag);
+                                              recvtype, src, MPIR_GATHER_TAG, comm_ptr, &status);
                         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                         /* small transfer size case. cast ok */
                         MPIR_Assert(recvblks * nbytes == (int) (recvblks * nbytes));
                         mpi_errno = MPIC_Recv(tmp_buf, (int) (recvblks * nbytes),
-                                              MPI_BYTE, src, MPIR_GATHER_TAG,
-                                              comm_ptr, &status, errflag);
+                                              MPI_BYTE, src, MPIR_GATHER_TAG, comm_ptr, &status);
                         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                         copy_offset = rank + mask;
                         copy_blks = recvblks;
@@ -167,7 +165,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                         MPIR_ERR_CHECK(mpi_errno);
 
                         mpi_errno = MPIC_Recv(recvbuf, 1, tmp_type, src,
-                                              MPIR_GATHER_TAG, comm_ptr, &status, errflag);
+                                              MPIR_GATHER_TAG, comm_ptr, &status);
                         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                         MPIR_Type_free_impl(&tmp_type);
@@ -188,7 +186,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                         offset = (mask - 1) * nbytes;
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
                                           recvblks * nbytes, MPI_BYTE, src,
-                                          MPIR_GATHER_TAG, comm_ptr, &status, errflag);
+                                          MPIR_GATHER_TAG, comm_ptr, &status);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     curr_cnt += (recvblks * nbytes);
                 }

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -309,11 +309,8 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -141,30 +141,14 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                                                 extent)), (MPI_Aint) recvblks * recvcount,
                                               recvtype, src, MPIR_GATHER_TAG, comm_ptr, &status,
                                               errflag);
-                        if (mpi_errno) {
-                            /* for communication errors, just record the error but continue */
-                            *errflag =
-                                MPIX_ERR_PROC_FAILED ==
-                                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED :
-                                MPIR_ERR_OTHER;
-                            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                        }
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                         /* small transfer size case. cast ok */
                         MPIR_Assert(recvblks * nbytes == (int) (recvblks * nbytes));
                         mpi_errno = MPIC_Recv(tmp_buf, (int) (recvblks * nbytes),
                                               MPI_BYTE, src, MPIR_GATHER_TAG,
                                               comm_ptr, &status, errflag);
-                        if (mpi_errno) {
-                            /* for communication errors, just record the error but continue */
-                            *errflag =
-                                MPIX_ERR_PROC_FAILED ==
-                                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED :
-                                MPIR_ERR_OTHER;
-                            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                        }
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                         copy_offset = rank + mask;
                         copy_blks = recvblks;
                     } else {
@@ -184,15 +168,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 
                         mpi_errno = MPIC_Recv(recvbuf, 1, tmp_type, src,
                                               MPIR_GATHER_TAG, comm_ptr, &status, errflag);
-                        if (mpi_errno) {
-                            /* for communication errors, just record the error but continue */
-                            *errflag =
-                                MPIX_ERR_PROC_FAILED ==
-                                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED :
-                                MPIR_ERR_OTHER;
-                            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                        }
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                         MPIR_Type_free_impl(&tmp_type);
                     }
@@ -213,14 +189,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
                                           recvblks * nbytes, MPI_BYTE, src,
                                           MPIR_GATHER_TAG, comm_ptr, &status, errflag);
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                     curr_cnt += (recvblks * nbytes);
                 }
             }
@@ -232,25 +201,11 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                 /* leaf nodes send directly from sendbuf */
                 mpi_errno = MPIC_Send(sendbuf, sendcount, sendtype, dst,
                                       MPIR_GATHER_TAG, comm_ptr, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                 mpi_errno = MPIC_Send(tmp_buf, curr_cnt, MPI_BYTE, dst,
                                       MPIR_GATHER_TAG, comm_ptr, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             } else {
                 MPI_Aint blocks[2];
                 MPI_Aint struct_displs[2];
@@ -275,14 +230,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 
                 mpi_errno = MPIC_Send(MPI_BOTTOM, 1, tmp_type, dst,
                                       MPIR_GATHER_TAG, comm_ptr, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Type_free_impl(&tmp_type);
                 if (types[1] != MPI_BYTE)
                     MPIR_Type_free_impl(&types[1]);

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -39,7 +39,7 @@ cvars:
  */
 int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
@@ -140,13 +140,13 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                                                   mask) % comm_size) * (MPI_Aint) recvcount *
                                                 extent)), (MPI_Aint) recvblks * recvcount,
                                               recvtype, src, MPIR_GATHER_TAG, comm_ptr, &status);
-                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                         /* small transfer size case. cast ok */
                         MPIR_Assert(recvblks * nbytes == (int) (recvblks * nbytes));
                         mpi_errno = MPIC_Recv(tmp_buf, (int) (recvblks * nbytes),
                                               MPI_BYTE, src, MPIR_GATHER_TAG, comm_ptr, &status);
-                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                         copy_offset = rank + mask;
                         copy_blks = recvblks;
                     } else {
@@ -166,7 +166,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 
                         mpi_errno = MPIC_Recv(recvbuf, 1, tmp_type, src,
                                               MPIR_GATHER_TAG, comm_ptr, &status);
-                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                         MPIR_Type_free_impl(&tmp_type);
                     }
@@ -187,7 +187,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
                                           recvblks * nbytes, MPI_BYTE, src,
                                           MPIR_GATHER_TAG, comm_ptr, &status);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     curr_cnt += (recvblks * nbytes);
                 }
             }
@@ -199,11 +199,11 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                 /* leaf nodes send directly from sendbuf */
                 mpi_errno = MPIC_Send(sendbuf, sendcount, sendtype, dst,
                                       MPIR_GATHER_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                 mpi_errno = MPIC_Send(tmp_buf, curr_cnt, MPI_BYTE, dst,
                                       MPIR_GATHER_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 MPI_Aint blocks[2];
                 MPI_Aint struct_displs[2];
@@ -228,7 +228,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 
                 mpi_errno = MPIC_Send(MPI_BOTTOM, 1, tmp_type, dst,
                                       MPIR_GATHER_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 MPIR_Type_free_impl(&tmp_type);
                 if (types[1] != MPI_BYTE)
                     MPIR_Type_free_impl(&types[1]);

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -155,11 +155,8 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -90,20 +90,8 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
             }
         }
         /* ... then wait for *all* of them to finish: */
-        mpi_errno = MPIC_Waitall(reqs, reqarray, starray, errflag);
-        if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-            MPIR_ERR_POP(mpi_errno);
-
-        /* --BEGIN ERROR HANDLING-- */
-        if (mpi_errno == MPI_ERR_IN_STATUS) {
-            for (i = 0; i < reqs; i++) {
-                if (starray[i].MPI_ERROR != MPI_SUCCESS) {
-                    mpi_errno = starray[i].MPI_ERROR;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
-                }
-            }
-        }
-        /* --END ERROR HANDLING-- */
+        mpi_errno = MPIC_Waitall(reqs, reqarray, starray);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     else if (root != MPI_PROC_NULL) {   /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -99,14 +99,7 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
             for (i = 0; i < reqs; i++) {
                 if (starray[i].MPI_ERROR != MPI_SUCCESS) {
                     mpi_errno = starray[i].MPI_ERROR;
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
             }
         }
@@ -129,25 +122,11 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
             if (comm_size >= min_procs) {
                 mpi_errno = MPIC_Ssend(sendbuf, sendcount, sendtype, root,
                                        MPIR_GATHERV_TAG, comm_ptr, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             } else {
                 mpi_errno = MPIC_Send(sendbuf, sendcount, sendtype, root,
                                       MPIR_GATHERV_TAG, comm_ptr, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -42,7 +42,7 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
                                 const MPI_Aint * recvcounts,
                                 const MPI_Aint * displs,
                                 MPI_Datatype recvtype,
-                                int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
@@ -91,7 +91,7 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
         }
         /* ... then wait for *all* of them to finish: */
         mpi_errno = MPIC_Waitall(reqs, reqarray, starray);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     else if (root != MPI_PROC_NULL) {   /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
@@ -110,11 +110,11 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
             if (comm_size >= min_procs) {
                 mpi_errno = MPIC_Ssend(sendbuf, sendcount, sendtype, root,
                                        MPIR_GATHERV_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 mpi_errno = MPIC_Send(sendbuf, sendcount, sendtype, root,
                                       MPIR_GATHERV_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
@@ -8,7 +8,7 @@
 int MPIR_Gatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                             void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                            MPIR_Errflag_t * errflag)
+                            MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
@@ -19,7 +19,7 @@ int MPIR_Gatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
                       comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -99,7 +99,7 @@ int MPIC_Wait(MPIR_Request * request_ptr)
    this is OK since there is no data that can be received corrupted. */
 
 int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+              MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int attr = 0;
@@ -196,7 +196,7 @@ int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int 
 }
 
 int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int attr = 0;
@@ -215,7 +215,7 @@ int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
     attr |= (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
         MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
 
-    switch (*errflag) {
+    switch (errflag) {
         case MPIR_ERR_NONE:
             break;
         case MPIR_ERR_PROC_FAILED:
@@ -249,7 +249,7 @@ int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
 int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                   int dest, int sendtag, void *recvbuf, MPI_Aint recvcount,
                   MPI_Datatype recvtype, int source, int recvtag,
-                  MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t * errflag)
+                  MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int attr = 0;
@@ -330,7 +330,7 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
 int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
                           int dest, int sendtag,
                           int source, int recvtag,
-                          MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t * errflag)
+                          MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Status mystatus;
@@ -349,7 +349,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
 
     if (status == MPI_STATUS_IGNORE)
         status = &mystatus;
-    switch (*errflag) {
+    switch (errflag) {
         case MPIR_ERR_NONE:
             break;
         case MPIR_ERR_PROC_FAILED:
@@ -434,7 +434,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
 }
 
 int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Request ** request_ptr, MPIR_Errflag_t * errflag)
+               MPIR_Comm * comm_ptr, MPIR_Request ** request_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int context_id;
@@ -469,7 +469,7 @@ int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
 }
 
 int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-                MPIR_Comm * comm_ptr, MPIR_Request ** request_ptr, MPIR_Errflag_t * errflag)
+                MPIR_Comm * comm_ptr, MPIR_Request ** request_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int context_id;
@@ -487,7 +487,7 @@ int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest
     MPIR_ERR_CHKANDJUMP1((count < 0), mpi_errno, MPI_ERR_COUNT,
                          "**countneg", "**countneg %d", count);
 
-    switch (*errflag) {
+    switch (errflag) {
         case MPIR_ERR_NONE:
             break;
         case MPIR_ERR_PROC_FAILED:

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
@@ -85,10 +85,10 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                              recvcount, recvtype, sched, 0, NULL, &vtx_id);
     }
 
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     /* All following sends/recvs and copies depend on this dtcopy */
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     n_invtcs = 0;
     for (i = 0; i < nphases; i++) {
@@ -119,7 +119,7 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + j * recvcount * delta * recvtype_extent,
                                      count, recvtype, src, tag, comm, sched, 0, NULL, &vtx_id);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             recv_id[i_recv++] = vtx_id;
             /* Send from the start of recv till `count` amount of data. */
             if (i == 0)
@@ -129,13 +129,13 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             else
                 mpi_errno = MPIR_TSP_sched_isend(tmp_recvbuf, count, recvtype, dst, tag,
                                                  comm, sched, n_invtcs, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         n_invtcs += (k - 1);
         delta *= k;
     }
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     if (rank != 0) {    /* No shift required for rank 0 */
         mpi_errno =
@@ -143,12 +143,12 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                      (size - rank) * recvcount * recvtype_extent, rank * recvcount,
                                      recvtype, (char *) recvbuf, rank * recvcount, recvtype, sched,
                                      0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         mpi_errno =
             MPIR_TSP_sched_localcopy((char *) tmp_recvbuf, (size - rank) * recvcount, recvtype,
                                      (char *) recvbuf + rank * recvcount * recvtype_extent,
                                      (size - rank) * recvcount, recvtype, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
@@ -36,7 +36,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int n
             MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), count * recvcount, recvtype,
                                  partner, tag, comm, sched, 0, NULL, &vtx_id);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* calculate offset and count of the data to be received from the partner */
         MPII_Recexchalgo_get_count_and_offset(partner, 0, k, nranks, &count, &offset);
@@ -48,7 +48,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int n
         mpi_errno =
             MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), count * recvcount, recvtype,
                                  partner, tag, comm, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     MPIR_FUNC_EXIT;
@@ -84,14 +84,14 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step1(int step1_sendto, int *
         mpi_errno =
             MPIR_TSP_sched_isend(buf_to_send, recvcount, recvtype, step1_sendto, tag, comm, sched,
                                  0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets the data from non-participating rank */
             MPI_Aint recv_offset = step1_recvfrom[i] * recv_extent * recvcount;
             mpi_errno = MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), recvcount, recvtype,
                                              step1_recvfrom[i], tag, comm, sched, n_invtcs, invtx,
                                              &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 
@@ -138,7 +138,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int s
             mpi_errno =
                 MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), count * recvcount, recvtype,
                                      nbr, tag, comm, sched, nrecvs, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
                              "phase %d nbr is %d send offset %d count %d depend on %d", phase,
@@ -157,7 +157,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int s
                 MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), count * recvcount, recvtype,
                                      nbr, tag, comm, sched, 0, NULL, &vtx_id);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             recv_id[j * (k - 1) + i] = vtx_id;
             nrecvs++;
@@ -200,13 +200,13 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step3(int step1_sendto, int *
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, recvcount * nranks, recvtype, step1_sendto, tag, comm,
                                  sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     for (i = 0; i < step1_nrecvs; i++) {
         mpi_errno = MPIR_TSP_sched_isend(recvbuf, recvcount * nranks, recvtype, step1_recvfrom[i],
                                          tag, comm, sched, nrecvs, recv_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     MPIR_FUNC_EXIT;
@@ -276,7 +276,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
             MPIR_TSP_sched_localcopy(sendbuf, recvcount, recvtype,
                                      (char *) recvbuf + rank * recv_extent * recvcount, recvcount,
                                      recvtype, sched, 0, NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         n_invtcs = 1;
         invtx = dtcopy_id;
     } else {
@@ -289,7 +289,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
                                                   recv_extent, recvcount, recvtype, n_invtcs,
                                                   &invtx, comm, sched);
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* For distance halving algorithm, exchange the data with digit reversed partner
      * so that finally the data is in the correct order. */
@@ -299,7 +299,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
                                                                   T, recvbuf, recvtype, recv_extent,
                                                                   recvcount, tag, comm, sched);
             mpi_errno = MPIR_TSP_sched_fence(sched);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring.c
@@ -69,7 +69,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
                                              (char *) buf1, recvcount, recvtype, sched, 0, NULL,
                                              &dtcopy_id[0]);
     }
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* In ring algorithm src and dst are fixed */
     src = (size + rank - 1) % size;
@@ -110,12 +110,12 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
                 vtcs[2] = recv_id[(i - 1) % 3];
             }
         }
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         mpi_errno = MPIR_TSP_sched_irecv((char *) rbuf, recvcount, recvtype,
                                          src, tag, comm, sched, nvtcs, vtcs, &recv_id[i % 3]);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         copy_dst = (size + rank - i - 1) % size;        /* Destination offset of the copy */
         mpi_errno = MPIR_TSP_sched_localcopy((char *) rbuf, recvcount, recvtype,
@@ -124,7 +124,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
                                              recvcount, recvtype, sched, 1, &recv_id[i % 3],
                                              &dtcopy_id[i % 3]);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         data_buf = sbuf;
         sbuf = rbuf;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
@@ -201,10 +201,10 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, sendcount, sendtype, tmp_recvbuf,
                                              recvcounts[rank], recvtype, sched, 0, NULL, &vtx_id);
 
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     idx = 0;
     delta = 1;
@@ -221,7 +221,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + recv_index[idx] * recvtype_extent,
                                      r_counts[i][j - 1], recvtype, src, tag, comm, sched, 0, NULL,
                                      &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             recv_id[idx] = vtx_id;
             idx++;
@@ -230,13 +230,13 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             mpi_errno =
                 MPIR_TSP_sched_isend(tmp_recvbuf, s_counts[i][j - 1], recvtype, dst, tag, comm,
                                      sched, n_invtcs, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         n_invtcs += (k - 1);
         delta *= k;
     }
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* No shift required for rank 0 */
     if (rank != 0) {
@@ -252,12 +252,12 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_TSP_sched_localcopy((char *) tmp_recvbuf + bottom_count * recvtype_extent,
                                          top_count, recvtype, recvbuf, top_count, recvtype, sched,
                                          0, NULL, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             mpi_errno = MPIR_TSP_sched_localcopy(tmp_recvbuf, bottom_count, recvtype,
                                                  (char *) recvbuf + top_count * recvtype_extent,
                                                  bottom_count, recvtype, sched, 0, NULL, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         } else {
             for (i = 0; i < size; i++) {
                 src = (rank + i) % size;        /* Rank whose data it is copying */
@@ -267,7 +267,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                                      (char *) recvbuf +
                                                      displs[src] * recvtype_extent, recvcounts[src],
                                                      recvtype, sched, 0, NULL, &vtx_id);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
@@ -42,7 +42,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int 
         mpi_errno =
             MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), send_count, recvtype, partner,
                                  tag, comm, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* calculate offset and count of the data to be received from the partner */
         MPII_Recexchalgo_get_count_and_offset(partner, 0, k, nranks, &count, &offset);
@@ -56,7 +56,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int 
         /* recv data from my partner */
         mpi_errno = MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), recv_count, recvtype,
                                          partner, tag, comm, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     MPIR_FUNC_EXIT;
@@ -93,7 +93,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int 
         mpi_errno =
             MPIR_TSP_sched_isend(buf_to_send, recvcounts[rank], recvtype, step1_sendto, tag, comm,
                                  sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets the data from non-participating rank */
             MPI_Aint recv_offset = displs[step1_recvfrom[i]] * recv_extent;
@@ -101,7 +101,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int 
                 MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset),
                                      recvcounts[step1_recvfrom[i]], recvtype, step1_recvfrom[i],
                                      tag, comm, sched, n_invtcs, invtx, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 
@@ -151,7 +151,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
                 send_count += recvcounts[offset + x];
             mpi_errno = MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), send_count, recvtype,
                                              nbr, tag, comm, sched, nrecvs, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
                              "phase %d nbr is %d send offset %d count %d depend on %d \n", phase,
@@ -172,7 +172,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
             mpi_errno =
                 MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), recv_count, recvtype,
                                      nbr, tag, comm, sched, 0, NULL, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             recv_id[j * (k - 1) + i] = vtx_id;
             nrecvs++;
@@ -219,13 +219,13 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step3(int step1_sendto, int 
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, total_count, recvtype, step1_sendto, tag, comm, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     for (i = 0; i < step1_nrecvs; i++) {
         mpi_errno = MPIR_TSP_sched_isend(recvbuf, total_count, recvtype, step1_recvfrom[i],
                                          tag, comm, sched, nrecvs, recv_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     MPIR_FUNC_EXIT;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring.c
@@ -97,7 +97,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
             mpi_errno =
                 MPIR_TSP_sched_isend(sbuf, recvcounts[send_rank], recvtype, dst, tag, comm, sched,
                                      nvtcs, vtcs, &send_id[i % 3]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             nvtcs = 0;
         } else {
             nvtcs = 2;
@@ -107,7 +107,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
             mpi_errno =
                 MPIR_TSP_sched_isend(sbuf, recvcounts[send_rank], recvtype, dst, tag, comm, sched,
                                      nvtcs, vtcs, &send_id[i % 3]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (i == 1) {
                 nvtcs = 2;
@@ -124,14 +124,14 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
         mpi_errno =
             MPIR_TSP_sched_irecv(rbuf, recvcounts[recv_rank], recvtype, src, tag, comm, sched,
                                  nvtcs, vtcs, &recv_id[i % 3]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* Copy to correct position in recvbuf */
         mpi_errno =
             MPIR_TSP_sched_localcopy(rbuf, recvcounts[recv_rank], recvtype,
                                      (char *) recvbuf + displs[recv_rank] * extent,
                                      recvcounts[recv_rank], recvtype, sched, 1, &recv_id[i % 3],
                                      &dtcopy_id[i % 3]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         data_buf = sbuf;
         sbuf = rbuf;
@@ -140,7 +140,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
     }
 
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
@@ -68,7 +68,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     if (in_step2 && !is_inplace && count > 0) { /* copy the data to recvbuf but only if you are a rank participating in Step 2 */
         mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
                                              recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Step 1 */
@@ -127,7 +127,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             mpi_errno =
                 MPIR_TSP_sched_localcopy(recvbuf, count, datatype, tmp_buf, count, datatype, sched,
                                          nvtcs, vtcs, &dtcopy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         }
         /* myidx is the index in the neighbors list such that
@@ -155,7 +155,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             mpi_errno =
                 MPIR_TSP_sched_isend(tmp_buf, count, datatype, nbr, tag, comm, sched, nvtcs, vtcs,
                                      &send_id[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (rank > nbr) {
                 myidx = i + 1;
             }
@@ -171,7 +171,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             mpi_errno =
                 MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
                                      vtcs, &recv_id[buf]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (count != 0) {
                 nvtcs = 1;
@@ -184,7 +184,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                 mpi_errno =
                     MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
                                                 sched, nvtcs, vtcs, &reduce_id[counter]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
 
         }
@@ -200,7 +200,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                 MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
                                      vtcs, &recv_id[buf]);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (count != 0) {
                 nvtcs = 1;
@@ -214,16 +214,16 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                     mpi_errno =
                         MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
                                                     sched, nvtcs, vtcs, &reduce_id[counter]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 } else {
                     mpi_errno =
                         MPIR_TSP_sched_reduce_local(recvbuf, nbr_buffer[buf], count, datatype, op,
                                                     sched, nvtcs, vtcs, &reduce_id[counter]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     mpi_errno =
                         MPIR_TSP_sched_localcopy(nbr_buffer[buf], count, datatype, recvbuf, count,
                                                  datatype, sched, 1, &reduce_id[counter], &vtx_id);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     reduce_id[counter] = vtx_id;
                 }
             }
@@ -236,7 +236,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, sched, 0, NULL,
                                  &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {
             if (count == 0) {
@@ -256,7 +256,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             mpi_errno =
                 MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm, sched,
                                      nvtcs, vtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
@@ -76,7 +76,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     if (in_step2 && !is_inplace && count > 0) { /* copy the data to tmp_recvbuf but only if you are a rank participating in Step 2 */
         mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
                                              recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After initial dt copy\n"));
 
@@ -141,13 +141,13 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, sched, 1,
                                  &sink_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {
             mpi_errno =
                 MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm, sched,
                                      nvtcs, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.c
@@ -98,7 +98,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
             mpi_errno = MPIR_TSP_sched_irecv(step1_recvbuf[i], count, datatype,
                                              step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
                                              &recv_id[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (count != 0) {   /* Reduce only if data is present */
                 /* setup reduce dependencies */
                 nvtcs = 1;
@@ -117,7 +117,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                 mpi_errno = MPIR_TSP_sched_reduce_local(step1_recvbuf[i], recvbuf, count,
                                                         datatype, op, sched, nvtcs, vtcs,
                                                         &reduce_id[i]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
@@ -67,7 +67,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
                                      NULL, &vtx_id);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_TSP_sched_fence(sched);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Phase 2: Ring based send recv reduce scatter */
@@ -91,7 +91,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
         mpi_errno =
             MPIR_TSP_sched_irecv(tmpbuf, cnts[recv_rank], datatype, src, tag, comm, sched, nvtcs,
                                  &vtcs, &recv_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         mpi_errno =
             MPIR_TSP_sched_reduce_local(tmpbuf, (char *) recvbuf + displs[recv_rank] * extent,
@@ -103,12 +103,12 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
         mpi_errno =
             MPIR_TSP_sched_isend((char *) recvbuf + displs[send_rank] * extent, cnts[send_rank],
                                  datatype, dst, tag, comm, sched, nvtcs, &vtcs, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
     MPIR_CHKLMEM_MALLOC(reduce_id, int *, 2 * sizeof(int), mpi_errno, "reduce_id", MPL_MEM_COLL);
 
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* Phase 3: Allgatherv ring, so everyone has the reduced data */
     MPIR_TSP_Iallgatherv_sched_intra_ring(MPI_IN_PLACE, -1, MPI_DATATYPE_NULL, recvbuf, cnts,

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
@@ -93,7 +93,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
                                              recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* initialize arrays to store graph vertex indices */
@@ -140,7 +140,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
             mpi_errno = MPIR_TSP_sched_irecv(recv_address, msgsize, datatype, child, tag, comm,
                                              sched, nvtcs, vtcs, &recv_id[i]);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             /* Setup dependencies for reduction. Reduction depends on the corresponding recv to complete */
             vtcs[0] = recv_id[i];
             nvtcs = 1;
@@ -149,7 +149,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
                 mpi_errno = MPIR_TSP_sched_reduce_local(recv_address, reduce_address, msgsize,
                                                         datatype, op, sched, nvtcs, vtcs,
                                                         &reduce_id[i]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {    /* wait for the previous allreduce to complete */
 
                 /* NOTE: Make sure that knomial tree is being constructed differently for allreduce for optimal performance.
@@ -162,11 +162,11 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
                 mpi_errno =
                     MPIR_TSP_sched_reduce_local(reduce_address, recv_address, msgsize, datatype, op,
                                                 sched, nvtcs, vtcs, &reduce_id[i]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 mpi_errno =
                     MPIR_TSP_sched_localcopy(recv_address, msgsize, datatype, reduce_address,
                                              msgsize, datatype, sched, 1, &reduce_id[i], &vtx_id);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 reduce_id[i] = vtx_id;
             }
         }
@@ -186,7 +186,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
             mpi_errno =
                 MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, my_tree.parent, tag, comm,
                                      sched, nvtcs, vtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         /* Broadcast start here */
@@ -200,7 +200,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
             mpi_errno =
                 MPIR_TSP_sched_irecv(reduce_address, msgsize, datatype,
                                      my_tree.parent, tag, comm, sched, 1, &sink_id, &bcast_recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         if (num_children) {
@@ -210,7 +210,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
             mpi_errno = MPIR_TSP_sched_imcast(reduce_address, msgsize, datatype,
                                               ut_int_array(my_tree.children), num_children, tag,
                                               comm, sched, nvtcs, vtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         offset += msgsize;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
@@ -79,14 +79,14 @@ brucks_sched_pup(int pack, void *rbuf, void *pupbuf, MPI_Datatype rtype, MPI_Ain
                 MPIR_TSP_sched_localcopy((char *) rbuf + offset * count * type_extent, count, rtype,
                                          (char *) pupbuf + *pupsize, count, rtype, sched, ninvtcs,
                                          invtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             dtcopy_id[counter++] = vtx_id;
         } else {
             mpi_errno =
                 MPIR_TSP_sched_localcopy((char *) pupbuf + *pupsize, count, rtype,
                                          (char *) rbuf + offset * count * type_extent, count, rtype,
                                          sched, ninvtcs, invtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             dtcopy_id[counter++] = vtx_id;
         }
 
@@ -102,7 +102,7 @@ brucks_sched_pup(int pack, void *rbuf, void *pupbuf, MPI_Datatype rtype, MPI_Ain
     }
 
     mpi_errno = MPIR_TSP_sched_selective_sink(sched, counter, dtcopy_id, &sink_id);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     MPL_free(dtcopy_id);
 
@@ -197,7 +197,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno = MPIR_TSP_sched_localcopy(recvbuf, size * recvcount, recvtype,
                                              tmp_buf, size * recvcount, recvtype, sched, 0, NULL,
                                              &invtcs[0]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         n_invtcs = 1;
         senddata = tmp_buf;
     } else {
@@ -210,15 +210,15 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                          (size - rank) * sendcount, sendtype,
                                          recvbuf, (size - rank) * recvcount, recvtype, sched,
                                          n_invtcs, invtcs, &vtx_id);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     mpi_errno = MPIR_TSP_sched_localcopy(senddata, rank * sendcount, sendtype,
                                          (void *) ((char *) recvbuf +
                                                    (size - rank) * recvcount * r_extent),
                                          rank * recvcount, recvtype, sched, n_invtcs, invtcs,
                                          &vtx_id);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* Step 2: Allocate buffer space for packing/receiving data for every phase */
     delta = 1;
@@ -285,7 +285,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             mpi_errno =
                 MPIR_TSP_sched_isend(tmp_sbuf[i][j - 1], packsize, MPI_BYTE, dst, tag,
                                      comm, sched, 1, &packids[j - 1], &sendids[j - 1]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (i != 0 && buffer_per_phase == 0) {      /* this dependency holds only when we don't have dedicated recv buffer per phase */
                 *recv_invtcs = unpackids[j - 1];
@@ -295,7 +295,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_TSP_sched_irecv(tmp_rbuf[i][j - 1], packsize, MPI_BYTE,
                                      src, tag, comm, sched, recv_ninvtcs, recv_invtcs,
                                      &recvids[j - 1]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             *(unpack_invtcs + 1) = recvids[j - 1];
             unpack_ninvtcs = 2;
@@ -322,7 +322,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                  (size - rank - 1) * recvcount, recvtype, tmp_buf,
                                  (size - rank - 1) * recvcount, recvtype, sched,
                                  num_unpacks_in_last_phase, unpackids, &invtcs[0]);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     mpi_errno =
         MPIR_TSP_sched_localcopy(recvbuf, (rank + 1) * recvcount, recvtype,
@@ -330,7 +330,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                            (size - rank - 1) * recvcount * r_extent),
                                  (rank + 1) * recvcount, recvtype, sched, num_unpacks_in_last_phase,
                                  unpackids, &invtcs[1]);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* invert the buffer now to get the result in desired order */
     for (i = 0; i < size; i++) {
@@ -340,7 +340,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                      (void *) ((char *) recvbuf +
                                                (size - i - 1) * recvcount * r_extent), recvcount,
                                      recvtype, sched, 2, invtcs, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
@@ -85,7 +85,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
     mpi_errno = MPIR_TSP_sched_localcopy((char *) data_buf, size * recvcount, recvtype,
                                          (char *) buf1, size * recvcount, recvtype, sched, 0,
                                          NULL, &dtcopy_id[0]);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                     (MPL_DBG_FDEST,
@@ -103,7 +103,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                              sendcount, sendtype,
                                              (char *) recvbuf + rank * recvcount * recvtype_extent,
                                              recvcount, recvtype, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* in ring algorithm, source and destination of messages are fixed */
@@ -134,7 +134,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno =
             MPIR_TSP_sched_isend((char *) sbuf, size * recvcount, recvtype, dst, tag, comm, sched,
                                  nvtcs, vtcs, &send_id[i % 3]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* schedule recv */
         if (i == 0)
             nvtcs = 0;
@@ -152,7 +152,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno =
             MPIR_TSP_sched_irecv((char *) rbuf, size * recvcount, recvtype, src, tag, comm, sched,
                                  nvtcs, vtcs, &recv_id[i % 3]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* destination offset of the copy */
         copy_dst = (size + rank - i - 1) % size;
@@ -168,7 +168,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                      recvcount, recvtype, sched, 1, &recv_id[i % 3],
                                      &dtcopy_id[i % 3]);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* swap sbuf and rbuf - using data_buf as intermediate buffer */
         data_buf = sbuf;
         sbuf = rbuf;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
@@ -99,9 +99,9 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
             MPIR_TSP_sched_localcopy((char *) recvbuf, size * recvcount, recvtype,
                                      (char *) data_buf, size * recvcount, recvtype, sched, 0, NULL,
                                      &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         mpi_errno = MPIR_TSP_sched_fence(sched);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         data_buf = (void *) sendbuf;
     }
@@ -112,13 +112,13 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
         mpi_errno =
             MPIR_TSP_sched_irecv((char *) recvbuf + src * recvcount * recvtype_extent,
                                  recvcount, recvtype, src, tag, comm, sched, 0, NULL, &recv_id[i]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         dst = (rank - i + size) % size;
         mpi_errno =
             MPIR_TSP_sched_isend((char *) data_buf + dst * sendcount * sendtype_extent,
                                  sendcount, sendtype, dst, tag, comm, sched, 0, NULL, &send_id[i]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Post more send/recv pairs as the previous ones finish */
@@ -133,21 +133,21 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
             vtcs[idx++] = send_id[(i + j) % bblock];
         }
         mpi_errno = MPIR_TSP_sched_selective_sink(sched, 2 * ww, vtcs, &invtcs);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         for (j = 0; j < ww; j++) {
             src = (rank + i + j) % size;
             mpi_errno =
                 MPIR_TSP_sched_irecv((char *) recvbuf + src * recvcount * recvtype_extent,
                                      recvcount, recvtype, src, tag, comm, sched, 1, &invtcs,
                                      &recv_id[(i + j) % bblock]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             dst = (rank - i - j + size) % size;
             mpi_errno =
                 MPIR_TSP_sched_isend((char *) data_buf + dst * sendcount * sendtype_extent,
                                      sendcount, sendtype, dst, tag, comm, sched, 1, &invtcs,
                                      &send_id[(i + j) % bblock]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
@@ -58,7 +58,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                 mpi_errno = MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[dst] * recv_extent,
                                                  recvcounts[dst], recvtype, dst, tag, comm, sched,
                                                  0, NULL, &vtx_id);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
 
@@ -68,13 +68,13 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                 mpi_errno = MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst] * send_extent,
                                                  sendcounts[dst], sendtype, dst, tag, comm, sched,
                                                  0, NULL, &vtx_id);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
 
         /* force our block of sends/recvs to complete before starting the next block */
         mpi_errno = MPIR_TSP_sched_fence(sched);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
@@ -54,12 +54,12 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
             mpi_errno = MPIR_TSP_sched_isend((char *) recvbuf + rdispls[dst] * recv_extent,
                                              recvcounts[dst], recvtype, dst, tag, comm,
                                              sched, nvtcs, vtcs, &send_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             mpi_errno =
                 MPIR_TSP_sched_irecv(tmp_buf, recvcounts[dst], recvtype, dst, tag, comm,
                                      sched, nvtcs, vtcs, &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             nvtcs = 2;
             vtcs[0] = send_id;
@@ -68,7 +68,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
                                                  ((char *) recvbuf +
                                                   rdispls[dst] * recv_extent), recvcounts[dst],
                                                  recvtype, sched, nvtcs, vtcs, &dtcopy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
@@ -66,14 +66,14 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
             MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[src] * recvtype_extent,
                                  recvcounts[src], recvtype, src, tag, comm, sched, 0, NULL,
                                  &recv_id[i]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         dst = (rank - i + size) % size;
         mpi_errno =
             MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst] * sendtype_extent,
                                  sendcounts[dst], sendtype, dst, tag, comm, sched, 0, NULL,
                                  &send_id[i]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Post more send/recv pairs as the previous ones finish */
@@ -88,7 +88,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
             vtcs[i_vtcs++] = send_id[(i + j) % bblock];
         }
         mpi_errno = MPIR_TSP_sched_selective_sink(sched, 2 * ww, vtcs, &invtcs);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         for (j = 0; j < ww; j++) {
             src = (rank + i + j) % size;
@@ -96,14 +96,14 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
                 MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[src] * recvtype_extent,
                                      recvcounts[src], recvtype, src, tag, comm, sched, 1, &invtcs,
                                      &recv_id[(i + j) % bblock]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             dst = (rank - i - j + size) % size;
             mpi_errno =
                 MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst] * sendtype_extent,
                                      sendcounts[dst], sendtype, dst, tag, comm, sched, 1, &invtcs,
                                      &send_id[(i + j) % bblock]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
@@ -50,7 +50,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                     mpi_errno = MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[dst],
                                                      recvcounts[dst], recvtypes[dst], dst, tag,
                                                      comm, sched, 0, NULL, &vtx_id);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
             }
         }
@@ -63,14 +63,14 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                     mpi_errno = MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst],
                                                      sendcounts[dst], sendtypes[dst], dst, tag,
                                                      comm, sched, 0, NULL, &vtx_id);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
             }
         }
 
         /* force our block of sends/recvs to complete before starting the next block */
         mpi_errno = MPIR_TSP_sched_fence(sched);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
@@ -61,11 +61,11 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
             mpi_errno = MPIR_TSP_sched_isend((char *) recvbuf + rdispls[dst],
                                              recvcounts[dst], recvtypes[dst], dst, tag, comm, sched,
                                              nvtcs, vtcs, &send_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             mpi_errno =
                 MPIR_TSP_sched_irecv(adj_tmp_buf, recvcounts[dst], recvtypes[dst], dst, tag, comm,
                                      sched, nvtcs, vtcs, &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             nvtcs = 2;
             vtcs[0] = send_id;
@@ -73,7 +73,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
             mpi_errno = MPIR_TSP_sched_localcopy(adj_tmp_buf, recvcounts[dst], recvtypes[dst],
                                                  ((char *) recvbuf + rdispls[dst]), recvcounts[dst],
                                                  recvtypes[dst], sched, nvtcs, vtcs, &dtcopy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
@@ -53,14 +53,14 @@ int MPIR_TSP_Ibarrier_sched_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_
             mpi_errno =
                 MPIR_TSP_sched_irecv(NULL, 0, MPI_BYTE, from, tag, comm, sched, 0, NULL,
                                      &recv_ids[i * (k - 1) + j - 1]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST, "dissem barrier - scheduling send to %d\n", to));
             mpi_errno =
                 MPIR_TSP_sched_isend(NULL, 0, MPI_BYTE, to, tag, comm, sched, i * (k - 1), recv_ids,
                                      &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST, "dissem barrier - scheduled phase %d\n", i));

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
@@ -85,7 +85,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
                                          0, NULL, &vtx_id);
             MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIR_TSP_sched_fence(sched);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 
@@ -145,7 +145,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
         mpi_errno =
             MPIR_TSP_sched_irecv((char *) tmp_buf + displs[rank], recv_size, MPI_BYTE,
                                  my_tree.parent, tag, comm, sched, 0, NULL, &recv_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "rank:%d posts recv", rank));
 
     }
@@ -162,13 +162,13 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
                                          child_subtree_size[i], MPI_BYTE,
                                          child, tag, comm, sched, num_send_dependencies, &recv_id,
                                          &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
 
     MPIR_Treealgo_tree_free(&my_tree);
     mpi_errno = MPIR_TSP_sched_fence(sched);    /* wait for scatter to complete */
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     if (allgatherv_algo == MPIR_CVAR_IALLGATHERV_INTRA_ALGORITHM_tsp_ring)
         /* Schedule Allgatherv ring */

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree.c
@@ -73,14 +73,14 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype 
                 MPIR_TSP_sched_irecv_status((char *) buffer + offset * extent, msgsize,
                                             datatype, my_tree.parent, tag, comm,
                                             &ibcast_state->status, sched, 0, NULL, &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             MPIR_TSP_sched_cb(&MPII_Ibcast_sched_test_length, ibcast_state, sched, 1, &recv_id,
                               &vtx_id);
 #else
             mpi_errno =
                 MPIR_TSP_sched_irecv((char *) buffer + offset * extent, msgsize, datatype,
                                      my_tree.parent, tag, comm, sched, 0, NULL, &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 #endif
         }
 
@@ -90,7 +90,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype 
                                               ut_int_array(my_tree.children), num_children, tag,
                                               comm, sched, (my_tree.parent != -1) ? 1 : 0, &recv_id,
                                               &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         offset += msgsize;
     }

--- a/src/mpi/coll/igather/igather_tsp_tree.c
+++ b/src/mpi/coll/igather/igather_tsp_tree.c
@@ -138,7 +138,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno =
             MPIR_TSP_sched_isend(tmp_buf, sendcount, sendtype, my_tree.parent, tag, comm, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "rank:%d posts recv\n", rank));
     } else {
         num_dependencies = 0;
@@ -152,7 +152,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
             mpi_errno =
                 MPIR_TSP_sched_localcopy(data_buf, sendcount, sendtype,
                                          tmp_buf, recvcount, recvtype, sched, 0, NULL, &dtcopy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             num_dependencies++;
         }
 
@@ -162,13 +162,13 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_TSP_sched_irecv((char *) tmp_buf + child_data_offset[i] * recvtype_extent,
                                      child_subtree_size[i] * recvcount, recvtype, child, tag, comm,
                                      sched, num_dependencies, &dtcopy_id, &recv_id[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         if (my_tree.parent != -1) {
             mpi_errno = MPIR_TSP_sched_isend(tmp_buf, recv_size, recvtype, my_tree.parent,
                                              tag, comm, sched, num_children, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
     }
@@ -178,12 +178,12 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                                              (char *) recvbuf + root * recvcount * recvtype_extent,
                                              (size - root) * recvcount, recvtype, sched,
                                              num_children, recv_id, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         mpi_errno =
             MPIR_TSP_sched_localcopy((char *) tmp_buf + (size - root) * recvcount * recvtype_extent,
                                      root * recvcount, recvtype, recvbuf, root * recvcount,
                                      recvtype, sched, 1, &dtcopy_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     MPIR_Treealgo_tree_free(&my_tree);

--- a/src/mpi/coll/igatherv/igatherv_tsp_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_tsp_linear.c
@@ -62,7 +62,7 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
                                                      recvcounts[i], recvtype, i, tag, comm_ptr,
                                                      sched, 0, NULL, &vtx_id);
                 }
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
     } else if (root != MPI_PROC_NULL) {
@@ -87,7 +87,7 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
                 mpi_errno =
                     MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, root, tag, comm_ptr, sched,
                                          0, NULL, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear.c
@@ -46,7 +46,7 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, MPI_A
         mpi_errno =
             MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     for (l = 0; l < indegree; ++l) {
@@ -54,7 +54,7 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, MPI_A
         mpi_errno =
             MPIR_TSP_sched_irecv(rb, recvcount, recvtype, srcs[l], tag, comm_ptr, sched, 0, NULL,
                                  &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
@@ -47,7 +47,7 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
         mpi_errno =
             MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     for (l = 0; l < indegree; ++l) {
@@ -55,7 +55,7 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
         mpi_errno =
             MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
@@ -49,7 +49,7 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Ai
         mpi_errno =
             MPIR_TSP_sched_isend(sb, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0, NULL,
                                  &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* need reverse the order to ensure matching when the graph is from MPI_Cart_create and
@@ -60,7 +60,7 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Ai
         mpi_errno =
             MPIR_TSP_sched_irecv(rb, recvcount, recvtype, srcs[l], tag, comm_ptr, sched, 0, NULL,
                                  &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
@@ -52,7 +52,7 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
         mpi_errno =
             MPIR_TSP_sched_isend(sb, sendcounts[k], sendtype, dsts[k], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* need reverse the order to ensure matching when the graph is from MPI_Cart_create and
@@ -63,7 +63,7 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
         mpi_errno =
             MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
@@ -50,7 +50,7 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
         mpi_errno =
             MPIR_TSP_sched_isend(sb, sendcounts[k], sendtypes[k], dsts[k], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* need reverse the order to ensure matching when the graph is from MPI_Cart_create and
@@ -63,7 +63,7 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
         mpi_errno =
             MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtypes[l], srcs[l], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree.c
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree.c
@@ -132,7 +132,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
         reduce_buffer = (void *) sendbuf;
     }
 
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* initialize arrays to store graph vertex indices */
     MPIR_CHKLMEM_MALLOC(vtcs, int *, sizeof(int) * (num_children + 1),
@@ -177,7 +177,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
             mpi_errno = MPIR_TSP_sched_irecv(recv_address, msgsize, datatype, child, tag, comm,
                                              sched, nvtcs, vtcs, &recv_id[i]);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             /* Setup dependencies for reduction. Reduction depends on the corresponding recv to complete */
             vtcs[0] = recv_id[i];
             nvtcs = 1;
@@ -204,7 +204,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
                 reduce_id[i] = vtx_id;
 
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         if (is_commutative && buffer_per_child) {       /* wait for all the reductions */
@@ -222,7 +222,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
             mpi_errno =
                 MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, my_tree.parent, tag, comm,
                                      sched, nvtcs, vtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         /* send data to the root of the collective operation */
@@ -236,7 +236,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
                     MPIR_TSP_sched_irecv((char *) recvbuf + offset * extent, msgsize, datatype,
                                          tree_root, tag, comm, sched, 0, NULL, &vtx_id);
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         offset += msgsize;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
@@ -88,7 +88,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
             mpi_errno =
                 MPIR_TSP_sched_isend((char *) tmp_results + send_offset, send_cnt,
                                      datatype, dst, tag, comm, sched, nvtcs, vtcs, &send_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             rank_for_offset =
                 (is_dist_halving) ? MPII_Recexchalgo_reverse_digits_step2(rank, nranks, k) : rank;
@@ -106,7 +106,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + recv_offset, recv_cnt,
                                      datatype, dst, tag, comm, sched, nvtcs, vtcs, &recv_id);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             nvtcs = 2;
             vtcs[0] = send_id;
@@ -115,7 +115,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                 MPIR_TSP_sched_reduce_local((char *) tmp_recvbuf + recv_offset,
                                             (char *) tmp_results + recv_offset,
                                             recv_cnt, datatype, op, sched, nvtcs, vtcs, &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 
@@ -203,7 +203,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
             mpi_errno = MPIR_TSP_sched_localcopy(recvbuf, total_count, datatype,
                                                  tmp_results, total_count, datatype, sched, 0,
                                                  NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After initial dt copy"));
 
@@ -218,7 +218,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         mpi_errno =
             MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, step1_sendto, tag, comm, sched,
                                  0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     } else {    /* Step 2 participating rank */
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
@@ -228,12 +228,12 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
             mpi_errno = MPIR_TSP_sched_irecv(tmp_recvbuf, total_count, datatype,
                                              step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
                                              &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             nvtcs++;
             vtcs[1] = recv_id;
             mpi_errno = MPIR_TSP_sched_reduce_local(tmp_recvbuf, tmp_results, total_count,
                                                     datatype, op, sched, nvtcs, vtcs, &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 
@@ -255,7 +255,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         mpi_errno = MPIR_TSP_sched_localcopy((char *) tmp_results + displs[rank] * extent,
                                              recvcounts[rank], datatype, recvbuf, recvcounts[rank],
                                              datatype, sched, nvtcs, vtcs, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After Step 2"));
@@ -266,7 +266,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, recvcounts[rank], datatype, step1_sendto, tag, comm,
                                  sched, 1, &sink_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
     for (i = 0; i < step1_nrecvs; i++) {
         nvtcs = 1;
@@ -274,7 +274,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         mpi_errno = MPIR_TSP_sched_isend((char *) tmp_results + displs[step1_recvfrom[i]] * extent,
                                          recvcounts[step1_recvfrom[i]], datatype, step1_recvfrom[i],
                                          tag, comm, sched, nvtcs, vtcs, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Done Step 3"));

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
@@ -64,7 +64,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             mpi_errno = MPIR_TSP_sched_localcopy(recvbuf, total_count, datatype,
                                                  tmp_results, total_count, datatype, sched, 0,
                                                  NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Step 1 */
@@ -78,7 +78,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
         mpi_errno =
             MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, step1_sendto, tag, comm, sched,
                                  0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {    /* Step 2 participating rank */
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
             /* recv dependencies */
@@ -87,12 +87,12 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             mpi_errno = MPIR_TSP_sched_irecv(tmp_recvbuf, total_count, datatype,
                                              step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
                                              &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             nvtcs++;
             vtcs[1] = recv_id;
             mpi_errno = MPIR_TSP_sched_reduce_local(tmp_recvbuf, tmp_results, total_count,
                                                     datatype, op, sched, nvtcs, vtcs, &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 
@@ -120,7 +120,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             mpi_errno =
                 MPIR_TSP_sched_isend((char *) tmp_results + send_offset, send_cnt * recvcount,
                                      datatype, dst, tag, comm, sched, nvtcs, vtcs, &send_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             MPII_Recexchalgo_get_count_and_offset(rank, phase, k, nranks, &recv_cnt, &offset);
             MPI_Aint recv_offset = offset * extent * recvcount;
@@ -128,7 +128,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             mpi_errno =
                 MPIR_TSP_sched_irecv(tmp_recvbuf, recv_cnt * recvcount,
                                      datatype, dst, tag, comm, sched, nvtcs, vtcs, &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             nvtcs = 2;
             vtcs[0] = send_id;
@@ -138,7 +138,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
                                             (char *) tmp_results + recv_offset,
                                             recv_cnt * recvcount, datatype, op, sched, nvtcs, vtcs,
                                             &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
     if (in_step2) {
@@ -149,7 +149,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             MPIR_TSP_sched_localcopy((char *) tmp_results + rank * recvcount * extent, recvcount,
                                      datatype, recvbuf, recvcount, datatype, sched, nvtcs, vtcs,
                                      &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
@@ -158,7 +158,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, recvcount, datatype, step1_sendto, tag, comm, sched, 1,
                                  &step1_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
     for (i = 0; i < step1_nrecvs; i++) {
         nvtcs = 1;
@@ -167,7 +167,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             MPIR_TSP_sched_isend((char *) tmp_results + recvcount * step1_recvfrom[i] * extent,
                                  recvcount, datatype, step1_recvfrom[i], tag, comm, sched, nvtcs,
                                  vtcs, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
@@ -49,7 +49,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
         mpi_errno =
             MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype, sched, 0,
                                      NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         mpi_errno =
             MPIR_TSP_sched_localcopy(sendbuf, count, datatype, partial_scan, count, datatype, sched,
                                      0, NULL, &dtcopy_id);
@@ -58,7 +58,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
             MPIR_TSP_sched_localcopy(recvbuf, count, datatype, partial_scan, count, datatype, sched,
                                      0, NULL, &dtcopy_id);
 
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     tmp_buf = MPIR_TSP_sched_malloc(count * extent, sched);
     mask = 0x1;
@@ -78,7 +78,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
                 MPIR_TSP_sched_isend(partial_scan, count, datatype, dst, tag, comm, sched, nvtcs,
                                      vtcs, &send_id);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (recv_reduce != -1) {
                 nvtcs++;
@@ -88,7 +88,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
                 MPIR_TSP_sched_irecv(tmp_buf, count, datatype, dst, tag, comm, sched, nvtcs, vtcs,
                                      &recv_id);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             nvtcs = 2;
             vtcs[0] = send_id;
@@ -97,30 +97,30 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
                 mpi_errno = MPIR_TSP_sched_reduce_local(tmp_buf, partial_scan, count,
                                                         datatype, op, sched, nvtcs, vtcs,
                                                         &reduce_id);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 mpi_errno = MPIR_TSP_sched_reduce_local(tmp_buf, recvbuf, count,
                                                         datatype, op, sched, nvtcs, vtcs,
                                                         &recv_reduce);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 if (is_commutative) {
                     mpi_errno = MPIR_TSP_sched_reduce_local(tmp_buf, partial_scan, count,
                                                             datatype, op, sched, nvtcs, vtcs,
                                                             &reduce_id);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 } else {
                     mpi_errno = MPIR_TSP_sched_reduce_local(partial_scan, tmp_buf, count,
                                                             datatype, op, sched, nvtcs, vtcs,
                                                             &reduce_id);
 
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                     mpi_errno = MPIR_TSP_sched_localcopy(tmp_buf, count, datatype,
                                                          partial_scan, count, datatype, sched, 1,
                                                          &reduce_id, &vtx_id);
                     reduce_id = vtx_id;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 }
                 recv_reduce = -1;

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree.c
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree.c
@@ -127,12 +127,12 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                                      (size - root) * sendcount, sendtype, tmp_buf,
                                      (size - root) * sendcount, sendtype, sched, 0, NULL,
                                      &dtcopy_id[0]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         mpi_errno =
             MPIR_TSP_sched_localcopy(sendbuf, root * sendcount, sendtype,
                                      (char *) tmp_buf + (size - root) * sendcount * sendtype_extent,
                                      root * sendcount, sendtype, sched, 0, NULL, &dtcopy_id[1]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         num_send_dependencies = 2;
     } else if (root == 0 && lrank == 0) {
@@ -150,7 +150,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     if (my_tree.parent != -1) {
         mpi_errno = MPIR_TSP_sched_irecv(tmp_buf, recv_size, recvtype, my_tree.parent,
                                          tag, comm, sched, 0, NULL, &recv_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "rank:%d posts recv", rank));
     }
 
@@ -161,19 +161,19 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                                          child_subtree_size[i] * sendcount, sendtype,
                                          child, tag, comm, sched, num_send_dependencies,
                                          (lrank == 0) ? dtcopy_id : &recv_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     if (num_children > 0 && lrank != 0) {       /* copy data from tmp_buf to recvbuf */
         mpi_errno = MPIR_TSP_sched_localcopy(tmp_buf, recvcount, recvtype, recvbuf,
                                              recvcount, recvtype, sched, 1, &recv_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     if (lrank == 0 && !is_inplace) {    /* root puts data in recvbuf */
         mpi_errno = MPIR_TSP_sched_localcopy(tmp_buf, sendcount, sendtype, recvbuf,
                                              recvcount, recvtype, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     MPIR_Treealgo_tree_free(&my_tree);

--- a/src/mpi/coll/iscatterv/iscatterv_tsp_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_tsp_linear.c
@@ -61,7 +61,7 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint 
                                                      sched, 0, NULL, &vtx_id);
                 }
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 
@@ -71,7 +71,7 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint 
             mpi_errno =
                 MPIR_TSP_sched_irecv(recvbuf, recvcount, recvtype, root, tag, comm_ptr, sched, 0,
                                      NULL, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
@@ -11,7 +11,6 @@ int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
-    MPIR_Errflag_t errflag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
@@ -19,7 +19,7 @@ int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
                                  comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, &errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
@@ -20,7 +20,7 @@ int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
                                           &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, &errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
@@ -12,7 +12,6 @@ int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
-    MPIR_Errflag_t errflag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ineighbor_allgatherv(sendbuf, sendcount, sendtype,

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
@@ -18,7 +18,7 @@ int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
                                         recvbuf, recvcount, recvtype, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, &errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
@@ -11,7 +11,6 @@ int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
-    MPIR_Errflag_t errflag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ineighbor_alltoall(sendbuf, sendcount, sendtype,

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
@@ -13,7 +13,6 @@ int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint sendc
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
-    MPIR_Errflag_t errflag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
@@ -21,7 +21,7 @@ int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint sendc
                                  rdispls, recvtype, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, &errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
@@ -13,7 +13,6 @@ int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendc
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
-    MPIR_Errflag_t errflag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =

--- a/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
@@ -21,7 +21,7 @@ int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendc
                                  rdispls, recvtypes, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, &errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/reduce/reduce_allcomm_nb.c
+++ b/src/mpi/coll/reduce/reduce_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
                            MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t * errflag)
+                           MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/reduce/reduce_allcomm_nb.c
+++ b/src/mpi/coll/reduce/reduce_allcomm_nb.c
@@ -16,7 +16,7 @@ int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
     mpi_errno = MPIR_Ireduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
@@ -19,7 +19,7 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
                                                MPI_Datatype datatype,
                                                MPI_Op op,
                                                int root,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, mpi_errno;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -37,7 +37,7 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
     if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr, &status);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does
          * local intracommunicator reduce, and then sends the data
@@ -65,12 +65,12 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
 
         /* now do a local reduce on this intracommunicator */
         mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype, op, 0, newcomm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         if (rank == 0) {
             mpi_errno = MPIC_Send(tmp_buf, count, datatype, root,
                                   MPIR_REDUCE_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
@@ -36,8 +36,7 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
 
     if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
-        mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0,
-                              MPIR_REDUCE_TAG, comm_ptr, &status, errflag);
+        mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr, &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does

--- a/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
@@ -98,12 +98,8 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
@@ -38,14 +38,7 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
         /* root receives data from rank 0 on remote group */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0,
                               MPIR_REDUCE_TAG, comm_ptr, &status, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does
          * local intracommunicator reduce, and then sends the data
@@ -73,26 +66,12 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
 
         /* now do a local reduce on this intracommunicator */
         mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype, op, 0, newcomm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         if (rank == 0) {
             mpi_errno = MPIC_Send(tmp_buf, count, datatype, root,
                                   MPIR_REDUCE_TAG, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -98,7 +98,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
             if (source < comm_size) {
                 source = (source + lroot) % comm_size;
                 mpi_errno = MPIC_Recv(tmp_buf, count, datatype, source,
-                                      MPIR_REDUCE_TAG, comm_ptr, &status, errflag);
+                                      MPIR_REDUCE_TAG, comm_ptr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                 /* The sender is above us, so the received buffer must be
@@ -131,8 +131,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
             mpi_errno = MPIC_Send(recvbuf, count, datatype, root,
                                   MPIR_REDUCE_TAG, comm_ptr, errflag);
         } else if (rank == root) {
-            mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0,
-                                  MPIR_REDUCE_TAG, comm_ptr, &status, errflag);
+            mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr, &status);
         }
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -160,11 +160,8 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -13,7 +13,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
                                void *recvbuf,
                                MPI_Aint count,
                                MPI_Datatype datatype,
-                               MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                               MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -99,7 +99,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
                 source = (source + lroot) % comm_size;
                 mpi_errno = MPIC_Recv(tmp_buf, count, datatype, source,
                                       MPIR_REDUCE_TAG, comm_ptr, &status);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 /* The sender is above us, so the received buffer must be
                  * the second argument (in the noncommutative case). */
@@ -120,7 +120,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
             source = ((relrank & (~mask)) + lroot) % comm_size;
             mpi_errno = MPIC_Send(recvbuf, count, datatype,
                                   source, MPIR_REDUCE_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             break;
         }
         mask <<= 1;
@@ -133,7 +133,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
         } else if (rank == root) {
             mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr, &status);
         }
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -99,14 +99,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
                 source = (source + lroot) % comm_size;
                 mpi_errno = MPIC_Recv(tmp_buf, count, datatype, source,
                                       MPIR_REDUCE_TAG, comm_ptr, &status, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                 /* The sender is above us, so the received buffer must be
                  * the second argument (in the noncommutative case). */
@@ -127,14 +120,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
             source = ((relrank & (~mask)) + lroot) % comm_size;
             mpi_errno = MPIC_Send(recvbuf, count, datatype,
                                   source, MPIR_REDUCE_TAG, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             break;
         }
         mask <<= 1;
@@ -148,14 +134,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
             mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0,
                                   MPIR_REDUCE_TAG, comm_ptr, &status, errflag);
         }
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -385,11 +385,8 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -116,8 +116,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
             newrank = -1;
         } else {        /* even */
             mpi_errno = MPIC_Recv(tmp_buf, count,
-                                  datatype, rank + 1,
-                                  MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  datatype, rank + 1, MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. */
@@ -239,7 +238,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                     disps[i] = disps[i - 1] + cnts[i - 1];
 
                 mpi_errno = MPIC_Recv(recvbuf, cnts[0], datatype,
-                                      0, MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                      0, MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 newrank = 0;
                 send_idx = 0;
@@ -322,7 +321,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                 mpi_errno = MPIC_Recv((char *) recvbuf +
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
-                                      MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                      MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
 

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -37,8 +37,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                                             MPI_Aint count,
                                             MPI_Datatype datatype,
                                             MPI_Op op,
-                                            int root,
-                                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                            int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -108,7 +107,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
         if (rank % 2 != 0) {    /* odd */
             mpi_errno = MPIC_Send(recvbuf, count,
                                   datatype, rank - 1, MPIR_REDUCE_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -117,7 +116,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
         } else {        /* even */
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank + 1, MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* do the reduction on received data. */
             /* This algorithm is used only for predefined ops
@@ -192,7 +191,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
                                       MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* tmp_buf contains data received in this step.
              * recvbuf contains data accumulated so far */
@@ -239,14 +238,14 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
 
                 mpi_errno = MPIC_Recv(recvbuf, cnts[0], datatype,
                                       0, MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 newrank = 0;
                 send_idx = 0;
                 last_idx = 2;
             } else if (newrank == 0) {  /* send */
                 mpi_errno = MPIC_Send(recvbuf, cnts[0], datatype,
                                       root, MPIR_REDUCE_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 newrank = -1;
             }
             newroot = 0;
@@ -312,7 +311,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                 mpi_errno = MPIC_Send((char *) recvbuf +
                                       disps[send_idx] * extent,
                                       send_cnt, datatype, dst, MPIR_REDUCE_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 break;
             } else {
                 /* recv and continue */
@@ -322,7 +321,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
                                       MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
 
             if (newrank > newdst)

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -108,14 +108,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
         if (rank % 2 != 0) {    /* odd */
             mpi_errno = MPIC_Send(recvbuf, count,
                                   datatype, rank - 1, MPIR_REDUCE_TAG, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -125,14 +118,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank + 1,
                                   MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. */
             /* This algorithm is used only for predefined ops
@@ -207,14 +193,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
                                       MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* tmp_buf contains data received in this step.
              * recvbuf contains data accumulated so far */
@@ -261,28 +240,14 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
 
                 mpi_errno = MPIC_Recv(recvbuf, cnts[0], datatype,
                                       0, MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 newrank = 0;
                 send_idx = 0;
                 last_idx = 2;
             } else if (newrank == 0) {  /* send */
                 mpi_errno = MPIC_Send(recvbuf, cnts[0], datatype,
                                       root, MPIR_REDUCE_TAG, comm_ptr, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 newrank = -1;
             }
             newroot = 0;
@@ -348,14 +313,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                 mpi_errno = MPIC_Send((char *) recvbuf +
                                       disps[send_idx] * extent,
                                       send_cnt, datatype, dst, MPIR_REDUCE_TAG, comm_ptr, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 break;
             } else {
                 /* recv and continue */
@@ -365,14 +323,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
                                       MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
 
             if (newrank > newdst)

--- a/src/mpi/coll/reduce/reduce_intra_smp.c
+++ b/src/mpi/coll/reduce/reduce_intra_smp.c
@@ -39,14 +39,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     if (comm_ptr->node_comm != NULL && MPIR_Get_intranode_rank(comm_ptr, root) == -1) {
         mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype,
                                 op, 0, comm_ptr->node_comm, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     /* do the internode reduce to the root's node */
@@ -58,14 +51,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
             mpi_errno = MPIR_Reduce(buf, NULL, count, datatype,
                                     op, MPIR_Get_internode_rank(comm_ptr, root),
                                     comm_ptr->node_roots_comm, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         } else {        /* I am on root's node. I have not participated in the earlier reduce. */
             if (comm_ptr->rank != root) {
                 /* I am not the root though. I don't have a valid recvbuf.
@@ -74,14 +60,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                 mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype,
                                         op, MPIR_Get_internode_rank(comm_ptr, root),
                                         comm_ptr->node_roots_comm, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                 /* point sendbuf at tmp_buf to make final intranode reduce easy */
                 sendbuf = tmp_buf;
@@ -91,14 +70,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                 mpi_errno = MPIR_Reduce(sendbuf, recvbuf, count, datatype,
                                         op, MPIR_Get_internode_rank(comm_ptr, root),
                                         comm_ptr->node_roots_comm, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
                 /* set sendbuf to MPI_IN_PLACE to make final intranode reduce easy. */
                 sendbuf = MPI_IN_PLACE;
@@ -112,14 +84,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
         mpi_errno = MPIR_Reduce(sendbuf, recvbuf, count, datatype,
                                 op, MPIR_Get_intranode_rank(comm_ptr, root),
                                 comm_ptr->node_comm, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/reduce/reduce_intra_smp.c
+++ b/src/mpi/coll/reduce/reduce_intra_smp.c
@@ -7,7 +7,7 @@
 
 int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                           MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                          MPIR_Errflag_t * errflag)
+                          MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -39,7 +39,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     if (comm_ptr->node_comm != NULL && MPIR_Get_intranode_rank(comm_ptr, root) == -1) {
         mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype,
                                 op, 0, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* do the internode reduce to the root's node */
@@ -51,7 +51,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
             mpi_errno = MPIR_Reduce(buf, NULL, count, datatype,
                                     op, MPIR_Get_internode_rank(comm_ptr, root),
                                     comm_ptr->node_roots_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         } else {        /* I am on root's node. I have not participated in the earlier reduce. */
             if (comm_ptr->rank != root) {
                 /* I am not the root though. I don't have a valid recvbuf.
@@ -60,7 +60,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                 mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype,
                                         op, MPIR_Get_internode_rank(comm_ptr, root),
                                         comm_ptr->node_roots_comm, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 /* point sendbuf at tmp_buf to make final intranode reduce easy */
                 sendbuf = tmp_buf;
@@ -70,7 +70,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                 mpi_errno = MPIR_Reduce(sendbuf, recvbuf, count, datatype,
                                         op, MPIR_Get_internode_rank(comm_ptr, root),
                                         comm_ptr->node_roots_comm, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 /* set sendbuf to MPI_IN_PLACE to make final intranode reduce easy. */
                 sendbuf = MPI_IN_PLACE;
@@ -84,7 +84,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
         mpi_errno = MPIR_Reduce(sendbuf, recvbuf, count, datatype,
                                 op, MPIR_Get_intranode_rank(comm_ptr, root),
                                 comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/reduce/reduce_intra_smp.c
+++ b/src/mpi/coll/reduce/reduce_intra_smp.c
@@ -124,12 +124,8 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t * errflag)
+                                   MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
@@ -17,7 +17,7 @@ int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const MPI
         MPIR_Ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
@@ -133,11 +133,8 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
@@ -16,7 +16,7 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
                                                           const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t * errflag)
+                                                          MPIR_Errflag_t errflag)
 {
     int rank, mpi_errno, root, local_size, total_count, i;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -63,25 +63,25 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         /* reduce to rank 0 of left group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Get the local intracommunicator */
@@ -94,7 +94,7 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
 
     mpi_errno = MPIR_Scatterv(tmp_buf, recvcounts, disps, datatype, recvbuf,
                               recvcounts[rank], datatype, 0, newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
@@ -63,53 +63,25 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         /* reduce to rank 0 of left group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     /* Get the local intracommunicator */
@@ -122,14 +94,7 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
 
     mpi_errno = MPIR_Scatterv(tmp_buf, recvcounts, disps, datatype, recvbuf,
                               recvcounts[rank], datatype, 0, newcomm_ptr, errflag);
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
@@ -103,14 +103,7 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                   incoming_data + recv_offset * true_extent,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_TAG,
                                   comm_ptr, MPI_STATUS_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         /* always perform the reduction at recv_offset, the data at send_offset
          * is now our peer's responsibility */
         if (rank > peer) {

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
@@ -141,11 +141,8 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
@@ -23,7 +23,7 @@
 int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                              const MPI_Aint recvcounts[], MPI_Datatype datatype,
                                              MPI_Op op, MPIR_Comm * comm_ptr,
-                                             MPIR_Errflag_t * errflag)
+                                             MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -103,7 +103,7 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                   incoming_data + recv_offset * true_extent,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_TAG,
                                   comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* always perform the reduction at recv_offset, the data at send_offset
          * is now our peer's responsibility */
         if (rank > peer) {

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -90,14 +90,7 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr,
                                       MPI_STATUS_IGNORE, errflag);
 
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, recvbuf, recvcounts[rank], datatype, op);

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -124,12 +124,8 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -15,7 +15,7 @@
  */
 int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
                                        const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -90,7 +90,7 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr,
                                       MPI_STATUS_IGNORE, errflag);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, recvbuf, recvcounts[rank], datatype, op);

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -20,7 +20,7 @@
 int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                  const MPI_Aint recvcounts[], MPI_Datatype datatype,
                                                  MPI_Op op, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t * errflag)
+                                                 MPIR_Errflag_t errflag)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -152,7 +152,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr,
                                       MPI_STATUS_IGNORE, errflag);
             received = 1;
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         /* if some processes in this process's subtree in this step
@@ -192,7 +192,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                     /* send the current result */
                     mpi_errno = MPIC_Send(tmp_recvbuf, 1, recvtype,
                                           dst, MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -202,7 +202,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                     mpi_errno = MPIC_Recv(tmp_recvbuf, 1, recvtype, dst,
                                           MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
                     received = 1;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
                 tmp_mask >>= 1;
                 k--;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -282,12 +282,8 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -200,8 +200,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                          (dst < tree_root + nprocs_completed) &&
                          (rank >= tree_root + nprocs_completed)) {
                     mpi_errno = MPIC_Recv(tmp_recvbuf, 1, recvtype, dst,
-                                          MPIR_REDUCE_SCATTER_TAG,
-                                          comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                          MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
                     received = 1;
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -152,14 +152,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr,
                                       MPI_STATUS_IGNORE, errflag);
             received = 1;
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
 
         /* if some processes in this process's subtree in this step
@@ -199,14 +192,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                     /* send the current result */
                     mpi_errno = MPIC_Send(tmp_recvbuf, 1, recvtype,
                                           dst, MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -217,14 +203,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                                           MPIR_REDUCE_SCATTER_TAG,
                                           comm_ptr, MPI_STATUS_IGNORE, errflag);
                     received = 1;
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
                 tmp_mask >>= 1;
                 k--;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -304,12 +304,8 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -116,14 +116,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(tmp_results, total_count,
                                   datatype, rank + 1, MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -133,14 +126,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
             mpi_errno = MPIC_Recv(tmp_recvbuf, total_count,
                                   datatype, rank - 1,
                                   MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -229,14 +215,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                                       send_cnt, datatype,
                                       dst, MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
 
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* tmp_recvbuf contains data received in this step.
              * tmp_results contains data accumulated so far */
@@ -275,14 +254,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                                       disps[rank - 1] * extent, recvcounts[rank - 1],
                                       datatype, rank - 1,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         } else {        /* even */
             if (recvcounts[rank]) {
@@ -290,14 +262,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                                       datatype, rank + 1,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr,
                                       MPI_STATUS_IGNORE, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -125,7 +125,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
         } else {        /* odd */
             mpi_errno = MPIC_Recv(tmp_recvbuf, total_count,
                                   datatype, rank - 1,
-                                  MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -207,8 +207,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                 mpi_errno = MPIC_Recv((char *) tmp_recvbuf +
                                       newdisps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
-                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
             else if ((recv_cnt == 0) && (send_cnt != 0))
                 mpi_errno = MPIC_Send((char *) tmp_results +
                                       newdisps[send_idx] * extent,
@@ -260,8 +259,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
             if (recvcounts[rank]) {
                 mpi_errno = MPIC_Recv(recvbuf, recvcounts[rank],
                                       datatype, rank + 1,
-                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -37,7 +37,7 @@
 int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvbuf,
                                                 const MPI_Aint recvcounts[], MPI_Datatype datatype,
                                                 MPI_Op op, MPIR_Comm * comm_ptr,
-                                                MPIR_Errflag_t * errflag)
+                                                MPIR_Errflag_t errflag)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -116,7 +116,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(tmp_results, total_count,
                                   datatype, rank + 1, MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -126,7 +126,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
             mpi_errno = MPIC_Recv(tmp_recvbuf, total_count,
                                   datatype, rank - 1,
                                   MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -214,7 +214,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                                       send_cnt, datatype,
                                       dst, MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* tmp_recvbuf contains data received in this step.
              * tmp_results contains data accumulated so far */
@@ -253,14 +253,14 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                                       disps[rank - 1] * extent, recvcounts[rank - 1],
                                       datatype, rank - 1,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         } else {        /* even */
             if (recvcounts[rank]) {
                 mpi_errno = MPIC_Recv(recvbuf, recvcounts[rank],
                                       datatype, rank + 1,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
@@ -17,7 +17,7 @@ int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, MPI
         MPIR_Ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                         MPIR_Errflag_t * errflag)
+                                         MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
@@ -121,13 +121,8 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
@@ -53,53 +53,25 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else {
         /* reduce to rank 0 of left group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     /* Get the local intracommunicator */
@@ -110,14 +82,7 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
 
     mpi_errno = MPIR_Scatter(tmp_buf, recvcount, datatype, recvbuf,
                              recvcount, datatype, 0, newcomm_ptr, errflag);
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
@@ -18,7 +18,7 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
                                                                 MPI_Datatype datatype,
                                                                 MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t * errflag)
+                                                                MPIR_Errflag_t errflag)
 {
     int rank, mpi_errno, root, local_size;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -53,25 +53,25 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         /* reduce to rank 0 of left group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
                                              root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Get the local intracommunicator */
@@ -82,7 +82,7 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
 
     mpi_errno = MPIR_Scatter(tmp_buf, recvcount, datatype, recvbuf,
                              recvcount, datatype, 0, newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
@@ -140,13 +140,8 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
@@ -101,14 +101,7 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
                                   incoming_data + recv_offset * true_extent,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_BLOCK_TAG,
                                   comm_ptr, MPI_STATUS_IGNORE, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         /* always perform the reduction at recv_offset, the data at send_offset
          * is now our peer's responsibility */
         if (rank > peer) {

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
@@ -25,7 +25,7 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
                                                    MPI_Aint recvcount,
                                                    MPI_Datatype datatype,
                                                    MPI_Op op,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -101,7 +101,7 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
                                   incoming_data + recv_offset * true_extent,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_BLOCK_TAG,
                                   comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* always perform the reduction at recv_offset, the data at send_offset
          * is now our peer's responsibility */
         if (rank > peer) {

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -94,14 +94,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
                                       MPI_STATUS_IGNORE, errflag);
 
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, recvbuf, recvcount, datatype, op);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -128,14 +128,8 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -25,7 +25,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
                                              MPI_Aint recvcount,
                                              MPI_Datatype datatype,
                                              MPI_Op op,
-                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -94,7 +94,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
                                       MPI_STATUS_IGNORE, errflag);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, recvbuf, recvcount, datatype, op);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -199,7 +199,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                          (rank >= tree_root + nprocs_completed)) {
                     mpi_errno = MPIC_Recv(tmp_recvbuf, 1, recvtype, dst,
                                           MPIR_REDUCE_SCATTER_BLOCK_TAG,
-                                          comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                          comm_ptr, MPI_STATUS_IGNORE);
                     received = 1;
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -150,14 +150,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
                                       MPI_STATUS_IGNORE, errflag);
             received = 1;
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
 
         /* if some processes in this process's subtree in this step
@@ -197,14 +190,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                     /* send the current result */
                     mpi_errno = MPIC_Send(tmp_recvbuf, 1, recvtype,
                                           dst, MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, errflag);
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -215,14 +201,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                                           MPIR_REDUCE_SCATTER_BLOCK_TAG,
                                           comm_ptr, MPI_STATUS_IGNORE, errflag);
                     received = 1;
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
                 tmp_mask >>= 1;
                 k--;

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -275,13 +275,8 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -25,8 +25,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                                                        MPI_Aint recvcount,
                                                        MPI_Datatype datatype,
                                                        MPI_Op op,
-                                                       MPIR_Comm * comm_ptr,
-                                                       MPIR_Errflag_t * errflag)
+                                                       MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -150,7 +149,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
                                       MPI_STATUS_IGNORE, errflag);
             received = 1;
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         /* if some processes in this process's subtree in this step
@@ -190,7 +189,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                     /* send the current result */
                     mpi_errno = MPIC_Send(tmp_recvbuf, 1, recvtype,
                                           dst, MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -201,7 +200,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                                           MPIR_REDUCE_SCATTER_BLOCK_TAG,
                                           comm_ptr, MPI_STATUS_IGNORE);
                     received = 1;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
                 tmp_mask >>= 1;
                 k--;

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -293,14 +293,8 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    /* --END ERROR HANDLING-- */
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -127,8 +127,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
         } else {        /* odd */
             mpi_errno = MPIC_Recv(tmp_recvbuf, total_count,
                                   datatype, rank - 1,
-                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
-                                  MPI_STATUS_IGNORE, errflag);
+                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -212,8 +211,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                 mpi_errno = MPIC_Recv((char *) tmp_recvbuf +
                                       newdisps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
-                                      MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, MPI_STATUS_IGNORE);
             else if ((recv_cnt == 0) && (send_cnt != 0))
                 mpi_errno = MPIC_Send((char *) tmp_results +
                                       newdisps[send_idx] * extent,
@@ -257,8 +255,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
         } else {        /* even */
             mpi_errno = MPIC_Recv(recvbuf, recvcount,
                                   datatype, rank + 1,
-                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
-                                  MPI_STATUS_IGNORE, errflag);
+                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, MPI_STATUS_IGNORE);
         }
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -40,8 +40,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                                                       MPI_Aint recvcount,
                                                       MPI_Datatype datatype,
                                                       MPI_Op op,
-                                                      MPIR_Comm * comm_ptr,
-                                                      MPIR_Errflag_t * errflag)
+                                                      MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -118,7 +117,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
             mpi_errno = MPIC_Send(tmp_results, total_count,
                                   datatype, rank + 1,
                                   MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -128,7 +127,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
             mpi_errno = MPIC_Recv(tmp_recvbuf, total_count,
                                   datatype, rank - 1,
                                   MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -218,7 +217,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                                       send_cnt, datatype,
                                       dst, MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, errflag);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* tmp_recvbuf contains data received in this step.
              * tmp_results contains data accumulated so far */
@@ -257,7 +256,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                                   datatype, rank + 1,
                                   MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, MPI_STATUS_IGNORE);
         }
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -118,14 +118,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
             mpi_errno = MPIC_Send(tmp_results, total_count,
                                   datatype, rank + 1,
                                   MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not pariticipate in recursive
@@ -136,14 +129,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                                   datatype, rank - 1,
                                   MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
                                   MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -234,14 +220,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                                       send_cnt, datatype,
                                       dst, MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, errflag);
 
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             /* tmp_recvbuf contains data received in this step.
              * tmp_results contains data accumulated so far */
@@ -281,14 +260,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                                   MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
                                   MPI_STATUS_IGNORE, errflag);
         }
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/scan/scan_allcomm_nb.c
+++ b/src/mpi/coll/scan/scan_allcomm_nb.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/scan/scan_allcomm_nb.c
+++ b/src/mpi/coll/scan/scan_allcomm_nb.c
@@ -15,7 +15,7 @@ int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI
     mpi_errno = MPIR_Iscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -131,12 +131,8 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -99,14 +99,7 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
                                       dst, MPIR_SCAN_TAG, tmp_buf,
                                       count, datatype, dst,
                                       MPIR_SCAN_TAG, comm_ptr, &status, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
             if (rank > dst) {
                 mpi_errno = MPIR_Reduce_local(tmp_buf, partial_scan, count, datatype, op);

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -44,7 +44,7 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
                                        void *recvbuf,
                                        MPI_Aint count,
                                        MPI_Datatype datatype,
-                                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     MPI_Status status;
     int rank, comm_size;
@@ -99,7 +99,7 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
                                       dst, MPIR_SCAN_TAG, tmp_buf,
                                       count, datatype, dst,
                                       MPIR_SCAN_TAG, comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (rank > dst) {
                 mpi_errno = MPIR_Reduce_local(tmp_buf, partial_scan, count, datatype, op);

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -172,12 +172,8 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -45,14 +45,7 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
      * one process, just copy the raw data. */
     if (comm_ptr->node_comm != NULL) {
         mpi_errno = MPIR_Scan(sendbuf, recvbuf, count, datatype, op, comm_ptr->node_comm, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
         MPIR_ERR_CHECK(mpi_errno);
@@ -66,27 +59,13 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
         mpi_errno = MPIC_Recv(localfulldata, count, datatype,
                               comm_ptr->node_comm->local_size - 1, MPIR_SCAN_TAG,
                               comm_ptr->node_comm, &status, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else if (comm_ptr->node_roots_comm == NULL &&
                comm_ptr->node_comm != NULL &&
                MPIR_Get_intranode_rank(comm_ptr, rank) == comm_ptr->node_comm->local_size - 1) {
         mpi_errno = MPIC_Send(recvbuf, count, datatype,
                               0, MPIR_SCAN_TAG, comm_ptr->node_comm, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else if (comm_ptr->node_roots_comm != NULL) {
         localfulldata = recvbuf;
     }
@@ -98,41 +77,20 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     if (comm_ptr->node_roots_comm != NULL) {
         mpi_errno = MPIR_Scan(localfulldata, prefulldata, count, datatype,
                               op, comm_ptr->node_roots_comm, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         if (MPIR_Get_internode_rank(comm_ptr, rank) != comm_ptr->node_roots_comm->local_size - 1) {
             mpi_errno = MPIC_Send(prefulldata, count, datatype,
                                   MPIR_Get_internode_rank(comm_ptr, rank) + 1,
                                   MPIR_SCAN_TAG, comm_ptr->node_roots_comm, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
         if (MPIR_Get_internode_rank(comm_ptr, rank) != 0) {
             mpi_errno = MPIC_Recv(tempbuf, count, datatype,
                                   MPIR_Get_internode_rank(comm_ptr, rank) - 1,
                                   MPIR_SCAN_TAG, comm_ptr->node_roots_comm, &status, errflag);
             noneed = 0;
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }
 
@@ -144,27 +102,13 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
 
     if (comm_ptr->node_comm != NULL) {
         mpi_errno = MPIR_Bcast(&noneed, 1, MPI_INT, 0, comm_ptr->node_comm, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     if (noneed == 0) {
         if (comm_ptr->node_comm != NULL) {
             mpi_errno = MPIR_Bcast(tempbuf, count, datatype, 0, comm_ptr->node_comm, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
 
         mpi_errno = MPIR_Reduce_local(tempbuf, recvbuf, count, datatype, op);

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -58,7 +58,7 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     if (comm_ptr->node_roots_comm != NULL && comm_ptr->node_comm != NULL) {
         mpi_errno = MPIC_Recv(localfulldata, count, datatype,
                               comm_ptr->node_comm->local_size - 1, MPIR_SCAN_TAG,
-                              comm_ptr->node_comm, &status, errflag);
+                              comm_ptr->node_comm, &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     } else if (comm_ptr->node_roots_comm == NULL &&
                comm_ptr->node_comm != NULL &&
@@ -88,7 +88,7 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
         if (MPIR_Get_internode_rank(comm_ptr, rank) != 0) {
             mpi_errno = MPIC_Recv(tempbuf, count, datatype,
                                   MPIR_Get_internode_rank(comm_ptr, rank) - 1,
-                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, &status, errflag);
+                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, &status);
             noneed = 0;
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }

--- a/src/mpi/coll/scatter/scatter_allcomm_nb.c
+++ b/src/mpi/coll/scatter/scatter_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Scatter_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                             void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                            MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/scatter/scatter_allcomm_nb.c
+++ b/src/mpi/coll/scatter/scatter_allcomm_nb.c
@@ -18,7 +18,7 @@ int MPIR_Scatter_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
                       &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/scatter/scatter_inter_linear.c
+++ b/src/mpi/coll/scatter/scatter_inter_linear.c
@@ -39,8 +39,7 @@ int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
         }
     } else {
         mpi_errno =
-            MPIC_Recv(recvbuf, recvcount, recvtype, root, MPIR_SCATTER_TAG, comm_ptr, &status,
-                      errflag);
+            MPIC_Recv(recvbuf, recvcount, recvtype, root, MPIR_SCATTER_TAG, comm_ptr, &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/scatter/scatter_inter_linear.c
+++ b/src/mpi/coll/scatter/scatter_inter_linear.c
@@ -58,9 +58,5 @@ int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
         }
     }
 
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
 }

--- a/src/mpi/coll/scatter/scatter_inter_linear.c
+++ b/src/mpi/coll/scatter/scatter_inter_linear.c
@@ -35,27 +35,13 @@ int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
             mpi_errno =
                 MPIC_Send(((char *) sendbuf + sendcount * i * extent), sendcount, sendtype, i,
                           MPIR_SCATTER_TAG, comm_ptr, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     } else {
         mpi_errno =
             MPIC_Recv(recvbuf, recvcount, recvtype, root, MPIR_SCATTER_TAG, comm_ptr, &status,
                       errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/scatter/scatter_inter_linear.c
+++ b/src/mpi/coll/scatter/scatter_inter_linear.c
@@ -14,7 +14,7 @@
 
 int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                              MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -35,12 +35,12 @@ int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
             mpi_errno =
                 MPIC_Send(((char *) sendbuf + sendcount * i * extent), sendcount, sendtype, i,
                           MPIR_SCATTER_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     } else {
         mpi_errno =
             MPIC_Recv(recvbuf, recvcount, recvtype, root, MPIR_SCATTER_TAG, comm_ptr, &status);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -38,14 +38,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
         mpi_errno =
             MPIC_Send(sendbuf, sendcount * remote_size, sendtype, 0, MPIR_SCATTER_TAG, comm_ptr,
                       errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         goto fn_exit;
     } else {
         /* remote group. rank 0 receives data from root. need to
@@ -63,14 +56,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
 
             mpi_errno = MPIC_Recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
                                   root, MPIR_SCATTER_TAG, comm_ptr, &status, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         } else {
             /* silience -Wmaybe-uninitialized due to MPIR_Scatter by non-zero ranks */
             recvtype_sz = 0;
@@ -85,14 +71,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
         /* now do the usual scatter on this intracommunicator */
         mpi_errno = MPIR_Scatter(tmp_buf, recvcount * recvtype_sz, MPI_BYTE,
                                  recvbuf, recvcount, recvtype, 0, newcomm_ptr, errflag);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -55,7 +55,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
                                 "tmp_buf", MPL_MEM_BUFFER);
 
             mpi_errno = MPIC_Recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
-                                  root, MPIR_SCATTER_TAG, comm_ptr, &status, errflag);
+                                  root, MPIR_SCATTER_TAG, comm_ptr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         } else {
             /* silience -Wmaybe-uninitialized due to MPIR_Scatter by non-zero ranks */

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -17,7 +17,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
                                                  int root, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t * errflag)
+                                                 MPIR_Errflag_t errflag)
 {
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -38,7 +38,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
         mpi_errno =
             MPIC_Send(sendbuf, sendcount * remote_size, sendtype, 0, MPIR_SCATTER_TAG, comm_ptr,
                       errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         goto fn_exit;
     } else {
         /* remote group. rank 0 receives data from root. need to
@@ -56,7 +56,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
 
             mpi_errno = MPIC_Recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
                                   root, MPIR_SCATTER_TAG, comm_ptr, &status);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         } else {
             /* silience -Wmaybe-uninitialized due to MPIR_Scatter by non-zero ranks */
             recvtype_sz = 0;
@@ -71,7 +71,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
         /* now do the usual scatter on this intracommunicator */
         mpi_errno = MPIR_Scatter(tmp_buf, recvcount * recvtype_sz, MPI_BYTE,
                                  recvbuf, recvcount, recvtype, 0, newcomm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -97,12 +97,8 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
-
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -28,7 +28,7 @@
 /* not declared static because a machine-specific function may call this one in some cases */
 int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     MPI_Status status;
     MPI_Aint extent = 0;
@@ -119,11 +119,11 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
             if (relative_rank % 2) {
                 mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype,
                                       src, MPIR_SCATTER_TAG, comm_ptr, &status);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 mpi_errno = MPIC_Recv(tmp_buf, tmp_buf_size, MPI_BYTE, src,
                                       MPIR_SCATTER_TAG, comm_ptr, &status);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 if (mpi_errno) {
                     curr_cnt = 0;
                 } else
@@ -163,7 +163,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
                                       send_subtree_cnt,
                                       MPI_BYTE, dst, MPIR_SCATTER_TAG, comm_ptr, errflag);
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             curr_cnt -= send_subtree_cnt;
         }
         mask >>= 1;

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -119,24 +119,12 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
             if (relative_rank % 2) {
                 mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype,
                                       src, MPIR_SCATTER_TAG, comm_ptr, &status, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             } else {
                 mpi_errno = MPIC_Recv(tmp_buf, tmp_buf_size, MPI_BYTE, src,
                                       MPIR_SCATTER_TAG, comm_ptr, &status, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                     curr_cnt = 0;
                 } else
                     /* the recv size is larger than what may be sent in
@@ -175,14 +163,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
                                       send_subtree_cnt,
                                       MPI_BYTE, dst, MPIR_SCATTER_TAG, comm_ptr, errflag);
             }
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             curr_cnt -= send_subtree_cnt;
         }
         mask >>= 1;

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -118,11 +118,11 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
              * receive data into a temporary buffer. */
             if (relative_rank % 2) {
                 mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype,
-                                      src, MPIR_SCATTER_TAG, comm_ptr, &status, errflag);
+                                      src, MPIR_SCATTER_TAG, comm_ptr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             } else {
                 mpi_errno = MPIC_Recv(tmp_buf, tmp_buf_size, MPI_BYTE, src,
-                                      MPIR_SCATTER_TAG, comm_ptr, &status, errflag);
+                                      MPIR_SCATTER_TAG, comm_ptr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 if (mpi_errno) {
                     curr_cnt = 0;

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -201,11 +201,8 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -20,7 +20,7 @@
 int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcounts,
                                  const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
                                  MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int rank, comm_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -67,14 +67,14 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
         }
         /* ... then wait for *all* of them to finish: */
         mpi_errno = MPIC_Waitall(reqs, reqarray, starray);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     else if (root != MPI_PROC_NULL) {   /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (recvcount) {
             mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype, root,
                                   MPIR_SCATTERV_TAG, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -66,25 +66,14 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
             }
         }
         /* ... then wait for *all* of them to finish: */
-        mpi_errno = MPIC_Waitall(reqs, reqarray, starray, errflag);
-        if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
-            MPIR_ERR_POP(mpi_errno);
-        /* --BEGIN ERROR HANDLING-- */
-        if (mpi_errno == MPI_ERR_IN_STATUS) {
-            for (i = 0; i < reqs; i++) {
-                if (starray[i].MPI_ERROR != MPI_SUCCESS) {
-                    mpi_errno = starray[i].MPI_ERROR;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
-                }
-            }
-        }
-        /* --END ERROR HANDLING-- */
+        mpi_errno = MPIC_Waitall(reqs, reqarray, starray);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
     else if (root != MPI_PROC_NULL) {   /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (recvcount) {
             mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype, root,
-                                  MPIR_SCATTERV_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  MPIR_SCATTERV_TAG, comm_ptr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -74,14 +74,7 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
             for (i = 0; i < reqs; i++) {
                 if (starray[i].MPI_ERROR != MPI_SUCCESS) {
                     mpi_errno = starray[i].MPI_ERROR;
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag =
-                            MPIX_ERR_PROC_FAILED ==
-                            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 }
             }
         }
@@ -92,14 +85,7 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
         if (recvcount) {
             mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype, root,
                                   MPIR_SCATTERV_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -106,11 +106,8 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mpi_errno_ret)
-        mpi_errno = mpi_errno_ret;
-    else if (*errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, *errflag, "**coll_fail");
-    return mpi_errno;
+    return mpi_errno_ret;
   fn_fail:
+    mpi_errno_ret = mpi_errno;
     goto fn_exit;
 }

--- a/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
@@ -8,7 +8,7 @@
 int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
                              const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
                              MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
@@ -19,7 +19,7 @@ int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
                        comm_ptr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIC_Wait(req_ptr, errflag);
+    mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Request_free(req_ptr);
 

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -44,7 +44,7 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                vtxp->u.isend.dt,
                                vtxp->u.isend.dest,
                                vtxp->u.isend.tag, vtxp->u.isend.comm, &vtxp->u.isend.req,
-                               &r->u.nbc.errflag);
+                               r->u.nbc.errflag);
 
                     if (MPIR_Request_is_complete(vtxp->u.isend.req)) {
                         MPIR_Request_free(vtxp->u.isend.req);
@@ -144,7 +144,7 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                    vtxp->u.imcast.dt,
                                    dests[i],
                                    vtxp->u.imcast.tag, vtxp->u.imcast.comm, &vtxp->u.imcast.req[i],
-                                   &r->u.nbc.errflag);
+                                   r->u.nbc.errflag);
 
                     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                                     (MPL_DBG_FDEST,
@@ -160,7 +160,7 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                 vtxp->u.issend.dt,
                                 vtxp->u.issend.dest,
                                 vtxp->u.issend.tag, vtxp->u.issend.comm, &vtxp->u.issend.req,
-                                &r->u.nbc.errflag);
+                                r->u.nbc.errflag);
 
                     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                                     (MPL_DBG_FDEST,

--- a/src/mpi/comm/comm_split_type_nbhd.c
+++ b/src/mpi/comm/comm_split_type_nbhd.c
@@ -252,7 +252,6 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
         *newcomm_ptr = NULL;
     } else {
         int *num_processes_at_node = NULL;
-        MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
         if (topo_type == MPIR_NETTOPO_TYPE__FAT_TREE ||
             topo_type == MPIR_NETTOPO_TYPE__CLOS_NETWORK) {
@@ -272,7 +271,7 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
         /* Send the count to processes */
         mpi_errno =
             MPIR_Allreduce(MPI_IN_PLACE, num_processes_at_node, num_nodes, MPI_INT,
-                           MPI_SUM, comm_ptr, &errflag);
+                           MPI_SUM, comm_ptr, MPIR_ERR_NONE);
 
         if (topo_type == MPIR_NETTOPO_TYPE__FAT_TREE ||
             topo_type == MPIR_NETTOPO_TYPE__CLOS_NETWORK) {
@@ -371,7 +370,8 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
             tree_depth = MPIR_hwtopo_get_depth(obj_containing_cpuset);
 
             /* get min tree depth to all processes */
-            MPIR_Allreduce(&tree_depth, &min_tree_depth, 1, MPI_INT, MPI_MIN, node_comm, &errflag);
+            MPIR_Allreduce(&tree_depth, &min_tree_depth, 1, MPI_INT, MPI_MIN, node_comm,
+                           MPIR_ERR_NONE);
 
             if (min_tree_depth) {
                 int num_hwloc_objs_at_depth;
@@ -385,7 +385,7 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
 
                 /* get parent_idx to all processes */
                 MPIR_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, parent_idx, 1, MPI_INT,
-                               node_comm, &errflag);
+                               node_comm, MPIR_ERR_NONE);
 
                 /* reorder parent indices */
                 for (i = 0; i < num_procs - 1; i++) {

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -727,8 +727,7 @@ static int init_comm_seq(MPIR_Comm * comm)
         /* Every rank need share the same seq from root. NOTE: it is possible for
          * different communicators to have the same seq. It is only used as an
          * opportunistic optimization */
-        MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-        mpi_errno = MPIR_Bcast_allcomm_auto(&tmp, 1, MPI_INT, 0, comm, &errflag);
+        mpi_errno = MPIR_Bcast_allcomm_auto(&tmp, 1, MPI_INT, 0, comm, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
         comm->seq = tmp;
@@ -1271,20 +1270,20 @@ int MPII_compare_info_hint(const char *hint_str, MPIR_Comm * comm_ptr, int *info
     int hint_str_equal_global = 0;
     char *hint_str_global = NULL;
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     /* Find the maximum hint_str size.  Each process locally compares
      * its hint_str size to the global max, and makes sure that this
      * comparison is successful on all processes. */
     mpi_errno =
-        MPIR_Allreduce(&hint_str_size, &hint_str_size_max, 1, MPI_INT, MPI_MAX, comm_ptr, &errflag);
+        MPIR_Allreduce(&hint_str_size, &hint_str_size_max, 1, MPI_INT, MPI_MAX, comm_ptr,
+                       MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     hint_str_equal = (hint_str_size == hint_str_size_max);
 
     mpi_errno =
         MPIR_Allreduce(&hint_str_equal, &hint_str_equal_global, 1, MPI_INT, MPI_LAND,
-                       comm_ptr, &errflag);
+                       comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (!hint_str_equal_global)
@@ -1297,14 +1296,14 @@ int MPII_compare_info_hint(const char *hint_str, MPIR_Comm * comm_ptr, int *info
 
     mpi_errno =
         MPIR_Allreduce(hint_str, hint_str_global, strlen(hint_str), MPI_CHAR,
-                       MPI_MAX, comm_ptr, &errflag);
+                       MPI_MAX, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     hint_str_equal = !memcmp(hint_str, hint_str_global, strlen(hint_str));
 
     mpi_errno =
         MPIR_Allreduce(&hint_str_equal, &hint_str_equal_global, 1, MPI_INT, MPI_LAND,
-                       comm_ptr, &errflag);
+                       comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/comm/ulfm_impl.c
+++ b/src/mpi/comm/ulfm_impl.c
@@ -127,7 +127,6 @@ int MPIR_Comm_shrink_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm_ptr)
     int mpi_errno = MPI_SUCCESS;
     MPIR_Group *global_failed = NULL, *comm_grp = NULL, *new_group_ptr = NULL;
     int attempts = 0;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -135,7 +134,7 @@ int MPIR_Comm_shrink_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm_ptr)
     MPIR_Comm_group_impl(comm_ptr, &comm_grp);
 
     do {
-        errflag = MPIR_ERR_NONE;
+        int errflag = MPIR_ERR_NONE;
 
         MPID_Comm_get_all_failed_procs(comm_ptr, &global_failed, MPIR_SHRINK_TAG);
         /* Ignore the mpi_errno value here as it will definitely communicate
@@ -158,7 +157,7 @@ int MPIR_Comm_shrink_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm_ptr)
         }
 
         mpi_errno = MPII_Allreduce_group(MPI_IN_PLACE, &errflag, 1, MPI_INT, MPI_MAX, comm_ptr,
-                                         new_group_ptr, MPIR_SHRINK_TAG, &errflag);
+                                         new_group_ptr, MPIR_SHRINK_TAG, MPIR_ERR_NONE);
         MPIR_Group_release(new_group_ptr);
 
         if (errflag) {
@@ -170,13 +169,13 @@ int MPIR_Comm_shrink_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm_ptr)
                 MPIR_Object_set_ref(new_group_ptr, 1);
                 MPIR_Group_release(new_group_ptr);
             }
+        } else {
+            mpi_errno = MPI_SUCCESS;
+            goto fn_exit;
         }
     } while (++attempts < 5);
 
-    if (errflag && attempts >= 5)
-        goto fn_fail;
-    else
-        mpi_errno = MPI_SUCCESS;
+    goto fn_fail;
 
   fn_exit:
     MPIR_Group_release(comm_grp);

--- a/src/mpi/comm/ulfm_impl.c
+++ b/src/mpi/comm/ulfm_impl.c
@@ -171,7 +171,7 @@ int MPIR_Comm_shrink_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm_ptr)
                 MPIR_Group_release(new_group_ptr);
             }
         }
-    } while (errflag && ++attempts < 5);
+    } while (++attempts < 5);
 
     if (errflag && attempts >= 5)
         goto fn_fail;
@@ -226,7 +226,7 @@ int MPIR_Comm_agree_impl(MPIR_Comm * comm_ptr, int *flag)
     /* Do an allreduce to decide whether or not anyone thinks the group
      * has changed */
     mpi_errno_tmp = MPII_Allreduce_group(MPI_IN_PLACE, &success, 1, MPI_INT, MPI_MIN, comm_ptr,
-                                         new_group_ptr, MPIR_AGREE_TAG, &errflag);
+                                         new_group_ptr, MPIR_AGREE_TAG, errflag);
     if (!success || errflag || mpi_errno_tmp)
         success = 0;
 
@@ -236,7 +236,7 @@ int MPIR_Comm_agree_impl(MPIR_Comm * comm_ptr, int *flag)
     /* Determine both the result of this function (mpi_errno) and the result
      * of flag that will be returned to the user. */
     MPII_Allreduce_group(MPI_IN_PLACE, values, 2, MPI_INT, MPI_BAND, comm_ptr,
-                         new_group_ptr, MPIR_AGREE_TAG, &errflag);
+                         new_group_ptr, MPIR_AGREE_TAG, errflag);
     /* Ignore the result of the operation this time. Everyone will either
      * return a failure because of !success earlier or they will return
      * something useful for flag because of this operation. If there was a new

--- a/src/mpi/stream/stream_enqueue.c
+++ b/src/mpi/stream/stream_enqueue.c
@@ -608,9 +608,8 @@ static void allreduce_enqueue_cb(void *data)
         }
     }
 
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     mpi_errno = MPIR_Allreduce(sendbuf, recvbuf, p->count, p->datatype, p->op, p->comm_ptr,
-                               &errflag);
+                               MPIR_ERR_NONE);
     MPIR_Assertp(mpi_errno == MPI_SUCCESS);
 
     if (p->host_recvbuf) {

--- a/src/mpi/stream/stream_impl.c
+++ b/src/mpi/stream/stream_impl.c
@@ -267,9 +267,8 @@ int MPIR_Stream_comm_create_impl(MPIR_Comm * comm_ptr, MPIR_Stream * stream_ptr,
     vci_table = MPL_malloc(comm_ptr->local_size * sizeof(int), MPL_MEM_OTHER);
     MPIR_ERR_CHKANDJUMP(!vci_table, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
-    MPIR_Errflag_t errflag;
-    errflag = MPIR_ERR_NONE;
-    mpi_errno = MPIR_Allgather_impl(&vci, 1, MPI_INT, vci_table, 1, MPI_INT, comm_ptr, &errflag);
+    mpi_errno =
+        MPIR_Allgather_impl(&vci, 1, MPI_INT, vci_table, 1, MPI_INT, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     (*newcomm_ptr)->stream_comm_type = MPIR_STREAM_COMM_SINGLE;
@@ -311,10 +310,9 @@ int MPIR_Stream_comm_create_multiplex_impl(MPIR_Comm * comm_ptr,
     displs = MPL_malloc((comm_ptr->local_size + 1) * sizeof(MPI_Aint), MPL_MEM_OTHER);
     MPIR_ERR_CHKANDJUMP(!displs, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPI_Aint num_tmp = num_streams;
     mpi_errno = MPIR_Allgather_impl(&num_tmp, 1, MPI_AINT,
-                                    num_table, 1, MPI_AINT, comm_ptr, &errflag);
+                                    num_table, 1, MPI_AINT, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPI_Aint num_total = 0;
@@ -346,9 +344,9 @@ int MPIR_Stream_comm_create_multiplex_impl(MPIR_Comm * comm_ptr,
         local_vcis[i] = stream_ptr ? stream_ptr->vci : 0;
     }
 
-    errflag = MPIR_ERR_NONE;
     mpi_errno = MPIR_Allgatherv_impl(local_vcis, num_streams, MPI_INT,
-                                     vci_table, num_table, displs, MPI_INT, comm_ptr, &errflag);
+                                     vci_table, num_table, displs, MPI_INT, comm_ptr,
+                                     MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     (*newcomm_ptr)->stream_comm_type = MPIR_STREAM_COMM_MULTIPLEX;

--- a/src/mpi/topo/dist_graph_create.c
+++ b/src/mpi/topo/dist_graph_create.c
@@ -205,7 +205,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
         MPIR_ERR_CHKANDJUMP(!buf, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         mpi_errno = MPIC_Recv(buf, count, MPI_INT, MPI_ANY_SOURCE, MPIR_TOPO_A_TAG,
-                              comm_ptr, MPI_STATUS_IGNORE, &errflag);
+                              comm_ptr, MPI_STATUS_IGNORE);
         MPIR_ERR_CHECK(mpi_errno);
 
         for (int j = 0; j < count / 2; ++j) {
@@ -238,7 +238,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
         MPIR_ERR_CHKANDJUMP(!buf, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         mpi_errno = MPIC_Recv(buf, count, MPI_INT, MPI_ANY_SOURCE, MPIR_TOPO_B_TAG,
-                              comm_ptr, MPI_STATUS_IGNORE, &errflag);
+                              comm_ptr, MPI_STATUS_IGNORE);
         MPIR_ERR_CHECK(mpi_errno);
 
         for (int j = 0; j < count / 2; ++j) {
@@ -259,7 +259,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
         buf = NULL;
     }
 
-    mpi_errno = MPIC_Waitall(idx, reqs, MPI_STATUSES_IGNORE, &errflag);
+    mpi_errno = MPIC_Waitall(idx, reqs, MPI_STATUSES_IGNORE);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* remove any excess memory allocation */

--- a/src/mpi/topo/dist_graph_create.c
+++ b/src/mpi/topo/dist_graph_create.c
@@ -132,11 +132,9 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
 
     /* compute the number of peers I will recv from */
     int in_out_peers[2] = { -1, 1 };
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     mpi_errno =
-        MPIR_Reduce_scatter_block(rs, in_out_peers, 2, MPI_INT, MPI_SUM, comm_ptr, &errflag);
+        MPIR_Reduce_scatter_block(rs, in_out_peers, 2, MPI_INT, MPI_SUM, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
     MPIR_Assert(in_out_peers[0] <= comm_size && in_out_peers[0] >= 0);
     MPIR_Assert(in_out_peers[1] <= comm_size && in_out_peers[1] >= 0);
@@ -152,14 +150,14 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
             /* send edges where i is a destination to process i */
             mpi_errno =
                 MPIC_Isend(&rin[i][0], rin_sizes[i], MPI_INT, i, MPIR_TOPO_A_TAG, comm_ptr,
-                           &reqs[idx++], &errflag);
+                           &reqs[idx++], MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
         }
         if (rout_sizes[i]) {
             /* send edges where i is a source to process i */
             mpi_errno =
                 MPIC_Isend(&rout[i][0], rout_sizes[i], MPI_INT, i, MPIR_TOPO_B_TAG, comm_ptr,
-                           &reqs[idx++], &errflag);
+                           &reqs[idx++], MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpid/ch3/channels/nemesis/src/ch3_win_fns.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_win_fns.c
@@ -124,7 +124,6 @@ static int MPIDI_CH3I_SHM_Wins_match(MPIR_Win ** win_ptr, MPIR_Win ** matched_wi
     MPIR_Comm *node_comm_ptr = NULL, *shm_node_comm_ptr = NULL;
     int *node_ranks = NULL, *node_ranks_in_shm_node = NULL;
     MPIR_Group *node_group_ptr = NULL, *shm_node_group_ptr = NULL;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPI_Aint *base_shm_offs;
 
     MPIDI_SHM_Win_t *elem = shm_wins_list;
@@ -201,9 +200,8 @@ static int MPIDI_CH3I_SHM_Wins_match(MPIR_Win ** win_ptr, MPIR_Win ** matched_wi
         base_shm_offs[node_rank] = (MPI_Aint) ((*win_ptr)->base)
             - (MPI_Aint) (shm_win->shm_base_addr);
         mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                                        base_shm_offs, 1, MPI_AINT, node_comm_ptr, &errflag);
+                                        base_shm_offs, 1, MPI_AINT, node_comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
         base_diff = 0;
         for (i = 0; i < comm_size; ++i) {
@@ -307,7 +305,6 @@ static int MPIDI_CH3I_Win_gather_info(void *base, MPI_Aint size, int disp_unit, 
     int comm_rank, comm_size;
     MPI_Aint *tmp_buf = NULL;
     int i, k;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int mpi_errno = MPI_SUCCESS;
     int mpl_err = 0;
     MPIR_CHKLMEM_DECL(1);
@@ -348,14 +345,12 @@ static int MPIDI_CH3I_Win_gather_info(void *base, MPI_Aint size, int disp_unit, 
 
         mpi_errno =
             MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
-                       &errflag);
+                       MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
         /* wait for other processes to attach to win */
-        mpi_errno = MPIR_Barrier(node_comm_ptr, &errflag);
+        mpi_errno = MPIR_Barrier(node_comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
         /* unlink shared memory region so it gets deleted when all processes exit */
         mpl_err = MPL_shm_seg_remove((*win_ptr)->info_shm_segment_handle);
@@ -367,9 +362,8 @@ static int MPIDI_CH3I_Win_gather_info(void *base, MPI_Aint size, int disp_unit, 
         /* get serialized handle from rank 0 and deserialize it */
         mpi_errno =
             MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
-                       &errflag);
+                       MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
         mpl_err = MPL_shm_hnd_deserialize((*win_ptr)->info_shm_segment_handle, serialized_hnd,
                                               strlen(serialized_hnd));
@@ -381,9 +375,8 @@ static int MPIDI_CH3I_Win_gather_info(void *base, MPI_Aint size, int disp_unit, 
                                      &(*win_ptr)->info_shm_base_addr, 0);
         MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**attach_shar_mem");
 
-        mpi_errno = MPIR_Barrier(node_comm_ptr, &errflag);
+        mpi_errno = MPIR_Barrier(node_comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
     }
 
     (*win_ptr)->basic_info_table = (MPIDI_Win_basic_info_t *) ((*win_ptr)->info_shm_base_addr);
@@ -397,7 +390,7 @@ static int MPIDI_CH3I_Win_gather_info(void *base, MPI_Aint size, int disp_unit, 
     tmp_buf[4 * comm_rank + 3] = (MPI_Aint) (*win_ptr)->handle;
 
     mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, tmp_buf, 4, MPI_AINT,
-                                    (*win_ptr)->comm_ptr, &errflag);
+                                    (*win_ptr)->comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (node_rank == 0) {
@@ -412,7 +405,7 @@ static int MPIDI_CH3I_Win_gather_info(void *base, MPI_Aint size, int disp_unit, 
     }
 
     /* Make sure that all local processes see the results written by node_rank == 0 */
-    mpi_errno = MPIR_Barrier(node_comm_ptr, &errflag);
+    mpi_errno = MPIR_Barrier(node_comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -434,7 +427,6 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
     int i, node_size, node_rank;
     MPIR_Comm *node_comm_ptr;
     MPI_Aint *node_sizes;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int noncontig = FALSE;
     MPIR_CHKPMEM_DECL(1);
     MPIR_CHKLMEM_DECL(1);
@@ -476,10 +468,9 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
 
     mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
                                node_sizes, sizeof(MPI_Aint), MPI_BYTE,
-                               node_comm_ptr, &errflag);
+                               node_comm_ptr, MPIR_ERR_NONE);
     MPIR_T_PVAR_TIMER_END(RMA, rma_wincreate_allgather);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
     (*win_ptr)->shm_segment_len = 0;
 
@@ -517,14 +508,12 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
 
             mpi_errno =
                 MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
-                                &errflag);
+                                MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
             /* wait for other processes to attach to win */
-            mpi_errno = MPIR_Barrier(node_comm_ptr, &errflag);
+            mpi_errno = MPIR_Barrier(node_comm_ptr, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
             /* unlink shared memory region so it gets deleted when all processes exit */
             mpl_err = MPL_shm_seg_remove((*win_ptr)->shm_segment_handle);
@@ -536,9 +525,8 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
             /* get serialized handle from rank 0 and deserialize it */
             mpi_errno =
                 MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
-                           &errflag);
+                           MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
             mpi_errno =
                 MPL_shm_hnd_deserialize((*win_ptr)->shm_segment_handle, serialized_hnd,
@@ -551,9 +539,8 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
                                          &(*win_ptr)->shm_base_addr, 0);
             MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**attach_shar_mem");
 
-            mpi_errno = MPIR_Barrier(node_comm_ptr, &errflag);
+            mpi_errno = MPIR_Barrier(node_comm_ptr, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
         }
 
         /* Allocated the interprocess mutex segment. */
@@ -580,14 +567,12 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
 
             mpi_errno =
                 MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
-                           &errflag);
+                           MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
             /* wait for other processes to attach to win */
-            mpi_errno = MPIR_Barrier(node_comm_ptr, &errflag);
+            mpi_errno = MPIR_Barrier(node_comm_ptr, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
             /* unlink shared memory region so it gets deleted when all processes exit */
             mpl_err = MPL_shm_seg_remove((*win_ptr)->shm_mutex_segment_handle);
@@ -599,9 +584,8 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
             /* get serialized handle from rank 0 and deserialize it */
             mpi_errno =
                 MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
-                           &errflag);
+                           MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
             mpi_errno =
                 MPL_shm_hnd_deserialize((*win_ptr)->shm_mutex_segment_handle, serialized_hnd,
@@ -614,9 +598,8 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
                                          (void **) &(*win_ptr)->shm_mutex, 0);
             MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**attach_shar_mem");
 
-            mpi_errno = MPIR_Barrier(node_comm_ptr, &errflag);
+            mpi_errno = MPIR_Barrier(node_comm_ptr, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
         }
 
         /* compute the base addresses of each process within the shared memory segment */

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -11,7 +11,7 @@
 #include "../../common/hcoll/hcoll.h"
 #endif
 
-static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
 #ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Barrier(comm, errflag))
@@ -21,7 +21,7 @@ static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 }
 
 static inline int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                             MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                             MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
 #ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Bcast(buffer, count, datatype, root, comm, errflag))
@@ -32,7 +32,7 @@ static inline int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype
 
 static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                 MPIR_Errflag_t * errflag)
+                                 MPIR_Errflag_t errflag)
 {
 #ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag))
@@ -43,7 +43,7 @@ static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint co
 
 static inline int MPID_Allgather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                 MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                 MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
 #ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
@@ -56,7 +56,7 @@ static inline int MPID_Allgather(const void *sendbuf, MPI_Aint sendcount, MPI_Da
 
 static inline int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
-                                  MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                  MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -69,7 +69,7 @@ static inline int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_D
 
 static inline int MPID_Scatter(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                               int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                               int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -82,7 +82,7 @@ static inline int MPID_Scatter(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 static inline int MPID_Scatterv(const void *sendbuf, const MPI_Aint * sendcounts, const MPI_Aint * displs,
                                 MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                MPIR_Errflag_t * errflag)
+                                MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -95,7 +95,7 @@ static inline int MPID_Scatterv(const void *sendbuf, const MPI_Aint * sendcounts
 
 static inline int MPID_Gather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                              int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                              int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -108,7 +108,7 @@ static inline int MPID_Gather(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
 static inline int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                               MPIR_Errflag_t * errflag)
+                               MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -121,7 +121,7 @@ static inline int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 
 static inline int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -134,7 +134,7 @@ static inline int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
 static inline int MPID_Alltoallv(const void *sendbuf, const MPI_Aint * sendcounts, const MPI_Aint * sdispls,
                                  MPI_Datatype sendtype, void *recvbuf, const MPI_Aint * recvcounts,
                                  const MPI_Aint * rdispls, MPI_Datatype recvtype, MPIR_Comm * comm,
-                                 MPIR_Errflag_t * errflag)
+                                 MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -149,7 +149,7 @@ static inline int MPID_Alltoallw(const void *sendbuf, const MPI_Aint sendcounts[
                                  const MPI_Datatype sendtypes[], void *recvbuf,
                                  const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                  const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                 MPIR_Errflag_t * errflag)
+                                 MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -162,7 +162,7 @@ static inline int MPID_Alltoallw(const void *sendbuf, const MPI_Aint sendcounts[
 
 static inline int MPID_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                               MPI_Datatype datatype, MPI_Op op, int root,
-                              MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                              MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -174,7 +174,7 @@ static inline int MPID_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count
 
 static inline int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                      MPIR_Errflag_t * errflag)
+                                      MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -187,7 +187,7 @@ static inline int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf, const 
 static inline int MPID_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                             MPI_Aint recvcount, MPI_Datatype datatype,
                                             MPI_Op op, MPIR_Comm * comm_ptr,
-                                            MPIR_Errflag_t * errflag)
+                                            MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -200,7 +200,7 @@ static inline int MPID_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
 
 static inline int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                            MPIR_Errflag_t * errflag)
+                            MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -212,7 +212,7 @@ static inline int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
 
 static inline int MPID_Exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                              MPIR_Errflag_t * errflag)
+                              MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -565,7 +565,7 @@ int MPID_Send( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 
 int MPID_Send_coll( const void *buf, MPI_Aint count, MPI_Datatype datatype,
                     int dest, int tag, MPIR_Comm *comm, int attr,
-                    MPIR_Request **request, MPIR_Errflag_t * errflag );
+                    MPIR_Request **request, MPIR_Errflag_t errflag );
 
 int MPID_Rsend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		int dest, int tag, MPIR_Comm *comm, int attr,
@@ -581,7 +581,7 @@ int MPID_Isend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 
 int MPID_Isend_coll( const void *buf, MPI_Aint count, MPI_Datatype datatype,
                      int dest, int tag, MPIR_Comm *comm, int attr,
-                     MPIR_Request **request, MPIR_Errflag_t * errflag );
+                     MPIR_Request **request, MPIR_Errflag_t errflag );
 
 int MPID_Irsend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		 int dest, int tag, MPIR_Comm *comm, int attr,

--- a/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
+++ b/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
@@ -75,17 +75,14 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
     }
 
     if (errcodes != MPI_ERRCODES_IGNORE) {
-        MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-        mpi_errno = MPIR_Bcast(&should_accept, 1, MPI_INT, root, comm_ptr, &errflag);
+        mpi_errno = MPIR_Bcast(&should_accept, 1, MPI_INT, root, comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
-        mpi_errno = MPIR_Bcast(&total_num_processes, 1, MPI_INT, root, comm_ptr, &errflag);
+        mpi_errno = MPIR_Bcast(&total_num_processes, 1, MPI_INT, root, comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
         
-        mpi_errno = MPIR_Bcast(errcodes, total_num_processes, MPI_INT, root, comm_ptr, &errflag);
+        mpi_errno = MPIR_Bcast(errcodes, total_num_processes, MPI_INT, root, comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
-
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
     }
 
     if (should_accept) {

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -586,7 +586,6 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
     pg_node *pg_list = NULL;
     MPIDI_PG_t **remote_pg = NULL;
     MPIR_Context_id_t recvcontext_id = MPIR_INVALID_CONTEXT_ID;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_ENTER;
@@ -648,7 +647,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
         mpi_errno = MPIC_Sendrecv(send_ints, 3, MPI_INT, 0,
                                      sendtag++, recv_ints, 3, MPI_INT,
                                      0, recvtag++, tmp_comm,
-                                     MPI_STATUS_IGNORE, &errflag);
+                                     MPI_STATUS_IGNORE, MPIR_ERR_NONE);
         if (mpi_errno != MPI_SUCCESS) {
             /* this is a no_port error because we may fail to connect
                on the send if the port name is invalid */
@@ -658,9 +657,8 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
 
     /* broadcast the received info to local processes */
     MPL_DBG_MSG(MPIDI_CH3_DBG_CONNECT,VERBOSE,"broadcasting the received 3 ints");
-    mpi_errno = MPIR_Bcast_allcomm_auto(recv_ints, 3, MPI_INT, root, comm_ptr, &errflag);
+    mpi_errno = MPIR_Bcast_allcomm_auto(recv_ints, 3, MPI_INT, root, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
     /* check if root was unable to connect to the port */
     MPIR_ERR_CHKANDJUMP1(recv_ints[0] == -1, mpi_errno, MPI_ERR_PORT, "**portexist", "**portexist %s", port_name);
@@ -692,7 +690,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
 				  MPI_INT, 0, sendtag++,
 				  remote_translation, remote_comm_size * 2, 
 				  MPI_INT, 0, recvtag++, tmp_comm,
-				  MPI_STATUS_IGNORE, &errflag);
+				  MPI_STATUS_IGNORE, MPIR_ERR_NONE);
 	MPIR_ERR_CHECK(mpi_errno);
 
 #ifdef MPICH_DBG_OUTPUT
@@ -713,9 +711,8 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
     /* Broadcast out the remote rank translation array */
     MPL_DBG_MSG(MPIDI_CH3_DBG_CONNECT,VERBOSE,"Broadcasting remote translation");
     mpi_errno = MPIR_Bcast_allcomm_auto(remote_translation, remote_comm_size * 2, MPI_INT,
-                                 root, comm_ptr, &errflag);
+                                 root, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
 #ifdef MPICH_DBG_OUTPUT
     MPL_DBG_MSG_D(MPIDI_CH3_DBG_OTHER,TERSE,"[%d]connect:Received remote_translation after broadcast:\n", rank);
@@ -744,7 +741,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
         mpi_errno = MPIC_Sendrecv(&i, 0, MPI_INT, 0,
                                      sendtag++, &j, 0, MPI_INT,
                                      0, recvtag++, tmp_comm,
-                                     MPI_STATUS_IGNORE, &errflag);
+                                     MPI_STATUS_IGNORE, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* All communication with remote root done. Release the communicator. */
@@ -752,7 +749,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
     }
 
     /*printf("connect:barrier\n");fflush(stdout);*/
-    mpi_errno = MPIR_Barrier_allcomm_auto(comm_ptr, &errflag);
+    mpi_errno = MPIR_Barrier_allcomm_auto(comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Free new_vc. It was explicitly allocated in MPIDI_CH3_Connect_to_root.*/
@@ -798,12 +795,8 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
 
         /* notify other processes to return an error */
         MPL_DBG_MSG(MPIDI_CH3_DBG_CONNECT,VERBOSE,"broadcasting 3 ints: error case");
-        mpi_errno2 = MPIR_Bcast_allcomm_auto(recv_ints, 3, MPI_INT, root, comm_ptr, &errflag);
+        mpi_errno2 = MPIR_Bcast_allcomm_auto(recv_ints, 3, MPI_INT, root, comm_ptr, MPIR_ERR_NONE);
         if (mpi_errno2) MPIR_ERR_ADD(mpi_errno, mpi_errno2);
-        if (errflag) {
-            MPIR_ERR_SET(mpi_errno2, MPI_ERR_OTHER, "**coll_fail");
-            MPIR_ERR_ADD(mpi_errno, mpi_errno2);
-        }
         goto fn_fail;
     }
 }
@@ -927,7 +920,6 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
     int  rank = comm_ptr->rank;
     int  mpi_errno = 0;
     int  recvtag = *recvtag_p;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -951,9 +943,8 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 
 	/* Broadcast the size and data to the local communicator */
 	/*printf("accept:broadcasting 1 int\n");fflush(stdout);*/
-	mpi_errno = MPIR_Bcast_allcomm_auto(&j, 1, MPI_INT, root, comm_ptr, &errflag);
+	mpi_errno = MPIR_Bcast_allcomm_auto(&j, 1, MPI_INT, root, comm_ptr, MPIR_ERR_NONE);
 	MPIR_ERR_CHECK(mpi_errno);
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
 	if (rank != root) {
 	    /* The root has already allocated this string */
@@ -963,9 +954,8 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 	    }
 	}
 	/*printf("accept:broadcasting string of length %d\n", j);fflush(stdout);*/
-	mpi_errno = MPIR_Bcast_allcomm_auto(pg_str, j, MPI_CHAR, root, comm_ptr, &errflag);
+	mpi_errno = MPIR_Bcast_allcomm_auto(pg_str, j, MPI_CHAR, root, comm_ptr, MPIR_ERR_NONE);
 	MPIR_ERR_CHECK(mpi_errno);
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 	/* Then reconstruct the received process group.  This step
 	   also initializes the created process group */
 
@@ -992,7 +982,6 @@ int MPID_PG_BCast( MPIR_Comm *peercomm_p, MPIR_Comm *comm_p, int root )
     pg_translation *local_translation = 0;
     pg_node *pg_list, *pg_next, *pg_head = 0;
     int rank, i, peer_comm_size;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(1);
 
     peer_comm_size = comm_p->local_size;
@@ -1009,9 +998,8 @@ int MPID_PG_BCast( MPIR_Comm *peercomm_p, MPIR_Comm *comm_p, int root )
     }
 
     /* Now, broadcast the number of local pgs */
-    mpi_errno = MPIR_Bcast( &n_local_pgs, 1, MPI_INT, root, comm_p, &errflag);
+    mpi_errno = MPIR_Bcast( &n_local_pgs, 1, MPI_INT, root, comm_p, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
     pg_list = pg_head;
     for (i=0; i<n_local_pgs; i++) {
@@ -1030,9 +1018,8 @@ int MPID_PG_BCast( MPIR_Comm *peercomm_p, MPIR_Comm *comm_p, int root )
 	    len     = pg_list->lenStr;
 	    pg_list = pg_list->next;
 	}
-	mpi_errno = MPIR_Bcast( &len, 1, MPI_INT, root, comm_p, &errflag);
+	mpi_errno = MPIR_Bcast( &len, 1, MPI_INT, root, comm_p, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 	if (rank != root) {
 	    pg_str = (char *)MPL_malloc(len, MPL_MEM_DYNAMIC);
             if (!pg_str) {
@@ -1040,13 +1027,12 @@ int MPID_PG_BCast( MPIR_Comm *peercomm_p, MPIR_Comm *comm_p, int root )
                 goto fn_exit;
             }
 	}
-	mpi_errno = MPIR_Bcast( pg_str, len, MPI_CHAR, root, comm_p, &errflag);
+	mpi_errno = MPIR_Bcast( pg_str, len, MPI_CHAR, root, comm_p, MPIR_ERR_NONE);
         if (mpi_errno) {
             if (rank != root)
                 MPL_free( pg_str );
             MPIR_ERR_POP(mpi_errno);
         }
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
 	if (rank != root) {
 	    /* flag is true if the pg was created, false if it
@@ -1090,7 +1076,6 @@ static int SendPGtoPeerAndFree( MPIR_Comm *tmp_comm, int *sendtag_p,
     int mpi_errno = 0;
     int sendtag = *sendtag_p, i;
     pg_node *pg_iter;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -1098,13 +1083,13 @@ static int SendPGtoPeerAndFree( MPIR_Comm *tmp_comm, int *sendtag_p,
 	pg_iter = pg_list;
 	i = pg_iter->lenStr;
 	/*printf("connect:sending 1 int: %d\n", i);fflush(stdout);*/
-	mpi_errno = MPIC_Send(&i, 1, MPI_INT, 0, sendtag++, tmp_comm, &errflag);
+	mpi_errno = MPIC_Send(&i, 1, MPI_INT, 0, sendtag++, tmp_comm, MPIR_ERR_NONE);
 	*sendtag_p = sendtag;
 	MPIR_ERR_CHECK(mpi_errno);
 	
 	/* printf("connect:sending string length %d\n", i);fflush(stdout); */
 	mpi_errno = MPIC_Send(pg_iter->str, i, MPI_CHAR, 0, sendtag++,
-			      tmp_comm, &errflag);
+			      tmp_comm, MPIR_ERR_NONE);
 	*sendtag_p = sendtag;
 	MPIR_ERR_CHECK(mpi_errno);
 	
@@ -1150,7 +1135,6 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
     pg_translation *local_translation = NULL, *remote_translation = NULL;
     pg_node *pg_list = NULL;
     MPIDI_PG_t **remote_pg = NULL;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_ENTER;
@@ -1199,15 +1183,14 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
         mpi_errno = MPIC_Sendrecv(send_ints, 3, MPI_INT, 0,
                                      sendtag++, recv_ints, 3, MPI_INT,
                                      0, recvtag++, tmp_comm,
-                                     MPI_STATUS_IGNORE, &errflag);
+                                     MPI_STATUS_IGNORE, MPIR_ERR_NONE);
 	MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* broadcast the received info to local processes */
     /*printf("accept:broadcasting 2 ints - %d and %d\n", recv_ints[0], recv_ints[1]);fflush(stdout);*/
-    mpi_errno = MPIR_Bcast_allcomm_auto(recv_ints, 3, MPI_INT, root, comm_ptr, &errflag);
+    mpi_errno = MPIR_Bcast_allcomm_auto(recv_ints, 3, MPI_INT, root, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
 
     n_remote_pgs     = recv_ints[0];
@@ -1239,7 +1222,7 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
 				  MPI_INT, 0, sendtag++,
 				  remote_translation, remote_comm_size * 2, 
 				  MPI_INT, 0, recvtag++, tmp_comm,
-				  MPI_STATUS_IGNORE, &errflag);
+				  MPI_STATUS_IGNORE, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
 #ifdef MPICH_DBG_OUTPUT
@@ -1261,9 +1244,8 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
     /* Broadcast out the remote rank translation array */
     MPL_DBG_MSG(MPIDI_CH3_DBG_CONNECT,VERBOSE,"Broadcast remote_translation");
     mpi_errno = MPIR_Bcast_allcomm_auto(remote_translation, remote_comm_size * 2, MPI_INT,
-                                 root, comm_ptr, &errflag);
+                                 root, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 #ifdef MPICH_DBG_OUTPUT
     MPL_DBG_MSG_D(MPIDI_CH3_DBG_OTHER,TERSE,"[%d]accept:Received remote_translation after broadcast:\n", rank);
     for (i=0; i<remote_comm_size; i++)
@@ -1290,7 +1272,7 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
         mpi_errno = MPIC_Sendrecv(&i, 0, MPI_INT, 0,
                                      sendtag++, &j, 0, MPI_INT,
                                      0, recvtag++, tmp_comm,
-                                     MPI_STATUS_IGNORE, &errflag);
+                                     MPI_STATUS_IGNORE, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* All communication with remote root done. Release the communicator. */
@@ -1298,7 +1280,7 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
     }
 
     MPL_DBG_MSG(MPIDI_CH3_DBG_CONNECT,VERBOSE,"Barrier");
-    mpi_errno = MPIR_Barrier_allcomm_auto(comm_ptr, &errflag);
+    mpi_errno = MPIR_Barrier_allcomm_auto(comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Free new_vc once the connection is completed. It was explicitly 
@@ -1347,7 +1329,6 @@ static int SetupNewIntercomm( MPIR_Comm *comm_ptr, int remote_comm_size,
 			      MPIR_Comm *intercomm )
 {
     int mpi_errno = MPI_SUCCESS, i;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     /* FIXME: How much of this could/should be common with the
        upper level (src/mpi/comm/ *.c) code? For best robustness, 
        this should use the same routine (not copy/paste code) as
@@ -1379,7 +1360,7 @@ static int SetupNewIntercomm( MPIR_Comm *comm_ptr, int remote_comm_size,
     MPIR_ERR_CHECK(mpi_errno);
     
     MPL_DBG_MSG(MPIDI_CH3_DBG_CONNECT,VERBOSE,"Barrier");
-    mpi_errno = MPIR_Barrier_allcomm_auto(comm_ptr, &errflag);
+    mpi_errno = MPIR_Barrier_allcomm_auto(comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
  fn_exit:

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -936,7 +936,7 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 	if (rank == root) {
 	    /* First, receive the pg description from the partner */
 	    mpi_errno = MPIC_Recv(&j, 1, MPI_INT, 0, recvtag++,
-				  tmp_comm, MPI_STATUS_IGNORE, &errflag);
+				  tmp_comm, MPI_STATUS_IGNORE);
 	    *recvtag_p = recvtag;
 	    MPIR_ERR_CHECK(mpi_errno);
 	    pg_str = (char*)MPL_malloc(j, MPL_MEM_DYNAMIC);
@@ -944,7 +944,7 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 		MPIR_ERR_POP(mpi_errno);
 	    }
 	    mpi_errno = MPIC_Recv(pg_str, j, MPI_CHAR, 0, recvtag++,
-				  tmp_comm, MPI_STATUS_IGNORE, &errflag);
+				  tmp_comm, MPI_STATUS_IGNORE);
 	    *recvtag_p = recvtag;
 	    MPIR_ERR_CHECK(mpi_errno);
 	}

--- a/src/mpid/ch3/src/ch3u_rma_sync.c
+++ b/src/mpid/ch3/src/ch3u_rma_sync.c
@@ -455,7 +455,6 @@ int MPID_Win_fence(int assert, MPIR_Win * win_ptr)
 {
     int i;
     MPIDI_RMA_Target_t *curr_target = NULL;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int comm_size = win_ptr->comm_ptr->local_size;
     int scalable_fence_enabled = 0;
     int *rma_target_marks = NULL;
@@ -490,9 +489,8 @@ int MPID_Win_fence(int assert, MPIR_Win * win_ptr)
             if (win_ptr->shm_allocated == TRUE) {
                 MPIR_Comm *node_comm_ptr = win_ptr->comm_ptr->node_comm;
 
-                mpi_errno = MPIR_Barrier(node_comm_ptr, &errflag);
+                mpi_errno = MPIR_Barrier(node_comm_ptr, MPIR_ERR_NONE);
                 MPIR_ERR_CHECK(mpi_errno);
-                MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
             }
 
             mpi_errno = MPIR_Ibarrier(win_ptr->comm_ptr, &fence_sync_req_ptr);
@@ -541,10 +539,8 @@ int MPID_Win_fence(int assert, MPIR_Win * win_ptr)
         win_ptr->at_completion_counter += comm_size;
 
         mpi_errno = MPIR_Reduce_scatter_block(MPI_IN_PLACE, rma_target_marks, 1,
-                                              MPI_INT, MPI_SUM, win_ptr->comm_ptr, &errflag);
+                                              MPI_INT, MPI_SUM, win_ptr->comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
-
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
         win_ptr->at_completion_counter -= comm_size;
         win_ptr->at_completion_counter += rma_target_marks[0];
@@ -583,9 +579,8 @@ int MPID_Win_fence(int assert, MPIR_Win * win_ptr)
     MPIR_ERR_CHECK(mpi_errno);
 
     if (scalable_fence_enabled) {
-        mpi_errno = MPIR_Barrier(win_ptr->comm_ptr, &errflag);
+        mpi_errno = MPIR_Barrier(win_ptr->comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
-        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
         /* Set window access state properly. */
         if (assert & MPI_MODE_NOSUCCEED) {
@@ -634,9 +629,8 @@ int MPID_Win_fence(int assert, MPIR_Win * win_ptr)
 
             if (win_ptr->shm_allocated == TRUE) {
                 MPIR_Comm *node_comm_ptr = win_ptr->comm_ptr->node_comm;
-                mpi_errno = MPIR_Barrier(node_comm_ptr, &errflag);
+                mpi_errno = MPIR_Barrier(node_comm_ptr, MPIR_ERR_NONE);
                 MPIR_ERR_CHECK(mpi_errno);
-                MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
             }
         }
     }

--- a/src/mpid/ch3/src/ch3u_win_fns.c
+++ b/src/mpid/ch3/src/ch3u_win_fns.c
@@ -33,7 +33,6 @@ int MPIDI_CH3U_Win_gather_info(void *base, MPI_Aint size, int disp_unit,
 {
     int mpi_errno = MPI_SUCCESS, i, k, comm_size, rank;
     MPI_Aint *tmp_buf;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKPMEM_DECL(1);
     MPIR_CHKLMEM_DECL(1);
 
@@ -63,10 +62,9 @@ int MPIDI_CH3U_Win_gather_info(void *base, MPI_Aint size, int disp_unit,
     tmp_buf[4 * rank + 3] = (MPI_Aint) (*win_ptr)->handle;
 
     mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                               tmp_buf, 4, MPI_AINT, (*win_ptr)->comm_ptr, &errflag);
+                               tmp_buf, 4, MPI_AINT, (*win_ptr)->comm_ptr, MPIR_ERR_NONE);
     MPIR_T_PVAR_TIMER_END(RMA, rma_wincreate_allgather);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
     k = 0;
     for (i = 0; i < comm_size; i++) {

--- a/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
+++ b/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
@@ -108,7 +108,7 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
         for (i = 1; i < comm_ptr->local_size; i++) {
             /* Get everyone's list of failed processes to aggregate */
             ret_errno = MPIC_Recv(remote_bitarray, bitarray_size, MPI_INT,
-                i, tag, comm_ptr, MPI_STATUS_IGNORE, &errflag);
+                i, tag, comm_ptr, MPI_STATUS_IGNORE);
             if (ret_errno) continue;
 
             /* Combine the received bitarray with my own */
@@ -135,7 +135,7 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
 
         /* Get the resulting bitarray back from rank 0 */
         mpi_errno = MPIC_Recv(remote_bitarray, bitarray_size, MPI_INT, 0,
-            tag, comm_ptr, MPI_STATUS_IGNORE, &errflag);
+            tag, comm_ptr, MPI_STATUS_IGNORE);
 
         /* Convert the bitarray into a group */
         *failed_group = bitarray_to_group(comm_ptr, remote_bitarray);

--- a/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
+++ b/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
@@ -79,7 +79,6 @@ static MPIR_Group *bitarray_to_group(MPIR_Comm *comm_ptr, int *bitarray)
 int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_group, int tag)
 {
     int mpi_errno = MPI_SUCCESS, ret_errno;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int i, j, bitarray_size;
     int *bitarray, *remote_bitarray;
     MPIR_Group *local_fail;
@@ -122,7 +121,7 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
         for (i = 1; i < comm_ptr->local_size; i++) {
             /* Send the list to each rank to be processed locally */
             ret_errno = MPIC_Send(bitarray, bitarray_size, MPI_INT, i,
-                tag, comm_ptr, &errflag);
+                tag, comm_ptr, MPIR_ERR_NONE);
             if (ret_errno) continue;
         }
 
@@ -131,7 +130,7 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
     } else {
         /* Send my bitarray to rank 0 */
         mpi_errno = MPIC_Send(bitarray, bitarray_size, MPI_INT, 0,
-            tag, comm_ptr, &errflag);
+            tag, comm_ptr, MPIR_ERR_NONE);
 
         /* Get the resulting bitarray back from rank 0 */
         mpi_errno = MPIC_Recv(remote_bitarray, bitarray_size, MPI_INT, 0,

--- a/src/mpid/ch3/src/mpid_isend.c
+++ b/src/mpid/ch3/src/mpid_isend.c
@@ -179,13 +179,13 @@ int MPID_Isend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
 
 int MPID_Isend_coll(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
                     MPIR_Comm * comm, int attr, MPIR_Request ** request,
-                    MPIR_Errflag_t * errflag)
+                    MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    switch (*errflag) {
+    switch (errflag) {
     case MPIR_ERR_NONE:
         break;
     case MPIR_ERR_PROC_FAILED:

--- a/src/mpid/ch3/src/mpid_send.c
+++ b/src/mpid/ch3/src/mpid_send.c
@@ -185,13 +185,13 @@ int MPID_Send(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank,
 
 int MPID_Send_coll(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
                    MPIR_Comm * comm, int attr, MPIR_Request ** request,
-                   MPIR_Errflag_t * errflag)
+                   MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    switch (*errflag) {
+    switch (errflag) {
     case MPIR_ERR_NONE:
         break;
     case MPIR_ERR_PROC_FAILED:

--- a/src/mpid/ch3/src/mpidi_rma.c
+++ b/src/mpid/ch3/src/mpidi_rma.c
@@ -133,7 +133,6 @@ int MPID_Win_free(MPIR_Win ** win_ptr)
     int mpi_errno = MPI_SUCCESS;
     int in_use;
     MPIR_Comm *comm_ptr;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -161,7 +160,7 @@ int MPID_Win_free(MPIR_Win ** win_ptr)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    mpi_errno = MPIR_Barrier((*win_ptr)->comm_ptr, &errflag);
+    mpi_errno = MPIR_Barrier((*win_ptr)->comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Free window resources in lower layer. */

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -451,7 +451,7 @@ PARAM:
     disp_unit_p: int *
     displs: const MPI_Aint *
     dst_vci: int
-    errflag: MPIR_Errflag_t *
+    errflag: MPIR_Errflag_t
     flag: int *
     group: MPIR_Group *
     handler_id: int

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -182,53 +182,52 @@ int MPID_Comm_set_hints(MPIR_Comm *, MPIR_Info *);
 int MPID_Comm_commit_post_hook(MPIR_Comm *);
 int MPID_Stream_create_hook(MPIR_Stream * stream);
 int MPID_Stream_free_hook(MPIR_Stream * stream);
-MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,
-                                        MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                        MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                            MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                            MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                             MPI_Datatype, MPIR_Comm *,
-                                            MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                            MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
                                              const MPI_Aint *, const MPI_Aint *, MPI_Datatype,
-                                             MPIR_Comm *,
-                                             MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                             MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                           MPI_Datatype, int, MPIR_Comm *,
-                                          MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                          MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *, const MPI_Aint *, const MPI_Aint *,
                                            MPI_Datatype, void *, MPI_Aint, MPI_Datatype, int,
-                                           MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                           MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                          MPI_Datatype, int, MPIR_Comm *,
-                                         MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                         MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *, MPI_Aint, MPI_Datatype, void *,
                                           const MPI_Aint *, const MPI_Aint *, MPI_Datatype, int,
-                                          MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                          MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                            MPI_Datatype, MPIR_Comm *,
-                                           MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                           MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *, const MPI_Aint *, const MPI_Aint *,
                                             MPI_Datatype, void *, const MPI_Aint *,
                                             const MPI_Aint *, MPI_Datatype, MPIR_Comm *,
-                                            MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                            MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *, const MPI_Aint[], const MPI_Aint[],
                                             const MPI_Datatype[], void *, const MPI_Aint[],
                                             const MPI_Aint[], const MPI_Datatype[], MPIR_Comm *,
-                                            MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                            MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op, int,
-                                         MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                         MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *, void *, const MPI_Aint[],
                                                  MPI_Datatype, MPI_Op, MPIR_Comm *,
-                                                 MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *, void *, MPI_Aint, MPI_Datatype,
                                                        MPI_Op, MPIR_Comm *,
-                                                       MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                                       MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                       MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                       MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                         MPIR_Comm *, MPIR_Errflag_t *) MPL_STATIC_INLINE_SUFFIX;
+                                         MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *, MPI_Aint, MPI_Datatype, void *,
                                                      MPI_Aint, MPI_Datatype,
                                                      MPIR_Comm *) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_coll.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_coll.h
@@ -6,14 +6,14 @@
 #ifndef NETMOD_AM_FALLBACK_COLL_H_INCLUDED
 #define NETMOD_AM_FALLBACK_COLL_H_INCLUDED
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Barrier_impl(comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                                 int root, MPIR_Comm * comm_ptr,
-                                                MPIR_Errflag_t * errflag)
+                                                MPIR_Errflag_t errflag)
 {
     return MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
 }
@@ -21,7 +21,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
                                                     MPI_Op op, MPIR_Comm * comm_ptr,
-                                                    MPIR_Errflag_t * errflag)
+                                                    MPIR_Errflag_t errflag)
 {
     return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
@@ -29,7 +29,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
                                recvcount, recvtype, comm_ptr, errflag);
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcounts, displs, recvtype, comm_ptr, errflag);
@@ -49,7 +49,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint s
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
                                                  int root, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t * errflag)
+                                                 MPIR_Errflag_t errflag)
 {
     return MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
                             recvcount, recvtype, root, comm_ptr, errflag);
@@ -60,7 +60,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
                                                   const MPI_Aint * recvcounts,
                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
                                                   int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t * errflag)
+                                                  MPIR_Errflag_t errflag)
 {
     return MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcounts, displs, recvtype, root, comm_ptr, errflag);
@@ -70,7 +70,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                   int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t * errflag)
+                                                  MPIR_Errflag_t errflag)
 {
     return MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcount, recvtype, root, comm_ptr, errflag);
@@ -80,7 +80,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
                               recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
@@ -89,7 +89,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
                               recvcount, recvtype, comm_ptr, errflag);
@@ -100,7 +100,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
                                                     const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                     void *recvbuf, const MPI_Aint * recvcounts,
                                                     const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                recvbuf, recvcounts, rdispls, recvtype, comm_ptr, errflag);
@@ -113,7 +113,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
                                                     const MPI_Aint recvcounts[],
                                                     const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
                                recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, errflag);
@@ -121,7 +121,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
 }
@@ -130,7 +130,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
                                                          const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
                                                          MPIR_Comm * comm_ptr,
-                                                         MPIR_Errflag_t * errflag)
+                                                         MPIR_Errflag_t errflag)
 {
     return MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag);
 }
@@ -139,7 +139,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
                                                                MPI_Aint recvcount,
                                                                MPI_Datatype datatype, MPI_Op op,
                                                                MPIR_Comm * comm_ptr,
-                                                               MPIR_Errflag_t * errflag)
+                                                               MPIR_Errflag_t errflag)
 {
     return MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
                                           datatype, op, comm_ptr, errflag);
@@ -147,14 +147,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -230,9 +230,8 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
     }
     /* Allgather */
     MPIR_Comm *comm = MPIR_Process.comm_world;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     mpi_errno = MPIR_Allgather_fallback(MPI_IN_PLACE, 0, MPI_BYTE,
-                                        all_names, my_len, MPI_BYTE, comm, &errflag);
+                                        all_names, my_len, MPI_BYTE, comm, MPIR_ERR_NONE);
 
     /* Step 2: insert and store non-root nic/vni on the root context */
     int root_ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, 0);
@@ -293,7 +292,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
             }
         }
     }
-    mpi_errno = MPIR_Barrier_fallback(comm, &errflag);
+    mpi_errno = MPIR_Barrier_fallback(comm, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_check:

--- a/src/mpid/ch4/netmod/ofi/ofi_coll.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll.h
@@ -9,7 +9,7 @@
 #include "ofi_impl.h"
 #include "ch4_csel_container.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -28,8 +28,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                                int root, MPIR_Comm * comm,
-                                                MPIR_Errflag_t * errflag)
+                                                int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -50,7 +49,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
                                                     MPI_Op op, MPIR_Comm * comm,
-                                                    MPIR_Errflag_t * errflag)
+                                                    MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -71,7 +70,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -94,7 +93,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                     MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -116,8 +115,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                 int root, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t * errflag)
+                                                 int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -141,7 +139,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
                                                   const MPI_Aint * recvcounts,
                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
                                                   int root, MPIR_Comm * comm,
-                                                  MPIR_Errflag_t * errflag)
+                                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -165,7 +163,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                   int root, MPIR_Comm * comm,
-                                                  MPIR_Errflag_t * errflag)
+                                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -188,7 +186,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                   MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -210,7 +208,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                   MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -234,7 +232,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
                                                     const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                     void *recvbuf, const MPI_Aint * recvcounts,
                                                     const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -261,7 +259,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
                                                     const MPI_Aint recvcounts[],
                                                     const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -283,7 +281,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                 MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                 MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -304,7 +302,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                          const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
-                                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                         MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -326,7 +324,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
                                                                MPI_Aint recvcount,
                                                                MPI_Datatype datatype, MPI_Op op,
                                                                MPIR_Comm * comm,
-                                                               MPIR_Errflag_t * errflag)
+                                                               MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -346,7 +344,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                               MPIR_Errflag_t * errflag)
+                                               MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -366,7 +364,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbu
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t * errflag)
+                                                 MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -103,11 +103,10 @@ static int update_nic_preferences(MPIR_Comm * comm)
                 }
             }
 
-            MPIR_Errflag_t errflag = MPIR_ERR_NONE;
             /* Collect the NIC IDs set for the other ranks. We always expect to receive a single
              * NIC id from each rank, i.e., one MPI_INT. */
             mpi_errno = MPIR_Allgather_allcomm_auto(MPI_IN_PLACE, 0, MPI_INT,
-                                                    pref_nic_copy, 1, MPI_INT, comm, &errflag);
+                                                    pref_nic_copy, 1, MPI_INT, comm, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
 
             if (MPIDI_OFI_COMM(comm).pref_nic == NULL) {

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -650,9 +650,8 @@ int MPIDI_OFI_post_init(void)
     MPIDI_OFI_global.num_vnis = MPIDI_OFI_global.num_nics = 1;
 
     /* Confirm that all processes have the same number of NICs */
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     mpi_errno = MPIR_Allreduce_allcomm_auto(&tmp_num_nics, &num_nics, 1, MPI_INT,
-                                            MPI_MIN, MPIR_Process.comm_world, &errflag);
+                                            MPI_MIN, MPIR_Process.comm_world, MPIR_ERR_NONE);
     MPIDI_OFI_global.num_vnis = tmp_num_vnis;
     MPIDI_OFI_global.num_nics = tmp_num_nics;
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -11,7 +11,7 @@
 #include "../../../common/hcoll/hcoll.h"
 #endif
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -30,7 +30,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Err
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                                                 int root, MPIR_Comm * comm_ptr,
-                                                MPIR_Errflag_t * errflag)
+                                                MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -50,7 +50,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
                                                     MPI_Op op, MPIR_Comm * comm_ptr,
-                                                    MPIR_Errflag_t * errflag)
+                                                    MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -70,7 +70,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -93,7 +93,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -109,7 +109,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint s
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
                                                  int root, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t * errflag)
+                                                 MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -126,7 +126,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
                                                   const MPI_Aint * recvcounts,
                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
                                                   int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t * errflag)
+                                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -142,7 +142,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                   int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t * errflag)
+                                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -158,7 +158,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -173,7 +173,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -196,7 +196,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
                                                     const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                     void *recvbuf, const MPI_Aint * recvcounts,
                                                     const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -221,7 +221,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
                                                     const MPI_Aint recvcounts[],
                                                     const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -235,7 +235,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -256,7 +256,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
                                                          const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
                                                          MPIR_Comm * comm_ptr,
-                                                         MPIR_Errflag_t * errflag)
+                                                         MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -272,7 +272,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
                                                                MPI_Aint recvcount,
                                                                MPI_Datatype datatype, MPI_Op op,
                                                                MPIR_Comm * comm_ptr,
-                                                               MPIR_Errflag_t * errflag)
+                                                               MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -286,7 +286,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -299,7 +299,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbu
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -148,9 +148,8 @@ static int all_vnis_address_exchange(void)
     }
     /* Allgather */
     MPIR_Comm *comm = MPIR_Process.comm_world;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     mpi_errno = MPIR_Allgather_allcomm_auto(MPI_IN_PLACE, 0, MPI_BYTE,
-                                            all_names, my_len, MPI_BYTE, comm, &errflag);
+                                            all_names, my_len, MPI_BYTE, comm, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* insert the addresses */

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -17,7 +17,6 @@ static int win_init(MPIR_Win * win);
 static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void **base_ptr)
 {
 
-    MPIR_Errflag_t err = MPIR_ERR_NONE;
     int mpi_errno = MPI_SUCCESS;
     int rank = 0;
     ucs_status_t status;
@@ -83,7 +82,8 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
 
     rkey_sizes = (MPI_Aint *) MPL_malloc(sizeof(MPI_Aint) * comm_ptr->local_size, MPL_MEM_OTHER);
     rkey_sizes[comm_ptr->rank] = (MPI_Aint) rkey_size;
-    mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 1, MPI_AINT, rkey_sizes, 1, MPI_AINT, comm_ptr, &err);
+    mpi_errno =
+        MPIR_Allgather(MPI_IN_PLACE, 1, MPI_AINT, rkey_sizes, 1, MPI_AINT, comm_ptr, MPIR_ERR_NONE);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -99,7 +99,8 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
 
     /* allgather */
     mpi_errno = MPIR_Allgatherv(rkey_buffer, rkey_size, MPI_BYTE,
-                                rkey_recv_buff, rkey_sizes, recv_disps, MPI_BYTE, comm_ptr, &err);
+                                rkey_recv_buff, rkey_sizes, recv_disps, MPI_BYTE, comm_ptr,
+                                MPIR_ERR_NONE);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -140,7 +141,7 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
 
     mpi_errno =
         MPIR_Allgather(MPI_IN_PLACE, sizeof(struct ucx_share), MPI_BYTE, share_data,
-                       sizeof(struct ucx_share), MPI_BYTE, comm_ptr, &err);
+                       sizeof(struct ucx_share), MPI_BYTE, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     for (i = 0; i < comm_ptr->local_size; i++) {

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -60,7 +60,6 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm *shm_comm_ptr = win->comm_ptr->node_comm;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int i;
     size_t total_shm_size = 0;
     MPIDIG_win_shared_info_t *shared_table = NULL;
@@ -119,7 +118,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
                                0,
                                MPI_DATATYPE_NULL,
                                ipc_shared_table,
-                               sizeof(win_shared_info_t), MPI_BYTE, shm_comm_ptr, &errflag);
+                               sizeof(win_shared_info_t), MPI_BYTE, shm_comm_ptr, MPIR_ERR_NONE);
     MPIR_T_PVAR_TIMER_END(RMA, rma_wincreate_allgather);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/shm/posix/posix_coll.h
+++ b/src/mpid/ch4/shm/posix/posix_coll.h
@@ -110,7 +110,7 @@ cvars:
 */
 
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -168,7 +168,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, MPIR_Errf
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, MPI_Aint count,
                                                    MPI_Datatype datatype, int root,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                   MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -233,7 +233,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, MPI_Aint count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                        MPI_Aint count, MPI_Datatype datatype,
                                                        MPI_Op op, MPIR_Comm * comm,
-                                                       MPIR_Errflag_t * errflag)
+                                                       MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -303,7 +303,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce(const void *sendbuf, void
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
                                                        MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                       MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -327,7 +327,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv(const void *sendbuf, MPI
                                                         const MPI_Aint * recvcounts,
                                                         const MPI_Aint * displs,
                                                         MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                        MPIR_Errflag_t * errflag)
+                                                        MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -350,7 +350,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gather(const void *sendbuf, MPI_Ain
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
                                                     int root, MPIR_Comm * comm,
-                                                    MPIR_Errflag_t * errflag)
+                                                    MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -374,7 +374,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gatherv(const void *sendbuf, MPI_Ai
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * displs, MPI_Datatype recvtype,
                                                      int root, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t * errflag)
+                                                     MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -398,7 +398,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatter(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      int root, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t * errflag)
+                                                     MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -423,7 +423,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatterv(const void *sendbuf,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       MPI_Aint recvcount, MPI_Datatype recvtype,
                                                       int root, MPIR_Comm * comm,
-                                                      MPIR_Errflag_t * errflag)
+                                                      MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -445,7 +445,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatterv(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                      MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
 
@@ -471,7 +471,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallv(const void *sendbuf,
                                                        const MPI_Aint * recvcounts,
                                                        const MPI_Aint * rdispls,
                                                        MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                       MPIR_Errflag_t * errflag)
+                                                       MPIR_Errflag_t errflag)
 {
     int mpi_errno;
 
@@ -498,7 +498,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallw(const void *sendbuf,
                                                        void *recvbuf, const MPI_Aint recvcounts[],
                                                        const MPI_Aint rdispls[],
                                                        const MPI_Datatype recvtypes[],
-                                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                       MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno;
 
@@ -521,7 +521,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallw(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
                                                     MPI_Op op, int root, MPIR_Comm * comm,
-                                                    MPIR_Errflag_t * errflag)
+                                                    MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -593,7 +593,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_scatter(const void *sendbuf,
                                                             const MPI_Aint recvcounts[],
                                                             MPI_Datatype datatype, MPI_Op op,
                                                             MPIR_Comm * comm,
-                                                            MPIR_Errflag_t * errflag)
+                                                            MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -615,7 +615,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_scatter_block(const void *se
                                                                   void *recvbuf, MPI_Aint recvcount,
                                                                   MPI_Datatype datatype, MPI_Op op,
                                                                   MPIR_Comm * comm,
-                                                                  MPIR_Errflag_t * errflag)
+                                                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -635,7 +635,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_scatter_block(const void *se
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scan(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                  MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -656,7 +656,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scan(const void *sendbuf, void *rec
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_exscan(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
                                                     MPI_Op op, MPIR_Comm * comm,
-                                                    MPIR_Errflag_t * errflag)
+                                                    MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
                                                                   MPI_Aint count,
                                                                   MPI_Datatype datatype,
                                                                   int root, MPIR_Comm * comm_ptr,
-                                                                  MPIR_Errflag_t * errflag)
+                                                                  MPIR_Errflag_t errflag)
 {
     MPIR_FUNC_ENTER;
 
@@ -100,7 +100,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
                 mpi_errno =
                     MPIR_Typerep_pack(ori_buffer, ori_count, ori_datatype, 0, buffer, count,
                                       &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
     }
@@ -110,7 +110,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
 #ifdef HAVE_ERROR_CHECKING
     /* When error checking is enabled, only (cellsize-(2*cacheline_size)) bytes are reserved for data.
      * Initial 2 cacheline_size bytes are reserved to put the amount of data being placed and the
-     * errflag respectively */
+     errflag respectively */
     cellsize -= (2 * MPIDU_SHM_CACHE_LINE_LEN);
 #endif
 
@@ -129,13 +129,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
                                                    chunk_count, MPI_BYTE, root, comm_ptr,
                                                    errflag,
                                                    MPIDI_POSIX_RELEASE_GATHER_OPCODE_BCAST);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_gather(NULL, NULL, 0, MPI_DATATYPE_NULL,
                                                   MPI_OP_NULL, root, comm_ptr, errflag,
                                                   MPIDI_POSIX_RELEASE_GATHER_OPCODE_BCAST);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         offset += chunk_count;
     }
 
@@ -145,7 +145,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
             mpi_errno =
                 MPIR_Typerep_unpack(buffer, count, ori_buffer, ori_count, ori_datatype, 0,
                                     &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         MPL_free(buffer);
     }
@@ -158,7 +158,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
   fallback:
     /* Fall back to other algo as release_gather based bcast cannot be used */
     mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -173,7 +173,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
                                                                    MPI_Datatype datatype,
                                                                    MPI_Op op, int root,
                                                                    MPIR_Comm * comm_ptr,
-                                                                   MPIR_Errflag_t * errflag)
+                                                                   MPIR_Errflag_t errflag)
 {
     int i;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
@@ -193,7 +193,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
         /* Simply copy the data from sendbuf to recvbuf if there is only 1 rank and MPI_IN_PLACE
          * is not used */
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         goto fn_exit;
     }
 
@@ -241,7 +241,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
             MPIDI_POSIX_mpi_release_gather_release(NULL, 0, MPI_DATATYPE_NULL, root,
                                                    comm_ptr, errflag,
                                                    MPIDI_POSIX_RELEASE_GATHER_OPCODE_REDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_gather((char *) sendbuf + offset * extent,
@@ -249,7 +249,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
                                                   chunk_count, datatype, op, root, comm_ptr,
                                                   errflag,
                                                   MPIDI_POSIX_RELEASE_GATHER_OPCODE_REDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         offset += chunk_count;
     }
 
@@ -261,7 +261,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
   fallback:
     /* Fall back to other algo as release_gather algo cannot be used */
     mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -275,7 +275,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
                                                                       MPI_Datatype datatype,
                                                                       MPI_Op op,
                                                                       MPIR_Comm * comm_ptr,
-                                                                      MPIR_Errflag_t * errflag)
+                                                                      MPIR_Errflag_t errflag)
 {
     int i;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
@@ -290,7 +290,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
         /* Simply copy the data from sendbuf to recvbuf if there is only 1 rank and MPI_IN_PLACE
          * is not used */
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         goto fn_exit;
     }
 
@@ -340,14 +340,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
                                                   chunk_count, datatype, op, 0, comm_ptr,
                                                   errflag,
                                                   MPIDI_POSIX_RELEASE_GATHER_OPCODE_ALLREDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_release((char *) recvbuf + offset * extent, chunk_count,
                                                    datatype, 0,
                                                    comm_ptr, errflag,
                                                    MPIDI_POSIX_RELEASE_GATHER_OPCODE_ALLREDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         offset += chunk_count;
     }
 
@@ -360,7 +360,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
 
   fallback:
     mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -368,7 +368,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
  * framework.
  */
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier_release_gather(MPIR_Comm * comm_ptr,
-                                                                    MPIR_Errflag_t * errflag)
+                                                                    MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
 
@@ -393,12 +393,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier_release_gather(MPIR_Comm * 
         MPIDI_POSIX_mpi_release_gather_gather(NULL, NULL, 0, MPI_DATATYPE_NULL, MPI_OP_NULL, 0,
                                               comm_ptr, errflag,
                                               MPIDI_POSIX_RELEASE_GATHER_OPCODE_BARRIER);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     mpi_errno =
         MPIDI_POSIX_mpi_release_gather_release(NULL, 0, MPI_DATATYPE_NULL, 0, comm_ptr, errflag,
                                                MPIDI_POSIX_RELEASE_GATHER_OPCODE_BARRIER);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -409,7 +409,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier_release_gather(MPIR_Comm * 
 
   fallback:
     mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     goto fn_exit;
 }
 

--- a/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
@@ -100,7 +100,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
                 mpi_errno =
                     MPIR_Typerep_pack(ori_buffer, ori_count, ori_datatype, 0, buffer, count,
                                       &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         }
     }
@@ -129,13 +129,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
                                                    chunk_count, MPI_BYTE, root, comm_ptr,
                                                    errflag,
                                                    MPIDI_POSIX_RELEASE_GATHER_OPCODE_BCAST);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_gather(NULL, NULL, 0, MPI_DATATYPE_NULL,
                                                   MPI_OP_NULL, root, comm_ptr, errflag,
                                                   MPIDI_POSIX_RELEASE_GATHER_OPCODE_BCAST);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         offset += chunk_count;
     }
 
@@ -145,7 +145,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
             mpi_errno =
                 MPIR_Typerep_unpack(buffer, count, ori_buffer, ori_count, ori_datatype, 0,
                                     &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
         MPL_free(buffer);
     }
@@ -158,7 +158,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
   fallback:
     /* Fall back to other algo as release_gather based bcast cannot be used */
     mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -193,7 +193,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
         /* Simply copy the data from sendbuf to recvbuf if there is only 1 rank and MPI_IN_PLACE
          * is not used */
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         goto fn_exit;
     }
 
@@ -241,7 +241,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
             MPIDI_POSIX_mpi_release_gather_release(NULL, 0, MPI_DATATYPE_NULL, root,
                                                    comm_ptr, errflag,
                                                    MPIDI_POSIX_RELEASE_GATHER_OPCODE_REDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_gather((char *) sendbuf + offset * extent,
@@ -249,7 +249,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
                                                   chunk_count, datatype, op, root, comm_ptr,
                                                   errflag,
                                                   MPIDI_POSIX_RELEASE_GATHER_OPCODE_REDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         offset += chunk_count;
     }
 
@@ -261,7 +261,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
   fallback:
     /* Fall back to other algo as release_gather algo cannot be used */
     mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -290,7 +290,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
         /* Simply copy the data from sendbuf to recvbuf if there is only 1 rank and MPI_IN_PLACE
          * is not used */
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         goto fn_exit;
     }
 
@@ -340,14 +340,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
                                                   chunk_count, datatype, op, 0, comm_ptr,
                                                   errflag,
                                                   MPIDI_POSIX_RELEASE_GATHER_OPCODE_ALLREDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_release((char *) recvbuf + offset * extent, chunk_count,
                                                    datatype, 0,
                                                    comm_ptr, errflag,
                                                    MPIDI_POSIX_RELEASE_GATHER_OPCODE_ALLREDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         offset += chunk_count;
     }
 
@@ -360,7 +360,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
 
   fallback:
     mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -393,12 +393,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier_release_gather(MPIR_Comm * 
         MPIDI_POSIX_mpi_release_gather_gather(NULL, NULL, 0, MPI_DATATYPE_NULL, MPI_OP_NULL, 0,
                                               comm_ptr, errflag,
                                               MPIDI_POSIX_RELEASE_GATHER_OPCODE_BARRIER);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
     mpi_errno =
         MPIDI_POSIX_mpi_release_gather_release(NULL, 0, MPI_DATATYPE_NULL, 0, comm_ptr, errflag,
                                                MPIDI_POSIX_RELEASE_GATHER_OPCODE_BARRIER);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -409,7 +409,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier_release_gather(MPIR_Comm * 
 
   fallback:
     mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     goto fn_exit;
 }
 

--- a/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
@@ -79,7 +79,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_root_datacopy_completion(void *v,
     nb_release_gather_info_ptr = &MPIDI_POSIX_COMM(comm_ptr, nb_release_gather);
     int rank = MPIR_Comm_rank(comm_ptr);
     int num_ranks = MPIR_Comm_size(comm_ptr);
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int last_seq_no = nb_release_gather_info_ptr->ibcast_last_seq_no_completed[segment];
 
     MPL_atomic_uint64_t *my_release_flag_addr =
@@ -95,7 +94,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_root_datacopy_completion(void *v,
             /* Root sends data to rank 0 */
             if (rank == root) {
                 MPIC_Isend(per_call_data->local_buf, per_call_data->count, per_call_data->datatype,
-                           0, per_call_data->tag, comm_ptr, &(per_call_data->sreq), &errflag);
+                           0, per_call_data->tag, comm_ptr, &(per_call_data->sreq), MPIR_ERR_NONE);
                 *done = 1;
             } else if (rank == 0) {
                 MPIC_Irecv(MPIDI_POSIX_RELEASE_GATHER_NB_IBCAST_DATA_ADDR(segment),

--- a/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
@@ -243,7 +243,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_reduce_start_sendrecv_completion(
     MPIDI_POSIX_release_gather_comm_t *nb_release_gather_info_ptr;
     nb_release_gather_info_ptr = &MPIDI_POSIX_COMM(comm_ptr, nb_release_gather);
     int rank = MPIR_Comm_rank(comm_ptr);
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     /* If root is not rank 0, rank 0 sends data to root */
     if (root != 0) {
@@ -253,7 +252,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_reduce_start_sendrecv_completion(
         } else if (rank == 0) {
             MPIC_Isend(MPIDI_POSIX_RELEASE_GATHER_NB_REDUCE_DATA_ADDR(rank, segment),
                        per_call_data->count, per_call_data->datatype, per_call_data->root,
-                       per_call_data->tag, comm_ptr, &(per_call_data->sreq), &errflag);
+                       per_call_data->tag, comm_ptr, &(per_call_data->sreq), MPIR_ERR_NONE);
         }
     }
 

--- a/src/mpid/ch4/shm/posix/release_gather/nb_release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_release_gather.c
@@ -123,11 +123,11 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
                 MPL_atomic_fetch_add_uint64(MPIDI_POSIX_shm_limit_counter, memory_to_be_allocated);
                 fallback = 0;
                 mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, &errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         } else {
             mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, &errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (fallback) {
                 MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_NO_MEM, "**nomem");
             }
@@ -156,7 +156,7 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
                                                  MPIDI_POSIX_Reduce_tree_type,
                                                  &nb_release_gather_info_ptr->reduce_tree,
                                                  &topotree_fail[1], &errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 /* Finalize was already called and MPIR_Process.hwloc_topology has been destroyed */
                 topotree_fail[0] = -1;
@@ -177,7 +177,7 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
                 MPIR_Treealgo_tree_create(rank, num_ranks, MPIDI_POSIX_Bcast_tree_type,
                                           MPIR_CVAR_BCAST_INTRANODE_TREE_KVAL, 0,
                                           &nb_release_gather_info_ptr->bcast_tree);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         if (topotree_fail[1] != 0) {
@@ -187,7 +187,7 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
                 MPIR_Treealgo_tree_create(rank, num_ranks, MPIDI_POSIX_Reduce_tree_type,
                                           MPIR_CVAR_REDUCE_INTRANODE_TREE_KVAL, 0,
                                           &nb_release_gather_info_ptr->reduce_tree);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         nb_release_gather_info_ptr->bcast_buf_addr = NULL;
         nb_release_gather_info_ptr->reduce_buf_addr = NULL;
@@ -205,7 +205,7 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
 
         mpi_errno = MPIDU_shm_alloc(comm_ptr, ibcast_flags_shm_size,
                                     (void **) &(nb_release_gather_info_ptr->ibcast_flags_addr));
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* Calculate gather and release flag address and initialize to the gather and release states */
         for (i = 0; i < MPIR_CVAR_BCAST_INTRANODE_NUM_CELLS; i++) {
             MPL_atomic_release_store_uint64(MPIDI_POSIX_RELEASE_GATHER_NB_IBCAST_GATHER_FLAG_ADDR
@@ -217,7 +217,7 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
         /* Allocate the shared memory for ibcast buffer */
         mpi_errno = MPIDU_shm_alloc(comm_ptr, MPIR_CVAR_BCAST_INTRANODE_BUFFER_TOTAL_SIZE,
                                     (void **) &(NB_RELEASE_GATHER_FIELD(comm_ptr, bcast_buf_addr)));
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     if (initialize_ireduce_buf) {
@@ -234,7 +234,7 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
 
         mpi_errno = MPIDU_shm_alloc(comm_ptr, ireduce_flags_shm_size,
                                     (void **) &(nb_release_gather_info_ptr->ireduce_flags_addr));
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         for (i = 0; i < MPIR_CVAR_REDUCE_INTRANODE_NUM_CELLS; i++) {
             MPL_atomic_release_store_uint64(MPIDI_POSIX_RELEASE_GATHER_NB_IREDUCE_GATHER_FLAG_ADDR
                                             (rank, i, num_ranks), -1);
@@ -246,7 +246,7 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
         mpi_errno =
             MPIDU_shm_alloc(comm_ptr, num_ranks * MPIR_CVAR_REDUCE_INTRANODE_BUFFER_TOTAL_SIZE,
                             (void **) &(NB_RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr)));
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* Store address of each of the children's reduce buffer */
         char *addr;
@@ -262,7 +262,7 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
     if (initialize_ibcast_buf || initialize_ireduce_buf) {
         /* Make sure all the flags are set before ranks start reading each other's flags from shm */
         mpi_errno = MPIR_Barrier_impl(comm_ptr, &errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
   fn_exit:
@@ -295,21 +295,21 @@ int MPIDI_POSIX_nb_release_gather_comm_free(MPIR_Comm * comm_ptr)
     if (NB_RELEASE_GATHER_FIELD(comm_ptr, bcast_buf_addr) != NULL) {
         /* destroy and detach the flags and buffer for Ibcast */
         mpi_errno = MPIDU_shm_free(NB_RELEASE_GATHER_FIELD(comm_ptr, ibcast_flags_addr));
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* destroy and detach shared memory used for bcast buffer */
         mpi_errno = MPIDU_shm_free(NB_RELEASE_GATHER_FIELD(comm_ptr, bcast_buf_addr));
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         MPL_free(NB_RELEASE_GATHER_FIELD(comm_ptr, ibcast_last_seq_no_completed));
     }
 
     if (NB_RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr) != NULL) {
         /* destroy and detach the flags and buffer for Ireduce */
         mpi_errno = MPIDU_shm_free(NB_RELEASE_GATHER_FIELD(comm_ptr, ireduce_flags_addr));
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         mpi_errno = MPIDU_shm_free(NB_RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr));
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         MPL_free(NB_RELEASE_GATHER_FIELD(comm_ptr, child_reduce_buf_addr));
         MPL_free(NB_RELEASE_GATHER_FIELD(comm_ptr, ireduce_last_seq_no_completed));

--- a/src/mpid/ch4/shm/posix/release_gather/nb_release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_release_gather.c
@@ -116,17 +116,17 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
                             to other algorithms.\n");
                 }
                 fallback = 1;
-                MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, &errflag);
+                MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, errflag);
                 MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_NO_MEM, "**nomem");
             } else {
                 /* More shm can be created, update the shared counter */
                 MPL_atomic_fetch_add_uint64(MPIDI_POSIX_shm_limit_counter, memory_to_be_allocated);
                 fallback = 0;
-                mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, &errflag);
+                mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         } else {
-            mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, &errflag);
+            mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (fallback) {
                 MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_NO_MEM, "**nomem");
@@ -155,7 +155,7 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
                                                  MPIR_CVAR_REDUCE_INTRANODE_TREE_KVAL,
                                                  MPIDI_POSIX_Reduce_tree_type,
                                                  &nb_release_gather_info_ptr->reduce_tree,
-                                                 &topotree_fail[1], &errflag);
+                                                 &topotree_fail[1]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 /* Finalize was already called and MPIR_Process.hwloc_topology has been destroyed */
@@ -163,7 +163,7 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
                 topotree_fail[1] = -1;
             }
             mpi_errno = MPIR_Allreduce_impl(MPI_IN_PLACE, topotree_fail, 2, MPI_INT,
-                                            MPI_MAX, comm_ptr, &errflag);
+                                            MPI_MAX, comm_ptr, errflag);
         } else {
             topotree_fail[0] = -1;
             topotree_fail[1] = -1;
@@ -261,7 +261,7 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
 
     if (initialize_ibcast_buf || initialize_ireduce_buf) {
         /* Make sure all the flags are set before ranks start reading each other's flags from shm */
-        mpi_errno = MPIR_Barrier_impl(comm_ptr, &errflag);
+        mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -277,17 +277,17 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
                 }
 
                 fallback = 1;
-                MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, &errflag);
+                MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, errflag);
                 MPIR_ERR_SETANDJUMP(mpi_errno_ret, MPI_ERR_NO_MEM, "**nomem");
             } else {
                 /* More shm can be created, update the shared counter */
                 MPL_atomic_fetch_add_uint64(MPIDI_POSIX_shm_limit_counter, memory_to_be_allocated);
                 fallback = 0;
-                mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, &errflag);
+                mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         } else {
-            mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, &errflag);
+            mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (fallback) {
                 MPIR_ERR_SETANDJUMP(mpi_errno_ret, MPI_ERR_NO_MEM, "**nomem");
@@ -317,7 +317,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
                                                  RELEASE_GATHER_FIELD(comm_ptr, reduce_tree_kval),
                                                  RELEASE_GATHER_FIELD(comm_ptr, reduce_tree_type),
                                                  &release_gather_info_ptr->reduce_tree,
-                                                 &topotree_fail[1], &errflag);
+                                                 &topotree_fail[1]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 /* Finalize was already called and MPIR_Process.hwloc_topology has been destroyed */
@@ -325,7 +325,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
                 topotree_fail[1] = -1;
             }
             mpi_errno = MPIR_Allreduce_impl(MPI_IN_PLACE, topotree_fail, 2, MPI_INT,
-                                            MPI_MAX, comm_ptr, &errflag);
+                                            MPI_MAX, comm_ptr, errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         } else {
             topotree_fail[0] = -1;
@@ -386,7 +386,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
                                         release_gather_info_ptr->release_state);
 
         /* Make sure all the flags are set before ranks start reading each other's flags from shm */
-        mpi_errno = MPIR_Barrier_impl(comm_ptr, &errflag);
+        mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -284,11 +284,11 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
                 MPL_atomic_fetch_add_uint64(MPIDI_POSIX_shm_limit_counter, memory_to_be_allocated);
                 fallback = 0;
                 mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, &errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         } else {
             mpi_errno = MPIR_Bcast_impl(&fallback, 1, MPI_INT, 0, comm_ptr, &errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (fallback) {
                 MPIR_ERR_SETANDJUMP(mpi_errno_ret, MPI_ERR_NO_MEM, "**nomem");
             }
@@ -318,7 +318,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
                                                  RELEASE_GATHER_FIELD(comm_ptr, reduce_tree_type),
                                                  &release_gather_info_ptr->reduce_tree,
                                                  &topotree_fail[1], &errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 /* Finalize was already called and MPIR_Process.hwloc_topology has been destroyed */
                 topotree_fail[0] = -1;
@@ -326,7 +326,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
             }
             mpi_errno = MPIR_Allreduce_impl(MPI_IN_PLACE, topotree_fail, 2, MPI_INT,
                                             MPI_MAX, comm_ptr, &errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         } else {
             topotree_fail[0] = -1;
             topotree_fail[1] = -1;
@@ -341,7 +341,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
                                           RELEASE_GATHER_FIELD(comm_ptr, bcast_tree_type),
                                           RELEASE_GATHER_FIELD(comm_ptr, bcast_tree_kval), 0,
                                           &release_gather_info_ptr->bcast_tree);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
         if (topotree_fail[1] != 0) {
@@ -352,7 +352,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
                                           RELEASE_GATHER_FIELD(comm_ptr, reduce_tree_type),
                                           RELEASE_GATHER_FIELD(comm_ptr, reduce_tree_kval), 0,
                                           &release_gather_info_ptr->reduce_tree);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         }
 
@@ -372,7 +372,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
             MPIR_ERR_ADD(mpi_errno_ret, MPIR_ERR_OTHER);
         }
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno_ret, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno_ret, errflag, mpi_errno_ret);
         MPIR_ERR_CHECK(mpi_errno_ret);
 
         /* Calculate gather and release flag address and initialize to the gather and release states */
@@ -387,7 +387,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
 
         /* Make sure all the flags are set before ranks start reading each other's flags from shm */
         mpi_errno = MPIR_Barrier_impl(comm_ptr, &errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     if (initialize_bcast_buf) {
@@ -402,7 +402,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
         if (mpi_errno) {
             MPIR_ERR_ADD(mpi_errno_ret, MPIR_ERR_OTHER);
         }
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     if (initialize_reduce_buf) {
@@ -422,7 +422,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
             /* for communication errors, just record the error but continue */
             MPIR_ERR_ADD(mpi_errno_ret, MPIR_ERR_OTHER);
         }
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno_ret, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno_ret, errflag, mpi_errno_ret);
         MPIR_ERR_CHECK(mpi_errno_ret);
 
         /* Store address of each of the children's reduce buffer */
@@ -466,7 +466,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_free(MPIR_Comm * comm_ptr)
 
     /* destroy and detach shared memory used for flags */
     mpi_errno = MPIDU_shm_free(RELEASE_GATHER_FIELD(comm_ptr, flags_addr));
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     if (RELEASE_GATHER_FIELD(comm_ptr, bcast_buf_addr) != NULL) {
         if (comm_ptr->rank == 0)
@@ -474,7 +474,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_free(MPIR_Comm * comm_ptr)
                                         RELEASE_GATHER_FIELD(comm_ptr, bcast_shm_size));
         /* destroy and detach shared memory used for bcast buffer */
         mpi_errno = MPIDU_shm_free(RELEASE_GATHER_FIELD(comm_ptr, bcast_buf_addr));
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     if (RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr) != NULL) {
@@ -483,7 +483,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_free(MPIR_Comm * comm_ptr)
                                         RELEASE_GATHER_FIELD(comm_ptr, reduce_shm_size));
         /* destroy and detach shared memory used for reduce buffers */
         mpi_errno = MPIDU_shm_free(RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr));
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         MPL_free(RELEASE_GATHER_FIELD(comm_ptr, child_reduce_buf_addr));
     }

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -102,7 +102,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
             if (rank == root) {
                 mpi_errno =
                     MPIC_Send(local_buf, count, datatype, 0, MPIR_BCAST_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             } else if (rank == 0) {
 #ifdef HAVE_ERROR_CHECKING
                 /* when error checking is enabled, the amount of data sender sent is retrieved from
@@ -114,7 +114,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
                 mpi_errno =
                     MPIC_Recv((char *) bcast_data_addr + 2 * MPIDU_SHM_CACHE_LINE_LEN, count,
                               datatype, root, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&status, MPI_BYTE, &recv_bytes);
                 MPIR_Typerep_copy(bcast_data_addr, &recv_bytes, sizeof(int),
                                   MPIR_TYPEREP_FLAG_NONE);
@@ -135,7 +135,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
                 mpi_errno =
                     MPIC_Recv(bcast_data_addr, count, datatype, root, MPIR_BCAST_TAG, comm_ptr,
                               MPI_STATUS_IGNORE, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 #endif
             }
         } else if (rank == 0) {
@@ -158,7 +158,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
             mpi_errno = MPIR_Localcopy(local_buf, count, datatype,
                                        bcast_data_addr, count, datatype);
 #endif
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         }
     }
 
@@ -229,7 +229,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
 #else
         mpi_errno = MPIR_Localcopy(bcast_data_addr, count, datatype, local_buf, count, datatype);
 #endif
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
     }
 
   fn_exit:
@@ -301,7 +301,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_gather(const void *i
             mpi_errno =
                 MPIR_Localcopy(inbuf, count, datatype, (void *) reduce_data_addr, count, datatype);
         }
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
         num_children = release_gather_info_ptr->reduce_tree.num_children;
         children = release_gather_info_ptr->reduce_tree.children;
     }
@@ -335,7 +335,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_gather(const void *i
                 mpi_errno =
                     MPIR_Reduce_local((void *) child_data_addr, (void *) reduce_data_addr,
                                       count, datatype, op);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
             /* Read child_flag_addr which 'may' be larger than the strongest waiting condition
              * so, it is safe */
@@ -354,13 +354,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_gather(const void *i
                 mpi_errno =
                     MPIC_Recv(outbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr,
                               MPI_STATUS_IGNORE, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             } else if (rank == 0) {
                 MPIR_ERR_CHKANDJUMP(!reduce_data_addr, mpi_errno, MPI_ERR_OTHER, "**nomem");
                 mpi_errno =
                     MPIC_Send((void *) reduce_data_addr, count, datatype, root, MPIR_REDUCE_TAG,
                               comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             }
         }
         /* No data copy is required if root was rank 0, because it reduced the data directly in its

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -113,7 +113,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
                 MPI_Aint recv_bytes;
                 mpi_errno =
                     MPIC_Recv((char *) bcast_data_addr + 2 * MPIDU_SHM_CACHE_LINE_LEN, count,
-                              datatype, root, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
+                              datatype, root, MPIR_BCAST_TAG, comm_ptr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&status, MPI_BYTE, &recv_bytes);
                 MPIR_Typerep_copy(bcast_data_addr, &recv_bytes, sizeof(int),
@@ -134,7 +134,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
                 /* When error checking is disabled, MPI_STATUS_IGNORE is used */
                 mpi_errno =
                     MPIC_Recv(bcast_data_addr, count, datatype, root, MPIR_BCAST_TAG, comm_ptr,
-                              MPI_STATUS_IGNORE, errflag);
+                              MPI_STATUS_IGNORE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
 #endif
             }
@@ -353,7 +353,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_gather(const void *i
             if (rank == root) {
                 mpi_errno =
                     MPIC_Recv(outbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr,
-                              MPI_STATUS_IGNORE, errflag);
+                              MPI_STATUS_IGNORE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
             } else if (rank == 0) {
                 MPIR_ERR_CHKANDJUMP(!reduce_data_addr, mpi_errno, MPI_ERR_OTHER, "**nomem");

--- a/src/mpid/ch4/shm/src/shm_am_fallback_coll.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_coll.h
@@ -6,14 +6,14 @@
 #ifndef SHM_AM_FALLBACK_COLL_H_INCLUDED
 #define SHM_AM_FALLBACK_COLL_H_INCLUDED
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Barrier_impl(comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
                                                  MPI_Datatype datatype, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
 }
@@ -21,7 +21,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                      MPI_Aint count, MPI_Datatype datatype,
                                                      MPI_Op op, MPIR_Comm * comm_ptr,
-                                                     MPIR_Errflag_t * errflag)
+                                                     MPIR_Errflag_t errflag)
 {
     return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
@@ -29,7 +29,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
                                recvcount, recvtype, comm_ptr, errflag);
@@ -40,7 +40,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_A
                                                       const MPI_Aint * recvcounts,
                                                       const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                      MPIR_Errflag_t * errflag)
+                                                      MPIR_Errflag_t errflag)
 {
     return MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcounts, displs, recvtype, comm_ptr, errflag);
@@ -50,7 +50,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                   int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t * errflag)
+                                                  MPIR_Errflag_t errflag)
 {
     return MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
                             recvcount, recvtype, root, comm_ptr, errflag);
@@ -61,7 +61,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint
                                                    const MPI_Aint * recvcounts,
                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
                                                    int root, MPIR_Comm * comm_ptr,
-                                                   MPIR_Errflag_t * errflag)
+                                                   MPIR_Errflag_t errflag)
 {
     return MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcounts, displs, recvtype, root, comm_ptr, errflag);
@@ -71,7 +71,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, MPI_Aint
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    int root, MPIR_Comm * comm_ptr,
-                                                   MPIR_Errflag_t * errflag)
+                                                   MPIR_Errflag_t errflag)
 {
     return MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcount, recvtype, root, comm_ptr, errflag);
@@ -82,7 +82,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
                                                     const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
                               recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
@@ -91,7 +91,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
                               recvcount, recvtype, comm_ptr, errflag);
@@ -104,7 +104,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                     MPIR_Errflag_t * errflag)
+                                                     MPIR_Errflag_t errflag)
 {
     return MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                recvbuf, recvcounts, rdispls, recvtype, comm_ptr, errflag);
@@ -117,7 +117,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
                                                      const MPI_Aint recvcounts[],
                                                      const MPI_Aint rdispls[],
                                                      const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
                                recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, errflag);
@@ -126,7 +126,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t * errflag)
+                                                  MPIR_Errflag_t errflag)
 {
     return MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
 }
@@ -135,7 +135,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, v
                                                           const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t * errflag)
+                                                          MPIR_Errflag_t errflag)
 {
     return MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag);
 }
@@ -144,7 +144,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
                                                                 MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t * errflag)
+                                                                MPIR_Errflag_t errflag)
 {
     return MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
                                           datatype, op, comm_ptr, errflag);
@@ -152,14 +152,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     return MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }

--- a/src/mpid/ch4/shm/src/shm_coll.h
+++ b/src/mpid/ch4/shm/src/shm_coll.h
@@ -9,7 +9,7 @@
 #include <shm.h>
 #include "../posix/shm_inline.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -23,7 +23,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errfla
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
                                                  MPI_Datatype datatype, int root, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t * errflag)
+                                                 MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -38,7 +38,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                      MPI_Aint count, MPI_Datatype datatype,
                                                      MPI_Op op, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t * errflag)
+                                                     MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                     MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -71,7 +71,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_A
                                                       const MPI_Aint * recvcounts,
                                                       const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                      MPIR_Errflag_t * errflag)
+                                                      MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -88,7 +88,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, MPI_Aint
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    int root, MPIR_Comm * comm,
-                                                   MPIR_Errflag_t * errflag)
+                                                   MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -106,7 +106,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
                                                     const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -123,7 +123,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                   int root, MPIR_Comm * comm,
-                                                  MPIR_Errflag_t * errflag)
+                                                  MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -141,7 +141,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint
                                                    const MPI_Aint * recvcounts,
                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
                                                    int root, MPIR_Comm * comm,
-                                                   MPIR_Errflag_t * errflag)
+                                                   MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -157,7 +157,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -177,7 +177,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t * errflag)
+                                                     MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -197,7 +197,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                     MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -213,7 +213,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t * errflag)
+                                                  MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -229,7 +229,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, v
                                                           const MPI_Aint * recvcounts,
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t * errflag)
+                                                          MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -246,7 +246,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
                                                                 void *recvbuf, MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t * errflag)
+                                                                MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -261,7 +261,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf,
                                                 MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int ret;
 
@@ -275,7 +275,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                                  MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/src/topotree.c
+++ b/src/mpid/ch4/shm/src/topotree.c
@@ -31,13 +31,13 @@ static int calc_pow(int k, int n)
  * skewness for max_ranks.
  * */
 int MPIDI_SHM_create_template_tree(MPIDI_SHM_topotree_t * template_tree, int k_val, int tree_type,
-                                   bool right_skewed, int max_ranks, MPIR_Errflag_t * errflag)
+                                   bool right_skewed, int max_ranks)
 {
-    int mpi_errno = MPI_SUCCESS, mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS;
     int i, j, child_id, child_idx;
 
     mpi_errno = MPIDI_SHM_topotree_allocate(template_tree, max_ranks, k_val);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (tree_type == MPIDI_POSIX_RELEASE_GATHER_TREE_TYPE_KARY) {
         /* Notice that skewness matters only for kary trees */
@@ -356,9 +356,9 @@ void MPIDI_SHM_gen_tree_sharedmemory(int *shared_region, MPIDI_SHM_topotree_t * 
 int MPIDI_SHM_gen_tree(int k_val, int *shared_region, int *max_entries_per_level,
                        int **ranks_per_package, int max_ranks_per_package, int *package_ctr,
                        int package_level, int num_ranks, bool package_leaders_first,
-                       bool right_skewed, int tree_type, MPIR_Errflag_t * errflag)
+                       bool right_skewed, int tree_type)
 {
-    int mpi_errno = MPI_SUCCESS, mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS;
     int i, j, p, r, rank, idx;
     int num_packages = max_entries_per_level[package_level];
     int package_count = 0;
@@ -369,10 +369,10 @@ int MPIDI_SHM_gen_tree(int k_val, int *shared_region, int *max_entries_per_level
     MPIR_CHKPMEM_DECL(1);
 
     mpi_errno = MPIDI_SHM_topotree_allocate(&tree, num_ranks, k_val);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDI_SHM_topotree_allocate(&package_tree, package_tree_sz, k_val);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_CHKPMEM_CALLOC(package_leaders, int *, num_packages * sizeof(int), mpi_errno,
                         "intra_node_package_leaders", MPL_MEM_OTHER);
@@ -392,8 +392,8 @@ int MPIDI_SHM_gen_tree(int k_val, int *shared_region, int *max_entries_per_level
     /* STEP 5. Create a template tree for the ranks */
     mpi_errno =
         MPIDI_SHM_create_template_tree(&template_tree, k_val, tree_type, right_skewed,
-                                       max_ranks_per_package, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                                       max_ranks_per_package);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDI_SHM_TOPOTREE_DEBUG) {
         for (i = 0; i < max_entries_per_level[package_level]; ++i) {
@@ -464,12 +464,11 @@ int MPIDI_SHM_gen_tree(int k_val, int *shared_region, int *max_entries_per_level
 int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, int bcast_tree_type,
                                  MPIR_Treealgo_tree_t * bcast_tree, int *bcast_topotree_fail,
                                  int reduce_k, int reduce_tree_type,
-                                 MPIR_Treealgo_tree_t * reduce_tree, int *reduce_topotree_fail,
-                                 MPIR_Errflag_t * errflag)
+                                 MPIR_Treealgo_tree_t * reduce_tree, int *reduce_topotree_fail)
 {
     int *shared_region;
     int num_ranks, rank;
-    int mpi_errno = MPI_SUCCESS, mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS;
     size_t shm_size;
     int **bind_map = NULL;
     int *max_entries_per_level = NULL;
@@ -477,6 +476,8 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
     int *package_ctr = NULL;
     int topo_depth = 0;
     int package_level = 0, i, max_ranks_per_package = 0;
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    int (*shared_region_ptr)[topo_depth];
 
     MPIR_FUNC_ENTER;
 
@@ -490,17 +491,17 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
 
     /* STEP 1. Create shared memory region for exchanging topology information (root only) */
     mpi_errno = MPIDU_shm_alloc(comm_ptr, shm_size, (void **) &shared_region);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* STEP 2. Every process fills affinity information in shared_region */
-    int (*shared_region_ptr)[topo_depth] = (int (*)[topo_depth]) shared_region;
+    shared_region_ptr = (int (*)[topo_depth]) shared_region;
     int depth = 0;
     while (depth < topo_depth) {
         shared_region_ptr[rank][depth++] = MPIR_hwtopo_get_lid(gid);
         gid = MPIR_hwtopo_get_ancestor(gid, topo_depth - depth - 1);
     }
     mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* STEP 3. Root has all the bind_map information, now build tree */
     if (rank == root) {
@@ -554,11 +555,11 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
         mpi_errno = MPIDI_SHM_gen_tree(bcast_k, shared_region, max_entries_per_level,
                                        ranks_per_package, max_ranks_per_package, package_ctr,
                                        package_level, num_ranks, 1 /*package_leaders_first */ ,
-                                       0 /*left_skewed */ , bcast_tree_type, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                                       0 /*left_skewed */ , bcast_tree_type);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Every rank copies their tree out from shared memory */
     MPIDI_SHM_copy_tree(shared_region, num_ranks, rank, bcast_tree, bcast_topotree_fail);
@@ -567,7 +568,7 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
 
     /* Wait until shared memory is available */
     mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_CHECK(mpi_errno);
     /* Generate the reduce tree */
     /* For Reduce, package leaders are added after the package local ranks, and the per_package
      * tree is right_skewed (children are added in the reverse order */
@@ -576,12 +577,12 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
         mpi_errno = MPIDI_SHM_gen_tree(reduce_k, shared_region, max_entries_per_level,
                                        ranks_per_package, max_ranks_per_package, package_ctr,
                                        package_level, num_ranks, 0 /*package_leaders_last */ ,
-                                       1 /*right_skewed */ , reduce_tree_type, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+                                       1 /*right_skewed */ , reduce_tree_type);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* each rank copy the reduce tree out */
     MPIDI_SHM_copy_tree(shared_region, num_ranks, rank, reduce_tree, reduce_topotree_fail);
@@ -590,7 +591,7 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
         MPIDI_SHM_print_topotree_file("REDUCE", comm_ptr->context_id, rank, reduce_tree);
     /* Wait for all ranks to copy out the tree */
     mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag, mpi_errno_ret);
+    MPIR_ERR_CHECK(mpi_errno);
     /* Cleanup */
     if (rank == root) {
         for (i = 0; i < max_entries_per_level[package_level]; ++i) {

--- a/src/mpid/ch4/shm/src/topotree.h
+++ b/src/mpid/ch4/shm/src/topotree.h
@@ -9,7 +9,7 @@
 #include "topotree_types.h"
 
 int MPIDI_SHM_create_template_tree(MPIDI_SHM_topotree_t * template_tree, int k_val, int tree_type,
-                                   bool right_skewed, int max_ranks, MPIR_Errflag_t * eflag);
+                                   bool right_skewed, int max_ranks);
 
 void MPIDI_SHM_copy_tree(int *shared_region, int num_ranks, int rank,
                          MPIR_Treealgo_tree_t * my_tree, int *topotree_fail);
@@ -28,12 +28,11 @@ void MPIDI_SHM_gen_tree_sharedmemory(int *shared_region, MPIDI_SHM_topotree_t * 
 int MPIDI_SHM_gen_tree(int k_val, int *shared_region, int *max_entries_per_level,
                        int **ranks_per_package, int max_ranks_per_package, int *package_ctr,
                        int package_level, int num_ranks, bool package_leaders_first,
-                       bool right_skewed, int tree_type, MPIR_Errflag_t * eflag);
+                       bool right_skewed, int tree_type);
 
 int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, int bcast_tree_type,
                                  MPIR_Treealgo_tree_t * bcast_tree, int *bcast_topotree_fail,
                                  int reduce_k, int reduce_tree_type,
-                                 MPIR_Treealgo_tree_t * reduce_tree, int *reduce_topotree_fail,
-                                 MPIR_Errflag_t * eflag);
+                                 MPIR_Treealgo_tree_t * reduce_tree, int *reduce_topotree_fai);
 
 #endif /* TOPOTREE_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -100,7 +100,7 @@ cvars:
 */
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_allcomm_composition_json(MPIR_Comm * comm,
-                                                                    MPIR_Errflag_t * errflag)
+                                                                    MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -137,7 +137,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_allcomm_composition_json(MPIR_Comm * 
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -183,7 +183,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * err
 MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_allcomm_composition_json(void *buffer, MPI_Aint count,
                                                                   MPI_Datatype datatype, int root,
                                                                   MPIR_Comm * comm,
-                                                                  MPIR_Errflag_t * errflag)
+                                                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -231,7 +231,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_allcomm_composition_json(void *buffer, 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                        int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                        int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -321,7 +321,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_allcomm_composition_json(const void
                                                                       void *recvbuf, MPI_Aint count,
                                                                       MPI_Datatype datatype,
                                                                       MPI_Op op, MPIR_Comm * comm,
-                                                                      MPIR_Errflag_t * errflag)
+                                                                      MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -398,7 +398,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_allcomm_composition_json(const void
 
 MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                            MPIR_Errflag_t * errflag)
+                                            MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative = -1;
@@ -533,7 +533,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
                                                                       MPI_Aint recvcount,
                                                                       MPI_Datatype recvtype,
                                                                       MPIR_Comm * comm,
-                                                                      MPIR_Errflag_t * errflag)
+                                                                      MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -594,7 +594,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
 MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, MPI_Aint sendcount,
                                             MPI_Datatype sendtype, void *recvbuf,
                                             MPI_Aint recvcount, MPI_Datatype recvtype,
-                                            MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                            MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint type_size;
@@ -666,7 +666,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendc
                                              MPI_Datatype sendtype, void *recvbuf,
                                              const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                              MPI_Datatype recvtype, MPIR_Comm * comm,
-                                             MPIR_Errflag_t * errflag)
+                                             MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -719,7 +719,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendc
 MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                           MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                          MPIR_Errflag_t * errflag)
+                                          MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -770,7 +770,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, MPI_Aint sendcoun
 MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const MPI_Aint * sendcounts,
                                            const MPI_Aint * displs, MPI_Datatype sendtype,
                                            void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                           int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                           int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -823,7 +823,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const MPI_Aint *
 MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *sendbuf, MPI_Aint sendcount,
                                          MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                          MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                         MPIR_Errflag_t * errflag)
+                                         MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -876,7 +876,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcoun
                                           MPI_Datatype sendtype, void *recvbuf,
                                           const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                           MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                          MPIR_Errflag_t * errflag)
+                                          MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -961,7 +961,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
                                                                      MPI_Aint recvcount,
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm,
-                                                                     MPIR_Errflag_t * errflag)
+                                                                     MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1020,7 +1020,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                           MPIR_Errflag_t * errflag)
+                                           MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint type_size;
@@ -1090,7 +1090,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *sendbuf, const MPI_Aint 
                                             const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                             void *recvbuf, const MPI_Aint * recvcounts,
                                             const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                            MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                            MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1146,7 +1146,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *sendbuf, const MPI_Aint 
                                             const MPI_Datatype sendtypes[], void *recvbuf,
                                             const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                             const MPI_Datatype recvtypes[], MPIR_Comm * comm,
-                                            MPIR_Errflag_t * errflag)
+                                            MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1201,7 +1201,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_allcomm_composition_json(const void *s
                                                                    void *recvbuf, MPI_Aint count,
                                                                    MPI_Datatype datatype, MPI_Op op,
                                                                    int root, MPIR_Comm * comm,
-                                                                   MPIR_Errflag_t * errflag)
+                                                                   MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1256,7 +1256,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_allcomm_composition_json(const void *s
 
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
                                          MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                         int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+                                         int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1327,7 +1327,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf,
                                                  const MPI_Aint recvcounts[], MPI_Datatype datatype,
                                                  MPI_Op op, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t * errflag)
+                                                 MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1376,7 +1376,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *sendbuf, void *recv
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                        MPI_Aint recvcount, MPI_Datatype datatype,
                                                        MPI_Op op, MPIR_Comm * comm,
-                                                       MPIR_Errflag_t * errflag)
+                                                       MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1425,7 +1425,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *sendbuf, void
 
 MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                       MPIR_Errflag_t * errflag)
+                                       MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1477,7 +1477,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_A
 
 MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                         MPIR_Errflag_t * errflag)
+                                         MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -160,12 +160,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
 #ifndef HAVE_ERROR_CHECKING
         coll_ret =
             MPIC_Recv(buffer, count, datatype, MPIR_Get_intranode_rank(comm, root), MPIR_BCAST_TAG,
-                      comm->node_comm, MPI_STATUS_IGNORE, errflag);
+                      comm->node_comm, MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
         coll_ret =
             MPIC_Recv(buffer, count, datatype, MPIR_Get_intranode_rank(comm, root), MPIR_BCAST_TAG,
-                      comm->node_comm, &status, errflag);
+                      comm->node_comm, &status);
         MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
         MPIR_Datatype_get_size_macro(datatype, type_size);
@@ -628,8 +628,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
         if (comm->rank == 0) {
             MPIC_Send(recvbuf, count, datatype, root, MPIR_REDUCE_TAG, comm, errflag);
         } else if (comm->rank == root) {
-            MPIC_Recv(ori_recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm, MPI_STATUS_IGNORE,
-                      errflag);
+            MPIC_Recv(ori_recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm, MPI_STATUS_IGNORE);
         }
     }
 
@@ -1287,7 +1286,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
     if (comm_ptr->node_roots_comm != NULL && comm_ptr->node_comm != NULL) {
         coll_ret = MPIC_Recv(localfulldata, count, datatype,
                              comm_ptr->node_comm->local_size - 1, MPIR_SCAN_TAG,
-                             comm_ptr->node_comm, &status, errflag);
+                             comm_ptr->node_comm, &status);
         MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     } else if (comm_ptr->node_roots_comm == NULL &&
                comm_ptr->node_comm != NULL &&
@@ -1317,7 +1316,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
         if (MPIR_Get_internode_rank(comm_ptr, rank) != 0) {
             coll_ret = MPIC_Recv(tempbuf, count, datatype,
                                  MPIR_Get_internode_rank(comm_ptr, rank) - 1,
-                                 MPIR_SCAN_TAG, comm_ptr->node_roots_comm, &status, errflag);
+                                 MPIR_SCAN_TAG, comm_ptr->node_roots_comm, &status);
             noneed = 0;
             MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
         }

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -84,7 +84,7 @@ cvars:
 #define MPIR_ALLREDUCE_SHM_PER_LEADER_MAX 4194304
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_alpha(MPIR_Comm * comm,
-                                                                   MPIR_Errflag_t * errflag)
+                                                                   MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int coll_ret = MPI_SUCCESS;
@@ -93,17 +93,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_alpha(MPIR_Comm * c
     if (comm->node_comm != NULL) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_barrier(comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_barrier(comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
 
     /* do the barrier across roots of all nodes */
     if (comm->node_roots_comm != NULL) {
         coll_ret = MPIDI_NM_mpi_barrier(comm->node_roots_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
     /* release the local processes on each node with a 1-byte
@@ -113,10 +113,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_alpha(MPIR_Comm * c
         int i = 0;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_bcast(&i, 1, MPI_BYTE, 0, comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_bcast(&i, 1, MPI_BYTE, 0, comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
 
@@ -124,7 +124,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_alpha(MPIR_Comm * c
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_beta(MPIR_Comm * comm,
-                                                                  MPIR_Errflag_t * errflag)
+                                                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -140,7 +140,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_beta(MPIR_Comm * co
 MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, MPI_Aint count,
                                                                  MPI_Datatype datatype,
                                                                  int root, MPIR_Comm * comm,
-                                                                 MPIR_Errflag_t * errflag)
+                                                                 MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int coll_ret = MPI_SUCCESS;
@@ -152,7 +152,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
 
     if (comm->node_roots_comm == NULL && comm->rank == root) {
         coll_ret = MPIC_Send(buffer, count, datatype, 0, MPIR_BCAST_TAG, comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
     if (comm->node_roots_comm != NULL && comm->rank != root &&
@@ -161,12 +161,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
         coll_ret =
             MPIC_Recv(buffer, count, datatype, MPIR_Get_intranode_rank(comm, root), MPIR_BCAST_TAG,
                       comm->node_comm, MPI_STATUS_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
         coll_ret =
             MPIC_Recv(buffer, count, datatype, MPIR_Get_intranode_rank(comm, root), MPIR_BCAST_TAG,
                       comm->node_comm, &status);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
         MPIR_Datatype_get_size_macro(datatype, type_size);
         nbytes = type_size * count;
@@ -176,7 +176,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
             MPIR_ERR_SET2(coll_ret, MPI_ERR_OTHER,
                           "**collective_size_mismatch",
                           "**collective_size_mismatch %d %d", recvd_size, nbytes);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
         }
 #endif
     }
@@ -185,15 +185,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
         coll_ret =
             MPIDI_NM_mpi_bcast(buffer, count, datatype, MPIR_Get_internode_rank(comm, root),
                                comm->node_roots_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
     if (comm->node_comm != NULL) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_bcast(buffer, count, datatype, 0, comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_bcast(buffer, count, datatype, 0, comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
 
@@ -203,7 +203,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
 MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_beta(void *buffer, MPI_Aint count,
                                                                 MPI_Datatype datatype,
                                                                 int root, MPIR_Comm * comm,
-                                                                MPIR_Errflag_t * errflag)
+                                                                MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int coll_ret = MPI_SUCCESS;
@@ -213,27 +213,27 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_beta(void *buffer, MP
         coll_ret =
             MPIDI_SHM_mpi_bcast(buffer, count, datatype, MPIR_Get_intranode_rank(comm, root),
                                 comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
         coll_ret =
             MPIDI_NM_mpi_bcast(buffer, count, datatype, MPIR_Get_intranode_rank(comm, root),
                                comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
     if (comm->node_roots_comm != NULL) {
         coll_ret =
             MPIDI_NM_mpi_bcast(buffer, count, datatype, MPIR_Get_internode_rank(comm, root),
                                comm->node_roots_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
     if (comm->node_comm != NULL && MPIR_Get_intranode_rank(comm, root) <= 0) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_bcast(buffer, count, datatype, 0, comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_bcast(buffer, count, datatype, 0, comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
 
@@ -243,7 +243,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_beta(void *buffer, MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_gamma(void *buffer, MPI_Aint count,
                                                                  MPI_Datatype datatype,
                                                                  int root, MPIR_Comm * comm,
-                                                                 MPIR_Errflag_t * errflag)
+                                                                 MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -261,7 +261,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_alpha(const void 
                                                                      MPI_Datatype datatype,
                                                                      MPI_Op op,
                                                                      MPIR_Comm * comm,
-                                                                     MPIR_Errflag_t * errflag)
+                                                                     MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int coll_ret = MPI_SUCCESS;
@@ -272,30 +272,30 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_alpha(const void 
             coll_ret =
                 MPIDI_SHM_mpi_reduce(recvbuf, NULL, count, datatype, op, 0, comm->node_comm,
                                      errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
             coll_ret =
                 MPIDI_NM_mpi_reduce(recvbuf, NULL, count, datatype, op, 0, comm->node_comm,
                                     errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
         } else {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
             coll_ret =
                 MPIDI_SHM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
                                      errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
             coll_ret =
                 MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
                                     errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
         }
     } else {
         if (sendbuf != MPI_IN_PLACE) {
             coll_ret = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
         }
     }
 
@@ -303,16 +303,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_alpha(const void 
         coll_ret =
             MPIDI_NM_mpi_allreduce(MPI_IN_PLACE, recvbuf, count, datatype, op,
                                    comm->node_roots_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
     if (comm->node_comm != NULL) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_bcast(recvbuf, count, datatype, 0, comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_bcast(recvbuf, count, datatype, 0, comm->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #endif
     }
 
@@ -324,7 +324,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_beta(const void *
                                                                     MPI_Datatype datatype,
                                                                     MPI_Op op,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Errflag_t * errflag)
+                                                                    MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -342,7 +342,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_gamma(const void 
                                                                      MPI_Datatype datatype,
                                                                      MPI_Op op,
                                                                      MPIR_Comm * comm,
-                                                                     MPIR_Errflag_t * errflag)
+                                                                     MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -372,7 +372,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
                                                                      MPI_Op op,
                                                                      int num_leads,
                                                                      MPIR_Comm * comm_ptr,
-                                                                     MPIR_Errflag_t * errflag)
+                                                                     MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS, coll_ret = MPI_SUCCESS;
     char *shm_addr;
@@ -398,7 +398,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
     if (MPIDI_COMM(comm_ptr, sub_node_comm) == NULL) {
         /* Create multi-leaders comm in a lazily */
         coll_ret = MPIDI_Comm_create_multi_leader_subcomms(comm_ptr, num_leads);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
     /* Allocate the shared memory buffer per node, if it is not already done */
@@ -422,7 +422,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
 
         coll_ret = MPIDU_shm_alloc(comm_ptr->node_comm, num_leads * shm_size_per_lead,
                                    (void **) &MPIDI_COMM_ALLREDUCE(comm_ptr, shm_addr));
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
     /* Store the address of shared buffer into a local variable */
@@ -454,7 +454,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
 #else
         coll_ret = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
 #endif
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
         /* Step 1: Leaders perform reduce on is intra_node_sub_communicator. Reduced data is
          * available in the leader's shared buffer */
@@ -470,7 +470,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
                                 (char *) shm_addr + my_leader_rank * shm_size_per_lead, chunk_count,
                                 datatype, op, 0, MPIDI_COMM(comm_ptr, sub_node_comm), errflag);
 #endif
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
         /* Step 2: Barrier to make sure all the leaders have data reduced into is respective shm
          * buffers. */
@@ -480,7 +480,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
 #else
             coll_ret = MPIDI_NM_mpi_barrier(MPIDI_COMM(comm_ptr, intra_node_leads_comm), errflag);
 #endif
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
         }
 
         /* Step 3: Each leader is responsible to reduce a portion of the data (chunk_count/num_leads),
@@ -512,7 +512,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
                                            (cache_chunk_count -
                                             1)) ? cache_chunk_size_floor : cache_chunk_size_ceil,
                                           datatype, op);
-                    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+                    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
                 }
             }
         }
@@ -525,7 +525,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
                                               per_leader_count, datatype, op, MPIDI_COMM(comm_ptr,
                                                                                          inter_node_leads_comm),
                                               errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
         }
 
         /* Step 5: Barrier to make sure non-leaders wait for leaders to finish reducing the data
@@ -535,7 +535,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
 #else
         coll_ret = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
 #endif
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
         /* Step 6: Copy data from shm buffer into the recvbuf buffer */
         /* TODO: Do not use offsets for single NIC runs, it shows a slowdown of 0.95x with 2 offsets.
@@ -558,7 +558,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
                                (char *) recvbuf + offset * extent +
                                ((local_copy_group + i) % num_offsets) * local_copy_offset,
                                chunk_count / num_offsets, datatype);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
         }
         offset += chunk_count;
     }
@@ -571,7 +571,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
                                                                   MPI_Datatype datatype,
                                                                   MPI_Op op, int root,
                                                                   MPIR_Comm * comm,
-                                                                  MPIR_Errflag_t * errflag)
+                                                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int coll_ret = MPI_SUCCESS;
@@ -606,7 +606,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
                                        errflag);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
 
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
         /* recvbuf becomes the sendbuf for internode reduce */
         inter_sendbuf = recvbuf;
@@ -620,7 +620,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
             MPIDI_NM_mpi_reduce(comm->node_roots_comm->rank == 0 ? MPI_IN_PLACE : inter_sendbuf,
                                 recvbuf, count, datatype, op, 0, comm->node_roots_comm, errflag);
 
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
     /* Send data to root via point-to-point message if root is not rank 0 in comm */
@@ -644,7 +644,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
                                                                  MPI_Datatype datatype,
                                                                  MPI_Op op, int root,
                                                                  MPIR_Comm * comm,
-                                                                 MPIR_Errflag_t * errflag)
+                                                                 MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int coll_ret = MPI_SUCCESS;
@@ -678,7 +678,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
         coll_ret =
             MPIDI_NM_mpi_reduce(sendbuf, tmp_buf, count, datatype, op, 0, comm->node_comm, errflag);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
     /* do the internode reduce to the root's node */
@@ -691,7 +691,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
                 MPIDI_NM_mpi_reduce(buf, NULL, count, datatype,
                                     op, MPIR_Get_internode_rank(comm, root),
                                     comm->node_roots_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
         } else {        /* I am on root's node. I have not participated in the earlier reduce. */
             if (comm->rank != root) {
                 /* I am not the root though. I don't have a valid recvbuf.
@@ -701,7 +701,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
                                         op, MPIR_Get_internode_rank(comm, root),
                                         comm->node_roots_comm, errflag);
 
-                MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+                MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
                 /* point sendbuf at tmp_buf to make final intranode reduce easy */
                 sendbuf = tmp_buf;
@@ -711,7 +711,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
                     MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype,
                                         op, MPIR_Get_internode_rank(comm, root),
                                         comm->node_roots_comm, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+                MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
                 /* set sendbuf to MPI_IN_PLACE to make final intranode reduce easy. */
                 sendbuf = MPI_IN_PLACE;
@@ -731,7 +731,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
             MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype,
                                 op, MPIR_Get_intranode_rank(comm, root), comm->node_comm, errflag);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
   fn_exit:
@@ -748,7 +748,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_gamma(const void *se
                                                                   MPI_Datatype datatype,
                                                                   MPI_Op op, int root,
                                                                   MPIR_Comm * comm,
-                                                                  MPIR_Errflag_t * errflag)
+                                                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -771,7 +771,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
                                                                     int recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm_ptr,
-                                                                    MPIR_Errflag_t * errflag)
+                                                                    MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS, coll_ret = MPI_SUCCESS;
     int num_nodes;
@@ -800,7 +800,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
     if (MPIDI_COMM(comm_ptr, multi_leads_comm) == NULL) {
         /* Create multi-leaders comm in a lazy manner */
         coll_ret = MPIDI_Comm_create_multi_leaders(comm_ptr);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
     /* Allocate the shared memory buffer per node, if it is not already done */
@@ -809,7 +809,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
             MPIDU_shm_alloc(comm_ptr->node_comm,
                             node_comm_size * num_ranks * MPIR_CVAR_ALLTOALL_SHM_PER_RANK,
                             (void **) &MPIDI_COMM_ALLTOALL(comm_ptr, shm_addr));
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
     /* Barrier to make sure that the shm buffer can be reused after the previous call to Alltoall */
@@ -818,7 +818,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
 #else
     coll_ret = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
 #endif
-    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
     /* Each rank on a node copy its data into shm buffer */
     /* Example - 2 ranks per node on 2 nodes. R0 and R1 on node 0, R2 and R3 on node 1.
@@ -837,7 +837,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
                                                                         my_node_comm_rank) *
                                                                      type_size * sendcount),
                                       sendcount, sendtype);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
             p++;
         }
     }
@@ -848,7 +848,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
 #else
     coll_ret = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
 #endif
-    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
     /* Call internode alltoall on the shm_bufs and multi-leaders communicator */
     /* In the above example, first half on shm_bufs are used by the first multi-leader comm of R0
@@ -863,7 +863,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
                                                type_size * sendcount), node_comm_size * sendcount,
                                      sendtype, recvbuf, sendcount * node_comm_size, sendtype,
                                      MPIDI_COMM(comm_ptr, multi_leads_comm), errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -876,7 +876,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_beta(const void *s
                                                                    MPI_Aint recvcount,
                                                                    MPI_Datatype recvtype,
                                                                    MPIR_Comm * comm_ptr,
-                                                                   MPIR_Errflag_t * errflag)
+                                                                   MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -900,7 +900,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoallv_intra_composition_alpha(const void 
                                                                      const MPI_Aint * rdispls,
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm_ptr,
-                                                                     MPIR_Errflag_t * errflag)
+                                                                     MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -926,7 +926,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoallw_intra_composition_alpha(const void 
                                                                      const MPI_Datatype
                                                                      recvtypes[],
                                                                      MPIR_Comm * comm_ptr,
-                                                                     MPIR_Errflag_t * errflag)
+                                                                     MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -949,7 +949,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
                                                                      int recvcount,
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm_ptr,
-                                                                     MPIR_Errflag_t * errflag)
+                                                                     MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS, coll_ret = MPI_SUCCESS;
     int node_comm_size = MPIR_Comm_size(comm_ptr->node_comm);
@@ -993,7 +993,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
     if (MPIDI_COMM(comm_ptr, multi_leads_comm) == NULL) {
         /* Create multi-leaders comm in a lazy manner */
         coll_ret = MPIDI_Comm_create_multi_leaders(comm_ptr);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
     /* Allocate the shared memory buffer per node, if it is not already done */
@@ -1001,7 +1001,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
         coll_ret =
             MPIDU_shm_alloc(comm_ptr->node_comm, node_comm_size * MPIR_CVAR_ALLGATHER_SHM_PER_RANK,
                             (void **) &MPIDI_COMM_ALLGATHER(comm_ptr, shm_addr));
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
     /* Barrier to make sure that the shm buffer can be reused after the previous call to Allgather */
@@ -1010,7 +1010,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
 #else
     coll_ret = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
 #endif
-    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
     /* Copy data to shm buffers */
     coll_ret = MPIR_Localcopy(sendbuf, sendcount, sendtype,
@@ -1018,7 +1018,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
                                                             shm_addr) + my_node_comm_rank * offset,
                               recvcount, recvtype);
 
-    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
     /* Barrier to make sure all the ranks in a node_comm copied data to shm buffer */
 #ifndef MPIDI_CH4_DIRECT_NETMOD
@@ -1033,7 +1033,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
                                sendcount * node_comm_size, sendtype,
                                recvbuf, recvcount * node_comm_size, recvtype,
                                MPIDI_COMM(comm_ptr, multi_leads_comm), errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1046,7 +1046,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_beta(const void *
                                                                     MPI_Aint recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm_ptr,
-                                                                    MPIR_Errflag_t * errflag)
+                                                                    MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1069,7 +1069,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgatherv_intra_composition_alpha(const void
                                                                       const MPI_Aint * displs,
                                                                       MPI_Datatype recvtype,
                                                                       MPIR_Comm * comm_ptr,
-                                                                      MPIR_Errflag_t * errflag)
+                                                                      MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1090,7 +1090,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Gather_intra_composition_alpha(const void *se
                                                                   void *recvbuf, MPI_Aint recvcount,
                                                                   MPI_Datatype recvtype,
                                                                   int root, MPIR_Comm * comm,
-                                                                  MPIR_Errflag_t * errflag)
+                                                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1113,7 +1113,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Gatherv_intra_composition_alpha(const void *s
                                                                    const MPI_Aint * displs,
                                                                    MPI_Datatype recvtype,
                                                                    int root, MPIR_Comm * comm,
-                                                                   MPIR_Errflag_t * errflag)
+                                                                   MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1135,7 +1135,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scatter_intra_composition_alpha(const void *s
                                                                    MPI_Aint recvcount,
                                                                    MPI_Datatype recvtype,
                                                                    int root, MPIR_Comm * comm,
-                                                                   MPIR_Errflag_t * errflag)
+                                                                   MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1158,7 +1158,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scatterv_intra_composition_alpha(const void *
                                                                     MPI_Aint recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     int root, MPIR_Comm * comm,
-                                                                    MPIR_Errflag_t * errflag)
+                                                                    MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1180,7 +1180,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_scatter_intra_composition_alpha(const 
                                                                           MPI_Datatype
                                                                           datatype, MPI_Op op,
                                                                           MPIR_Comm * comm_ptr,
-                                                                          MPIR_Errflag_t * errflag)
+                                                                          MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1204,7 +1204,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_scatter_block_intra_composition_alpha(
                                                                                 MPIR_Comm *
                                                                                 comm_ptr,
                                                                                 MPIR_Errflag_t
-                                                                                * errflag)
+                                                                                errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1225,7 +1225,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
                                                                 MPI_Datatype datatype,
                                                                 MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t * errflag)
+                                                                MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     int coll_ret = MPI_SUCCESS;
@@ -1269,15 +1269,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret =
             MPIDI_SHM_mpi_scan(sendbuf, recvbuf, count, datatype, op, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
         coll_ret =
             MPIDI_NM_mpi_scan(sendbuf, recvbuf, count, datatype, op, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     } else if (sendbuf != MPI_IN_PLACE) {
         coll_ret = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
     /* get result from local node's last processor which
      * contains the reduce result of the whole node. Name it as
@@ -1287,13 +1287,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
         coll_ret = MPIC_Recv(localfulldata, count, datatype,
                              comm_ptr->node_comm->local_size - 1, MPIR_SCAN_TAG,
                              comm_ptr->node_comm, &status);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     } else if (comm_ptr->node_roots_comm == NULL &&
                comm_ptr->node_comm != NULL &&
                MPIR_Get_intranode_rank(comm_ptr, rank) == comm_ptr->node_comm->local_size - 1) {
         coll_ret = MPIC_Send(recvbuf, count, datatype,
                              0, MPIR_SCAN_TAG, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     } else if (comm_ptr->node_roots_comm != NULL) {
         localfulldata = recvbuf;
     }
@@ -1305,20 +1305,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
         coll_ret =
             MPIDI_NM_mpi_scan(localfulldata, prefulldata, count, datatype,
                               op, comm_ptr->node_roots_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 
         if (MPIR_Get_internode_rank(comm_ptr, rank) != comm_ptr->node_roots_comm->local_size - 1) {
             coll_ret = MPIC_Send(prefulldata, count, datatype,
                                  MPIR_Get_internode_rank(comm_ptr, rank) + 1,
                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
         }
         if (MPIR_Get_internode_rank(comm_ptr, rank) != 0) {
             coll_ret = MPIC_Recv(tempbuf, count, datatype,
                                  MPIR_Get_internode_rank(comm_ptr, rank) - 1,
                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, &status);
             noneed = 0;
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
         }
     }
 
@@ -1331,10 +1331,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
     if (comm_ptr->node_comm != NULL) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_bcast(&noneed, 1, MPI_INT, 0, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_bcast(&noneed, 1, MPI_INT, 0, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
 
@@ -1343,16 +1343,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
 #ifndef MPIDI_CH4_DIRECT_NETMOD
             coll_ret =
                 MPIDI_SHM_mpi_bcast(tempbuf, count, datatype, 0, comm_ptr->node_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #else
             coll_ret =
                 MPIDI_NM_mpi_bcast(tempbuf, count, datatype, 0, comm_ptr->node_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
         }
 
         coll_ret = MPIR_Reduce_local(tempbuf, recvbuf, count, datatype, op);
-        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);
     }
 
   fn_exit:
@@ -1368,7 +1368,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_beta(const void *sendb
                                                                MPI_Datatype datatype,
                                                                MPI_Op op,
                                                                MPIR_Comm * comm_ptr,
-                                                               MPIR_Errflag_t * errflag)
+                                                               MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1387,7 +1387,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Exscan_intra_composition_alpha(const void *se
                                                                   MPI_Datatype datatype,
                                                                   MPI_Op op,
                                                                   MPIR_Comm * comm_ptr,
-                                                                  MPIR_Errflag_t * errflag)
+                                                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -93,20 +93,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_alpha(MPIR_Comm * c
     if (comm->node_comm != NULL) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_barrier(comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_barrier(comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
 
     /* do the barrier across roots of all nodes */
     if (comm->node_roots_comm != NULL) {
         coll_ret = MPIDI_NM_mpi_barrier(comm->node_roots_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
     /* release the local processes on each node with a 1-byte
@@ -116,12 +113,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_alpha(MPIR_Comm * c
         int i = 0;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_bcast(&i, 1, MPI_BYTE, 0, comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_bcast(&i, 1, MPI_BYTE, 0, comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
 
@@ -157,13 +152,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
 
     if (comm->node_roots_comm == NULL && comm->rank == root) {
         coll_ret = MPIC_Send(buffer, count, datatype, 0, MPIR_BCAST_TAG, comm->node_comm, errflag);
-        if (coll_ret) {
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(coll_ret) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(coll_ret, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
     if (comm->node_roots_comm != NULL && comm->rank != root &&
@@ -172,36 +161,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
         coll_ret =
             MPIC_Recv(buffer, count, datatype, MPIR_Get_intranode_rank(comm, root), MPIR_BCAST_TAG,
                       comm->node_comm, MPI_STATUS_IGNORE, errflag);
-        if (coll_ret) {
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(coll_ret) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(coll_ret, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
         coll_ret =
             MPIC_Recv(buffer, count, datatype, MPIR_Get_intranode_rank(comm, root), MPIR_BCAST_TAG,
                       comm->node_comm, &status, errflag);
-        if (coll_ret) {
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(coll_ret) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(coll_ret, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
         MPIR_Datatype_get_size_macro(datatype, type_size);
         nbytes = type_size * count;
         /* check that we received as much as we expected */
         MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
         if (recvd_size != nbytes) {
-            if (*errflag == MPIR_ERR_NONE)
-                *errflag = MPIR_ERR_OTHER;
             MPIR_ERR_SET2(coll_ret, MPI_ERR_OTHER,
                           "**collective_size_mismatch",
                           "**collective_size_mismatch %d %d", recvd_size, nbytes);
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
         }
 #endif
     }
@@ -210,18 +185,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
         coll_ret =
             MPIDI_NM_mpi_bcast(buffer, count, datatype, MPIR_Get_internode_rank(comm, root),
                                comm->node_roots_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
     if (comm->node_comm != NULL) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_bcast(buffer, count, datatype, 0, comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_bcast(buffer, count, datatype, 0, comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
 
@@ -241,32 +213,27 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_beta(void *buffer, MP
         coll_ret =
             MPIDI_SHM_mpi_bcast(buffer, count, datatype, MPIR_Get_intranode_rank(comm, root),
                                 comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
         coll_ret =
             MPIDI_NM_mpi_bcast(buffer, count, datatype, MPIR_Get_intranode_rank(comm, root),
                                comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
     if (comm->node_roots_comm != NULL) {
         coll_ret =
             MPIDI_NM_mpi_bcast(buffer, count, datatype, MPIR_Get_internode_rank(comm, root),
                                comm->node_roots_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
     if (comm->node_comm != NULL && MPIR_Get_intranode_rank(comm, root) <= 0) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_bcast(buffer, count, datatype, 0, comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_bcast(buffer, count, datatype, 0, comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
 
@@ -305,35 +272,30 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_alpha(const void 
             coll_ret =
                 MPIDI_SHM_mpi_reduce(recvbuf, NULL, count, datatype, op, 0, comm->node_comm,
                                      errflag);
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
             coll_ret =
                 MPIDI_NM_mpi_reduce(recvbuf, NULL, count, datatype, op, 0, comm->node_comm,
                                     errflag);
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
         } else {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
             coll_ret =
                 MPIDI_SHM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
                                      errflag);
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
             coll_ret =
                 MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
                                     errflag);
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
         }
     } else {
         if (sendbuf != MPI_IN_PLACE) {
             coll_ret = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
         }
     }
 
@@ -341,19 +303,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_alpha(const void 
         coll_ret =
             MPIDI_NM_mpi_allreduce(MPI_IN_PLACE, recvbuf, count, datatype, op,
                                    comm->node_roots_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
     if (comm->node_comm != NULL) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_bcast(recvbuf, count, datatype, 0, comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_bcast(recvbuf, count, datatype, 0, comm->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #endif
     }
 
@@ -439,8 +398,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
     if (MPIDI_COMM(comm_ptr, sub_node_comm) == NULL) {
         /* Create multi-leaders comm in a lazily */
         coll_ret = MPIDI_Comm_create_multi_leader_subcomms(comm_ptr, num_leads);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
     /* Allocate the shared memory buffer per node, if it is not already done */
@@ -464,8 +422,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
 
         coll_ret = MPIDU_shm_alloc(comm_ptr->node_comm, num_leads * shm_size_per_lead,
                                    (void **) &MPIDI_COMM_ALLREDUCE(comm_ptr, shm_addr));
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
     /* Store the address of shared buffer into a local variable */
@@ -497,8 +454,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
 #else
         coll_ret = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
 #endif
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
         /* Step 1: Leaders perform reduce on is intra_node_sub_communicator. Reduced data is
          * available in the leader's shared buffer */
@@ -514,8 +470,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
                                 (char *) shm_addr + my_leader_rank * shm_size_per_lead, chunk_count,
                                 datatype, op, 0, MPIDI_COMM(comm_ptr, sub_node_comm), errflag);
 #endif
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
         /* Step 2: Barrier to make sure all the leaders have data reduced into is respective shm
          * buffers. */
@@ -525,8 +480,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
 #else
             coll_ret = MPIDI_NM_mpi_barrier(MPIDI_COMM(comm_ptr, intra_node_leads_comm), errflag);
 #endif
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
         }
 
         /* Step 3: Each leader is responsible to reduce a portion of the data (chunk_count/num_leads),
@@ -558,8 +512,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
                                            (cache_chunk_count -
                                             1)) ? cache_chunk_size_floor : cache_chunk_size_ceil,
                                           datatype, op);
-                    if (coll_ret)
-                        MPIR_ERR_ADD(mpi_errno, coll_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
                 }
             }
         }
@@ -572,8 +525,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
                                               per_leader_count, datatype, op, MPIDI_COMM(comm_ptr,
                                                                                          inter_node_leads_comm),
                                               errflag);
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
         }
 
         /* Step 5: Barrier to make sure non-leaders wait for leaders to finish reducing the data
@@ -583,8 +535,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
 #else
         coll_ret = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
 #endif
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
         /* Step 6: Copy data from shm buffer into the recvbuf buffer */
         /* TODO: Do not use offsets for single NIC runs, it shows a slowdown of 0.95x with 2 offsets.
@@ -607,8 +558,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
                                (char *) recvbuf + offset * extent +
                                ((local_copy_group + i) % num_offsets) * local_copy_offset,
                                chunk_count / num_offsets, datatype);
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
         }
         offset += chunk_count;
     }
@@ -649,21 +599,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
     /* intranode reduce on all nodes */
     if (comm->node_comm != NULL) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno = MPIDI_SHM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
-                                         errflag);
-#else
-        mpi_errno = MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
+        coll_ret = MPIDI_SHM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
                                         errflag);
+#else
+        coll_ret = MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
+                                       errflag);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
 
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(coll_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
+
         /* recvbuf becomes the sendbuf for internode reduce */
         inter_sendbuf = recvbuf;
     } else {
@@ -672,18 +616,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
 
     /* internode reduce with rank 0 in node_roots_comm as the root */
     if (comm->node_roots_comm != NULL) {
-        mpi_errno =
+        coll_ret =
             MPIDI_NM_mpi_reduce(comm->node_roots_comm->rank == 0 ? MPI_IN_PLACE : inter_sendbuf,
                                 recvbuf, count, datatype, op, 0, comm->node_roots_comm, errflag);
 
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(coll_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
     /* Send data to root via point-to-point message if root is not rank 0 in comm */
@@ -735,21 +672,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
     /* do the intranode reduce on all nodes other than the root's node */
     if (comm->node_comm != NULL && MPIR_Get_intranode_rank(comm, root) == -1) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno =
+        coll_ret =
             MPIDI_SHM_mpi_reduce(sendbuf, tmp_buf, count, datatype, op, 0, comm->node_comm,
                                  errflag);
 #else
-        mpi_errno =
+        coll_ret =
             MPIDI_NM_mpi_reduce(sendbuf, tmp_buf, count, datatype, op, 0, comm->node_comm, errflag);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(coll_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
     /* do the internode reduce to the root's node */
@@ -758,52 +688,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
             /* I am not on root's node.  Use tmp_buf if we
              * participated in the first reduce, otherwise use sendbuf */
             const void *buf = (comm->node_comm == NULL ? sendbuf : tmp_buf);
-            mpi_errno =
+            coll_ret =
                 MPIDI_NM_mpi_reduce(buf, NULL, count, datatype,
                                     op, MPIR_Get_internode_rank(comm, root),
                                     comm->node_roots_comm, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(coll_ret, mpi_errno);
-            }
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
         } else {        /* I am on root's node. I have not participated in the earlier reduce. */
             if (comm->rank != root) {
                 /* I am not the root though. I don't have a valid recvbuf.
                  * Use tmp_buf as recvbuf. */
-                mpi_errno =
+                coll_ret =
                     MPIDI_NM_mpi_reduce(sendbuf, tmp_buf, count, datatype,
                                         op, MPIR_Get_internode_rank(comm, root),
                                         comm->node_roots_comm, errflag);
 
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(coll_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
                 /* point sendbuf at tmp_buf to make final intranode reduce easy */
                 sendbuf = tmp_buf;
             } else {
                 /* I am the root. in_place is automatically handled. */
-                mpi_errno =
+                coll_ret =
                     MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype,
                                         op, MPIR_Get_internode_rank(comm, root),
                                         comm->node_roots_comm, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag =
-                        MPIX_ERR_PROC_FAILED ==
-                        MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(coll_ret, mpi_errno);
-                }
+                MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
                 /* set sendbuf to MPI_IN_PLACE to make final intranode reduce easy. */
                 sendbuf = MPI_IN_PLACE;
@@ -815,22 +724,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
     /* do the intranode reduce on the root's node */
     if (comm->node_comm != NULL && MPIR_Get_intranode_rank(comm, root) != -1) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno =
+        coll_ret =
             MPIDI_SHM_mpi_reduce(sendbuf, recvbuf, count, datatype,
                                  op, MPIR_Get_intranode_rank(comm, root), comm->node_comm, errflag);
 #else
-        mpi_errno =
+        coll_ret =
             MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype,
                                 op, MPIR_Get_intranode_rank(comm, root), comm->node_comm, errflag);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(coll_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
   fn_exit:
@@ -872,7 +774,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
                                                                     MPIR_Comm * comm_ptr,
                                                                     MPIR_Errflag_t * errflag)
 {
-    int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS, coll_ret = MPI_SUCCESS;
     int num_nodes;
     int num_ranks = MPIR_Comm_size(comm_ptr);
     int node_comm_size = MPIR_Comm_size(comm_ptr->node_comm);
@@ -898,47 +800,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
 
     if (MPIDI_COMM(comm_ptr, multi_leads_comm) == NULL) {
         /* Create multi-leaders comm in a lazy manner */
-        mpi_errno = MPIDI_Comm_create_multi_leaders(comm_ptr);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        coll_ret = MPIDI_Comm_create_multi_leaders(comm_ptr);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
     /* Allocate the shared memory buffer per node, if it is not already done */
     if (MPIDI_COMM(comm_ptr, alltoall_comp_info->shm_addr) == NULL) {
-        mpi_errno =
+        coll_ret =
             MPIDU_shm_alloc(comm_ptr->node_comm,
                             node_comm_size * num_ranks * MPIR_CVAR_ALLTOALL_SHM_PER_RANK,
                             (void **) &MPIDI_COMM_ALLTOALL(comm_ptr, shm_addr));
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
     /* Barrier to make sure that the shm buffer can be reused after the previous call to Alltoall */
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_SHM_mpi_barrier(comm_ptr->node_comm, errflag);
+    coll_ret = MPIDI_SHM_mpi_barrier(comm_ptr->node_comm, errflag);
 #else
-    mpi_errno = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
+    coll_ret = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
 #endif
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
     /* Each rank on a node copy its data into shm buffer */
     /* Example - 2 ranks per node on 2 nodes. R0 and R1 on node 0, R2 and R3 on node 1.
@@ -948,41 +829,27 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
      * (0, 1, 8, 9, 4, 5, 12, 13). The node 1 shm_buf becomes (2, 3, 10, 11, 6, 7, 14, 15). */
     for (i = 0; i < node_comm_size; i++) {
         for (j = 0; j < num_nodes; j++) {
-            mpi_errno = MPIR_Localcopy((void *) ((char *) sendbuf +
-                                                 (i + j * node_comm_size) * type_size * sendcount),
-                                       sendcount, sendtype, (void *) ((char *)
-                                                                      MPIDI_COMM_ALLTOALL(comm_ptr,
-                                                                                          shm_addr)
-                                                                      + (p * node_comm_size +
-                                                                         my_node_comm_rank) *
-                                                                      type_size * sendcount),
-                                       sendcount, sendtype);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag =
-                    MPIX_ERR_PROC_FAILED ==
-                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-            }
+            coll_ret = MPIR_Localcopy((void *) ((char *) sendbuf +
+                                                (i + j * node_comm_size) * type_size * sendcount),
+                                      sendcount, sendtype, (void *) ((char *)
+                                                                     MPIDI_COMM_ALLTOALL(comm_ptr,
+                                                                                         shm_addr)
+                                                                     + (p * node_comm_size +
+                                                                        my_node_comm_rank) *
+                                                                     type_size * sendcount),
+                                      sendcount, sendtype);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
             p++;
         }
     }
 
     /* Barrier to make sure each rank has copied the data to the shm buf */
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_SHM_mpi_barrier(comm_ptr->node_comm, errflag);
+    coll_ret = MPIDI_SHM_mpi_barrier(comm_ptr->node_comm, errflag);
 #else
-    mpi_errno = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
+    coll_ret = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
 #endif
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
     /* Call internode alltoall on the shm_bufs and multi-leaders communicator */
     /* In the above example, first half on shm_bufs are used by the first multi-leader comm of R0
@@ -990,24 +857,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
      * comm. That is, for the alltoall, R1's buf is (4, 5, 12, 13) and R3's buf is (6, 7, 14, 15).
      * After Alltoall R1's buf is (4, 5, 6, 7) and R3's buf is (12, 13, 14, 15), which is the
      * expected result */
-    mpi_errno = MPIDI_NM_mpi_alltoall((void *) ((char *)
-                                                MPIDI_COMM_ALLTOALL(comm_ptr,
-                                                                    shm_addr) +
-                                                my_node_comm_rank * num_nodes * node_comm_size *
-                                                type_size * sendcount), node_comm_size * sendcount,
-                                      sendtype, recvbuf, sendcount * node_comm_size, sendtype,
-                                      MPIDI_COMM(comm_ptr, multi_leads_comm), errflag);
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    coll_ret = MPIDI_NM_mpi_alltoall((void *) ((char *)
+                                               MPIDI_COMM_ALLTOALL(comm_ptr,
+                                                                   shm_addr) +
+                                               my_node_comm_rank * num_nodes * node_comm_size *
+                                               type_size * sendcount), node_comm_size * sendcount,
+                                     sendtype, recvbuf, sendcount * node_comm_size, sendtype,
+                                     MPIDI_COMM(comm_ptr, multi_leads_comm), errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
   fn_exit:
-    return mpi_errno_ret;
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_beta(const void *sendbuf,
@@ -1092,7 +952,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
                                                                      MPIR_Comm * comm_ptr,
                                                                      MPIR_Errflag_t * errflag)
 {
-    int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS, coll_ret = MPI_SUCCESS;
     int node_comm_size = MPIR_Comm_size(comm_ptr->node_comm);
     int my_node_comm_rank = MPIR_Comm_rank(comm_ptr->node_comm);
     MPI_Aint type_size, extent, true_extent, lb;
@@ -1133,86 +993,51 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
 
     if (MPIDI_COMM(comm_ptr, multi_leads_comm) == NULL) {
         /* Create multi-leaders comm in a lazy manner */
-        mpi_errno = MPIDI_Comm_create_multi_leaders(comm_ptr);
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        coll_ret = MPIDI_Comm_create_multi_leaders(comm_ptr);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
     /* Allocate the shared memory buffer per node, if it is not already done */
     if (MPIDI_COMM(comm_ptr, allgather_comp_info->shm_addr) == NULL) {
-        mpi_errno =
+        coll_ret =
             MPIDU_shm_alloc(comm_ptr->node_comm, node_comm_size * MPIR_CVAR_ALLGATHER_SHM_PER_RANK,
                             (void **) &MPIDI_COMM_ALLGATHER(comm_ptr, shm_addr));
-        if (mpi_errno) {
-            /* for communication errors, just record the error but continue */
-            *errflag =
-                MPIX_ERR_PROC_FAILED ==
-                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-        }
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
     /* Barrier to make sure that the shm buffer can be reused after the previous call to Allgather */
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_SHM_mpi_barrier(comm_ptr->node_comm, errflag);
+    coll_ret = MPIDI_SHM_mpi_barrier(comm_ptr->node_comm, errflag);
 #else
-    mpi_errno = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
+    coll_ret = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
 #endif
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
     /* Copy data to shm buffers */
-    mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
-                               (char *) MPIDI_COMM_ALLGATHER(comm_ptr,
-                                                             shm_addr) + my_node_comm_rank * offset,
-                               recvcount, recvtype);
+    coll_ret = MPIR_Localcopy(sendbuf, sendcount, sendtype,
+                              (char *) MPIDI_COMM_ALLGATHER(comm_ptr,
+                                                            shm_addr) + my_node_comm_rank * offset,
+                              recvcount, recvtype);
 
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
     /* Barrier to make sure all the ranks in a node_comm copied data to shm buffer */
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_SHM_mpi_barrier(comm_ptr->node_comm, errflag);
+    coll_ret = MPIDI_SHM_mpi_barrier(comm_ptr->node_comm, errflag);
 #else
-    mpi_errno = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
+    coll_ret = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag);
 #endif
 
     /* Perform inter-node allgather on the multi leader comms */
-    mpi_errno =
+    coll_ret =
         MPIDI_NM_mpi_allgather((char *) MPIDI_COMM_ALLGATHER(comm_ptr, shm_addr),
                                sendcount * node_comm_size, sendtype,
                                recvbuf, recvcount * node_comm_size, recvtype,
                                MPIDI_COMM(comm_ptr, multi_leads_comm), errflag);
-    if (mpi_errno) {
-        /* for communication errors, just record the error but continue */
-        *errflag =
-            MPIX_ERR_PROC_FAILED ==
-            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-    }
+    MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
   fn_exit:
-    return mpi_errno_ret;
+    return mpi_errno;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_beta(const void *sendbuf,
@@ -1445,18 +1270,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret =
             MPIDI_SHM_mpi_scan(sendbuf, recvbuf, count, datatype, op, comm_ptr->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
         coll_ret =
             MPIDI_NM_mpi_scan(sendbuf, recvbuf, count, datatype, op, comm_ptr->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     } else if (sendbuf != MPI_IN_PLACE) {
         coll_ret = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
     /* get result from local node's last processor which
      * contains the reduce result of the whole node. Name it as
@@ -1466,15 +1288,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
         coll_ret = MPIC_Recv(localfulldata, count, datatype,
                              comm_ptr->node_comm->local_size - 1, MPIR_SCAN_TAG,
                              comm_ptr->node_comm, &status, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     } else if (comm_ptr->node_roots_comm == NULL &&
                comm_ptr->node_comm != NULL &&
                MPIR_Get_intranode_rank(comm_ptr, rank) == comm_ptr->node_comm->local_size - 1) {
         coll_ret = MPIC_Send(recvbuf, count, datatype,
                              0, MPIR_SCAN_TAG, comm_ptr->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     } else if (comm_ptr->node_roots_comm != NULL) {
         localfulldata = recvbuf;
     }
@@ -1486,23 +1306,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
         coll_ret =
             MPIDI_NM_mpi_scan(localfulldata, prefulldata, count, datatype,
                               op, comm_ptr->node_roots_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 
         if (MPIR_Get_internode_rank(comm_ptr, rank) != comm_ptr->node_roots_comm->local_size - 1) {
             coll_ret = MPIC_Send(prefulldata, count, datatype,
                                  MPIR_Get_internode_rank(comm_ptr, rank) + 1,
                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, errflag);
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
         }
         if (MPIR_Get_internode_rank(comm_ptr, rank) != 0) {
             coll_ret = MPIC_Recv(tempbuf, count, datatype,
                                  MPIR_Get_internode_rank(comm_ptr, rank) - 1,
                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, &status, errflag);
             noneed = 0;
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
         }
     }
 
@@ -1515,12 +1332,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
     if (comm_ptr->node_comm != NULL) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         coll_ret = MPIDI_SHM_mpi_bcast(&noneed, 1, MPI_INT, 0, comm_ptr->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
         coll_ret = MPIDI_NM_mpi_bcast(&noneed, 1, MPI_INT, 0, comm_ptr->node_comm, errflag);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
 
@@ -1529,19 +1344,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
 #ifndef MPIDI_CH4_DIRECT_NETMOD
             coll_ret =
                 MPIDI_SHM_mpi_bcast(tempbuf, count, datatype, 0, comm_ptr->node_comm, errflag);
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #else
             coll_ret =
                 MPIDI_NM_mpi_bcast(tempbuf, count, datatype, 0, comm_ptr->node_comm, errflag);
-            if (coll_ret)
-                MPIR_ERR_ADD(mpi_errno, coll_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
         }
 
         coll_ret = MPIR_Reduce_local(tempbuf, recvbuf, count, datatype, op);
-        if (coll_ret)
-            MPIR_ERR_ADD(mpi_errno, coll_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(coll_ret, *errflag, mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -391,7 +391,6 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
     int local_avtid = 0, remote_avtid = 0;
     int local_size_send = 0, remote_size_recv = 0;
     int cts_tag = 0;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int pure_intracomm = 1;
     int local_size = 0;
     uint64_t *local_gpids = NULL;
@@ -442,7 +441,8 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
         mpi_errno = MPIC_Sendrecv(&local_size_send, 1, MPI_INT,
                                   remote_leader, cts_tag,
                                   &remote_size_recv, 1, MPI_INT,
-                                  remote_leader, cts_tag, peer_comm, MPI_STATUS_IGNORE, &errflag);
+                                  remote_leader, cts_tag, peer_comm, MPI_STATUS_IGNORE,
+                                  MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
         if (remote_size_recv & MPIDI_DYNPROC_MASK)
@@ -479,7 +479,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                                       remote_leader, cts_tag,
                                       remote_upid_size, *remote_size, MPI_INT,
                                       remote_leader, cts_tag,
-                                      peer_comm, MPI_STATUS_IGNORE, &errflag);
+                                      peer_comm, MPI_STATUS_IGNORE, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
             upid_send_size = 0;
             for (i = 0; i < local_size; i++)
@@ -493,7 +493,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                                       remote_leader, cts_tag,
                                       remote_upids, upid_recv_size, MPI_BYTE,
                                       remote_leader, cts_tag,
-                                      peer_comm, MPI_STATUS_IGNORE, &errflag);
+                                      peer_comm, MPI_STATUS_IGNORE, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
 
             /* Stage 1.2 convert remote UPID to GPID and get GPID for local group */
@@ -504,7 +504,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                                       remote_leader, cts_tag,
                                       *remote_gpids, *remote_size, MPI_UINT64_T,
                                       remote_leader, cts_tag,
-                                      peer_comm, MPI_STATUS_IGNORE, &errflag);
+                                      peer_comm, MPI_STATUS_IGNORE, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
         }
         /* Stage 1.3 check if local/remote groups are disjoint */
@@ -594,7 +594,6 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
     int i;
     int upid_recv_size = 0;
     int map_info[4];
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int *_remote_upid_size = NULL;
     char *_remote_upids = NULL;
 
@@ -614,23 +613,23 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
         map_info[2] = *is_low_group;
         map_info[3] = pure_intracomm;
         mpi_errno =
-            MPIR_Bcast_allcomm_auto(map_info, 4, MPI_INT, local_leader, local_comm, &errflag);
+            MPIR_Bcast_allcomm_auto(map_info, 4, MPI_INT, local_leader, local_comm, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
         if (!pure_intracomm) {
             mpi_errno = MPIR_Bcast_allcomm_auto(remote_upid_size, *remote_size, MPI_INT,
-                                                local_leader, local_comm, &errflag);
+                                                local_leader, local_comm, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIR_Bcast_allcomm_auto(remote_upids, upid_recv_size, MPI_BYTE,
-                                                local_leader, local_comm, &errflag);
+                                                local_leader, local_comm, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno = MPIR_Bcast_allcomm_auto(*remote_gpids, *remote_size, MPI_UINT64_T,
-                                                local_leader, local_comm, &errflag);
+                                                local_leader, local_comm, MPIR_ERR_NONE);
         }
     } else {
         mpi_errno =
-            MPIR_Bcast_allcomm_auto(map_info, 4, MPI_INT, local_leader, local_comm, &errflag);
+            MPIR_Bcast_allcomm_auto(map_info, 4, MPI_INT, local_leader, local_comm, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
         *remote_size = map_info[0];
         upid_recv_size = map_info[1];
@@ -643,18 +642,18 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
             MPIR_CHKLMEM_MALLOC(_remote_upid_size, int *, (*remote_size) * sizeof(int),
                                 mpi_errno, "_remote_upid_size", MPL_MEM_COMM);
             mpi_errno = MPIR_Bcast_allcomm_auto(_remote_upid_size, *remote_size, MPI_INT,
-                                                local_leader, local_comm, &errflag);
+                                                local_leader, local_comm, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_CHKLMEM_MALLOC(_remote_upids, char *, upid_recv_size * sizeof(char),
                                 mpi_errno, "_remote_upids", MPL_MEM_COMM);
             mpi_errno = MPIR_Bcast_allcomm_auto(_remote_upids, upid_recv_size, MPI_BYTE,
-                                                local_leader, local_comm, &errflag);
+                                                local_leader, local_comm, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
 
             MPIDIU_upids_to_gpids(*remote_size, _remote_upid_size, _remote_upids, *remote_gpids);
         } else {
             mpi_errno = MPIR_Bcast_allcomm_auto(*remote_gpids, *remote_size, MPI_UINT64_T,
-                                                local_leader, local_comm, &errflag);
+                                                local_leader, local_comm, MPIR_ERR_NONE);
         }
     }
 

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -79,9 +79,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend_coll(const void *buf,
                                              int rank,
                                              int tag,
                                              MPIR_Comm * comm, int attr,
-                                             MPIR_Request ** request, MPIR_Errflag_t * errflag)
+                                             MPIR_Request ** request, MPIR_Errflag_t errflag)
 {
-    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, *errflag);
+    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
     return MPID_Isend(buf, count, datatype, rank, tag, comm, attr, request);
 }
 
@@ -100,7 +100,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send_coll(const void *buf,
                                             int rank,
                                             int tag,
                                             MPIR_Comm * comm, int attr,
-                                            MPIR_Request ** request, MPIR_Errflag_t * errflag)
+                                            MPIR_Request ** request, MPIR_Errflag_t errflag)
 {
     return MPID_Isend_coll(buf, count, datatype, rank, tag, comm, attr, request, errflag);
 }

--- a/src/mpid/ch4/src/ch4_spawn.c
+++ b/src/mpid/ch4/src/ch4_spawn.c
@@ -73,8 +73,7 @@ int MPID_Comm_spawn_multiple(int count, char *commands[], char **argvs[], const 
         bcast_ints[0] = total_num_processes;
         bcast_ints[1] = spawn_error;
     }
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-    mpi_errno = MPIR_Bcast(bcast_ints, 2, MPI_INT, root, comm_ptr, &errflag);
+    mpi_errno = MPIR_Bcast(bcast_ints, 2, MPI_INT, root, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
     if (comm_ptr->rank != root) {
         total_num_processes = bcast_ints[0];
@@ -88,7 +87,7 @@ int MPID_Comm_spawn_multiple(int count, char *commands[], char **argvs[], const 
     int should_accept = 1;
     if (errcodes != MPI_ERRCODES_IGNORE) {
         mpi_errno =
-            MPIR_Bcast(pmi_errcodes, total_num_processes, MPI_INT, root, comm_ptr, &errflag);
+            MPIR_Bcast(pmi_errcodes, total_num_processes, MPI_INT, root, comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
         for (int i = 0; i < total_num_processes; i++) {
@@ -368,7 +367,6 @@ static int dynamic_intercomm_create(const char *port_name, MPIR_Info * info, int
 
     MPIR_Comm *peer_intercomm = NULL;
     int tag;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int bcast_ints[2];          /* used to bcast tag and errno */
     if (comm_ptr->rank == root) {
         /* NOTE: do not goto fn_fail on error, or it will leave children hanging */
@@ -394,12 +392,12 @@ static int dynamic_intercomm_create(const char *port_name, MPIR_Info * info, int
       bcast_tag_and_errno:
         bcast_ints[0] = tag;
         bcast_ints[1] = mpi_errno;
-        mpi_errno = MPIR_Bcast_allcomm_auto(bcast_ints, 2, MPI_INT, root, comm_ptr, &errflag);
+        mpi_errno = MPIR_Bcast_allcomm_auto(bcast_ints, 2, MPI_INT, root, comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = bcast_ints[1];
         MPIR_ERR_CHECK(mpi_errno);
     } else {
-        mpi_errno = MPIR_Bcast_allcomm_auto(bcast_ints, 2, MPI_INT, root, comm_ptr, &errflag);
+        mpi_errno = MPIR_Bcast_allcomm_auto(bcast_ints, 2, MPI_INT, root, comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
         if (bcast_ints[1]) {
             /* errno from root cannot be directly returned */

--- a/src/mpid/ch4/src/mpidig_win.h
+++ b/src/mpid/ch4/src/mpidig_win.h
@@ -482,7 +482,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int need_unlock = 0;
     MPIR_FUNC_ENTER;
 
@@ -523,7 +522,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
      * the VCI lock internally. */
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
     need_unlock = 0;
-    mpi_errno = MPIR_Barrier(win->comm_ptr, &errflag);
+    mpi_errno = MPIR_Barrier(win->comm_ptr, MPIR_ERR_NONE);
 
   fn_exit:
     if (need_unlock) {

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -105,9 +105,8 @@ int MPIDU_bc_allgather(MPIR_Comm * allgather_comm, void *bc, int bc_len, int sam
     /* a 64k memcpy is small (< 1ms), MPI_IN_PLACE not critical here */
     void *recv_buf = segment + local_size * recv_bc_len;
     if (rank == node_root) {
-        MPIR_Errflag_t errflag = MPIR_ERR_NONE;
         MPIR_Allgatherv_fallback(segment, local_size * recv_bc_len, MPI_BYTE, recv_buf,
-                                 recv_cnts, recv_offs, MPI_BYTE, allgather_comm, &errflag);
+                                 recv_cnts, recv_offs, MPI_BYTE, allgather_comm, MPIR_ERR_NONE);
 
     }
 

--- a/src/mpid/common/hcoll/hcoll.h
+++ b/src/mpid/common/hcoll/hcoll.h
@@ -23,21 +23,21 @@ int hcoll_initialize(void);
 int hcoll_comm_create(MPIR_Comm * comm, void *param);
 int hcoll_comm_destroy(MPIR_Comm * comm, void *param);
 
-int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
 int hcoll_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+                MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
 int hcoll_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                 MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+                 MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
 int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
-                    MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+                    MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
 int hcoll_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
 int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
-                   MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+                   MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
 int hcoll_Alltoallv(const void *sbuf, const MPI_Aint * scounts, const MPI_Aint * sdispls,
                     MPI_Datatype sdtype, void *rbuf, const MPI_Aint * rcounts,
                     const MPI_Aint * rdispls, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * err);
+                    MPIR_Errflag_t err);
 
 int hcoll_do_progress(int *made_progress);
 

--- a/src/mpid/common/hcoll/hcoll_ops.c
+++ b/src/mpid/common/hcoll/hcoll_ops.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 #include "hcoll.h"
 
-int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t err)
 {
     int rc = -1;
     MPI_Comm comm = comm_ptr->handle;
@@ -22,7 +22,7 @@ int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 }
 
 int hcoll_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+                MPIR_Comm * comm_ptr, MPIR_Errflag_t err)
 {
     dte_data_representation_t dtype;
     int rc = -1;
@@ -49,7 +49,7 @@ int hcoll_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
 }
 
 int hcoll_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                 MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+                 MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t err)
 {
     dte_data_representation_t dtype;
     hcoll_dte_op_t *Op;
@@ -80,7 +80,7 @@ int hcoll_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatyp
 }
 
 int hcoll_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t err)
 {
     dte_data_representation_t Dtype;
     hcoll_dte_op_t *Op;
@@ -111,7 +111,7 @@ int hcoll_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Data
 
 int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
                     void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * err)
+                    MPIR_Errflag_t err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -145,7 +145,7 @@ int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
 
 int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
                    void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                   MPIR_Errflag_t * err)
+                   MPIR_Errflag_t err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -180,7 +180,7 @@ int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
 int hcoll_Alltoallv(const void *sbuf, const MPI_Aint * scounts, const MPI_Aint * sdispls,
                     MPI_Datatype sdtype, void *rbuf, const MPI_Aint * rcounts,
                     const MPI_Aint * rdispls, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * err)
+                    MPIR_Errflag_t err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -170,7 +170,7 @@ static int send_nb(dte_data_representation_t data,
     dtype = MPI_CHAR;
     request = NULL;
     MPIR_Errflag_t err = MPIR_ERR_NONE;
-    mpi_errno = MPIC_Isend(buffer, size, dtype, ec_h.rank, tag, comm, &request, &err);
+    mpi_errno = MPIC_Isend(buffer, size, dtype, ec_h.rank, tag, comm, &request, err);
     MPIR_Assert(request);
     req->data = (void *) request;
     req->status = HCOLRTE_REQUEST_ACTIVE;

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -227,16 +227,16 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
                  * during realloc of entries, so this is easier */
                 ret_errno = MPIC_Isend(e->u.send.buf, *e->u.send.count_p, e->u.send.datatype,
                                        e->u.send.dest, s->tag, comm, &e->u.send.sreq,
-                                       &r->u.nbc.errflag);
+                                       r->u.nbc.errflag);
             } else {
                 if (e->u.send.is_sync) {
                     ret_errno = MPIC_Issend(e->u.send.buf, e->u.send.count, e->u.send.datatype,
                                             e->u.send.dest, s->tag, comm, &e->u.send.sreq,
-                                            &r->u.nbc.errflag);
+                                            r->u.nbc.errflag);
                 } else {
                     ret_errno = MPIC_Isend(e->u.send.buf, e->u.send.count, e->u.send.datatype,
                                            e->u.send.dest, s->tag, comm, &e->u.send.sreq,
-                                           &r->u.nbc.errflag);
+                                           r->u.nbc.errflag);
                 }
             }
             /* Check if the error is actually fatal to the NBC or we can continue. */

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -1097,14 +1097,14 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
                         MPL_DBG_MSG_FMT(MPIR_DBG_COMM, VERBOSE,
                                         (MPL_DBG_FDEST, "completed RECV entry %d, rreq=%p\n",
                                          (int) i, e->u.recv.rreq));
-                        MPIR_Process_status(&e->u.recv.rreq->status, &s->req->u.nbc.errflag);
+                        int err = MPIR_Process_status(&e->u.recv.rreq->status);
                         if (e->u.recv.status != MPI_STATUS_IGNORE) {
                             MPI_Aint recvd;
                             e->u.recv.status->MPI_ERROR = e->u.recv.rreq->status.MPI_ERROR;
                             MPIR_Get_count_impl(&e->u.recv.rreq->status, MPI_BYTE, &recvd);
                             MPIR_STATUS_SET_COUNT(*(e->u.recv.status), recvd);
                         }
-                        if (s->req->u.nbc.errflag != MPIR_ERR_NONE)
+                        if (err)
                             e->status = MPIDU_SCHED_ENTRY_STATUS_FAILED;
                         else
                             e->status = MPIDU_SCHED_ENTRY_STATUS_COMPLETE;


### PR DESCRIPTION
## Pull Request Description
First, the collective parameter errflag does not need be in/out pointer, because the return is always in `mpi_errno`.

Then we can easily embed errflag into an integer attribute parameter. With attribute, we can easily extend to pass more flag information to lower devices. For example, we can annotate buffer attributes or tell netmod not to use inject.


Note: some of the commits need be squashed before merge.


[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
