### PR TITLE
hydra: fix undedfined behavior in seed

### DIFF
--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -446,16 +446,12 @@ static HYD_status gen_kvsname(char kvsname[], int pgid)
     char hostname[MAX_HOSTNAME_LEN - 40];       /* Remove space taken up by the integers and other
                                                  * characters below. */
     unsigned int seed;
-    MPL_time_t tv;
-    double secs;
     int rnd;
 
     if (gethostname(hostname, MAX_HOSTNAME_LEN - 40) < 0)
         HYDU_ERR_SETANDJUMP(status, HYD_SOCK_ERROR, "unable to get local hostname\n");
 
-    MPL_wtime(&tv);
-    MPL_wtime_todouble(&tv, &secs);
-    seed = (unsigned int) (secs * 1e6);
+    seed = (unsigned int) time(NULL);
     srand(seed);
     rnd = rand();
 


### PR DESCRIPTION
## Pull Request Description

The undefined behavior sanitizer reports the following error when running mpiexec:

```bash
mpiexec/pmiserv_utils.c:458:12: runtime error: 1.66985e+15 is outside the range of representable values of type 'unsigned int'
```

This fixes the undefined behavior as reported by the sanitizer: the `time()` function replaces now the seed computation.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
