### PR TITLE
doc/wiki: update homebrew doc for gnu-indent

### DIFF
--- a/doc/wiki/source_code/Code_Formatting_And_Cleanup_Script.md
+++ b/doc/wiki/source_code/Code_Formatting_And_Cleanup_Script.md
@@ -72,13 +72,10 @@ distribution is still using version 2.2.11 we require this version in
 
 For certain distribution, in particular, Mac using Homebrew, a custom
 version need be installed. One can either install from source tar ball,
-or using a custom brew recipe.
+or using [a custom brew recipe](https://gist.github.com/thomasgillis/187ea639e7535f969b276b5b1f2e812f#file-gnu-indent-rb).
 
-To install from \`indent-2.2.12\` tarball, simply do \`./configure &&
+To install from \`indent-2.2.11\` tarball, simply do \`./configure &&
 make && make install\`. On Mac, it will complain at "missing texi2html".
 One can bypass that by manually edit \`Makefile\` by search \`^SUBDIRS\`
 and delete the \`doc\` target.
 
-Alternatively, there is patch to homebrew that one can try:
-
-<https://gist.github.com/wesbland/501063f151c1eb815d8001abf2285cbe>


### PR DESCRIPTION
## Pull Request Description

clarify the installation procedure for `gnu-indent` v2.2.11 with homebrew:
- update a typo in the version number in the doc
- add a link to an example of a custom formula + installation commands


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
