### PR TITLE
mpid: remove fail_flag from shm_alloc

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_win.c
+++ b/src/mpid/ch4/shm/posix/posix_win.c
@@ -155,7 +155,6 @@ int MPIDI_POSIX_mpi_win_allocate_hook(MPIR_Win * win)
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_win_t *posix_win ATTRIBUTE((unused)) = NULL;
     MPIR_Comm *shm_comm_ptr = win->comm_ptr->node_comm;
-    bool mapfail_flag = false;
     MPIR_FUNC_ENTER;
 
     posix_win_init_common(win);
@@ -168,12 +167,12 @@ int MPIDI_POSIX_mpi_win_allocate_hook(MPIR_Win * win)
     posix_win = &win->dev.shm.posix;
 
     /* allocate interprocess mutex for RMA atomics over shared memory */
-    mpi_errno =
-        MPIDU_shm_alloc(shm_comm_ptr, sizeof(MPL_proc_mutex_t), (void **) &posix_win->shm_mutex_ptr,
-                        &mapfail_flag);
+    int err;
+    err = MPIDU_shm_alloc(shm_comm_ptr, sizeof(MPL_proc_mutex_t),
+                          (void **) &posix_win->shm_mutex_ptr);
 
     /* disable SHM_ALLOCATED optimization if mutex allocation fails */
-    if (!mapfail_flag) {
+    if (!err) {
         if (shm_comm_ptr->rank == 0)
             MPIDI_POSIX_RMA_MUTEX_INIT(posix_win->shm_mutex_ptr);
         MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_SHM_ALLOCATED;
@@ -193,7 +192,6 @@ int MPIDI_POSIX_mpi_win_allocate_shared_hook(MPIR_Win * win)
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_win_t *posix_win = NULL;
     MPIR_Comm *shm_comm_ptr = win->comm_ptr->node_comm;
-    bool mapfail_flag = false;
     MPIR_FUNC_ENTER;
 
     posix_win_init_common(win);
@@ -206,12 +204,12 @@ int MPIDI_POSIX_mpi_win_allocate_shared_hook(MPIR_Win * win)
     posix_win = &win->dev.shm.posix;
 
     /* allocate interprocess mutex for RMA atomics over shared memory */
-    mpi_errno =
-        MPIDU_shm_alloc(win->comm_ptr, sizeof(MPL_proc_mutex_t),
-                        (void **) &posix_win->shm_mutex_ptr, &mapfail_flag);
+    int err;
+    err = MPIDU_shm_alloc(win->comm_ptr, sizeof(MPL_proc_mutex_t),
+                          (void **) &posix_win->shm_mutex_ptr);
 
     /* disable SHM_ALLOCATED optimization if mutex allocation fails */
-    if (!mapfail_flag) {
+    if (!err) {
         if (win->comm_ptr->rank == 0)
             MPIDI_POSIX_RMA_MUTEX_INIT(posix_win->shm_mutex_ptr);
         MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_SHM_ALLOCATED;
@@ -260,7 +258,6 @@ int MPIDI_POSIX_mpi_win_detach_hook(MPIR_Win * win ATTRIBUTE((unused)),
 int MPIDI_POSIX_shm_win_init_hook(MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
-    bool mapfail_flag = false;
     MPIDI_POSIX_win_t *posix_win ATTRIBUTE((unused)) = NULL;
     MPIR_Comm *shm_comm_ptr = win->comm_ptr->node_comm;
     MPIR_FUNC_ENTER;
@@ -274,12 +271,11 @@ int MPIDI_POSIX_shm_win_init_hook(MPIR_Win * win)
         goto fn_exit;
 
     /* allocate interprocess mutex for RMA atomics over shared memory */
-    mpi_errno =
-        MPIDU_shm_alloc(shm_comm_ptr, sizeof(MPL_proc_mutex_t), (void **) &posix_win->shm_mutex_ptr,
-                        &mapfail_flag);
-    MPIR_ERR_CHECK(mpi_errno);
+    int err;
+    err = MPIDU_shm_alloc(shm_comm_ptr, sizeof(MPL_proc_mutex_t),
+                          (void **) &posix_win->shm_mutex_ptr);
 
-    if (!mapfail_flag) {
+    if (!err) {
         if (shm_comm_ptr->rank == 0)
             MPIDI_POSIX_RMA_MUTEX_INIT(posix_win->shm_mutex_ptr);
 

--- a/src/mpid/ch4/shm/posix/release_gather/nb_release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_release_gather.c
@@ -29,7 +29,6 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
     size_t ibcast_flags_shm_size = 0, ireduce_flags_shm_size = 0;
     const long pg_sz = sysconf(_SC_PAGESIZE);
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-    bool mapfail_flag = false;
     int topotree_fail[2] = { -1, -1 };  /* -1 means topo trees not created due to reasons like not
                                          * specifying binding, no hwloc etc. 0 means topo trees were
                                          * created successfully. 1 means topo trees were created
@@ -205,12 +204,8 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
                             MPI_ERR_OTHER, "**nomem");
 
         mpi_errno = MPIDU_shm_alloc(comm_ptr, ibcast_flags_shm_size,
-                                    (void **) &(nb_release_gather_info_ptr->ibcast_flags_addr),
-                                    &mapfail_flag);
-        if (mpi_errno || mapfail_flag) {
-            /* for communication errors, just record the error but continue */
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
+                                    (void **) &(nb_release_gather_info_ptr->ibcast_flags_addr));
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         /* Calculate gather and release flag address and initialize to the gather and release states */
         for (i = 0; i < MPIR_CVAR_BCAST_INTRANODE_NUM_CELLS; i++) {
             MPL_atomic_release_store_uint64(MPIDI_POSIX_RELEASE_GATHER_NB_IBCAST_GATHER_FLAG_ADDR
@@ -221,12 +216,8 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
         }
         /* Allocate the shared memory for ibcast buffer */
         mpi_errno = MPIDU_shm_alloc(comm_ptr, MPIR_CVAR_BCAST_INTRANODE_BUFFER_TOTAL_SIZE,
-                                    (void **) &(NB_RELEASE_GATHER_FIELD(comm_ptr, bcast_buf_addr)),
-                                    &mapfail_flag);
-        if (mpi_errno || mapfail_flag) {
-            /* for communication errors, just record the error but continue */
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
+                                    (void **) &(NB_RELEASE_GATHER_FIELD(comm_ptr, bcast_buf_addr)));
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
     }
 
     if (initialize_ireduce_buf) {
@@ -242,12 +233,8 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
             MPL_malloc(num_ranks * sizeof(void *), MPL_MEM_COLL);
 
         mpi_errno = MPIDU_shm_alloc(comm_ptr, ireduce_flags_shm_size,
-                                    (void **) &(nb_release_gather_info_ptr->ireduce_flags_addr),
-                                    &mapfail_flag);
-        if (mpi_errno || mapfail_flag) {
-            /* for communication errors, just record the error but continue */
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
+                                    (void **) &(nb_release_gather_info_ptr->ireduce_flags_addr));
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
         for (i = 0; i < MPIR_CVAR_REDUCE_INTRANODE_NUM_CELLS; i++) {
             MPL_atomic_release_store_uint64(MPIDI_POSIX_RELEASE_GATHER_NB_IREDUCE_GATHER_FLAG_ADDR
                                             (rank, i, num_ranks), -1);
@@ -256,14 +243,10 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
             nb_release_gather_info_ptr->ireduce_last_seq_no_completed[i] = -1;
         }
         /* Allocate the shared memory for ireduce buffer */
-        mpi_errno = MPIDU_shm_alloc(comm_ptr,
-                                    num_ranks * MPIR_CVAR_REDUCE_INTRANODE_BUFFER_TOTAL_SIZE,
-                                    (void **) &(NB_RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr)),
-                                    &mapfail_flag);
-        if (mpi_errno || mapfail_flag) {
-            /* for communication errors, just record the error but continue */
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
-        }
+        mpi_errno =
+            MPIDU_shm_alloc(comm_ptr, num_ranks * MPIR_CVAR_REDUCE_INTRANODE_BUFFER_TOTAL_SIZE,
+                            (void **) &(NB_RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr)));
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
 
         /* Store address of each of the children's reduce buffer */
         char *addr;

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -184,7 +184,6 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
     size_t flags_shm_size = 0;
     const long pg_sz = sysconf(_SC_PAGESIZE);
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-    bool mapfail_flag = false;
     int topotree_fail[2] = { -1, -1 };  /* -1 means topo trees not created due to reasons like not
                                          * specifying binding, no hwloc etc. 0 means topo trees were
                                          * created successfully. 1 means topo trees were created
@@ -367,8 +366,8 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
 
         mpi_errno =
             MPIDU_shm_alloc(comm_ptr, flags_shm_size,
-                            (void **) &(release_gather_info_ptr->flags_addr), &mapfail_flag);
-        if (mpi_errno || mapfail_flag) {
+                            (void **) &(release_gather_info_ptr->flags_addr));
+        if (mpi_errno) {
             /* for communication errors, just record the error but continue */
             MPIR_ERR_ADD(mpi_errno_ret, MPIR_ERR_OTHER);
         }
@@ -399,9 +398,8 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
         /* Allocate the shared memory for bcast buffer */
         mpi_errno =
             MPIDU_shm_alloc(comm_ptr, RELEASE_GATHER_FIELD(comm_ptr, bcast_shm_size),
-                            (void **) &(RELEASE_GATHER_FIELD(comm_ptr, bcast_buf_addr)),
-                            &mapfail_flag);
-        if (mapfail_flag) {
+                            (void **) &(RELEASE_GATHER_FIELD(comm_ptr, bcast_buf_addr)));
+        if (mpi_errno) {
             MPIR_ERR_ADD(mpi_errno_ret, MPIR_ERR_OTHER);
         }
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag);
@@ -419,9 +417,8 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
 
         mpi_errno =
             MPIDU_shm_alloc(comm_ptr, num_ranks * RELEASE_GATHER_FIELD(comm_ptr, reduce_shm_size),
-                            (void **) &(RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr)),
-                            &mapfail_flag);
-        if (mapfail_flag) {
+                            (void **) &(RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr)));
+        if (mpi_errno) {
             /* for communication errors, just record the error but continue */
             MPIR_ERR_ADD(mpi_errno_ret, MPIR_ERR_OTHER);
         }

--- a/src/mpid/ch4/shm/src/topotree.c
+++ b/src/mpid/ch4/shm/src/topotree.c
@@ -477,7 +477,6 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
     int *package_ctr = NULL;
     int topo_depth = 0;
     int package_level = 0, i, max_ranks_per_package = 0;
-    bool mapfail_flag = false;
 
     MPIR_FUNC_ENTER;
 
@@ -490,11 +489,8 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
     shm_size = sizeof(int) * topo_depth * num_ranks + sizeof(int) * 5 * num_ranks;
 
     /* STEP 1. Create shared memory region for exchanging topology information (root only) */
-    mpi_errno = MPIDU_shm_alloc(comm_ptr, shm_size, (void **) &shared_region, &mapfail_flag);
-    if (mpi_errno || mapfail_flag) {
-        /* for communication errors, just record the error but continue */
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
-    }
+    mpi_errno = MPIDU_shm_alloc(comm_ptr, shm_size, (void **) &shared_region);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, *errflag);
 
     /* STEP 2. Every process fills affinity information in shared_region */
     int (*shared_region_ptr)[topo_depth] = (int (*)[topo_depth]) shared_region;

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -416,7 +416,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
                                                                      MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS, coll_ret = MPI_SUCCESS;
-    bool mapfail_flag = false;
     char *shm_addr;
     int my_leader_rank = -1, iter;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
@@ -464,9 +463,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_delta(const void 
         MPIDI_COMM(comm_ptr, shm_size_per_lead) = shm_size_per_lead;
 
         coll_ret = MPIDU_shm_alloc(comm_ptr->node_comm, num_leads * shm_size_per_lead,
-                                   (void **) &MPIDI_COMM_ALLREDUCE(comm_ptr, shm_addr),
-                                   &mapfail_flag);
-        if (coll_ret || mapfail_flag)
+                                   (void **) &MPIDI_COMM_ALLREDUCE(comm_ptr, shm_addr));
+        if (coll_ret)
             MPIR_ERR_ADD(mpi_errno, coll_ret);
     }
 
@@ -881,7 +879,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
     int my_node_comm_rank = MPIR_Comm_rank(comm_ptr->node_comm);
     int i, j, p = 0;
     MPI_Aint type_size;
-    bool mapfail_flag = false;
 
     if (sendcount == 0)
         goto fn_exit;
@@ -917,8 +914,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
         mpi_errno =
             MPIDU_shm_alloc(comm_ptr->node_comm,
                             node_comm_size * num_ranks * MPIR_CVAR_ALLTOALL_SHM_PER_RANK,
-                            (void **) &MPIDI_COMM_ALLTOALL(comm_ptr, shm_addr), &mapfail_flag);
-        if (mpi_errno || mapfail_flag) {
+                            (void **) &MPIDI_COMM_ALLTOALL(comm_ptr, shm_addr));
+        if (mpi_errno) {
             /* for communication errors, just record the error but continue */
             *errflag =
                 MPIX_ERR_PROC_FAILED ==
@@ -1100,7 +1097,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
     int my_node_comm_rank = MPIR_Comm_rank(comm_ptr->node_comm);
     MPI_Aint type_size, extent, true_extent, lb;
     int is_contig, offset;
-    bool mapfail_flag = false;
 
     if (sendcount < 1 && sendbuf != MPI_IN_PLACE)
         goto fn_exit;
@@ -1152,8 +1148,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
     if (MPIDI_COMM(comm_ptr, allgather_comp_info->shm_addr) == NULL) {
         mpi_errno =
             MPIDU_shm_alloc(comm_ptr->node_comm, node_comm_size * MPIR_CVAR_ALLGATHER_SHM_PER_RANK,
-                            (void **) &MPIDI_COMM_ALLGATHER(comm_ptr, shm_addr), &mapfail_flag);
-        if (mpi_errno || mapfail_flag) {
+                            (void **) &MPIDI_COMM_ALLGATHER(comm_ptr, shm_addr));
+        if (mpi_errno) {
             /* for communication errors, just record the error but continue */
             *errflag =
                 MPIX_ERR_PROC_FAILED ==

--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -568,12 +568,9 @@ static int win_shm_alloc_impl(MPI_Aint size, int disp_unit, MPIR_Comm * comm_ptr
         size_t my_offset = (shm_comm_ptr) ? shm_offsets[shm_comm_ptr->rank] : 0;
         MPIDIG_WIN(win, mmap_sz) = mapsize;
         mpi_errno =
-            MPIDU_shm_alloc_symm_all(comm_ptr, mapsize, my_offset, &MPIDIG_WIN(win, mmap_addr),
-                                     &symheap_mapfail_flag);
-        if (mpi_errno != MPI_SUCCESS)
-            goto fn_fail;
-
-        if (symheap_mapfail_flag) {
+            MPIDU_shm_alloc_symm_all(comm_ptr, mapsize, my_offset, &MPIDIG_WIN(win, mmap_addr));
+        if (mpi_errno != MPI_SUCCESS) {
+            symheap_mapfail_flag = true;
             MPIDIG_WIN(win, mmap_sz) = 0;
             MPIDIG_WIN(win, mmap_addr) = NULL;
         }
@@ -583,13 +580,11 @@ static int win_shm_alloc_impl(MPI_Aint size, int disp_unit, MPIR_Comm * comm_ptr
     if (!global_symheap_flag || symheap_mapfail_flag) {
         if (shm_comm_ptr != NULL && mapsize) {
             MPIDIG_WIN(win, mmap_sz) = mapsize;
-            mpi_errno =
-                MPIDU_shm_alloc(shm_comm_ptr, mapsize, &MPIDIG_WIN(win, mmap_addr),
-                                &shm_mapfail_flag);
-            if (mpi_errno != MPI_SUCCESS)
-                goto fn_fail;
-
-            if (shm_mapfail_flag) {
+            int err = MPIDU_shm_alloc(shm_comm_ptr, mapsize, &MPIDIG_WIN(win, mmap_addr));
+            if (err == MPI_SUCCESS) {
+                symheap_mapfail_flag = false;
+            } else {
+                symheap_mapfail_flag = true;
                 MPIDIG_WIN(win, mmap_sz) = 0;
                 MPIDIG_WIN(win, mmap_addr) = NULL;
             }

--- a/src/mpid/common/shm/mpidu_shm.h
+++ b/src/mpid/common/shm/mpidu_shm.h
@@ -33,27 +33,22 @@ size_t MPIDU_shm_get_mapsize(size_t size, size_t * psz);
  *               has more than one process or private if the node has only one process.
  *               Either way, the value of ptr will be such that the base address of
  *               process memory will be symmetric across all processes in comm_ptr
- * - fail_flag:  if symmetric shared memory could not be allocated this flag is set to
- *               `true`, otherwise it is set to `false`
  *
  * The function returns MPI_SUCCESS if no error has happened while allocating memory.
  * Failure allocating symmetric memory is not considered an error. The function returns
  * MPI_ERR_OTHER if any other error occurred. */
-int MPIDU_shm_alloc_symm_all(MPIR_Comm * comm_ptr, size_t len, size_t offset, void **ptr,
-                             bool * fail_flag);
+int MPIDU_shm_alloc_symm_all(MPIR_Comm * comm_ptr, size_t len, size_t offset, void **ptr);
 
 /* MPIDU_shm_alloc - collectively allocate and return shared memory
  *
  * - shm_comm_ptr:  node communicator used for the collective call
  * - len         :  total length of memory requested by all processes in a node
  * - ptr         :  pointer to allocated shared memory
- * - fail_flag   :  if shared memory could not be allocated this flag is set to `true`,
- *                  otherwise it is set to `false`
  *
  * The function returns MPI_SUCCESS if no error has happened while allocating memory.
  * Failure allocating shared memory is not considered an error. The function returns
  * MPI_ERR_OTHER if any other error occurred. */
-int MPIDU_shm_alloc(MPIR_Comm * shm_comm_ptr, size_t len, void **ptr, bool * fail_flag);
+int MPIDU_shm_alloc(MPIR_Comm * shm_comm_ptr, size_t len, void **ptr);
 
 /* MPIDU_shm_free - free memory allocated using either of the previous two methods
  *


### PR DESCRIPTION
## Pull Request Description
The shm alloc API may either return error in the fail_flag pointer or in the mpi_errno. This complicates the usage since we need always check for both places and the distinctions are not clear. Rather, always return the error in mpi_errno. We always can use specific error class if we need to special treat certain error.

This is split from #6311 

Note: both commits need be squashed after review.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
