### PR TITLE
comm: only free comm_parent in finalize

### DIFF
--- a/src/mpi/comm/builtin_comms.c
+++ b/src/mpi/comm/builtin_comms.c
@@ -157,6 +157,11 @@ int MPIR_finalize_builtin_comms(void)
         MPIR_Free_contextid(COMM_WORLD_CTXID);
     }
 
+    if (MPIR_Process.comm_parent) {
+        mpi_errno = finalize_builtin_comm(MPIR_Process.comm_parent);
+        MPIR_ERR_CHECK(mpi_errno);
+        MPIR_Process.comm_parent = NULL;
+    }
 #ifdef MPID_NEEDS_ICOMM_WORLD
     if (MPIR_Process.icomm_world) {
         mpi_errno = finalize_builtin_comm(MPIR_Process.icomm_world);

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -801,6 +801,10 @@ int MPIR_Intercomm_create_from_groups_impl(MPIR_Group * local_group_ptr, int loc
 
 int MPIR_Comm_free_impl(MPIR_Comm * comm_ptr)
 {
+    if (comm_ptr == MPIR_Process.comm_parent) {
+        /* We only release comm_parent in MPI_Finalize */
+        return MPI_SUCCESS;
+    }
     return MPIR_Comm_release(comm_ptr);
 }
 


### PR DESCRIPTION
## Pull Request Description
The comm obtained from MPI_Comm_get_parent is special since it is merely a reference to MPIR_Process.comm_parent, which is similar to builtin comms. Make MPI_Comm_free(MPI_COMM_PARENT) a no-op and free MPIR_Process.comm_parent in finalize.

Fixes #6319
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
