### PR TITLE
comm: set comm_parent to NULL upon freeing

### DIFF
--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -801,11 +801,18 @@ int MPIR_Intercomm_create_from_groups_impl(MPIR_Group * local_group_ptr, int loc
 
 int MPIR_Comm_free_impl(MPIR_Comm * comm_ptr)
 {
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Comm_release(comm_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+
     if (comm_ptr == MPIR_Process.comm_parent) {
-        /* We only release comm_parent in MPI_Finalize */
-        return MPI_SUCCESS;
+        MPIR_Process.comm_parent = NULL;
     }
-    return MPIR_Comm_release(comm_ptr);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 int MPIR_Comm_get_info_impl(MPIR_Comm * comm_ptr, MPIR_Info ** info_p_p)


### PR DESCRIPTION
## Pull Request Description
According to the standard, it is allowed to disconnect or free comm_parent, but we need to set it to NULL afterward.

Fixes #6319 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
