### PR TITLE
request: Cleanup bsend request handling

### DIFF
--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -105,23 +105,9 @@ int MPIR_Request_completion_processing(MPIR_Request * request_ptr, MPI_Status * 
                     request_ptr->cc_ptr = &request_ptr->cc;
                     request_ptr->u.persist.real_request = NULL;
 
-                    if (prequest_ptr->kind != MPIR_REQUEST_KIND__GREQUEST) {
-                        MPIR_Status_set_cancel_bit(status,
-                                                   MPIR_STATUS_GET_CANCEL_BIT((prequest_ptr->status)));
-                        mpi_errno = prequest_ptr->status.MPI_ERROR;
-                    } else {
-                        mpi_errno = MPIR_Grequest_query(prequest_ptr);
-                        MPIR_Status_set_cancel_bit(status,
-                                                   MPIR_STATUS_GET_CANCEL_BIT
-                                                   (prequest_ptr->status));
-                        if (mpi_errno == MPI_SUCCESS) {
-                            mpi_errno = prequest_ptr->status.MPI_ERROR;
-                        }
-                        rc = MPIR_Grequest_free(prequest_ptr);
-                        if (mpi_errno == MPI_SUCCESS) {
-                            mpi_errno = rc;
-                        }
-                    }
+                    MPIR_Status_set_cancel_bit(status,
+                                               MPIR_STATUS_GET_CANCEL_BIT((prequest_ptr->status)));
+                    mpi_errno = prequest_ptr->status.MPI_ERROR;
 
                     MPIR_Request_free(prequest_ptr);
                 } else {
@@ -272,13 +258,7 @@ int MPIR_Request_get_error(MPIR_Request * request_ptr)
         case MPIR_REQUEST_KIND__PREQUEST_SEND:
             {
                 if (request_ptr->u.persist.real_request != NULL) {
-                    if (request_ptr->u.persist.real_request->kind == MPIR_REQUEST_KIND__GREQUEST) {
-                        /* This is needed for persistent Bsend requests */
-                        mpi_errno = MPIR_Grequest_query(request_ptr->u.persist.real_request);
-                    }
-                    if (mpi_errno == MPI_SUCCESS) {
-                        mpi_errno = request_ptr->u.persist.real_request->status.MPI_ERROR;
-                    }
+                    mpi_errno = request_ptr->u.persist.real_request->status.MPI_ERROR;
                 } else {
                     mpi_errno = request_ptr->status.MPI_ERROR;
                 }


### PR DESCRIPTION
## Pull Request Description

Bsend operations no longer use an internal generalized request since [635a02ed]. Remove related references in request handling functions.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
