### PR TITLE
coll: remove MPID_Send_coll etc and use attr instead

### DIFF
--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -47,7 +47,7 @@ MPI_Bsend_init:
     MPIR_Request *request_ptr = NULL;
 
     mpi_errno = MPID_Bsend_init(buf, count, datatype, dest, tag, comm_ptr,
-                                MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+                                0, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -170,7 +170,7 @@ MPI_Improbe:
     MPIR_Request *msgp = NULL;
 
     *message = MPI_MESSAGE_NULL;
-    mpi_errno = MPID_Improbe(source, tag, comm_ptr, MPIR_CONTEXT_INTRA_PT2PT, flag, &msgp, status);
+    mpi_errno = MPID_Improbe(source, tag, comm_ptr, 0, flag, &msgp, status);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (*flag) {
@@ -206,7 +206,7 @@ MPI_Iprobe:
     .earlyreturn: pt2pt_proc_null
 {
     /* FIXME: Is this correct for intercomms? */
-    mpi_errno = MPID_Iprobe(source, tag, comm_ptr, MPIR_CONTEXT_INTRA_PT2PT, flag, status);
+    mpi_errno = MPID_Iprobe(source, tag, comm_ptr, 0, flag, status);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 }
@@ -217,8 +217,7 @@ MPI_Irecv:
 {
     MPIR_Request *request_ptr = NULL;
 
-    mpi_errno = MPID_Irecv(buf, count, datatype, source, tag, comm_ptr,
-                           MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    mpi_errno = MPID_Irecv(buf, count, datatype, source, tag, comm_ptr, 0, &request_ptr);
     /* return the handle of the request to the user */
     /* MPIU_OBJ_HANDLE_PUBLISH is unnecessary for irecv, lower-level access is
      * responsible for its own consistency, while upper-level field access is
@@ -240,8 +239,7 @@ MPI_Irsend:
 {
     MPIR_Request *request_ptr = NULL;
 
-    mpi_errno = MPID_Irsend(buf, count, datatype, dest, tag, comm_ptr,
-                            MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    mpi_errno = MPID_Irsend(buf, count, datatype, dest, tag, comm_ptr, 0, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -258,8 +256,7 @@ MPI_Isend:
 {
     MPIR_Request *request_ptr = NULL;
 
-    mpi_errno = MPID_Isend(buf, count, datatype, dest, tag, comm_ptr,
-                           MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    mpi_errno = MPID_Isend(buf, count, datatype, dest, tag, comm_ptr, 0, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -276,8 +273,7 @@ MPI_Issend:
 {
     MPIR_Request *request_ptr = NULL;
 
-    mpi_errno = MPID_Issend(buf, count, datatype, dest, tag, comm_ptr,
-                            MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    mpi_errno = MPID_Issend(buf, count, datatype, dest, tag, comm_ptr, 0, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -295,7 +291,7 @@ MPI_Mprobe:
     MPIR_Request *msgp = NULL;
 
     *message = MPI_MESSAGE_NULL;
-    mpi_errno = MPID_Mprobe(source, tag, comm_ptr, MPIR_CONTEXT_INTRA_PT2PT, &msgp, status);
+    mpi_errno = MPID_Mprobe(source, tag, comm_ptr, 0, &msgp, status);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Assert(msgp != NULL);
@@ -334,7 +330,7 @@ MPI_Probe:
     .desc: Blocking test for a message
     .earlyreturn: pt2pt_proc_null
 {
-    mpi_errno = MPID_Probe(source, tag, comm_ptr, MPIR_CONTEXT_INTRA_PT2PT, status);
+    mpi_errno = MPID_Probe(source, tag, comm_ptr, 0, status);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 }
@@ -353,8 +349,7 @@ MPI_Recv:
     /* MT: Note that MPID_Recv may release the SINGLE_CS if it
      * decides to block internally.  MPID_Recv in that case will
      * re-aquire the SINGLE_CS before returning */
-    mpi_errno = MPID_Recv(buf, count, datatype, source, tag, comm_ptr,
-                          MPIR_CONTEXT_INTRA_PT2PT, status, &request_ptr);
+    mpi_errno = MPID_Recv(buf, count, datatype, source, tag, comm_ptr, 0, status, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -380,8 +375,7 @@ MPI_Recv_init:
 {
     MPIR_Request *request_ptr = NULL;
 
-    mpi_errno = MPID_Recv_init(buf, count, datatype, source, tag, comm_ptr,
-                               MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    mpi_errno = MPID_Recv_init(buf, count, datatype, source, tag, comm_ptr, 0, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -395,8 +389,7 @@ MPI_Rsend:
 {
     MPIR_Request *request_ptr = NULL;
 
-    mpi_errno = MPID_Rsend(buf, count, datatype, dest, tag, comm_ptr,
-                           MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    mpi_errno = MPID_Rsend(buf, count, datatype, dest, tag, comm_ptr, 0, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -422,8 +415,7 @@ MPI_Rsend_init:
 {
     MPIR_Request *request_ptr = NULL;
 
-    mpi_errno = MPID_Rsend_init(buf, count, datatype, dest, tag, comm_ptr,
-                                MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    mpi_errno = MPID_Rsend_init(buf, count, datatype, dest, tag, comm_ptr, 0, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -443,8 +435,7 @@ MPI_Send:
 {
     MPIR_Request *request_ptr = NULL;
 
-    mpi_errno = MPID_Send(buf, count, datatype, dest, tag, comm_ptr,
-                          MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    mpi_errno = MPID_Send(buf, count, datatype, dest, tag, comm_ptr, 0, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -468,8 +459,7 @@ MPI_Send_init:
 {
     MPIR_Request *request_ptr = NULL;
 
-    mpi_errno = MPID_Send_init(buf, count, datatype, dest, tag, comm_ptr,
-                               MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    mpi_errno = MPID_Send_init(buf, count, datatype, dest, tag, comm_ptr, 0, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -502,8 +492,7 @@ MPI_Ssend:
 {
     MPIR_Request *request_ptr = NULL;
 
-    mpi_errno = MPID_Ssend(buf, count, datatype, dest, tag, comm_ptr,
-                           MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    mpi_errno = MPID_Ssend(buf, count, datatype, dest, tag, comm_ptr, 0, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -528,8 +517,7 @@ MPI_Ssend_init:
 {
     MPIR_Request *request_ptr = NULL;
 
-    mpi_errno = MPID_Ssend_init(buf, count, datatype, dest, tag, comm_ptr,
-                                MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+    mpi_errno = MPID_Ssend_init(buf, count, datatype, dest, tag, comm_ptr, 0, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -319,7 +319,7 @@ MPL_STATIC_INLINE_PREFIX int MPIR_Stream_comm_set_attr(MPIR_Comm * comm, int src
 {
     int mpi_errno = MPI_SUCCESS;
 
-    *attr_out = MPIR_CONTEXT_INTRA_PT2PT;
+    *attr_out = 0;
 
     MPIR_ERR_CHKANDJUMP(comm->stream_comm_type != MPIR_STREAM_COMM_MULTIPLEX,
                         mpi_errno, MPI_ERR_OTHER, "**streamcomm_notmult");

--- a/src/include/mpir_contextid.h
+++ b/src/include/mpir_contextid.h
@@ -48,10 +48,8 @@ typedef uint16_t MPIR_Context_id_t;
 #define MPIR_CONTEXT_SUFFIX_WIDTH (1)
 #define MPIR_CONTEXT_SUFFIX_SHIFT (0)
 #define MPIR_CONTEXT_SUFFIX_MASK ((1 << MPIR_CONTEXT_SUFFIX_WIDTH) - 1)
-#define MPIR_CONTEXT_INTRA_PT2PT (0)
-#define MPIR_CONTEXT_INTRA_COLL  (1)
-#define MPIR_CONTEXT_INTER_PT2PT (0)
-#define MPIR_CONTEXT_INTER_COLL  (1)
+#define MPIR_CONTEXT_PT2PT_OFFSET 0
+#define MPIR_CONTEXT_COLL_OFFSET  1
 
 /* Used to derive context IDs for sub-communicators from a parent communicator's
    context ID value.  This field comes after the one bit suffix.

--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -6,6 +6,15 @@
 #ifndef MPIR_PT2PT_H_INCLUDED
 #define MPIR_PT2PT_H_INCLUDED
 
+/* attr bits allocation:
+ *     0: context offset
+ *     1: MPIR_ERR_PROC_FAILED
+ *     2: MPIR_ERR_OTHER
+ *     3: sync flag
+ *  8-15: source (sender) vci
+ * 16-23: destination (receiver) vci
+ * 24-31: reserved (must be 0)
+ */
 /* NOTE: All explicit vci (allocated) must be greater than 0 */
 
 #define MPIR_PT2PT_ATTR_SRC_VCI_SHIFT 8

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -269,7 +269,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
             /* Try to send the message.  We must use MPID_Isend
              * because this call must not block */
             mpi_errno = MPID_Isend(msg->msgbuf, msg->count, MPI_PACKED,
-                                   dest, tag, comm_ptr, MPIR_CONTEXT_INTRA_PT2PT, &p->request);
+                                   dest, tag, comm_ptr, 0, &p->request);
             MPIR_ERR_CHKINTERNAL(mpi_errno, mpi_errno, "Bsend internal error: isend returned err");
             /* If the error is "request not available", we should
              * put this on the pending list.  This will depend on

--- a/src/mpi/pt2pt/sendrecv.c
+++ b/src/mpi/pt2pt/sendrecv.c
@@ -21,9 +21,7 @@ int MPIR_Sendrecv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sen
         MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Status_set_procnull(&rreq->status);
     } else {
-        mpi_errno =
-            MPID_Irecv(recvbuf, recvcount, recvtype, source, recvtag, comm_ptr,
-                       MPIR_CONTEXT_INTRA_PT2PT, &rreq);
+        mpi_errno = MPID_Irecv(recvbuf, recvcount, recvtype, source, recvtag, comm_ptr, 0, &rreq);
         if (mpi_errno != MPI_SUCCESS)
             goto fn_fail;
     }
@@ -33,9 +31,7 @@ int MPIR_Sendrecv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sen
         sreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
         MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     } else {
-        mpi_errno =
-            MPID_Isend(sendbuf, sendcount, sendtype, dest, sendtag, comm_ptr,
-                       MPIR_CONTEXT_INTRA_PT2PT, &sreq);
+        mpi_errno = MPID_Isend(sendbuf, sendcount, sendtype, dest, sendtag, comm_ptr, 0, &sreq);
         if (mpi_errno != MPI_SUCCESS) {
             /* --BEGIN ERROR HANDLING-- */
             if (mpi_errno == MPIX_ERR_NOREQ)
@@ -122,8 +118,7 @@ int MPIR_Sendrecv_replace_impl(void *buf, MPI_Aint count, MPI_Datatype datatype,
         MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Status_set_procnull(&rreq->status);
     } else {
-        mpi_errno = MPID_Irecv(buf, count, datatype, source, recvtag,
-                               comm_ptr, MPIR_CONTEXT_INTRA_PT2PT, &rreq);
+        mpi_errno = MPID_Irecv(buf, count, datatype, source, recvtag, comm_ptr, 0, &rreq);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -134,7 +129,7 @@ int MPIR_Sendrecv_replace_impl(void *buf, MPI_Aint count, MPI_Datatype datatype,
         MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     } else {
         mpi_errno = MPID_Isend(tmpbuf, actual_pack_bytes, MPI_PACKED, dest,
-                               sendtag, comm_ptr, MPIR_CONTEXT_INTRA_PT2PT, &sreq);
+                               sendtag, comm_ptr, 0, &sreq);
         if (mpi_errno != MPI_SUCCESS) {
             /* --BEGIN ERROR HANDLING-- */
             if (mpi_errno == MPIX_ERR_NOREQ)
@@ -189,14 +184,12 @@ int MPIR_Isendrecv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
         goto fn_exit;
     } else if (unlikely(source == MPI_PROC_NULL)) {
         /* recv from MPI_PROC_NULL, just send */
-        mpi_errno = MPID_Isend(sendbuf, sendcount, sendtype, dest, sendtag, comm_ptr,
-                               MPIR_CONTEXT_INTRA_PT2PT, p_req);
+        mpi_errno = MPID_Isend(sendbuf, sendcount, sendtype, dest, sendtag, comm_ptr, 0, p_req);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     } else if (unlikely(dest == MPI_PROC_NULL)) {
         /* send to MPI_PROC_NULL, just recv */
-        mpi_errno = MPID_Irecv(recvbuf, recvcount, recvtype, source, recvtag, comm_ptr,
-                               MPIR_CONTEXT_INTRA_PT2PT, p_req);
+        mpi_errno = MPID_Irecv(recvbuf, recvcount, recvtype, source, recvtag, comm_ptr, 0, p_req);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -240,14 +233,12 @@ int MPIR_Isendrecv_replace_impl(void *buf, MPI_Aint count, MPI_Datatype datatype
         goto fn_exit;
     } else if (unlikely(source == MPI_PROC_NULL)) {
         /* recv from MPI_PROC_NULL, just send */
-        mpi_errno = MPID_Isend(buf, count, datatype, dest, sendtag, comm_ptr,
-                               MPIR_CONTEXT_INTRA_PT2PT, p_req);
+        mpi_errno = MPID_Isend(buf, count, datatype, dest, sendtag, comm_ptr, 0, p_req);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     } else if (unlikely(dest == MPI_PROC_NULL)) {
         /* send to MPI_PROC_NULL, just recv */
-        mpi_errno = MPID_Irecv(buf, count, datatype, source, recvtag, comm_ptr,
-                               MPIR_CONTEXT_INTRA_PT2PT, p_req);
+        mpi_errno = MPID_Irecv(buf, count, datatype, source, recvtag, comm_ptr, 0, p_req);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }

--- a/src/mpi/stream/stream_enqueue.c
+++ b/src/mpi/stream/stream_enqueue.c
@@ -33,10 +33,10 @@ static void send_enqueue_cb(void *data)
         MPIR_Assertp(p->actual_pack_bytes == p->data_sz);
 
         mpi_errno = MPID_Send(p->host_buf, p->data_sz, MPI_BYTE, p->dest, p->tag, p->comm_ptr,
-                              MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+                              0, &request_ptr);
     } else {
         mpi_errno = MPID_Send(p->buf, p->count, p->datatype, p->dest, p->tag, p->comm_ptr,
-                              MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+                              0, &request_ptr);
     }
     MPIR_Assertp(mpi_errno == MPI_SUCCESS);
     MPIR_Assertp(request_ptr != NULL);
@@ -120,10 +120,10 @@ static void recv_enqueue_cb(void *data)
     struct recv_data *p = data;
     if (p->host_buf) {
         mpi_errno = MPID_Recv(p->host_buf, p->data_sz, MPI_BYTE, p->source, p->tag, p->comm_ptr,
-                              MPIR_CONTEXT_INTRA_PT2PT, p->status, &request_ptr);
+                              0, p->status, &request_ptr);
     } else {
         mpi_errno = MPID_Recv(p->buf, p->count, p->datatype, p->source, p->tag, p->comm_ptr,
-                              MPIR_CONTEXT_INTRA_PT2PT, p->status, &request_ptr);
+                              0, p->status, &request_ptr);
     }
     MPIR_Assertp(mpi_errno == MPI_SUCCESS);
     MPIR_Assertp(request_ptr != NULL);
@@ -210,10 +210,10 @@ static void isend_enqueue_cb(void *data)
         MPIR_Assertp(p->actual_pack_bytes == p->data_sz);
 
         mpi_errno = MPID_Send(p->host_buf, p->data_sz, MPI_BYTE, p->dest, p->tag, p->comm_ptr,
-                              MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+                              0, &request_ptr);
     } else {
         mpi_errno = MPID_Send(p->buf, p->count, p->datatype, p->dest, p->tag, p->comm_ptr,
-                              MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+                              0, &request_ptr);
     }
     MPIR_Assertp(mpi_errno == MPI_SUCCESS);
     MPIR_Assertp(request_ptr != NULL);
@@ -279,10 +279,10 @@ static void irecv_enqueue_cb(void *data)
     struct recv_data *p = data;
     if (p->host_buf) {
         mpi_errno = MPID_Recv(p->host_buf, p->data_sz, MPI_BYTE, p->source, p->tag, p->comm_ptr,
-                              MPIR_CONTEXT_INTRA_PT2PT, p->status, &request_ptr);
+                              0, p->status, &request_ptr);
     } else {
         mpi_errno = MPID_Recv(p->buf, p->count, p->datatype, p->source, p->tag, p->comm_ptr,
-                              MPIR_CONTEXT_INTRA_PT2PT, p->status, &request_ptr);
+                              0, p->status, &request_ptr);
     }
     MPIR_Assertp(mpi_errno == MPI_SUCCESS);
     MPIR_Assertp(request_ptr != NULL);

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -563,10 +563,6 @@ int MPID_Send( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 	       int dest, int tag, MPIR_Comm *comm, int attr,
 	       MPIR_Request **request );
 
-int MPID_Send_coll( const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                    int dest, int tag, MPIR_Comm *comm, int attr,
-                    MPIR_Request **request, MPIR_Errflag_t errflag );
-
 int MPID_Rsend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		int dest, int tag, MPIR_Comm *comm, int attr,
 		MPIR_Request **request );
@@ -578,10 +574,6 @@ int MPID_Ssend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 int MPID_Isend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		int dest, int tag, MPIR_Comm *comm, int attr,
 		MPIR_Request **request );
-
-int MPID_Isend_coll( const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                     int dest, int tag, MPIR_Comm *comm, int attr,
-                     MPIR_Request **request, MPIR_Errflag_t errflag );
 
 int MPID_Irsend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		 int dest, int tag, MPIR_Comm *comm, int attr,

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -571,9 +571,9 @@ void MPIDI_CH3I_Comm_find(MPIR_Context_id_t context_id, MPIR_Comm **comm)
     MPIR_FUNC_ENTER;
 
     COMM_FOREACH((*comm)) {
-        if ((*comm)->context_id == context_id || ((*comm)->context_id + MPIR_CONTEXT_INTRA_COLL) == context_id ||
-            ((*comm)->node_comm && ((*comm)->node_comm->context_id == context_id || ((*comm)->node_comm->context_id + MPIR_CONTEXT_INTRA_COLL) == context_id)) ||
-            ((*comm)->node_roots_comm && ((*comm)->node_roots_comm->context_id == context_id || ((*comm)->node_roots_comm->context_id + MPIR_CONTEXT_INTRA_COLL) == context_id)) ) {
+        if ((*comm)->context_id == context_id || ((*comm)->context_id + MPIR_CONTEXT_COLL_OFFSET) == context_id ||
+            ((*comm)->node_comm && ((*comm)->node_comm->context_id == context_id || ((*comm)->node_comm->context_id + MPIR_CONTEXT_COLL_OFFSET) == context_id)) ||
+            ((*comm)->node_roots_comm && ((*comm)->node_roots_comm->context_id == context_id || ((*comm)->node_roots_comm->context_id + MPIR_CONTEXT_COLL_OFFSET) == context_id)) ) {
             MPL_DBG_MSG_D(MPIDI_CH3_DBG_OTHER,VERBOSE,"Found matching context id: %d", (*comm)->context_id);
             break;
         }

--- a/src/mpid/ch3/src/ch3u_recvq.c
+++ b/src/mpid/ch3/src/ch3u_recvq.c
@@ -896,7 +896,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
     while (NULL != rreq) {
         /* We'll have to do this matching twice. Once for the pt2pt context id
          * and once for the collective context id */
-        match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRA_PT2PT;
+        /* pt2pt */
+        match.parts.context_id = comm_ptr->recvcontext_id;
 
         if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
             MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
@@ -906,7 +907,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
             continue;
         }
 
-        match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRA_COLL;
+        /* coll */
+        match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_COLL_OFFSET;
 
         if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
             if (MPIR_TAG_MASK_ERROR_BITS(rreq->dev.match.parts.tag) != MPIR_AGREE_TAG &&
@@ -920,9 +922,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
         }
 
         if (MPIR_Comm_is_parent_comm(comm_ptr)) {
-            int offset;
-            offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?  MPIR_CONTEXT_INTRA_PT2PT : MPIR_CONTEXT_INTER_PT2PT;
-            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRANODE_OFFSET + offset;
+            /* node_comm pt2pt */
+            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRANODE_OFFSET;
 
             if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
                 if (MPIR_TAG_MASK_ERROR_BITS(rreq->dev.match.parts.tag) != MPIR_AGREE_TAG &&
@@ -935,8 +936,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                 }
             }
 
-            offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?  MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
-            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRANODE_OFFSET + offset;
+            /* node_comm coll */
+            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRANODE_OFFSET + MPIR_CONTEXT_COLL_OFFSET;
 
             if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
                 if (MPIR_TAG_MASK_ERROR_BITS(rreq->dev.match.parts.tag) != MPIR_AGREE_TAG &&
@@ -949,8 +950,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                 }
             }
 
-            offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?  MPIR_CONTEXT_INTRA_PT2PT : MPIR_CONTEXT_INTER_PT2PT;
-            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTERNODE_OFFSET + offset;
+            /* node_roots_comm pt2pt */
+            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTERNODE_OFFSET;
 
             if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
                 if (MPIR_TAG_MASK_ERROR_BITS(rreq->dev.match.parts.tag) != MPIR_AGREE_TAG &&
@@ -963,8 +964,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                 }
             }
 
-            offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?  MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
-            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTERNODE_OFFSET + offset;
+            /* node_roots_comm coll */
+            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTERNODE_OFFSET + MPIR_CONTEXT_COLL_OFFSET;
 
             if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
                 if (MPIR_TAG_MASK_ERROR_BITS(rreq->dev.match.parts.tag) != MPIR_AGREE_TAG &&
@@ -988,7 +989,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
     while (NULL != rreq) {
         /* We'll have to do this matching twice. Once for the pt2pt context id
          * and once for the collective context id */
-        match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRA_PT2PT;
+        /* pt2pt */
+        match.parts.context_id = comm_ptr->recvcontext_id;
 
         if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
             MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
@@ -998,7 +1000,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
             continue;
         }
 
-        match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRA_COLL;
+        /* coll */
+        match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_COLL_OFFSET;
 
         if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
             if (MPIR_TAG_MASK_ERROR_BITS(rreq->dev.match.parts.tag) != MPIR_AGREE_TAG &&
@@ -1012,9 +1015,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
         }
 
         if (MPIR_Comm_is_parent_comm(comm_ptr)) {
-            int offset;
-            offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?  MPIR_CONTEXT_INTRA_PT2PT : MPIR_CONTEXT_INTER_PT2PT;
-            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRANODE_OFFSET + offset;
+            /* node_comm coll */
+            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRANODE_OFFSET;
 
             if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
                 if (MPIR_TAG_MASK_ERROR_BITS(rreq->dev.match.parts.tag) != MPIR_AGREE_TAG &&
@@ -1027,8 +1029,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                 }
             }
 
-            offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?  MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
-            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRANODE_OFFSET + offset;
+            /* node_comm coll */
+            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTRANODE_OFFSET + MPIR_CONTEXT_COLL_OFFSET;
 
             if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
                 if (MPIR_TAG_MASK_ERROR_BITS(rreq->dev.match.parts.tag) != MPIR_AGREE_TAG &&
@@ -1041,8 +1043,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                 }
             }
 
-            offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?  MPIR_CONTEXT_INTRA_PT2PT : MPIR_CONTEXT_INTER_PT2PT;
-            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTERNODE_OFFSET + offset;
+            /* node_roots_comm pt2pt */
+            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTERNODE_OFFSET;
 
             if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
                 if (MPIR_TAG_MASK_ERROR_BITS(rreq->dev.match.parts.tag) != MPIR_AGREE_TAG &&
@@ -1055,8 +1057,8 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                 }
             }
 
-            offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?  MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
-            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTERNODE_OFFSET + offset;
+            /* node_roots_comm coll */
+            match.parts.context_id = comm_ptr->recvcontext_id + MPIR_CONTEXT_INTERNODE_OFFSET + MPIR_CONTEXT_COLL_OFFSET;
 
             if (MATCH_WITH_LEFT_RIGHT_MASK(rreq->dev.match, match, mask)) {
                 if (MPIR_TAG_MASK_ERROR_BITS(rreq->dev.match.parts.tag) != MPIR_AGREE_TAG &&

--- a/src/mpid/ch3/src/ch3u_rma_sync.c
+++ b/src/mpid/ch3/src/ch3u_rma_sync.c
@@ -706,8 +706,7 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
 
             if (dst != rank) {
                 MPIR_Request *req_ptr;
-                mpi_errno = MPID_Isend(&i, 0, MPI_INT, dst, SYNC_POST_TAG, win_comm_ptr,
-                                       MPIR_CONTEXT_INTRA_PT2PT, &req_ptr);
+                mpi_errno = MPID_Isend(&i, 0, MPI_INT, dst, SYNC_POST_TAG, win_comm_ptr, 0, &req_ptr);
                 MPIR_ERR_CHECK(mpi_errno);
                 req[i] = req_ptr->handle;
             }
@@ -824,7 +823,7 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
                 MPIDI_Comm_get_vc(comm_ptr, src, &target_vc);
 
                 mpi_errno = MPID_Irecv(NULL, 0, MPI_INT, src, SYNC_POST_TAG,
-                                       comm_ptr, MPIR_CONTEXT_INTRA_PT2PT, &req_ptr);
+                                       comm_ptr, 0, &req_ptr);
                 MPIR_ERR_CHECK(mpi_errno);
 
                 if (win_ptr->shm_allocated == TRUE && orig_vc->node_id == target_vc->node_id) {

--- a/src/mpid/ch3/src/mpid_isend.c
+++ b/src/mpid/ch3/src/mpid_isend.c
@@ -36,9 +36,25 @@ int MPID_Isend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
     int eager_threshold = -1;
     int mpi_errno = MPI_SUCCESS;
 
+    if (MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr)) {
+        return MPID_Issend(buf, count, datatype, rank, tag, comm, attr, &sreq);
+    }
+
     MPIR_FUNC_ENTER;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
+    int errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+
+    switch (errflag) {
+        case MPIR_ERR_NONE:
+            break;
+        case MPIR_ERR_PROC_FAILED:
+            MPIR_TAG_SET_PROC_FAILURE_BIT(tag);
+            break;
+        default:
+            MPIR_TAG_SET_ERROR_BIT(tag);
+    }
+
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                   "rank=%d, tag=%d, context=%d", 
                   rank, tag, comm->context_id + context_offset));
@@ -174,30 +190,5 @@ int MPID_Isend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
     
   fn_fail:
     MPIR_FUNC_EXIT;
-    return mpi_errno;
-}
-
-int MPID_Isend_coll(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-                    MPIR_Comm * comm, int attr, MPIR_Request ** request,
-                    MPIR_Errflag_t errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    MPIR_FUNC_ENTER;
-
-    switch (errflag) {
-    case MPIR_ERR_NONE:
-        break;
-    case MPIR_ERR_PROC_FAILED:
-        MPIR_TAG_SET_PROC_FAILURE_BIT(tag);
-        break;
-    default:
-        MPIR_TAG_SET_ERROR_BIT(tag);
-    }
-
-    mpi_errno = MPID_Isend(buf, count, datatype, rank, tag, comm, attr, request);
-
-    MPIR_FUNC_EXIT;
-
     return mpi_errno;
 }

--- a/src/mpid/ch3/src/mpid_send.c
+++ b/src/mpid/ch3/src/mpid_send.c
@@ -24,9 +24,25 @@ int MPID_Send(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank,
     int eager_threshold = -1;
     int mpi_errno = MPI_SUCCESS;    
 
+    if (MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr)) {
+        return MPID_Ssend(buf, count, datatype, rank, tag, comm, attr, request);
+    }
+
     MPIR_FUNC_ENTER;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
+    int errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+
+    switch (errflag) {
+        case MPIR_ERR_NONE:
+            break;
+        case MPIR_ERR_PROC_FAILED:
+            MPIR_TAG_SET_PROC_FAILURE_BIT(tag);
+            break;
+        default:
+            MPIR_TAG_SET_ERROR_BIT(tag);
+    }
+
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                 "rank=%d, tag=%d, context=%d", 
 		rank, tag, comm->context_id + context_offset));
@@ -180,30 +196,5 @@ int MPID_Send(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank,
 		  );
     
     MPIR_FUNC_EXIT;
-    return mpi_errno;
-}
-
-int MPID_Send_coll(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-                   MPIR_Comm * comm, int attr, MPIR_Request ** request,
-                   MPIR_Errflag_t errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    MPIR_FUNC_ENTER;
-
-    switch (errflag) {
-    case MPIR_ERR_NONE:
-        break;
-    case MPIR_ERR_PROC_FAILED:
-        MPIR_TAG_SET_PROC_FAILURE_BIT(tag);
-        break;
-    default:
-        MPIR_TAG_SET_ERROR_BIT(tag);
-    }
-
-    mpi_errno = MPID_Send(buf, count, datatype, rank, tag, comm, attr, request);
-
-    MPIR_FUNC_EXIT;
-
     return mpi_errno;
 }

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -73,18 +73,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Isend_coll(const void *buf,
-                                             MPI_Aint count,
-                                             MPI_Datatype datatype,
-                                             int rank,
-                                             int tag,
-                                             MPIR_Comm * comm, int attr,
-                                             MPIR_Request ** request, MPIR_Errflag_t errflag)
-{
-    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
-    return MPID_Isend(buf, count, datatype, rank, tag, comm, attr, request);
-}
-
 MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,
                                        MPI_Aint count,
                                        MPI_Datatype datatype,
@@ -92,17 +80,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,
                                        int tag, MPIR_Comm * comm, int attr, MPIR_Request ** request)
 {
     return MPID_Isend(buf, count, datatype, rank, tag, comm, attr, request);
-}
-
-MPL_STATIC_INLINE_PREFIX int MPID_Send_coll(const void *buf,
-                                            MPI_Aint count,
-                                            MPI_Datatype datatype,
-                                            int rank,
-                                            int tag,
-                                            MPIR_Comm * comm, int attr,
-                                            MPIR_Request ** request, MPIR_Errflag_t errflag)
-{
-    return MPID_Isend_coll(buf, count, datatype, rank, tag, comm, attr, request, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *buf,

--- a/src/mpid/ch4/src/ch4_stream_enqueue.c
+++ b/src/mpid/ch4/src/ch4_stream_enqueue.c
@@ -60,7 +60,7 @@ static void send_enqueue_cb(void *data)
 
     struct send_data *p = data;
     mpi_errno = MPID_Send(p->buf, p->count, p->datatype, p->dest, p->tag, p->comm_ptr,
-                          MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+                          0, &request_ptr);
     MPIR_Assertp(mpi_errno == MPI_SUCCESS);
     MPIR_Assertp(request_ptr != NULL);
 
@@ -139,7 +139,7 @@ static void recv_enqueue_cb(void *data)
 
     struct recv_data *p = data;
     mpi_errno = MPID_Irecv(p->buf, p->count, p->datatype, p->source, p->tag, p->comm_ptr,
-                           MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+                           0, &request_ptr);
     MPIR_Assertp(mpi_errno == MPI_SUCCESS);
     MPIR_Assertp(request_ptr != NULL);
 
@@ -211,7 +211,7 @@ static void isend_enqueue_cb(void *data)
 
     struct send_data *p = data;
     mpi_errno = MPID_Send(p->buf, p->count, p->datatype, p->dest, p->tag, p->comm_ptr,
-                          MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+                          0, &request_ptr);
     MPIR_Assertp(mpi_errno == MPI_SUCCESS);
     MPIR_Assertp(request_ptr != NULL);
 
@@ -282,7 +282,7 @@ static void irecv_enqueue_cb(void *data)
 
     struct recv_data *p = data;
     mpi_errno = MPID_Irecv(p->buf, p->count, p->datatype, p->source, p->tag, p->comm_ptr,
-                           MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
+                           0, &request_ptr);
     MPIR_Assertp(mpi_errno == MPI_SUCCESS);
     MPIR_Assertp(request_ptr != NULL);
 

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -281,7 +281,7 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
         case MPIDU_SCHED_ENTRY_PT2PT_SEND:
             ret_errno = MPID_Isend(e->u.send.buf, e->u.send.count, e->u.send.datatype,
                                    e->u.send.dest, e->u.send.tag, e->u.send.comm,
-                                   MPIR_CONTEXT_INTRA_PT2PT, &e->u.send.sreq);
+                                   0, &e->u.send.sreq);
             if (unlikely(ret_errno)) {
                 e->status = MPIDU_SCHED_ENTRY_STATUS_FAILED;
             } else {
@@ -291,7 +291,7 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
         case MPIDU_SCHED_ENTRY_PT2PT_RECV:
             ret_errno = MPID_Irecv(e->u.recv.buf, e->u.recv.count, e->u.recv.datatype,
                                    e->u.recv.src, e->u.recv.tag, e->u.recv.comm,
-                                   MPIR_CONTEXT_INTRA_PT2PT, &e->u.recv.rreq);
+                                   0, &e->u.recv.rreq);
             if (unlikely(ret_errno)) {
                 e->status = MPIDU_SCHED_ENTRY_STATUS_FAILED;
             } else {


### PR DESCRIPTION
## Pull Request Description
Remove the MPID_Send_coll and MPID_Isend_coll interface and use attr to carry the errflag instead.

Also use attr to carry the errflag for MPIC_Ssend and MPIC_Issend. Previously it sets the tag for error bits, which is not reliable. For example, ch4:ofi does not use error bits in tag.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
