### PR TITLE
request: Fix handling of inactive persistent collective requests

### DIFF
--- a/src/binding/c/request_api.txt
+++ b/src/binding/c/request_api.txt
@@ -95,7 +95,7 @@ MPI_Request_get_status:
     'MPI_Request_free' should be made to release the request object.
 */
 { -- early_return --
-    if (request == MPI_REQUEST_NULL) {
+    if (request == MPI_REQUEST_NULL || !MPIR_Request_is_active(request_ptr)) {
         *flag = 1;
         MPIR_Status_set_empty(status);
         goto fn_exit;
@@ -133,7 +133,7 @@ MPI_Test:
     .desc: Test for the completion of a request
     .docnotes: waitstatus
 { -- early_return --
-    if (*request == MPI_REQUEST_NULL) {
+    if (*request == MPI_REQUEST_NULL || !MPIR_Request_is_active(request_ptr)) {
         *flag = 1;
         MPIR_Status_set_empty(status);
         goto fn_exit;
@@ -242,7 +242,7 @@ MPI_Wait:
     .desc: Waits for an MPI request to complete
     .docnotes: waitstatus
 { -- early_return --
-    if (*request == MPI_REQUEST_NULL) {
+    if (*request == MPI_REQUEST_NULL || !MPIR_Request_is_active(request_ptr)) {
         MPIR_Status_set_empty(status);
         goto fn_exit;
     }

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -352,6 +352,8 @@ static inline int MPIR_Request_is_active(MPIR_Request * req_ptr)
             case MPIR_REQUEST_KIND__PREQUEST_SEND:
             case MPIR_REQUEST_KIND__PREQUEST_RECV:
                 return (req_ptr)->u.persist.real_request != NULL;
+            case MPIR_REQUEST_KIND__PREQUEST_COLL:
+                return (req_ptr)->u.persist_coll.real_request != NULL;
             case MPIR_REQUEST_KIND__PART_SEND:
             case MPIR_REQUEST_KIND__PART_RECV:
                 return MPIR_Part_request_is_active(req_ptr);

--- a/src/mpi/coll/nbcutil.c
+++ b/src/mpi/coll/nbcutil.c
@@ -68,12 +68,14 @@ void MPIR_Persist_coll_free_cb(MPIR_Request * request)
         MPIR_Datatype_release_if_not_builtin(coll->datatype);
     }
 
-    if (request->u.persist_coll.sched_type == MPIR_SCHED_NORMAL) {
-        MPIR_Sched_free(request->u.persist_coll.sched);
-    } else if (request->u.persist_coll.sched_type == MPIR_SCHED_GENTRAN) {
-        MPIR_TSP_sched_free(request->u.persist_coll.sched);
-    } else {
-        /* TODO: proper error return */
-        MPIR_Assert(0);
+    if (request->u.persist_coll.sched) {
+        if (request->u.persist_coll.sched_type == MPIR_SCHED_NORMAL) {
+            MPIR_Sched_free(request->u.persist_coll.sched);
+        } else if (request->u.persist_coll.sched_type == MPIR_SCHED_GENTRAN) {
+            MPIR_TSP_sched_free(request->u.persist_coll.sched);
+        } else {
+            /* TODO: proper error return */
+            MPIR_Assert(0);
+        }
     }
 }

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -147,6 +147,7 @@
 /coll/p_exscan
 /coll/p_gather
 /coll/p_gatherv
+/coll/p_inactive
 /coll/p_neighb_allgather
 /coll/p_neighb_allgatherv
 /coll/p_neighb_alltoall

--- a/test/mpi/coll/Makefile.am
+++ b/test/mpi/coll/Makefile.am
@@ -106,6 +106,7 @@ noinst_PROGRAMS =      \
     p_neighb_alltoallv \
     p_neighb_alltoallw \
     p_order            \
+    p_inactive         \
     red3               \
     red4               \
     red_scat_block     \

--- a/test/mpi/coll/p_inactive.c
+++ b/test/mpi/coll/p_inactive.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+/* test/wait on an inactive persistent collective operation. */
+
+#include "mpi.h"
+#include "mpitest.h"
+
+static void init_status(MPI_Status * status);
+static int check_empty_status(MPI_Status status);
+
+int main(int argc, char **argv)
+{
+    MPI_Status status;
+    MPI_Request req;
+    int flag;
+    int errs = 0;
+    int a;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Bcast_init(&a, 1, MPI_INT, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &req);
+
+    /* test should return flag=true and empty status */
+    init_status(&status);
+    MPI_Test(&req, &flag, &status);
+    if (!flag) {
+        ++errs;
+    }
+    errs += check_empty_status(status);
+
+    /* wait should return empty status */
+    init_status(&status);
+    MPI_Wait(&req, &status);
+    errs += check_empty_status(status);
+
+    MPI_Request_free(&req);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}
+
+/* static routines to init and verify status object */
+
+static void init_status(MPI_Status * status)
+{
+    status->MPI_TAG = 42;
+    status->MPI_SOURCE = 42;
+    MPI_Status_set_elements(status, MPI_INT, 42);
+    MPI_Status_set_cancelled(status, 1);
+}
+
+static int check_empty_status(MPI_Status status)
+{
+    int errs = 0;
+
+    if (status.MPI_TAG != MPI_ANY_TAG) {
+        ++errs;
+    }
+
+    if (status.MPI_SOURCE != MPI_ANY_SOURCE) {
+        ++errs;
+    }
+
+    int count;
+    MPI_Get_elements(&status, MPI_INT, &count);
+    if (count != 0) {
+        ++errs;
+    }
+
+    int flag;
+    MPI_Test_cancelled(&status, &flag);
+    if (flag != 0) {
+        ++errs;
+    }
+
+    return errs;
+}

--- a/test/mpi/coll/testlist.in
+++ b/test/mpi/coll/testlist.in
@@ -200,3 +200,4 @@ p_neighb_alltoall 4 strict=false
 p_neighb_alltoallv 4 strict=false
 p_neighb_alltoallw 4 strict=false
 p_order 2 strict=false
+p_inactive timeLimit=10

--- a/test/mpi/coll/testlist.in
+++ b/test/mpi/coll/testlist.in
@@ -174,30 +174,30 @@ ring_neighbor_alltoall 2
 ring_neighbor_alltoall 1
 
 # Tests for persistent collectives
-p_bcast 4 strict=false
-p_bcast2 8 strict=false
+p_bcast 4
+p_bcast2 8
 
 coll_large 8
-p_allred 4 strict=false
-p_red 4 strict=false
-p_alltoall 8 strict=false
-p_allgather 10 strict=false
-p_allgatherv 10 strict=false
-p_red_scat_block 4 strict=false
-p_redscat 4 strict=false
-p_scan 4 strict=false
-p_gather 4 strict=false
-p_gatherv 5 strict=false
-p_scatter 4 strict=false
-p_scatterv 4 strict=false
-p_alltoallv 10 strict=false
-p_alltoallw 10 strict=false
-p_exscan 5 strict=false
-p_barrier 2 strict=false
-p_neighb_allgather 4 strict=false
-p_neighb_allgatherv 4 strict=false
-p_neighb_alltoall 4 strict=false
-p_neighb_alltoallv 4 strict=false
-p_neighb_alltoallw 4 strict=false
-p_order 2 strict=false
+p_allred 4
+p_red 4
+p_alltoall 8
+p_allgather 10
+p_allgatherv 10
+p_red_scat_block 4
+p_redscat 4
+p_scan 4
+p_gather 4
+p_gatherv 5
+p_scatter 4
+p_scatterv 4
+p_alltoallv 10
+p_alltoallw 10
+p_exscan 5
+p_barrier 2
+p_neighb_allgather 4
+p_neighb_allgatherv 4
+p_neighb_alltoall 4
+p_neighb_alltoallv 4
+p_neighb_alltoallw 4
+p_order 2
 p_inactive timeLimit=10


### PR DESCRIPTION
## Pull Request Description

Persistent collective requests in inactive state should complete the same as other inactive requests. Fixes a hang in MPI_WAIT with such a request. Depends on #6333 for early return binding changes.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
