### PR TITLE
init: allow multiple init cycle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3699,6 +3699,10 @@ if test "$enable_g_mem" != "yes" ; then
     fi
 fi
 
+# make sure we support signal
+AC_CHECK_HEADERS(signal.h)
+AC_CHECK_FUNCS(signal)
+
 # ----------------------------------------------------------------------------
 # Look for some non-posix, but commonly provided functions
 # ----------------------------------------------------------------------------

--- a/maint/extractcvars
+++ b/maint/extractcvars
@@ -249,17 +249,11 @@ int ${fn_ns}_init(void)
     int mpi_errno = MPI_SUCCESS;
     int rc, got_rc;
     const char *tmp_str;
-    static int initialized = FALSE;
     MPIR_T_cvar_value_t defaultval;
 
     int debug = 0;
     rc = MPL_env2bool("MPIR_CVAR_DEBUG_CVARS", &debug);
     MPIR_ERR_CHKANDJUMP1((-1 == rc),mpi_errno,MPI_ERR_OTHER,"**envvarparse","**envvarparse %s","MPIR_CVAR_DEBUG_CVARS");
-
-    /* FIXME any MT issues here? */
-    if (initialized)
-        return MPI_SUCCESS;
-    initialized = TRUE;
 
 EOT
 

--- a/src/include/mpir_contextid.h
+++ b/src/include/mpir_contextid.h
@@ -99,6 +99,8 @@ typedef uint16_t MPIR_Context_id_t;
 #define MPIR_MAX_CONTEXT_MASK \
     ((1 << (MPIR_CONTEXT_ID_BITS - (MPIR_CONTEXT_PREFIX_SHIFT + MPIR_CONTEXT_DYNAMIC_PROC_WIDTH))) / MPIR_CONTEXT_INT_BITS)
 
+void MPIR_context_id_init(void);
+
 /* Utility routines.  Where possible, these are kept in the source directory
    with the other comm routines (src/mpi/comm, in mpicomm.h).  However,
    to create a new communicator after a spawn or connect-accept operation,

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -35,7 +35,6 @@ cvars:
  * available context id values.
  */
 static uint32_t context_mask[MPIR_MAX_CONTEXT_MASK];
-static int initialize_context_mask = 1;
 const int ALL_OWN_MASK_FLAG = MPIR_MAX_CONTEXT_MASK;
 
 /* utility function to pretty print a context ID for debugging purposes, see
@@ -154,7 +153,7 @@ static int check_context_ids_on_finalize(void *context_mask_ptr)
 }
 #endif
 
-static void context_id_init(void)
+void MPIR_context_id_init(void)
 {
     int i;
 
@@ -169,7 +168,6 @@ static void context_id_init(void)
 #else
     context_mask[0] = 0xFFFFFFFC;
 #endif
-    initialize_context_mask = 0;
 
 #ifdef MPICH_DEBUG_HANDLEALLOC
     /* check for context ID leaks in MPI_Finalize.  Use (_PRIO-1) to make sure
@@ -378,10 +376,6 @@ int MPIR_Get_contextid_sparse_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr
         /* We lock only around access to the mask (except in the global locking
          * case).  If another thread is using the mask, we take a mask of zero. */
         MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_CTX_MUTEX);
-
-        if (initialize_context_mask) {
-            context_id_init();
-        }
 
         if (eager_nelem < 0) {
             /* Ensure that at least one word of deadlock-free context IDs is
@@ -900,10 +894,6 @@ static int sched_get_cid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcomm,
     int mpi_errno = MPI_SUCCESS;
     struct gcn_state *st = NULL;
     MPIR_CHKPMEM_DECL(1);
-
-    if (initialize_context_mask) {
-        context_id_init();
-    }
 
     MPIR_CHKPMEM_MALLOC(st, struct gcn_state *, sizeof(struct gcn_state), mpi_errno, "gcn_state",
                         MPL_MEM_COMM);

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -161,6 +161,7 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
      * other and can be initialized in any order. */
     /**********************************************************************/
 
+    MPIR_context_id_init();
     MPIR_Typerep_init();
     MPII_thread_mutex_create();
     MPII_init_request();

--- a/src/mpi_t/mpit_finalize.c
+++ b/src/mpi_t/mpit_finalize.c
@@ -139,6 +139,8 @@ static void MPIR_T_pvar_env_finalize(void)
     }
 }
 
+extern int MPIR_T_env_initialized;
+
 void MPIR_T_env_finalize(void)
 {
     MPIR_T_enum_env_finalize();
@@ -146,4 +148,5 @@ void MPIR_T_env_finalize(void)
     MPIR_T_pvar_env_finalize();
     MPIR_T_cat_env_finalize();
     MPIR_T_events_finalize();
+    MPIR_T_env_initialized = FALSE;
 }

--- a/src/mpi_t/mpit_initthread.c
+++ b/src/mpi_t/mpit_initthread.c
@@ -30,13 +30,14 @@ static inline int MPIR_T_cvar_env_init(void)
     return MPIR_T_cvar_init();
 }
 
+int MPIR_T_env_initialized = FALSE;
+
 int MPIR_T_env_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    static int initialized = FALSE;
 
-    if (!initialized) {
-        initialized = TRUE;
+    if (!MPIR_T_env_initialized) {
+        MPIR_T_env_initialized = TRUE;
         MPIR_T_enum_env_init();
         MPIR_T_cat_env_init();
         mpi_errno = MPIR_T_cvar_env_init();

--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -831,8 +831,10 @@ int MPIDI_CH3I_Progress_init(void)
     prev_sighandler = signal(SIGUSR1, sigusr1_handler);
     MPIR_ERR_CHKANDJUMP1(prev_sighandler == SIG_ERR, mpi_errno, MPI_ERR_OTHER, "**signal", "**signal %s",
                          MPIR_Strerror(errno, strerrbuf, MPIR_STRERROR_BUF_SIZE));
-    if (prev_sighandler == SIG_IGN || prev_sighandler == SIG_DFL)
+    if (prev_sighandler == SIG_IGN || prev_sighandler == SIG_DFL ||
+        prev_sighandler == sigusr1_handler) {
         prev_sighandler = NULL;
+    }
 #endif
 
  fn_exit:

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_finalize.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_finalize.c
@@ -56,6 +56,8 @@ int MPID_nem_finalize(void)
         MPL_free(MPID_nem_fbox_fall_back_to_queue_count);
     }
 
+    memset(&MPID_nem_mem_region, 0, sizeof(MPID_nem_mem_region));
+
  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch3/channels/nemesis/subconfigure.m4
+++ b/src/mpid/ch3/channels/nemesis/subconfigure.m4
@@ -94,10 +94,6 @@ fi
 AC_ARG_ENABLE(fast, [--enable-fast - pick the appropriate options for fast execution.
 This turns off error checking and timing collection],,enable_fast=no)
 
-# make sure we support signal
-AC_CHECK_HEADERS(signal.h)
-AC_CHECK_FUNCS(signal)
-
 nemesis_nets_dirs=""
 nemesis_nets_strings=""
 nemesis_nets_array=""   

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -1225,6 +1225,8 @@ int MPIDI_CH3I_Sock_finalize(void)
 
     if (MPIDI_CH3I_Socki_initialized == 0) {
         MPIDI_CH3I_Socki_free_eventq_mem();
+        MPIDI_CH3I_Socki_eventq_pool = NULL;
+        MPIDI_CH3I_Socki_set_next_id = 0;
     }
 #ifdef USE_SOCK_VERIFY
   fn_exit:

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -1200,6 +1200,12 @@ int MPIDI_CH3I_Sock_init(void)
     MPIDI_CH3I_DBG_SOCK_CONNECT = MPL_dbg_class_alloc("SOCK_CONNECT", "sock_connect");
 #endif
 
+#ifdef HAVE_SIGNAL
+    /* ch3:sock do not support fault-tolerance feature, disable the signal so
+     * hydra's -disable-auto-cleanup can still work */
+    signal(SIGUSR1, SIG_IGN);
+#endif
+
     MPIDI_CH3I_Socki_initialized++;
 
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -765,7 +765,7 @@ int MPIDI_PG_ForwardPGInfo( MPIR_Comm *peer_ptr, MPIR_Comm *comm_ptr,
 /*
  * The lpid counter counts new processes that this process knows about.
  */
-static int lpid_counter = 0;
+int MPIDI_lpid_counter = 0;
 
 /* Fully initialize a VC.  This invokes the channel-specific 
    VC initialization routine MPIDI_CH3_VC_Init . */
@@ -776,7 +776,7 @@ int MPIDI_VC_Init( MPIDI_VC_t *vc, MPIDI_PG_t *pg, int rank )
     MPIR_Object_set_ref(vc, 0);
     vc->pg      = pg;
     vc->pg_rank = rank;
-    vc->lpid    = lpid_counter++;
+    vc->lpid    = MPIDI_lpid_counter++;
     vc->node_id = -1;
     MPIDI_VC_Init_seqnum_send(vc);
     MPIDI_VC_Init_seqnum_recv(vc);

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -47,6 +47,7 @@ int MPIDI_PG_Init(MPIDI_PG_Compare_ids_fn_t compare_ids_fn,
     return mpi_errno;
 }
 
+extern int MPIDI_lpid_counter;
 /*@ 
    MPIDI_PG_Finalize - Finalize the process groups, including freeing all
    process group structures
@@ -98,6 +99,7 @@ int MPIDI_PG_Finalize(void)
 	MPIDI_PG_Destroy(MPIDI_Process.my_pg);
     } 
     MPIDI_Process.my_pg = NULL;
+    MPIDI_lpid_counter = 0;
 
     /* ifdefing out this check because the list will not be NULL in 
        Ch3_finalize because

--- a/src/mpid/ch3/src/mpidi_rma.c
+++ b/src/mpid/ch3/src/mpidi_rma.c
@@ -123,6 +123,10 @@ void MPIDI_RMA_finalize(void)
 
     MPL_free(global_rma_op_pool_start);
     MPL_free(global_rma_target_pool_start);
+    global_rma_op_pool_head = NULL;
+    global_rma_op_pool_start = NULL;
+    global_rma_target_pool_head = NULL;
+    global_rma_target_pool_start = NULL;
 
     MPIR_FUNC_EXIT;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -921,6 +921,8 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     MPID_Thread_mutex_destroy(&MPIDI_OFI_THREAD_SPAWN_MUTEX, &err);
     MPIR_Assert(err == 0);
 
+    memset(&MPIDI_OFI_global, 0, sizeof(MPIDI_OFI_global));
+
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -368,6 +368,8 @@ int MPIDI_UCX_mpi_finalize_hook(void)
 
     for (int i = 0; i < MPIDI_UCX_global.num_vnis; i++) {
         if (MPIDI_UCX_global.ctx[i].worker != NULL) {
+            ucp_worker_release_address(MPIDI_UCX_global.ctx[i].worker,
+                                       MPIDI_UCX_global.ctx[i].if_address);
             ucp_worker_destroy(MPIDI_UCX_global.ctx[i].worker);
         }
     }

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -412,8 +412,10 @@ int MPID_Init(int requested, int *provided)
     MPIR_ERR_CHKANDJUMP1(MPIDI_global.prev_sighandler == SIG_ERR, mpi_errno, MPI_ERR_OTHER,
                          "**signal", "**signal %s",
                          MPIR_Strerror(errno, strerrbuf, MPIR_STRERROR_BUF_SIZE));
-    if (MPIDI_global.prev_sighandler == SIG_IGN || MPIDI_global.prev_sighandler == SIG_DFL)
+    if (MPIDI_global.prev_sighandler == SIG_IGN || MPIDI_global.prev_sighandler == SIG_DFL ||
+        MPIDI_global.prev_sighandler == MPIDI_sigusr1_handler) {
         MPIDI_global.prev_sighandler = NULL;
+    }
 #endif
 
     mpi_errno = MPIDI_Self_init();
@@ -685,6 +687,8 @@ int MPID_Finalize(void)
         MPID_Thread_mutex_destroy(&MPIDI_VCI(i).lock, &err);
         MPIR_Assert(err == 0);
     }
+
+    memset(&MPIDI_global, 0, sizeof(MPIDI_global));
 
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/src/ch4_proc.c
+++ b/src/mpid/ch4/src/ch4_proc.c
@@ -196,6 +196,7 @@ int MPIDIU_avt_destroy(void)
     }
 
     MPL_free(MPIDI_global.avt_mgr.av_tables);
+    memset(&MPIDI_global.avt_mgr, 0, sizeof(MPIDI_global.avt_mgr));
 
     MPIR_FUNC_EXIT;
     return MPI_SUCCESS;

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -395,10 +395,6 @@ if test "$ac_cv_func_gethostname" = "yes" ; then
     PAC_FUNC_NEEDS_DECL([#include <unistd.h>],gethostname)
 fi
 
-# make sure we support signal
-AC_CHECK_HEADERS(signal.h)
-AC_CHECK_FUNCS(signal)
-
 AC_CONFIG_FILES([
 src/mpid/ch4/src/mpid_ch4_net_array.c
 src/mpid/ch4/include/netmodpre.h

--- a/src/mpl/src/dbg/mpl_dbg.c
+++ b/src/mpl/src/dbg/mpl_dbg.c
@@ -484,6 +484,10 @@ int MPL_dbg_init(int wnum, int wrank)
     int ret;
     FILE *dbg_fp = NULL;
 
+    /* in case of re-init */
+    num_classnames = 0;
+    num_unregistered_classes = 0;
+
     /* if the DBG_MSG system was already initialized, say by the
      * device, then return immediately.  Note that the device is then
      * responsible for handling the file mode (e.g., reopen when the

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -416,6 +416,7 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
 
                 /* Add this process to the end of the list */
                 if (!included) {
+                    MPL_free(current_list);
                     HYDU_MALLOC_OR_JUMP(str, char *, PMI_MAXVALLEN, status);
 
                     MPL_snprintf(str, PMI_MAXVALLEN, "%s,%d", pg_scratch->dead_processes,
@@ -423,6 +424,7 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
                 } else {
                     str = current_list;
                 }
+                MPL_free(pg_scratch->dead_processes);
                 pg_scratch->dead_processes = str;
             }
 

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -589,9 +589,12 @@ HYD_status fn_finalize(struct pmip_downstream *p, struct PMIU_cmd *pmi)
     status = send_cmd_downstream(p->pmi_fd, &pmi_response);
     HYDU_ERR_POP(status, "error sending PMI response\n");
 
-    status = HYDT_dmx_deregister_fd(p->pmi_fd);
-    HYDU_ERR_POP(status, "unable to deregister fd\n");
-    close(p->pmi_fd);
+    if (HYD_pmcd_pmip.user_global.auto_cleanup) {
+        /* deregister to prevent the cleanup kill on fd close */
+        status = HYDT_dmx_deregister_fd(p->pmi_fd);
+        HYDU_ERR_POP(status, "unable to deregister fd\n");
+        close(p->pmi_fd);
+    }
 
     /* mark singleton's stdio sockets as closed */
     if (pg->is_singleton) {

--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -306,8 +306,11 @@ PMI_API_PUBLIC int PMI_Finalize(void)
         pmi_errno = PMIU_cmd_get_response(PMI_fd, &pmicmd);
         PMIU_ERR_POP(pmi_errno);
 
-        shutdown(PMI_fd, SHUT_RDWR);
-        close(PMI_fd);
+        if (0) {
+            /* closing PMI_fd prevents re-init. Disable for now. */
+            shutdown(PMI_fd, SHUT_RDWR);
+            close(PMI_fd);
+        }
     }
 
   fn_exit:

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -235,6 +235,7 @@ void MPIR_pmi_finalize(void)
     MPL_free(MPIR_Process.node_local_map);
 
     MPL_free(hwloc_topology_xmlfile);
+    hwloc_topology_xmlfile = NULL;
 }
 
 void MPIR_pmi_abort(int exit_code, const char *error_msg)

--- a/test/mpi/init/Makefile.am
+++ b/test/mpi/init/Makefile.am
@@ -18,6 +18,7 @@ noinst_PROGRAMS = \
     initstat      \
     session       \
     session_mult_init \
+    session_re_init \
     session_psets \
     session_self  \
     version       \
@@ -27,3 +28,5 @@ noinst_PROGRAMS = \
 
 session_mult_init_SOURCES = session.c
 session_mult_init_CPPFLAGS = -DMULT_INIT $(AM_CPPFLAGS)
+session_re_init_SOURCES = session.c
+session_re_init_CPPFLAGS = -DRE_INIT $(AM_CPPFLAGS)

--- a/test/mpi/init/session.c
+++ b/test/mpi/init/session.c
@@ -42,6 +42,9 @@ int main(int argc, char *argv[])
     MPI_Finalize();
 #else
     int rank = library_foo_test();
+#ifdef RE_INIT
+    library_foo_test();
+#endif
 #endif
     if (rank == 0 && errs == 0) {
         printf("No Errors\n");

--- a/test/mpi/init/testlist
+++ b/test/mpi/init/testlist
@@ -9,5 +9,6 @@ library_version 1
 session 4
 session_mult_init 4
 session_mult_init 4 arg=5
+session_re_init 4 mpiexecarg=-disable-auto-cleanup
 session_psets 1
 session_self 1


### PR DESCRIPTION
## Pull Request Description
The use of sessions may create the situation of multiple init/finalize cycles, as pointed out in issue #6101. This PR addresses issues that prevents multiple init/finalize. In addition, we need disable hydra auto_cleanup or hydra will assume a single PMI_Init/PMI_Finalize.

Fixes #6101 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
