### PR TITLE
confdb: extract hwloc ldflags on osx

### DIFF
--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -108,18 +108,28 @@ AC_DEFUN([PAC_CONFIG_HWLOC],[
             fi
             PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/hwloc/include],[CPPFLAGS])
             PAC_APPEND_FLAG([-I${main_top_builddir}/modules/hwloc/include],[CPPFLAGS])
+            hwloc_config_status="${main_top_builddir}/modules/hwloc/config.status"
         ], [
             dnl ---- sub-configure (hydra) ----
             if test "$FROM_MPICH" = "yes"; then
                 hwloc_includedir="-I${main_top_srcdir}/modules/hwloc/include -I${main_top_builddir}/modules/hwloc/include"
                 hwloc_lib="${main_top_builddir}/modules/hwloc/hwloc/libhwloc_embedded.la"
+                hwloc_config_status="${main_top_builddir}/modules/hwloc/config.status"
             else
                 PAC_CONFIG_HWLOC_EMBEDDED()
                 dnl Note that single quote is intentional to pass the variable as is
                 hwloc_srcdir="hwloc_embedded_dir"
                 hwloc_includedir='-I${srcdir}/${hwloc_srcdir}/include -I${builddir}/${hwloc_srcdir}/include'
                 hwloc_lib='${builddir}/${hwloc_srcdir}/hwloc/libhwloc_embedded.la'
+                hwloc_config_status="${builddir}/${hwloc_srcdir}/config.status"
             fi
         ])
+
+        # capture the line -- S["HWLOC_DARWIN_LDFLAGS"]=" -framework Foundation -framework IOKit"
+        hwloc_darwin_ldflags=$(awk -F'"' '/^S."HWLOC_DARWIN_LDFLAGS"/ {print $[]4}' "$hwloc_config_status")
+        if test -n "$hwloc_darwin_ldflags" ; then
+            echo "hwloc_darwin_ldflags = $hwloc_darwin_ldflags"
+            PAC_APPEND_FLAG([$hwloc_darwin_ldflags], [LDFLAGS])
+        fi
     fi
 ])


### PR DESCRIPTION
## Pull Request Description
On osx we need add " -framework Foundation -framework IOKit" to ldflags. Extract that from hwloc's config.status.

This reverts commit 2c1a749fbafc3dd944f2fc9bcc1da3c8d2ec9faf.



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
